### PR TITLE
resource/aws_route: Print more useful error message when missing valid target type

### DIFF
--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -206,7 +207,7 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 	default:
-		return fmt.Errorf("An invalid target type specified: %s", setTarget)
+		return fmt.Errorf("A valid target type is missing. Specify one of the following attributes: %s", strings.Join(allowedTargets, ", "))
 	}
 	log.Printf("[DEBUG] Route create config: %s", createOpts)
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Update aws_route error message to list which target types are expected when none are given

The current error message does not actually print anything after the colon since `setTarget` is an empty string, and while it's not too hard to figure out the actual problem, this can save a trip to the documentation.