### PR TITLE
resource/aws_glue_catalog_database: Properly return error when missing colon during import

### DIFF
--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -76,7 +76,10 @@ func resourceAwsGlueCatalogDatabaseCreate(d *schema.ResourceData, meta interface
 func resourceAwsGlueCatalogDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
 	glueconn := meta.(*AWSClient).glueconn
 
-	catalogID, name := readAwsGlueCatalogID(d.Id())
+	catalogID, name, err := readAwsGlueCatalogID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	dbUpdateInput := &glue.UpdateDatabaseInput{
 		CatalogId: aws.String(catalogID),
@@ -117,7 +120,10 @@ func resourceAwsGlueCatalogDatabaseUpdate(d *schema.ResourceData, meta interface
 func resourceAwsGlueCatalogDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	glueconn := meta.(*AWSClient).glueconn
 
-	catalogID, name := readAwsGlueCatalogID(d.Id())
+	catalogID, name, err := readAwsGlueCatalogID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	input := &glue.GetDatabaseInput{
 		CatalogId: aws.String(catalogID),
@@ -153,10 +159,13 @@ func resourceAwsGlueCatalogDatabaseRead(d *schema.ResourceData, meta interface{}
 
 func resourceAwsGlueCatalogDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
 	glueconn := meta.(*AWSClient).glueconn
-	catalogID, name := readAwsGlueCatalogID(d.Id())
+	catalogID, name, err := readAwsGlueCatalogID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	log.Printf("[DEBUG] Glue Catalog Database: %s:%s", catalogID, name)
-	_, err := glueconn.DeleteDatabase(&glue.DeleteDatabaseInput{
+	_, err = glueconn.DeleteDatabase(&glue.DeleteDatabaseInput{
 		Name: aws.String(name),
 	})
 	if err != nil {
@@ -167,20 +176,26 @@ func resourceAwsGlueCatalogDatabaseDelete(d *schema.ResourceData, meta interface
 
 func resourceAwsGlueCatalogDatabaseExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	glueconn := meta.(*AWSClient).glueconn
-	catalogID, name := readAwsGlueCatalogID(d.Id())
+	catalogID, name, err := readAwsGlueCatalogID(d.Id())
+	if err != nil {
+		return false, err
+	}
 
 	input := &glue.GetDatabaseInput{
 		CatalogId: aws.String(catalogID),
 		Name:      aws.String(name),
 	}
 
-	_, err := glueconn.GetDatabase(input)
+	_, err = glueconn.GetDatabase(input)
 	return err == nil, err
 }
 
-func readAwsGlueCatalogID(id string) (catalogID string, name string) {
+func readAwsGlueCatalogID(id string) (catalogID string, name string, err error) {
 	idParts := strings.Split(id, ":")
-	return idParts[0], idParts[1]
+	if len(idParts) != 2 {
+		return "", "", fmt.Errorf("Unexpected format of ID (%q), expected CATALOG-ID:DATABASE-NAME", id)
+	}
+	return idParts[0], idParts[1], nil
 }
 
 func createAwsGlueCatalogID(d *schema.ResourceData, accountid string) (catalogID string) {

--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -121,7 +121,10 @@ func testAccCheckGlueDatabaseDestroy(s *terraform.State) error {
 			continue
 		}
 
-		catalogId, dbName := readAwsGlueCatalogID(rs.Primary.ID)
+		catalogId, dbName, err := readAwsGlueCatalogID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		input := &glue.GetDatabaseInput{
 			CatalogId: aws.String(catalogId),
@@ -174,7 +177,10 @@ func testAccCheckGlueCatalogDatabaseExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		catalogId, dbName := readAwsGlueCatalogID(rs.Primary.ID)
+		catalogId, dbName, err := readAwsGlueCatalogID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
 		glueconn := testAccProvider.Meta().(*AWSClient).glueconn
 		out, err := glueconn.GetDatabase(&glue.GetDatabaseInput{


### PR DESCRIPTION
Fixes #5122 

Changes proposed in this pull request:

* Check length of splitting on `:` in ID reading function before accessing second element to prevent panic

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCatalogDatabase'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueCatalogDatabase -timeout 120m
=== RUN   TestAccAWSGlueCatalogDatabase_importBasic
--- PASS: TestAccAWSGlueCatalogDatabase_importBasic (14.27s)
=== RUN   TestAccAWSGlueCatalogDatabase_full
--- PASS: TestAccAWSGlueCatalogDatabase_full (28.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.388s
```
