### PR TITLE
Updates to tags and ACLs should happen only for non new resources

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -854,7 +854,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.HasChange("volume_tags") {
-		if !d.IsNewResource() || !restricted {
+		if !d.IsNewResource() || restricted {
 			if err := setVolumeTags(conn, d); err != nil {
 				return err
 			} else {

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -588,7 +588,7 @@ func resourceAwsS3BucketUpdate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
-	if d.HasChange("acl") {
+	if d.HasChange("acl") && !d.IsNewResource() {
 		if err := resourceAwsS3BucketAclUpdate(s3conn, d); err != nil {
 			return err
 		}

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -197,6 +197,9 @@ func diffTags(oldTags, newTags []*ec2.Tag) ([]*ec2.Tag, []*ec2.Tag) {
 		old, ok := create[*t.Key]
 		if !ok || old != *t.Value {
 			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, *t.Key)
 		}
 	}
 

--- a/aws/tags_test.go
+++ b/aws/tags_test.go
@@ -47,6 +47,24 @@ func TestDiffTags(t *testing.T) {
 				"foo": "bar",
 			},
 		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Changes proposed in this pull request:

* During creation of EC2 instances, an extra call to `CreateTags` is applied to the attached EBS volume. This is unnecessary since the tags are already created when passed to the initial `RunInstances` call. Remove this extra call.
* `diffTags` incorrectly returns tags that exist in `oldTags` and `newTags` as needing to be created again. This causes unnecessary calls to `CreateTags`. Fix this to return only tags that need to be deleted and created.
* During creation of S3 buckets, an extra call to `PutObjectACL` is applied to the S3 bucket. This is unnecessary since the ACLs are already created when passed to the initial `CreateBucket` call. Remove this extra call.

Output from acceptance testing:

```
$  make testacc TESTARGS='-run=TestAccAWSInstance.*Tag'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSInstance.*Tag -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (176.93s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- PASS: TestAccAWSInstance_volumeTagsComputed (142.11s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (205.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	524.841s

$  make testacc TESTARGS='-run=TestAccAWSS3.*Tag'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSS3.*Tag -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (83.62s)
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (80.15s)
=== RUN   TestAccAWSS3BucketMetric_WithFilterMultipleTags
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (80.13s)
=== RUN   TestAccAWSS3BucketMetric_WithFilterSingleTag
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (82.22s)
=== RUN   TestAccAWSS3MultiBucket_withTags
--- PASS: TestAccAWSS3MultiBucket_withTags (43.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	369.731s

```
**NOTE: I have not run all the tests, only those listed above**