### PR TITLE
docs/resource/api_gateway_request_validator: Add missing resource documentation

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -430,6 +430,9 @@
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-model") %>>
                             <a href="/docs/providers/aws/r/api_gateway_model.html">aws_api_gateway_model</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-api-gateway-request-validator") %>>
+                            <a href="/docs/providers/aws/r/api_gateway_request_validator.html">aws_api_gateway_request_validator</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-api-gateway-resource") %>>
                             <a href="/docs/providers/aws/r/api_gateway_resource.html">aws_api_gateway_resource</a>
                         </li>

--- a/website/docs/r/api_gateway_request_validator.html.markdown
+++ b/website/docs/r/api_gateway_request_validator.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_request_validator"
+sidebar_current: "docs-aws-resource-api-gateway-request-validator"
+description: |-
+  Manages an API Gateway Request Validator.
+---
+
+# aws_api_gateway_request_validator
+
+Manages an API Gateway Request Validator.
+
+## Example Usage
+
+```hcl
+resource "aws_api_gateway_request_validator" "example" {
+  name                        = "example"
+  rest_api_id                 = "${aws_api_gateway_rest_api.example.id}"
+  validate_request_body       = true
+  validate_request_parameters = true
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `name` - (Required) The name of the request validator
+* `rest_api_id` - (Required) The ID of the associated Rest API
+* `validate_request_body` - (Optional) Boolean whether to validate request body. Defaults to `false`.
+* `validate_request_parameters` - (Optional) Boolean whether to validate request parameters. Defaults to `false`.
+
+## Attribute Reference
+
+The following attribute is exported in addition to the arguments listed above:
+
+* `id` - The unique ID of the request validator


### PR DESCRIPTION
Fixes #2550 
Reference https://github.com/hashicorp/terraform-website/issues/42

Changes proposed in this pull request:

* Add missing resource documentation page for `aws_api_gateway_request_validator` resource
* Add sidebar link to new resource documentation page

Output from acceptance testing: N/A
