### PR TITLE
resource/aws_cloudwatch_log_group: Remove tags restrictions in AWS GovCloud (US) and AWS China

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -246,11 +246,6 @@ func (c *AWSClient) DynamoDB() *dynamodb.DynamoDB {
 	return c.dynamodbconn
 }
 
-func (c *AWSClient) IsGovCloud() bool {
-	_, isGovCloud := endpoints.PartitionForRegion([]endpoints.Partition{endpoints.AwsUsGovPartition()}, c.region)
-	return isGovCloud
-}
-
 func (c *AWSClient) IsChinaCloud() bool {
 	_, isChinaCloud := endpoints.PartitionForRegion([]endpoints.Partition{endpoints.AwsCnPartition()}, c.region)
 	return isChinaCloud

--- a/aws/resource_aws_cloudwatch_log_group.go
+++ b/aws/resource_aws_cloudwatch_log_group.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/hashicorp/errwrap"
 )
 
 func resourceAwsCloudWatchLogGroup() *schema.Resource {
@@ -100,12 +99,12 @@ func resourceAwsCloudWatchLogGroupCreate(d *schema.ResourceData, meta interface{
 func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 	log.Printf("[DEBUG] Reading CloudWatch Log Group: %q", d.Get("name").(string))
-	lg, exists, err := lookupCloudWatchLogGroup(conn, d.Id(), nil)
+	lg, err := lookupCloudWatchLogGroup(conn, d.Id())
 	if err != nil {
 		return err
 	}
 
-	if !exists {
+	if lg == nil {
 		log.Printf("[DEBUG] CloudWatch Group %q Not Found", d.Id())
 		d.SetId("")
 		return nil
@@ -116,44 +115,42 @@ func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{})
 	d.Set("arn", lg.Arn)
 	d.Set("name", lg.LogGroupName)
 	d.Set("kms_key_id", lg.KmsKeyId)
+	d.Set("retention_in_days", lg.RetentionInDays)
 
-	if lg.RetentionInDays != nil {
-		d.Set("retention_in_days", lg.RetentionInDays)
+	tags := make(map[string]string, 0)
+	tagsOutput, err := conn.ListTagsLogGroup(&cloudwatchlogs.ListTagsLogGroupInput{
+		LogGroupName: aws.String(d.Id()),
+	})
+	if err != nil {
+		return fmt.Errorf("error listing CloudWatch Logs Group %q tags: %s", d.Id(), err)
 	}
-
-	if !meta.(*AWSClient).IsChinaCloud() && !meta.(*AWSClient).IsGovCloud() {
-		tags, err := flattenCloudWatchTags(d, conn)
-		if err != nil {
-			return err
-		}
-		d.Set("tags", tags)
+	if tagsOutput != nil {
+		tags = aws.StringValueMap(tagsOutput.Tags)
 	}
+	d.Set("tags", tags)
 
 	return nil
 }
 
-func lookupCloudWatchLogGroup(conn *cloudwatchlogs.CloudWatchLogs,
-	name string, nextToken *string) (*cloudwatchlogs.LogGroup, bool, error) {
+func lookupCloudWatchLogGroup(conn *cloudwatchlogs.CloudWatchLogs, name string) (*cloudwatchlogs.LogGroup, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		LogGroupNamePrefix: aws.String(name),
-		NextToken:          nextToken,
 	}
-	resp, err := conn.DescribeLogGroups(input)
-	if err != nil {
-		return nil, true, err
-	}
-
-	for _, lg := range resp.LogGroups {
-		if *lg.LogGroupName == name {
-			return lg, true, nil
+	var logGroup *cloudwatchlogs.LogGroup
+	err := conn.DescribeLogGroupsPages(input, func(page *cloudwatchlogs.DescribeLogGroupsOutput, lastPage bool) bool {
+		for _, lg := range page.LogGroups {
+			if aws.StringValue(lg.LogGroupName) == name {
+				logGroup = lg
+				return false
+			}
 		}
+		return !lastPage
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	if resp.NextToken != nil {
-		return lookupCloudWatchLogGroup(conn, name, resp.NextToken)
-	}
-
-	return nil, false, nil
+	return logGroup, nil
 }
 
 func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -184,9 +181,7 @@ func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	restricted := meta.(*AWSClient).IsChinaCloud() || meta.(*AWSClient).IsGovCloud()
-
-	if !restricted && d.HasChange("tags") {
+	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})
 		n := nraw.(map[string]interface{})
@@ -268,24 +263,4 @@ func resourceAwsCloudWatchLogGroupDelete(d *schema.ResourceData, meta interface{
 	log.Println("[INFO] CloudWatch Log Group deleted")
 
 	return nil
-}
-
-func flattenCloudWatchTags(d *schema.ResourceData, conn *cloudwatchlogs.CloudWatchLogs) (map[string]interface{}, error) {
-	tagsOutput, err := conn.ListTagsLogGroup(&cloudwatchlogs.ListTagsLogGroupInput{
-		LogGroupName: aws.String(d.Get("name").(string)),
-	})
-	if err != nil {
-		return nil, errwrap.Wrapf("Error Getting CloudWatch Logs Tag List: {{err}}", err)
-	}
-	if tagsOutput != nil {
-		output := make(map[string]interface{}, len(tagsOutput.Tags))
-
-		for i, v := range tagsOutput.Tags {
-			output[i] = *v
-		}
-
-		return output, nil
-	}
-
-	return make(map[string]interface{}), nil
 }

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -271,11 +271,11 @@ func testAccCheckCloudWatchLogGroupExists(n string, lg *cloudwatchlogs.LogGroup)
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
-		logGroup, exists, err := lookupCloudWatchLogGroup(conn, rs.Primary.ID, nil)
+		logGroup, err := lookupCloudWatchLogGroup(conn, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		if !exists {
+		if logGroup == nil {
 			return fmt.Errorf("Bad: LogGroup %q does not exist", rs.Primary.ID)
 		}
 
@@ -292,12 +292,12 @@ func testAccCheckAWSCloudWatchLogGroupDestroy(s *terraform.State) error {
 		if rs.Type != "aws_cloudwatch_log_group" {
 			continue
 		}
-		_, exists, err := lookupCloudWatchLogGroup(conn, rs.Primary.ID, nil)
+		logGroup, err := lookupCloudWatchLogGroup(conn, rs.Primary.ID)
 		if err != nil {
 			return nil
 		}
 
-		if exists {
+		if logGroup != nil {
 			return fmt.Errorf("Bad: LogGroup still exists: %q", rs.Primary.ID)
 		}
 


### PR DESCRIPTION
At some point (sorry, I cannot find the relevant blog post if there was one), AWS GovCloud (US) started supporting resource tags with CloudWatch Log groups.

Changes proposed in this pull request:

* Remove `aws_cloudwatch_log_group` resource `tags` handling restrictions in AWS GovCloud (US) and AWS China
* Remove `IsGovCloud()` function
* Simplify CloudWatch Log group lookup to use paginated SDK function and remove extraneous `exists` boolean return value

Output from acceptance testing (AWS Commercial):

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchLogGroup -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_importBasic
--- PASS: TestAccAWSCloudWatchLogGroup_importBasic (14.59s)
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (10.61s)
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix (11.89s)
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix_retention
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix_retention (20.23s)
=== RUN   TestAccAWSCloudWatchLogGroup_generatedName
--- PASS: TestAccAWSCloudWatchLogGroup_generatedName (11.10s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (21.01s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (12.12s)
=== RUN   TestAccAWSCloudWatchLogGroup_disappears
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (8.48s)
=== RUN   TestAccAWSCloudWatchLogGroup_tagging
--- PASS: TestAccAWSCloudWatchLogGroup_tagging (37.42s)
=== RUN   TestAccAWSCloudWatchLogGroup_kmsKey
--- PASS: TestAccAWSCloudWatchLogGroup_kmsKey (51.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	199.426s
```

Output from acceptance testing (AWS GovCloud (US)):

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudWatchLogGroup -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_importBasic
--- PASS: TestAccAWSCloudWatchLogGroup_importBasic (19.56s)
=== RUN   TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (17.06s)
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix (16.04s)
=== RUN   TestAccAWSCloudWatchLogGroup_namePrefix_retention
--- PASS: TestAccAWSCloudWatchLogGroup_namePrefix_retention (29.74s)
=== RUN   TestAccAWSCloudWatchLogGroup_generatedName
--- PASS: TestAccAWSCloudWatchLogGroup_generatedName (15.42s)
=== RUN   TestAccAWSCloudWatchLogGroup_retentionPolicy
--- PASS: TestAccAWSCloudWatchLogGroup_retentionPolicy (28.87s)
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (18.56s)
=== RUN   TestAccAWSCloudWatchLogGroup_disappears
--- PASS: TestAccAWSCloudWatchLogGroup_disappears (11.86s)
=== RUN   TestAccAWSCloudWatchLogGroup_tagging
--- PASS: TestAccAWSCloudWatchLogGroup_tagging (54.80s)
=== RUN   TestAccAWSCloudWatchLogGroup_kmsKey
--- PASS: TestAccAWSCloudWatchLogGroup_kmsKey (58.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	270.097s
```