### PR TITLE
resource/aws_kms_grant: Properly return error when listing KMS grants

### DIFF
--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -393,13 +393,16 @@ func findKmsGrantById(conn *kms.KMS, keyId string, grantId string, marker *strin
 
 		return nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing KMS Grants: %s", err)
+	}
 
 	grant = getKmsGrantById(out.Grants, grantId)
 	if grant != nil {
 		return grant, nil
 	}
-	if *out.Truncated {
-		log.Printf("[DEBUG] KMS Grant list truncated, getting next page via marker: %s", *out.NextMarker)
+	if aws.BoolValue(out.Truncated) {
+		log.Printf("[DEBUG] KMS Grant list truncated, getting next page via marker: %s", aws.StringValue(out.NextMarker))
 		return findKmsGrantById(conn, keyId, grantId, out.NextMarker)
 	}
 


### PR DESCRIPTION
Fixes #5062 

Changes proposed in this pull request:

* Properly return `ListGrants` errors from `findKmsGrantById()` instead of crashing
* Additionally prevent potential nil dereferencing panics by using SDK methods in `findKmsGrantById()`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAWSKmsGrant'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAWSKmsGrant -timeout 120m
=== RUN   TestAWSKmsGrant_Basic
--- PASS: TestAWSKmsGrant_Basic (53.14s)
=== RUN   TestAWSKmsGrant_withConstraints
--- PASS: TestAWSKmsGrant_withConstraints (82.90s)
=== RUN   TestAWSKmsGrant_withRetiringPrincipal
--- PASS: TestAWSKmsGrant_withRetiringPrincipal (52.32s)
=== RUN   TestAWSKmsGrant_bare
--- PASS: TestAWSKmsGrant_bare (52.20s)
=== RUN   TestAWSKmsGrant_ARN
--- PASS: TestAWSKmsGrant_ARN (51.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	292.322s
```
