### PR TITLE
resource/aws_db_instance: Use API provided ARN instead of manually created one

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -8,8 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -898,20 +896,16 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 			_, err = conn.CreateDBInstance(&opts)
 			if err != nil {
-				if awsErr, ok := err.(awserr.Error); ok {
-					if awsErr.Code() == "InvalidParameterValue" && strings.Contains(awsErr.Message(), "ENHANCED_MONITORING") {
-						return resource.RetryableError(awsErr)
-					}
+				if isAWSErr(err, "InvalidParameterValue", "ENHANCED_MONITORING") {
+					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)
 			}
 			return nil
 		})
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				if awsErr.Code() == "InvalidParameterValue" {
-					return fmt.Errorf("Error creating DB Instance: %s, %+v", err, opts)
-				}
+			if isAWSErr(err, "InvalidParameterValue", "") {
+				return fmt.Errorf("Error creating DB Instance: %s, %+v", err, opts)
 			}
 			return fmt.Errorf("Error creating DB Instance: %s", err)
 
@@ -1022,13 +1016,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	// set tags
 	conn := meta.(*AWSClient).rdsconn
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("db:%s", d.Id()),
-	}.String()
+	arn := aws.StringValue(v.DBInstanceArn)
 	d.Set("arn", arn)
 	resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
 		ResourceName: aws.String(arn),
@@ -1322,14 +1310,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "rds",
-		Region:    meta.(*AWSClient).region,
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("db:%s", d.Id()),
-	}.String()
-	if err := setTagsRDS(conn, d, arn); err != nil {
+	if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
 		return err
 	} else {
 		d.SetPartial("tags")
@@ -1353,8 +1334,7 @@ func resourceAwsDbInstanceRetrieve(id string, conn *rds.RDS) (*rds.DBInstance, e
 
 	resp, err := conn.DescribeDBInstances(&opts)
 	if err != nil {
-		dbinstanceerr, ok := err.(awserr.Error)
-		if ok && dbinstanceerr.Code() == "DBInstanceNotFound" {
+		if isAWSErr(err, rds.ErrCodeDBInstanceNotFoundFault, "") {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("Error retrieving DB Instances: %s", err)

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -288,7 +288,7 @@ func TestAccAWSDBInstance_noSnapshot(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceNoSnapshot,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSnapshotInstanceConfig(),
+				Config: testAccAWSDBInstanceConfig_FinalSnapshotIdentifier_SkipFinalSnapshot(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.snapshot", &snap),
 				),
@@ -306,7 +306,7 @@ func TestAccAWSDBInstance_snapshot(t *testing.T) {
 		Providers: testAccProviders,
 		// testAccCheckAWSDBInstanceSnapshot verifies a database snapshot is
 		// created, and subequently deletes it
-		CheckDestroy: testAccCheckAWSDBInstanceSnapshot(rInt),
+		CheckDestroy: testAccCheckAWSDBInstanceSnapshot,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSnapshotInstanceConfigWithSnapshot(rInt),
@@ -327,7 +327,7 @@ func TestAccAWSDBInstance_s3(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBInstanceNoSnapshot,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSnapshotInstanceConfigWithS3Import(bucket, bucketPrefix, uniqueId),
@@ -346,7 +346,7 @@ func TestAccAWSDBInstance_enhancedMonitoring(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSDBInstanceNoSnapshot,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSnapshotInstanceConfig_enhancedMonitoring(rName),
@@ -684,86 +684,81 @@ func testAccCheckAWSDBInstanceReplicaAttributes(source, replica *rds.DBInstance)
 	}
 }
 
-func testAccCheckAWSDBInstanceSnapshot(rInt int) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_db_instance" {
-				continue
-			}
-
-			awsClient := testAccProvider.Meta().(*AWSClient)
-			conn := awsClient.rdsconn
-
-			var err error
-			log.Printf("[INFO] Trying to locate the DBInstance Final Snapshot")
-			snapshot_identifier := fmt.Sprintf("foobarbaz-test-terraform-final-snapshot-%d", rInt)
-			snapOutput, snapErr := conn.DescribeDBSnapshots(
-				&rds.DescribeDBSnapshotsInput{
-					DBSnapshotIdentifier: aws.String(snapshot_identifier),
-				})
-
-			if snapErr != nil {
-				if isAWSErr(snapErr, rds.ErrCodeDBSnapshotNotFoundFault, "") {
-					return fmt.Errorf("Snapshot %s not found", snapshot_identifier)
-				}
-			} else { // snapshot was found,
-				if snapOutput == nil || len(snapOutput.DBSnapshots) == 0 {
-					return fmt.Errorf("Snapshot %s not found", snapshot_identifier)
-				}
-				// verify we have the tags copied to the snapshot
-				tagsARN := aws.StringValue(snapOutput.DBSnapshots[0].DBSnapshotArn)
-				resp, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
-					ResourceName: aws.String(tagsARN),
-				})
-				if err != nil {
-					return fmt.Errorf("Error retrieving tags for ARN (%s): %s", tagsARN, err)
-				}
-
-				if resp.TagList == nil || len(resp.TagList) == 0 {
-					return fmt.Errorf("Tag list is nil or zero: %s", resp.TagList)
-				}
-
-				var found bool
-				for _, t := range resp.TagList {
-					if *t.Key == "Name" && *t.Value == "tf-tags-db" {
-						found = true
-					}
-				}
-				if !found {
-					return fmt.Errorf("Expected to find tag Name (%s), but wasn't found. Tags: %s", "tf-tags-db", resp.TagList)
-				}
-				// end tag search
-
-				log.Printf("[INFO] Deleting the Snapshot %s", snapshot_identifier)
-				_, snapDeleteErr := conn.DeleteDBSnapshot(
-					&rds.DeleteDBSnapshotInput{
-						DBSnapshotIdentifier: aws.String(snapshot_identifier),
-					})
-				if snapDeleteErr != nil {
-					return err
-				}
-			} // end snapshot was found
-
-			resp, err := conn.DescribeDBInstances(
-				&rds.DescribeDBInstancesInput{
-					DBInstanceIdentifier: aws.String(rs.Primary.ID),
-				})
-
-			if err != nil {
-				if !isAWSErr(err, rds.ErrCodeDBInstanceNotFoundFault, "") {
-					return err
-				}
-
-			} else {
-				if len(resp.DBInstances) != 0 &&
-					*resp.DBInstances[0].DBInstanceIdentifier == rs.Primary.ID {
-					return fmt.Errorf("DB Instance still exists")
-				}
-			}
+func testAccCheckAWSDBInstanceSnapshot(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_db_instance" {
+			continue
 		}
 
-		return nil
+		awsClient := testAccProvider.Meta().(*AWSClient)
+		conn := awsClient.rdsconn
+
+		log.Printf("[INFO] Trying to locate the DBInstance Final Snapshot")
+		snapOutput, err := conn.DescribeDBSnapshots(
+			&rds.DescribeDBSnapshotsInput{
+				DBSnapshotIdentifier: aws.String(rs.Primary.Attributes["final_snapshot_identifier"]),
+			})
+
+		if err != nil {
+			return err
+		}
+
+		if snapOutput == nil || len(snapOutput.DBSnapshots) == 0 {
+			return fmt.Errorf("Snapshot %s not found", rs.Primary.Attributes["final_snapshot_identifier"])
+		}
+
+		// verify we have the tags copied to the snapshot
+		tagsARN := aws.StringValue(snapOutput.DBSnapshots[0].DBSnapshotArn)
+		listTagsOutput, err := conn.ListTagsForResource(&rds.ListTagsForResourceInput{
+			ResourceName: aws.String(tagsARN),
+		})
+		if err != nil {
+			return fmt.Errorf("Error retrieving tags for ARN (%s): %s", tagsARN, err)
+		}
+
+		if listTagsOutput.TagList == nil || len(listTagsOutput.TagList) == 0 {
+			return fmt.Errorf("Tag list is nil or zero: %s", listTagsOutput.TagList)
+		}
+
+		var found bool
+		for _, t := range listTagsOutput.TagList {
+			if *t.Key == "Name" && *t.Value == "tf-tags-db" {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("Expected to find tag Name (%s), but wasn't found. Tags: %s", "tf-tags-db", listTagsOutput.TagList)
+		}
+		// end tag search
+
+		log.Printf("[INFO] Deleting the Snapshot %s", rs.Primary.Attributes["final_snapshot_identifier"])
+		_, err = conn.DeleteDBSnapshot(
+			&rds.DeleteDBSnapshotInput{
+				DBSnapshotIdentifier: aws.String(rs.Primary.Attributes["final_snapshot_identifier"]),
+			})
+		if err != nil {
+			return err
+		}
+
+		resp, err := conn.DescribeDBInstances(
+			&rds.DescribeDBInstancesInput{
+				DBInstanceIdentifier: aws.String(rs.Primary.ID),
+			})
+
+		if err != nil {
+			if isAWSErr(err, rds.ErrCodeDBInstanceNotFoundFault, "") {
+				continue
+			}
+			return err
+
+		}
+
+		if len(resp.DBInstances) != 0 && aws.StringValue(resp.DBInstances[0].DBInstanceIdentifier) == rs.Primary.ID {
+			return fmt.Errorf("DB Instance still exists")
+		}
 	}
+
+	return nil
 }
 
 func testAccCheckAWSDBInstanceNoSnapshot(s *terraform.State) error {
@@ -774,34 +769,26 @@ func testAccCheckAWSDBInstanceNoSnapshot(s *terraform.State) error {
 			continue
 		}
 
-		var err error
 		resp, err := conn.DescribeDBInstances(
 			&rds.DescribeDBInstancesInput{
 				DBInstanceIdentifier: aws.String(rs.Primary.ID),
 			})
 
-		if err != nil {
-			if !isAWSErr(err, rds.ErrCodeDBInstanceNotFoundFault, "") {
-				return err
-			}
-
-		} else {
-			if len(resp.DBInstances) != 0 &&
-				*resp.DBInstances[0].DBInstanceIdentifier == rs.Primary.ID {
-				return fmt.Errorf("DB Instance still exists")
-			}
+		if err != nil && !isAWSErr(err, rds.ErrCodeDBInstanceNotFoundFault, "") {
+			return err
 		}
 
-		snapshot_identifier := "foobarbaz-test-terraform-final-snapshot-2"
-		_, snapErr := conn.DescribeDBSnapshots(
+		if len(resp.DBInstances) != 0 && aws.StringValue(resp.DBInstances[0].DBInstanceIdentifier) == rs.Primary.ID {
+			return fmt.Errorf("DB Instance still exists")
+		}
+
+		_, err = conn.DescribeDBSnapshots(
 			&rds.DescribeDBSnapshotsInput{
-				DBSnapshotIdentifier: aws.String(snapshot_identifier),
+				DBSnapshotIdentifier: aws.String(rs.Primary.Attributes["final_snapshot_identifier"]),
 			})
 
-		if snapErr != nil {
-			if !isAWSErr(err, rds.ErrCodeDBSnapshotNotFoundFault, "") {
-				return err
-			}
+		if err != nil && !isAWSErr(err, rds.ErrCodeDBSnapshotNotFoundFault, "") {
+			return err
 		}
 	}
 
@@ -1031,7 +1018,7 @@ func testAccReplicaInstanceConfig(val int) string {
 	`, val, val)
 }
 
-func testAccSnapshotInstanceConfig() string {
+func testAccAWSDBInstanceConfig_FinalSnapshotIdentifier_SkipFinalSnapshot() string {
 	return fmt.Sprintf(`
 resource "aws_db_instance" "snapshot" {
 	identifier = "tf-test-%d"


### PR DESCRIPTION
Potentially related: #5229 

Changes proposed in this pull request:

* Use API provided ARN instead of manually created one
* Use `isAWSErr()` helper
* Cleanup some `aws_db_instance` test functions

Output from acceptance testing:

```
21 tests passed (all tests)
=== RUN   TestAccAWSDBInstance_namePrefix
--- PASS: TestAccAWSDBInstance_namePrefix (392.73s)
=== RUN   TestAccAWSDBInstance_generatedName
--- PASS: TestAccAWSDBInstance_generatedName (392.81s)
=== RUN   TestAccAWSDBInstance_MinorVersion
--- PASS: TestAccAWSDBInstance_MinorVersion (393.00s)
=== RUN   TestAccAWSDBInstance_importBasic
--- PASS: TestAccAWSDBInstance_importBasic (393.81s)
=== RUN   TestAccAWSDBInstance_ec2Classic
--- PASS: TestAccAWSDBInstance_ec2Classic (402.44s)
=== RUN   TestAccAWSDBInstance_kmsKey
--- PASS: TestAccAWSDBInstance_kmsKey (412.23s)
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (433.58s)
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfiguration
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (467.68s)
=== RUN   TestAccAWSDBInstance_optionGroup
--- PASS: TestAccAWSDBInstance_optionGroup (473.72s)
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (473.76s)
=== RUN   TestAccAWSDBInstance_iamAuth
--- PASS: TestAccAWSDBInstance_iamAuth (554.75s)
=== RUN   TestAccAWSDBInstance_portUpdate
--- PASS: TestAccAWSDBInstance_portUpdate (559.17s)
=== RUN   TestAccAWSDBInstance_separate_iops_update
--- PASS: TestAccAWSDBInstance_separate_iops_update (598.86s)
=== RUN   TestAccAWSDBInstance_noSnapshot
--- PASS: TestAccAWSDBInstance_noSnapshot (604.50s)
=== RUN   TestAccAWSDBInstance_enhancedMonitoring
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (609.17s)
=== RUN   TestAccAWSDBInstance_snapshot
--- PASS: TestAccAWSDBInstance_snapshot (746.94s)
=== RUN   TestAccAWSDBInstance_s3
--- PASS: TestAccAWSDBInstance_s3 (768.78s)
=== RUN   TestAccAWSDBInstance_subnetGroup
--- PASS: TestAccAWSDBInstance_subnetGroup (907.98s)
=== RUN   TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (532.18s)
=== RUN   TestAccAWSDBInstance_MSSQL_TZ
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1453.06s)
=== RUN   TestAccAWSDBInstance_replica
--- PASS: TestAccAWSDBInstance_replica (1545.29s)
```
