### PR TITLE
Add support for timeout in api_gateway_integration

### DIFF
--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -138,6 +139,13 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"timeout_milliseconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validateApiGatewayIntegrationTimeout,
+				Default:      29000,
+			},
 		},
 	}
 }
@@ -213,6 +221,11 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		cacheNamespace = aws.String(v.(string))
 	}
 
+	var timeoutInMillis *int64
+	if v, ok := d.GetOk("timeout_milliseconds"); ok {
+		timeoutInMillis = aws.Int64(int64(v.(int)))
+	}
+
 	_, err := conn.PutIntegration(&apigateway.PutIntegrationInput{
 		HttpMethod: aws.String(d.Get("http_method").(string)),
 		ResourceId: aws.String(d.Get("resource_id").(string)),
@@ -229,6 +242,7 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		ContentHandling:     contentHandling,
 		ConnectionType:      connectionType,
 		ConnectionId:        connectionId,
+		TimeoutInMillis:     timeoutInMillis,
 	})
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Integration: %s", err)
@@ -292,6 +306,10 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 
 	if integration.CacheNamespace != nil {
 		d.Set("cache_namespace", integration.CacheNamespace)
+	}
+
+	if integration.TimeoutInMillis != nil {
+		d.Set("timeout_milliseconds", integration.TimeoutInMillis)
 	}
 
 	return nil
@@ -446,6 +464,14 @@ func resourceAwsApiGatewayIntegrationUpdate(d *schema.ResourceData, meta interfa
 			Op:    aws.String("replace"),
 			Path:  aws.String("/connectionId"),
 			Value: aws.String(d.Get("connection_id").(string)),
+		})
+	}
+
+	if d.HasChange("timeout_milliseconds") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/timeoutInMillis"),
+			Value: aws.String(strconv.Itoa(d.Get("timeout_milliseconds").(int))),
 		})
 	}
 

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -37,6 +37,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "timeout_milliseconds", "29000"),
 				),
 			},
 
@@ -56,6 +57,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", "{'foobar': 'bar}"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.text/html", "<html>Foo</html>"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "timeout_milliseconds", "2000"),
 				),
 			},
 
@@ -75,6 +77,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "timeout_milliseconds", "2000"),
 				),
 			},
 
@@ -90,6 +93,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "0"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "timeout_milliseconds", "2000"),
 				),
 			},
 
@@ -108,6 +112,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "timeout_milliseconds", "29000"),
 				),
 			},
 		},
@@ -356,7 +361,7 @@ resource "aws_api_gateway_integration" "test" {
   uri = "https://www.google.de"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
-  content_handling = "CONVERT_TO_TEXT"
+	content_handling = "CONVERT_TO_TEXT"
 }
 `
 
@@ -401,7 +406,8 @@ resource "aws_api_gateway_integration" "test" {
   uri = "https://www.google.de"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
-  content_handling = "CONVERT_TO_TEXT"
+	content_handling = "CONVERT_TO_TEXT"
+	timeout_milliseconds = 2000
 }
 `
 
@@ -446,7 +452,8 @@ resource "aws_api_gateway_integration" "test" {
   uri = "https://www.google.de/updated"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
-  content_handling = "CONVERT_TO_TEXT"
+	content_handling = "CONVERT_TO_TEXT"
+	timeout_milliseconds = 2000
 }
 `
 
@@ -491,7 +498,8 @@ resource "aws_api_gateway_integration" "test" {
   uri = "https://www.google.de"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
-  content_handling = "CONVERT_TO_BINARY"
+	content_handling = "CONVERT_TO_BINARY"
+	timeout_milliseconds = 2000
 }
 `
 
@@ -535,7 +543,8 @@ resource "aws_api_gateway_integration" "test" {
   type = "HTTP"
   uri = "https://www.google.de"
   integration_http_method = "GET"
-  passthrough_behavior = "WHEN_NO_MATCH"
+	passthrough_behavior = "WHEN_NO_MATCH"
+	timeout_milliseconds = 2000
 }
 `
 
@@ -570,7 +579,8 @@ resource "aws_api_gateway_integration" "test" {
   uri = "https://www.google.de"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
-  content_handling = "CONVERT_TO_TEXT"
+	content_handling = "CONVERT_TO_TEXT"
+	timeout_milliseconds = 2000
 }
 `
 
@@ -623,7 +633,8 @@ resource "aws_api_gateway_integration" "test" {
   uri = "https://www.google.de"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
-  content_handling = "CONVERT_TO_TEXT"
+	content_handling = "CONVERT_TO_TEXT"
+	timeout_milliseconds = 2000
 }
 `
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1863,3 +1863,12 @@ func validateNeptuneParamGroupNamePrefix(v interface{}, k string) (ws []string, 
 	}
 	return
 }
+
+func validateApiGatewayIntegrationTimeout(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(int)
+	if value < 50 || value > 29000 {
+		errors = append(errors, fmt.Errorf(
+			"%s must be between 50 and 29000", k))
+	}
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2730,3 +2730,33 @@ func TestValidateNeptuneParamGroupNamePrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateApiGatewayIntegrationTimeout(t *testing.T) {
+	cases := []struct {
+		Value    int
+		ErrCount int
+	}{
+		{
+			Value:    49,
+			ErrCount: 1,
+		},
+		{
+			Value:    29001,
+			ErrCount: 1,
+		},
+		{
+			Value:    50,
+			ErrCount: 0,
+		},
+		{
+			Value:    29000,
+			ErrCount: 0,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := validateApiGatewayIntegrationTimeout(tc.Value, "timeout_milliseconds")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Integration Timeout value to trigger a validation error for timeout of %d ms", tc.Value)
+		}
+	}
+}

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -38,6 +38,7 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   type                 = "MOCK"
   cache_key_parameters = ["method.request.path.param"]
   cache_namespace      = "foobar"
+  timeout_milliseconds = 29000
 
   request_parameters = {
     "integration.request.header.X-Authorization" = "'static'"
@@ -223,3 +224,4 @@ The following arguments are supported:
 * `cache_namespace` - (Optional) The integration's cache namespace.
 * `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
 * `content_handling` - (Optional) Specifies how to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the passthroughBehaviors is configured to support payload pass-through.
+* `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.


### PR DESCRIPTION
Fixes #2405

Changes proposed in this pull request:

* Add `timeout_milliseconds` property to aws_api_gateway_integration
* Add tests for validation of the value
* Add config to existing basic integration acceptance tests

Output from acceptance testing:

```
23:54 $ make testacc TESTARGS='-run TestAccAWSAPIGatewayIntegration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run TestAccAWSAPIGatewayIntegration_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAPIGatewayIntegration_basic
--- PASS: TestAccAWSAPIGatewayIntegration_basic (90.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	90.085s


...
```
