### PR TITLE
resource/aws_rds_cluster_parameter_group: Use API provided ARN instead of manually generating

### DIFF
--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 
@@ -27,11 +26,11 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -39,7 +38,7 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateDbParamGroupName,
 			},
-			"name_prefix": &schema.Schema{
+			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -47,32 +46,32 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 				ConflictsWith: []string{"name"},
 				ValidateFunc:  validateDbParamGroupNamePrefix,
 			},
-			"family": &schema.Schema{
+			"family": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Default:  "Managed by Terraform",
 			},
-			"parameter": &schema.Schema{
+			"parameter": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"apply_method": &schema.Schema{
+						"apply_method": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "immediate",
@@ -116,13 +115,16 @@ func resourceAwsRDSClusterParameterGroupCreate(d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Create DB Cluster Parameter Group: %#v", createOpts)
-	_, err := rdsconn.CreateDBClusterParameterGroup(&createOpts)
+	output, err := rdsconn.CreateDBClusterParameterGroup(&createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating DB Cluster Parameter Group: %s", err)
 	}
 
 	d.SetId(*createOpts.DBClusterParameterGroupName)
 	log.Printf("[INFO] DB Cluster Parameter Group ID: %s", d.Id())
+
+	// Set for update
+	d.Set("arn", output.DBClusterParameterGroup.DBClusterParameterGroupArn)
 
 	return resourceAwsRDSClusterParameterGroupUpdate(d, meta)
 }
@@ -150,9 +152,11 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Unable to find Cluster Parameter Group: %#v", describeResp.DBClusterParameterGroups)
 	}
 
-	d.Set("name", describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName)
-	d.Set("family", describeResp.DBClusterParameterGroups[0].DBParameterGroupFamily)
+	arn := aws.StringValue(describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupArn)
+	d.Set("arn", arn)
 	d.Set("description", describeResp.DBClusterParameterGroups[0].Description)
+	d.Set("family", describeResp.DBClusterParameterGroups[0].DBParameterGroupFamily)
+	d.Set("name", describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName)
 
 	// Only include user customized parameters as there's hundreds of system/default ones
 	describeParametersOpts := rds.DescribeDBClusterParametersInput{
@@ -167,14 +171,6 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 
 	d.Set("parameter", flattenParameters(describeParametersResp.Parameters))
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("cluster-pg:%s", d.Id()),
-	}.String()
-	d.Set("arn", arn)
 	resp, err := rdsconn.ListTagsForResource(&rds.ListTagsForResourceInput{
 		ResourceName: aws.String(arn),
 	})
@@ -240,14 +236,7 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 		}
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("cluster-pg:%s", d.Id()),
-	}.String()
-	if err := setTagsRDS(rdsconn, d, arn); err != nil {
+	if err := setTagsRDS(rdsconn, d, d.Get("arn").(string)); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")

--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -30,6 +30,7 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
 					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestMatchResourceAttr("aws_rds_cluster_parameter_group.bar", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Changes proposed in this pull request:

* Use API provided ARN instead of manually generating
* Remove extraneous `&schema.Schema` in attributes

Output from acceptance testing:

```
6 tests passed (all tests)
=== RUN   TestAccAWSDBClusterParameterGroup_disappears
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (5.43s)
=== RUN   TestAccAWSDBClusterParameterGroupOnly
--- PASS: TestAccAWSDBClusterParameterGroupOnly (6.84s)
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (6.89s)
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (6.91s)
=== RUN   TestAccAWSDBClusterParameterGroup_importBasic
--- PASS: TestAccAWSDBClusterParameterGroup_importBasic (7.72s)
=== RUN   TestAccAWSDBClusterParameterGroup_basic
--- PASS: TestAccAWSDBClusterParameterGroup_basic (11.48s)
```
