### PR TITLE
resource/aws_lambda_function: Support dotnetcore2.1 runtime validation

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -104,6 +104,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 					// lambda.RuntimeNodejs has reached end of life since October 2016 so not included here
 					lambda.RuntimeDotnetcore10,
 					lambda.RuntimeDotnetcore20,
+					lambda.RuntimeDotnetcore21,
 					lambda.RuntimeGo1X,
 					lambda.RuntimeJava8,
 					lambda.RuntimeNodejs43,


### PR DESCRIPTION
Closes #5148 

Changes proposed in this pull request:

* Support `dotnetcore2.1` in `runtime` validation

Output from acceptance testing: Trivial plan-time validation update
