### PR TITLE
Fix aws_lambda_event_source_mapping flapping

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_esm_basic_%s", rString)
@@ -35,22 +36,18 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
 				),
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"batch_size", strconv.Itoa(200)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"enabled", strconv.FormatBool(false)),
-					resource.TestMatchResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"function_arn", uFuncArnRe),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"starting_position", "TRIM_HORIZON"),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(200)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(false)),
+					resource.TestMatchResourceAttr(resourceName, "function_arn", uFuncArnRe),
+					resource.TestCheckResourceAttr(resourceName, "starting_position", "TRIM_HORIZON"),
 				),
 			},
 		},
@@ -63,6 +60,7 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 	// a diff.
 
 	var conf lambda.EventSourceMappingConfiguration
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_esm_basic_%s", rString)
@@ -80,20 +78,17 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
 				),
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis_removeBatchSize(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"batch_size", strconv.Itoa(100)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"starting_position", "TRIM_HORIZON"),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(100)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr(resourceName, "starting_position", "TRIM_HORIZON"),
 				),
 			},
 		},
@@ -102,6 +97,7 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 
 func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_sqs_basic_%s", rString)
@@ -120,24 +116,20 @@ func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfig_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
-					resource.TestCheckNoResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+					resource.TestCheckNoResourceAttr(resourceName,
 						"starting_position"),
 				),
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"batch_size", strconv.Itoa(5)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"enabled", strconv.FormatBool(false)),
-					resource.TestMatchResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"function_arn", uFuncArnRe),
-					resource.TestCheckNoResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"starting_position"),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(5)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(false)),
+					resource.TestMatchResourceAttr(resourceName, "function_name", uFuncArnRe),
+					resource.TestCheckNoResourceAttr(resourceName, "starting_position"),
 				),
 			},
 		},
@@ -505,7 +497,7 @@ resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
     event_source_arn = "${aws_kinesis_stream.kinesis_stream_test.arn}"
     enabled = true
     depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
-    function_name = "${aws_lambda_function.lambda_function_test_create.arn}"
+    function_arn = "${aws_lambda_function.lambda_function_test_create.arn}"
     starting_position = "TRIM_HORIZON"
 }`, roleName, policyName, attName, streamName, funcName, uFuncName)
 }
@@ -592,7 +584,7 @@ resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
 	event_source_arn = "${aws_kinesis_stream.kinesis_stream_test.arn}"
 	enabled = true
 	depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
-	function_name = "${aws_lambda_function.lambda_function_test_create.arn}"
+	function_arn = "${aws_lambda_function.lambda_function_test_create.arn}"
 	starting_position = "TRIM_HORIZON"
 }`, roleName, policyName, attName, streamName, funcName, uFuncName)
 }
@@ -681,7 +673,7 @@ resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
     event_source_arn = "${aws_kinesis_stream.kinesis_stream_test.arn}"
     enabled = false
     depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
-    function_name = "${aws_lambda_function.lambda_function_test_update.arn}"
+    function_arn = "${aws_lambda_function.lambda_function_test_update.arn}"
     starting_position = "TRIM_HORIZON"
 }`, roleName, policyName, attName, streamName, funcName, uFuncName)
 }

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -20,7 +20,7 @@ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
   batch_size        = 100
   event_source_arn  = "arn:aws:kinesis:REGION:123456789012:stream/stream_name"
   enabled           = true
-  function_name     = "arn:aws:lambda:REGION:123456789012:function:function_name"
+  function_arn     = "arn:aws:lambda:REGION:123456789012:function:function_name"
   starting_position = "TRIM_HORIZON|LATEST"
 }
 ```
@@ -30,12 +30,12 @@ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
 * `batch_size` - (Optional) The largest number of records that Lambda will retrieve from your event source at the time of invocation. Defaults to `100` for DynamoDB and Kinesis, `10` for SQS.
 * `event_source_arn` - (Required) The event source ARN - can either be a Kinesis or DynamoDB stream.
 * `enabled` - (Optional) Determines if the mapping will be enabled on creation. Defaults to `true`.
-* `function_name` - (Required) The name or the ARN of the Lambda function that will be subscribing to events.
+* `function_arn` - (Required) The ARN of the Lambda function that will be subscribing to events.
+* `function_name` - **DEPRECATED** (Required) The name or the ARN of the Lambda function that will be subscribing to events. (You should use `function_arn` instead)
 * `starting_position` - (Optional) The position in the stream where AWS Lambda should start reading. Must be one of either `TRIM_HORIZON` or `LATEST` if getting events from Kinesis or DynamoDB.  Must not be provided if getting events from SQS.
 
 ## Attributes Reference
 
-* `function_arn` - The the ARN of the Lambda function the event source mapping is sending events to. (Note: this is a computed value that differs from `function_name` above.)
 * `last_modified` - The date this resource was last modified.
 * `last_processing_result` - The result of the last AWS Lambda invocation of your Lambda function.
 * `state` - The state of the event source mapping.


### PR DESCRIPTION
Changes proposed in this pull request:

* When creating an event source mapping with a function name instead of an arn, it would show a diff on every plan. function_name supports both arn and name though, so what this does is set the `function_name` to the ARN if it is an import or if an ARN was given as an attribute and it extracts the function's name if a function name was given as the attribute.

Output from acceptance testing:

```
TESTARGS='-run=TestAccAWSLambdaEventSourceMapping'  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSLambdaEventSourceMapping -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (114.88s)
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (111.80s)
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (129.41s)
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_import
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_import (100.45s)
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_disappears
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_disappears (96.39s)
=== RUN   TestAccAWSLambdaEventSourceMapping_sqsDisappears
--- PASS: TestAccAWSLambdaEventSourceMapping_sqsDisappears (136.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       689.550s
```
