### PR TITLE
aws_lb_listener: wait for listener creation

### DIFF
--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -25,6 +25,10 @@ func resourceAwsLbListener() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,
@@ -151,11 +155,26 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
-	resp, err := elbconn.DescribeListeners(&elbv2.DescribeListenersInput{
+	var resp *elbv2.DescribeListenersOutput
+	var request = &elbv2.DescribeListenersInput{
 		ListenerArns: []*string{aws.String(d.Id())},
+	}
+
+	err := resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		var err error
+		resp, err = elbconn.DescribeListeners(request)
+		if err != nil {
+			if d.IsNewResource() && isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
+				return resource.RetryableError(err)
+			} else {
+				return resource.NonRetryableError(err)
+			}
+		}
+		return nil
 	})
+
 	if err != nil {
-		if isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
+		if !d.IsNewResource() && isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
 			log.Printf("[WARN] DescribeListeners - removing %s from state", d.Id())
 			d.SetId("")
 			return nil


### PR DESCRIPTION
AWS resources can take some time to appear in listings. When we created
a listener before, it could happen that the creation succeeded but the
listing of the resource right after creation would return a resource not
found.

This can me normal on AWS where changes can take some time to propagate.
The correct behaviour in this case is to retry reading the resource
until we find it (because we know that it has been created
successfully).

We don't change the behaviour on resource reads that are not following a
creation where a resource not found is still going to remove the
resource from the tfstate.

This should fix https://github.com/terraform-providers/terraform-provider-aws/issues/2456
