### PR TITLE
New Resource: aws_macie_s3_bucket_association

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -70,6 +70,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
 	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/aws/aws-sdk-go/service/macie"
 	"github.com/aws/aws-sdk-go/service/mediastore"
 	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/aws/aws-sdk-go/service/neptune"
@@ -210,6 +211,7 @@ type AWSClient struct {
 	elastictranscoderconn *elastictranscoder.ElasticTranscoder
 	lambdaconn            *lambda.Lambda
 	lightsailconn         *lightsail.Lightsail
+	macieconn             *macie.Macie
 	mqconn                *mq.MQ
 	opsworksconn          *opsworks.OpsWorks
 	organizationsconn     *organizations.Organizations
@@ -501,6 +503,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.lambdaconn = lambda.New(awsLambdaSess)
 	client.lexmodelconn = lexmodelbuildingservice.New(sess)
 	client.lightsailconn = lightsail.New(sess)
+	client.macieconn = macie.New(sess)
 	client.mqconn = mq.New(sess)
 	client.neptuneconn = neptune.New(sess)
 	client.opsworksconn = opsworks.New(sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -491,6 +491,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_load_balancer_backend_server_policy":          resourceAwsLoadBalancerBackendServerPolicies(),
 			"aws_load_balancer_listener_policy":                resourceAwsLoadBalancerListenerPolicies(),
 			"aws_lb_ssl_negotiation_policy":                    resourceAwsLBSSLNegotiationPolicy(),
+			"aws_macie_s3_bucket_association":                  resourceAwsMacieS3BucketAssociation(),
 			"aws_main_route_table_association":                 resourceAwsMainRouteTableAssociation(),
 			"aws_mq_broker":                                    resourceAwsMqBroker(),
 			"aws_mq_configuration":                             resourceAwsMqConfiguration(),

--- a/aws/resource_aws_macie_s3_bucket_association.go
+++ b/aws/resource_aws_macie_s3_bucket_association.go
@@ -1,0 +1,235 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsMacieS3BucketAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMacieS3BucketAssociationCreate,
+		Read:   resourceAwsMacieS3BucketAssociationRead,
+		Update: resourceAwsMacieS3BucketAssociationUpdate,
+		Delete: resourceAwsMacieS3BucketAssociationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"member_account_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsAccountId,
+			},
+			"classification_type": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"one_time": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsMacieS3BucketAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).macieconn
+
+	req := &macie.AssociateS3ResourcesInput{
+		S3Resources: []*macie.S3ResourceClassification{
+			{
+				BucketName: aws.String(d.Get("bucket_name").(string)),
+			},
+		},
+	}
+	if v, ok := d.GetOk("member_account_id"); ok {
+		req.MemberAccountId = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("prefix"); ok {
+		req.S3Resources[0].Prefix = aws.String(v.(string))
+	}
+
+	ct := &macie.ClassificationType{
+		Continuous: aws.String(macie.S3ContinuousClassificationTypeFull),
+	}
+	ct.OneTime = aws.String(macieS3BucketAssociationOneTimeClassification(d))
+	req.S3Resources[0].ClassificationType = ct
+
+	log.Printf("[DEBUG] Creating Macie S3 bucket association: %#v", req)
+	resp, err := conn.AssociateS3Resources(req)
+	if err != nil {
+		return fmt.Errorf("Error creating Macie S3 bucket association: %s", err)
+	}
+	if len(resp.FailedS3Resources) > 0 {
+		return fmt.Errorf("Error creating Macie S3 bucket association: %s", resp.FailedS3Resources[0])
+	}
+
+	d.SetId(macieS3BucketAssociationId(d))
+	return resourceAwsMacieS3BucketAssociationRead(d, meta)
+}
+
+func resourceAwsMacieS3BucketAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).macieconn
+
+	req := &macie.ListS3ResourcesInput{}
+	if v, ok := d.GetOk("member_account_id"); ok {
+		req.MemberAccountId = aws.String(v.(string))
+	}
+
+	bucketName := d.Get("bucket_name").(string)
+	prefix := d.Get("prefix")
+	var res *macie.S3ResourceClassification
+	for {
+		resp, err := conn.ListS3Resources(req)
+		if err != nil {
+			return fmt.Errorf("Error listing Macie S3 bucket associations: %s", err)
+		}
+
+		for _, v := range resp.S3Resources {
+			if aws.StringValue(v.BucketName) == bucketName && aws.StringValue(v.Prefix) == prefix {
+				res = v
+				break
+			}
+		}
+		if res != nil {
+			break
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+		req.NextToken = resp.NextToken
+	}
+
+	if res == nil {
+		log.Printf("[WARN] Macie S3 bucket association (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	m := map[string]interface{}{}
+	if aws.StringValue(res.ClassificationType.OneTime) == macie.S3OneTimeClassificationTypeFull {
+		m["one_time"] = true
+	} else {
+		m["one_time"] = false
+	}
+	if err := d.Set("classification_type", []map[string]interface{}{m}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsMacieS3BucketAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).macieconn
+
+	if d.HasChange("classification_type") {
+		req := &macie.UpdateS3ResourcesInput{
+			S3ResourcesUpdate: []*macie.S3ResourceClassificationUpdate{
+				{
+					BucketName:               aws.String(d.Get("bucket_name").(string)),
+					ClassificationTypeUpdate: &macie.ClassificationTypeUpdate{},
+				},
+			},
+		}
+		if v, ok := d.GetOk("member_account_id"); ok {
+			req.MemberAccountId = aws.String(v.(string))
+		}
+		if v, ok := d.GetOk("prefix"); ok {
+			req.S3ResourcesUpdate[0].Prefix = aws.String(v.(string))
+		}
+		req.S3ResourcesUpdate[0].ClassificationTypeUpdate.OneTime = aws.String(macieS3BucketAssociationOneTimeClassification(d))
+
+		log.Printf("[DEBUG] Updating Macie S3 bucket association: %#v", req)
+		resp, err := conn.UpdateS3Resources(req)
+		if err != nil {
+			return fmt.Errorf("Error updating Macie S3 bucket association: %s", err)
+		}
+		if len(resp.FailedS3Resources) > 0 {
+			return fmt.Errorf("Error updating Macie S3 bucket association: %s", resp.FailedS3Resources[0])
+		}
+	}
+
+	return resourceAwsMacieS3BucketAssociationRead(d, meta)
+}
+
+func resourceAwsMacieS3BucketAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).macieconn
+
+	log.Printf("[DEBUG] Deleting Macie S3 bucket association: %s", d.Id())
+
+	req := &macie.DisassociateS3ResourcesInput{
+		AssociatedS3Resources: []*macie.S3Resource{
+			{
+				BucketName: aws.String(d.Get("bucket_name").(string)),
+			},
+		},
+	}
+	if v, ok := d.GetOk("member_account_id"); ok {
+		req.MemberAccountId = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("prefix"); ok {
+		req.AssociatedS3Resources[0].Prefix = aws.String(v.(string))
+	}
+
+	resp, err := conn.DisassociateS3Resources(req)
+	if err != nil {
+		return fmt.Errorf("Error deleting Macie S3 bucket association: %s", err)
+	}
+	if len(resp.FailedS3Resources) > 0 {
+		failed := resp.FailedS3Resources[0]
+		// {
+		// 	ErrorCode: "InvalidInputException",
+		// 	ErrorMessage: "The request was rejected. The specified S3 resource (bucket or prefix) is not associated with Macie.",
+		// 	FailedItem: {
+		// 	 BucketName: "tf-macie-example-002"
+		// 	}
+		// }
+		if aws.StringValue(failed.ErrorCode) == macie.ErrCodeInvalidInputException &&
+			strings.Contains(aws.StringValue(failed.ErrorMessage), "is not associated with Macie") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Macie S3 bucket association: %s", failed)
+	}
+
+	return nil
+}
+
+func macieS3BucketAssociationId(d *schema.ResourceData) string {
+	return fmt.Sprintf("%s/%s", d.Get("bucket_name"), d.Get("prefix"))
+}
+
+func macieS3BucketAssociationOneTimeClassification(d *schema.ResourceData) string {
+	oneTime := false
+	if v := d.Get("classification_type").([]interface{}); len(v) > 0 {
+		if m := v[0].(map[string]interface{}); m["one_time"].(bool) {
+			oneTime = true
+		}
+	}
+	if oneTime {
+		return macie.S3OneTimeClassificationTypeFull
+	} else {
+		return macie.S3OneTimeClassificationTypeNone
+	}
+}

--- a/aws/resource_aws_macie_s3_bucket_association_test.go
+++ b/aws/resource_aws_macie_s3_bucket_association_test.go
@@ -1,0 +1,174 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/macie"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSMacieS3BucketAssociation_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSMacieS3BucketAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMacieS3BucketAssociationConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMacieS3BucketAssociationExists("aws_macie_s3_bucket_association.test"),
+					resource.TestCheckResourceAttr("aws_macie_s3_bucket_association.test", "classification_type.0.one_time", "false"),
+				),
+			},
+			{
+				Config: testAccAWSMacieS3BucketAssociationConfig_basicOneTime(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMacieS3BucketAssociationExists("aws_macie_s3_bucket_association.test"),
+					resource.TestCheckResourceAttr("aws_macie_s3_bucket_association.test", "classification_type.0.one_time", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSMacieS3BucketAssociation_accountIdAndPrefix(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSMacieS3BucketAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSMacieS3BucketAssociationConfig_accountIdAndPrefix(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMacieS3BucketAssociationExists("aws_macie_s3_bucket_association.test"),
+					resource.TestCheckResourceAttr("aws_macie_s3_bucket_association.test", "classification_type.0.one_time", "false"),
+				),
+			},
+			{
+				Config: testAccAWSMacieS3BucketAssociationConfig_accountIdAndPrefixOneTime(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSMacieS3BucketAssociationExists("aws_macie_s3_bucket_association.test"),
+					resource.TestCheckResourceAttr("aws_macie_s3_bucket_association.test", "classification_type.0.one_time", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSMacieS3BucketAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).macieconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_macie_s3_bucket_association" {
+			continue
+		}
+
+		req := &macie.ListS3ResourcesInput{}
+		acctId := rs.Primary.Attributes["member_account_id"]
+		if acctId != "" {
+			req.MemberAccountId = aws.String(acctId)
+		}
+
+		for {
+			resp, err := conn.ListS3Resources(req)
+			if err != nil {
+				return err
+			}
+
+			for _, v := range resp.S3Resources {
+				if aws.StringValue(v.BucketName) == rs.Primary.Attributes["bucket_name"] && aws.StringValue(v.Prefix) == rs.Primary.Attributes["prefix"] {
+					return fmt.Errorf("S3 resource %s/%s is not dissociated from Macie", rs.Primary.Attributes["bucket_name"], rs.Primary.Attributes["prefix"])
+				}
+			}
+
+			if resp.NextToken == nil {
+				break
+			}
+			req.NextToken = resp.NextToken
+		}
+	}
+	return nil
+}
+
+func testAccCheckAWSMacieS3BucketAssociationExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSMacieS3BucketAssociationConfig_basic(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = "tf-macie-test-bucket-%d"
+}
+
+resource "aws_macie_s3_bucket_association" "test" {
+  bucket_name = "${aws_s3_bucket.test.id}"
+}
+`, randInt)
+}
+
+func testAccAWSMacieS3BucketAssociationConfig_basicOneTime(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = "tf-macie-test-bucket-%d"
+}
+
+resource "aws_macie_s3_bucket_association" "test" {
+  bucket_name = "${aws_s3_bucket.test.id}"
+
+  classification_type {
+    one_time = true
+  }
+}
+`, randInt)
+}
+
+func testAccAWSMacieS3BucketAssociationConfig_accountIdAndPrefix(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = "tf-macie-test-bucket-%d"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_macie_s3_bucket_association" "test" {
+  bucket_name       = "${aws_s3_bucket.test.id}"
+  member_account_id = "${data.aws_caller_identity.current.account_id}"
+  prefix            = "data"
+}
+`, randInt)
+}
+
+func testAccAWSMacieS3BucketAssociationConfig_accountIdAndPrefixOneTime(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = "tf-macie-test-bucket-%d"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_macie_s3_bucket_association" "test" {
+  bucket_name       = "${aws_s3_bucket.test.id}"
+  member_account_id = "${data.aws_caller_identity.current.account_id}"
+  prefix            = "data"
+
+  classification_type {
+    one_time = true
+  }
+}
+`, randInt)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1509,6 +1509,17 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-macie") %>>
+                    <a href="#">Macie Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-macie-s3-bucket-association") %>>
+                            <a href="/docs/providers/aws/r/macie_s3_bucket_association.html">aws_macie_s3_bucket_association</a>
+                        </li>
+
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current("docs-aws-resource-mq") %>>
                     <a href="#">MQ Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/macie_s3_bucket_association.html.markdown
+++ b/website/docs/r/macie_s3_bucket_association.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "aws"
+page_title: "AWS: aws_macie_s3_bucket_association"
+sidebar_current: "docs-aws-macie-s3-bucket-association"
+description: |-
+  Associates an S3 resource with Amazon Macie for monitoring and data classification.
+---
+
+# aws_macie_s3_bucket_association
+
+Associates an S3 resource with Amazon Macie for monitoring and data classification.
+
+## Example Usage
+
+```hcl
+resource "aws_macie_s3_bucket_association" "example" {
+  bucket_name = "tf-macie-example"
+  prefix      = "data"
+
+  classification_type {
+    one_time = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket_name` - (Required) The name of the S3 bucket that you want to associate with Amazon Macie.
+* `classification_type` - (Optional) The configuration of how Amazon Macie classifies the S3 objects.
+* `member_account_id` - (Optional) The ID of the Amazon Macie member account whose S3 resources you want to associate with Macie. If `member_account_id` isn't specified, the action associates specified S3 resources with Macie for the current master account.
+* `prefix` - (Optional) Object key prefix identifying one or more S3 objects to which the association applies.
+
+The `classification_type` object supports the following:
+
+* `one_time` - (Optional) A boolean value indicating whether or not Macie perfoms a one-time classification of all of the existing objects in the bucket. Defaults to `false` indicating that Macie only classifies objects that are added after the association was created.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the association.


### PR DESCRIPTION
Fixes #4992.
This is the initial Amazon Macie resource, associating S3 resources with Amazon Macie for monitoring and data classification.

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSMacieS3BucketAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSMacieS3BucketAssociation_ -timeout 120m
=== RUN   TestAccAWSMacieS3BucketAssociation_basic
--- PASS: TestAccAWSMacieS3BucketAssociation_basic (67.79s)
=== RUN   TestAccAWSMacieS3BucketAssociation_accountIdAndPrefix
--- PASS: TestAccAWSMacieS3BucketAssociation_accountIdAndPrefix (71.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	152.742s
```