### PR TITLE
data-source/aws_acm_certificate:  does not fail if acm certificate is not found

### DIFF
--- a/aws/data_source_aws_acm_certificate.go
+++ b/aws/data_source_aws_acm_certificate.go
@@ -66,7 +66,8 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 		return true
 	})
 	if err != nil {
-		return fmt.Errorf("Error listing certificates: %q", err)
+		log.Printf("[DEBUG] No certificate for domain %s found in this region", target)
+		return nil
 	}
 
 	if len(arns) == 0 {


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/issues/16380

Changes proposed in this pull request:

Data source allows search for acm cert and return null if it does not exist.
It will continue and it will not error

Output from acceptance testing: AWS Commercial
```
$make testacc TEST=./aws TESTARGS="-run=TestAccAWSAcmCertificateDataSource_noMatchReturnsError"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAcmCertificateDataSource_noMatchReturnsError -timeout 120m
=== RUN   TestAccAWSAcmCertificateDataSource_noMatchReturnsError
--- PASS: TestAccAWSAcmCertificateDataSource_noMatchReturnsError (30.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	30.392s
```
