### PR TITLE
r/launch_template: only set credit specification if t2 instance type

### DIFF
--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -161,6 +161,25 @@ func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_nonBurstable(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resName := "aws_launch_template.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_nonBurstable,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -341,3 +360,13 @@ resource "aws_launch_template" "foo" {
 }
 `, rInt)
 }
+
+const testAccAWSLaunchTemplateConfig_nonBurstable = `
+resource "aws_launch_template" "foo" {
+  name = "non-burstable-launch-template"
+  instance_type = "m1.small"
+  credit_specification {
+    cpu_credits = "standard"
+  }
+}
+`


### PR DESCRIPTION
Fixes #5081

Changes proposed in this pull request:

* only set credit specification if t2 instance type

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
go install
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (14.76s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (13.17s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (12.73s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (16.34s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (12.05s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (23.42s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (23.39s)
=== RUN   TestAccAWSLaunchTemplate_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_nonBurstable (11.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	127.287s
```
