### PR TITLE
resource/aws_glue_catalog_database: Prevent error when deleted outside Terraform

### DIFF
--- a/aws/resource_aws_glue_catalog_database.go
+++ b/aws/resource_aws_glue_catalog_database.go
@@ -136,6 +136,7 @@ func resourceAwsGlueCatalogDatabaseRead(d *schema.ResourceData, meta interface{}
 		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
 			log.Printf("[WARN] Glue Catalog Database (%s) not found, removing from state", d.Id())
 			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("Error reading Glue Catalog Database: %s", err.Error())
@@ -187,7 +188,13 @@ func resourceAwsGlueCatalogDatabaseExists(d *schema.ResourceData, meta interface
 	}
 
 	_, err = glueconn.GetDatabase(input)
-	return err == nil, err
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func readAwsGlueCatalogID(id string) (catalogID string, name string, err error) {

--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -113,6 +113,41 @@ func TestAccAWSGlueCatalogDatabase_full(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCatalogDatabase_recreates(t *testing.T) {
+	resourceName := "aws_glue_catalog_database.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCatalogDatabase_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogDatabaseExists(resourceName),
+				),
+			},
+			{
+				// Simulate deleting the database outside Terraform
+				PreConfig: func() {
+					conn := testAccProvider.Meta().(*AWSClient).glueconn
+					input := &glue.DeleteDatabaseInput{
+						Name: aws.String(fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					}
+					_, err := conn.DeleteDatabase(input)
+					if err != nil {
+						t.Fatalf("error deleting Glue Catalog Database: %s", err)
+					}
+				},
+				Config:             testAccGlueCatalogDatabase_basic(rInt),
+				ExpectNonEmptyPlan: true,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
 func testAccCheckGlueDatabaseDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).glueconn
 


### PR DESCRIPTION
Fixes #5136 

Changes proposed in this pull request:

* Ignore `EntityNotFoundException` in exists function for `aws_glue_catalog_database` resource

Previously:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCatalogDatabase_recreates'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueCatalogDatabase_recreates -timeout 120m
=== RUN   TestAccAWSGlueCatalogDatabase_recreates
--- FAIL: TestAccAWSGlueCatalogDatabase_recreates (10.99s)
	testing.go:518: Step 1 error: Error refreshing: 1 error(s) occurred:

		* aws_glue_catalog_database.test: 1 error(s) occurred:

		* aws_glue_catalog_database.test: aws_glue_catalog_database.test: EntityNotFoundException: Database my_test_catalog_database_6550552809316099925 not found.
			status code: 400, request id: 4080a81b-8455-11e8-8ae0-d76c07653239
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	11.031s
make: *** [testacc] Error 1
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCatalogDatabase'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueCatalogDatabase -timeout 120m
=== RUN   TestAccAWSGlueCatalogDatabase_importBasic
--- PASS: TestAccAWSGlueCatalogDatabase_importBasic (14.76s)
=== RUN   TestAccAWSGlueCatalogDatabase_full
--- PASS: TestAccAWSGlueCatalogDatabase_full (27.74s)
=== RUN   TestAccAWSGlueCatalogDatabase_recreates
--- PASS: TestAccAWSGlueCatalogDatabase_recreates (12.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	55.008s
```
