### PR TITLE
resource/aws_glue_crawler: Support DynamoDB targets

### DIFF
--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -64,6 +64,67 @@ func testSweepGlueCrawlers(region string) error {
 	return nil
 }
 
+func TestAccAWSGlueCrawler_DynamodbTarget(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfig_DynamodbTarget(rName, "table1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.path", "table1"),
+					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "role", rName),
+					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.delete_behavior", "DEPRECATE_IN_DATABASE"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.update_behavior", "UPDATE_IN_DATABASE"),
+					resource.TestCheckResourceAttr(resourceName, "table_prefix", ""),
+				),
+			},
+			{
+				Config: testAccGlueCrawlerConfig_DynamodbTarget(rName, "table2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
+					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.0.path", "table2"),
+					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "role", rName),
+					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "schedule", ""),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.delete_behavior", "DEPRECATE_IN_DATABASE"),
+					resource.TestCheckResourceAttr(resourceName, "schema_change_policy.0.update_behavior", "UPDATE_IN_DATABASE"),
+					resource.TestCheckResourceAttr(resourceName, "table_prefix", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCrawler_JdbcTarget(t *testing.T) {
 	var crawler glue.Crawler
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -82,6 +143,7 @@ func TestAccAWSGlueCrawler_JdbcTarget(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.connection_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.#", "0"),
@@ -104,6 +166,7 @@ func TestAccAWSGlueCrawler_JdbcTarget(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.connection_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.#", "0"),
@@ -238,6 +301,7 @@ func TestAccAWSGlueCrawler_S3Target(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "role", rName),
@@ -259,6 +323,7 @@ func TestAccAWSGlueCrawler_S3Target(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_target.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "role", rName),
@@ -809,6 +874,26 @@ resource "aws_glue_crawler" "test" {
   }
 }
 `, rName, description, rName)
+}
+
+func testAccGlueCrawlerConfig_DynamodbTarget(rName, path string) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %q
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = ["aws_iam_role_policy_attachment.test-AWSGlueServiceRole"]
+
+  database_name = "${aws_glue_catalog_database.test.name}"
+  name          = %q
+  role          = "${aws_iam_role.test.name}"
+
+  dynamodb_target {
+    path = %q
+  }
+}
+`, rName, rName, path)
 }
 
 func testAccGlueCrawlerConfig_JdbcTarget(rName, path string) string {

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -12,6 +12,20 @@ Manages a Glue Crawler. More information can be found in the [AWS Glue Develeper
 
 ## Example Usage
 
+### DynamoDB Target
+
+```hcl
+resource "aws_glue_crawler" "example" {
+  database_name = "${aws_glue_catalog_database.example.name}"
+  name          = "example"
+  role          = "${aws_iam_role.example.name}"
+
+  dynamodb_target {
+    path = "table-name"
+  }
+}
+```
+
 ### JDBC Target
 
 ```hcl
@@ -36,7 +50,7 @@ resource "aws_glue_crawler" "example" {
   role          = "${aws_iam_role.example.name}"
 
   s3_target {
-    path = "s3://${aws_s3_bucket.example.bucket}
+    path = "s3://${aws_s3_bucket.example.bucket}"
   }
 }
 ```
@@ -53,11 +67,16 @@ The following arguments are supported:
 * `classifiers` (Optional) List of custom classifiers. By default, all AWS classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.
 * `configuration` (Optional) JSON string of configuration information.
 * `description` (Optional) Description of the crawler.
+* `dynamodb_target` (Optional) List of nested DynamoDB target arguments. See below.
 * `jdbc_target` (Optional) List of nested JBDC target arguments. See below.
 * `s3_target` (Optional) List nested Amazon S3 target arguments. See below.
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
 * `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior.
 * `table_prefix` (Optional) The table prefix used for catalog tables that are created.
+
+### dynamodb_target Argument Reference
+
+* `path` - (Required) The name of the DynamoDB table to crawl.
 
 ### jdbc_target Argument Reference
 


### PR DESCRIPTION
Closes #5151 

Changes proposed in this pull request:

* Add `dynamodb_target` argument to `aws_glue_crawler` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCrawler'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueCrawler -timeout 120m
=== RUN   TestAccAWSGlueCrawler_DynamodbTarget
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (39.50s)
=== RUN   TestAccAWSGlueCrawler_JdbcTarget
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (35.23s)
=== RUN   TestAccAWSGlueCrawler_JdbcTarget_Exclusions
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (37.73s)
=== RUN   TestAccAWSGlueCrawler_JdbcTarget_Multiple
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (47.33s)
=== RUN   TestAccAWSGlueCrawler_S3Target
--- PASS: TestAccAWSGlueCrawler_S3Target (35.74s)
=== RUN   TestAccAWSGlueCrawler_S3Target_Exclusions
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (36.40s)
=== RUN   TestAccAWSGlueCrawler_S3Target_Multiple
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (46.11s)
=== RUN   TestAccAWSGlueCrawler_Classifiers
--- PASS: TestAccAWSGlueCrawler_Classifiers (40.93s)
=== RUN   TestAccAWSGlueCrawler_Configuration
--- PASS: TestAccAWSGlueCrawler_Configuration (36.57s)
=== RUN   TestAccAWSGlueCrawler_Description
--- PASS: TestAccAWSGlueCrawler_Description (35.28s)
=== RUN   TestAccAWSGlueCrawler_Schedule
--- PASS: TestAccAWSGlueCrawler_Schedule (36.86s)
=== RUN   TestAccAWSGlueCrawler_SchemaChangePolicy
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (35.60s)
=== RUN   TestAccAWSGlueCrawler_TablePrefix
--- PASS: TestAccAWSGlueCrawler_TablePrefix (37.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	500.622s
```
