### PR TITLE
resource/aws_vpc_ipv4_cidr_block_association: Support resource import

### DIFF
--- a/aws/aws_vpc_ipv4_cidr_block_association_test.go
+++ b/aws/aws_vpc_ipv4_cidr_block_association_test.go
@@ -28,6 +28,16 @@ func TestAccAwsVpcIpv4CidrBlockAssociation_basic(t *testing.T) {
 					testAccCheckAdditionalAwsVpcIpv4CidrBlock(&associationTertiary, "170.2.0.0/16"),
 				),
 			},
+			{
+				ResourceName:      "aws_vpc_ipv4_cidr_block_association.secondary_cidr",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_vpc_ipv4_cidr_block_association.tertiary_cidr",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
+++ b/website/docs/r/vpc_ipv4_cidr_block_association.html.markdown
@@ -46,3 +46,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the VPC CIDR association
+
+## Import
+
+`aws_vpc_ipv4_cidr_block_association` can be imported by using the VPC CIDR Association ID, e.g.
+
+```
+$ terraform import aws_vpc_ipv4_cidr_block_association.example vpc-cidr-assoc-xxxxxxxx
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Use `DescribeVpcs` with `cidr-block-association.association-id` filter in read function
* Add `Importer` to resource schema

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsVpcIpv4CidrBlockAssociation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsVpcIpv4CidrBlockAssociation_basic -timeout 120m
=== RUN   TestAccAwsVpcIpv4CidrBlockAssociation_basic
--- PASS: TestAccAwsVpcIpv4CidrBlockAssociation_basic (49.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.493s
```
