### PR TITLE
set arn attribute from DB subnet group response instead of arn endpoint

### DIFF
--- a/aws/resource_aws_db_subnet_group.go
+++ b/aws/resource_aws_db_subnet_group.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 
@@ -151,13 +150,7 @@ func resourceAwsDbSubnetGroupRead(d *schema.ResourceData, meta interface{}) erro
 	// set tags
 	conn := meta.(*AWSClient).rdsconn
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("subgrp:%s", d.Id()),
-	}.String()
+	arn := aws.StringValue(subnetGroup.DBSubnetGroupArn)
 	d.Set("arn", arn)
 	resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
 		ResourceName: aws.String(arn),
@@ -201,13 +194,7 @@ func resourceAwsDbSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("subgrp:%s", d.Id()),
-	}.String()
+	arn := d.Get("arn").(string)
 	if err := setTagsRDS(conn, d, arn); err != nil {
 		return err
 	} else {

--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -37,6 +37,8 @@ func TestAccAWSDBSubnetGroup_basic(t *testing.T) {
 						"aws_db_subnet_group.foo", "name", rName),
 					resource.TestCheckResourceAttr(
 						"aws_db_subnet_group.foo", "description", "Managed by Terraform"),
+					resource.TestMatchResourceAttr(
+						"aws_db_subnet_group.foo", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:subgrp:%s", rName))),
 					testCheck,
 				),
 			},


### PR DESCRIPTION

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDBSubnetGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDBSubnetGroup_basic -timeout 120m
=== RUN   TestAccAWSDBSubnetGroup_basic
--- PASS: TestAccAWSDBSubnetGroup_basic (90.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	91.000s
...
```
