### PR TITLE
provider: Allow AssumeRoleARN and credential validation call to shortcut account ID and partition lookup

### DIFF
--- a/aws/auth_helpers.go
+++ b/aws/auth_helpers.go
@@ -18,92 +18,137 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-multierror"
 )
 
-func GetAccountID(iamconn *iam.IAM, stsconn *sts.STS, authProviderName string) (string, error) {
-	var errors error
+func GetAccountInformation(iamconn *iam.IAM, stsconn *sts.STS, authProviderName string) (string, string, error) {
+	var accountID, partition string
+	var err, errors error
 
-	// First, try STS GetCallerIdentity
-	log.Println("[DEBUG] Trying to get account ID via sts:GetCallerIdentity")
-	outCallerIdentity, err := stsconn.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-	if err == nil {
-		return parseAccountIDFromArn(*outCallerIdentity.Arn)
+	if authProviderName == ec2rolecreds.ProviderName {
+		accountID, partition, err = GetAccountInformationFromEC2Metadata()
+	} else {
+		accountID, partition, err = GetAccountInformationFromIAMGetUser(iamconn)
 	}
-	log.Printf("[DEBUG] Getting account ID via sts:GetCallerIdentity failed: %s", err)
+	if accountID != "" {
+		return accountID, partition, nil
+	}
 	errors = multierror.Append(errors, err)
 
-	// If we have creds from instance profile, we can use metadata API
-	if authProviderName == ec2rolecreds.ProviderName {
-		log.Println("[DEBUG] Trying to get account ID via AWS Metadata API")
+	accountID, partition, err = GetAccountInformationFromSTSGetCallerIdentity(stsconn)
+	if accountID != "" {
+		return accountID, partition, nil
+	}
+	errors = multierror.Append(errors, err)
 
-		cfg := &aws.Config{}
-		setOptionalEndpoint(cfg)
-		sess, err := session.NewSession(cfg)
-		if err != nil {
-			return "", errwrap.Wrapf("Error creating AWS session: {{err}}", err)
-		}
+	accountID, partition, err = GetAccountInformationFromIAMListRoles(iamconn)
+	if accountID != "" {
+		return accountID, partition, nil
+	}
+	errors = multierror.Append(errors, err)
 
-		metadataClient := ec2metadata.New(sess)
-		info, err := metadataClient.IAMInfo()
-		if err == nil {
-			return parseAccountIDFromArn(info.InstanceProfileArn)
-		}
-		log.Printf("[DEBUG] Failed to get account info from metadata service: %s", err)
-		errors = multierror.Append(errors, err)
-		// We can end up here if there's an issue with the instance metadata service
-		// or if we're getting credentials from AdRoll's Hologram (in which case IAMInfo will
-		// error out). In any event, if we can't get account info here, we should try
-		// the other methods available.
-		// If we have creds from something that looks like an IAM instance profile, but
-		// we were unable to retrieve account info from the instance profile, it's probably
-		// a safe assumption that we're not an IAM user
-	} else {
-		// Creds aren't from an IAM instance profile, so try try iam:GetUser
-		log.Println("[DEBUG] Trying to get account ID via iam:GetUser")
-		outUser, err := iamconn.GetUser(nil)
-		if err == nil {
-			return parseAccountIDFromArn(*outUser.User.Arn)
-		}
-		errors = multierror.Append(errors, err)
-		awsErr, ok := err.(awserr.Error)
-		// AccessDenied and ValidationError can be raised
-		// if credentials belong to federated profile, so we ignore these
-		if !ok || (awsErr.Code() != "AccessDenied" && awsErr.Code() != "ValidationError" && awsErr.Code() != "InvalidClientTokenId") {
-			return "", fmt.Errorf("Failed getting account ID via 'iam:GetUser': %s", err)
-		}
-		log.Printf("[DEBUG] Getting account ID via iam:GetUser failed: %s", err)
+	return accountID, partition, errors
+}
+
+func GetAccountInformationFromEC2Metadata() (string, string, error) {
+	log.Println("[DEBUG] Trying to get account information via EC2 Metadata")
+
+	cfg := &aws.Config{}
+	setOptionalEndpoint(cfg)
+	sess, err := session.NewSession(cfg)
+	if err != nil {
+		return "", "", fmt.Errorf("error creating EC2 Metadata session: %s", err)
 	}
 
-	// Then try IAM ListRoles
-	log.Println("[DEBUG] Trying to get account ID via iam:ListRoles")
-	outRoles, err := iamconn.ListRoles(&iam.ListRolesInput{
+	metadataClient := ec2metadata.New(sess)
+	info, err := metadataClient.IAMInfo()
+	if err != nil {
+		// We can end up here if there's an issue with the instance metadata service
+		// or if we're getting credentials from AdRoll's Hologram (in which case IAMInfo will
+		// error out).
+		err = fmt.Errorf("failed getting account information via EC2 Metadata IAM information: %s", err)
+		log.Printf("[DEBUG] %s", err)
+		return "", "", err
+	}
+
+	return parseAccountInformationFromARN(info.InstanceProfileArn)
+}
+
+func GetAccountInformationFromIAMGetUser(iamconn *iam.IAM) (string, string, error) {
+	log.Println("[DEBUG] Trying to get account information via iam:GetUser")
+
+	output, err := iamconn.GetUser(&iam.GetUserInput{})
+	if err != nil {
+		// AccessDenied and ValidationError can be raised
+		// if credentials belong to federated profile, so we ignore these
+		if isAWSErr(err, "AccessDenied", "") {
+			return "", "", nil
+		}
+		if isAWSErr(err, "InvalidClientTokenId", "") {
+			return "", "", nil
+		}
+		if isAWSErr(err, "ValidationError", "") {
+			return "", "", nil
+		}
+		err = fmt.Errorf("failed getting account information via iam:GetUser: %s", err)
+		log.Printf("[DEBUG] %s", err)
+		return "", "", err
+	}
+
+	if output == nil || output.User == nil {
+		err = errors.New("empty iam:GetUser response")
+		log.Printf("[DEBUG] %s", err)
+		return "", "", err
+	}
+
+	return parseAccountInformationFromARN(aws.StringValue(output.User.Arn))
+}
+
+func GetAccountInformationFromIAMListRoles(iamconn *iam.IAM) (string, string, error) {
+	log.Println("[DEBUG] Trying to get account information via iam:ListRoles")
+
+	output, err := iamconn.ListRoles(&iam.ListRolesInput{
 		MaxItems: aws.Int64(int64(1)),
 	})
 	if err != nil {
-		log.Printf("[DEBUG] Failed to get account ID via iam:ListRoles: %s", err)
-		errors = multierror.Append(errors, err)
-		return "", fmt.Errorf("Failed getting account ID via all available methods. Errors: %s", errors)
-	}
-
-	if len(outRoles.Roles) < 1 {
-		err = fmt.Errorf("Failed to get account ID via iam:ListRoles: No roles available")
+		err = fmt.Errorf("failed getting account information via iam:ListRoles: %s", err)
 		log.Printf("[DEBUG] %s", err)
-		errors = multierror.Append(errors, err)
-		return "", fmt.Errorf("Failed getting account ID via all available methods. Errors: %s", errors)
+		return "", "", err
 	}
 
-	return parseAccountIDFromArn(*outRoles.Roles[0].Arn)
+	if output == nil || len(output.Roles) < 1 {
+		err = fmt.Errorf("empty iam:ListRoles response")
+		log.Printf("[DEBUG] %s", err)
+		return "", "", err
+	}
+
+	return parseAccountInformationFromARN(aws.StringValue(output.Roles[0].Arn))
 }
 
-func parseAccountIDFromArn(inputARN string) (string, error) {
+func GetAccountInformationFromSTSGetCallerIdentity(stsconn *sts.STS) (string, string, error) {
+	log.Println("[DEBUG] Trying to get account information via sts:GetCallerIdentity")
+
+	output, err := stsconn.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", "", fmt.Errorf("error calling sts:GetCallerIdentity: %s", err)
+	}
+
+	if output == nil || output.Arn == nil {
+		err = errors.New("empty sts:GetCallerIdentity response")
+		log.Printf("[DEBUG] %s", err)
+		return "", "", err
+	}
+
+	return parseAccountInformationFromARN(aws.StringValue(output.Arn))
+}
+
+func parseAccountInformationFromARN(inputARN string) (string, string, error) {
 	arn, err := arn.Parse(inputARN)
 	if err != nil {
-		return "", fmt.Errorf("Unable to parse ID from invalid ARN: %q", arn)
+		return "", "", fmt.Errorf("error parsing ARN (%s): %s", inputARN, err)
 	}
-	return arn.AccountID, nil
+	return arn.AccountID, arn.Partition, nil
 }
 
 // This function is responsible for reading credentials from the

--- a/aws/auth_helpers_test.go
+++ b/aws/auth_helpers_test.go
@@ -368,7 +368,7 @@ func TestGetAccountIDAndPartitionFromSTSGetCallerIdentity(t *testing.T) {
 	}
 }
 
-func TestAWSparseAccountIDAndPartitionFromARN(t *testing.T) {
+func TestAWSParseAccountIDAndPartitionFromARN(t *testing.T) {
 	var testCases = []struct {
 		InputARN          string
 		ErrCount          int
@@ -402,19 +402,21 @@ func TestAWSparseAccountIDAndPartitionFromARN(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		accountID, partition, err := parseAccountIDAndPartitionFromARN(testCase.InputARN)
-		if err != nil && testCase.ErrCount == 0 {
-			t.Fatalf("Expected no error when parsing ARN, received error: %s", err)
-		}
-		if err == nil && testCase.ErrCount > 0 {
-			t.Fatalf("Expected %d error(s) when parsing ARN, received none", testCase.ErrCount)
-		}
-		if accountID != testCase.ExpectedAccountID {
-			t.Fatalf("Parsed account ID doesn't match with expected (%q != %q)", accountID, testCase.ExpectedAccountID)
-		}
-		if partition != testCase.ExpectedPartition {
-			t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
-		}
+		t.Run(testCase.InputARN, func(t *testing.T) {
+			accountID, partition, err := parseAccountIDAndPartitionFromARN(testCase.InputARN)
+			if err != nil && testCase.ErrCount == 0 {
+				t.Fatalf("Expected no error when parsing ARN, received error: %s", err)
+			}
+			if err == nil && testCase.ErrCount > 0 {
+				t.Fatalf("Expected %d error(s) when parsing ARN, received none", testCase.ErrCount)
+			}
+			if accountID != testCase.ExpectedAccountID {
+				t.Fatalf("Parsed account ID doesn't match with expected (%q != %q)", accountID, testCase.ExpectedAccountID)
+			}
+			if partition != testCase.ExpectedPartition {
+				t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+			}
+		})
 	}
 }
 

--- a/aws/auth_helpers_test.go
+++ b/aws/auth_helpers_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-func TestGetAccountInformation(t *testing.T) {
+func TestGetAccountIDAndPartition(t *testing.T) {
 	var testCases = []struct {
 		Description          string
 		AuthProviderName     string
@@ -145,7 +145,7 @@ func TestGetAccountInformation(t *testing.T) {
 			iamConn := iam.New(iamSess)
 			stsConn := sts.New(stsSess)
 
-			accountID, partition, err := GetAccountInformation(iamConn, stsConn, testCase.AuthProviderName)
+			accountID, partition, err := GetAccountIDAndPartition(iamConn, stsConn, testCase.AuthProviderName)
 			if err != nil && testCase.ErrCount == 0 {
 				t.Fatalf("Expected no error, received error: %s", err)
 			}
@@ -162,7 +162,7 @@ func TestGetAccountInformation(t *testing.T) {
 	}
 }
 
-func TestGetAccountInformationFromEC2Metadata(t *testing.T) {
+func TestGetAccountIDAndPartitionFromEC2Metadata(t *testing.T) {
 	t.Run("EC2 metadata success", func(t *testing.T) {
 		resetEnv := unsetEnv(t)
 		defer resetEnv()
@@ -170,7 +170,7 @@ func TestGetAccountInformationFromEC2Metadata(t *testing.T) {
 		awsTs := awsMetadataApiMock(append(ec2metadata_securityCredentialsEndpoints, ec2metadata_instanceIdEndpoint, ec2metadata_iamInfoEndpoint))
 		defer awsTs()
 
-		id, partition, err := GetAccountInformationFromEC2Metadata()
+		id, partition, err := GetAccountIDAndPartitionFromEC2Metadata()
 		if err != nil {
 			t.Fatalf("Getting account ID from EC2 metadata API failed: %s", err)
 		}
@@ -184,7 +184,7 @@ func TestGetAccountInformationFromEC2Metadata(t *testing.T) {
 	})
 }
 
-func TestGetAccountInformationFromIAMGetUser(t *testing.T) {
+func TestGetAccountIDAndPartitionFromIAMGetUser(t *testing.T) {
 	var testCases = []struct {
 		Description       string
 		MockEndpoints     []*awsMockEndpoint
@@ -235,7 +235,7 @@ func TestGetAccountInformationFromIAMGetUser(t *testing.T) {
 
 			iamConn := iam.New(iamSess)
 
-			accountID, partition, err := GetAccountInformationFromIAMGetUser(iamConn)
+			accountID, partition, err := GetAccountIDAndPartitionFromIAMGetUser(iamConn)
 			if err != nil && testCase.ErrCount == 0 {
 				t.Fatalf("Expected no error, received error: %s", err)
 			}
@@ -252,7 +252,7 @@ func TestGetAccountInformationFromIAMGetUser(t *testing.T) {
 	}
 }
 
-func TestGetAccountInformationFromIAMListRoles(t *testing.T) {
+func TestGetAccountIDAndPartitionFromIAMListRoles(t *testing.T) {
 	var testCases = []struct {
 		Description       string
 		MockEndpoints     []*awsMockEndpoint
@@ -293,7 +293,7 @@ func TestGetAccountInformationFromIAMListRoles(t *testing.T) {
 
 			iamConn := iam.New(iamSess)
 
-			accountID, partition, err := GetAccountInformationFromIAMListRoles(iamConn)
+			accountID, partition, err := GetAccountIDAndPartitionFromIAMListRoles(iamConn)
 			if err != nil && testCase.ErrCount == 0 {
 				t.Fatalf("Expected no error, received error: %s", err)
 			}
@@ -310,7 +310,7 @@ func TestGetAccountInformationFromIAMListRoles(t *testing.T) {
 	}
 }
 
-func TestGetAccountInformationFromSTSGetCallerIdentity(t *testing.T) {
+func TestGetAccountIDAndPartitionFromSTSGetCallerIdentity(t *testing.T) {
 	var testCases = []struct {
 		Description       string
 		MockEndpoints     []*awsMockEndpoint
@@ -351,7 +351,7 @@ func TestGetAccountInformationFromSTSGetCallerIdentity(t *testing.T) {
 
 			stsConn := sts.New(stsSess)
 
-			accountID, partition, err := GetAccountInformationFromSTSGetCallerIdentity(stsConn)
+			accountID, partition, err := GetAccountIDAndPartitionFromSTSGetCallerIdentity(stsConn)
 			if err != nil && testCase.ErrCount == 0 {
 				t.Fatalf("Expected no error, received error: %s", err)
 			}
@@ -368,7 +368,7 @@ func TestGetAccountInformationFromSTSGetCallerIdentity(t *testing.T) {
 	}
 }
 
-func TestAWSParseAccountInformationFromARN(t *testing.T) {
+func TestAWSparseAccountIDAndPartitionFromARN(t *testing.T) {
 	var testCases = []struct {
 		InputARN          string
 		ErrCount          int
@@ -402,7 +402,7 @@ func TestAWSParseAccountInformationFromARN(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		accountID, partition, err := parseAccountInformationFromARN(testCase.InputARN)
+		accountID, partition, err := parseAccountIDAndPartitionFromARN(testCase.InputARN)
 		if err != nil && testCase.ErrCount == 0 {
 			t.Fatalf("Expected no error when parsing ARN, received error: %s", err)
 		}

--- a/aws/auth_helpers_test.go
+++ b/aws/auth_helpers_test.go
@@ -10,304 +10,393 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
-func TestAWSGetAccountID_shouldBeValid_fromEC2Role(t *testing.T) {
+func TestGetAccountInformation(t *testing.T) {
+	var testCases = []struct {
+		Description          string
+		AuthProviderName     string
+		EC2MetadataEndpoints []*endpoint
+		IAMEndpoints         []*awsMockEndpoint
+		STSEndpoints         []*awsMockEndpoint
+		ErrCount             int
+		ExpectedAccountID    string
+		ExpectedPartition    string
+	}{
+		{
+			Description:          "EC2 Metadata over iam:GetUser when using EC2 Instance Profile",
+			AuthProviderName:     ec2rolecreds.ProviderName,
+			EC2MetadataEndpoints: append(ec2metadata_securityCredentialsEndpoints, ec2metadata_instanceIdEndpoint, ec2metadata_iamInfoEndpoint),
+			IAMEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{200, iamResponse_GetUser_valid, "text/xml"},
+				},
+			},
+			ExpectedAccountID: ec2metadata_iamInfoEndpoint_expectedAccountID,
+			ExpectedPartition: ec2metadata_iamInfoEndpoint_expectedPartition,
+		},
+		{
+			Description:          "Mimic the metadata service mocked by Hologram (https://github.com/AdRoll/hologram)",
+			AuthProviderName:     ec2rolecreds.ProviderName,
+			EC2MetadataEndpoints: ec2metadata_securityCredentialsEndpoints,
+			IAMEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{403, iamResponse_GetUser_unauthorized, "text/xml"},
+				},
+			},
+			STSEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
+					Response: &awsMockResponse{200, stsResponse_GetCallerIdentity_valid, "text/xml"},
+				},
+			},
+			ExpectedAccountID: stsResponse_GetCallerIdentity_valid_expectedAccountID,
+			ExpectedPartition: stsResponse_GetCallerIdentity_valid_expectedPartition,
+		},
+		{
+			Description: "iam:ListRoles if iam:GetUser AccessDenied and sts:GetCallerIdentity fails",
+			IAMEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{403, iamResponse_GetUser_unauthorized, "text/xml"},
+				},
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
+					Response: &awsMockResponse{200, iamResponse_ListRoles_valid, "text/xml"},
+				},
+			},
+			STSEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
+					Response: &awsMockResponse{403, stsResponse_GetCallerIdentity_unauthorized, "text/xml"},
+				},
+			},
+			ExpectedAccountID: iamResponse_ListRoles_valid_expectedAccountID,
+			ExpectedPartition: iamResponse_ListRoles_valid_expectedPartition,
+		},
+		{
+			Description: "iam:ListRoles if iam:GetUser ValidationError and sts:GetCallerIdentity fails",
+			IAMEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{400, iamResponse_GetUser_federatedFailure, "text/xml"},
+				},
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
+					Response: &awsMockResponse{200, iamResponse_ListRoles_valid, "text/xml"},
+				},
+			},
+			STSEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
+					Response: &awsMockResponse{403, stsResponse_GetCallerIdentity_unauthorized, "text/xml"},
+				},
+			},
+			ExpectedAccountID: iamResponse_ListRoles_valid_expectedAccountID,
+			ExpectedPartition: iamResponse_ListRoles_valid_expectedPartition,
+		},
+		{
+			Description: "Error when all endpoints fail",
+			IAMEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{400, iamResponse_GetUser_federatedFailure, "text/xml"},
+				},
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
+					Response: &awsMockResponse{403, iamResponse_ListRoles_unauthorized, "text/xml"},
+				},
+			},
+			STSEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
+					Response: &awsMockResponse{403, stsResponse_GetCallerIdentity_unauthorized, "text/xml"},
+				},
+			},
+			ErrCount: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		resetEnv := unsetEnv(t)
+		defer resetEnv()
+		// capture the test server's close method, to call after the test returns
+		awsTs := awsMetadataApiMock(testCase.EC2MetadataEndpoints)
+		defer awsTs()
+
+		closeIam, iamSess, err := getMockedAwsApiSession("IAM", testCase.IAMEndpoints)
+		defer closeIam()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		closeSts, stsSess, err := getMockedAwsApiSession("STS", testCase.STSEndpoints)
+		defer closeSts()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		iamConn := iam.New(iamSess)
+		stsConn := sts.New(stsSess)
+
+		accountID, partition, err := GetAccountInformation(iamConn, stsConn, testCase.AuthProviderName)
+		if err != nil && testCase.ErrCount == 0 {
+			t.Fatalf("%s: Expected no error, received error: %s", testCase.Description, err)
+		}
+		if err == nil && testCase.ErrCount > 0 {
+			t.Fatalf("%s: Expected %d error(s), received none", testCase.Description, testCase.ErrCount)
+		}
+		if accountID != testCase.ExpectedAccountID {
+			t.Fatalf("%s: Parsed account ID doesn't match with expected (%q != %q)", testCase.Description, accountID, testCase.ExpectedAccountID)
+		}
+		if partition != testCase.ExpectedPartition {
+			t.Fatalf("%s: Parsed partition doesn't match with expected (%q != %q)", testCase.Description, partition, testCase.ExpectedPartition)
+		}
+	}
+}
+
+func TestGetAccountInformationFromEC2Metadata(t *testing.T) {
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 	// capture the test server's close method, to call after the test returns
-	awsTs := awsMetadataApiMock(append(securityCredentialsEndpoints, instanceIdEndpoint, iamInfoEndpoint))
+	awsTs := awsMetadataApiMock(append(ec2metadata_securityCredentialsEndpoints, ec2metadata_instanceIdEndpoint, ec2metadata_iamInfoEndpoint))
 	defer awsTs()
 
-	closeEmpty, emptySess, err := getMockedAwsApiSession("zero", []*awsMockEndpoint{})
-	defer closeEmpty()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	iamConn := iam.New(emptySess)
-	stsConn := sts.New(emptySess)
-
-	id, err := GetAccountID(iamConn, stsConn, ec2rolecreds.ProviderName)
+	id, partition, err := GetAccountInformationFromEC2Metadata()
 	if err != nil {
 		t.Fatalf("Getting account ID from EC2 metadata API failed: %s", err)
 	}
 
-	expectedAccountId := "123456789013"
-	if id != expectedAccountId {
-		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+	if id != ec2metadata_iamInfoEndpoint_expectedAccountID {
+		t.Fatalf("Expected account ID: %s, given: %s", ec2metadata_iamInfoEndpoint_expectedAccountID, id)
+	}
+	if partition != ec2metadata_iamInfoEndpoint_expectedPartition {
+		t.Fatalf("Expected partition: %s, given: %s", ec2metadata_iamInfoEndpoint_expectedPartition, partition)
 	}
 }
 
-func TestAWSGetAccountID_shouldBeValid_EC2RoleHasPriority(t *testing.T) {
-	resetEnv := unsetEnv(t)
-	defer resetEnv()
-	// capture the test server's close method, to call after the test returns
-	awsTs := awsMetadataApiMock(append(securityCredentialsEndpoints, instanceIdEndpoint, iamInfoEndpoint))
-	defer awsTs()
-
-	iamEndpoints := []*awsMockEndpoint{
+func TestGetAccountInformationFromIAMGetUser(t *testing.T) {
+	var testCases = []struct {
+		MockEndpoints     []*awsMockEndpoint
+		ErrCount          int
+		ExpectedAccountID string
+		ExpectedPartition string
+	}{
 		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
-			Response: &awsMockResponse{200, iamResponse_GetUser_valid, "text/xml"},
+			MockEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{400, iamResponse_GetUser_federatedFailure, "text/xml"},
+				},
+			},
+			// We ignore this error
+			ErrCount: 0,
+		},
+		{
+			MockEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{403, iamResponse_GetUser_unauthorized, "text/xml"},
+				},
+			},
+			// We ignore this error
+			ErrCount: 0,
+		},
+		{
+			MockEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
+					Response: &awsMockResponse{200, iamResponse_GetUser_valid, "text/xml"},
+				},
+			},
+			ExpectedAccountID: iamResponse_GetUser_valid_expectedAccountID,
+			ExpectedPartition: iamResponse_GetUser_valid_expectedPartition,
 		},
 	}
-	closeIam, iamSess, err := getMockedAwsApiSession("IAM", iamEndpoints)
-	defer closeIam()
-	if err != nil {
-		t.Fatal(err)
-	}
-	iamConn := iam.New(iamSess)
-	closeSts, stsSess, err := getMockedAwsApiSession("STS", []*awsMockEndpoint{})
-	defer closeSts()
-	if err != nil {
-		t.Fatal(err)
-	}
-	stsConn := sts.New(stsSess)
 
-	id, err := GetAccountID(iamConn, stsConn, ec2rolecreds.ProviderName)
-	if err != nil {
-		t.Fatalf("Getting account ID from EC2 metadata API failed: %s", err)
-	}
+	for _, testCase := range testCases {
+		closeIam, iamSess, err := getMockedAwsApiSession("IAM", testCase.MockEndpoints)
+		defer closeIam()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	expectedAccountId := "123456789013"
-	if id != expectedAccountId {
-		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+		iamConn := iam.New(iamSess)
+
+		accountID, partition, err := GetAccountInformationFromIAMGetUser(iamConn)
+		if err != nil && testCase.ErrCount == 0 {
+			t.Fatalf("Expected no error, received error: %s", err)
+		}
+		if err == nil && testCase.ErrCount > 0 {
+			t.Fatalf("Expected %d error(s), received none", testCase.ErrCount)
+		}
+		if accountID != testCase.ExpectedAccountID {
+			t.Fatalf("Parsed account ID doesn't match with expected (%q != %q)", accountID, testCase.ExpectedAccountID)
+		}
+		if partition != testCase.ExpectedPartition {
+			t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+		}
 	}
 }
 
-func TestAWSGetAccountID_shouldBeValid_fromIamUser(t *testing.T) {
-	iamEndpoints := []*awsMockEndpoint{
+func TestGetAccountInformationFromIAMListRoles(t *testing.T) {
+	var testCases = []struct {
+		MockEndpoints     []*awsMockEndpoint
+		ErrCount          int
+		ExpectedAccountID string
+		ExpectedPartition string
+	}{
 		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
-			Response: &awsMockResponse{200, iamResponse_GetUser_valid, "text/xml"},
+			MockEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
+					Response: &awsMockResponse{403, iamResponse_ListRoles_unauthorized, "text/xml"},
+				},
+			},
+			ErrCount: 1,
+		},
+		{
+			MockEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
+					Response: &awsMockResponse{200, iamResponse_ListRoles_valid, "text/xml"},
+				},
+			},
+			ExpectedAccountID: iamResponse_ListRoles_valid_expectedAccountID,
+			ExpectedPartition: iamResponse_ListRoles_valid_expectedPartition,
 		},
 	}
 
-	closeIam, iamSess, err := getMockedAwsApiSession("IAM", iamEndpoints)
-	defer closeIam()
-	if err != nil {
-		t.Fatal(err)
-	}
-	closeSts, stsSess, err := getMockedAwsApiSession("STS", []*awsMockEndpoint{})
-	defer closeSts()
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, testCase := range testCases {
+		closeIam, iamSess, err := getMockedAwsApiSession("IAM", testCase.MockEndpoints)
+		defer closeIam()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	iamConn := iam.New(iamSess)
-	stsConn := sts.New(stsSess)
+		iamConn := iam.New(iamSess)
 
-	id, err := GetAccountID(iamConn, stsConn, "")
-	if err != nil {
-		t.Fatalf("Getting account ID via GetUser failed: %s", err)
-	}
-
-	expectedAccountId := "123456789012"
-	if id != expectedAccountId {
-		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+		accountID, partition, err := GetAccountInformationFromIAMListRoles(iamConn)
+		if err != nil && testCase.ErrCount == 0 {
+			t.Fatalf("Expected no error, received error: %s", err)
+		}
+		if err == nil && testCase.ErrCount > 0 {
+			t.Fatalf("Expected %d error(s), received none", testCase.ErrCount)
+		}
+		if accountID != testCase.ExpectedAccountID {
+			t.Fatalf("Parsed account ID doesn't match with expected (%q != %q)", accountID, testCase.ExpectedAccountID)
+		}
+		if partition != testCase.ExpectedPartition {
+			t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+		}
 	}
 }
 
-func TestAWSGetAccountID_shouldBeValid_fromGetCallerIdentity(t *testing.T) {
-	iamEndpoints := []*awsMockEndpoint{
+func TestGetAccountInformationFromSTSGetCallerIdentity(t *testing.T) {
+	var testCases = []struct {
+		MockEndpoints     []*awsMockEndpoint
+		ErrCount          int
+		ExpectedAccountID string
+		ExpectedPartition string
+	}{
 		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
-			Response: &awsMockResponse{403, iamResponse_GetUser_unauthorized, "text/xml"},
-		},
-	}
-	closeIam, iamSess, err := getMockedAwsApiSession("IAM", iamEndpoints)
-	defer closeIam()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stsEndpoints := []*awsMockEndpoint{
-		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
-			Response: &awsMockResponse{200, stsResponse_GetCallerIdentity_valid, "text/xml"},
-		},
-	}
-	closeSts, stsSess, err := getMockedAwsApiSession("STS", stsEndpoints)
-	defer closeSts()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testGetAccountID(t, iamSess, stsSess, credentials.SharedCredsProviderName)
-}
-
-func TestAWSGetAccountID_shouldBeValid_EC2RoleFallsBackToCallerIdentity(t *testing.T) {
-	// This mimics the metadata service mocked by Hologram (https://github.com/AdRoll/hologram)
-	resetEnv := unsetEnv(t)
-	defer resetEnv()
-
-	awsTs := awsMetadataApiMock(securityCredentialsEndpoints)
-	defer awsTs()
-
-	iamEndpoints := []*awsMockEndpoint{
-		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
-			Response: &awsMockResponse{403, iamResponse_GetUser_unauthorized, "text/xml"},
-		},
-	}
-	closeIam, iamSess, err := getMockedAwsApiSession("IAM", iamEndpoints)
-	defer closeIam()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stsEndpoints := []*awsMockEndpoint{
-		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
-			Response: &awsMockResponse{200, stsResponse_GetCallerIdentity_valid, "text/xml"},
-		},
-	}
-	closeSts, stsSess, err := getMockedAwsApiSession("STS", stsEndpoints)
-	defer closeSts()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	testGetAccountID(t, iamSess, stsSess, ec2rolecreds.ProviderName)
-}
-
-func TestAWSGetAccountID_shouldBeValid_fromIamListRoles(t *testing.T) {
-	iamEndpoints := []*awsMockEndpoint{
-		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
-			Response: &awsMockResponse{403, iamResponse_GetUser_unauthorized, "text/xml"},
+			MockEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
+					Response: &awsMockResponse{403, stsResponse_GetCallerIdentity_unauthorized, "text/xml"},
+				},
+			},
+			ErrCount: 1,
 		},
 		{
-			Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
-			Response: &awsMockResponse{200, iamResponse_ListRoles_valid, "text/xml"},
+			MockEndpoints: []*awsMockEndpoint{
+				{
+					Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
+					Response: &awsMockResponse{200, stsResponse_GetCallerIdentity_valid, "text/xml"},
+				},
+			},
+			ExpectedAccountID: stsResponse_GetCallerIdentity_valid_expectedAccountID,
+			ExpectedPartition: stsResponse_GetCallerIdentity_valid_expectedPartition,
 		},
 	}
-	closeIam, iamSess, err := getMockedAwsApiSession("IAM", iamEndpoints)
-	defer closeIam()
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	stsEndpoints := []*awsMockEndpoint{
-		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
-			Response: &awsMockResponse{403, stsResponse_GetCallerIdentity_unauthorized, "text/xml"},
-		},
-	}
-	closeSts, stsSess, err := getMockedAwsApiSession("STS", stsEndpoints)
-	defer closeSts()
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, testCase := range testCases {
+		closeSts, stsSess, err := getMockedAwsApiSession("STS", testCase.MockEndpoints)
+		defer closeSts()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	iamConn := iam.New(iamSess)
-	stsConn := sts.New(stsSess)
+		stsConn := sts.New(stsSess)
 
-	id, err := GetAccountID(iamConn, stsConn, "")
-	if err != nil {
-		t.Fatalf("Getting account ID via ListRoles failed: %s", err)
-	}
-
-	expectedAccountId := "123456789012"
-	if id != expectedAccountId {
-		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+		accountID, partition, err := GetAccountInformationFromSTSGetCallerIdentity(stsConn)
+		if err != nil && testCase.ErrCount == 0 {
+			t.Fatalf("Expected no error, received error: %s", err)
+		}
+		if err == nil && testCase.ErrCount > 0 {
+			t.Fatalf("Expected %d error(s), received none", testCase.ErrCount)
+		}
+		if accountID != testCase.ExpectedAccountID {
+			t.Fatalf("Parsed account ID doesn't match with expected (%q != %q)", accountID, testCase.ExpectedAccountID)
+		}
+		if partition != testCase.ExpectedPartition {
+			t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+		}
 	}
 }
 
-func TestAWSGetAccountID_shouldBeValid_federatedRole(t *testing.T) {
-	iamEndpoints := []*awsMockEndpoint{
+func TestAWSParseAccountInformationFromARN(t *testing.T) {
+	var testCases = []struct {
+		InputARN          string
+		ErrCount          int
+		ExpectedAccountID string
+		ExpectedPartition string
+	}{
 		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
-			Response: &awsMockResponse{400, iamResponse_GetUser_federatedFailure, "text/xml"},
+			InputARN: "invalid-arn",
+			ErrCount: 1,
 		},
 		{
-			Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
-			Response: &awsMockResponse{200, iamResponse_ListRoles_valid, "text/xml"},
-		},
-	}
-	closeIam, iamSess, err := getMockedAwsApiSession("IAM", iamEndpoints)
-	defer closeIam()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	closeSts, stsSess, err := getMockedAwsApiSession("STS", []*awsMockEndpoint{})
-	defer closeSts()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	iamConn := iam.New(iamSess)
-	stsConn := sts.New(stsSess)
-
-	id, err := GetAccountID(iamConn, stsConn, "")
-	if err != nil {
-		t.Fatalf("Getting account ID via ListRoles failed: %s", err)
-	}
-
-	expectedAccountId := "123456789012"
-	if id != expectedAccountId {
-		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
-	}
-}
-
-func TestAWSGetAccountID_shouldError_unauthorizedFromIam(t *testing.T) {
-	iamEndpoints := []*awsMockEndpoint{
-		{
-			Request:  &awsMockRequest{"POST", "/", "Action=GetUser&Version=2010-05-08"},
-			Response: &awsMockResponse{403, iamResponse_GetUser_unauthorized, "text/xml"},
+			InputARN:          "arn:aws:iam::123456789012:instance-profile/name",
+			ExpectedAccountID: "123456789012",
+			ExpectedPartition: "aws",
 		},
 		{
-			Request:  &awsMockRequest{"POST", "/", "Action=ListRoles&MaxItems=1&Version=2010-05-08"},
-			Response: &awsMockResponse{403, iamResponse_ListRoles_unauthorized, "text/xml"},
+			InputARN:          "arn:aws:iam::123456789012:user/name",
+			ExpectedAccountID: "123456789012",
+			ExpectedPartition: "aws",
+		},
+		{
+			InputARN:          "arn:aws:sts::123456789012:assumed-role/name",
+			ExpectedAccountID: "123456789012",
+			ExpectedPartition: "aws",
+		},
+		{
+			InputARN:          "arn:aws-us-gov:sts::123456789012:assumed-role/name",
+			ExpectedAccountID: "123456789012",
+			ExpectedPartition: "aws-us-gov",
 		},
 	}
-	closeIam, iamSess, err := getMockedAwsApiSession("IAM", iamEndpoints)
-	defer closeIam()
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	closeSts, stsSess, err := getMockedAwsApiSession("STS", []*awsMockEndpoint{})
-	defer closeSts()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	iamConn := iam.New(iamSess)
-	stsConn := sts.New(stsSess)
-
-	id, err := GetAccountID(iamConn, stsConn, "")
-	if err == nil {
-		t.Fatal("Expected error when getting account ID")
-	}
-
-	if id != "" {
-		t.Fatalf("Expected no account ID, given: %s", id)
-	}
-}
-
-func TestAWSParseAccountIDFromArn(t *testing.T) {
-	validArn := "arn:aws:iam::101636750127:instance-profile/aws-elasticbeanstalk-ec2-role"
-	expectedId := "101636750127"
-	id, err := parseAccountIDFromArn(validArn)
-	if err != nil {
-		t.Fatalf("Expected no error when parsing valid ARN: %s", err)
-	}
-	if id != expectedId {
-		t.Fatalf("Parsed id doesn't match with expected (%q != %q)", id, expectedId)
-	}
-
-	invalidArn := "blablah"
-	id, err = parseAccountIDFromArn(invalidArn)
-	if err == nil {
-		t.Fatalf("Expected error when parsing invalid ARN (%q)", invalidArn)
+	for _, testCase := range testCases {
+		accountID, partition, err := parseAccountInformationFromARN(testCase.InputARN)
+		if err != nil && testCase.ErrCount == 0 {
+			t.Fatalf("Expected no error when parsing ARN, received error: %s", err)
+		}
+		if err == nil && testCase.ErrCount > 0 {
+			t.Fatalf("Expected %d error(s) when parsing ARN, received none", testCase.ErrCount)
+		}
+		if accountID != testCase.ExpectedAccountID {
+			t.Fatalf("Parsed account ID doesn't match with expected (%q != %q)", accountID, testCase.ExpectedAccountID)
+		}
+		if partition != testCase.ExpectedPartition {
+			t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+		}
 	}
 }
 
@@ -388,7 +477,7 @@ func TestAWSGetCredentials_shouldIAM(t *testing.T) {
 	defer resetEnv()
 
 	// capture the test server's close method, to call after the test returns
-	ts := awsMetadataApiMock(append(securityCredentialsEndpoints, instanceIdEndpoint, iamInfoEndpoint))
+	ts := awsMetadataApiMock(append(ec2metadata_securityCredentialsEndpoints, ec2metadata_instanceIdEndpoint, ec2metadata_iamInfoEndpoint))
 	defer ts()
 
 	// An empty config, no key supplied
@@ -424,7 +513,7 @@ func TestAWSGetCredentials_shouldIgnoreIAM(t *testing.T) {
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 	// capture the test server's close method, to call after the test returns
-	ts := awsMetadataApiMock(append(securityCredentialsEndpoints, instanceIdEndpoint, iamInfoEndpoint))
+	ts := awsMetadataApiMock(append(ec2metadata_securityCredentialsEndpoints, ec2metadata_instanceIdEndpoint, ec2metadata_iamInfoEndpoint))
 	defer ts()
 	simple := []struct {
 		Key, Secret, Token string
@@ -531,7 +620,7 @@ func TestAWSGetCredentials_shouldCatchEC2RoleProvider(t *testing.T) {
 	resetEnv := unsetEnv(t)
 	defer resetEnv()
 	// capture the test server's close method, to call after the test returns
-	ts := awsMetadataApiMock(append(securityCredentialsEndpoints, instanceIdEndpoint, iamInfoEndpoint))
+	ts := awsMetadataApiMock(append(ec2metadata_securityCredentialsEndpoints, ec2metadata_instanceIdEndpoint, ec2metadata_iamInfoEndpoint))
 	defer ts()
 
 	creds, err := GetCredentials(&Config{})
@@ -635,22 +724,6 @@ func TestAWSGetCredentials_shouldBeENV(t *testing.T) {
 	}
 	if v.SessionToken != s {
 		t.Fatalf("SessionToken mismatch, expected: (%s), got (%s)", s, v.SessionToken)
-	}
-}
-
-func testGetAccountID(t *testing.T, iamSess, stsSess *session.Session, credProviderName string) {
-
-	iamConn := iam.New(iamSess)
-	stsConn := sts.New(stsSess)
-
-	id, err := GetAccountID(iamConn, stsConn, credProviderName)
-	if err != nil {
-		t.Fatalf("Getting account ID failed: %s", err)
-	}
-
-	expectedAccountId := "123456789012"
-	if id != expectedAccountId {
-		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
 	}
 }
 
@@ -791,12 +864,12 @@ type endpoint struct {
 	Body string `json:"body"`
 }
 
-var instanceIdEndpoint = &endpoint{
+var ec2metadata_instanceIdEndpoint = &endpoint{
 	Uri:  "/latest/meta-data/instance-id",
 	Body: "mock-instance-id",
 }
 
-var securityCredentialsEndpoints = []*endpoint{
+var ec2metadata_securityCredentialsEndpoints = []*endpoint{
 	&endpoint{
 		Uri:  "/latest/meta-data/iam/security-credentials/",
 		Body: "test_role",
@@ -807,10 +880,13 @@ var securityCredentialsEndpoints = []*endpoint{
 	},
 }
 
-var iamInfoEndpoint = &endpoint{
+var ec2metadata_iamInfoEndpoint = &endpoint{
 	Uri:  "/latest/meta-data/iam/info",
-	Body: "{\"Code\": \"Success\",\"LastUpdated\": \"2016-03-17T12:27:32Z\",\"InstanceProfileArn\": \"arn:aws:iam::123456789013:instance-profile/my-instance-profile\",\"InstanceProfileId\": \"AIPAABCDEFGHIJKLMN123\"}",
+	Body: "{\"Code\": \"Success\",\"LastUpdated\": \"2016-03-17T12:27:32Z\",\"InstanceProfileArn\": \"arn:aws:iam::000000000000:instance-profile/my-instance-profile\",\"InstanceProfileId\": \"AIPAABCDEFGHIJKLMN123\"}",
 }
+
+const ec2metadata_iamInfoEndpoint_expectedAccountID = `000000000000`
+const ec2metadata_iamInfoEndpoint_expectedPartition = `aws`
 
 const iamResponse_GetUser_valid = `<GetUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <GetUserResult>
@@ -818,7 +894,7 @@ const iamResponse_GetUser_valid = `<GetUserResponse xmlns="https://iam.amazonaws
       <UserId>AIDACKCEVSQ6C2EXAMPLE</UserId>
       <Path>/division_abc/subdivision_xyz/</Path>
       <UserName>Bob</UserName>
-      <Arn>arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/Bob</Arn>
+      <Arn>arn:aws:iam::111111111111:user/division_abc/subdivision_xyz/Bob</Arn>
       <CreateDate>2013-10-02T17:01:44Z</CreateDate>
       <PasswordLastUsed>2014-10-10T14:37:51Z</PasswordLastUsed>
     </User>
@@ -827,6 +903,9 @@ const iamResponse_GetUser_valid = `<GetUserResponse xmlns="https://iam.amazonaws
     <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
   </ResponseMetadata>
 </GetUserResponse>`
+
+const iamResponse_GetUser_valid_expectedAccountID = `111111111111`
+const iamResponse_GetUser_valid_expectedPartition = `aws`
 
 const iamResponse_GetUser_unauthorized = `<ErrorResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <Error>
@@ -839,14 +918,17 @@ const iamResponse_GetUser_unauthorized = `<ErrorResponse xmlns="https://iam.amaz
 
 const stsResponse_GetCallerIdentity_valid = `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetCallerIdentityResult>
-   <Arn>arn:aws:iam::123456789012:user/Alice</Arn>
+   <Arn>arn:aws:iam::222222222222:user/Alice</Arn>
     <UserId>AKIAI44QH8DHBEXAMPLE</UserId>
-    <Account>123456789012</Account>
+    <Account>222222222222</Account>
   </GetCallerIdentityResult>
   <ResponseMetadata>
     <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
   </ResponseMetadata>
 </GetCallerIdentityResponse>`
+
+const stsResponse_GetCallerIdentity_valid_expectedAccountID = `222222222222`
+const stsResponse_GetCallerIdentity_valid_expectedPartition = `aws`
 
 const stsResponse_GetCallerIdentity_unauthorized = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <Error>
@@ -876,7 +958,7 @@ const iamResponse_ListRoles_valid = `<ListRolesResponse xmlns="https://iam.amazo
         <AssumeRolePolicyDocument>%7B%22Version%22%3A%222008-10-17%22%2C%22Statement%22%3A%5B%7B%22Sid%22%3A%22%22%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
         <RoleId>AROACKCEVSQ6C2EXAMPLE</RoleId>
         <RoleName>elasticbeanstalk-role</RoleName>
-        <Arn>arn:aws:iam::123456789012:role/elasticbeanstalk-role</Arn>
+        <Arn>arn:aws:iam::444444444444:role/elasticbeanstalk-role</Arn>
         <CreateDate>2013-10-02T17:01:44Z</CreateDate>
       </member>
     </Roles>
@@ -885,6 +967,9 @@ const iamResponse_ListRoles_valid = `<ListRolesResponse xmlns="https://iam.amazo
     <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
   </ResponseMetadata>
 </ListRolesResponse>`
+
+const iamResponse_ListRoles_valid_expectedAccountID = `444444444444`
+const iamResponse_ListRoles_valid_expectedPartition = `aws`
 
 const iamResponse_ListRoles_unauthorized = `<ErrorResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <Error>

--- a/aws/config.go
+++ b/aws/config.go
@@ -426,13 +426,13 @@ func (c *Config) Client() (interface{}, error) {
 	client.stsconn = sts.New(awsStsSess)
 
 	if c.AssumeRoleARN != "" {
-		client.accountid, client.partition, _ = parseAccountInformationFromARN(c.AssumeRoleARN)
+		client.accountid, client.partition, _ = parseAccountIDAndPartitionFromARN(c.AssumeRoleARN)
 	}
 
 	// Validate credentials early and fail before we do any graph walking.
 	if !c.SkipCredsValidation {
 		var err error
-		client.accountid, client.partition, err = GetAccountInformationFromSTSGetCallerIdentity(client.stsconn)
+		client.accountid, client.partition, err = GetAccountIDAndPartitionFromSTSGetCallerIdentity(client.stsconn)
 		if err != nil {
 			return nil, fmt.Errorf("error validating provider credentials: %s", err)
 		}
@@ -440,7 +440,7 @@ func (c *Config) Client() (interface{}, error) {
 
 	if client.accountid == "" && !c.SkipRequestingAccountId {
 		var err error
-		client.accountid, client.partition, err = GetAccountInformation(client.iamconn, client.stsconn, cp.ProviderName)
+		client.accountid, client.partition, err = GetAccountIDAndPartition(client.iamconn, client.stsconn, cp.ProviderName)
 		if err != nil {
 			return nil, fmt.Errorf("Failed getting account information via all available methods. Errors: %s", err)
 		}


### PR DESCRIPTION
Potentially supersedes: #5060 

Changes proposed in this pull request:

* If provider configuration is set to assume role, use provided ARN to bypass account information calls
* If provider credential validation is enabled, use results to bypass further account information calls
* Refactor GetAccountID back to GetAccountInformation to ensure non-SDK-default partitions can be handled (and make it much more readable 😄 )
* Refactor GetAccountInformation testing

Output from acceptance testing: (provided as a smoke test)

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsAvailabilityZone'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAwsAvailabilityZone -timeout 120m
=== RUN   TestAccDataSourceAwsAvailabilityZone
--- PASS: TestAccDataSourceAwsAvailabilityZone (9.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.021s
```
