### PR TITLE
docs/resource/aws_kinesis_firehose_delivery_stream: Add missing processing_configuration argument for splunk_configuration

### DIFF
--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -328,6 +328,7 @@ The `splunk_configuration` objects supports the following:
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedEventsOnly` and `AllEvents`.  Default value is `FailedEventsOnly`.
 * `retry_duration` - (Optional) After an initial failure to deliver to Amazon Elasticsearch, the total amount of time, in seconds between 0 to 7200, during which Firehose re-attempts delivery (including the first attempt).  After this time has elapsed, the failed documents are written to Amazon S3.  The default value is 300s.  There will be no retry if the value is 0.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. More details are given below.
+* `processing_configuration` - (Optional) The data processing configuration.  More details are given below.
 
 The `cloudwatch_logging_options` object supports the following:
 


### PR DESCRIPTION
Closes #5054 

Changes proposed in this pull request:

* Add missing documentation for:

https://github.com/terraform-providers/terraform-provider-aws/blob/455093e92d78aebc8f94abf076e025a4094a2707/aws/resource_aws_kinesis_firehose_delivery_stream.go#L1285

Output from acceptance testing: N/A
