### PR TITLE
Data source eip filters

### DIFF
--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -23,6 +23,7 @@ func dataSourceAwsEip() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"filter": ec2CustomFiltersSchema(),
 		},
 	}
 }
@@ -46,6 +47,16 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 				"public-ip": publicIp.(string),
 			},
 		)...)
+	}
+
+	if filters, filtersOk := d.GetOk("filter"); filtersOk {
+		req.Filters = append(req.Filters, buildEC2CustomFilterList(
+			filters.(*schema.Set),
+		)...)
+	}
+
+	if len(req.Filters) == 0 {
+		req.Filters = nil
 	}
 
 	log.Printf("[DEBUG] Reading EIP: %s", req)

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -33,12 +32,20 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	req := &ec2.DescribeAddressesInput{}
 
-	if id, ok := d.GetOk("id"); ok {
-		req.AllocationIds = []*string{aws.String(id.(string))}
+	if id, idOk := d.GetOk("id"); idOk {
+		req.Filters = buildEC2AttributeFilterList(
+			map[string]string{
+				"allocation-id": id.(string),
+			},
+		)
 	}
 
-	if public_ip := d.Get("public_ip"); public_ip != "" {
-		req.PublicIps = []*string{aws.String(public_ip.(string))}
+	if publicIp, publicIpOk := d.GetOk("public_ip"); publicIpOk {
+		req.Filters = append(req.Filters, buildEC2AttributeFilterList(
+			map[string]string{
+				"public-ip": publicIp.(string),
+			},
+		)...)
 	}
 
 	log.Printf("[DEBUG] Reading EIP: %s", req)

--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -14,6 +15,11 @@ func dataSourceAwsEip() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"association_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -37,6 +43,14 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		req.Filters = buildEC2AttributeFilterList(
 			map[string]string{
 				"allocation-id": id.(string),
+			},
+		)
+	}
+
+	if assocId, assocIdOk := d.GetOk("association_id"); assocIdOk {
+		req.Filters = buildEC2AttributeFilterList(
+			map[string]string{
+				"association-id": assocId.(string),
 			},
 		)
 	}
@@ -75,6 +89,10 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(*eip.AllocationId)
 	d.Set("public_ip", eip.PublicIp)
+
+	if eip.AssociationId != nil {
+		d.Set("association_id", aws.StringValue(eip.AssociationId))
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -55,6 +55,21 @@ func TestAccDataSourceAwsEip_association(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsEip_private(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEipConfig_private,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsEipCheck("data.aws_eip.test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsEipCheck(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -144,5 +159,20 @@ resource "aws_eip" "test" {
 
 data "aws_eip" "test" {
   association_id = "${aws_eip.test.association_id}"
+}
+`
+
+const testAccDataSourceEipConfig_private = `
+resource "aws_instance" "test" {
+  ami = "ami-55a7ea65"
+  instance_type = "m3.medium"
+}
+
+resource "aws_eip" "test" {
+  instance = "${aws_instance.test.id}"
+}
+
+data "aws_eip" "test" {
+  private_ip = "${aws_eip.test.private_ip}"
 }
 `

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -40,6 +40,21 @@ func TestAccDataSourceAwsEip_filter(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsEip_association(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEipConfig_association,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsEipCheck("data.aws_eip.test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsEipCheck(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -114,5 +129,20 @@ data "aws_eip" "by_assoc_id" {
     name = "association-id"
     values = ["${aws_eip.test.association_id}"]
   }
+}
+`
+
+const testAccDataSourceEipConfig_association = `
+resource "aws_instance" "test" {
+  ami = "ami-55a7ea65"
+  instance_type = "m3.medium"
+}
+
+resource "aws_eip" "test" {
+  instance = "${aws_instance.test.id}"
+}
+
+data "aws_eip" "test" {
+  association_id = "${aws_eip.test.association_id}"
 }
 `

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -42,6 +42,19 @@ Elastic IP whose data will be exported as attributes.
 
 * `public_ip` - (Optional) The public IP of the specific EIP to retrieve.
 
+* `assocation_id` - (Optional) The Association ID of the specific EIP to retrieve.
+
+* `filter` - (Optional) Custom filter block as described below.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAddresses.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A VPC will be selected if any one of the given values matches.
+
 ## Attributes Reference
 
 All of the argument attributes are also exported as result attributes. This

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -40,9 +40,11 @@ Elastic IP whose data will be exported as attributes.
 
 * `id` - (Optional) The allocation id of the specific EIP to retrieve.
 
-* `public_ip` - (Optional) The public IP of the specific EIP to retrieve.
-
 * `assocation_id` - (Optional) The Association ID of the specific EIP to retrieve.
+
+* `private_ip` - (Optional) The Private IP of the specific EIP to retrieve.
+
+* `public_ip` - (Optional) The public IP of the specific EIP to retrieve.
 
 * `filter` - (Optional) Custom filter block as described below.
 


### PR DESCRIPTION
Fixes #4551

Changes proposed in this pull request:

* add `filter` attribute
* add `association_id` attribute
* add `private_ip` attribute

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEip'
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsEip -timeout 120m
=== RUN   TestAccDataSourceAwsEip_basic
--- PASS: TestAccDataSourceAwsEip_basic (14.31s)
=== RUN   TestAccDataSourceAwsEip_filter
--- PASS: TestAccDataSourceAwsEip_filter (72.64s)
=== RUN   TestAccDataSourceAwsEip_association
--- PASS: TestAccDataSourceAwsEip_association (84.53s)
=== RUN   TestAccDataSourceAwsEip_private
--- PASS: TestAccDataSourceAwsEip_private (73.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	245.162s
```
