### PR TITLE
resource/aws_neptune_cluster: Support import and refactoring

### DIFF
--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -20,7 +20,9 @@ func resourceAwsNeptuneCluster() *schema.Resource {
 		Read:   resourceAwsNeptuneClusterRead,
 		Update: resourceAwsNeptuneClusterUpdate,
 		Delete: resourceAwsNeptuneClusterDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(120 * time.Minute),
 			Update: schema.DefaultTimeout(120 * time.Minute),
@@ -238,8 +240,11 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 	tags := tagsFromMapNeptune(d.Get("tags").(map[string]interface{}))
 
 	// Check if any of the parameters that require a cluster modification after creation are set
-	var clusterUpdate bool
-	clusterUpdate = false
+	clusterUpdate := false
+	restoreDBClusterFromSnapshot := false
+	if _, ok := d.GetOk("snapshot_identifier"); ok {
+		restoreDBClusterFromSnapshot = true
+	}
 
 	if v, ok := d.GetOk("cluster_identifier"); ok {
 		d.Set("cluster_identifier", v.(string))
@@ -249,198 +254,110 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 		} else {
 			d.Set("cluster_identifier", resource.PrefixedUniqueId("tf-"))
 		}
-
 	}
 
-	if _, ok := d.GetOk("snapshot_identifier"); ok {
-		opts := neptune.RestoreDBClusterFromSnapshotInput{
-			DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
-			Engine:              aws.String(d.Get("engine").(string)),
-			SnapshotIdentifier:  aws.String(d.Get("snapshot_identifier").(string)),
-			Tags:                tags,
-			Port:                aws.Int64(int64(d.Get("port").(int))),
-		}
+	createDbClusterInput := &neptune.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+		Engine:              aws.String(d.Get("engine").(string)),
+		Port:                aws.Int64(int64(d.Get("port").(int))),
+		StorageEncrypted:    aws.Bool(d.Get("storage_encrypted").(bool)),
+		Tags:                tags,
+	}
+	restoreDBClusterFromSnapshotInput := &neptune.RestoreDBClusterFromSnapshotInput{
+		DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+		Engine:              aws.String(d.Get("engine").(string)),
+		Port:                aws.Int64(int64(d.Get("port").(int))),
+		SnapshotIdentifier:  aws.String(d.Get("snapshot_identifier").(string)),
+		Tags:                tags,
+	}
 
-		if attr, ok := d.GetOk("engine_version"); ok {
-			opts.EngineVersion = aws.String(attr.(string))
-		}
+	if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
+		createDbClusterInput.AvailabilityZones = expandStringList(attr.List())
+		restoreDBClusterFromSnapshotInput.AvailabilityZones = expandStringList(attr.List())
+	}
 
-		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			opts.AvailabilityZones = expandStringList(attr.List())
-		}
-
-		if attr, ok := d.GetOk("neptune_subnet_group_name"); ok {
-			opts.DBSubnetGroupName = aws.String(attr.(string))
-		}
-
-		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			clusterUpdate = true
-			opts.VpcSecurityGroupIds = expandStringList(attr.List())
-		}
-
-		if _, ok := d.GetOk("neptune_cluster_parameter_group_name"); ok {
+	if attr, ok := d.GetOk("backup_retention_period"); ok {
+		createDbClusterInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
+		if restoreDBClusterFromSnapshot {
 			clusterUpdate = true
 		}
+	}
 
-		if _, ok := d.GetOk("backup_retention_period"); ok {
+	if attr, ok := d.GetOk("engine_version"); ok {
+		createDbClusterInput.EngineVersion = aws.String(attr.(string))
+		restoreDBClusterFromSnapshotInput.EngineVersion = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
+		createDbClusterInput.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
+		restoreDBClusterFromSnapshotInput.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
+	}
+
+	if attr, ok := d.GetOk("kms_key_arn"); ok {
+		createDbClusterInput.KmsKeyId = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("neptune_cluster_parameter_group_name"); ok {
+		createDbClusterInput.DBClusterParameterGroupName = aws.String(attr.(string))
+		if restoreDBClusterFromSnapshot {
 			clusterUpdate = true
 		}
+	}
 
-		log.Printf("[DEBUG] Neptune Cluster restore from snapshot configuration: %s", opts)
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			_, err := conn.RestoreDBClusterFromSnapshot(&opts)
-			if err != nil {
-				if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
-					return resource.RetryableError(err)
-				}
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("Error creating Neptune Cluster: %s", err)
+	if attr, ok := d.GetOk("neptune_subnet_group_name"); ok {
+		createDbClusterInput.DBSubnetGroupName = aws.String(attr.(string))
+		restoreDBClusterFromSnapshotInput.DBSubnetGroupName = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("preferred_backup_window"); ok {
+		createDbClusterInput.PreferredBackupWindow = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("preferred_maintenance_window"); ok {
+		createDbClusterInput.PreferredMaintenanceWindow = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("replication_source_identifier"); ok {
+		createDbClusterInput.ReplicationSourceIdentifier = aws.String(attr.(string))
+	}
+
+	if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+		createDbClusterInput.VpcSecurityGroupIds = expandStringList(attr.List())
+		if restoreDBClusterFromSnapshot {
+			clusterUpdate = true
 		}
-	} else if _, ok := d.GetOk("replication_source_identifier"); ok {
-		createOpts := &neptune.CreateDBClusterInput{
-			DBClusterIdentifier:         aws.String(d.Get("cluster_identifier").(string)),
-			Engine:                      aws.String(d.Get("engine").(string)),
-			StorageEncrypted:            aws.Bool(d.Get("storage_encrypted").(bool)),
-			ReplicationSourceIdentifier: aws.String(d.Get("replication_source_identifier").(string)),
-			Tags: tags,
-			Port: aws.Int64(int64(d.Get("port").(int))),
-		}
+		restoreDBClusterFromSnapshotInput.VpcSecurityGroupIds = expandStringList(attr.List())
+	}
 
-		if attr, ok := d.GetOk("neptune_subnet_group_name"); ok {
-			createOpts.DBSubnetGroupName = aws.String(attr.(string))
-		}
-
-		if attr, ok := d.GetOk("neptune_cluster_parameter_group_name"); ok {
-			createOpts.DBClusterParameterGroupName = aws.String(attr.(string))
-		}
-
-		if attr, ok := d.GetOk("engine_version"); ok {
-			createOpts.EngineVersion = aws.String(attr.(string))
-		}
-
-		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
-		}
-
-		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			createOpts.AvailabilityZones = expandStringList(attr.List())
-		}
-
-		if v, ok := d.GetOk("backup_retention_period"); ok {
-			createOpts.BackupRetentionPeriod = aws.Int64(int64(v.(int)))
-		}
-
-		if v, ok := d.GetOk("preferred_backup_window"); ok {
-			createOpts.PreferredBackupWindow = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("preferred_maintenance_window"); ok {
-			createOpts.PreferredMaintenanceWindow = aws.String(v.(string))
-		}
-
-		if attr, ok := d.GetOk("kms_key_arn"); ok {
-			createOpts.KmsKeyId = aws.String(attr.(string))
-		}
-
-		log.Printf("[DEBUG] Create Neptune Cluster as read replica: %s", createOpts)
-		var resp *neptune.CreateDBClusterOutput
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			var err error
-			resp, err = conn.CreateDBCluster(createOpts)
-			if err != nil {
-				if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
-					return resource.RetryableError(err)
-				}
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("error creating Neptune cluster: %s", err)
-		}
-
-		log.Printf("[DEBUG]: Neptune Cluster create response: %s", resp)
-
+	if restoreDBClusterFromSnapshot {
+		log.Printf("[DEBUG] Neptune Cluster restore from snapshot configuration: %s", restoreDBClusterFromSnapshotInput)
 	} else {
+		log.Printf("[DEBUG] Neptune Cluster create options: %s", createDbClusterInput)
+	}
 
-		createOpts := &neptune.CreateDBClusterInput{
-			DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
-			Engine:              aws.String(d.Get("engine").(string)),
-			StorageEncrypted:    aws.Bool(d.Get("storage_encrypted").(bool)),
-			Tags:                tags,
-			Port:                aws.Int64(int64(d.Get("port").(int))),
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+		if restoreDBClusterFromSnapshot {
+			_, err = conn.RestoreDBClusterFromSnapshot(restoreDBClusterFromSnapshotInput)
+		} else {
+			_, err = conn.CreateDBCluster(createDbClusterInput)
 		}
-
-		if attr, ok := d.GetOk("neptune_subnet_group_name"); ok {
-			createOpts.DBSubnetGroupName = aws.String(attr.(string))
-		}
-
-		if attr, ok := d.GetOk("neptune_cluster_parameter_group_name"); ok {
-			createOpts.DBClusterParameterGroupName = aws.String(attr.(string))
-		}
-
-		if attr, ok := d.GetOk("engine_version"); ok {
-			createOpts.EngineVersion = aws.String(attr.(string))
-		}
-
-		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
-		}
-
-		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
-			createOpts.AvailabilityZones = expandStringList(attr.List())
-		}
-
-		if v, ok := d.GetOk("backup_retention_period"); ok {
-			createOpts.BackupRetentionPeriod = aws.Int64(int64(v.(int)))
-		}
-
-		if v, ok := d.GetOk("preferred_backup_window"); ok {
-			createOpts.PreferredBackupWindow = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("preferred_maintenance_window"); ok {
-			createOpts.PreferredMaintenanceWindow = aws.String(v.(string))
-		}
-
-		if attr, ok := d.GetOk("kms_key_arn"); ok {
-			createOpts.KmsKeyId = aws.String(attr.(string))
-		}
-
-		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
-			createOpts.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
-		}
-
-		log.Printf("[DEBUG] Neptune Cluster create options: %s", createOpts)
-		var resp *neptune.CreateDBClusterOutput
-		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			var err error
-			resp, err = conn.CreateDBCluster(createOpts)
-			if err != nil {
-				if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
-					return resource.RetryableError(err)
-				}
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
 		if err != nil {
-			return fmt.Errorf("error creating Neptune cluster: %s", err)
+			if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
 		}
-
-		log.Printf("[DEBUG]: Neptune Cluster create response: %s", resp)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error creating Neptune Cluster: %s", err)
 	}
 
 	d.SetId(d.Get("cluster_identifier").(string))
 
 	log.Printf("[INFO] Neptune Cluster ID: %s", d.Id())
-
-	log.Println(
-		"[INFO] Waiting for Neptune Cluster to be available")
+	log.Println("[INFO] Waiting for Neptune Cluster to be available")
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceAwsNeptuneClusterCreatePendingStates,
@@ -452,9 +369,9 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Wait, catching any errors
-	_, err := stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for Neptune Cluster state to be \"available\": %s", err)
+		return fmt.Errorf("error waiting for Neptune Cluster state to be \"available\": %s", err)
 	}
 
 	if v, ok := d.GetOk("iam_roles"); ok {
@@ -511,26 +428,26 @@ func flattenAwsNeptuneClusterResource(d *schema.ResourceData, meta interface{}, 
 	conn := meta.(*AWSClient).neptuneconn
 
 	if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving AvailabilityZones to state for Neptune Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving AvailabilityZones to state for Neptune Cluster (%s): %s", d.Id(), err)
 	}
 
+	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
 	d.Set("cluster_identifier", dbc.DBClusterIdentifier)
 	d.Set("cluster_resource_id", dbc.DbClusterResourceId)
-	d.Set("neptune_subnet_group_name", dbc.DBSubnetGroup)
-	d.Set("neptune_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
 	d.Set("endpoint", dbc.Endpoint)
-	d.Set("engine", dbc.Engine)
 	d.Set("engine_version", dbc.EngineVersion)
+	d.Set("engine", dbc.Engine)
+	d.Set("hosted_zone_id", dbc.HostedZoneId)
+	d.Set("iam_database_authentication_enabled", dbc.IAMDatabaseAuthenticationEnabled)
+	d.Set("kms_key_arn", dbc.KmsKeyId)
+	d.Set("neptune_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
+	d.Set("neptune_subnet_group_name", dbc.DBSubnetGroup)
 	d.Set("port", dbc.Port)
-	d.Set("storage_encrypted", dbc.StorageEncrypted)
-	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
 	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
 	d.Set("preferred_maintenance_window", dbc.PreferredMaintenanceWindow)
-	d.Set("kms_key_arn", dbc.KmsKeyId)
 	d.Set("reader_endpoint", dbc.ReaderEndpoint)
 	d.Set("replication_source_identifier", dbc.ReplicationSourceIdentifier)
-	d.Set("iam_database_authentication_enabled", dbc.IAMDatabaseAuthenticationEnabled)
-	d.Set("hosted_zone_id", dbc.HostedZoneId)
+	d.Set("storage_encrypted", dbc.StorageEncrypted)
 
 	var sg []string
 	for _, g := range dbc.VpcSecurityGroups {

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -39,6 +39,12 @@ func TestAccAWSNeptuneCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone_id"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+			},
 		},
 	})
 }
@@ -59,6 +65,12 @@ func TestAccAWSNeptuneCluster_namePrefix(t *testing.T) {
 						"aws_neptune_cluster.test", "cluster_identifier", regexp.MustCompile("^tf-test-")),
 				),
 			},
+			{
+				ResourceName:            "aws_neptune_cluster.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cluster_identifier_prefix", "skip_final_snapshot"},
+			},
 		},
 	})
 }
@@ -77,6 +89,12 @@ func TestAccAWSNeptuneCluster_takeFinalSnapshot(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
 				),
+			},
+			{
+				ResourceName:            "aws_neptune_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"final_snapshot_identifier", "skip_final_snapshot"},
 			},
 		},
 	})
@@ -106,6 +124,12 @@ func TestAccAWSNeptuneCluster_updateTags(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_neptune_cluster.default", "tags.%", "2"),
 				),
+			},
+			{
+				ResourceName:            "aws_neptune_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
 			},
 		},
 	})
@@ -142,6 +166,12 @@ func TestAccAWSNeptuneCluster_updateIamRoles(t *testing.T) {
 						"aws_neptune_cluster.default", "iam_roles.#", "1"),
 				),
 			},
+			{
+				ResourceName:            "aws_neptune_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+			},
 		},
 	})
 }
@@ -163,6 +193,12 @@ func TestAccAWSNeptuneCluster_kmsKey(t *testing.T) {
 						"aws_neptune_cluster.default", "kms_key_arn", keyRegex),
 				),
 			},
+			{
+				ResourceName:            "aws_neptune_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+			},
 		},
 	})
 }
@@ -182,6 +218,12 @@ func TestAccAWSNeptuneCluster_encrypted(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_neptune_cluster.default", "storage_encrypted", "true"),
 				),
+			},
+			{
+				ResourceName:            "aws_neptune_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
 			},
 		},
 	})
@@ -208,8 +250,7 @@ func TestAccAWSNeptuneCluster_backupsUpdate(t *testing.T) {
 						"aws_neptune_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
 				),
 			},
-
-			resource.TestStep{
+			{
 				Config: testAccAWSNeptuneClusterConfig_backupsUpdate(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNeptuneClusterExists("aws_neptune_cluster.default", &v),
@@ -220,6 +261,12 @@ func TestAccAWSNeptuneCluster_backupsUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_neptune_cluster.default", "preferred_maintenance_window", "wed:01:00-wed:01:30"),
 				),
+			},
+			{
+				ResourceName:            "aws_neptune_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "skip_final_snapshot"},
 			},
 		},
 	})
@@ -240,6 +287,12 @@ func TestAccAWSNeptuneCluster_iamAuth(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_neptune_cluster.default", "iam_database_authentication_enabled", "true"),
 				),
+			},
+			{
+				ResourceName:            "aws_neptune_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
 			},
 		},
 	})

--- a/website/docs/r/neptune_cluster.html.markdown
+++ b/website/docs/r/neptune_cluster.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_neptune_cluster"
-sidebar_current: "docs-aws-resource-neptune-cluster"
+sidebar_current: "docs-aws-resource-neptune-cluster-x"
 description: |-
   Provides an Neptune Cluster Resource
 ---
@@ -39,24 +39,20 @@ See the AWS [Docs](https://docs.aws.amazon.com/neptune/latest/userguide/limits.h
 
 The following arguments are supported:
 
-* `apply_immediately` - (Optional) Specifies whether any cluster modifications
-  are applied immediately, or during the next maintenance window. Default is `false`.
-* `availability_zones` - (Optional) A list of EC2 Availability Zones that
-  instances in the Neptune cluster can be created in.
+* `apply_immediately` - (Optional) Specifies whether any cluster modifications are applied immediately, or during the next maintenance window. Default is `false`.
+* `availability_zones` - (Optional) A list of EC2 Availability Zones that instances in the Neptune cluster can be created in.
 * `backup_retention_period` - (Optional) The days to retain backups for. Default `1`
 * `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifer`.
 * `engine` - (Optional) The name of the database engine to be used for this Neptune cluster. Defaults to `neptune`.
 * `engine_version` - (Optional) The database engine version.
-* `final_snapshot_identifier` - (Optional) The name of your final Neptune snapshot
-    when this Neptune cluster is deleted. If omitted, no final snapshot will be made.
+* `final_snapshot_identifier` - (Optional) The name of your final Neptune snapshot when this Neptune cluster is deleted. If omitted, no final snapshot will be made.
 * `iam_roles` - (Optional) A List of ARNs for the IAM roles to associate to the Neptune Cluster.
 * `iam_database_authentication_enabled` - (Optional) Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled.
 * `kms_key_arn` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_arn`, `storage_encrypted` needs to be set to true.
 * `neptune_subnet_group_name` - (Optional) A Neptune subnet group to associate with this Neptune instance.
 * `neptune_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
-* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC
-Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
+* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter. Time in UTC. Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
 * `preferred_maintenance_window` - (Optional) The weekly time range during which system maintenance can occur, in (UTC) e.g. wed:04:00-wed:04:30
 * `port` - (Optional) The port on which the Neptune accepts connections. Default is `8182`.
 * `replication_source_identifier` - (Optional) ARN of a source Neptune cluster or Neptune instance if this Neptune cluster is to be created as a Read Replica.
@@ -70,13 +66,13 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The Neptune Cluster Amazon Resource Name (ARN)
 * `cluster_resource_id` - The Neptune Cluster Resource ID
 * `cluster_members` – List of Neptune Instances that are a part of this cluster
 * `endpoint` - The DNS address of the Neptune instance
 * `hosted_zone_id` - The Route53 Hosted Zone ID of the endpoint
 * `id` - The Neptune Cluster Identifier
-* `reader_endpoint` - A read-only endpoint for the Neptune cluster, automatically
-load-balanced across replicas
+* `reader_endpoint` - A read-only endpoint for the Neptune cluster, automatically load-balanced across replicas
 * `status` - The Neptune instance status
 
 ## Timeouts
@@ -86,5 +82,12 @@ load-balanced across replicas
 
 - `create` - (Default `120 minutes`) Used for Cluster creation
 - `update` - (Default `120 minutes`) Used for Cluster modifications
-- `delete` - (Default `120 minutes`) Used for destroying cluster. This includes
-any cleanup task during the destroying process.
+- `delete` - (Default `120 minutes`) Used for destroying cluster. This includes any cleanup task during the destroying process.
+
+## Import
+
+`aws_neptune_cluster` can be imported by using the cluster identifier, e.g.
+
+```
+$ terraform import aws_neptune_cluster.example my-cluster
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Support resource import
* Refactor create/restore input logic to simplify
* Alphabetize `d.Set()` calls
* Ensure documentation page has `-x` to match sidebar

Output from acceptance testing:

```
9 tests passed (all tests)
=== RUN   TestAccAWSNeptuneCluster_updateTags
--- PASS: TestAccAWSNeptuneCluster_updateTags (113.70s)
=== RUN   TestAccAWSNeptuneCluster_kmsKey
--- PASS: TestAccAWSNeptuneCluster_kmsKey (117.63s)
=== RUN   TestAccAWSNeptuneCluster_basic
--- PASS: TestAccAWSNeptuneCluster_basic (118.67s)
=== RUN   TestAccAWSNeptuneCluster_namePrefix
--- PASS: TestAccAWSNeptuneCluster_namePrefix (119.00s)
=== RUN   TestAccAWSNeptuneCluster_encrypted
--- PASS: TestAccAWSNeptuneCluster_encrypted (119.10s)
=== RUN   TestAccAWSNeptuneCluster_iamAuth
--- PASS: TestAccAWSNeptuneCluster_iamAuth (138.85s)
=== RUN   TestAccAWSNeptuneCluster_backupsUpdate
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (163.50s)
=== RUN   TestAccAWSNeptuneCluster_takeFinalSnapshot
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (169.30s)
=== RUN   TestAccAWSNeptuneCluster_updateIamRoles
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (184.62s)
```
