### PR TITLE
resource/aws_rds_cluster_instance: Support configuring-log-exports status

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -288,10 +288,19 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 
 	// reuse db_instance refresh func
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"creating", "backing-up", "modifying",
-			"configuring-enhanced-monitoring", "maintenance",
-			"rebooting", "renaming", "resetting-master-credentials",
-			"starting", "upgrading"},
+		Pending: []string{
+			"backing-up",
+			"configuring-enhanced-monitoring",
+			"configuring-log-exports",
+			"creating",
+			"maintenance",
+			"modifying",
+			"rebooting",
+			"renaming",
+			"resetting-master-credentials",
+			"starting",
+			"upgrading",
+		},
 		Target:     []string{"available"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
@@ -492,10 +501,19 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 
 		// reuse db_instance refresh func
 		stateConf := &resource.StateChangeConf{
-			Pending: []string{"creating", "backing-up", "modifying",
-				"configuring-enhanced-monitoring", "maintenance",
-				"rebooting", "renaming", "resetting-master-credentials",
-				"starting", "upgrading"},
+			Pending: []string{
+				"backing-up",
+				"configuring-enhanced-monitoring",
+				"configuring-log-exports",
+				"creating",
+				"maintenance",
+				"modifying",
+				"rebooting",
+				"renaming",
+				"resetting-master-credentials",
+				"starting",
+				"upgrading",
+			},
 			Target:     []string{"available"},
 			Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
@@ -540,7 +558,11 @@ func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{
 	// re-uses db_instance refresh func
 	log.Println("[INFO] Waiting for RDS Cluster Instance to be destroyed")
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"modifying", "deleting"},
+		Pending: []string{
+			"configuring-log-exports",
+			"modifying",
+			"deleting",
+		},
 		Target:     []string{},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
 		Timeout:    d.Timeout(schema.TimeoutDelete),

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -288,19 +288,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 
 	// reuse db_instance refresh func
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			"backing-up",
-			"configuring-enhanced-monitoring",
-			"configuring-log-exports",
-			"creating",
-			"maintenance",
-			"modifying",
-			"rebooting",
-			"renaming",
-			"resetting-master-credentials",
-			"starting",
-			"upgrading",
-		},
+		Pending:    resourceAwsRdsClusterInstanceCreateUpdatePendingStates,
 		Target:     []string{"available"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
@@ -501,19 +489,7 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 
 		// reuse db_instance refresh func
 		stateConf := &resource.StateChangeConf{
-			Pending: []string{
-				"backing-up",
-				"configuring-enhanced-monitoring",
-				"configuring-log-exports",
-				"creating",
-				"maintenance",
-				"modifying",
-				"rebooting",
-				"renaming",
-				"resetting-master-credentials",
-				"starting",
-				"upgrading",
-			},
+			Pending:    resourceAwsRdsClusterInstanceCreateUpdatePendingStates,
 			Target:     []string{"available"},
 			Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
@@ -558,11 +534,7 @@ func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{
 	// re-uses db_instance refresh func
 	log.Println("[INFO] Waiting for RDS Cluster Instance to be destroyed")
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			"configuring-log-exports",
-			"modifying",
-			"deleting",
-		},
+		Pending:    resourceAwsRdsClusterInstanceDeletePendingStates,
 		Target:     []string{},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
@@ -576,4 +548,24 @@ func resourceAwsRDSClusterInstanceDelete(d *schema.ResourceData, meta interface{
 
 	return nil
 
+}
+
+var resourceAwsRdsClusterInstanceCreateUpdatePendingStates = []string{
+	"backing-up",
+	"configuring-enhanced-monitoring",
+	"configuring-log-exports",
+	"creating",
+	"maintenance",
+	"modifying",
+	"rebooting",
+	"renaming",
+	"resetting-master-credentials",
+	"starting",
+	"upgrading",
+}
+
+var resourceAwsRdsClusterInstanceDeletePendingStates = []string{
+	"configuring-log-exports",
+	"modifying",
+	"deleting",
 }


### PR DESCRIPTION
Fixes #5121 

Changes proposed in this pull request:

* Allow `configuring-log-exports` status as pending status for create/update/delete

Output from acceptance testing:

```
9 tests passed (all tests)
=== RUN   TestAccAWSRDSClusterInstance_generatedName
--- PASS: TestAccAWSRDSClusterInstance_generatedName (596.88s)
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (597.24s)
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (616.43s)
=== RUN   TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSClusterInstance_disappears (651.02s)
=== RUN   TestAccAWSRDSClusterInstance_importBasic
--- PASS: TestAccAWSRDSClusterInstance_importBasic (656.24s)
=== RUN   TestAccAWSRDSClusterInstance_az
--- PASS: TestAccAWSRDSClusterInstance_az (660.98s)
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (674.07s)
=== RUN   TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (781.15s)
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (1237.64s)
```
