### PR TITLE
Update docs for aws_acm_certificate data source

### DIFF
--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -9,10 +9,8 @@ description: |-
 # Data Source: aws_acm_certificate
 
 Use this data source to get the ARN of a certificate in AWS Certificate
-Manager (ACM). The process of requesting and verifying a certificate in ACM
-requires some manual steps, which means that Terraform cannot automate the
-creation of ACM certificates. But using this data source, you can reference
-them by domain without having to hard code the ARNs as input.
+Manager (ACM), you can reference
+it by domain without having to hard code the ARNs as input.
 
 ## Example Usage
 


### PR DESCRIPTION
The aws_acm_certficate can be automated now so this description is confusing

Changes proposed in this pull request:

* Update the documentation for aws_acm_certificate data source
