### PR TITLE
aws_wafregional_web_acl + aws_web_acl rule group support

### DIFF
--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -50,7 +50,20 @@ func resourceAwsWafWebAcl() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"action": &schema.Schema{
 							Type:     schema.TypeSet,
-							Required: true,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": &schema.Schema{
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"override_action": &schema.Schema{
+							Type:     schema.TypeSet,
+							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -72,6 +85,7 @@ func resourceAwsWafWebAcl() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								waf.WafRuleTypeRegular,
 								waf.WafRuleTypeRateBased,
+								waf.WafRuleTypeGroup,
 							}, false),
 						},
 						"rule_id": &schema.Schema{
@@ -184,16 +198,33 @@ func updateWebAclResource(d *schema.ResourceData, meta interface{}, ChangeAction
 		rules := d.Get("rules").(*schema.Set)
 		for _, rule := range rules.List() {
 			aclRule := rule.(map[string]interface{})
-			action := aclRule["action"].(*schema.Set).List()[0].(map[string]interface{})
-			aclRuleUpdate := &waf.WebACLUpdate{
-				Action: aws.String(ChangeAction),
-				ActivatedRule: &waf.ActivatedRule{
-					Priority: aws.Int64(int64(aclRule["priority"].(int))),
-					RuleId:   aws.String(aclRule["rule_id"].(string)),
-					Type:     aws.String(aclRule["type"].(string)),
-					Action:   &waf.WafAction{Type: aws.String(action["type"].(string))},
-				},
+
+			var aclRuleUpdate *waf.WebACLUpdate
+			switch aclRule["type"].(string) {
+			case waf.WafRuleTypeGroup:
+				overrideAction := aclRule["override_action"].(*schema.Set).List()[0].(map[string]interface{})
+				aclRuleUpdate = &waf.WebACLUpdate{
+					Action: aws.String(ChangeAction),
+					ActivatedRule: &waf.ActivatedRule{
+						Priority:       aws.Int64(int64(aclRule["priority"].(int))),
+						RuleId:         aws.String(aclRule["rule_id"].(string)),
+						Type:           aws.String(aclRule["type"].(string)),
+						OverrideAction: &waf.WafOverrideAction{Type: aws.String(overrideAction["type"].(string))},
+					},
+				}
+			default:
+				action := aclRule["action"].(*schema.Set).List()[0].(map[string]interface{})
+				aclRuleUpdate = &waf.WebACLUpdate{
+					Action: aws.String(ChangeAction),
+					ActivatedRule: &waf.ActivatedRule{
+						Priority: aws.Int64(int64(aclRule["priority"].(int))),
+						RuleId:   aws.String(aclRule["rule_id"].(string)),
+						Type:     aws.String(aclRule["type"].(string)),
+						Action:   &waf.WafAction{Type: aws.String(action["type"].(string))},
+					},
+				}
 			}
+
 			req.Updates = append(req.Updates, aclRuleUpdate)
 		}
 		return conn.UpdateWebACL(req)

--- a/aws/resource_aws_wafregional_web_acl_test.go
+++ b/aws/resource_aws_wafregional_web_acl_test.go
@@ -72,6 +72,35 @@ func TestAccAWSWafRegionalWebAcl_createRateBased(t *testing.T) {
 	})
 }
 
+func TestAccAWSWafRegionalWebAcl_createGroup(t *testing.T) {
+	var v waf.WebACL
+	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalWebAclDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafRegionalWebAclConfigGroup(wafAclName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSWafRegionalWebAcl_changeNameForceNew(t *testing.T) {
 	var before, after waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
@@ -428,6 +457,31 @@ resource "aws_wafregional_web_acl" "waf_acl" {
     priority = 1
     type = "RATE_BASED"
     rule_id = "${aws_wafregional_rate_based_rule.wafrule.id}"
+  }
+}`, name, name, name, name)
+}
+
+func testAccAWSWafRegionalWebAclConfigGroup(name string) string {
+	return fmt.Sprintf(`
+
+resource "aws_wafregional_rule_group" "wafrulegroup" {
+  name = "%s"
+  metric_name = "%s"
+}
+
+resource "aws_wafregional_web_acl" "waf_acl" {
+  name = "%s"
+  metric_name = "%s"
+  default_action {
+    type = "ALLOW"
+  }
+  rule {
+    override_action {
+       type = "NONE"
+    }
+    priority = 1
+    type = "GROUP"
+    rule_id = "${aws_wafregional_rule_group.wafrulegroup.id}" # todo
   }
 }`, name, name, name, name)
 }

--- a/aws/resource_aws_wafregional_web_acl_test.go
+++ b/aws/resource_aws_wafregional_web_acl_test.go
@@ -295,10 +295,11 @@ func computeWafRegionalWebAclRuleIndex(ruleId **string, priority int, ruleType s
 			"type": actionType,
 		}
 		m := map[string]interface{}{
-			"rule_id":  **ruleId,
-			"type":     ruleType,
-			"priority": priority,
-			"action":   []interface{}{actionMap},
+			"rule_id":         **ruleId,
+			"type":            ruleType,
+			"priority":        priority,
+			"action":          []interface{}{actionMap},
+			"override_action": []interface{}{},
 		}
 
 		f := schema.HashResource(ruleResource)

--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -80,11 +80,12 @@ See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ActivatedRule.
 #### Arguments
 
 * `action` - (Required) The action that CloudFront or AWS WAF takes when a web request matches the conditions in the rule.
-  e.g. `ALLOW`, `BLOCK` or `COUNT`
+  e.g. `ALLOW`, `BLOCK` or `COUNT`.  Not used if `type` is `GROUP`.
+* `override_action` - (Required) Override the action that a group requests CloudFront or AWS WAF takes when a web request matches the conditions in the rule.  Only used if `type` is `GROUP`.
 * `priority` - (Required) Specifies the order in which the rules in a WebACL are evaluated.
   Rules with a lower value are evaluated before rules with a higher value.
 * `rule_id` - (Required) ID of the associated [rule](/docs/providers/aws/r/waf_rule.html)
-* `type` - (Optional) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), or `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html). The default is REGULAR. If you add a RATE_BASED rule, you need to set `type` as `RATE_BASED`.
+* `type` - (Optional) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html), or `GROUP`, as defined by [RuleGroup](https://docs.aws.amazon.com/waf/latest/APIReference/API_RuleGroup.html). The default is REGULAR. If you add a RATE_BASED rule, you need to set `type` as `RATE_BASED`. If you add a GROUP rule, you need to set `type` as `GROUP`.
 
 ## Attributes Reference
 

--- a/website/docs/r/wafregional_web_acl.html.markdown
+++ b/website/docs/r/wafregional_web_acl.html.markdown
@@ -75,7 +75,7 @@ See [docs](https://docs.aws.amazon.com/waf/latest/APIReference/API_regional_Acti
 * `priority` - (Required) Specifies the order in which the rules in a WebACL are evaluated.
   Rules with a lower value are evaluated before rules with a higher value.
 * `rule_id` - (Required) ID of the associated [rule](/docs/providers/aws/r/wafregional_rule.html)
-* `type` - (Optional) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html), or `GROUP`, as defined by [RuleGroup](https://docs.aws.amazon.com/waf/latest/APIReference/API_RuleGroup.html). The default is REGULAR. If you add a RATE_BASED rule, you need to set `type` as `RATE_BASED`.
+* `type` - (Optional) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html), or `GROUP`, as defined by [RuleGroup](https://docs.aws.amazon.com/waf/latest/APIReference/API_RuleGroup.html). The default is REGULAR. If you add a RATE_BASED rule, you need to set `type` as `RATE_BASED`. If you add a GROUP rule, you need to set `type` as `GROUP`.
 
 ### `default_action` / `action`
 

--- a/website/docs/r/wafregional_web_acl.html.markdown
+++ b/website/docs/r/wafregional_web_acl.html.markdown
@@ -70,11 +70,12 @@ See [docs](https://docs.aws.amazon.com/waf/latest/APIReference/API_regional_Acti
 
 #### Arguments
 
-* `action` - (Required) The action that CloudFront or AWS WAF takes when a web request matches the conditions in the rule.
+* `action` - (Required) The action that CloudFront or AWS WAF takes when a web request matches the conditions in the rule.  Not used if `type` is `GROUP`.
+* `override_action` - (Required) Override the action that a group requests CloudFront or AWS WAF takes when a web request matches the conditions in the rule.  Only used if `type` is `GROUP`.
 * `priority` - (Required) Specifies the order in which the rules in a WebACL are evaluated.
   Rules with a lower value are evaluated before rules with a higher value.
 * `rule_id` - (Required) ID of the associated [rule](/docs/providers/aws/r/wafregional_rule.html)
-* `type` - (Optional) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), or `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html). The default is REGULAR. If you add a RATE_BASED rule, you need to set `type` as `RATE_BASED`.
+* `type` - (Optional) The rule type, either `REGULAR`, as defined by [Rule](http://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html), `RATE_BASED`, as defined by [RateBasedRule](http://docs.aws.amazon.com/waf/latest/APIReference/API_RateBasedRule.html), or `GROUP`, as defined by [RuleGroup](https://docs.aws.amazon.com/waf/latest/APIReference/API_RuleGroup.html). The default is REGULAR. If you add a RATE_BASED rule, you need to set `type` as `RATE_BASED`.
 
 ### `default_action` / `action`
 


### PR DESCRIPTION
Fixes #4077
Fixes #4052

Changes proposed in this pull request:

* Add support for `type=GROUP` in `aws_waf_web_acl`
* Add support for `type=GROUP` in `aws_wafregional_web_acl`
* Add `override_action` for entries where `type=GROUP` in both modified providers
* Add a test for this new type that uses an `aws_waf_rule_group`
* Add a test for this new type that uses an `aws_wafregional_rule_group`
* Add documentation for the new options and parameters

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run="TestAccAWSWafRegionalWebAcl_|TestAccAWSWafWebAcl_"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run="TestAccAWSWafRegionalWebAcl_|TestAccAWSWafWebAcl_" -timeout 120m
=== RUN   TestAccAWSWafWebAcl_basic
--- PASS: TestAccAWSWafWebAcl_basic (52.20s)
=== RUN   TestAccAWSWafWebAcl_group
--- PASS: TestAccAWSWafWebAcl_group (37.65s)
=== RUN   TestAccAWSWafWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (87.57s)
=== RUN   TestAccAWSWafWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafWebAcl_changeDefaultAction (88.39s)
=== RUN   TestAccAWSWafWebAcl_disappears
--- PASS: TestAccAWSWafWebAcl_disappears (46.77s)
=== RUN   TestAccAWSWafRegionalWebAcl_basic
--- PASS: TestAccAWSWafRegionalWebAcl_basic (37.98s)
=== RUN   TestAccAWSWafRegionalWebAcl_createRateBased
--- PASS: TestAccAWSWafRegionalWebAcl_createRateBased (38.70s)
=== RUN   TestAccAWSWafRegionalWebAcl_createGroup
--- PASS: TestAccAWSWafRegionalWebAcl_createGroup (39.40s)
=== RUN   TestAccAWSWafRegionalWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafRegionalWebAcl_changeNameForceNew (69.61s)
=== RUN   TestAccAWSWafRegionalWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafRegionalWebAcl_changeDefaultAction (69.73s)
=== RUN   TestAccAWSWafRegionalWebAcl_disappears
--- PASS: TestAccAWSWafRegionalWebAcl_disappears (36.35s)
=== RUN   TestAccAWSWafRegionalWebAcl_noRules
--- PASS: TestAccAWSWafRegionalWebAcl_noRules (31.51s)
=== RUN   TestAccAWSWafRegionalWebAcl_changeRules
--- PASS: TestAccAWSWafRegionalWebAcl_changeRules (60.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       696.781s
```
