### PR TITLE
Use GetParameter instead of GetParameters in SSM parameter data

### DIFF
--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -70,9 +70,9 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 		Resource:  fmt.Sprintf("parameter/%s", strings.TrimPrefix(d.Id(), "/")),
 	}
 	d.Set("arn", arn.String())
-	d.Set("name", *param.Name)
-	d.Set("type", *param.Type)
-	d.Set("value", *param.Value)
+	d.Set("name", param.Name)
+	d.Set("type", param.Type)
+	d.Set("value", param.Value)
 
 	return nil
 }

--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -47,25 +47,19 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 
-	paramInput := &ssm.GetParametersInput{
-		Names: []*string{
-			aws.String(name),
-		},
+	paramInput := &ssm.GetParameterInput{
+		Name:           aws.String(name),
 		WithDecryption: aws.Bool(d.Get("with_decryption").(bool)),
 	}
 
 	log.Printf("[DEBUG] Reading SSM Parameter: %s", paramInput)
-	resp, err := ssmconn.GetParameters(paramInput)
+	resp, err := ssmconn.GetParameter(paramInput)
 
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error describing SSM parameter: {{err}}", err)
 	}
 
-	if len(resp.InvalidParameters) > 0 {
-		return fmt.Errorf("[ERROR] SSM Parameter %s is invalid", name)
-	}
-
-	param := resp.Parameters[0]
+	param := resp.Parameter
 	d.SetId(*param.Name)
 
 	arn := arn.ARN{
@@ -76,9 +70,9 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 		Resource:  fmt.Sprintf("parameter/%s", strings.TrimPrefix(d.Id(), "/")),
 	}
 	d.Set("arn", arn.String())
-	d.Set("name", param.Name)
-	d.Set("type", param.Type)
-	d.Set("value", param.Value)
+	d.Set("name", *param.Name)
+	d.Set("type", *param.Type)
+	d.Set("value", *param.Value)
 
 	return nil
 }


### PR DESCRIPTION
Changes proposed in this pull request:

* Use GetParameter instead of GetParameters in SSM parameter data. This datasource only handles one SSM parameter. It shouldn't call the function that returns a list.

Output from acceptance testing:

```
TESTARGS='-run=TestAccAWSSsmParameterDataSource_'  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSsmParameterDataSource_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSsmParameterDataSource_basic
--- PASS: TestAccAWSSsmParameterDataSource_basic (39.04s)
=== RUN   TestAccAWSSsmParameterDataSource_fullPath
--- PASS: TestAccAWSSsmParameterDataSource_fullPath (20.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       59.828s
...
```
