### PR TITLE
db_event_subscription source_type doc expansion

### DIFF
--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -59,8 +59,8 @@ The following arguments are supported:
 * `name_prefix` - (Optional) The name of the DB event subscription. Conflicts with `name`.
 * `sns_topic` - (Required) The SNS topic to send events to.
 * `source_ids` - (Optional) A list of identifiers of the event sources for which events will be returned. If not specified, then all sources are included in the response. If specified, a source_type must also be specified.
-* `source_type` - (Optional) The type of source that will be generating the events.
-* `event_categories` - (Optional) A list of event categories for a SourceType that you want to subscribe to. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide//USER_Events.html
+* `source_type` - (Optional) The type of source that will be generating the events. Valid options are `db-instance`, `db-security-group`, `db-parameter-group`, `db-cluster` or `db-cluster-snapshot`. If not set, all sources will be subscribed to.
+* `event_categories` - (Optional) A list of event categories for a SourceType that you want to subscribe to. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html or run `aws rds describe-event-categories`.
 * `enabled` - (Optional) A boolean flag to enable/disable the subscription. Defaults to true.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/db_event_subscription.html.markdown
+++ b/website/docs/r/db_event_subscription.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional) The name of the DB event subscription. Conflicts with `name`.
 * `sns_topic` - (Required) The SNS topic to send events to.
 * `source_ids` - (Optional) A list of identifiers of the event sources for which events will be returned. If not specified, then all sources are included in the response. If specified, a source_type must also be specified.
-* `source_type` - (Optional) The type of source that will be generating the events. Valid options are `db-instance`, `db-security-group`, `db-parameter-group`, `db-cluster` or `db-cluster-snapshot`. If not set, all sources will be subscribed to.
+* `source_type` - (Optional) The type of source that will be generating the events. Valid options are `db-instance`, `db-security-group`, `db-parameter-group`, `db-snapshot`, `db-cluster` or `db-cluster-snapshot`. If not set, all sources will be subscribed to.
 * `event_categories` - (Optional) A list of event categories for a SourceType that you want to subscribe to. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html or run `aws rds describe-event-categories`.
 * `enabled` - (Optional) A boolean flag to enable/disable the subscription. Defaults to true.
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds valid options for `source_type` argument (sourced from running `aws rds describe-event-categories`)
- Fixes double slash in URL given for `event_categories` argument
- Adds AWS CLI command for describing valid options for `event_categories` argument

Output from acceptance testing:

Not run; documentation change only.
