### PR TITLE
resource/aws_storagegateway_gateway: Add SMB settings arguments

### DIFF
--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -86,6 +86,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_Cached(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "CACHED"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -119,6 +121,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_FileS3(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "FILE_S3"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -152,6 +156,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_Stored(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "STORED"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -185,6 +191,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_Vtl(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "VTL"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -262,6 +270,68 @@ func TestAccAWSStorageGatewayGateway_GatewayTimezone(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"activation_key", "gateway_ip_address"},
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings(t *testing.T) {
+	var gateway storagegateway.DescribeGatewayInformationOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.0.domain_name", "terraformtesting.com"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"activation_key", "gateway_ip_address", "smb_active_directory_settings"},
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayGateway_SmbGuestPassword(t *testing.T) {
+	var gateway storagegateway.DescribeGatewayInformationOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, "myguestpassword1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", "myguestpassword1"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, "myguestpassword2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", "myguestpassword2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"activation_key", "gateway_ip_address", "smb_guest_password"},
 			},
 		},
 	})
@@ -515,4 +585,163 @@ resource "aws_storagegateway_gateway" "test" {
   gateway_type       = "FILE_S3"
 }
 `, rName, gatewayTimezone)
+}
+
+func testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "10.0.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.test.id}"
+  }
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_route_table_association" "test" {
+  count = 2
+
+  subnet_id      = "${aws_subnet.test.*.id[count.index]}"
+  route_table_id = "${aws_route_table.test.id}"
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_directory_service_directory" "test" {
+  name     = "terraformtesting.com"
+  password = "SuperSecretPassw0rd"
+  size     = "Small"
+
+  vpc_settings {
+    subnet_ids = ["${aws_subnet.test.*.id}"]
+    vpc_id     = "${aws_vpc.test.id}"
+  }
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_vpc_dhcp_options" "test" {
+  domain_name         = "${aws_directory_service_directory.test.name}"
+  domain_name_servers = ["${aws_directory_service_directory.test.dns_ip_addresses}"]
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_vpc_dhcp_options_association" "test" {
+  dhcp_options_id = "${aws_vpc_dhcp_options.test.id}"
+  vpc_id          = "${aws_vpc.test.id}"
+}
+
+data "aws_ami" "aws-thinstaller" {
+  most_recent = true
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["aws-thinstaller-*"]
+  }
+}
+
+resource "aws_instance" "test" {
+  depends_on = ["aws_internet_gateway.test", "aws_vpc_dhcp_options_association.test"]
+
+  ami                         = "${data.aws_ami.aws-thinstaller.id}"
+  associate_public_ip_address = true
+  # https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
+  instance_type               = "m4.xlarge"
+  vpc_security_group_ids      = ["${aws_security_group.test.id}"]
+  subnet_id                   = "${aws_subnet.test.*.id[0]}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_storagegateway_gateway" "test" {
+  gateway_ip_address = "${aws_instance.test.public_ip}"
+  gateway_name       = %q
+  gateway_timezone   = "GMT"
+  gateway_type       = "FILE_S3"
+
+  smb_active_directory_settings {
+    domain_name = "${aws_directory_service_directory.test.name}"
+    password    = "${aws_directory_service_directory.test.password}"
+    username    = "Administrator"
+  }
+}
+`, rName, rName, rName, rName, rName, rName, rName, rName, rName)
+}
+
+func testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, smbGuestPassword string) string {
+	return testAccAWSStorageGateway_FileGatewayBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_gateway" "test" {
+  gateway_ip_address = "${aws_instance.test.public_ip}"
+  gateway_name       = %q
+  gateway_timezone   = "GMT"
+  gateway_type       = "FILE_S3"
+  smb_guest_password = %q
+}
+`, rName, smbGuestPassword)
 }

--- a/website/docs/r/storagegateway_gateway.html.markdown
+++ b/website/docs/r/storagegateway_gateway.html.markdown
@@ -72,7 +72,19 @@ The following arguments are supported:
 * `gateway_ip_address` - (Optional) Gateway IP address to retrieve activation key during resource creation. Conflicts with `activation_key`. Gateway must be accessible on port 80 from where Terraform is running. Additional information is available in the [Storage Gateway User Guide](https://docs.aws.amazon.com/storagegateway/latest/userguide/get-activation-key.html).
 * `gateway_type` - (Optional) Type of the gateway. The default value is `STORED`. Valid values: `CACHED`, `FILE_S3`, `STORED`, `VTL`.
 * `media_changer_type` - (Optional) Type of medium changer to use for tape gateway. Terraform cannot detect drift of this argument. Valid values: `STK-L700`, `AWS-Gateway-VTL`.
+* `smb_active_directory_settings` - (Optional) Nested argument with Active Directory domain join information for Server Message Block (SMB) file shares. Only valid for `FILE_S3` gateway type. Must be set before creating `ActiveDirectory` authentication SMB file shares. More details below.
+* `smb_guest_password` - (Optional) Guest password for Server Message Block (SMB) file shares. Only valid for `FILE_S3` gateway type. Must be set before creating `GuestAccess` authentication SMB file shares. Terraform can only detect drift of the existence of a guest password, not its actual value from the gateway. Terraform can however update the password with changing the argument.
 * `tape_drive_type` - (Optional) Type of tape drive to use for tape gateway. Terraform cannot detect drift of this argument. Valid values: `IBM-ULT3580-TD5`.
+
+### smb_active_directory_settings
+
+Information to join the gateway to an Active Directory domain for Server Message Block (SMB) file shares.
+
+~> **NOTE** It is not possible to unconfigure this setting without recreating the gateway. Also, Terraform can only detect drift of the `domain_name` argument from the gateway.
+
+* `domain_name` - (Required) The name of the domain that you want the gateway to join.
+* `password` - (Required) The password of the user who has permission to add the gateway to the Active Directory domain.
+* `username` - (Required) The user name of user who has permission to add the gateway to the Active Directory domain.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Reference: #943 

Changes proposed in this pull request:

* Add `smb_active_directory_settings` nested argument for joining gateway to Active Directory domain
* Add `smb_guest_password` for setting `smbguest` password

Output from acceptance testing:

```
8 tests passed (all tests)
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_Cached
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Cached (218.80s)
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_Vtl
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Vtl (219.81s)
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_Stored
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_Stored (228.91s)
=== RUN   TestAccAWSStorageGatewayGateway_GatewayType_FileS3
--- PASS: TestAccAWSStorageGatewayGateway_GatewayType_FileS3 (235.57s)
=== RUN   TestAccAWSStorageGatewayGateway_GatewayTimezone
--- PASS: TestAccAWSStorageGatewayGateway_GatewayTimezone (245.08s)
=== RUN   TestAccAWSStorageGatewayGateway_SmbGuestPassword
--- PASS: TestAccAWSStorageGatewayGateway_SmbGuestPassword (261.42s)
=== RUN   TestAccAWSStorageGatewayGateway_GatewayName
--- PASS: TestAccAWSStorageGatewayGateway_GatewayName (263.58s)
=== RUN   TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings
--- PASS: TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings (645.19s)
```
