### PR TITLE
Correct aws_glue_job resource's docs

### DIFF
--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 * `execution_property` – (Optional) Execution property of the job. Defined below.
 * `max_retries` – (Optional) The maximum number of times to retry this job if it fails.
 * `name` – (Required) The name you assign to this job. It must be unique in your account.
-* `role` – (Required) The ARN of the IAM role associated with this job.
+* `role_arn` – (Required) The ARN of the IAM role associated with this job.
 * `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours).
 
 ### command Argument Reference


### PR DESCRIPTION
Changed `role` to `role_arn` in resource `aws_glue_job`'s documentation. This is already correct in the provided examples.