### PR TITLE
vendor: aws/aws-sdk-go@v1.14.29

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/csm/reporter.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/csm/reporter.go
@@ -90,14 +90,13 @@ func (rep *Reporter) sendAPICallAttemptMetric(r *request.Request) {
 }
 
 func setError(m *metric, err awserr.Error) {
-	msg := err.Message()
+	msg := err.Error()
 	code := err.Code()
 
 	switch code {
 	case "RequestError",
 		"SerializationError",
 		request.CanceledErrorCode:
-
 		m.SDKException = &code
 		m.SDKExceptionMessage = &msg
 	default:

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
@@ -97,7 +97,7 @@ func isNestedErrorRetryable(parentErr awserr.Error) bool {
 	}
 
 	if t, ok := err.(temporaryError); ok {
-		return t.Temporary()
+		return t.Temporary() || isErrConnectionReset(err)
 	}
 
 	return isErrConnectionReset(err)

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.26"
+const SDKVersion = "1.14.29"

--- a/vendor/github.com/aws/aws-sdk-go/service/sagemaker/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sagemaker/api.go
@@ -891,6 +891,112 @@ func (c *SageMaker) CreateTrainingJobWithContext(ctx aws.Context, input *CreateT
 	return out, req.Send()
 }
 
+const opCreateTransformJob = "CreateTransformJob"
+
+// CreateTransformJobRequest generates a "aws/request.Request" representing the
+// client's request for the CreateTransformJob operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateTransformJob for more information on using the CreateTransformJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateTransformJobRequest method.
+//    req, resp := client.CreateTransformJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/CreateTransformJob
+func (c *SageMaker) CreateTransformJobRequest(input *CreateTransformJobInput) (req *request.Request, output *CreateTransformJobOutput) {
+	op := &request.Operation{
+		Name:       opCreateTransformJob,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateTransformJobInput{}
+	}
+
+	output = &CreateTransformJobOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateTransformJob API operation for Amazon SageMaker Service.
+//
+// Starts a transform job. After the results are obtained, Amazon SageMaker
+// saves them to an Amazon S3 location that you specify.
+//
+// To perform batch transformations, you create a transform job and use the
+// data that you have readily available.
+//
+// In the request body, you provide the following:
+//
+//    * TransformJobName - Identifies the transform job. The name must be unique
+//    within an AWS Region in an AWS account.
+//
+//    * ModelName - Identifies the model to use.
+//
+//    * TransformInput - Describes the dataset to be transformed and the Amazon
+//    S3 location where it is stored.
+//
+//    * TransformOutput - Identifies the Amazon S3 location where you want Amazon
+//    SageMaker to save the results from the transform job.
+//
+//    * TransformResources - Identifies the ML compute instances for the transform
+//    job.
+//
+// For more information about how batch transformation works Amazon SageMaker,
+// see How It Works (http://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon SageMaker Service's
+// API operation CreateTransformJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceInUse "ResourceInUse"
+//   Resource being accessed is in use.
+//
+//   * ErrCodeResourceLimitExceeded "ResourceLimitExceeded"
+//   You have exceeded an Amazon SageMaker resource limit. For example, you might
+//   have too many training jobs created.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/CreateTransformJob
+func (c *SageMaker) CreateTransformJob(input *CreateTransformJobInput) (*CreateTransformJobOutput, error) {
+	req, out := c.CreateTransformJobRequest(input)
+	return out, req.Send()
+}
+
+// CreateTransformJobWithContext is the same as CreateTransformJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateTransformJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SageMaker) CreateTransformJobWithContext(ctx aws.Context, input *CreateTransformJobInput, opts ...request.Option) (*CreateTransformJobOutput, error) {
+	req, out := c.CreateTransformJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteEndpoint = "DeleteEndpoint"
 
 // DeleteEndpointRequest generates a "aws/request.Request" representing the
@@ -1884,6 +1990,85 @@ func (c *SageMaker) DescribeTrainingJob(input *DescribeTrainingJobInput) (*Descr
 // for more information on using Contexts.
 func (c *SageMaker) DescribeTrainingJobWithContext(ctx aws.Context, input *DescribeTrainingJobInput, opts ...request.Option) (*DescribeTrainingJobOutput, error) {
 	req, out := c.DescribeTrainingJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeTransformJob = "DescribeTransformJob"
+
+// DescribeTransformJobRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeTransformJob operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeTransformJob for more information on using the DescribeTransformJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeTransformJobRequest method.
+//    req, resp := client.DescribeTransformJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/DescribeTransformJob
+func (c *SageMaker) DescribeTransformJobRequest(input *DescribeTransformJobInput) (req *request.Request, output *DescribeTransformJobOutput) {
+	op := &request.Operation{
+		Name:       opDescribeTransformJob,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeTransformJobInput{}
+	}
+
+	output = &DescribeTransformJobOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeTransformJob API operation for Amazon SageMaker Service.
+//
+// Returns information about a transform job.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon SageMaker Service's
+// API operation DescribeTransformJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFound "ResourceNotFound"
+//   Resource being access is not found.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/DescribeTransformJob
+func (c *SageMaker) DescribeTransformJob(input *DescribeTransformJobInput) (*DescribeTransformJobOutput, error) {
+	req, out := c.DescribeTransformJobRequest(input)
+	return out, req.Send()
+}
+
+// DescribeTransformJobWithContext is the same as DescribeTransformJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeTransformJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SageMaker) DescribeTransformJobWithContext(ctx aws.Context, input *DescribeTransformJobInput, opts ...request.Option) (*DescribeTransformJobOutput, error) {
+	req, out := c.DescribeTransformJobRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -3069,6 +3254,136 @@ func (c *SageMaker) ListTrainingJobsForHyperParameterTuningJobPagesWithContext(c
 	return p.Err()
 }
 
+const opListTransformJobs = "ListTransformJobs"
+
+// ListTransformJobsRequest generates a "aws/request.Request" representing the
+// client's request for the ListTransformJobs operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListTransformJobs for more information on using the ListTransformJobs
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListTransformJobsRequest method.
+//    req, resp := client.ListTransformJobsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/ListTransformJobs
+func (c *SageMaker) ListTransformJobsRequest(input *ListTransformJobsInput) (req *request.Request, output *ListTransformJobsOutput) {
+	op := &request.Operation{
+		Name:       opListTransformJobs,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListTransformJobsInput{}
+	}
+
+	output = &ListTransformJobsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTransformJobs API operation for Amazon SageMaker Service.
+//
+// Lists transform jobs.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon SageMaker Service's
+// API operation ListTransformJobs for usage and error information.
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/ListTransformJobs
+func (c *SageMaker) ListTransformJobs(input *ListTransformJobsInput) (*ListTransformJobsOutput, error) {
+	req, out := c.ListTransformJobsRequest(input)
+	return out, req.Send()
+}
+
+// ListTransformJobsWithContext is the same as ListTransformJobs with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTransformJobs for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SageMaker) ListTransformJobsWithContext(ctx aws.Context, input *ListTransformJobsInput, opts ...request.Option) (*ListTransformJobsOutput, error) {
+	req, out := c.ListTransformJobsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListTransformJobsPages iterates over the pages of a ListTransformJobs operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListTransformJobs method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListTransformJobs operation.
+//    pageNum := 0
+//    err := client.ListTransformJobsPages(params,
+//        func(page *ListTransformJobsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *SageMaker) ListTransformJobsPages(input *ListTransformJobsInput, fn func(*ListTransformJobsOutput, bool) bool) error {
+	return c.ListTransformJobsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListTransformJobsPagesWithContext same as ListTransformJobsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SageMaker) ListTransformJobsPagesWithContext(ctx aws.Context, input *ListTransformJobsInput, fn func(*ListTransformJobsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListTransformJobsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListTransformJobsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListTransformJobsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opStartNotebookInstance = "StartNotebookInstance"
 
 // StartNotebookInstanceRequest generates a "aws/request.Request" representing the
@@ -3205,7 +3520,7 @@ func (c *SageMaker) StopHyperParameterTuningJobRequest(input *StopHyperParameter
 // the tuning job launched.
 //
 // All model artifacts output from the training jobs are stored in Amazon Simple
-// Storage Service (Amazon S3). All data that the training jobs write toAmazon
+// Storage Service (Amazon S3). All data that the training jobs write to Amazon
 // CloudWatch Logs are still available in CloudWatch. After the tuning job moves
 // to the Stopped state, it releases all reserved resources for the tuning job.
 //
@@ -3413,6 +3728,92 @@ func (c *SageMaker) StopTrainingJob(input *StopTrainingJobInput) (*StopTrainingJ
 // for more information on using Contexts.
 func (c *SageMaker) StopTrainingJobWithContext(ctx aws.Context, input *StopTrainingJobInput, opts ...request.Option) (*StopTrainingJobOutput, error) {
 	req, out := c.StopTrainingJobRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opStopTransformJob = "StopTransformJob"
+
+// StopTransformJobRequest generates a "aws/request.Request" representing the
+// client's request for the StopTransformJob operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See StopTransformJob for more information on using the StopTransformJob
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the StopTransformJobRequest method.
+//    req, resp := client.StopTransformJobRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/StopTransformJob
+func (c *SageMaker) StopTransformJobRequest(input *StopTransformJobInput) (req *request.Request, output *StopTransformJobOutput) {
+	op := &request.Operation{
+		Name:       opStopTransformJob,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &StopTransformJobInput{}
+	}
+
+	output = &StopTransformJobOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(jsonrpc.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// StopTransformJob API operation for Amazon SageMaker Service.
+//
+// Stops a transform job.
+//
+// When Amazon SageMaker receives a StopTransformJob request, the status of
+// the job changes to Stopping. After Amazon SageMaker stops the job, the status
+// is set to Stopped. When you stop a transform job before it is completed,
+// Amazon SageMaker doesn't store the job's output in Amazon S3.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon SageMaker Service's
+// API operation StopTransformJob for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceNotFound "ResourceNotFound"
+//   Resource being access is not found.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/sagemaker-2017-07-24/StopTransformJob
+func (c *SageMaker) StopTransformJob(input *StopTransformJobInput) (*StopTransformJobOutput, error) {
+	req, out := c.StopTransformJobRequest(input)
+	return out, req.Send()
+}
+
+// StopTransformJobWithContext is the same as StopTransformJob with the addition of
+// the ability to pass a context and additional request options.
+//
+// See StopTransformJob for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *SageMaker) StopTransformJobWithContext(ctx aws.Context, input *StopTransformJobInput, opts ...request.Option) (*StopTransformJobOutput, error) {
+	req, out := c.StopTransformJobRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -5167,7 +5568,7 @@ type CreateTrainingJobInput struct {
 	Tags []*Tag `type:"list"`
 
 	// The name of the training job. The name must be unique within an AWS Region
-	// in an AWS account. It appears in the Amazon SageMaker console.
+	// in an AWS account.
 	//
 	// TrainingJobName is a required field
 	TrainingJobName *string `min:"1" type:"string" required:"true"`
@@ -5355,6 +5756,216 @@ func (s CreateTrainingJobOutput) GoString() string {
 // SetTrainingJobArn sets the TrainingJobArn field's value.
 func (s *CreateTrainingJobOutput) SetTrainingJobArn(v string) *CreateTrainingJobOutput {
 	s.TrainingJobArn = &v
+	return s
+}
+
+type CreateTransformJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// Determins the number of records included in a single batch. SingleRecord
+	// means only one record is used per batch. MultiRecord means a batch is set
+	// to contain as many records that could possibly fit within the MaxPayloadInMB
+	// limit.
+	BatchStrategy *string `type:"string" enum:"BatchStrategy"`
+
+	// The environment variables to set in the Docker container. We support up to
+	// 16 key and values entries in the map.
+	Environment map[string]*string `type:"map"`
+
+	// The maximum number of parallel requests on each instance node that can be
+	// launched in a transform job. The default value is 1. To allow Amazon SageMaker
+	// to determine the appropriate number for MaxConcurrentTransforms, set the
+	// value to 0.
+	MaxConcurrentTransforms *int64 `type:"integer"`
+
+	// The maximum payload size allowed, in MB. A payload is the data portion of
+	// a record (without metadata). The value in MaxPayloadInMB must be greater
+	// than the size of a single record.You can approximate the size of a record
+	// by dividing the size of your dataset by the number of records. The value
+	// you enter should be proportional to the number of records you want per batch.
+	// It is recommended to enter a slightly higher value to ensure the records
+	// will fit within the maximum payload size. The default value is 6 MB. For
+	// an unlimited payload size, set the value to 0.
+	MaxPayloadInMB *int64 `type:"integer"`
+
+	// The name of the model that you want to use for the transform job.
+	//
+	// ModelName is a required field
+	ModelName *string `type:"string" required:"true"`
+
+	// An array of key-value pairs. Adding tags is optional. For more information,
+	// see Using Cost Allocation Tags (http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-what)
+	// in the AWS Billing and Cost Management User Guide.
+	Tags []*Tag `type:"list"`
+
+	// Describes the input source and the way the transform job consumes it.
+	//
+	// TransformInput is a required field
+	TransformInput *TransformInput `type:"structure" required:"true"`
+
+	// The name of the transform job. The name must be unique within an AWS Region
+	// in an AWS account.
+	//
+	// TransformJobName is a required field
+	TransformJobName *string `min:"1" type:"string" required:"true"`
+
+	// Describes the results of the transform job.
+	//
+	// TransformOutput is a required field
+	TransformOutput *TransformOutput `type:"structure" required:"true"`
+
+	// Describes the resources, including ML instance types and ML instance count,
+	// to use for the transform job.
+	//
+	// TransformResources is a required field
+	TransformResources *TransformResources `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateTransformJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTransformJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateTransformJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateTransformJobInput"}
+	if s.ModelName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ModelName"))
+	}
+	if s.TransformInput == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransformInput"))
+	}
+	if s.TransformJobName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransformJobName"))
+	}
+	if s.TransformJobName != nil && len(*s.TransformJobName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TransformJobName", 1))
+	}
+	if s.TransformOutput == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransformOutput"))
+	}
+	if s.TransformResources == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransformResources"))
+	}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.TransformInput != nil {
+		if err := s.TransformInput.Validate(); err != nil {
+			invalidParams.AddNested("TransformInput", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TransformOutput != nil {
+		if err := s.TransformOutput.Validate(); err != nil {
+			invalidParams.AddNested("TransformOutput", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.TransformResources != nil {
+		if err := s.TransformResources.Validate(); err != nil {
+			invalidParams.AddNested("TransformResources", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBatchStrategy sets the BatchStrategy field's value.
+func (s *CreateTransformJobInput) SetBatchStrategy(v string) *CreateTransformJobInput {
+	s.BatchStrategy = &v
+	return s
+}
+
+// SetEnvironment sets the Environment field's value.
+func (s *CreateTransformJobInput) SetEnvironment(v map[string]*string) *CreateTransformJobInput {
+	s.Environment = v
+	return s
+}
+
+// SetMaxConcurrentTransforms sets the MaxConcurrentTransforms field's value.
+func (s *CreateTransformJobInput) SetMaxConcurrentTransforms(v int64) *CreateTransformJobInput {
+	s.MaxConcurrentTransforms = &v
+	return s
+}
+
+// SetMaxPayloadInMB sets the MaxPayloadInMB field's value.
+func (s *CreateTransformJobInput) SetMaxPayloadInMB(v int64) *CreateTransformJobInput {
+	s.MaxPayloadInMB = &v
+	return s
+}
+
+// SetModelName sets the ModelName field's value.
+func (s *CreateTransformJobInput) SetModelName(v string) *CreateTransformJobInput {
+	s.ModelName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateTransformJobInput) SetTags(v []*Tag) *CreateTransformJobInput {
+	s.Tags = v
+	return s
+}
+
+// SetTransformInput sets the TransformInput field's value.
+func (s *CreateTransformJobInput) SetTransformInput(v *TransformInput) *CreateTransformJobInput {
+	s.TransformInput = v
+	return s
+}
+
+// SetTransformJobName sets the TransformJobName field's value.
+func (s *CreateTransformJobInput) SetTransformJobName(v string) *CreateTransformJobInput {
+	s.TransformJobName = &v
+	return s
+}
+
+// SetTransformOutput sets the TransformOutput field's value.
+func (s *CreateTransformJobInput) SetTransformOutput(v *TransformOutput) *CreateTransformJobInput {
+	s.TransformOutput = v
+	return s
+}
+
+// SetTransformResources sets the TransformResources field's value.
+func (s *CreateTransformJobInput) SetTransformResources(v *TransformResources) *CreateTransformJobInput {
+	s.TransformResources = v
+	return s
+}
+
+type CreateTransformJobOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the transform job.
+	//
+	// TransformJobArn is a required field
+	TransformJobArn *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateTransformJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateTransformJobOutput) GoString() string {
+	return s.String()
+}
+
+// SetTransformJobArn sets the TransformJobArn field's value.
+func (s *CreateTransformJobOutput) SetTransformJobArn(v string) *CreateTransformJobOutput {
+	s.TransformJobArn = &v
 	return s
 }
 
@@ -6911,6 +7522,218 @@ func (s *DescribeTrainingJobOutput) SetTuningJobArn(v string) *DescribeTrainingJ
 // SetVpcConfig sets the VpcConfig field's value.
 func (s *DescribeTrainingJobOutput) SetVpcConfig(v *VpcConfig) *DescribeTrainingJobOutput {
 	s.VpcConfig = v
+	return s
+}
+
+type DescribeTransformJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the transform job that you want to view details of.
+	//
+	// TransformJobName is a required field
+	TransformJobName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeTransformJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTransformJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeTransformJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeTransformJobInput"}
+	if s.TransformJobName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransformJobName"))
+	}
+	if s.TransformJobName != nil && len(*s.TransformJobName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TransformJobName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTransformJobName sets the TransformJobName field's value.
+func (s *DescribeTransformJobInput) SetTransformJobName(v string) *DescribeTransformJobInput {
+	s.TransformJobName = &v
+	return s
+}
+
+type DescribeTransformJobOutput struct {
+	_ struct{} `type:"structure"`
+
+	// SingleRecord means only one record was used per a batch. <code>MultiRecord</code>
+	// means batches contained as many records that could possibly fit within the
+	// MaxPayloadInMB limit.
+	BatchStrategy *string `type:"string" enum:"BatchStrategy"`
+
+	// A timestamp that shows when the transform Job was created.
+	//
+	// CreationTime is a required field
+	CreationTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	Environment map[string]*string `type:"map"`
+
+	// If the transform job failed, the reason that it failed.
+	FailureReason *string `type:"string"`
+
+	// The maximum number of parallel requests on each instance node that can be
+	// launched in a transform job. The default value is 1.
+	MaxConcurrentTransforms *int64 `type:"integer"`
+
+	// The maximum payload size , in MB used in the transform job.
+	MaxPayloadInMB *int64 `type:"integer"`
+
+	// The name of the model used in the transform job.
+	//
+	// ModelName is a required field
+	ModelName *string `type:"string" required:"true"`
+
+	// Indicates when the transform job is Completed, Stopped, or Failed. You are
+	// billed for the time interval between this time and the value of TransformStartTime.
+	TransformEndTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// Describes the dataset to be transformed and the Amazon S3 location where
+	// it is stored.
+	//
+	// TransformInput is a required field
+	TransformInput *TransformInput `type:"structure" required:"true"`
+
+	// The Amazon Resource Name (ARN) of the transform job.
+	//
+	// TransformJobArn is a required field
+	TransformJobArn *string `type:"string" required:"true"`
+
+	// The name of the transform job.
+	//
+	// TransformJobName is a required field
+	TransformJobName *string `min:"1" type:"string" required:"true"`
+
+	// The status of the transform job. If the transform job failed, the reason
+	// is returned in the FailureReason field.
+	//
+	// TransformJobStatus is a required field
+	TransformJobStatus *string `type:"string" required:"true" enum:"TransformJobStatus"`
+
+	// Identifies the Amazon S3 location where you want Amazon SageMaker to save
+	// the results from the transform job.
+	TransformOutput *TransformOutput `type:"structure"`
+
+	// Describes the resources, including ML instance types and ML instance count,
+	// to use for the transform job.
+	//
+	// TransformResources is a required field
+	TransformResources *TransformResources `type:"structure" required:"true"`
+
+	// Indicates when the transform job starts on ML instances. You are billed for
+	// the time interval between this time and the value of TransformEndTime.
+	TransformStartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+}
+
+// String returns the string representation
+func (s DescribeTransformJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTransformJobOutput) GoString() string {
+	return s.String()
+}
+
+// SetBatchStrategy sets the BatchStrategy field's value.
+func (s *DescribeTransformJobOutput) SetBatchStrategy(v string) *DescribeTransformJobOutput {
+	s.BatchStrategy = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *DescribeTransformJobOutput) SetCreationTime(v time.Time) *DescribeTransformJobOutput {
+	s.CreationTime = &v
+	return s
+}
+
+// SetEnvironment sets the Environment field's value.
+func (s *DescribeTransformJobOutput) SetEnvironment(v map[string]*string) *DescribeTransformJobOutput {
+	s.Environment = v
+	return s
+}
+
+// SetFailureReason sets the FailureReason field's value.
+func (s *DescribeTransformJobOutput) SetFailureReason(v string) *DescribeTransformJobOutput {
+	s.FailureReason = &v
+	return s
+}
+
+// SetMaxConcurrentTransforms sets the MaxConcurrentTransforms field's value.
+func (s *DescribeTransformJobOutput) SetMaxConcurrentTransforms(v int64) *DescribeTransformJobOutput {
+	s.MaxConcurrentTransforms = &v
+	return s
+}
+
+// SetMaxPayloadInMB sets the MaxPayloadInMB field's value.
+func (s *DescribeTransformJobOutput) SetMaxPayloadInMB(v int64) *DescribeTransformJobOutput {
+	s.MaxPayloadInMB = &v
+	return s
+}
+
+// SetModelName sets the ModelName field's value.
+func (s *DescribeTransformJobOutput) SetModelName(v string) *DescribeTransformJobOutput {
+	s.ModelName = &v
+	return s
+}
+
+// SetTransformEndTime sets the TransformEndTime field's value.
+func (s *DescribeTransformJobOutput) SetTransformEndTime(v time.Time) *DescribeTransformJobOutput {
+	s.TransformEndTime = &v
+	return s
+}
+
+// SetTransformInput sets the TransformInput field's value.
+func (s *DescribeTransformJobOutput) SetTransformInput(v *TransformInput) *DescribeTransformJobOutput {
+	s.TransformInput = v
+	return s
+}
+
+// SetTransformJobArn sets the TransformJobArn field's value.
+func (s *DescribeTransformJobOutput) SetTransformJobArn(v string) *DescribeTransformJobOutput {
+	s.TransformJobArn = &v
+	return s
+}
+
+// SetTransformJobName sets the TransformJobName field's value.
+func (s *DescribeTransformJobOutput) SetTransformJobName(v string) *DescribeTransformJobOutput {
+	s.TransformJobName = &v
+	return s
+}
+
+// SetTransformJobStatus sets the TransformJobStatus field's value.
+func (s *DescribeTransformJobOutput) SetTransformJobStatus(v string) *DescribeTransformJobOutput {
+	s.TransformJobStatus = &v
+	return s
+}
+
+// SetTransformOutput sets the TransformOutput field's value.
+func (s *DescribeTransformJobOutput) SetTransformOutput(v *TransformOutput) *DescribeTransformJobOutput {
+	s.TransformOutput = v
+	return s
+}
+
+// SetTransformResources sets the TransformResources field's value.
+func (s *DescribeTransformJobOutput) SetTransformResources(v *TransformResources) *DescribeTransformJobOutput {
+	s.TransformResources = v
+	return s
+}
+
+// SetTransformStartTime sets the TransformStartTime field's value.
+func (s *DescribeTransformJobOutput) SetTransformStartTime(v time.Time) *DescribeTransformJobOutput {
+	s.TransformStartTime = &v
 	return s
 }
 
@@ -9028,7 +9851,8 @@ func (s *ListTrainingJobsForHyperParameterTuningJobOutput) SetTrainingJobSummari
 type ListTrainingJobsInput struct {
 	_ struct{} `type:"structure"`
 
-	// A filter that only training jobs created after the specified time (timestamp).
+	// A filter that returns only training jobs created after the specified time
+	// (timestamp).
 	CreationTimeAfter *time.Time `type:"timestamp" timestampFormat:"unix"`
 
 	// A filter that returns only training jobs created before the specified time
@@ -9180,6 +10004,162 @@ func (s *ListTrainingJobsOutput) SetNextToken(v string) *ListTrainingJobsOutput 
 // SetTrainingJobSummaries sets the TrainingJobSummaries field's value.
 func (s *ListTrainingJobsOutput) SetTrainingJobSummaries(v []*TrainingJobSummary) *ListTrainingJobsOutput {
 	s.TrainingJobSummaries = v
+	return s
+}
+
+type ListTransformJobsInput struct {
+	_ struct{} `type:"structure"`
+
+	// A filter that returns only transform jobs created after the specified time.
+	CreationTimeAfter *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// A filter that returns only transform jobs created before the specified time.
+	CreationTimeBefore *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// A filter that returns only transform jobs modified after the specified time.
+	LastModifiedTimeAfter *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// A filter that returns only transform jobs modified before the specified time.
+	LastModifiedTimeBefore *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The maximum number of transform jobs to return in the response. The default
+	// value is 10.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// A string in the transform job name. This filter returns only transform jobs
+	// whose name contains the specified string.
+	NameContains *string `type:"string"`
+
+	// If the result of the previous ListTransformJobs request was truncated, the
+	// response includes a NextToken. To retrieve the next set of transform jobs,
+	// use the token in the next request.
+	NextToken *string `type:"string"`
+
+	// The field to sort results by. The default is CreationTime.
+	SortBy *string `type:"string" enum:"SortBy"`
+
+	// The sort order for results. The default is Descending.
+	SortOrder *string `type:"string" enum:"SortOrder"`
+
+	// A filter that retrieves only transform jobs with a specific status.
+	StatusEquals *string `type:"string" enum:"TransformJobStatus"`
+}
+
+// String returns the string representation
+func (s ListTransformJobsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTransformJobsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTransformJobsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTransformJobsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCreationTimeAfter sets the CreationTimeAfter field's value.
+func (s *ListTransformJobsInput) SetCreationTimeAfter(v time.Time) *ListTransformJobsInput {
+	s.CreationTimeAfter = &v
+	return s
+}
+
+// SetCreationTimeBefore sets the CreationTimeBefore field's value.
+func (s *ListTransformJobsInput) SetCreationTimeBefore(v time.Time) *ListTransformJobsInput {
+	s.CreationTimeBefore = &v
+	return s
+}
+
+// SetLastModifiedTimeAfter sets the LastModifiedTimeAfter field's value.
+func (s *ListTransformJobsInput) SetLastModifiedTimeAfter(v time.Time) *ListTransformJobsInput {
+	s.LastModifiedTimeAfter = &v
+	return s
+}
+
+// SetLastModifiedTimeBefore sets the LastModifiedTimeBefore field's value.
+func (s *ListTransformJobsInput) SetLastModifiedTimeBefore(v time.Time) *ListTransformJobsInput {
+	s.LastModifiedTimeBefore = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListTransformJobsInput) SetMaxResults(v int64) *ListTransformJobsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNameContains sets the NameContains field's value.
+func (s *ListTransformJobsInput) SetNameContains(v string) *ListTransformJobsInput {
+	s.NameContains = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTransformJobsInput) SetNextToken(v string) *ListTransformJobsInput {
+	s.NextToken = &v
+	return s
+}
+
+// SetSortBy sets the SortBy field's value.
+func (s *ListTransformJobsInput) SetSortBy(v string) *ListTransformJobsInput {
+	s.SortBy = &v
+	return s
+}
+
+// SetSortOrder sets the SortOrder field's value.
+func (s *ListTransformJobsInput) SetSortOrder(v string) *ListTransformJobsInput {
+	s.SortOrder = &v
+	return s
+}
+
+// SetStatusEquals sets the StatusEquals field's value.
+func (s *ListTransformJobsInput) SetStatusEquals(v string) *ListTransformJobsInput {
+	s.StatusEquals = &v
+	return s
+}
+
+type ListTransformJobsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// If the response is truncated, Amazon SageMaker returns this token. To retrieve
+	// the next set of transform jobs, use it in the next request.
+	NextToken *string `type:"string"`
+
+	// An array of TransformJobSummary objects.
+	//
+	// TransformJobSummaries is a required field
+	TransformJobSummaries []*TransformJobSummary `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTransformJobsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTransformJobsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListTransformJobsOutput) SetNextToken(v string) *ListTransformJobsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetTransformJobSummaries sets the TransformJobSummaries field's value.
+func (s *ListTransformJobsOutput) SetTransformJobSummaries(v []*TransformJobSummary) *ListTransformJobsOutput {
+	s.TransformJobSummaries = v
 	return s
 }
 
@@ -10386,6 +11366,61 @@ func (s StopTrainingJobOutput) GoString() string {
 	return s.String()
 }
 
+type StopTransformJobInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the transform job to stop.
+	//
+	// TransformJobName is a required field
+	TransformJobName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s StopTransformJobInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StopTransformJobInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StopTransformJobInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StopTransformJobInput"}
+	if s.TransformJobName == nil {
+		invalidParams.Add(request.NewErrParamRequired("TransformJobName"))
+	}
+	if s.TransformJobName != nil && len(*s.TransformJobName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("TransformJobName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTransformJobName sets the TransformJobName field's value.
+func (s *StopTransformJobInput) SetTransformJobName(v string) *StopTransformJobInput {
+	s.TransformJobName = &v
+	return s
+}
+
+type StopTransformJobOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopTransformJobOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StopTransformJobOutput) GoString() string {
+	return s.String()
+}
+
 // Specifies how long model training can run. When model training reaches the
 // limit, Amazon SageMaker ends the training job. Use this API to cap model
 // training cost.
@@ -10636,6 +11671,470 @@ func (s *TrainingJobSummary) SetTrainingJobName(v string) *TrainingJobSummary {
 // SetTrainingJobStatus sets the TrainingJobStatus field's value.
 func (s *TrainingJobSummary) SetTrainingJobStatus(v string) *TrainingJobSummary {
 	s.TrainingJobStatus = &v
+	return s
+}
+
+// Describes the location of the channel data.
+type TransformDataSource struct {
+	_ struct{} `type:"structure"`
+
+	// The S3 location of the data source that is associated with a channel.
+	//
+	// S3DataSource is a required field
+	S3DataSource *TransformS3DataSource `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s TransformDataSource) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransformDataSource) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TransformDataSource) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TransformDataSource"}
+	if s.S3DataSource == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3DataSource"))
+	}
+	if s.S3DataSource != nil {
+		if err := s.S3DataSource.Validate(); err != nil {
+			invalidParams.AddNested("S3DataSource", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetS3DataSource sets the S3DataSource field's value.
+func (s *TransformDataSource) SetS3DataSource(v *TransformS3DataSource) *TransformDataSource {
+	s.S3DataSource = v
+	return s
+}
+
+// Describes the input source of a transform job and the way the transform job
+// consumes it.
+type TransformInput struct {
+	_ struct{} `type:"structure"`
+
+	// Compressing data helps save on storage space. If your transform data is compressed,
+	// specify the compression type.and Amazon SageMaker will automatically decompress
+	// the data for the transform job accordingly. The default value is None.
+	CompressionType *string `type:"string" enum:"CompressionType"`
+
+	// The multipurpose internet mail extension (MIME) type of the data. Amazon
+	// SageMaker uses the MIME type with each http call to transfer data to the
+	// transform job.
+	ContentType *string `type:"string"`
+
+	// Describes the location of the channel data, meaning the S3 location of the
+	// input data that the model can consume.
+	//
+	// DataSource is a required field
+	DataSource *TransformDataSource `type:"structure" required:"true"`
+
+	// The method to use to split the transform job's data into smaller batches.
+	// The default value is None. If you don't want to split the data, specify (None).
+	// If you want to split records on a newline character boundary, specify Line.
+	// To split records according to the RecordIO format, specify RecordIO.
+	//
+	// Amazon SageMaker will send maximum number of records per batch in each request
+	// up to the MaxPayloadInMB limit. For more information, see RecordIO data format
+	// (http://mxnet.io/architecture/note_data_loading.html#data-format).
+	//
+	// For information about the RecordIO format, see Data Format (http://mxnet.io/architecture/note_data_loading.html#data-format).
+	SplitType *string `type:"string" enum:"SplitType"`
+}
+
+// String returns the string representation
+func (s TransformInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransformInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TransformInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TransformInput"}
+	if s.DataSource == nil {
+		invalidParams.Add(request.NewErrParamRequired("DataSource"))
+	}
+	if s.DataSource != nil {
+		if err := s.DataSource.Validate(); err != nil {
+			invalidParams.AddNested("DataSource", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCompressionType sets the CompressionType field's value.
+func (s *TransformInput) SetCompressionType(v string) *TransformInput {
+	s.CompressionType = &v
+	return s
+}
+
+// SetContentType sets the ContentType field's value.
+func (s *TransformInput) SetContentType(v string) *TransformInput {
+	s.ContentType = &v
+	return s
+}
+
+// SetDataSource sets the DataSource field's value.
+func (s *TransformInput) SetDataSource(v *TransformDataSource) *TransformInput {
+	s.DataSource = v
+	return s
+}
+
+// SetSplitType sets the SplitType field's value.
+func (s *TransformInput) SetSplitType(v string) *TransformInput {
+	s.SplitType = &v
+	return s
+}
+
+// Provides a summary information for a transform job. Multiple TransformJobSummary
+// objects are returned as a list after calling ListTransformJobs.
+type TransformJobSummary struct {
+	_ struct{} `type:"structure"`
+
+	// A timestamp that shows when the transform Job was created.
+	//
+	// CreationTime is a required field
+	CreationTime *time.Time `type:"timestamp" timestampFormat:"unix" required:"true"`
+
+	// If the transform job failed, the reason it failed.
+	FailureReason *string `type:"string"`
+
+	// Indicates when the transform job was last modified.
+	LastModifiedTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// Indicates when the transform job ends on compute instances. For successful
+	// jobs and stopped jobs, this is the exact time recorded after the results
+	// are uploaded. For failed jobs, this is when Amazon SageMaker detected that
+	// the job failed.
+	TransformEndTime *time.Time `type:"timestamp" timestampFormat:"unix"`
+
+	// The Amazon Resource Name (ARN) of the transform job.
+	//
+	// TransformJobArn is a required field
+	TransformJobArn *string `type:"string" required:"true"`
+
+	// The name of the transform job.
+	//
+	// TransformJobName is a required field
+	TransformJobName *string `min:"1" type:"string" required:"true"`
+
+	// The status of the transform job.
+	//
+	// TransformJobStatus is a required field
+	TransformJobStatus *string `type:"string" required:"true" enum:"TransformJobStatus"`
+}
+
+// String returns the string representation
+func (s TransformJobSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransformJobSummary) GoString() string {
+	return s.String()
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *TransformJobSummary) SetCreationTime(v time.Time) *TransformJobSummary {
+	s.CreationTime = &v
+	return s
+}
+
+// SetFailureReason sets the FailureReason field's value.
+func (s *TransformJobSummary) SetFailureReason(v string) *TransformJobSummary {
+	s.FailureReason = &v
+	return s
+}
+
+// SetLastModifiedTime sets the LastModifiedTime field's value.
+func (s *TransformJobSummary) SetLastModifiedTime(v time.Time) *TransformJobSummary {
+	s.LastModifiedTime = &v
+	return s
+}
+
+// SetTransformEndTime sets the TransformEndTime field's value.
+func (s *TransformJobSummary) SetTransformEndTime(v time.Time) *TransformJobSummary {
+	s.TransformEndTime = &v
+	return s
+}
+
+// SetTransformJobArn sets the TransformJobArn field's value.
+func (s *TransformJobSummary) SetTransformJobArn(v string) *TransformJobSummary {
+	s.TransformJobArn = &v
+	return s
+}
+
+// SetTransformJobName sets the TransformJobName field's value.
+func (s *TransformJobSummary) SetTransformJobName(v string) *TransformJobSummary {
+	s.TransformJobName = &v
+	return s
+}
+
+// SetTransformJobStatus sets the TransformJobStatus field's value.
+func (s *TransformJobSummary) SetTransformJobStatus(v string) *TransformJobSummary {
+	s.TransformJobStatus = &v
+	return s
+}
+
+// Describes the results of a transform job output.
+type TransformOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The MIME type used to specify the output data. Amazon SageMaker uses the
+	// MIME type with each http call to transfer data from the transform job.
+	Accept *string `type:"string"`
+
+	// Defines how to assemble the results of the transform job as a single S3 object.
+	// You should select a format that is most convienant to you. To concatenate
+	// the results in binary format, specify None. To add a newline character at
+	// the end of every transformed record, specify Line. To assemble the output
+	// in RecordIO format, specify RecordIO. The default value is None.
+	//
+	// For information about the RecordIO format, see Data Format (http://mxnet.io/architecture/note_data_loading.html#data-format).
+	AssembleWith *string `type:"string" enum:"AssemblyType"`
+
+	// The AWS Key Management Service (AWS KMS) key for Amazon S3 server-side encryption
+	// that Amazon SageMaker uses to encrypt the transformed data.
+	//
+	// If you don't provide a KMS key ID, Amazon SageMaker uses the default KMS
+	// key for Amazon S3 for your role's account. For more information, see KMS-Managed
+	// Encryption Keys (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html)
+	// in the Amazon Simple Storage Service Developer Guide.
+	//
+	// The KMS key policy must grant permission to the IAM role that you specify
+	// in your CreateTramsformJob request. For more information, see Using Key Policies
+	// in AWS KMS (http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
+	// in the AWS Key Management Service Developer Guide.
+	KmsKeyId *string `type:"string"`
+
+	// The Amazon S3 path where you want Amazon SageMaker to store the results of
+	// the transform job. For example, s3://bucket-name/key-name-prefix.
+	//
+	// For every S3 object used as input for the transform job, the transformed
+	// data is stored in a corresponding subfolder in the location under the output
+	// prefix.For example, the input data s3://bucket-name/input-name-prefix/dataset01/data.csv
+	// will have the transformed data stored at s3://bucket-name/key-name-prefix/dataset01/,
+	// based on the original name, as a series of .part files (.part0001, part0002,
+	// etc).
+	//
+	// S3OutputPath is a required field
+	S3OutputPath *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s TransformOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransformOutput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TransformOutput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TransformOutput"}
+	if s.S3OutputPath == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3OutputPath"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccept sets the Accept field's value.
+func (s *TransformOutput) SetAccept(v string) *TransformOutput {
+	s.Accept = &v
+	return s
+}
+
+// SetAssembleWith sets the AssembleWith field's value.
+func (s *TransformOutput) SetAssembleWith(v string) *TransformOutput {
+	s.AssembleWith = &v
+	return s
+}
+
+// SetKmsKeyId sets the KmsKeyId field's value.
+func (s *TransformOutput) SetKmsKeyId(v string) *TransformOutput {
+	s.KmsKeyId = &v
+	return s
+}
+
+// SetS3OutputPath sets the S3OutputPath field's value.
+func (s *TransformOutput) SetS3OutputPath(v string) *TransformOutput {
+	s.S3OutputPath = &v
+	return s
+}
+
+// Describes the resources, including ML instance types and ML instance count,
+// to use for transform job.
+type TransformResources struct {
+	_ struct{} `type:"structure"`
+
+	// The number of ML compute instances to use in the transform job. For distributed
+	// transform, provide a value greater than 1. The default value is 1.
+	//
+	// InstanceCount is a required field
+	InstanceCount *int64 `min:"1" type:"integer" required:"true"`
+
+	// The ML compute instance type for the transform job. For using built-in algorithms
+	// to transform moderately sized datasets, ml.m4.xlarge or ml.m5.large should
+	// suffice. There is no default value for InstanceType.
+	//
+	// InstanceType is a required field
+	InstanceType *string `type:"string" required:"true" enum:"TransformInstanceType"`
+}
+
+// String returns the string representation
+func (s TransformResources) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransformResources) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TransformResources) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TransformResources"}
+	if s.InstanceCount == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceCount"))
+	}
+	if s.InstanceCount != nil && *s.InstanceCount < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("InstanceCount", 1))
+	}
+	if s.InstanceType == nil {
+		invalidParams.Add(request.NewErrParamRequired("InstanceType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetInstanceCount sets the InstanceCount field's value.
+func (s *TransformResources) SetInstanceCount(v int64) *TransformResources {
+	s.InstanceCount = &v
+	return s
+}
+
+// SetInstanceType sets the InstanceType field's value.
+func (s *TransformResources) SetInstanceType(v string) *TransformResources {
+	s.InstanceType = &v
+	return s
+}
+
+// Describes the S3 data source.
+type TransformS3DataSource struct {
+	_ struct{} `type:"structure"`
+
+	// If you choose S3Prefix, S3Uri identifies a key name prefix. Amazon SageMaker
+	// uses all objects with the specified key name prefix for batch transform.
+	//
+	// If you choose ManifestFile, S3Uri identifies an object that is a manifest
+	// file containing a list of object keys that you want Amazon SageMaker to use
+	// for batch transform.
+	//
+	// S3DataType is a required field
+	S3DataType *string `type:"string" required:"true" enum:"S3DataType"`
+
+	// Depending on the value specified for the S3DataType, identifies either a
+	// key name prefix or a manifest. For example:
+	//
+	//    *  A key name prefix might look like this: s3://bucketname/exampleprefix.
+	//
+	//
+	//    *  A manifest might look like this: s3://bucketname/example.manifest
+	//
+	//  The manifest is an S3 object which is a JSON file with the following format:
+	//
+	//
+	// [
+	//
+	//  {"prefix": "s3://customer_bucket/some/prefix/"},
+	//
+	//  "relative/path/to/custdata-1",
+	//
+	//  "relative/path/custdata-2",
+	//
+	//  ...
+	//
+	//  ]
+	//
+	//  The preceding JSON matches the following S3Uris:
+	//
+	// s3://customer_bucket/some/prefix/relative/path/to/custdata-1
+	//
+	// s3://customer_bucket/some/prefix/relative/path/custdata-1
+	//
+	// ...
+	//
+	//  The complete set of S3Uris in this manifest constitutes the input data for
+	//    the channel for this datasource. The object that each S3Uris points to
+	//    must be readable by the IAM role that Amazon SageMaker uses to perform
+	//    tasks on your behalf.
+	//
+	// S3Uri is a required field
+	S3Uri *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s TransformS3DataSource) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TransformS3DataSource) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TransformS3DataSource) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TransformS3DataSource"}
+	if s.S3DataType == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3DataType"))
+	}
+	if s.S3Uri == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3Uri"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetS3DataType sets the S3DataType field's value.
+func (s *TransformS3DataSource) SetS3DataType(v string) *TransformS3DataSource {
+	s.S3DataType = &v
+	return s
+}
+
+// SetS3Uri sets the S3Uri field's value.
+func (s *TransformS3DataSource) SetS3Uri(v string) *TransformS3DataSource {
+	s.S3Uri = &v
 	return s
 }
 
@@ -11037,6 +12536,22 @@ func (s *VpcConfig) SetSubnets(v []*string) *VpcConfig {
 	s.Subnets = v
 	return s
 }
+
+const (
+	// AssemblyTypeNone is a AssemblyType enum value
+	AssemblyTypeNone = "None"
+
+	// AssemblyTypeLine is a AssemblyType enum value
+	AssemblyTypeLine = "Line"
+)
+
+const (
+	// BatchStrategyMultiRecord is a BatchStrategy enum value
+	BatchStrategyMultiRecord = "MultiRecord"
+
+	// BatchStrategySingleRecord is a BatchStrategy enum value
+	BatchStrategySingleRecord = "SingleRecord"
+)
 
 const (
 	// CompressionTypeNone is a CompressionType enum value
@@ -11445,6 +12960,17 @@ const (
 )
 
 const (
+	// SplitTypeNone is a SplitType enum value
+	SplitTypeNone = "None"
+
+	// SplitTypeLine is a SplitType enum value
+	SplitTypeLine = "Line"
+
+	// SplitTypeRecordIo is a SplitType enum value
+	SplitTypeRecordIo = "RecordIO"
+)
+
+const (
 	// TrainingInputModePipe is a TrainingInputMode enum value
 	TrainingInputModePipe = "Pipe"
 
@@ -11561,4 +13087,101 @@ const (
 
 	// TrainingJobStatusStopped is a TrainingJobStatus enum value
 	TrainingJobStatusStopped = "Stopped"
+)
+
+const (
+	// TransformInstanceTypeMlM4Xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM4Xlarge = "ml.m4.xlarge"
+
+	// TransformInstanceTypeMlM42xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM42xlarge = "ml.m4.2xlarge"
+
+	// TransformInstanceTypeMlM44xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM44xlarge = "ml.m4.4xlarge"
+
+	// TransformInstanceTypeMlM410xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM410xlarge = "ml.m4.10xlarge"
+
+	// TransformInstanceTypeMlM416xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM416xlarge = "ml.m4.16xlarge"
+
+	// TransformInstanceTypeMlC4Xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC4Xlarge = "ml.c4.xlarge"
+
+	// TransformInstanceTypeMlC42xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC42xlarge = "ml.c4.2xlarge"
+
+	// TransformInstanceTypeMlC44xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC44xlarge = "ml.c4.4xlarge"
+
+	// TransformInstanceTypeMlC48xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC48xlarge = "ml.c4.8xlarge"
+
+	// TransformInstanceTypeMlP2Xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlP2Xlarge = "ml.p2.xlarge"
+
+	// TransformInstanceTypeMlP28xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlP28xlarge = "ml.p2.8xlarge"
+
+	// TransformInstanceTypeMlP216xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlP216xlarge = "ml.p2.16xlarge"
+
+	// TransformInstanceTypeMlP32xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlP32xlarge = "ml.p3.2xlarge"
+
+	// TransformInstanceTypeMlP38xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlP38xlarge = "ml.p3.8xlarge"
+
+	// TransformInstanceTypeMlP316xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlP316xlarge = "ml.p3.16xlarge"
+
+	// TransformInstanceTypeMlC5Xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC5Xlarge = "ml.c5.xlarge"
+
+	// TransformInstanceTypeMlC52xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC52xlarge = "ml.c5.2xlarge"
+
+	// TransformInstanceTypeMlC54xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC54xlarge = "ml.c5.4xlarge"
+
+	// TransformInstanceTypeMlC59xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC59xlarge = "ml.c5.9xlarge"
+
+	// TransformInstanceTypeMlC518xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlC518xlarge = "ml.c5.18xlarge"
+
+	// TransformInstanceTypeMlM5Large is a TransformInstanceType enum value
+	TransformInstanceTypeMlM5Large = "ml.m5.large"
+
+	// TransformInstanceTypeMlM5Xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM5Xlarge = "ml.m5.xlarge"
+
+	// TransformInstanceTypeMlM52xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM52xlarge = "ml.m5.2xlarge"
+
+	// TransformInstanceTypeMlM54xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM54xlarge = "ml.m5.4xlarge"
+
+	// TransformInstanceTypeMlM512xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM512xlarge = "ml.m5.12xlarge"
+
+	// TransformInstanceTypeMlM524xlarge is a TransformInstanceType enum value
+	TransformInstanceTypeMlM524xlarge = "ml.m5.24xlarge"
+)
+
+const (
+	// TransformJobStatusInProgress is a TransformJobStatus enum value
+	TransformJobStatusInProgress = "InProgress"
+
+	// TransformJobStatusCompleted is a TransformJobStatus enum value
+	TransformJobStatusCompleted = "Completed"
+
+	// TransformJobStatusFailed is a TransformJobStatus enum value
+	TransformJobStatusFailed = "Failed"
+
+	// TransformJobStatusStopping is a TransformJobStatus enum value
+	TransformJobStatusStopping = "Stopping"
+
+	// TransformJobStatusStopped is a TransformJobStatus enum value
+	TransformJobStatusStopped = "Stopped"
 )

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,1004 +39,1004 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "uwTg0AHlK9Mt3NIjhzf/LpmDnH4=",
+			"checksumSHA1": "vCC8pc9mFj0mor1ymm1DQ21n0W8=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "EwL79Cq6euk+EV/t/n2E+jzPNmU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "925zPp8gtaXi2gkWrgZ1gAA003A=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "JTilCBYWVAfhbKSnrxCNhE8IFns=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
-			"checksumSHA1": "GTdSvwEbZz636RtRQDrQMOU9q9Q=",
+			"checksumSHA1": "eI5TmiOTCFjEUNvWeceFycs9dRU=",
 			"path": "github.com/aws/aws-sdk-go/aws/csm",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "HogDW/Wu6ZKTDrQ2HSzG8/vj9Ag=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "uPkjJo+J10vbEukYYXmf0w7Cn4Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Q1co3y5Y8rRIEjEXEfUZ9SwTmic=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
-			"checksumSHA1": "CYLheDSqXftEAmmdj+tTiT+83Ko=",
+			"checksumSHA1": "Ia/AZ2fZp7J4lMO6fpkvfLU/HGY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "zx1mZCdOwgbjBV3jMfb0kyDd//Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "u3cA2IiD36A+VnFIH7XtGjYk2NU=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "tQVg7Sz2zv+KkhbiXxPH0mh9spg=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkuri",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Ij9RP5HrBWBYYb3/LEMHNNZXH9g=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "stsUCJVnZ5yMrmzSExbjbYp5tZ8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "bOQjEfKXaTqe7dZhDDER/wZUzQc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "ftqeTvBbv+e/ozhnlAgbO1CEbLs=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "/2Ppb4vP/H+B3cM7bOOEeA7Z0iY=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "cW7mfCta/3RjWAsEn4BeJKe8TdI=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "d8MH0CgeCpRAQTFIjcEaPFDXw0w=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "k1TqEWHeP84mmRewv19ZVORhSm8=",
 			"path": "github.com/aws/aws-sdk-go/service/acmpca",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "OsJUdGg5DvY7vtvPfGcixbKX3kQ=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "RpzI2CVxVXCkMK0Tuhc54YvyoqE=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "owhfVKeKxjXt4P5KO6PSIjnMLIA=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "/nF1VEl/Y9I9EYbUHvUuhqjipUk=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "kko+es9ly+l/e9ngcpCdPx2DBAc=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "42OCpXRErVgOtgPsuTrdg7y++TA=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "kHOf0VEd2Qy8PYZsg7/zG+JkF1o=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "gJiK41PSoCEfE02VEry4f6nBg0s=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "bbCNma+YJRqcjnIqmTagqs1IwWI=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "bupt0rs/P2QN+iuFeFC7oY1HZ14=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "P8cLAj/ovFt7uH3bB4dRg/2KApI=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudhsmv2",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "eCrAi2QJw0Ft6A8XK5ZGLpsPKwM=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "ItkRLsVGZt8uvkI4+7+mi9Ccy28=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Y+x1N7TFB7OesWPRoYXRwGOdQzs=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "PxsIahbkFuks12VthBlqFJIUzX0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "ciAsJhe41ygl47dhStzMJfGVFPQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "SZxCqkGWIvyq5Rtl0haxfOgwKdE=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Q+W+AVveTI7xM3ay6HAi0FB4Dpc=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "6lozLpoMkQvw1r2cZMXujYiLqK8=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "JNLWxWRvZ8UNPV8nWHgzIybuMuE=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "iPP1QQAsTiK0TYWVn7ksDLfDXDE=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "JbgQL/r+cBKIKt+tQY8VSj0C2j8=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "orboEPrXFUPc3m7ZG8uPhZNZDdM=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "spYFA1gAmUHAUFd24v2xwMOLxrY=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "/zBS/FARxFnNMfLUg1Vq1FVK95c=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "olDBindEWwTHzKfpWaS+xID4y90=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "i7fuDfXYhe4JMJhail5nZUg69Dk=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "jURA8oKlQkbYPPrBQIeOPbQAVN0=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "SbAY0nrovBl4mmb7HEzL/28JR88=",
 			"path": "github.com/aws/aws-sdk-go/service/dlm",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "GFq6SaQ4h48iP+gjllWjMyIbQfU=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "aBYDdFhx/8bxKl0l++Gh2P2+4eM=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "T4Yw3GPZg+KwAEudsypRfhbUrVw=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "niBN6QYBEhoHvxQpSH8qWjEMNYo=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "UuBR+vag1picSiwj3T5mcl1a0Jc=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "mzgRjocmzU6VLUsim7E8/fffffk=",
 			"path": "github.com/aws/aws-sdk-go/service/eks",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "A5DCzVFhE5iT60fQXjlyLDHKFsg=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "K0yPG0O4/Wv2pYASbxO6LjH8318=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "aNIs4oJTp3x73Fx24tKO2cDY5OM=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "VFjWDQMsGpFMrNfcc//ABRpo6Ew=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "cRuJDtc9rVpXUqfLrg1cJleaPjQ=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "XKNeVP6DCohd9Re9g4xGLuqXe0c=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Xv0Wj758E+E1a+cBdH2xy15wuOU=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "X+8twdJk/x1+8y1LxnKXXd3eVoY=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "PJQ5SFC+Ai5Mqn8rfGhuwttfqZk=",
 			"path": "github.com/aws/aws-sdk-go/service/fms",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "xI94HsdAG+dBFCm38FoELBdbe9c=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "FEfr6yYlSRWsIV0M0kxm0/jOw0E=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "KWE5gG/M/Fz9tnmcFgGPphwwX2Y=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "HNndTio5+fNOiLr23i+QZpPp8HU=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "vbd5sSkaWFvxpM//BkS7IQffm5U=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "si/Re/DEfX8xWIjpLS4NNISO/Ns=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Q2K/MWy6yy/kV9CZ0YhaEHBNgkI=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "OvCoIYyhBSlrCvsk8uidGznXIss=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "44R3VB9KreeYj0LFf3KBd37kPXI=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "rwHYPohmwgbKTkEpVoR3PtvqU28=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "zrWHv2XG/KP9E82ophSO0XF+Cu8=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "xq1jxTLdjjWU+aupMh143C+Yb1Q=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "+l6bA5aVzmBXH2Isj1xZkd5RKNY=",
 			"path": "github.com/aws/aws-sdk-go/service/macie",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "8p+iBG3V+xlFkx+j4QJrjRsRWCk=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "HoX+EX8JW8kDZxJAs8545YRfjuI=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "ahm1SzqWwGUqPih6jPZwIevl2Pg=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "0YZZzbKYjappFNT8MUR5qNGQkRY=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "rrANYUKEHHEofZJYCP1pQhO35TE=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "p/+jOAMB5MSAnPloxJIFy77Hfck=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "W6AvJYPtvCLTeA0USbhvid2rP1o=",
 			"path": "github.com/aws/aws-sdk-go/service/neptune",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "x3PsW91a7fh+Q466y3WM3fdtnGg=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Davg8yRIMOcfa7/6zp7Fj6GnpuA=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "RfTumx3C/ryCRp8ACLwhfnF+Cw0=",
 			"path": "github.com/aws/aws-sdk-go/service/pinpoint",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "j1i1tZ94/kDvvzgpv5xqxwNvgyY=",
 			"path": "github.com/aws/aws-sdk-go/service/pricing",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "YtPLtWvoM6wD68VUp7dU+qk6hyM=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "wLRUH2H2vTS7yMgnCqhMcZ8GvWc=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "oe9xtK3GMCwCDmra0+JC6GwJ99k=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "kDpS3awFGJ29i8/crTXFM20AEcU=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
-			"checksumSHA1": "0U6ukhqF23CsyO8oOX2vqWCAEoY=",
+			"checksumSHA1": "UpyYeZUppBDbik08x1K5oUwXbk0=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "JqG/wC6zOGiK99YlSy31DADaV5w=",
 			"path": "github.com/aws/aws-sdk-go/service/secretsmanager",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "x2vfgk/EnGjOWPywWL+LKJKYCF0=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Z61MRqI0vu8oGAaCZSCDes9gIvk=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "TPGJU1VzYOhJIdTbWal1ivDwT+4=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "7kmVHadImICOa4/MOXErR53CdbQ=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "hliWYTmov/HswyMpYq93zJtdkk0=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "bW9FW0Qe3VURaSoY305kA/wCFrM=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "ECIZck5xhocpUl8GeUAdeSnCgvg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "6QZEYfLhDmYpeqGlClYSZkYnvjY=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "7XSW9vBDuN9ZR5wfuCvCaF6QPy0=",
 			"path": "github.com/aws/aws-sdk-go/service/storagegateway",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "uguCtF1eoCG71dvEVqrYbFs7py0=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "vlL9ibWgidiPj0uQ2L/OF6DCVEs=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "Ro5RX6aw32UGrGueBK+zhA8+Z30=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "uRMuwxPD/AlpvFpKppgAYzvlC0A=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "UGQwnAeB9SoJKyPPIpbDJVQws5g=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "9e9afa0895e9daff556cc18f90dc53eb91f41ffd",
-			"revisionTime": "2018-07-12T21:02:49Z",
-			"version": "v1.14.26",
-			"versionExact": "v1.14.26"
+			"revision": "ad774ec7aa8110faa8acdb510930f733a874ca4c",
+			"revisionTime": "2018-07-18T20:23:19Z",
+			"version": "v1.14.29",
+			"versionExact": "v1.14.29"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
Includes some connection reset retry handling (potentially for Go 1.11 support), nice. https://github.com/aws/aws-sdk-go/pull/2055

Changes proposed in this pull request:

* `govendor fetch github.com/aws/aws-sdk-go/...@v1.14.29`

Output from acceptance testing: Handled via daily acceptance testing
