### PR TITLE
Optimize resource_aws_ssm_parameter

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -72,16 +72,18 @@ func resourceAwsSsmParameter() *schema.Resource {
 
 func resourceAwsSmmParameterExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	ssmconn := meta.(*AWSClient).ssmconn
-
-	resp, err := ssmconn.GetParameters(&ssm.GetParametersInput{
-		Names:          []*string{aws.String(d.Id())},
-		WithDecryption: aws.Bool(true),
+	_, err := ssmconn.GetParameter(&ssm.GetParameterInput{
+		Name:           aws.String(d.Id()),
+		WithDecryption: aws.Bool(false),
 	})
-
 	if err != nil {
+		if isAWSErr(err, ssm.ErrCodeParameterNotFound, "") {
+			return false, nil
+		}
 		return false, err
 	}
-	return len(resp.InvalidParameters) == 0, nil
+
+	return true, nil
 }
 
 func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
@@ -89,20 +91,15 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Reading SSM Parameter: %s", d.Id())
 
-	resp, err := ssmconn.GetParameters(&ssm.GetParametersInput{
-		Names:          []*string{aws.String(d.Id())},
+	resp, err := ssmconn.GetParameter(&ssm.GetParameterInput{
+		Name:           aws.String(d.Id()),
 		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {
 		return fmt.Errorf("error getting SSM parameter: %s", err)
 	}
-	if len(resp.Parameters) == 0 {
-		log.Printf("[WARN] SSM Param %q not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
 
-	param := resp.Parameters[0]
+	param := resp.Parameter
 	d.Set("name", param.Name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)
@@ -114,6 +111,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 				Values: []*string{aws.String(d.Get("name").(string))},
 			},
 		},
+		MaxResults: aws.Int64(50),
 	}
 	detailedParameters := []*ssm.ParameterMetadata{}
 	err = ssmconn.DescribeParametersPages(describeParamsInput,


### PR DESCRIPTION
Changes proposed in this pull request:
* Changed resource_aws_ssm_parameter to use GetParameter instead of GetParameters
* Set MaxResults of DescribeParameters to 50 (maximum value)

Output from acceptance testing:

```
TESTARGS='-run=TestAccAWSSSMParameter_'  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSSMParameter_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMParameter_importBasic
--- PASS: TestAccAWSSSMParameter_importBasic (20.12s)
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (16.35s)
=== RUN   TestAccAWSSSMParameter_disappears
--- PASS: TestAccAWSSSMParameter_disappears (10.70s)
=== RUN   TestAccAWSSSMParameter_update
--- PASS: TestAccAWSSSMParameter_update (28.46s)
=== RUN   TestAccAWSSSMParameter_updateDescription
--- PASS: TestAccAWSSSMParameter_updateDescription (26.93s)
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (29.84s)
=== RUN   TestAccAWSSSMParameter_fullPath
--- PASS: TestAccAWSSSMParameter_fullPath (16.46s)
=== RUN   TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_secure (16.27s)
=== RUN   TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_secure_with_key (47.42s)
=== RUN   TestAccAWSSSMParameter_secure_keyUpdate
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (59.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       272.432s
```
