### PR TITLE
documentation only: add a note to /r/codepipeline.markdown to indicat…

### DIFF
--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -133,7 +133,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the pipeline.
 * `role_arn` - (Required) A service role Amazon Resource Name (ARN) that grants AWS CodePipeline permission to make calls to AWS services on your behalf.
 * `artifact_store` (Required) An artifact_store block. Artifact stores are documented below.
-* `stage` (Required) A stage block. Stages are documented below.
+* `stage` (Minimum of at least two `stage` blocks is required) A stage block. Stages are documented below.
 
 
 An `artifact_store` block supports the following arguments:


### PR DESCRIPTION
Documentation change only, no code change.

The AWS codepipeline resource [requires a minimum of 2 stage blocks](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_codepipeline.go#L87-L89), but the documentation doesn't mention this.

Changes proposed in this pull request:

* Add a note to the CodePipeline documentation to indicate that a minimum of two stage blocks is required.


