### PR TITLE
Fix the difference between aws_waf_byte_match_set and aws_wafregional_byte_match_set

### DIFF
--- a/aws/resource_aws_wafregional_byte_match_set_test.go
+++ b/aws/resource_aws_wafregional_byte_match_set_test.go
@@ -30,27 +30,27 @@ func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.#", "2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
 				),
 			},
 		},
@@ -74,27 +74,27 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.#", "2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -104,34 +104,34 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.#", "2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuple(t *testing.T) {
+func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 	var before, after waf.ByteMatchSet
 	byteMatchSetName := fmt.Sprintf("byte-batch-set-%s", acctest.RandString(5))
 
@@ -147,57 +147,57 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuple(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.#", "2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
 				),
 			},
 			{
-				Config: testAccAWSWafRegionalByteMatchSetConfigChangeByteMatchTuple(byteMatchSetName),
+				Config: testAccAWSWafRegionalByteMatchSetConfigChangeByteMatchTuples(byteMatchSetName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &after),
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.#", "2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2397850647.field_to_match.4253810390.data", "GET"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.field_to_match.4253810390.data", "GET"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2397850647.field_to_match.4253810390.type", "METHOD"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.field_to_match.4253810390.type", "METHOD"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2397850647.positional_constraint", "STARTS_WITH"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.positional_constraint", "STARTS_WITH"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2397850647.target_string", "badrefer1+"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.target_string", "badrefer1+"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.2397850647.text_transformation", "LOWERCASE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.text_transformation", "LOWERCASE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.4153613423.field_to_match.3756326843.data", ""),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.field_to_match.3756326843.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.4153613423.field_to_match.3756326843.type", "URI"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.field_to_match.3756326843.type", "URI"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.4153613423.positional_constraint", "ENDS_WITH"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.positional_constraint", "ENDS_WITH"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.4153613423.target_string", "badrefer2+"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.target_string", "badrefer2+"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuple.4153613423.text_transformation", "LOWERCASE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.text_transformation", "LOWERCASE"),
 				),
 			},
 		},
@@ -218,7 +218,7 @@ func TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_match_set", &byteMatchSet),
 					resource.TestCheckResourceAttr("aws_wafregional_byte_match_set.byte_match_set", "name", byteMatchSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_byte_match_set.byte_match_set", "byte_match_tuple.#", "0"),
+					resource.TestCheckResourceAttr("aws_wafregional_byte_match_set.byte_match_set", "byte_match_tuples.#", "0"),
 				),
 			},
 		},
@@ -356,7 +356,7 @@ func testAccAWSWafRegionalByteMatchSetConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_byte_match_set" "byte_set" {
   name = "%s"
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation = "NONE"
     target_string = "badrefer1"
     positional_constraint = "CONTAINS"
@@ -366,7 +366,7 @@ resource "aws_wafregional_byte_match_set" "byte_set" {
     }
   }
 
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation = "NONE"
     target_string = "badrefer2"
     positional_constraint = "CONTAINS"
@@ -382,7 +382,7 @@ func testAccAWSWafRegionalByteMatchSetConfigChangeName(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_byte_match_set" "byte_set" {
   name = "%s"
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation = "NONE"
     target_string = "badrefer1"
     positional_constraint = "CONTAINS"
@@ -392,7 +392,7 @@ resource "aws_wafregional_byte_match_set" "byte_set" {
     }
   }
 
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation = "NONE"
     target_string = "badrefer2"
     positional_constraint = "CONTAINS"
@@ -411,11 +411,11 @@ resource "aws_wafregional_byte_match_set" "byte_match_set" {
 }`, name)
 }
 
-func testAccAWSWafRegionalByteMatchSetConfigChangeByteMatchTuple(name string) string {
+func testAccAWSWafRegionalByteMatchSetConfigChangeByteMatchTuples(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_byte_match_set" "byte_set" {
   name = "%s"
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation = "LOWERCASE"
     target_string = "badrefer1+"
     positional_constraint = "STARTS_WITH"
@@ -425,7 +425,7 @@ resource "aws_wafregional_byte_match_set" "byte_set" {
     }
   }
 
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation = "LOWERCASE"
     target_string = "badrefer2+"
     positional_constraint = "ENDS_WITH"

--- a/website/docs/r/wafregional_byte_match_set.html.markdown
+++ b/website/docs/r/wafregional_byte_match_set.html.markdown
@@ -15,7 +15,7 @@ Provides a WAF Regional Byte Match Set Resource for use with Application Load Ba
 ```hcl
 resource "aws_wafregional_byte_match_set" "byte_set" {
   name = "tf_waf_byte_match_set"
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation = "NONE"
     target_string = "badrefer1"
     positional_constraint = "CONTAINS"
@@ -32,9 +32,11 @@ resource "aws_wafregional_byte_match_set" "byte_set" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the ByteMatchSet.
-* `byte_match_tuple` - (Optional)Settings for the ByteMatchSet, such as the bytes (typically a string that corresponds with ASCII characters) that you want AWS WAF to search for in web requests. ByteMatchTuple documented below.
+* `byte_match_tuple` - **Deprecated**, use `byte_match_tuples` instead.
+* `byte_match_tuples` - (Optional)Settings for the ByteMatchSet, such as the bytes (typically a string that corresponds with ASCII characters) that you want AWS WAF to search for in web requests. ByteMatchTuple documented below.
 
-ByteMatchTuple(byte_match_tuple) support the following:
+
+ByteMatchTuples(byte_match_tuples) support the following:
 
 * `field_to_match` - (Required) Settings for the ByteMatchTuple. FieldToMatch documented below.
 * `positional_constraint` - (Required) Within the portion of a web request that you want to search.


### PR DESCRIPTION
Changes proposed in this pull request:

Some aws waf and aws waf-regional API have same attributes each other. However, Terraform `aws_waf_***` resources and `aws_wafregional_***` resources have same attributes with the different name, one is singular and the other is plural.  Although this is mentioned a little in #4137 , this discrepancy can also be seen in several other resources about AWS WAF(Regional).

This PR will fix such inconsistencies. I think it would be better to unify in singular names, because these attributes type is not `list` but `map` .

Output from acceptance testing:

WIP

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafByteMatchSet*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafByteMatchSet* -timeout 120m
=== RUN   TestAccAWSWafByteMatchSet_basic
--- PASS: TestAccAWSWafByteMatchSet_basic (42.07s)
=== RUN   TestAccAWSWafByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafByteMatchSet_changeNameForceNew (77.94s)
=== RUN   TestAccAWSWafByteMatchSet_changeTuple
--- PASS: TestAccAWSWafByteMatchSet_changeTuple (72.65s)
=== RUN   TestAccAWSWafByteMatchSet_noTuples
--- PASS: TestAccAWSWafByteMatchSet_noTuples (37.13s)
=== RUN   TestAccAWSWafByteMatchSet_disappears
--- PASS: TestAccAWSWafByteMatchSet_disappears (35.07s)
PASS
ok      github.com/chroju/terraform-provider-aws/aws    264.901s
```
