### PR TITLE
Remove tag on create logic for gov cloud since no longer applicable

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -854,7 +854,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.HasChange("volume_tags") {
-		if !d.IsNewResource() || !restricted {
+		if !d.IsNewResource() || restricted {
 			if err := setVolumeTags(conn, d); err != nil {
 				return err
 			} else {


### PR DESCRIPTION
Changes proposed in this pull request:

* It used to be that restricted cloud accounts (e.g. gov cloud) cannot create volumes with tags, they can only update it after creation. See [here](https://aws.amazon.com/blogs/aws/new-tag-ec2-instances-ebs-volumes-on-creation/). However, this has recently changed as [announced here](https://aws.amazon.com/about-aws/whats-new/2018/07/tag-on-create-for-amazon-ec2-and-amazon-ebs-is-now-available-in-the-aws-govcloud-region/). This PR removes the logic behind the restriction for gov cloud. *NOTE it is unclear whether China cloud still has this restriction so leaving that logic in there*

> This capability is available at no additional cost in all AWS commercial regions, and the AWS GovCloud (US) Region.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSInstance.*Tag'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSInstance.*Tag -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (183.15s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- FAIL: TestAccAWSInstance_volumeTagsComputed (18.74s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_instance.foo: 1 error(s) occurred:
		
		* aws_instance.foo: Error launching source instance: InstanceLimitExceeded: You have requested more instances (1) than your current instance limit of 0 allows for the specified instance type. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.
			status code: 400, request id: 67bd5f4e-4e29-4ea7-9ca7-27d85acacbfb
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (225.67s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	427.607s
make: *** [testacc] Error 1

```

*Note: test failure due to account limits*
