### PR TITLE
Ignore propagated routes during table import

### DIFF
--- a/aws/import_aws_route_table.go
+++ b/aws/import_aws_route_table.go
@@ -40,6 +40,10 @@ func resourceAwsRouteTableImportState(
 				continue
 			}
 
+			if route.Origin != nil && *route.Origin == "EnableVgwRoutePropagation" {
+				continue
+			}
+
 			if route.DestinationPrefixListId != nil {
 				// Skipping because VPC endpoint routes are handled separately
 				// See aws_vpc_endpoint


### PR DESCRIPTION
Similar to how they're ignored when performing a
`resourceAwsRouteTableRead`.

Relates to #5099

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

This syncs the continue logic from resourceAwsRouteTableImportState and resourceAwsRouteTableRead. Really these should be using a helper function, but given there's already 3 other places with this code copy-pasted, I wasn't sure what the preferred way of doing this would be. Writing a test for this seems like it'd be pretty difficult, since a full test would require a gateway connected that has routes propagating into it. I assume that's why the existing resourceAwsRouteTableRead doesn't have a comparable test.

Output from test runs below. Apologies I don't have AWS creds in place that I can run this test against. The change proposed here is rather trivial though, and this at least shows it compiles / passes existing *normal* tests.

```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.009s
```

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
--- FAIL: TestAccAWSAvailabilityZones_basic (1.44s)
	provider_test.go:75: No valid credential sources found for AWS Provider.
			Please see https://terraform.io/docs/providers/aws/index.html for more information on
			providing credentials for the AWS Provider
=== RUN   TestAccAWSAvailabilityZones_stateFilter
--- FAIL: TestAccAWSAvailabilityZones_stateFilter (0.96s)
	provider_test.go:75: No valid credential sources found for AWS Provider.
			Please see https://terraform.io/docs/providers/aws/index.html for more information on
			providing credentials for the AWS Provider
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	2.437s
make: *** [testacc] Error 1
```