### PR TITLE
examples/eks-getting-started: Update heptio-authenticator-aws to aws-iam-authenticator

### DIFF
--- a/examples/eks-getting-started/outputs.tf
+++ b/examples/eks-getting-started/outputs.tf
@@ -42,7 +42,7 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: heptio-authenticator-aws
+      command: aws-iam-authenticator
       args:
         - "token"
         - "-i"


### PR DESCRIPTION
Changes proposed in this pull request:

* Update example code to match updated documentation from https://github.com/terraform-providers/terraform-provider-aws/commit/70f66c84739592bd2bbda781fe39cefb425defc2

Output from acceptance testing: N/A
