### PR TITLE
d/aws_vpc: allow for multiple cidr blocks

### DIFF
--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -20,6 +20,27 @@ func dataSourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"cidr_block_associations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"association_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"dhcp_options_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -140,6 +161,17 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("default", vpc.IsDefault)
 	d.Set("state", vpc.State)
 	d.Set("tags", tagsToMap(vpc.Tags))
+
+	cidrAssociations := []interface{}{}
+	for _, associationSet := range vpc.CidrBlockAssociationSet {
+		association := map[string]interface{}{
+			"association_id": aws.StringValue(associationSet.AssociationId),
+			"cidr_block":     aws.StringValue(associationSet.CidrBlock),
+			"state":          aws.StringValue(associationSet.CidrBlockState.State),
+		}
+		cidrAssociations = append(cidrAssociations, association)
+	}
+	d.Set("cidr_block_associations", cidrAssociations)
 
 	if vpc.Ipv6CidrBlockAssociationSet != nil {
 		d.Set("ipv6_association_id", vpc.Ipv6CidrBlockAssociationSet[0].AssociationId)

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -59,6 +59,25 @@ func TestAccDataSourceAwsVpc_ipv6Associated(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsVpc_multipleCidr(t *testing.T) {
+	rInt := rand.Intn(16)
+	rName := "data.aws_vpc.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcConfigMultipleCidr(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "cidr_block_associations.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsVpcCheck(name, cidr, tag string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -146,4 +165,24 @@ data "aws_vpc" "by_filter" {
     values = ["${aws_vpc.test.cidr_block}"]
   }
 }`, cidr, tag)
+}
+
+func testAccDataSourceAwsVpcConfigMultipleCidr(octet int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.%d.0.0/16"
+}
+
+resource "aws_vpc_ipv4_cidr_block_association" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "172.%d.0.0/16"
+}
+
+data "aws_vpc" "test" {
+  filter {
+    name = "cidr-block-association.cidr-block"
+    values = ["${aws_vpc_ipv4_cidr_block_association.test.cidr_block}"]
+  }
+}
+`, octet, octet)
 }

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -81,3 +81,9 @@ The following attribute is additionally exported:
 * `ipv6_cidr_block` - The IPv6 CIDR block.
 * `enable_dns_support` - Whether or not the VPC has DNS support
 * `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support
+
+`cidr_block_associations` is also exported with the following attributes:
+
+* `association_id` - The association ID for the the IPv4 CIDR block.
+* `cidr_block` - The CIDR block for the association.
+* `state` - The State of the association.


### PR DESCRIPTION
Fixes #5042

Changes proposed in this pull request:

* allow for multiple cidr blocks

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsVpc_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsVpc_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpc_basic
--- PASS: TestAccDataSourceAwsVpc_basic (26.17s)
=== RUN   TestAccDataSourceAwsVpc_ipv6Associated
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (25.49s)
=== RUN   TestAccDataSourceAwsVpc_multipleCidr
--- PASS: TestAccDataSourceAwsVpc_multipleCidr (49.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	101.320s
```
