### PR TITLE
issue #4350 change datapointsToAlarm attribute in aws_cloudwatch_metric_alarm

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -75,8 +75,10 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Optional: true,
 			},
 			"datapoints_to_alarm": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"dimensions": {
 				Type:     schema.TypeMap,

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -35,8 +35,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Required: true,
 			},
 			"evaluation_periods": {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"metric_name": {
 				Type:     schema.TypeString,
@@ -77,7 +78,6 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 			"datapoints_to_alarm": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Computed:     true,
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"dimensions": {


### PR DESCRIPTION
~~Fixes #4350~~

Changes proposed in this pull request:

* ~~Change 1
changed datapointsToAlarm to computed attribute.~~
* Change 2
Set validation for minimum value.
https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSCloudWatchMetricAlarm_ -timeout 120m
=== RUN   TestAccAWSCloudWatchMetricAlarm_importBasic
--- PASS: TestAccAWSCloudWatchMetricAlarm_importBasic (36.07s)
=== RUN   TestAccAWSCloudWatchMetricAlarm_basic
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (28.09s)
=== RUN   TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (33.13s)
=== RUN   TestAccAWSCloudWatchMetricAlarm_treatMissingData
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (49.53s)
=== RUN   TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (51.51s)
=== RUN   TestAccAWSCloudWatchMetricAlarm_extendedStatistic
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (28.78s)
=== RUN   TestAccAWSCloudWatchMetricAlarm_missingStatistic
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (8.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	235.760s
...
```
