### PR TITLE
r/launch_template: modify default_version

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -818,8 +818,6 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 
 	// Create new version only if content has changed since previous version
 	var defaultVersion string
-	var output *ec2.CreateLaunchTemplateVersionOutput
-
 	description := d.Get("description").(string)
 	latestVersionDescription := aws.StringValue(dltv.LaunchTemplateVersions[0].VersionDescription)
 
@@ -834,7 +832,7 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 			launchTemplateVersionOpts.VersionDescription = aws.String(description)
 		}
 
-		output, err = conn.CreateLaunchTemplateVersion(launchTemplateVersionOpts)
+		output, err := conn.CreateLaunchTemplateVersion(launchTemplateVersionOpts)
 		if err != nil {
 			return fmt.Errorf("Error creating new Launch Template Version for Launch Template(%s): %w", d.Id(), err)
 		}

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"log"
 	"strconv"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -832,17 +832,6 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 		if v, vOk := d.GetOk("update_default_version"); vOk && v.(bool) {
 			defaultVersion = strconv.FormatInt(aws.Int64Value(createVersion.LaunchTemplateVersion.VersionNumber), 10)
-		}
-
-		if v, vOk := d.GetOk("update_default_version"); vOk && v.(bool) {
-			modifyLaunchTemplateOpts := &ec2.ModifyLaunchTemplateInput{
-				LaunchTemplateId: aws.String(d.Id()),
-				DefaultVersion:   aws.String(strconv.FormatInt(aws.Int64Value(createVersion.LaunchTemplateVersion.VersionNumber), 10)),
-			}
-			_, modifyErr := conn.ModifyLaunchTemplate(modifyLaunchTemplateOpts)
-			if modifyErr != nil {
-				return modifyErr
-			}
 		}
 	}
 

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -833,6 +833,17 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 		if v, vOk := d.GetOk("update_default_version"); vOk && v.(bool) {
 			defaultVersion = strconv.FormatInt(aws.Int64Value(createVersion.LaunchTemplateVersion.VersionNumber), 10)
 		}
+
+		if v, vOk := d.GetOk("update_default_version"); vOk && v.(bool) {
+			modifyLaunchTemplateOpts := &ec2.ModifyLaunchTemplateInput{
+				LaunchTemplateId: aws.String(d.Id()),
+				DefaultVersion:   aws.String(strconv.FormatInt(aws.Int64Value(createVersion.LaunchTemplateVersion.VersionNumber), 10)),
+			}
+			_, modifyErr := conn.ModifyLaunchTemplate(modifyLaunchTemplateOpts)
+			if modifyErr != nil {
+				return modifyErr
+			}
+		}
 	}
 
 	if d.HasChange("default_version") {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -939,6 +939,58 @@ func TestAccAWSLaunchTemplate_hibernation(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_defaultVersion(t *testing.T) {
+	resourceName := "aws_launch_template.test"
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_defaultVersion(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
+	resourceName := "aws_launch_template.test"
+	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateconfig_updateDefaultVersion(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1657,4 +1709,29 @@ resource "aws_launch_template" "test" {
   }
 }
 `, rName, enabled)
+}
+
+func testAccAWSLaunchTemplateConfig_defaultVersion(rName string, version int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = "%s"
+  default_version = %d
+
+  tags {
+    bar = "baz"
+  }
+}
+`, rName, version)
+}
+
+func testAccAWSLaunchTemplateconfig_updateDefaultVersion(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = "%s"
+  update_default_version = true
+  user_data = "bar"
+  tags {
+    bar = "baz"
+  }
+}`, rName)
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -991,31 +991,6 @@ func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
 	})
 }
 
-func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
-	resName := "aws_launch_template.foo"
-	rInt := acctest.RandInt()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resName, "default_version", "1"),
-				),
-			},
-			{
-				Config: testAccAWSLaunchTemplateconfig_updateDefaultVersion(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resName, "default_version", "2"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -1741,6 +1741,7 @@ func testAccAWSLaunchTemplateConfig_defaultVersion(rName string, version int) st
 resource "aws_launch_template" "test" {
   name = "%s"
   default_version = %d
+  user_data = "bar"
 
   tags {
     bar = "baz"
@@ -1759,16 +1760,4 @@ resource "aws_launch_template" "test" {
     bar = "baz"
   }
 }`, rName)
-}
-
-func testAccAWSLaunchTemplateconfig_updateDefaultVersion(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_launch_template" "foo" {
-  name = "foo_%d"
-  update_default_version = true
-
-  tags {
-    bar = "baz"
-  }
-}`, rInt)
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -991,6 +991,31 @@ func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
+	resName := "aws_launch_template.foo"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateconfig_updateDefaultVersion(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1734,4 +1759,16 @@ resource "aws_launch_template" "test" {
     bar = "baz"
   }
 }`, rName)
+}
+
+func testAccAWSLaunchTemplateconfig_updateDefaultVersion(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "foo" {
+  name = "foo_%d"
+  update_default_version = true
+
+  tags {
+    bar = "baz"
+  }
+}`, rInt)
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -77,7 +77,7 @@ func testSweepLaunchTemplates(region string) error {
 func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,7 +85,7 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Config: testAccAWSLaunchTemplateConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
@@ -107,7 +107,7 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 func TestAccAWSLaunchTemplate_disappears(t *testing.T) {
 	var launchTemplate ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -115,7 +115,7 @@ func TestAccAWSLaunchTemplate_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Config: testAccAWSLaunchTemplateConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &launchTemplate),
 					testAccCheckAWSLaunchTemplateDisappears(&launchTemplate),
@@ -288,7 +288,7 @@ func TestAccAWSLaunchTemplate_ElasticInferenceAccelerator(t *testing.T) {
 func TestAccAWSLaunchTemplate_data(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -296,7 +296,7 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_data(rInt),
+				Config: testAccAWSLaunchTemplateConfig_data(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "block_device_mappings.#", "1"),
@@ -404,7 +404,7 @@ func TestAccAWSLaunchTemplate_update(t *testing.T) {
 func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -412,7 +412,7 @@ func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Config: testAccAWSLaunchTemplateConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -425,7 +425,7 @@ func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAWSLaunchTemplateConfig_tagsUpdate(rInt),
+				Config: testAccAWSLaunchTemplateConfig_tagsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
@@ -439,7 +439,7 @@ func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 func TestAccAWSLaunchTemplate_capacityReservation_preference(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -447,7 +447,7 @@ func TestAccAWSLaunchTemplate_capacityReservation_preference(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_capacityReservation_preference(rInt, "open"),
+				Config: testAccAWSLaunchTemplateConfig_capacityReservation_preference(rName, "open"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 				),
@@ -464,7 +464,7 @@ func TestAccAWSLaunchTemplate_capacityReservation_preference(t *testing.T) {
 func TestAccAWSLaunchTemplate_capacityReservation_target(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -472,7 +472,7 @@ func TestAccAWSLaunchTemplate_capacityReservation_target(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_capacityReservation_target(rInt),
+				Config: testAccAWSLaunchTemplateConfig_capacityReservation_target(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 				),
@@ -640,6 +640,7 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 func TestAccAWSLaunchTemplate_networkInterfaceAddresses(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -647,7 +648,7 @@ func TestAccAWSLaunchTemplate_networkInterfaceAddresses(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_networkInterfaceAddresses,
+				Config: testAccAWSLaunchTemplateConfig_networkInterfaceAddresses(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -777,7 +778,7 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 func TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -785,7 +786,7 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_ipv6_count(rInt),
+				Config: testAccAWSLaunchTemplateConfig_ipv6_count(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "network_interfaces.#", "1"),
@@ -847,7 +848,7 @@ func TestAccAWSLaunchTemplate_instanceMarketOptions(t *testing.T) {
 func TestAccAWSLaunchTemplate_licenseSpecification(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resourceName := "aws_launch_template.example"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -855,7 +856,7 @@ func TestAccAWSLaunchTemplate_licenseSpecification(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_licenseSpecification(rInt),
+				Config: testAccAWSLaunchTemplateConfig_licenseSpecification(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "license_specification.#", "1"),
@@ -941,7 +942,9 @@ func TestAccAWSLaunchTemplate_hibernation(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_defaultVersion(t *testing.T) {
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	description := "Test Description 1"
+	descriptionNew := "Test Description 2"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -949,31 +952,28 @@ func TestAccAWSLaunchTemplate_defaultVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Config: testAccAWSLaunchTemplateConfig_description(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
 				),
 			},
+			// An updated config should cause a new version to be created
+			// but keep the default_version unchanged if unset
 			{
-				Config: testAccAWSLaunchTemplateConfig_defaultVersion(rInt, 1),
+				Config: testAccAWSLaunchTemplateConfig_description(rName, descriptionNew),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
 				),
 			},
+			// An updated config to set the default_version to an existing version
+			// should not cause a new version to be created
 			{
-				Config: testAccAWSLaunchTemplateConfig_defaultVersion(rInt, 2),
+				Config: testAccAWSLaunchTemplateConfig_descriptionDefaultVersion(rName, descriptionNew, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
-				),
-			},
-			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
-					resource.TestCheckResourceAttr(resourceName, "latest_version", "3"),
 				),
 			},
 			{
@@ -987,7 +987,9 @@ func TestAccAWSLaunchTemplate_defaultVersion(t *testing.T) {
 
 func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
 	resourceName := "aws_launch_template.test"
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	description := "Test Description 1"
+	descriptionNew := "Test Description 2"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -995,31 +997,37 @@ func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Config: testAccAWSLaunchTemplateConfig_description(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
 				),
 			},
+			// Updating a field should create a new version but not update the default_version
+			// if update_default_version is set to false
 			{
-				Config: testAccAWSLaunchTemplateconfig_updateDefaultVersion(rInt),
+				Config: testAccAWSLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, descriptionNew, false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
+					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
 				),
 			},
+			// Only updating the update_default_version field should not create a new version
+			// but use the default_version computed
 			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Config: testAccAWSLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, descriptionNew, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
-					resource.TestCheckResourceAttr(resourceName, "latest_version", "3"),
+					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
 				),
 			},
+			// Updating a field should create a new version and update the default_version
+			// if update_default_version is set to true
 			{
-				Config: testAccAWSLaunchTemplateconfig_updateDefaultVersion(rInt),
+				Config: testAccAWSLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, description, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "default_version", "4"),
-					resource.TestCheckResourceAttr(resourceName, "latest_version", "4"),
+					resource.TestCheckResourceAttr(resourceName, "default_version", "3"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "3"),
 				),
 			},
 			{
@@ -1106,28 +1114,28 @@ func testAccCheckAWSLaunchTemplateDisappears(launchTemplate *ec2.LaunchTemplate)
 	}
 }
 
-func testAccAWSLaunchTemplateConfig_basic(rInt int) string {
+func testAccAWSLaunchTemplateConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test_%d"
+  name = %q
 
   tags = {
     test = "bar"
   }
 }
-`, rInt)
+`, rName)
 }
 
-func testAccAWSLaunchTemplateConfig_ipv6_count(rInt int) string {
+func testAccAWSLaunchTemplateConfig_ipv6_count(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "set_ipv6_count_test_%d"
+  name = %q
 
   network_interfaces {
     ipv6_address_count = 1
   }
 }
-`, rInt)
+`, rName)
 }
 
 func testAccAWSLaunchTemplateConfig_BlockDeviceMappings_EBS(rName string) string {
@@ -1266,10 +1274,10 @@ resource "aws_launch_template" "test" {
 `, rName, elasticInferenceAcceleratorType)
 }
 
-func testAccAWSLaunchTemplateConfig_data(rInt int) string {
+func testAccAWSLaunchTemplateConfig_data(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test_%d"
+  name = %q
 
   block_device_mappings {
     device_name = "test"
@@ -1326,34 +1334,34 @@ resource "aws_launch_template" "test" {
     }
   }
 }
-`, rInt)
+`, rName)
 }
 
-func testAccAWSLaunchTemplateConfig_tagsUpdate(rInt int) string {
+func testAccAWSLaunchTemplateConfig_tagsUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test_%d"
+  name = %q
 
   tags = {
     bar = "baz"
   }
 }
-`, rInt)
+`, rName)
 }
 
-func testAccAWSLaunchTemplateConfig_capacityReservation_preference(rInt int, preference string) string {
+func testAccAWSLaunchTemplateConfig_capacityReservation_preference(rName string, preference string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test_%d"
+  name = %q
 
   capacity_reservation_specification {
     capacity_reservation_preference = %q
   }
 }
-`, rInt, preference)
+`, rName, preference)
 }
 
-func testAccAWSLaunchTemplateConfig_capacityReservation_target(rInt int) string {
+func testAccAWSLaunchTemplateConfig_capacityReservation_target(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -1372,7 +1380,7 @@ resource "aws_ec2_capacity_reservation" "test" {
 }
 
 resource "aws_launch_template" "test" {
-  name = "test_%d"
+  name = %q
 
   capacity_reservation_specification {
     capacity_reservation_target {
@@ -1380,7 +1388,7 @@ resource "aws_launch_template" "test" {
     }
   }
 }
-`, rInt)
+`, rName)
 }
 
 func testAccAWSLaunchTemplateConfig_cpuOptions(rName string, coreCount, threadsPerCore int) string {
@@ -1419,7 +1427,7 @@ resource "aws_launch_template" "test" {
 `, rName)
 }
 
-func testAccAWSLaunchTemplateConfig_licenseSpecification(rInt int) string {
+func testAccAWSLaunchTemplateConfig_licenseSpecification(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_licensemanager_license_configuration" "example" {
   name                  = "Example"
@@ -1427,20 +1435,20 @@ resource "aws_licensemanager_license_configuration" "example" {
 }
 
 resource "aws_launch_template" "example" {
-  name = "test_%d"
+  name = %q
 
   license_specification {
     license_configuration_arn = "${aws_licensemanager_license_configuration.example.id}"
   }
 }
-`, rInt)
+`, rName)
 }
 
 func testAccAWSLaunchTemplateConfig_description(rName, description string) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name        = "%s"
-  description = "%s"
+  name        = %q
+  description = %q
 }
 `, rName, description)
 }
@@ -1493,7 +1501,8 @@ resource "aws_launch_template" "test" {
 `, rName, partNum)
 }
 
-const testAccAWSLaunchTemplateConfig_networkInterfaceAddresses = `
+func testAccAWSLaunchTemplateConfig_networkInterfaceAddresses(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
@@ -1508,14 +1517,16 @@ resource "aws_network_interface" "test" {
 }
 
 resource "aws_launch_template" "test" {
-  name = "network-interface-launch-template"
+  name = %q
 
   network_interfaces {
     network_interface_id = "${aws_network_interface.test.id}"
     ipv4_addresses = ["10.1.0.10", "10.1.0.11"]
   }
 }
-`
+`, rName)
+
+}
 
 func testAccAWSLaunchTemplateConfig_associatePublicIpAddress(rName, associatePublicIPAddress string) string {
 	return fmt.Sprintf(`
@@ -1754,29 +1765,29 @@ resource "aws_launch_template" "test" {
 `, rName, enabled)
 }
 
-func testAccAWSLaunchTemplateConfig_defaultVersion(rInt int, version int) string {
+func testAccAWSLaunchTemplateConfig_descriptionDefaultVersion(rName, description string, version int) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test_%d"
+  name            = %q
+  description     = %q
   default_version = %d
-  user_data = "bar"
 
   tags = {
     test = "baz"
   }
 }
-`, rInt, version)
+`, rName, description, version)
 }
 
-func testAccAWSLaunchTemplateconfig_updateDefaultVersion(rInt int) string {
+func testAccAWSLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, description string, update bool) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "test" {
-  name = "test_%d"
-  update_default_version = true
-  user_data = "bar"
+  name                   = %q
+  description            = %q
+  update_default_version = %v
   
   tags = {
     test = "baz"
   }
-}`, rInt)
+}`, rName, description, update)
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -1012,12 +1012,12 @@ func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
 				),
 			},
-			// Only updating the update_default_version field should not create a new version
-			// but use the default_version computed
+			// Only updating the update_default_version to true should not create a new version
+			// but update the template version to the latest available
 			{
 				Config: testAccAWSLaunchTemplateconfig_descriptionUpdateDefaultVersion(rName, descriptionNew, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "default_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_version", "2"),
 					resource.TestCheckResourceAttr(resourceName, "latest_version", "2"),
 				),
 			},

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -112,6 +112,8 @@ The following arguments are supported:
 * `name` - The name of the launch template. If you leave this blank, Terraform will auto-generate a unique name.
 * `name_prefix` - Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `description` - Description of the launch template.
+* `default_version` - Default Version of the launch template.
+* `update_default_version` - Whether to update Default Version each update. Conflicts with `default_version`. 
 * `block_device_mappings` - Specify volumes to attach to the instance besides the volumes specified by the AMI.
   See [Block Devices](#block-devices) below for details.
 * `capacity_reservation_specification` - Targeting for EC2 capacity reservations. See [Capacity Reservation Specification](#capacity-reservation-specification) below for more details.
@@ -336,7 +338,6 @@ The following attributes are exported along with all argument references:
 
 * `arn` - Amazon Resource Name (ARN) of the launch template.
 * `id` - The ID of the launch template.
-* `default_version` - The default version of the launch template.
 * `latest_version` - The latest version of the launch template.
 
 ## Import


### PR DESCRIPTION
Fixes #4655

Changes proposed in this pull request:

* make `default_version` attribute modifyable
* add `update_default_version` attribute

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (14.93s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (13.25s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (12.21s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (16.13s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (11.60s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (24.52s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (22.95s)
=== RUN   TestAccAWSLaunchTemplate_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_nonBurstable (11.66s)
=== RUN   TestAccAWSLaunchTemplate_defaultVersion
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (22.40s)
=== RUN   TestAccAWSLaunchTemplate_updateDefaultVersion
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (23.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	173.215s
```
