### PR TITLE
[WIP] new resource for ses domain identity Policy

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -545,6 +545,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_secretsmanager_secret_version":                resourceAwsSecretsManagerSecretVersion(),
 			"aws_ses_active_receipt_rule_set":                  resourceAwsSesActiveReceiptRuleSet(),
 			"aws_ses_domain_identity":                          resourceAwsSesDomainIdentity(),
+			"aws_ses_domain_identity_policy":                   resourceAwsSesDomainIdentityPolicy(),
 			"aws_ses_domain_identity_verification":             resourceAwsSesDomainIdentityVerification(),
 			"aws_ses_domain_dkim":                              resourceAwsSesDomainDkim(),
 			"aws_ses_domain_mail_from":                         resourceAwsSesDomainMailFrom(),

--- a/aws/resource_aws_ses_domain_identity_policy.go
+++ b/aws/resource_aws_ses_domain_identity_policy.go
@@ -1,0 +1,140 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func resourceAwsSesDomainIdentityPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSesDomainIdentityPolicyCreate,
+		Read:   resourceAwsSesDomainIdentityPolicyRead,
+		Update: resourceAwsSesDomainIdentityPolicyUpdate,
+		Delete: resourceAwsSesDomainIdentityPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+		},
+	}
+}
+
+func resourceAwsSesDomainIdentityPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	arn := d.Get("arn").(string)
+	policyName := d.Get("name").(string)
+	policy := d.Get("policy").(string)
+
+	req := ses.PutIdentityPolicyInput{
+		Identity: aws.String(arn),
+		PolicyName: aws.String(policyName),
+		Policy: aws.String(policy),
+	}
+
+	_, err := conn.PutIdentityPolicy(&req)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resource.PrefixedUniqueId(fmt.Sprintf("%s-", policyName)))
+	return resourceAwsSesDomainIdentityPolicyRead(d, meta)
+}
+
+func resourceAwsSesDomainIdentityPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	arn := d.Get("arn").(string)
+	policyName := d.Get("name").(string)
+	policy := d.Get("policy").(string)
+
+	req := ses.PutIdentityPolicyInput{
+		Identity:   aws.String(arn),
+		PolicyName: aws.String(policyName),
+		Policy:     aws.String(policy),
+	}
+
+	_, err := conn.PutIdentityPolicy(&req)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsSesDomainIdentityPolicyRead(d, meta)
+}
+
+func resourceAwsSesDomainIdentityPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	arn := d.Get("arn").(string)
+	policyName := d.Get("name").(string)
+	policyNames := make([]*string, 1)
+	policyNames[0] = aws.String(policyName)
+
+	policiesOutput, err := conn.GetIdentityPolicies(&ses.GetIdentityPoliciesInput{
+		Identity: aws.String(arn),
+		PolicyNames: policyNames,
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFound" {
+			log.Printf("[WARN] SES Domain Identity Policy (%s) not found, error code (404)", policyName)
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	if policiesOutput.Policies == nil {
+		log.Printf("[WARN] SES Domain Identity Policy (%s) not found (nil)", policyName)
+		d.SetId("")
+		return nil
+	}
+	policies := policiesOutput.Policies
+
+	policy, ok := policies[*aws.String(policyName)]
+	if !ok {
+		log.Printf("[WARN] SES Domain Identity Policy (%s) not found in attributes", policyName)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("policy", policy)
+	return nil
+}
+
+func resourceAwsSesDomainIdentityPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	arn := d.Get("arn").(string)
+	policyName := d.Get("name").(string)
+
+	req := ses.DeleteIdentityPolicyInput{
+		Identity: aws.String(arn),
+		PolicyName: aws.String(policyName),
+	}
+
+	log.Printf("[DEBUG] Deleting SES Domain Identity Policy: %s", req)
+	_, err := conn.DeleteIdentityPolicy(&req)
+	return err
+}

--- a/aws/resource_aws_ses_domain_identity_policy.go
+++ b/aws/resource_aws_ses_domain_identity_policy.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ses"
-	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -48,9 +48,9 @@ func resourceAwsSesDomainIdentityPolicyCreate(d *schema.ResourceData, meta inter
 	policy := d.Get("policy").(string)
 
 	req := ses.PutIdentityPolicyInput{
-		Identity: aws.String(arn),
+		Identity:   aws.String(arn),
 		PolicyName: aws.String(policyName),
-		Policy: aws.String(policy),
+		Policy:     aws.String(policy),
 	}
 
 	_, err := conn.PutIdentityPolicy(&req)
@@ -92,7 +92,7 @@ func resourceAwsSesDomainIdentityPolicyRead(d *schema.ResourceData, meta interfa
 	policyNames[0] = aws.String(policyName)
 
 	policiesOutput, err := conn.GetIdentityPolicies(&ses.GetIdentityPoliciesInput{
-		Identity: aws.String(arn),
+		Identity:    aws.String(arn),
 		PolicyNames: policyNames,
 	})
 	if err != nil {
@@ -130,7 +130,7 @@ func resourceAwsSesDomainIdentityPolicyDelete(d *schema.ResourceData, meta inter
 	policyName := d.Get("name").(string)
 
 	req := ses.DeleteIdentityPolicyInput{
-		Identity: aws.String(arn),
+		Identity:   aws.String(arn),
 		PolicyName: aws.String(policyName),
 	}
 

--- a/aws/resource_aws_ses_domain_identity_policy_test.go
+++ b/aws/resource_aws_ses_domain_identity_policy_test.go
@@ -4,9 +4,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
 	"fmt"
 	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSSESDomainIdentityPolicy_basic(t *testing.T) {
@@ -56,4 +56,3 @@ POLICY
 }
 `, domain)
 }
-

--- a/aws/resource_aws_ses_domain_identity_policy_test.go
+++ b/aws/resource_aws_ses_domain_identity_policy_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAWSSESDomainIdentityPolicy_basic(t *testing.T) {
+	domain := fmt.Sprintf(
+		"%s.terraformtesting.com.",
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSESDomainIdentityConfig_withPolicy(domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESDomainIdentityExists("aws_ses_domain_identity.test"),
+					resource.TestMatchResourceAttr("aws_ses_domain_identity_policy.custom", "policy",
+						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSSESDomainIdentityConfig_withPolicy(domain string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_domain_identity" "test" {
+    name = "%s"
+}
+
+resource "aws_ses_domain_identity_policy" "custom" {
+	arn = "${aws_ses_domain_identity.test.arn}"
+	name = "test"
+	policy = <<POLICY
+{
+   "Version":"2012-10-17",
+   "Id": "default",
+   "Statement":[{
+   	"Sid":"default",
+   	"Effect":"Allow",
+   	"Principal":{"AWS":"*"},
+   	"Action":["SES:SendEmail","SES:SendRawEmail"],
+   	"Resource":"${aws_ses_domain_identity.test.arn}"
+  }]
+}
+POLICY
+}
+`, domain)
+}
+


### PR DESCRIPTION
Changes proposed in this pull request:

* Adding a new resource for aws_ses_domain_identity_policy

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSESDomainIdentityPolicy'

...
```

This is my first Terraform pull request and I'm a novice when it comes to Go. I tried running the `make testacc` command above but got a lot of "cannot find package" errors. Is anyone able to assist in either getting me up to speed, or getting this PR polished and tested?

A note on this resource: SES Domain Identities can have any number of policies attached to them, similar to how an S3 bucket has a policy. SES Domain Identity Policies allow for things like cross-account sending access (by setting the 'Principals' field in the policy accordingly) which is clearly missing from Terraform at the moment, hence this PR.