### PR TITLE
docs/resource/aws_codebuild_webhook: Further clarifications about CodeBuild and GitHub webhook behaviors

### DIFF
--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -14,7 +14,7 @@ Manages a CodeBuild webhook, which is an endpoint accepted by the CodeBuild serv
 
 ### GitHub
 
-When working with GitHub (github.com) source CodeBuild webhooks, the CodeBuild service will automatically create (on `aws_codebuild_webhook` resource creation) and delete (on `aws_codebuild_webhook` resource deletion) the GitHub repository webhook using its granted OAuth permissions. This behavior cannot be controlled by Terraform.
+When working with [GitHub](https://github.com) source CodeBuild webhooks, the CodeBuild service will automatically create (on `aws_codebuild_webhook` resource creation) and delete (on `aws_codebuild_webhook` resource deletion) the GitHub repository webhook using its granted OAuth permissions. This behavior cannot be controlled by Terraform.
 
 ~> **Note:** The AWS account that Terraform uses to create this resource *must* have authorized CodeBuild to access GitHub's OAuth API in each applicable region. This is a manual step that must be done *before* creating webhooks with this resource. If OAuth is not configured, AWS will return an error similar to `ResourceNotFoundException: Could not find access token for server type github`. More information can be found in the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-pull-request.html).
 
@@ -28,7 +28,7 @@ resource "aws_codebuild_webhook" "example" {
 
 ### GitHub Enterprise
 
-When working with GitHub Enterprise (GHE) source CodeBuild webhooks, the GHE repository webhook must be separately managed (e.g. manually or with the `github_repository_webhook` resource).
+When working with [GitHub Enterprise](https://enterprise.github.com/) source CodeBuild webhooks, the GHE repository webhook must be separately managed (e.g. manually or with the `github_repository_webhook` resource).
 
 More information creating webhooks with GitHub Enterprise can be found in the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-enterprise.html).
 

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -8,13 +8,17 @@ description: |-
 
 # aws_codebuild_webhook
 
-Provides a CodeBuild Webhook resource.
+Manages a CodeBuild webhook, which is an endpoint accepted by the CodeBuild service to trigger builds from source code repositories. Depending on the source type of the CodeBuild project, the CodeBuild service may also automatically create and delete the actual repository webhook as well.
 
 ## Example Usage
 
 ### GitHub
 
-~> **Note:** For GitHub source projects, the AWS account that Terraform uses to create this resource *must* have authorized CodeBuild to access GitHub's OAuth API in each applicable region. This is a manual step that must be done *before* creating webhooks with this resource. If OAuth is not configured, AWS will return an error similar to `ResourceNotFoundException: Could not find access token for server type github`. More information can be found in the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-pull-request.html).
+When working with GitHub (github.com) source CodeBuild webhooks, the CodeBuild service will automatically create (on `aws_codebuild_webhook` resource creation) and delete (on `aws_codebuild_webhook` resource deletion) the GitHub repository webhook using its granted OAuth permissions. This behavior cannot be controlled by Terraform.
+
+~> **Note:** The AWS account that Terraform uses to create this resource *must* have authorized CodeBuild to access GitHub's OAuth API in each applicable region. This is a manual step that must be done *before* creating webhooks with this resource. If OAuth is not configured, AWS will return an error similar to `ResourceNotFoundException: Could not find access token for server type github`. More information can be found in the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-pull-request.html).
+
+~> **Note:** Further managing the automatically created GitHub webhook with the `github_repository_webhook` resource is only possible with importing that resource after creation of the `aws_codebuild_webhook` resource. The CodeBuild API does not ever provide the `secret` attribute for the `aws_codebuild_webhook` resource in this scenario.
 
 ```hcl
 resource "aws_codebuild_webhook" "example" {
@@ -23,6 +27,8 @@ resource "aws_codebuild_webhook" "example" {
 ```
 
 ### GitHub Enterprise
+
+When working with GitHub Enterprise (GHE) source CodeBuild webhooks, the GHE repository webhook must be separately managed (e.g. manually or with the `github_repository_webhook` resource).
 
 More information creating webhooks with GitHub Enterprise can be found in the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-enterprise.html).
 
@@ -59,7 +65,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the build project.
 * `payload_url` - The CodeBuild endpoint where webhook events are sent.
-* `secret` - The secret token of the associated repository. Not returned for all source types.
+* `secret` - The secret token of the associated repository. Not returned by the CodeBuild API for all source types.
 * `url` - The URL to the webhook.
 
 ~> **Note:** The `secret` attribute is only set on resource creation, so if the secret is manually rotated, terraform will not pick up the change on subsequent runs.  In that case, the webhook resource should be tainted and re-created to get the secret back in sync.


### PR DESCRIPTION
Closes #5085 

Changes proposed in this pull request:

* Define the differences between CodeBuild webhooks and repository webhooks, especially with CodeBuild automatically creating repository webhooks with GitHub.

Output from acceptance testing: N/A
