### PR TITLE
Add member_clusters to aws_elasticache_replication_group

### DIFF
--- a/aws/data_source_aws_elasticache_replication_group.go
+++ b/aws/data_source_aws_elasticache_replication_group.go
@@ -45,6 +45,12 @@ func dataSourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"member_clusters": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 			"node_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -106,6 +112,7 @@ func dataSourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta i
 		d.Set("primary_endpoint_address", rg.NodeGroups[0].PrimaryEndpoint.Address)
 	}
 	d.Set("number_cache_clusters", len(rg.MemberClusters))
+	d.Set("member_clusters", flattenStringList(rg.MemberClusters))
 	d.Set("node_type", rg.CacheNodeType)
 	d.Set("snapshot_window", rg.SnapshotWindow)
 	d.Set("snapshot_retention_limit", rg.SnapshotRetentionLimit)

--- a/aws/data_source_aws_elasticache_replication_group_test.go
+++ b/aws/data_source_aws_elasticache_replication_group_test.go
@@ -24,6 +24,7 @@ func TestAccDataSourceAwsElasticacheReplicationGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "port", "6379"),
 					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "primary_endpoint_address"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttrSet("data.aws_elasticache_replication_group.bar", "member_clusters"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "node_type", "cache.m1.small"),
 					resource.TestCheckResourceAttr("data.aws_elasticache_replication_group.bar", "snapshot_window", "01:00-02:00"),
 				),

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -50,6 +50,13 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 		Optional: true,
 	}
 
+	resourceSchema["member_clusters"] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Computed: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+		Set:      schema.HashString,
+	}
+
 	resourceSchema["primary_endpoint_address"] = &schema.Schema{
 		Type:     schema.TypeString,
 		Computed: true,
@@ -313,6 +320,7 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 
 	d.Set("replication_group_description", rgp.Description)
 	d.Set("number_cache_clusters", len(rgp.MemberClusters))
+	d.Set("member_clusters", flattenStringList(rgp.MemberClusters))
 	if err := d.Set("cluster_mode", flattenElasticacheNodeGroupsToClusterMode(aws.BoolValue(rgp.ClusterEnabled), rgp.NodeGroups)); err != nil {
 		return fmt.Errorf("error setting cluster_mode attribute: %s", err)
 	}

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -89,6 +89,8 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 						"aws_elasticache_replication_group.bar", "cluster_mode.#", "0"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
+					resource.TestCheckResourceAttrSet(
+						"aws_elasticache_replication_group.bar", "member_clusters"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "auto_minor_version_upgrade", "false"),
 				),

--- a/website/docs/d/elasticache_replication_group.html.markdown
+++ b/website/docs/d/elasticache_replication_group.html.markdown
@@ -34,6 +34,7 @@ In addition to all arguments above, the following attributes are exported:
 * `automatic_failover_enabled` - A flag whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails.
 * `node_type` – The cluster node type.
 * `number_cache_clusters` – The number of cache clusters that the replication group has.
+* `member_clusters` - The identifiers of all the nodes that are part of this replication group.
 * `snapshot_window` - The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard).
 * `snapshot_retention_limit` - The number of days for which ElastiCache retains automatic cache cluster snapshots before deleting them.
 * `port` – The port number on which the configuration endpoint will accept connections.

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -140,6 +140,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the ElastiCache Replication Group.
 * `configuration_endpoint_address` - The address of the replication group configuration endpoint when cluster mode is enabled.
 * `primary_endpoint_address` - (Redis only) The address of the endpoint for the primary node in the replication group, if the cluster mode is disabled.
+* `member_clusters` - The identifiers of all the nodes that are part of this replication group.
 
 ## Timeouts
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Add `member_clusters` attribute to Elasticache replication group data source and resource. This is useful when setting up Cloudwatch alarms on the clusters.

Output from acceptance testing:
_(I wasn't able to get the acceptance tests running on my AWS account)_
```
$ make testacc TESTARGS='-run=TestAcc.*ElasticacheReplicationGroup_basic'
...
--- FAIL: TestAccDataSourceAwsElasticacheReplicationGroup_basic (17.55s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_elasticache_replication_group.bar: 1 error(s) occurred:
		
		* aws_elasticache_replication_group.bar: Error creating Elasticache Replication Group: CacheParameterGroupNotFound: CacheParameterGroup not found: default.redis3.2
			status code: 404, request id: 9436287e-7ea9-11e8-8f9f-5357cdd1eabd
...
--- FAIL: TestAccAWSElasticacheReplicationGroup_basic (18.06s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_elasticache_security_group.bar: 1 error(s) occurred:
		
		* aws_elasticache_security_group.bar: Error creating CacheSecurityGroup: InvalidParameterValue: Use of cache security groups is not permitted in this API version for your account.
			status code: 400, request id: 9d97e424-7ea9-11e8-811f-674747b34208
...
```
