### PR TITLE
Be explicit about protocol options for target group

### DIFF
--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) The name of the target group. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
 * `port` - (Required) The port on which targets receive traffic, unless overridden when registering a specific target.
-* `protocol` - (Required) The protocol to use for routing traffic to the targets.
+* `protocol` - (Required) The protocol to use for routing traffic to the targets. Should be one of "TCP", "HTTP", "HTTPS" or "TLS".
 * `vpc_id` - (Required) The identifier of the VPC in which to create the target group.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.


### PR DESCRIPTION
Without this change, you might assume lowercase "http" is a valid option but it isn't. The plan passes but the apply errors with message:

    Error creating LB Target Group: ValidationError: 1 validation error detected: Value 'http' at 'protocol' failed to satisfy constraint: Member must satisfy enum value set: [TCP, HTTP, HTTPS, TLS]

This change make sure the docs are clear on the valid options.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
