### PR TITLE
resource/aws_db_option_group: Use API provided ARN instead of manually created one

### DIFF
--- a/aws/resource_aws_db_option_group.go
+++ b/aws/resource_aws_db_option_group.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -146,13 +144,16 @@ func resourceAwsDbOptionGroupCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	log.Printf("[DEBUG] Create DB Option Group: %#v", createOpts)
-	_, err := rdsconn.CreateOptionGroup(createOpts)
+	output, err := rdsconn.CreateOptionGroup(createOpts)
 	if err != nil {
 		return fmt.Errorf("Error creating DB Option Group: %s", err)
 	}
 
 	d.SetId(strings.ToLower(groupName))
 	log.Printf("[INFO] DB Option Group ID: %s", d.Id())
+
+	// Set for update
+	d.Set("arn", output.OptionGroup.OptionGroupArn)
 
 	return resourceAwsDbOptionGroupUpdate(d, meta)
 }
@@ -166,12 +167,10 @@ func resourceAwsDbOptionGroupRead(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Describe DB Option Group: %#v", params)
 	options, err := rdsconn.DescribeOptionGroups(params)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if "OptionGroupNotFoundFault" == awsErr.Code() {
-				d.SetId("")
-				log.Printf("[DEBUG] DB Option Group (%s) not found", d.Get("name").(string))
-				return nil
-			}
+		if isAWSErr(err, rds.ErrCodeOptionGroupNotFoundFault, "") {
+			d.SetId("")
+			log.Printf("[DEBUG] DB Option Group (%s) not found", d.Get("name").(string))
+			return nil
 		}
 		return fmt.Errorf("Error Describing DB Option Group: %s", err)
 	}
@@ -196,13 +195,7 @@ func resourceAwsDbOptionGroupRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("option", flattenOptions(option.Options))
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("og:%s", d.Id()),
-	}.String()
+	arn := aws.StringValue(option.OptionGroupArn)
 	d.Set("arn", arn)
 	resp, err := rdsconn.ListTagsForResource(&rds.ListTagsForResourceInput{
 		ResourceName: aws.String(arn),
@@ -288,14 +281,7 @@ func resourceAwsDbOptionGroupUpdate(d *schema.ResourceData, meta interface{}) er
 
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("og:%s", d.Id()),
-	}.String()
-	if err := setTagsRDS(rdsconn, d, arn); err != nil {
+	if err := setTagsRDS(rdsconn, d, d.Get("arn").(string)); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
@@ -315,11 +301,9 @@ func resourceAwsDbOptionGroupDelete(d *schema.ResourceData, meta interface{}) er
 	ret := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := rdsconn.DeleteOptionGroup(deleteOpts)
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				if awsErr.Code() == "InvalidOptionGroupStateFault" {
-					log.Printf("[DEBUG] AWS believes the RDS Option Group is still in use, retrying")
-					return resource.RetryableError(awsErr)
-				}
+			if isAWSErr(err, rds.ErrCodeInvalidOptionGroupStateFault, "") {
+				log.Printf("[DEBUG] AWS believes the RDS Option Group is still in use, retrying")
+				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
Changes proposed in this pull request:

* Use API provided ARN instead of manually created one
* Use `isAWSErr()` helper

Output from acceptance testing:

```
11 tests passed (all tests)
=== RUN   TestAccAWSDBOptionGroup_namePrefix
--- PASS: TestAccAWSDBOptionGroup_namePrefix (6.61s)
=== RUN   TestAccAWSDBOptionGroup_timeoutBlock
--- PASS: TestAccAWSDBOptionGroup_timeoutBlock (6.63s)
=== RUN   TestAccAWSDBOptionGroup_basic
--- PASS: TestAccAWSDBOptionGroup_basic (6.64s)
=== RUN   TestAccAWSDBOptionGroup_generatedName
--- PASS: TestAccAWSDBOptionGroup_generatedName (6.89s)
=== RUN   TestAccAWSDBOptionGroup_defaultDescription
--- PASS: TestAccAWSDBOptionGroup_defaultDescription (6.91s)
=== RUN   TestAccAWSDBOptionGroup_multipleOptions
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (7.11s)
=== RUN   TestAccAWSDBOptionGroup_sqlServerOptionsUpdate
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (11.48s)
=== RUN   TestAccAWSDBOptionGroup_OptionSettings
--- PASS: TestAccAWSDBOptionGroup_OptionSettings (11.68s)
=== RUN   TestAccAWSDBOptionGroup_OracleOptionsUpdate
--- PASS: TestAccAWSDBOptionGroup_OracleOptionsUpdate (12.99s)
=== RUN   TestAccAWSDBOptionGroup_importBasic
--- PASS: TestAccAWSDBOptionGroup_importBasic (14.72s)
=== RUN   TestAccAWSDBOptionGroup_basicDestroyWithInstance
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (463.01s)
```
