### PR TITLE
resource/aws_rds_cluster_instance: Add arn attribute

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/rds"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -31,6 +30,11 @@ func resourceAwsRDSClusterInstance() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"identifier": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -359,22 +363,23 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 		d.Set("db_subnet_group_name", db.DBSubnetGroup.DBSubnetGroupName)
 	}
 
-	d.Set("publicly_accessible", db.PubliclyAccessible)
-	d.Set("cluster_identifier", db.DBClusterIdentifier)
-	d.Set("engine", db.Engine)
-	d.Set("engine_version", db.EngineVersion)
-	d.Set("instance_class", db.DBInstanceClass)
-	d.Set("identifier", db.DBInstanceIdentifier)
-	d.Set("dbi_resource_id", db.DbiResourceId)
-	d.Set("storage_encrypted", db.StorageEncrypted)
-	d.Set("kms_key_id", db.KmsKeyId)
+	d.Set("arn", db.DBInstanceArn)
 	d.Set("auto_minor_version_upgrade", db.AutoMinorVersionUpgrade)
-	d.Set("promotion_tier", db.PromotionTier)
-	d.Set("preferred_backup_window", db.PreferredBackupWindow)
-	d.Set("preferred_maintenance_window", db.PreferredMaintenanceWindow)
 	d.Set("availability_zone", db.AvailabilityZone)
+	d.Set("cluster_identifier", db.DBClusterIdentifier)
+	d.Set("dbi_resource_id", db.DbiResourceId)
+	d.Set("engine_version", db.EngineVersion)
+	d.Set("engine", db.Engine)
+	d.Set("identifier", db.DBInstanceIdentifier)
+	d.Set("instance_class", db.DBInstanceClass)
+	d.Set("kms_key_id", db.KmsKeyId)
 	d.Set("performance_insights_enabled", db.PerformanceInsightsEnabled)
 	d.Set("performance_insights_kms_key_id", db.PerformanceInsightsKMSKeyId)
+	d.Set("preferred_backup_window", db.PreferredBackupWindow)
+	d.Set("preferred_maintenance_window", db.PreferredMaintenanceWindow)
+	d.Set("promotion_tier", db.PromotionTier)
+	d.Set("publicly_accessible", db.PubliclyAccessible)
+	d.Set("storage_encrypted", db.StorageEncrypted)
 
 	if db.MonitoringInterval != nil {
 		d.Set("monitoring_interval", db.MonitoringInterval)
@@ -388,15 +393,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 		d.Set("db_parameter_group_name", db.DBParameterGroups[0].DBParameterGroupName)
 	}
 
-	// Fetch and save tags
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("db:%s", d.Id()),
-	}.String()
-	if err := saveTagsRDS(conn, d, arn); err != nil {
+	if err := saveTagsRDS(conn, d, aws.StringValue(db.DBInstanceArn)); err != nil {
 		log.Printf("[WARN] Failed to save tags for RDS Cluster Instance (%s): %s", *db.DBClusterIdentifier, err)
 	}
 
@@ -505,14 +502,7 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("db:%s", d.Id()),
-	}.String()
-	if err := setTagsRDS(conn, d, arn); err != nil {
+	if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
 		return err
 	}
 

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -29,6 +29,7 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.cluster_instances", &v),
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
+					resource.TestMatchResourceAttr("aws_rds_cluster_instance.cluster_instances", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:[^:]+:db:.+`)),
 					resource.TestCheckResourceAttr("aws_rds_cluster_instance.cluster_instances", "auto_minor_version_upgrade", "true"),
 					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "preferred_maintenance_window"),
 					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "preferred_backup_window"),

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -97,6 +97,7 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - Amazon Resource Name (ARN) of cluster instance
 * `cluster_identifier` - The RDS Cluster Identifier
 * `identifier` - The Instance identifier
 * `id` - The Instance identifier


### PR DESCRIPTION
Changes proposed in this pull request:

* Use API provided ARN instead of manually created one
* Add `arn` attribute to `aws_rds_cluster_instance` resource

Output from acceptance testing:

```
9 tests passed (all tests)
=== RUN   TestAccAWSRDSClusterInstance_generatedName
--- PASS: TestAccAWSRDSClusterInstance_generatedName (587.09s)
=== RUN   TestAccAWSRDSClusterInstance_az
--- PASS: TestAccAWSRDSClusterInstance_az (616.64s)
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (617.55s)
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (656.90s)
=== RUN   TestAccAWSRDSClusterInstance_importBasic
--- PASS: TestAccAWSRDSClusterInstance_importBasic (686.30s)
=== RUN   TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (706.43s)
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (734.96s)
=== RUN   TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSClusterInstance_disappears (751.92s)
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (2148.03s)
```
