### PR TITLE
resource/aws_iam_role: Add permissions_boundary argument

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -85,6 +84,12 @@ func resourceAwsIamRole() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"permissions_boundary": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(20, 2048),
+			},
+
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -151,6 +156,10 @@ func resourceAwsIamRoleCreate(d *schema.ResourceData, meta interface{}) error {
 		request.MaxSessionDuration = aws.Int64(int64(v.(int)))
 	}
 
+	if v, ok := d.GetOk("permissions_boundary"); ok {
+		request.PermissionsBoundary = aws.String(v.(string))
+	}
+
 	var createResp *iam.CreateRoleOutput
 	err := resource.Retry(30*time.Second, func() *resource.RetryError {
 		var err error
@@ -178,7 +187,8 @@ func resourceAwsIamRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	getResp, err := iamconn.GetRole(request)
 	if err != nil {
-		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") { // XXX test me
+			log.Printf("[WARN] IAM Role %q not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
@@ -187,31 +197,18 @@ func resourceAwsIamRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	role := getResp.Role
 
-	if err := d.Set("name", role.RoleName); err != nil {
-		return err
-	}
-	if err := d.Set("max_session_duration", role.MaxSessionDuration); err != nil {
-		return err
-	}
-	if err := d.Set("arn", role.Arn); err != nil {
-		return err
-	}
-	if err := d.Set("path", role.Path); err != nil {
-		return err
-	}
-	if err := d.Set("unique_id", role.RoleId); err != nil {
-		return err
-	}
+	d.Set("arn", role.Arn)
 	if err := d.Set("create_date", role.CreateDate.Format(time.RFC3339)); err != nil {
 		return err
 	}
-
-	if role.Description != nil {
-		// the description isn't present in the response to CreateRole.
-		if err := d.Set("description", role.Description); err != nil {
-			return err
-		}
+	d.Set("description", role.Description)
+	d.Set("max_session_duration", role.MaxSessionDuration)
+	d.Set("name", role.RoleName)
+	d.Set("path", role.Path)
+	if role.PermissionsBoundary != nil {
+		d.Set("permissions_boundary", role.PermissionsBoundary.PermissionsBoundaryArn)
 	}
+	d.Set("unique_id", role.RoleId)
 
 	assumRolePolicy, err := url.QueryUnescape(*role.AssumeRolePolicyDocument)
 	if err != nil {
@@ -233,7 +230,7 @@ func resourceAwsIamRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err := iamconn.UpdateAssumeRolePolicy(assumeRolePolicyInput)
 		if err != nil {
-			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+			if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 				d.SetId("")
 				return nil
 			}
@@ -248,7 +245,7 @@ func resourceAwsIamRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		_, err := iamconn.UpdateRoleDescription(roleDescriptionInput)
 		if err != nil {
-			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+			if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 				d.SetId("")
 				return nil
 			}
@@ -271,7 +268,29 @@ func resourceAwsIamRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return nil
+	if d.HasChange("permissions_boundary") {
+		permissionsBoundary := d.Get("permissions_boundary").(string)
+		if permissionsBoundary != "" {
+			input := &iam.PutRolePermissionsBoundaryInput{
+				PermissionsBoundary: aws.String(permissionsBoundary),
+				RoleName:            aws.String(d.Id()),
+			}
+			_, err := iamconn.PutRolePermissionsBoundary(input)
+			if err != nil {
+				return fmt.Errorf("error updating IAM Role permissions boundary: %s", err)
+			}
+		} else {
+			input := &iam.DeleteRolePermissionsBoundaryInput{
+				RoleName: aws.String(d.Id()),
+			}
+			_, err := iamconn.DeleteRolePermissionsBoundary(input)
+			if err != nil {
+				return fmt.Errorf("error deleting IAM Role permissions boundary: %s", err)
+			}
+		}
+	}
+
+	return resourceAwsIamRoleRead(d, meta)
 }
 
 func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
@@ -358,16 +377,25 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	request := &iam.DeleteRoleInput{
+	deleteRolePermissionsBoundaryInput := &iam.DeleteRolePermissionsBoundaryInput{
+		RoleName: aws.String(d.Id()),
+	}
+
+	log.Println("[DEBUG] Delete IAM Role Permissions Boundary request:", deleteRolePermissionsBoundaryInput)
+	_, err = iamconn.DeleteRolePermissionsBoundary(deleteRolePermissionsBoundaryInput)
+	if err != nil && !isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		return fmt.Errorf("Error deleting IAM Role %s Permissions Boundary: %s", d.Id(), err)
+	}
+
+	deleteRoleInput := &iam.DeleteRoleInput{
 		RoleName: aws.String(d.Id()),
 	}
 
 	// IAM is eventually consistent and deletion of attached policies may take time
 	return resource.Retry(30*time.Second, func() *resource.RetryError {
-		_, err := iamconn.DeleteRole(request)
+		_, err := iamconn.DeleteRole(deleteRoleInput)
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if ok && awsErr.Code() == "DeleteConflict" {
+			if isAWSErr(err, iam.ErrCodeDeleteConflictException, "") {
 				return resource.RetryableError(err)
 			}
 

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the role.
 
 * `max_session_duration` - (Optional) The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.
+* `permissions_boundary` - (Optional) The ARN of the policy that is used to set the permissions boundary for the role.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Reference: #5174 

Changes proposed in this pull request:

* Add permissions boundary support to `aws_iam_role` resource
* Minor refactoring for newer practices
* Support testing in AWS GovCloud (US)

Output from acceptance testing: AWS Commercial

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMRole_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMRole_ -timeout 120m
=== RUN   TestAccAWSIAMRole_importBasic
--- PASS: TestAccAWSIAMRole_importBasic (8.49s)
=== RUN   TestAccAWSIAMRole_basic
--- PASS: TestAccAWSIAMRole_basic (8.98s)
=== RUN   TestAccAWSIAMRole_basicWithDescription
--- PASS: TestAccAWSIAMRole_basicWithDescription (18.79s)
=== RUN   TestAccAWSIAMRole_namePrefix
--- PASS: TestAccAWSIAMRole_namePrefix (8.12s)
=== RUN   TestAccAWSIAMRole_testNameChange
--- PASS: TestAccAWSIAMRole_testNameChange (15.75s)
=== RUN   TestAccAWSIAMRole_badJSON
--- PASS: TestAccAWSIAMRole_badJSON (1.32s)
=== RUN   TestAccAWSIAMRole_force_detach_policies
--- PASS: TestAccAWSIAMRole_force_detach_policies (9.02s)
=== RUN   TestAccAWSIAMRole_MaxSessionDuration
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (14.01s)
=== RUN   TestAccAWSIAMRole_PermissionsBoundary
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (27.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	111.930s
```

Output from acceptance testing: AWS GovCloud (US)

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMRole_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMRole_ -timeout 120m
=== RUN   TestAccAWSIAMRole_importBasic
--- PASS: TestAccAWSIAMRole_importBasic (17.05s)
=== RUN   TestAccAWSIAMRole_basic
--- PASS: TestAccAWSIAMRole_basic (16.47s)
=== RUN   TestAccAWSIAMRole_basicWithDescription
--- PASS: TestAccAWSIAMRole_basicWithDescription (37.45s)
=== RUN   TestAccAWSIAMRole_namePrefix
--- PASS: TestAccAWSIAMRole_namePrefix (16.62s)
=== RUN   TestAccAWSIAMRole_testNameChange
--- PASS: TestAccAWSIAMRole_testNameChange (36.21s)
=== RUN   TestAccAWSIAMRole_badJSON
--- PASS: TestAccAWSIAMRole_badJSON (1.58s)
=== RUN   TestAccAWSIAMRole_force_detach_policies
--- PASS: TestAccAWSIAMRole_force_detach_policies (21.17s)
=== RUN   TestAccAWSIAMRole_MaxSessionDuration
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (29.57s)
=== RUN   TestAccAWSIAMRole_PermissionsBoundary
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (51.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	227.253s
```
