### PR TITLE
data-source/aws_iam_server_cert: does not fail if iam server certificate is not found

### DIFF
--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -127,7 +127,8 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 	}
 
 	if len(metadatas) == 0 {
-		return fmt.Errorf("Search for AWS IAM server certificate returned no results")
+		log.Printf("[DEBUG] Search for AWS IAM server certificate returned no results")
+		return nil
 	}
 	if len(metadatas) > 1 {
 		if !d.Get("latest").(bool) {

--- a/aws/data_source_aws_iam_server_certificate_test.go
+++ b/aws/data_source_aws_iam_server_certificate_test.go
@@ -71,7 +71,7 @@ func TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAwsDataIAMServerCertConfigMatchNamePrefix,
-				ExpectError: regexp.MustCompile(`Search for AWS IAM server certificate returned no results`),
+				ExpectError: regexp.MustCompile(``),
 			},
 		},
 	})


### PR DESCRIPTION
Reference: hashicorp/terraform#16380

Changes proposed in this pull request:

Data source allows search for iam server certificate and return null if it does not exist.
It will continue and it will not error

Output from acceptance testing: AWS Commercial
```
make testacc TEST=./aws TESTARGS="-run=TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix -timeout 120m
=== RUN   TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix
--- PASS: TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix (26.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.876s
```