### PR TITLE
Consistent ConflictsWith

### DIFF
--- a/aws/resource_aws_db_event_subscription.go
+++ b/aws/resource_aws_db_event_subscription.go
@@ -39,10 +39,11 @@ func resourceAwsDbEventSubscription() *schema.Resource {
 				ValidateFunc:  validateDbEventSubscriptionName,
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateDbEventSubscriptionName,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateDbEventSubscriptionName,
 			},
 			"sns_topic": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_db_option_group.go
+++ b/aws/resource_aws_db_option_group.go
@@ -45,11 +45,12 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 				ValidateFunc:  validateDbOptionGroupName,
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateDbOptionGroupNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateDbOptionGroupNamePrefix,
 			},
 			"engine_name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -41,11 +41,12 @@ func resourceAwsDbParameterGroup() *schema.Resource {
 				ValidateFunc:  validateDbParamGroupName,
 			},
 			"name_prefix": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateDbParamGroupNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateDbParamGroupNamePrefix,
 			},
 			"family": &schema.Schema{
 				Type:     schema.TypeString,

--- a/aws/resource_aws_db_subnet_group.go
+++ b/aws/resource_aws_db_subnet_group.go
@@ -40,11 +40,12 @@ func resourceAwsDbSubnetGroup() *schema.Resource {
 				ValidateFunc:  validateDbSubnetGroupName,
 			},
 			"name_prefix": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateDbSubnetGroupNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateDbSubnetGroupNamePrefix,
 			},
 
 			"description": &schema.Schema{

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -124,8 +124,9 @@ func resourceAwsElasticBeanstalkEnvironment() *schema.Resource {
 				ConflictsWith: []string{"template_name"},
 			},
 			"template_name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"solution_stack_name"},
 			},
 			"wait_for_ready_timeout": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -40,10 +40,11 @@ func resourceAwsElb() *schema.Resource {
 				ValidateFunc:  validateElbName,
 			},
 			"name_prefix": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateElbNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateElbNamePrefix,
 			},
 
 			"arn": &schema.Schema{

--- a/aws/resource_aws_emr_security_configuration.go
+++ b/aws/resource_aws_emr_security_configuration.go
@@ -28,10 +28,11 @@ func resourceAwsEMRSecurityConfiguration() *schema.Resource {
 				ValidateFunc:  validateMaxLength(10280),
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateMaxLength(10280 - resource.UniqueIDSuffixLength),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateMaxLength(10280 - resource.UniqueIDSuffixLength),
 			},
 
 			"configuration": {

--- a/aws/resource_aws_iam_group_policy.go
+++ b/aws/resource_aws_iam_group_policy.go
@@ -35,9 +35,10 @@ func resourceAwsIamGroupPolicy() *schema.Resource {
 				ConflictsWith: []string{"name_prefix"},
 			},
 			"name_prefix": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 			},
 			"group": &schema.Schema{
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_instance_profile.go
+++ b/aws/resource_aws_iam_instance_profile.go
@@ -61,9 +61,10 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8196-L8201
 					value := v.(string)

--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -62,9 +62,10 @@ func resourceAwsIamPolicy() *schema.Resource {
 				},
 			},
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8329-L8334
 					value := v.(string)

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -59,9 +59,10 @@ func resourceAwsIamRole() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8329-L8334
 					value := v.(string)

--- a/aws/resource_aws_iam_role_policy.go
+++ b/aws/resource_aws_iam_role_policy.go
@@ -41,10 +41,11 @@ func resourceAwsIamRolePolicy() *schema.Resource {
 				ValidateFunc:  validateIamRolePolicyName,
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateIamRolePolicyNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateIamRolePolicyNamePrefix,
 			},
 			"role": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -66,10 +66,11 @@ func resourceAwsIAMServerCertificate() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateMaxLength(128 - resource.UniqueIDSuffixLength),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateMaxLength(128 - resource.UniqueIDSuffixLength),
 			},
 
 			"arn": {

--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -40,9 +40,10 @@ func resourceAwsIamUserPolicy() *schema.Resource {
 				ConflictsWith: []string{"name_prefix"},
 			},
 			"name_prefix": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 			},
 			"user": &schema.Schema{
 				Type:     schema.TypeString,

--- a/aws/resource_aws_key_pair.go
+++ b/aws/resource_aws_key_pair.go
@@ -35,10 +35,11 @@ func resourceAwsKeyPair() *schema.Resource {
 				ValidateFunc:  validateMaxLength(255),
 			},
 			"key_name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateMaxLength(255 - resource.UniqueIDSuffixLength),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"key_name"},
+				ValidateFunc:  validateMaxLength(255 - resource.UniqueIDSuffixLength),
 			},
 			"public_key": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_kms_alias.go
+++ b/aws/resource_aws_kms_alias.go
@@ -38,10 +38,11 @@ func resourceAwsKmsAlias() *schema.Resource {
 				ValidateFunc:  validateAwsKmsName,
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateAwsKmsName,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateAwsKmsName,
 			},
 			"target_key_id": {
 				Type:             schema.TypeString,

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -68,10 +68,11 @@ func resourceAwsLambdaPermission() *schema.Resource {
 				ValidateFunc:  validatePolicyStatementId,
 			},
 			"statement_id_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validatePolicyStatementId,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"statement_id"},
+				ValidateFunc:  validatePolicyStatementId,
 			},
 		},
 	}

--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -35,10 +35,11 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 255-resource.UniqueIDSuffixLength),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validation.StringLenBetween(1, 255-resource.UniqueIDSuffixLength),
 			},
 
 			"image_id": {

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -34,10 +34,11 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateLaunchTemplateName,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateLaunchTemplateName,
 			},
 
 			"description": {
@@ -376,9 +377,10 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			},
 
 			"vpc_security_group_ids": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"security_group_names"},
 			},
 
 			"tag_specifications": {

--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -56,10 +56,11 @@ func resourceAwsLb() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateElbNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateElbNamePrefix,
 			},
 
 			"internal": {

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -50,10 +50,11 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				ValidateFunc:  validateMaxLength(32),
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateMaxLength(32 - resource.UniqueIDSuffixLength),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateMaxLength(32 - resource.UniqueIDSuffixLength),
 			},
 
 			"port": {

--- a/aws/resource_aws_lightsail_key_pair.go
+++ b/aws/resource_aws_lightsail_key_pair.go
@@ -28,9 +28,10 @@ func resourceAwsLightsailKeyPair() *schema.Resource {
 				ConflictsWith: []string{"name_prefix"},
 			},
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 			},
 
 			// optional fields

--- a/aws/resource_aws_neptune_cluster_parameter_group.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group.go
@@ -38,11 +38,12 @@ func resourceAwsNeptuneClusterParameterGroup() *schema.Resource {
 				ValidateFunc:  validateNeptuneParamGroupName,
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateNeptuneParamGroupNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateNeptuneParamGroupNamePrefix,
 			},
 			"family": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_neptune_subnet_group.go
+++ b/aws/resource_aws_neptune_subnet_group.go
@@ -36,11 +36,12 @@ func resourceAwsNeptuneSubnetGroup() *schema.Resource {
 				ValidateFunc:  validateNeptuneSubnetGroupName,
 			},
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateNeptuneSubnetGroupNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateNeptuneSubnetGroupNamePrefix,
 			},
 
 			"description": {

--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -36,11 +36,12 @@ func resourceAwsNetworkAcl() *schema.Resource {
 				Computed: false,
 			},
 			"subnet_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
-				Computed:   false,
-				Deprecated: "Attribute subnet_id is deprecated on network_acl resources. Use subnet_ids instead",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      false,
+				ConflictsWith: []string{"subnet_ids"},
+				Deprecated:    "Attribute subnet_id is deprecated on network_acl resources. Use subnet_ids instead",
 			},
 			"subnet_ids": {
 				Type:          schema.TypeSet,

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -58,11 +58,12 @@ func resourceAwsRDSCluster() *schema.Resource {
 				ValidateFunc:  validateRdsIdentifier,
 			},
 			"cluster_identifier_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateRdsIdentifierPrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"cluster_identifier"},
+				ValidateFunc:  validateRdsIdentifierPrefix,
 			},
 
 			"cluster_members": {

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -40,11 +40,12 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 				ValidateFunc:  validateDbParamGroupName,
 			},
 			"name_prefix": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateDbParamGroupNamePrefix,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateDbParamGroupNamePrefix,
 			},
 			"family": &schema.Schema{
 				Type:     schema.TypeString,

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -42,9 +42,10 @@ func resourceAwsS3Bucket() *schema.Resource {
 				ConflictsWith: []string{"bucket_prefix"},
 			},
 			"bucket_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"bucket"},
 			},
 
 			"bucket_domain_name": {

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -47,10 +47,11 @@ func resourceAwsSecurityGroup() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validateMaxLength(100),
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateMaxLength(100),
 			},
 
 			"description": {

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -52,9 +52,10 @@ func resourceAwsSnsTopic() *schema.Resource {
 				ConflictsWith: []string{"name_prefix"},
 			},
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 			},
 			"display_name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -56,9 +56,10 @@ func resourceAwsSqsQueue() *schema.Resource {
 				ValidateFunc:  validateSQSQueueName,
 			},
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 			},
 			"delay_seconds": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
Changes proposed in this pull request:

* Add ConflictsWith to some properties which already marked as conflict on their counterparts.
Useful for IntelliJ-Terraform plugin since it would highlight both sides as conflicts.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSAvailabilityZones -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
--- FAIL: TestAccAWSAvailabilityZones_basic (0.00s)
        provider_test.go:62: AWS_ACCESS_KEY_ID must be set for acceptance tests
=== RUN   TestAccAWSAvailabilityZones_stateFilter
--- FAIL: TestAccAWSAvailabilityZones_stateFilter (0.00s)
        provider_test.go:62: AWS_ACCESS_KEY_ID must be set for acceptance tests
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       0.008s
make: *** [GNUmakefile:20: testacc] Error 1
```
