### PR TITLE
[Docs] Update docs to denote "renderingFailure" event type

### DIFF
--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the event destination
 * `configuration_set_name` - (Required) The name of the configuration set
 * `enabled` - (Optional) If true, the event destination will be enabled
-* `matching_types` - (Required) A list of matching types. May be any of `"send"`, `"reject"`, `"bounce"`, `"complaint"`, `"delivery"`, `"open"`, or `"click"`.
+* `matching_types` - (Required) A list of matching types. May be any of `"send"`, `"reject"`, `"bounce"`, `"complaint"`, `"delivery"`, `"open"`, `"click"`, or `"renderingFailure"`.
 * `cloudwatch_destination` - (Optional) CloudWatch destination for the events
 * `kinesis_destination` - (Optional) Send the events to a kinesis firehose destination
 * `sns_destination` - (Optional) Send the events to an SNS Topic destination


### PR DESCRIPTION
The documentation has a missing option. Added it to match code.

References:
- https://github.com/terraform-providers/terraform-provider-aws/blob/ee46189350e2bb18cea4c86e4e6f713948afc8ae/aws/resource_aws_ses_event_destination.go#L57
- https://github.com/aws/aws-sdk-go/blob/master/service/ses/api.go#L15019