### PR TITLE
resource/aws_codebuild_project: Prevent panic with missing environment variable type

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -835,7 +835,12 @@ func resourceAwsCodeBuildProjectEnvironmentHash(v interface{}) int {
 	for _, e := range environmentVariables {
 		if e != nil { // Old statefiles might have nil values in them
 			ev := e.(map[string]interface{})
-			buf.WriteString(fmt.Sprintf("%s:%s:%s-", ev["name"].(string), ev["type"].(string), ev["value"].(string)))
+			buf.WriteString(fmt.Sprintf("%s:", ev["name"].(string)))
+			// type is sometimes not returned by the API
+			if v, ok := ev["type"]; ok {
+				buf.WriteString(fmt.Sprintf("%s:", v.(string)))
+			}
+			buf.WriteString(fmt.Sprintf("%s-", ev["value"].(string)))
 		}
 	}
 


### PR DESCRIPTION
This fixes a panic caused by https://github.com/terraform-providers/terraform-provider-aws/commit/20b148fed56633f6ad1a0d46ce39eb4dc6ae26db, which was released in version 1.21.0 of the AWS provider to support `aws_codebuild_project` environment variable types.

```
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: panic: interface conversion: interface {} is nil, not string
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: 
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: goroutine 3260 [running]:
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsCodeBuildProjectEnvironmentHash(0x27aa2a0, 0xc4207216e0, 0xc42177aa58)
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_codebuild_project.go:838 +0x8f6
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).hash(0xc42177aa40, 0x27aa2a0, 0xc4207216e0, 0x7f594678c870, 0x0)
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:205 +0x3d
2018-06-27T17:20:34.979Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).add(0xc42177aa40, 0x27aa2a0, 0xc4207216e0, 0x2a8b700, 0x2483801, 0xc42177aa40)
2018-06-27T17:20:34.980Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:192 +0x72
2018-06-27T17:20:34.980Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Set).Add(0xc42177aa40, 0x27aa2a0, 0xc4207216e0)
2018-06-27T17:20:34.980Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:69 +0x44
2018-06-27T17:20:34.980Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.NewSet(0x2e6e130, 0xc422013e30, 0x1, 0x1, 0xc42177a860)
2018-06-27T17:20:34.980Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/set.go:56 +0x7a
2018-06-27T17:20:34.980Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsCodeBuildProjectRead(0xc420fb2f50, 0x2954240, 0xc420096840, 0xc420fb2f50, 0x0)
2018-06-27T17:20:34.980Z [DEBUG] plugin.terraform-provider-aws_v1.25.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_codebuild_project.go:567 +0x278
```

Changes proposed in this pull request:

* Ignore missing type in environment variable TypeSet hashing instead of panicking

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_importBasic
--- PASS: TestAccAWSCodeBuildProject_importBasic (21.44s)
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (31.19s)
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (30.25s)
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (29.04s)
=== RUN   TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_Cache (52.90s)
=== RUN   TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_Description (37.35s)
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (49.93s)
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (31.71s)
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (31.02s)
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (37.94s)
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (37.15s)
=== RUN   TestAccAWSCodeBuildProject_Tags
--- PASS: TestAccAWSCodeBuildProject_Tags (29.12s)
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (58.06s)
=== RUN   TestAccAWSCodeBuildProject_WindowsContainer
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (30.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	507.613s
```
