### PR TITLE
Add description to region data source

### DIFF
--- a/aws/data_source_aws_region.go
+++ b/aws/data_source_aws_region.go
@@ -31,6 +31,11 @@ func dataSourceAwsRegion() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -80,6 +85,8 @@ func dataSourceAwsRegionRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("endpoint", strings.TrimPrefix(regionEndpointEc2.URL, "https://"))
 
 	d.Set("name", region.ID())
+
+	d.Set("description", region.Description())
 
 	return nil
 }

--- a/aws/data_source_aws_region_test.go
+++ b/aws/data_source_aws_region_test.go
@@ -93,6 +93,7 @@ func TestAccDataSourceAwsRegion_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", "ec2.us-east-1.amazonaws.com"),
 					resource.TestCheckResourceAttr(resourceName, "name", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "US East (N. Virginia)"),
 				),
 			},
 		},
@@ -109,6 +110,8 @@ func TestAccDataSourceAwsRegion_endpoint(t *testing.T) {
 	endpoint2 := "ec2.us-east-2.amazonaws.com"
 	name1 := "us-east-1"
 	name2 := "us-east-2"
+	description1 := "US East (N. Virginia)"
+	description2 := "US East (Ohio)"
 	resourceName := "data.aws_region.test"
 
 	resource.Test(t, resource.TestCase{
@@ -122,6 +125,7 @@ func TestAccDataSourceAwsRegion_endpoint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
+					resource.TestCheckResourceAttr(resourceName, "description", description1),
 				),
 			},
 			resource.TestStep{
@@ -131,6 +135,7 @@ func TestAccDataSourceAwsRegion_endpoint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "false"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
+					resource.TestCheckResourceAttr(resourceName, "description", description2),
 				),
 			},
 			resource.TestStep{
@@ -151,6 +156,8 @@ func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
 	endpoint2 := "ec2.us-east-2.amazonaws.com"
 	name1 := "us-east-1"
 	name2 := "us-east-2"
+	description1 := "US East (N. Virginia)"
+	description2 := "US East (Ohio)"
 	resourceName := "data.aws_region.test"
 
 	resource.Test(t, resource.TestCase{
@@ -164,6 +171,7 @@ func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
+					resource.TestCheckResourceAttr(resourceName, "description", description1),
 				),
 			},
 			resource.TestStep{
@@ -173,6 +181,7 @@ func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "false"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
+					resource.TestCheckResourceAttr(resourceName, "description", description2),
 				),
 			},
 			resource.TestStep{
@@ -182,6 +191,7 @@ func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
+					resource.TestCheckResourceAttr(resourceName, "description", description1),
 				),
 			},
 			resource.TestStep{
@@ -206,6 +216,8 @@ func TestAccDataSourceAwsRegion_name(t *testing.T) {
 	endpoint2 := "ec2.us-east-2.amazonaws.com"
 	name1 := "us-east-1"
 	name2 := "us-east-2"
+	description1 := "US East (N. Virginia)"
+	description2 := "US East (Ohio)"
 	resourceName := "data.aws_region.test"
 
 	resource.Test(t, resource.TestCase{
@@ -219,6 +231,7 @@ func TestAccDataSourceAwsRegion_name(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
+					resource.TestCheckResourceAttr(resourceName, "description", description1),
 				),
 			},
 			resource.TestStep{
@@ -228,6 +241,7 @@ func TestAccDataSourceAwsRegion_name(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "current", "false"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
+					resource.TestCheckResourceAttr(resourceName, "description", description2),
 				),
 			},
 			resource.TestStep{

--- a/website/docs/d/region.html.markdown
+++ b/website/docs/d/region.html.markdown
@@ -44,3 +44,5 @@ In addition to all arguments above, the following attributes are exported:
   provider, or `false` otherwise.
 
 * `endpoint` - The EC2 endpoint for the selected region.
+
+* `description` - The region's description in this format: "Location (Region name)".


### PR DESCRIPTION
Changes proposed in this pull request:

* Adds the description given by the go sdk to the region data source. Corresponds to the region names given here: https://docs.aws.amazon.com/general/latest/gr/rande.html

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccDataSourceAwsRegion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceAwsRegion -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAwsRegion_basic
--- PASS: TestAccDataSourceAwsRegion_basic (9.52s)
=== RUN   TestAccDataSourceAwsRegion_endpoint
--- PASS: TestAccDataSourceAwsRegion_endpoint (12.29s)
=== RUN   TestAccDataSourceAwsRegion_endpointAndName
--- PASS: TestAccDataSourceAwsRegion_endpointAndName (18.11s)
=== RUN   TestAccDataSourceAwsRegion_name
--- PASS: TestAccDataSourceAwsRegion_name (12.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.854s
```
