### PR TITLE
diffTags should not identify existing tags as needing creation

### DIFF
--- a/aws/tags.go
+++ b/aws/tags.go
@@ -197,6 +197,9 @@ func diffTags(oldTags, newTags []*ec2.Tag) ([]*ec2.Tag, []*ec2.Tag) {
 		old, ok := create[*t.Key]
 		if !ok || old != *t.Value {
 			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, *t.Key)
 		}
 	}
 

--- a/aws/tags_test.go
+++ b/aws/tags_test.go
@@ -47,6 +47,24 @@ func TestDiffTags(t *testing.T) {
 				"foo": "bar",
 			},
 		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Changes proposed in this pull request:

* `diffTags` incorrectly returns tags that are the same in `oldTags` and `newTags` as needing to be created again. This causes unnecessary calls to `CreateTags`. Fix this to return only tags that need to be deleted and created

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSInstance.*Tag'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSInstance.*Tag -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInstance_volumeTags
--- PASS: TestAccAWSInstance_volumeTags (186.28s)
=== RUN   TestAccAWSInstance_volumeTagsComputed
--- FAIL: TestAccAWSInstance_volumeTagsComputed (18.64s)
	testing.go:518: Step 0 error: Error applying: 1 error(s) occurred:
		
		* aws_instance.foo: 1 error(s) occurred:
		
		* aws_instance.foo: Error launching source instance: InstanceLimitExceeded: You have requested more instances (1) than your current instance limit of 0 allows for the specified instance type. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.
			status code: 400, request id: ad836a70-ded9-4335-94f4-18871c6c96c0
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (290.62s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	495.584s
make: *** [testacc] Error 1

```
*Note failures due to account limits*

This PR split out from #5072.



