### PR TITLE
data-source/aws_iam_role: Add permissions_boundary attribute

### DIFF
--- a/aws/data_source_aws_iam_role_test.go
+++ b/aws/data_source_aws_iam_role_test.go
@@ -22,6 +22,7 @@ func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "unique_id"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "assume_role_policy"),
 					resource.TestCheckResourceAttr("data.aws_iam_role.test", "path", "/testpath/"),
+					resource.TestCheckResourceAttr("data.aws_iam_role.test", "permissions_boundary", ""),
 					resource.TestCheckResourceAttr("data.aws_iam_role.test", "name", roleName),
 					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "create_date"),
 					resource.TestMatchResourceAttr("data.aws_iam_role.test", "arn",

--- a/website/docs/d/iam_role.html.markdown
+++ b/website/docs/d/iam_role.html.markdown
@@ -30,4 +30,5 @@ data "aws_iam_role" "example" {
 * `arn` - The Amazon Resource Name (ARN) specifying the role.
 * `assume_role_policy` - The policy document associated with the role.
 * `path` - The path to the role.
+* `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the role.
 * `unique_id` - The stable and unique string identifying the role.


### PR DESCRIPTION
Reference: #5174 

Changes proposed in this pull request:

* Add permissions boundary support to `aws_iam_role` data source
* Minor refactoring for newer practices

Output from acceptance testing: AWS Commercial

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMRole_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMRole_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMRole_basic
--- PASS: TestAccAWSDataSourceIAMRole_basic (10.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.867s
```

Output from acceptance testing: AWS GovCloud (US)

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMRole_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMRole_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMRole_basic
--- PASS: TestAccAWSDataSourceIAMRole_basic (19.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.994s
```
