### PR TITLE
data-source/aws_iam_user: Add permissions_boundary attribute

### DIFF
--- a/aws/data_source_aws_iam_user_test.go
+++ b/aws/data_source_aws_iam_user_test.go
@@ -21,8 +21,9 @@ func TestAccAWSDataSourceIAMUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_iam_user.test", "user_id"),
 					resource.TestCheckResourceAttr("data.aws_iam_user.test", "path", "/"),
+					resource.TestCheckResourceAttr("data.aws_iam_user.test", "permissions_boundary", ""),
 					resource.TestCheckResourceAttr("data.aws_iam_user.test", "user_name", userName),
-					resource.TestMatchResourceAttr("data.aws_iam_user.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:user/"+userName)),
+					resource.TestMatchResourceAttr("data.aws_iam_user.test", "arn", regexp.MustCompile("^arn:[^:]+:iam::[0-9]{12}:user/"+userName)),
 				),
 			},
 		},

--- a/website/docs/d/iam_user.html.markdown
+++ b/website/docs/d/iam_user.html.markdown
@@ -27,7 +27,6 @@ data "aws_iam_user" "example" {
 ## Attributes Reference
 
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS for this user.
-
 * `path` - Path in which this user was created.
-
+* `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the user.
 * `user_id` - The unique ID assigned by AWS for this user.


### PR DESCRIPTION
Reference: #5174 

Changes proposed in this pull request:

* Add permissions boundary support to `aws_iam_user` data source
* Minor refactoring for newer practices
* Support AWS GovCloud (US) acceptance testing

Output from acceptance testing: AWS Commercial

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMUser_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMUser_basic
--- PASS: TestAccAWSDataSourceIAMUser_basic (10.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.924s
```

Output from acceptance testing: AWS GovCloud (US)

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMUser_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMUser_basic
--- PASS: TestAccAWSDataSourceIAMUser_basic (19.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.240s
```
