### PR TITLE
aws_rds_cluster: Add arn attribute

### DIFF
--- a/aws/data_source_aws_rds_cluster.go
+++ b/aws/data_source_aws_rds_cluster.go
@@ -14,6 +14,11 @@ func dataSourceAwsRdsCluster() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAwsRdsClusterRead,
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"cluster_identifier": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceAwsRdsCluster_basic(t *testing.T) {
+func TestAccDataSourceAWSRDSCluster_basic(t *testing.T) {
 	clusterName := fmt.Sprintf("testaccawsrdscluster-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	dataSourceName := "data.aws_rds_cluster.test"
+	resourceName := "aws_rds_cluster.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -18,13 +20,14 @@ func TestAccDataSourceAwsRdsCluster_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsRdsClusterConfigBasic(clusterName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "cluster_identifier", clusterName),
-					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "database_name", "mydb"),
-					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "db_cluster_parameter_group_name", "default.aurora5.6"),
-					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "db_subnet_group_name", clusterName),
-					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "master_username", "foo"),
-					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("data.aws_rds_cluster.rds_cluster_test", "tags.Environment", "test"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_identifier", resourceName, "cluster_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "database_name", resourceName, "database_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "db_cluster_parameter_group_name", resourceName, "db_cluster_parameter_group_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "db_subnet_group_name", resourceName, "db_subnet_group_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "master_username", resourceName, "master_username"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Environment", resourceName, "tags.Environment"),
 				),
 			},
 		},
@@ -32,7 +35,7 @@ func TestAccDataSourceAwsRdsCluster_basic(t *testing.T) {
 }
 
 func testAccDataSourceAwsRdsClusterConfigBasic(clusterName string) string {
-	return fmt.Sprintf(`resource "aws_rds_cluster" "rds_cluster_test" {
+	return fmt.Sprintf(`resource "aws_rds_cluster" "test" {
 	cluster_identifier = "%s"
 	database_name = "mydb"
 	db_cluster_parameter_group_name = "default.aurora5.6"
@@ -74,7 +77,7 @@ resource "aws_db_subnet_group" "test" {
 	subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
 }
 
-data "aws_rds_cluster" "rds_cluster_test" {
-	cluster_identifier = "${aws_rds_cluster.rds_cluster_test.cluster_identifier}"
+data "aws_rds_cluster" "test" {
+	cluster_identifier = "${aws_rds_cluster.test.cluster_identifier}"
 }`, clusterName, clusterName)
 }

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -33,6 +32,10 @@ func resourceAwsRDSCluster() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
 			"availability_zones": {
 				Type:     schema.TypeSet,
@@ -819,25 +822,26 @@ func flattenAwsRdsClusterResource(d *schema.ResourceData, meta interface{}, dbc 
 		d.Set("database_name", dbc.DatabaseName)
 	}
 
+	d.Set("arn", dbc.DBClusterArn)
 	d.Set("backtrack_window", int(aws.Int64Value(dbc.BacktrackWindow)))
+	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
 	d.Set("cluster_identifier", dbc.DBClusterIdentifier)
 	d.Set("cluster_resource_id", dbc.DbClusterResourceId)
-	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
 	d.Set("db_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
+	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
 	d.Set("endpoint", dbc.Endpoint)
-	d.Set("engine", dbc.Engine)
 	d.Set("engine_version", dbc.EngineVersion)
+	d.Set("engine", dbc.Engine)
+	d.Set("hosted_zone_id", dbc.HostedZoneId)
+	d.Set("iam_database_authentication_enabled", dbc.IAMDatabaseAuthenticationEnabled)
+	d.Set("kms_key_id", dbc.KmsKeyId)
 	d.Set("master_username", dbc.MasterUsername)
 	d.Set("port", dbc.Port)
-	d.Set("storage_encrypted", dbc.StorageEncrypted)
-	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
 	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", dbc.PreferredMaintenanceWindow)
-	d.Set("kms_key_id", dbc.KmsKeyId)
 	d.Set("reader_endpoint", dbc.ReaderEndpoint)
 	d.Set("replication_source_identifier", dbc.ReplicationSourceIdentifier)
-	d.Set("iam_database_authentication_enabled", dbc.IAMDatabaseAuthenticationEnabled)
-	d.Set("hosted_zone_id", dbc.HostedZoneId)
+	d.Set("storage_encrypted", dbc.StorageEncrypted)
 
 	if err := d.Set("enabled_cloudwatch_logs_exports", flattenStringList(dbc.EnabledCloudwatchLogsExports)); err != nil {
 		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %s", err)
@@ -869,14 +873,7 @@ func flattenAwsRdsClusterResource(d *schema.ResourceData, meta interface{}, dbc 
 	}
 
 	// Fetch and save tags
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("cluster:%s", d.Id()),
-	}.String()
-	if err := saveTagsRDS(conn, d, arn); err != nil {
+	if err := saveTagsRDS(conn, d, aws.StringValue(dbc.DBClusterArn)); err != nil {
 		log.Printf("[WARN] Failed to save tags for RDS Cluster (%s): %s", *dbc.DBClusterIdentifier, err)
 	}
 
@@ -1006,14 +1003,7 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("cluster:%s", d.Id()),
-	}.String()
-	if err := setTagsRDS(conn, d, arn); err != nil {
+	if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -31,6 +31,7 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 				Config: testAccAWSClusterConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "backtrack_window", "0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
 					resource.TestCheckResourceAttr(resourceName, "db_cluster_parameter_group_name", "default.aurora5.6"),

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -154,6 +154,7 @@ This will not recreate the resource if the S3 object changes in some way. It's o
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - Amazon Resource Name (ARN) of cluster
 * `id` - The RDS Cluster Identifier
 * `cluster_identifier` - The RDS Cluster Identifier
 * `cluster_resource_id` - The RDS Cluster Resource ID


### PR DESCRIPTION
Changes proposed in this pull request:

* Use API provided ARN instead of manually created one
* Add `arn` attribute to `aws_rds_cluster` resource
* Add `arn` attribute to `aws_rds_cluster` data source

Output from acceptance testing:

```
19 tests passed (all tests)
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (3.99s)
=== RUN   TestAccAWSRDSCluster_updateTags
--- PASS: TestAccAWSRDSCluster_updateTags (105.37s)
=== RUN   TestAccAWSRDSCluster_takeFinalSnapshot
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (108.83s)
=== RUN   TestAccAWSRDSCluster_iamAuth
--- PASS: TestAccAWSRDSCluster_iamAuth (109.02s)
=== RUN   TestAccAWSRDSCluster_encrypted
--- PASS: TestAccAWSRDSCluster_encrypted (109.18s)
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (109.53s)
=== RUN   TestAccAWSRDSCluster_importBasic
--- PASS: TestAccAWSRDSCluster_importBasic (110.01s)
=== RUN   TestAccAWSRDSCluster_EngineVersion
--- PASS: TestAccAWSRDSCluster_EngineVersion (110.46s)
=== RUN   TestAccAWSRDSCluster_namePrefix
--- PASS: TestAccAWSRDSCluster_namePrefix (112.04s)
=== RUN   TestAccAWSRDSCluster_generatedName
--- PASS: TestAccAWSRDSCluster_generatedName (112.11s)
=== RUN   TestAccAWSRDSCluster_kmsKey
--- PASS: TestAccAWSRDSCluster_kmsKey (117.09s)
=== RUN   TestAccAWSRDSCluster_BacktrackWindow
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (117.20s)
=== RUN   TestAccAWSRDSCluster_updateCloudwatchLogsExports
--- PASS: TestAccAWSRDSCluster_updateCloudwatchLogsExports (124.09s)
=== RUN   TestAccAWSRDSCluster_backupsUpdate
--- PASS: TestAccAWSRDSCluster_backupsUpdate (124.15s)
=== RUN   TestAccAWSRDSCluster_updateIamRoles
--- PASS: TestAccAWSRDSCluster_updateIamRoles (124.63s)
=== RUN   TestAccDataSourceAWSRDSCluster_basic
--- PASS: TestAccDataSourceAWSRDSCluster_basic (143.74s)
=== RUN   TestAccAWSRDSCluster_Port
--- PASS: TestAccAWSRDSCluster_Port (210.26s)
=== RUN   TestAccAWSRDSCluster_EncryptedCrossRegionReplication
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1477.97s)
=== RUN   TestAccAWSRDSCluster_s3Restore
--- PASS: TestAccAWSRDSCluster_s3Restore (1513.79s)
```
