### PR TITLE
New Resource: aws_storagegateway_nfs_file_share

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -583,6 +583,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ssm_parameter":                                resourceAwsSsmParameter(),
 			"aws_ssm_resource_data_sync":                       resourceAwsSsmResourceDataSync(),
 			"aws_storagegateway_gateway":                       resourceAwsStorageGatewayGateway(),
+			"aws_storagegateway_nfs_file_share":                resourceAwsStorageGatewayNfsFileShare(),
 			"aws_spot_datafeed_subscription":                   resourceAwsSpotDataFeedSubscription(),
 			"aws_spot_instance_request":                        resourceAwsSpotInstanceRequest(),
 			"aws_spot_fleet_request":                           resourceAwsSpotFleetRequest(),

--- a/aws/resource_aws_storagegateway_nfs_file_share.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share.go
@@ -99,13 +99,13 @@ func resourceAwsStorageGatewayNfsFileShare() *schema.Resource {
 						"group_id": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      0,
+							Default:      65534,
 							ValidateFunc: validation.IntBetween(0, 4294967294),
 						},
 						"owner_id": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      0,
+							Default:      65534,
 							ValidateFunc: validation.IntBetween(0, 4294967294),
 						},
 					},

--- a/aws/resource_aws_storagegateway_nfs_file_share.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share.go
@@ -1,0 +1,392 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsStorageGatewayNfsFileShare() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsStorageGatewayNfsFileShareCreate,
+		Read:   resourceAwsStorageGatewayNfsFileShareRead,
+		Update: resourceAwsStorageGatewayNfsFileShareUpdate,
+		Delete: resourceAwsStorageGatewayNfsFileShareDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_list": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 100,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"default_storage_class": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "S3_STANDARD",
+				ValidateFunc: validation.StringInSlice([]string{
+					"S3_ONEZONE_IA",
+					"S3_STANDARD_IA",
+					"S3_STANDARD",
+				}, false),
+			},
+			"fileshare_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gateway_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"guess_mime_type_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"kms_encrypted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"kms_key_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
+			"location_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"nfs_file_share_defaults": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"directory_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "0777",
+						},
+						"file_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "0666",
+						},
+						"group_id": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 4294967294),
+						},
+						"owner_id": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 4294967294),
+						},
+					},
+				},
+			},
+			"object_acl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  storagegateway.ObjectACLPrivate,
+				ValidateFunc: validation.StringInSlice([]string{
+					storagegateway.ObjectACLAuthenticatedRead,
+					storagegateway.ObjectACLAwsExecRead,
+					storagegateway.ObjectACLBucketOwnerFullControl,
+					storagegateway.ObjectACLBucketOwnerRead,
+					storagegateway.ObjectACLPrivate,
+					storagegateway.ObjectACLPublicRead,
+					storagegateway.ObjectACLPublicReadWrite,
+				}, false),
+			},
+			"read_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"requester_pays": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"squash": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "RootSquash",
+				ValidateFunc: validation.StringInSlice([]string{
+					"AllSquash",
+					"NoSquash",
+					"RootSquash",
+				}, false),
+			},
+		},
+	}
+}
+
+func resourceAwsStorageGatewayNfsFileShareCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.CreateNFSFileShareInput{
+		ClientList:           expandStringSet(d.Get("client_list").(*schema.Set)),
+		ClientToken:          aws.String(resource.UniqueId()),
+		DefaultStorageClass:  aws.String(d.Get("default_storage_class").(string)),
+		GatewayARN:           aws.String(d.Get("gateway_arn").(string)),
+		GuessMIMETypeEnabled: aws.Bool(d.Get("guess_mime_type_enabled").(bool)),
+		KMSEncrypted:         aws.Bool(d.Get("kms_encrypted").(bool)),
+		LocationARN:          aws.String(d.Get("location_arn").(string)),
+		NFSFileShareDefaults: expandStorageGatewayNfsFileShareDefaults(d.Get("nfs_file_share_defaults").([]interface{})),
+		ObjectACL:            aws.String(d.Get("object_acl").(string)),
+		ReadOnly:             aws.Bool(d.Get("read_only").(bool)),
+		RequesterPays:        aws.Bool(d.Get("requester_pays").(bool)),
+		Role:                 aws.String(d.Get("role_arn").(string)),
+		Squash:               aws.String(d.Get("squash").(string)),
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+		input.KMSKey = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating Storage Gateway NFS File Share: %s", input)
+	output, err := conn.CreateNFSFileShare(input)
+	if err != nil {
+		return fmt.Errorf("error creating Storage Gateway NFS File Share: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.FileShareARN))
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"CREATING", "MISSING"},
+		Target:     []string{"AVAILABLE"},
+		Refresh:    storageGatewayNfsFileShareRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for Storage Gateway NFS File Share creation: %s", err)
+	}
+
+	return resourceAwsStorageGatewayNfsFileShareRead(d, meta)
+}
+
+func resourceAwsStorageGatewayNfsFileShareRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.DescribeNFSFileSharesInput{
+		FileShareARNList: []*string{aws.String(d.Id())},
+	}
+
+	log.Printf("[DEBUG] Reading Storage Gateway NFS File Share: %s", input)
+	output, err := conn.DescribeNFSFileShares(input)
+	if err != nil {
+		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+			log.Printf("[WARN] Storage Gateway NFS File Share %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Storage Gateway NFS File Share: %s", err)
+	}
+
+	if output == nil || len(output.NFSFileShareInfoList) == 0 || output.NFSFileShareInfoList[0] == nil {
+		log.Printf("[WARN] Storage Gateway NFS File Share %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	fileshare := output.NFSFileShareInfoList[0]
+
+	d.Set("arn", fileshare.FileShareARN)
+
+	if err := d.Set("client_list", schema.NewSet(schema.HashString, flattenStringList(fileshare.ClientList))); err != nil {
+		return fmt.Errorf("error setting client_list: %s", err)
+	}
+
+	d.Set("default_storage_class", fileshare.DefaultStorageClass)
+	d.Set("fileshare_id", fileshare.FileShareId)
+	d.Set("gateway_arn", fileshare.GatewayARN)
+	d.Set("guess_mime_type_enabled", fileshare.GuessMIMETypeEnabled)
+	d.Set("kms_encrypted", fileshare.KMSEncrypted)
+	d.Set("kms_key_arn", fileshare.KMSKey)
+	d.Set("location_arn", fileshare.LocationARN)
+
+	if err := d.Set("nfs_file_share_defaults", flattenStorageGatewayNfsFileShareDefaults(fileshare.NFSFileShareDefaults)); err != nil {
+		return fmt.Errorf("error setting nfs_file_share_defaults: %s", err)
+	}
+
+	d.Set("object_acl", fileshare.ObjectACL)
+	d.Set("path", fileshare.Path)
+	d.Set("read_only", fileshare.ReadOnly)
+	d.Set("requester_pays", fileshare.RequesterPays)
+	d.Set("role_arn", fileshare.Role)
+	d.Set("squash", fileshare.Squash)
+
+	return nil
+}
+
+func resourceAwsStorageGatewayNfsFileShareUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.UpdateNFSFileShareInput{
+		ClientList:           expandStringSet(d.Get("client_list").(*schema.Set)),
+		DefaultStorageClass:  aws.String(d.Get("default_storage_class").(string)),
+		FileShareARN:         aws.String(d.Id()),
+		GuessMIMETypeEnabled: aws.Bool(d.Get("guess_mime_type_enabled").(bool)),
+		KMSEncrypted:         aws.Bool(d.Get("kms_encrypted").(bool)),
+		NFSFileShareDefaults: expandStorageGatewayNfsFileShareDefaults(d.Get("nfs_file_share_defaults").([]interface{})),
+		ObjectACL:            aws.String(d.Get("object_acl").(string)),
+		ReadOnly:             aws.Bool(d.Get("read_only").(bool)),
+		RequesterPays:        aws.Bool(d.Get("requester_pays").(bool)),
+		Squash:               aws.String(d.Get("squash").(string)),
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+		input.KMSKey = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Updating Storage Gateway NFS File Share: %s", input)
+	_, err := conn.UpdateNFSFileShare(input)
+	if err != nil {
+		return fmt.Errorf("error updating Storage Gateway NFS File Share: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"UPDATING"},
+		Target:     []string{"AVAILABLE"},
+		Refresh:    storageGatewayNfsFileShareRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		Delay:      5 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for Storage Gateway NFS File Share update: %s", err)
+	}
+
+	return resourceAwsStorageGatewayNfsFileShareRead(d, meta)
+}
+
+func resourceAwsStorageGatewayNfsFileShareDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.DeleteFileShareInput{
+		FileShareARN: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Storage Gateway NFS File Share: %s", input)
+	_, err := conn.DeleteFileShare(input)
+	if err != nil {
+		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Storage Gateway NFS File Share: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:        []string{"AVAILABLE", "DELETING", "FORCE_DELETING"},
+		Target:         []string{"MISSING"},
+		Refresh:        storageGatewayNfsFileShareRefreshFunc(d.Id(), conn),
+		Timeout:        d.Timeout(schema.TimeoutDelete),
+		Delay:          5 * time.Second,
+		MinTimeout:     5 * time.Second,
+		NotFoundChecks: 1,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		if isResourceNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("error waiting for Storage Gateway NFS File Share deletion: %s", err)
+	}
+
+	return nil
+}
+
+func storageGatewayNfsFileShareRefreshFunc(fileShareArn string, conn *storagegateway.StorageGateway) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &storagegateway.DescribeNFSFileSharesInput{
+			FileShareARNList: []*string{aws.String(fileShareArn)},
+		}
+
+		log.Printf("[DEBUG] Reading Storage Gateway NFS File Share: %s", input)
+		output, err := conn.DescribeNFSFileShares(input)
+		if err != nil {
+			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+				return nil, "MISSING", nil
+			}
+			return nil, "ERROR", fmt.Errorf("error reading Storage Gateway NFS File Share: %s", err)
+		}
+
+		if output == nil || len(output.NFSFileShareInfoList) == 0 || output.NFSFileShareInfoList[0] == nil {
+			return nil, "MISSING", nil
+		}
+
+		fileshare := output.NFSFileShareInfoList[0]
+
+		return fileshare, aws.StringValue(fileshare.FileShareStatus), nil
+	}
+}
+
+func expandStorageGatewayNfsFileShareDefaults(l []interface{}) *storagegateway.NFSFileShareDefaults {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	nfsFileShareDefaults := &storagegateway.NFSFileShareDefaults{
+		DirectoryMode: aws.String(m["directory_mode"].(string)),
+		FileMode:      aws.String(m["file_mode"].(string)),
+		GroupId:       aws.Int64(int64(m["group_id"].(int))),
+		OwnerId:       aws.Int64(int64(m["owner_id"].(int))),
+	}
+
+	return nfsFileShareDefaults
+}
+
+func flattenStorageGatewayNfsFileShareDefaults(nfsFileShareDefaults *storagegateway.NFSFileShareDefaults) []interface{} {
+	if nfsFileShareDefaults == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"directory_mode": aws.StringValue(nfsFileShareDefaults.DirectoryMode),
+		"file_mode":      aws.StringValue(nfsFileShareDefaults.FileMode),
+		"group_id":       int(aws.Int64Value(nfsFileShareDefaults.GroupId)),
+		"owner_id":       int(aws.Int64Value(nfsFileShareDefaults.OwnerId)),
+	}
+
+	return []interface{}{m}
+}

--- a/aws/resource_aws_storagegateway_nfs_file_share_test.go
+++ b/aws/resource_aws_storagegateway_nfs_file_share_test.go
@@ -1,0 +1,697 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSStorageGatewayNfsFileShare_basic(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_Required(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:[^:]+:share/share-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "client_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_list.217649824", "0.0.0.0/0"),
+					resource.TestCheckResourceAttr(resourceName, "default_storage_class", "S3_STANDARD"),
+					resource.TestMatchResourceAttr(resourceName, "fileshare_id", regexp.MustCompile(`^share-`)),
+					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "guess_mime_type_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "location_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
+					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "squash", "RootSquash"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_ClientList(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_ClientList_Single(rName, "1.1.1.1/32"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "client_list.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_ClientList_Multiple(rName, "2.2.2.2/32", "3.3.3.3/32"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "client_list.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_ClientList_Single(rName, "4.4.4.4/32"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "client_list.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_DefaultStorageClass(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_DefaultStorageClass(rName, "S3_STANDARD_IA"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "default_storage_class", "S3_STANDARD_IA"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_DefaultStorageClass(rName, "S3_ONEZONE_IA"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "default_storage_class", "S3_ONEZONE_IA"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_GuessMIMETypeEnabled(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_GuessMIMETypeEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "guess_mime_type_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_GuessMIMETypeEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "guess_mime_type_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_KMSEncrypted(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSStorageGatewayNfsFileShareConfig_KMSEncrypted(rName, true),
+				ExpectError: regexp.MustCompile(`KMSKey is missing`),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_KMSEncrypted(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_KMSKeyArn(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_KMSKeyArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "true"),
+					resource.TestMatchResourceAttr(resourceName, "kms_key_arn", regexp.MustCompile(`^arn:`)),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_KMSKeyArn_Update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "true"),
+					resource.TestMatchResourceAttr(resourceName, "kms_key_arn", regexp.MustCompile(`^arn:`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_KMSEncrypted(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_NFSFileShareDefaults(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_NFSFileShareDefaults(rName, "0700", "0600", 1, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.directory_mode", "0700"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.file_mode", "0600"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.group_id", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.owner_id", "2"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_NFSFileShareDefaults(rName, "0770", "0660", 3, 4),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.directory_mode", "0770"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.file_mode", "0660"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.group_id", "3"),
+					resource.TestCheckResourceAttr(resourceName, "nfs_file_share_defaults.0.owner_id", "4"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_ObjectACL(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_ObjectACL(rName, storagegateway.ObjectACLPublicRead),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPublicRead),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_ObjectACL(rName, storagegateway.ObjectACLPublicReadWrite),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPublicReadWrite),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_ReadOnly(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_ReadOnly(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "false"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_ReadOnly(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_RequesterPays(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_RequesterPays(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_RequesterPays(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "requester_pays", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayNfsFileShare_Squash(t *testing.T) {
+	var nfsFileShare storagegateway.NFSFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_nfs_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayNfsFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_Squash(rName, "NoSquash"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "squash", "NoSquash"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayNfsFileShareConfig_Squash(rName, "AllSquash"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName, &nfsFileShare),
+					resource.TestCheckResourceAttr(resourceName, "squash", "AllSquash"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSStorageGatewayNfsFileShareDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_storagegateway_nfs_file_share" {
+			continue
+		}
+
+		input := &storagegateway.DescribeNFSFileSharesInput{
+			FileShareARNList: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.DescribeNFSFileShares(input)
+
+		if err != nil {
+			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+				continue
+			}
+			return err
+		}
+
+		if output != nil && len(output.NFSFileShareInfoList) > 0 && output.NFSFileShareInfoList[0] != nil {
+			return fmt.Errorf("Storage Gateway NFS File Share %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccCheckAWSStorageGatewayNfsFileShareExists(resourceName string, nfsFileShare *storagegateway.NFSFileShareInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+		input := &storagegateway.DescribeNFSFileSharesInput{
+			FileShareARNList: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.DescribeNFSFileShares(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || len(output.NFSFileShareInfoList) == 0 || output.NFSFileShareInfoList[0] == nil {
+			return fmt.Errorf("Storage Gateway NFS File Share %q does not exist", rs.Primary.ID)
+		}
+
+		*nfsFileShare = *output.NFSFileShareInfoList[0]
+
+		return nil
+	}
+}
+
+func testAccAWSStorageGateway_S3FileShareBase(rName string) string {
+	return testAccAWSStorageGateway_FileGatewayBase(rName) + fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "storagegateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = "${aws_iam_role.test.name}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %q
+  force_destroy = true
+}
+
+resource "aws_storagegateway_gateway" "test" {
+  depends_on = ["aws_iam_role_policy.test"]
+
+  gateway_ip_address = "${aws_instance.test.public_ip}"
+  gateway_name       = %q
+  gateway_timezone   = "GMT"
+  gateway_type       = "FILE_S3"
+}
+`, rName, rName, rName)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_Required(rName string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + `
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list  = ["0.0.0.0/0"]
+  gateway_arn  = "${aws_storagegateway_gateway.test.arn}"
+  location_arn = "${aws_s3_bucket.test.arn}"
+  role_arn     = "${aws_iam_role.test.arn}"
+}
+`
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_ClientList_Single(rName, clientList1 string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list           = [%q]
+  gateway_arn           = "${aws_storagegateway_gateway.test.arn}"
+  location_arn          = "${aws_s3_bucket.test.arn}"
+  role_arn              = "${aws_iam_role.test.arn}"
+}
+`, clientList1)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_ClientList_Multiple(rName, clientList1, clientList2 string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list           = [%q, %q]
+  gateway_arn           = "${aws_storagegateway_gateway.test.arn}"
+  location_arn          = "${aws_s3_bucket.test.arn}"
+  role_arn              = "${aws_iam_role.test.arn}"
+}
+`, clientList1, clientList2)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_DefaultStorageClass(rName, defaultStorageClass string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list           = ["0.0.0.0/0"]
+  default_storage_class = %q
+  gateway_arn           = "${aws_storagegateway_gateway.test.arn}"
+  location_arn          = "${aws_s3_bucket.test.arn}"
+  role_arn              = "${aws_iam_role.test.arn}"
+}
+`, defaultStorageClass)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_GuessMIMETypeEnabled(rName string, guessMimeTypeEnabled bool) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list             = ["0.0.0.0/0"]
+  gateway_arn             = "${aws_storagegateway_gateway.test.arn}"
+  guess_mime_type_enabled = %t
+  location_arn            = "${aws_s3_bucket.test.arn}"
+  role_arn                = "${aws_iam_role.test.arn}"
+}
+`, guessMimeTypeEnabled)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_KMSEncrypted(rName string, kmsEncrypted bool) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list   = ["0.0.0.0/0"]
+  gateway_arn   = "${aws_storagegateway_gateway.test.arn}"
+  kms_encrypted = %t
+  location_arn  = "${aws_s3_bucket.test.arn}"
+  role_arn      = "${aws_iam_role.test.arn}"
+}
+`, kmsEncrypted)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_KMSKeyArn(rName string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + `
+resource "aws_kms_key" "test" {
+  count = 2
+
+  deletion_window_in_days = 7
+  description             = "Terraform Acceptance Testing"
+}
+
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list             = ["0.0.0.0/0"]
+  gateway_arn             = "${aws_storagegateway_gateway.test.arn}"
+  kms_encrypted           = true
+  kms_key_arn             = "${aws_kms_key.test.0.arn}"
+  location_arn            = "${aws_s3_bucket.test.arn}"
+  role_arn                = "${aws_iam_role.test.arn}"
+}
+`
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_KMSKeyArn_Update(rName string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + `
+resource "aws_kms_key" "test" {
+  count = 2
+
+  deletion_window_in_days = 7
+  description             = "Terraform Acceptance Testing"
+}
+
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list             = ["0.0.0.0/0"]
+  gateway_arn             = "${aws_storagegateway_gateway.test.arn}"
+  kms_encrypted           = true
+  kms_key_arn             = "${aws_kms_key.test.1.arn}"
+  location_arn            = "${aws_s3_bucket.test.arn}"
+  role_arn                = "${aws_iam_role.test.arn}"
+}
+`
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_NFSFileShareDefaults(rName, directoryMode, fileMode string, groupID, ownerID int) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list           = ["0.0.0.0/0"]
+  gateway_arn           = "${aws_storagegateway_gateway.test.arn}"
+  location_arn          = "${aws_s3_bucket.test.arn}"
+  role_arn              = "${aws_iam_role.test.arn}"
+
+  nfs_file_share_defaults {
+    directory_mode = %q
+    file_mode      = %q
+    group_id       = %d
+    owner_id       = %d
+  }
+}
+`, directoryMode, fileMode, groupID, ownerID)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_ObjectACL(rName, objectACL string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list  = ["0.0.0.0/0"]
+  gateway_arn  = "${aws_storagegateway_gateway.test.arn}"
+  location_arn = "${aws_s3_bucket.test.arn}"
+  object_acl   = %q
+  role_arn     = "${aws_iam_role.test.arn}"
+}
+`, objectACL)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_ReadOnly(rName string, readOnly bool) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list   = ["0.0.0.0/0"]
+  gateway_arn   = "${aws_storagegateway_gateway.test.arn}"
+  location_arn  = "${aws_s3_bucket.test.arn}"
+  read_only     = %t
+  role_arn      = "${aws_iam_role.test.arn}"
+}
+`, readOnly)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_RequesterPays(rName string, requesterPays bool) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list    = ["0.0.0.0/0"]
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  requester_pays = %t
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`, requesterPays)
+}
+
+func testAccAWSStorageGatewayNfsFileShareConfig_Squash(rName, squash string) string {
+	return testAccAWSStorageGateway_S3FileShareBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_nfs_file_share" "test" {
+  client_list  = ["0.0.0.0/0"]
+  gateway_arn  = "${aws_storagegateway_gateway.test.arn}"
+  location_arn = "${aws_s3_bucket.test.arn}"
+  role_arn     = "${aws_iam_role.test.arn}"
+  squash       = %q
+}
+`, squash)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2131,6 +2131,10 @@
                             <a href="/docs/providers/aws/r/storagegateway_gateway.html">aws_storagegateway_gateway</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-storagegateway-nfs-file-share") %>>
+                            <a href="/docs/providers/aws/r/storagegateway_nfs_file_share.html">aws_storagegateway_nfs_file_share</a>
+                        </li>
+
                     </ul>
                 </li>
 

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -45,8 +45,8 @@ Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, h
 
 * `directory_mode` - (Optional) The Unix directory mode in the string form "nnnn". Defaults to `"0777"`.
 * `file_mode` - (Optional) The Unix file mode in the string form "nnnn". Defaults to `"0666"`.
-* `group_id` - (Optional) The default group ID for the file share (unless the files have another group ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
-* `owner_id` - (Optional) The default owner ID for the file share (unless the files have another owner ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
+* `group_id` - (Optional) The default group ID for the file share (unless the files have another group ID specified). Defaults to `65534` (`nfsnobody`). Valid values: `0` through `4294967294`.
+* `owner_id` - (Optional) The default owner ID for the file share (unless the files have another owner ID specified). Defaults to `65534` (`nfsnobody`). Valid values: `0` through `4294967294`.
 
 ## Attribute Reference
 

--- a/website/docs/r/storagegateway_nfs_file_share.html.markdown
+++ b/website/docs/r/storagegateway_nfs_file_share.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "aws"
+page_title: "AWS: aws_storagegateway_nfs_file_share"
+sidebar_current: "docs-aws-resource-storagegateway-nfs-file-share"
+description: |-
+  Manages an AWS Storage Gateway NFS File Share
+---
+
+# aws_storagegateway_nfs_file_share
+
+Manages an AWS Storage Gateway NFS File Share.
+
+## Example Usage
+
+```hcl
+resource "aws_storagegateway_nfs_file_share" "example" {
+  client_list  = ["0.0.0.0/0"]
+  gateway_arn  = "${aws_storagegateway_gateway.example.arn}"
+  location_arn = "${aws_s3_bucket.example.arn}"
+  role_arn     = "${aws_s3_bucket.example.arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `client_list` - (Required) The list of clients that are allowed to access the file gateway. The list must contain either valid IP addresses or valid CIDR blocks. Set to `["0.0.0.0/0"]` to not limit access. Minimum 1 item. Maximum 100 items.
+* `gateway_arn` - (Required) Amazon Resource Name (ARN) of the file gateway.
+* `location_arn` - (Required) The ARN of the backed storage used for storing file data.
+* `role_arn` - (Required) The ARN of the AWS Identity and Access Management (IAM) role that a file gateway assumes when it accesses the underlying storage.
+* `default_storage_class` - (Optional) The default storage class for objects put into an Amazon S3 bucket by the file gateway. Defaults to `S3_STANDARD`. Valid values: `S3_STANDARD`, `S3_STANDARD_IA`, `S3_ONEZONE_IA`.
+* `guess_mime_type_enabled` - (Optional) Boolean value that enables guessing of the MIME type for uploaded objects based on file extensions. Defaults to `true`.
+* `kms_encrypted` - (Optional) Boolean value if `true` to use Amazon S3 server side encryption with your own AWS KMS key, or `false` to use a key managed by Amazon S3. Defaults to `false`.
+* `kms_key_arn` - (Optional) Amazon Resource Name (ARN) for KMS key used for Amazon S3 server side encryption. This value can only be set when `kms_encrypted` is true.
+* `nfs_file_share_defaults` - (Optional) Nested argument with file share default values. More information below.
+* `object_acl` - (Optional) Access Control List permission for S3 bucket objects. Defaults to `private`.
+* `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
+* `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
+* `squash` - (Optional) Maps a user to anonymous user. Defaults to `RootSquash`. Valid values: `RootSquash` (only root is mapped to anonymous user), `NoSquash` (no one is mapped to anonymous user), `AllSquash` (everyone is mapped to anonymous user)
+
+### nfs_file_share_defaults
+
+Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, have Unix file permissions assigned to them. Upon discovery in an S3 bucket by Storage Gateway, the S3 objects that represent files and folders are assigned these default Unix permissions.
+
+* `directory_mode` - (Optional) The Unix directory mode in the string form "nnnn". Defaults to `"0777"`.
+* `file_mode` - (Optional) The Unix file mode in the string form "nnnn". Defaults to `"0666"`.
+* `group_id` - (Optional) The default group ID for the file share (unless the files have another group ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
+* `owner_id` - (Optional) The default owner ID for the file share (unless the files have another owner ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Amazon Resource Name (ARN) of the NFS File Share.
+* `arn` - Amazon Resource Name (ARN) of the NFS File Share.
+* `fileshare_id` - ID of the NFS File Share.
+* `path` - File share path used by the NFS client to identify the mount point.
+
+## Timeouts
+
+`aws_storagegateway_nfs_file_share` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `10m`) How long to wait for file share creation.
+* `update` - (Default `10m`) How long to wait for file share updates.
+* `delete` - (Default `10m`) How long to wait for file share deletion.
+
+## Import
+
+`aws_storagegateway_nfs_file_share` can be imported by using the NFS File Share Amazon Resource Name (ARN), e.g.
+
+```
+$ terraform import aws_storagegateway_nfs_file_share.example arn:aws:storagegateway:us-east-1:123456789012:share/share-12345678
+```


### PR DESCRIPTION
Reference: #943 

Changes proposed in this pull request:

* New Resource: `aws_storagegateway_nfs_file_share`

Output from acceptance testing:

```
11 tests passed (all tests)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_KMSEncrypted
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSEncrypted (275.23s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_basic
--- PASS: TestAccAWSStorageGatewayNfsFileShare_basic (326.06s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_NFSFileShareDefaults
--- PASS: TestAccAWSStorageGatewayNfsFileShare_NFSFileShareDefaults (328.63s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_RequesterPays
--- PASS: TestAccAWSStorageGatewayNfsFileShare_RequesterPays (361.01s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_Squash
--- PASS: TestAccAWSStorageGatewayNfsFileShare_Squash (364.62s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_GuessMIMETypeEnabled
--- PASS: TestAccAWSStorageGatewayNfsFileShare_GuessMIMETypeEnabled (371.67s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_ReadOnly
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ReadOnly (385.75s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_DefaultStorageClass
--- PASS: TestAccAWSStorageGatewayNfsFileShare_DefaultStorageClass (391.59s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_ObjectACL
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ObjectACL (393.31s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_ClientList
--- PASS: TestAccAWSStorageGatewayNfsFileShare_ClientList (441.47s)
=== RUN   TestAccAWSStorageGatewayNfsFileShare_KMSKeyArn
--- PASS: TestAccAWSStorageGatewayNfsFileShare_KMSKeyArn (452.08s)
```
