### PR TITLE
r/aws_launch_template: Set latest version computed on change

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/customdiff"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -415,6 +416,20 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 
 			"tags": tagsSchema(),
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ComputedIf("latest_version", func(diff *schema.ResourceDiff, meta interface{}) bool {
+				for _, changedKey := range diff.GetChangedKeysPrefix("") {
+					switch changedKey {
+					case "name", "name_prefix", "description", "default_version", "latest_version":
+						continue
+					default:
+						return true
+					}
+				}
+				return false
+			}),
+		),
 	}
 }
 

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -105,7 +105,6 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 func TestAccAWSLaunchTemplate_update(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resName := "aws_launch_template.foo"
-	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,20 +112,24 @@ func TestAccAWSLaunchTemplate_update(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Config: testAccAWSLaunchTemplateConfig_asg_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resName, &template),
 					resource.TestCheckResourceAttr(resName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "launch_template.0.version", "1"),
 				),
 			},
 			{
-				Config: testAccAWSLaunchTemplateConfig_data(rInt),
+				Config: testAccAWSLaunchTemplateConfig_asg_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resName, &template),
 					resource.TestCheckResourceAttr(resName, "default_version", "1"),
 					resource.TestCheckResourceAttr(resName, "latest_version", "2"),
-					resource.TestCheckResourceAttrSet(resName, "image_id"),
+					resource.TestCheckResourceAttrSet(resName, "instance_type"),
+					resource.TestCheckResourceAttr(
+						"aws_autoscaling_group.bar", "launch_template.0.version", "2"),
 				),
 			},
 		},
@@ -412,6 +415,75 @@ resource "aws_launch_template" "test" {
 
   network_interfaces {
     network_interface_id = "${aws_network_interface.test.id}"
+  }
+}
+`
+
+const testAccAWSLaunchTemplateConfig_asg_basic = `
+data "aws_ami" "test_ami" {
+  most_recent = true
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_launch_template" "foo" {
+  name_prefix = "foobar"
+  image_id = "${data.aws_ami.test_ami.id}"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_autoscaling_group" "bar" {
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
+  desired_capacity = 0
+  max_size = 0
+  min_size = 0
+  launch_template = {
+    id = "${aws_launch_template.foo.id}"
+    version = "${aws_launch_template.foo.latest_version}"
+  }
+}
+`
+
+const testAccAWSLaunchTemplateConfig_asg_update = `
+data "aws_ami" "test_ami" {
+  most_recent = true
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+resource "aws_launch_template" "foo" {
+  name_prefix = "foobar"
+  image_id = "${data.aws_ami.test_ami.id}"
+  instance_type = "t2.nano"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_autoscaling_group" "bar" {
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}"]
+  desired_capacity = 0
+  max_size = 0
+  min_size = 0
+  launch_template = {
+    id = "${aws_launch_template.foo.id}"
+    version = "${aws_launch_template.foo.latest_version}"
   }
 }
 `


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Proposed changes:
* Set `latest_version` as computed on any filed change except name and description. Currently on every change to launch template new version is created. But this version is set to state only after apply is done. So other resources that use `latest_version` will pick up the change only on second apply.

Can be used as a workaround for #4655 , if later resources use `latest_version` in `launch_template` specification.

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_update'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_update -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (79.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	79.827s
```

UPD: Rebased.
