### PR TITLE
resource/aws_glue_crawler: Prevent error when deleted outside Terraform

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -427,5 +427,11 @@ func resourceAwsGlueCrawlerExists(d *schema.ResourceData, meta interface{}) (boo
 	}
 
 	_, err := glueConn.GetCrawler(input)
-	return err == nil, err
+	if err != nil {
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
Similar fix as #5141 (with `aws_glue_catalog_database`) but for `aws_glue_crawler`

Changes proposed in this pull request:

* Return false with `EntityNotFoundException` error instead of that error in `aws_glue_crawler` exists function

Previously:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCrawler_recreates'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueCrawler_recreates -timeout 120m
=== RUN   TestAccAWSGlueCrawler_recreates
--- FAIL: TestAccAWSGlueCrawler_recreates (38.53s)
	testing.go:518: Step 1 error: Error refreshing: 1 error(s) occurred:

		* aws_glue_crawler.test: 1 error(s) occurred:

		* aws_glue_crawler.test: aws_glue_crawler.test: EntityNotFoundException: Crawler entry with name tf-acc-test-1396396921265002761 does not exist
			status code: 400, request id: f95a1094-852a-11e8-ab6d-47badaefc25f
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	38.579s
make: *** [testacc] Error 1
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCrawler'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGlueCrawler -timeout 120m
=== RUN   TestAccAWSGlueCrawler_JdbcTarget
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (38.12s)
=== RUN   TestAccAWSGlueCrawler_JdbcTarget_Exclusions
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (35.12s)
=== RUN   TestAccAWSGlueCrawler_JdbcTarget_Multiple
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (48.99s)
=== RUN   TestAccAWSGlueCrawler_S3Target
--- PASS: TestAccAWSGlueCrawler_S3Target (36.02s)
=== RUN   TestAccAWSGlueCrawler_S3Target_Exclusions
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (38.08s)
=== RUN   TestAccAWSGlueCrawler_S3Target_Multiple
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (46.00s)
=== RUN   TestAccAWSGlueCrawler_recreates
--- PASS: TestAccAWSGlueCrawler_recreates (30.43s)
=== RUN   TestAccAWSGlueCrawler_Classifiers
--- PASS: TestAccAWSGlueCrawler_Classifiers (46.90s)
=== RUN   TestAccAWSGlueCrawler_Configuration
--- PASS: TestAccAWSGlueCrawler_Configuration (35.69s)
=== RUN   TestAccAWSGlueCrawler_Description
--- PASS: TestAccAWSGlueCrawler_Description (36.54s)
=== RUN   TestAccAWSGlueCrawler_Schedule
--- PASS: TestAccAWSGlueCrawler_Schedule (37.76s)
=== RUN   TestAccAWSGlueCrawler_SchemaChangePolicy
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (37.69s)
=== RUN   TestAccAWSGlueCrawler_TablePrefix
--- PASS: TestAccAWSGlueCrawler_TablePrefix (37.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	504.410s
```
