### PR TITLE
New Resource: aws_storagegateway_smb_file_share

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -587,6 +587,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ssm_resource_data_sync":                       resourceAwsSsmResourceDataSync(),
 			"aws_storagegateway_gateway":                       resourceAwsStorageGatewayGateway(),
 			"aws_storagegateway_nfs_file_share":                resourceAwsStorageGatewayNfsFileShare(),
+			"aws_storagegateway_smb_file_share":                resourceAwsStorageGatewaySmbFileShare(),
 			"aws_storagegateway_upload_buffer":                 resourceAwsStorageGatewayUploadBuffer(),
 			"aws_storagegateway_working_storage":               resourceAwsStorageGatewayWorkingStorage(),
 			"aws_spot_datafeed_subscription":                   resourceAwsSpotDataFeedSubscription(),

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -86,6 +86,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_Cached(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "CACHED"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -119,6 +121,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_FileS3(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "FILE_S3"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -152,6 +156,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_Stored(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "STORED"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -185,6 +191,8 @@ func TestAccAWSStorageGatewayGateway_GatewayType_Vtl(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway_timezone", "GMT"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_type", "VTL"),
 					resource.TestCheckResourceAttr(resourceName, "medium_changer_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "tape_drive_type", ""),
 				),
 			},
@@ -262,6 +270,68 @@ func TestAccAWSStorageGatewayGateway_GatewayTimezone(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"activation_key", "gateway_ip_address"},
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayGateway_SmbActiveDirectorySettings(t *testing.T) {
+	var gateway storagegateway.DescribeGatewayInformationOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "smb_active_directory_settings.0.domain_name", "terraformtesting.com"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"activation_key", "gateway_ip_address", "smb_active_directory_settings"},
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayGateway_SmbGuestPassword(t *testing.T) {
+	var gateway storagegateway.DescribeGatewayInformationOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_gateway.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, "myguestpassword1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", "myguestpassword1"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, "myguestpassword2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayGatewayExists(resourceName, &gateway),
+					resource.TestCheckResourceAttr(resourceName, "smb_guest_password", "myguestpassword2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"activation_key", "gateway_ip_address", "smb_guest_password"},
 			},
 		},
 	})
@@ -515,4 +585,163 @@ resource "aws_storagegateway_gateway" "test" {
   gateway_type       = "FILE_S3"
 }
 `, rName, gatewayTimezone)
+}
+
+func testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "10.0.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.test.id}"
+  }
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_route_table_association" "test" {
+  count = 2
+
+  subnet_id      = "${aws_subnet.test.*.id[count.index]}"
+  route_table_id = "${aws_route_table.test.id}"
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_directory_service_directory" "test" {
+  name     = "terraformtesting.com"
+  password = "SuperSecretPassw0rd"
+  size     = "Small"
+
+  vpc_settings {
+    subnet_ids = ["${aws_subnet.test.*.id}"]
+    vpc_id     = "${aws_vpc.test.id}"
+  }
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_vpc_dhcp_options" "test" {
+  domain_name         = "${aws_directory_service_directory.test.name}"
+  domain_name_servers = ["${aws_directory_service_directory.test.dns_ip_addresses}"]
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_vpc_dhcp_options_association" "test" {
+  dhcp_options_id = "${aws_vpc_dhcp_options.test.id}"
+  vpc_id          = "${aws_vpc.test.id}"
+}
+
+data "aws_ami" "aws-thinstaller" {
+  most_recent = true
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["aws-thinstaller-*"]
+  }
+}
+
+resource "aws_instance" "test" {
+  depends_on = ["aws_internet_gateway.test", "aws_vpc_dhcp_options_association.test"]
+
+  ami                         = "${data.aws_ami.aws-thinstaller.id}"
+  associate_public_ip_address = true
+  # https://docs.aws.amazon.com/storagegateway/latest/userguide/Requirements.html
+  instance_type               = "m4.xlarge"
+  vpc_security_group_ids      = ["${aws_security_group.test.id}"]
+  subnet_id                   = "${aws_subnet.test.*.id[0]}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_storagegateway_gateway" "test" {
+  gateway_ip_address = "${aws_instance.test.public_ip}"
+  gateway_name       = %q
+  gateway_timezone   = "GMT"
+  gateway_type       = "FILE_S3"
+
+  smb_active_directory_settings {
+    domain_name = "${aws_directory_service_directory.test.name}"
+    password    = "${aws_directory_service_directory.test.password}"
+    username    = "Administrator"
+  }
+}
+`, rName, rName, rName, rName, rName, rName, rName, rName, rName)
+}
+
+func testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, smbGuestPassword string) string {
+	return testAccAWSStorageGateway_FileGatewayBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_gateway" "test" {
+  gateway_ip_address = "${aws_instance.test.public_ip}"
+  gateway_name       = %q
+  gateway_timezone   = "GMT"
+  gateway_type       = "FILE_S3"
+  smb_guest_password = %q
+}
+`, rName, smbGuestPassword)
 }

--- a/aws/resource_aws_storagegateway_smb_file_share.go
+++ b/aws/resource_aws_storagegateway_smb_file_share.go
@@ -1,0 +1,330 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsStorageGatewaySmbFileShare() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsStorageGatewaySmbFileShareCreate,
+		Read:   resourceAwsStorageGatewaySmbFileShareRead,
+		Update: resourceAwsStorageGatewaySmbFileShareUpdate,
+		Delete: resourceAwsStorageGatewaySmbFileShareDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"authentication": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "ActiveDirectory",
+				ValidateFunc: validation.StringInSlice([]string{
+					"ActiveDirectory",
+					"GuestAccess",
+				}, false),
+			},
+			"default_storage_class": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "S3_STANDARD",
+				ValidateFunc: validation.StringInSlice([]string{
+					"S3_ONEZONE_IA",
+					"S3_STANDARD_IA",
+					"S3_STANDARD",
+				}, false),
+			},
+			"fileshare_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gateway_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"guess_mime_type_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"invalid_user_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"kms_encrypted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"kms_key_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateArn,
+			},
+			"location_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"object_acl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  storagegateway.ObjectACLPrivate,
+				ValidateFunc: validation.StringInSlice([]string{
+					storagegateway.ObjectACLAuthenticatedRead,
+					storagegateway.ObjectACLAwsExecRead,
+					storagegateway.ObjectACLBucketOwnerFullControl,
+					storagegateway.ObjectACLBucketOwnerRead,
+					storagegateway.ObjectACLPrivate,
+					storagegateway.ObjectACLPublicRead,
+					storagegateway.ObjectACLPublicReadWrite,
+				}, false),
+			},
+			"read_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"requester_pays": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"valid_user_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceAwsStorageGatewaySmbFileShareCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.CreateSMBFileShareInput{
+		Authentication:       aws.String(d.Get("authentication").(string)),
+		ClientToken:          aws.String(resource.UniqueId()),
+		DefaultStorageClass:  aws.String(d.Get("default_storage_class").(string)),
+		GatewayARN:           aws.String(d.Get("gateway_arn").(string)),
+		GuessMIMETypeEnabled: aws.Bool(d.Get("guess_mime_type_enabled").(bool)),
+		InvalidUserList:      expandStringSet(d.Get("invalid_user_list").(*schema.Set)),
+		KMSEncrypted:         aws.Bool(d.Get("kms_encrypted").(bool)),
+		LocationARN:          aws.String(d.Get("location_arn").(string)),
+		ObjectACL:            aws.String(d.Get("object_acl").(string)),
+		ReadOnly:             aws.Bool(d.Get("read_only").(bool)),
+		RequesterPays:        aws.Bool(d.Get("requester_pays").(bool)),
+		Role:                 aws.String(d.Get("role_arn").(string)),
+		ValidUserList:        expandStringSet(d.Get("valid_user_list").(*schema.Set)),
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+		input.KMSKey = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating Storage Gateway SMB File Share: %s", input)
+	output, err := conn.CreateSMBFileShare(input)
+	if err != nil {
+		return fmt.Errorf("error creating Storage Gateway SMB File Share: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.FileShareARN))
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"CREATING", "MISSING"},
+		Target:     []string{"AVAILABLE"},
+		Refresh:    storageGatewaySmbFileShareRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for Storage Gateway SMB File Share creation: %s", err)
+	}
+
+	return resourceAwsStorageGatewaySmbFileShareRead(d, meta)
+}
+
+func resourceAwsStorageGatewaySmbFileShareRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.DescribeSMBFileSharesInput{
+		FileShareARNList: []*string{aws.String(d.Id())},
+	}
+
+	log.Printf("[DEBUG] Reading Storage Gateway SMB File Share: %s", input)
+	output, err := conn.DescribeSMBFileShares(input)
+	if err != nil {
+		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+			log.Printf("[WARN] Storage Gateway SMB File Share %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Storage Gateway SMB File Share: %s", err)
+	}
+
+	if output == nil || len(output.SMBFileShareInfoList) == 0 || output.SMBFileShareInfoList[0] == nil {
+		log.Printf("[WARN] Storage Gateway SMB File Share %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	fileshare := output.SMBFileShareInfoList[0]
+
+	d.Set("arn", fileshare.FileShareARN)
+	d.Set("authentication", fileshare.Authentication)
+	d.Set("default_storage_class", fileshare.DefaultStorageClass)
+	d.Set("fileshare_id", fileshare.FileShareId)
+	d.Set("gateway_arn", fileshare.GatewayARN)
+	d.Set("guess_mime_type_enabled", fileshare.GuessMIMETypeEnabled)
+
+	if err := d.Set("invalid_user_list", schema.NewSet(schema.HashString, flattenStringList(fileshare.InvalidUserList))); err != nil {
+		return fmt.Errorf("error setting invalid_user_list: %s", err)
+	}
+
+	d.Set("kms_encrypted", fileshare.KMSEncrypted)
+	d.Set("kms_key_arn", fileshare.KMSKey)
+	d.Set("location_arn", fileshare.LocationARN)
+	d.Set("object_acl", fileshare.ObjectACL)
+	d.Set("path", fileshare.Path)
+	d.Set("read_only", fileshare.ReadOnly)
+	d.Set("requester_pays", fileshare.RequesterPays)
+	d.Set("role_arn", fileshare.Role)
+
+	if err := d.Set("valid_user_list", schema.NewSet(schema.HashString, flattenStringList(fileshare.ValidUserList))); err != nil {
+		return fmt.Errorf("error setting valid_user_list: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsStorageGatewaySmbFileShareUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.UpdateSMBFileShareInput{
+		DefaultStorageClass:  aws.String(d.Get("default_storage_class").(string)),
+		FileShareARN:         aws.String(d.Id()),
+		GuessMIMETypeEnabled: aws.Bool(d.Get("guess_mime_type_enabled").(bool)),
+		InvalidUserList:      expandStringSet(d.Get("invalid_user_list").(*schema.Set)),
+		KMSEncrypted:         aws.Bool(d.Get("kms_encrypted").(bool)),
+		ObjectACL:            aws.String(d.Get("object_acl").(string)),
+		ReadOnly:             aws.Bool(d.Get("read_only").(bool)),
+		RequesterPays:        aws.Bool(d.Get("requester_pays").(bool)),
+		ValidUserList:        expandStringSet(d.Get("valid_user_list").(*schema.Set)),
+	}
+
+	if v, ok := d.GetOk("kms_key_arn"); ok && v.(string) != "" {
+		input.KMSKey = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Updating Storage Gateway SMB File Share: %s", input)
+	_, err := conn.UpdateSMBFileShare(input)
+	if err != nil {
+		return fmt.Errorf("error updating Storage Gateway SMB File Share: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"UPDATING"},
+		Target:     []string{"AVAILABLE"},
+		Refresh:    storageGatewaySmbFileShareRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		Delay:      5 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for Storage Gateway SMB File Share update: %s", err)
+	}
+
+	return resourceAwsStorageGatewaySmbFileShareRead(d, meta)
+}
+
+func resourceAwsStorageGatewaySmbFileShareDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.DeleteFileShareInput{
+		FileShareARN: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Storage Gateway SMB File Share: %s", input)
+	_, err := conn.DeleteFileShare(input)
+	if err != nil {
+		if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Storage Gateway SMB File Share: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:        []string{"AVAILABLE", "DELETING", "FORCE_DELETING"},
+		Target:         []string{"MISSING"},
+		Refresh:        storageGatewaySmbFileShareRefreshFunc(d.Id(), conn),
+		Timeout:        d.Timeout(schema.TimeoutDelete),
+		Delay:          5 * time.Second,
+		MinTimeout:     5 * time.Second,
+		NotFoundChecks: 1,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		if isResourceNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("error waiting for Storage Gateway SMB File Share deletion: %s", err)
+	}
+
+	return nil
+}
+
+func storageGatewaySmbFileShareRefreshFunc(fileShareArn string, conn *storagegateway.StorageGateway) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &storagegateway.DescribeSMBFileSharesInput{
+			FileShareARNList: []*string{aws.String(fileShareArn)},
+		}
+
+		log.Printf("[DEBUG] Reading Storage Gateway SMB File Share: %s", input)
+		output, err := conn.DescribeSMBFileShares(input)
+		if err != nil {
+			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+				return nil, "MISSING", nil
+			}
+			return nil, "ERROR", fmt.Errorf("error reading Storage Gateway SMB File Share: %s", err)
+		}
+
+		if output == nil || len(output.SMBFileShareInfoList) == 0 || output.SMBFileShareInfoList[0] == nil {
+			return nil, "MISSING", nil
+		}
+
+		fileshare := output.SMBFileShareInfoList[0]
+
+		return fileshare, aws.StringValue(fileshare.FileShareStatus), nil
+	}
+}

--- a/aws/resource_aws_storagegateway_smb_file_share_test.go
+++ b/aws/resource_aws_storagegateway_smb_file_share_test.go
@@ -1,0 +1,760 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_Authentication_ActiveDirectory(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:[^:]+:share/share-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "authentication", "ActiveDirectory"),
+					resource.TestCheckResourceAttr(resourceName, "default_storage_class", "S3_STANDARD"),
+					resource.TestMatchResourceAttr(resourceName, "fileshare_id", regexp.MustCompile(`^share-`)),
+					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "guess_mime_type_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "invalid_user_list.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "location_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
+					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_Authentication_GuestAccess(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:[^:]+:share/share-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "authentication", "GuestAccess"),
+					resource.TestCheckResourceAttr(resourceName, "default_storage_class", "S3_STANDARD"),
+					resource.TestMatchResourceAttr(resourceName, "fileshare_id", regexp.MustCompile(`^share-`)),
+					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "guess_mime_type_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "invalid_user_list.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_arn", ""),
+					resource.TestMatchResourceAttr(resourceName, "location_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPrivate),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "false"),
+					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
+					resource.TestMatchResourceAttr(resourceName, "role_arn", regexp.MustCompile(`^arn:`)),
+					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_DefaultStorageClass(rName, "S3_STANDARD_IA"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "default_storage_class", "S3_STANDARD_IA"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_DefaultStorageClass(rName, "S3_ONEZONE_IA"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "default_storage_class", "S3_ONEZONE_IA"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_GuessMIMETypeEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "guess_mime_type_enabled", "false"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_GuessMIMETypeEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "guess_mime_type_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_InvalidUserList(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_InvalidUserList_Single(rName, "invaliduser1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "invalid_user_list.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_InvalidUserList_Multiple(rName, "invaliduser2", "invaliduser3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "invalid_user_list.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_InvalidUserList_Single(rName, "invaliduser4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "invalid_user_list.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSStorageGatewaySmbFileShareConfig_KMSEncrypted(rName, true),
+				ExpectError: regexp.MustCompile(`KMSKey is missing`),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_KMSEncrypted(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_KMSKeyArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "true"),
+					resource.TestMatchResourceAttr(resourceName, "kms_key_arn", regexp.MustCompile(`^arn:`)),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_KMSKeyArn_Update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "true"),
+					resource.TestMatchResourceAttr(resourceName, "kms_key_arn", regexp.MustCompile(`^arn:`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_KMSEncrypted(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "kms_encrypted", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_ObjectACL(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_ObjectACL(rName, storagegateway.ObjectACLPublicRead),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPublicRead),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_ObjectACL(rName, storagegateway.ObjectACLPublicReadWrite),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "object_acl", storagegateway.ObjectACLPublicReadWrite),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_ReadOnly(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_ReadOnly(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "false"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_ReadOnly(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "read_only", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_RequesterPays(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_RequesterPays(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "requester_pays", "false"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_RequesterPays(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "requester_pays", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewaySmbFileShare_ValidUserList(t *testing.T) {
+	var smbFileShare storagegateway.SMBFileShareInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_smb_file_share.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewaySmbFileShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_ValidUserList_Single(rName, "validuser1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_ValidUserList_Multiple(rName, "validuser2", "validuser3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSStorageGatewaySmbFileShareConfig_ValidUserList_Single(rName, "validuser4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName, &smbFileShare),
+					resource.TestCheckResourceAttr(resourceName, "valid_user_list.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSStorageGatewaySmbFileShareDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_storagegateway_smb_file_share" {
+			continue
+		}
+
+		input := &storagegateway.DescribeSMBFileSharesInput{
+			FileShareARNList: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.DescribeSMBFileShares(input)
+
+		if err != nil {
+			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified file share was not found.") {
+				continue
+			}
+			return err
+		}
+
+		if output != nil && len(output.SMBFileShareInfoList) > 0 && output.SMBFileShareInfoList[0] != nil {
+			return fmt.Errorf("Storage Gateway SMB File Share %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+
+}
+
+func testAccCheckAWSStorageGatewaySmbFileShareExists(resourceName string, smbFileShare *storagegateway.SMBFileShareInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+		input := &storagegateway.DescribeSMBFileSharesInput{
+			FileShareARNList: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.DescribeSMBFileShares(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || len(output.SMBFileShareInfoList) == 0 || output.SMBFileShareInfoList[0] == nil {
+			return fmt.Errorf("Storage Gateway SMB File Share %q does not exist", rs.Primary.ID)
+		}
+
+		*smbFileShare = *output.SMBFileShareInfoList[0]
+
+		return nil
+	}
+}
+
+func testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_SmbActiveDirectorySettings(rName) + fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %q
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "storagegateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = "${aws_iam_role.test.name}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %q
+  force_destroy = true
+}
+`, rName, rName)
+}
+
+func testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_SmbGuestPassword(rName, "smbguestpassword") + fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %q
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "storagegateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = "${aws_iam_role.test.name}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.test.arn}",
+        "${aws_s3_bucket.test.arn}/*"
+      ],
+      "Effect": "Allow"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket        = %q
+  force_destroy = true
+}
+`, rName, rName)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_Authentication_ActiveDirectory(rName string) string {
+	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + `
+resource "aws_storagegateway_smb_file_share" "test" {
+  authentication = "ActiveDirectory"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_Authentication_GuestAccess(rName string) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + `
+resource "aws_storagegateway_smb_file_share" "test" {
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_DefaultStorageClass(rName, defaultStorageClass string) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication        = "GuestAccess"
+  default_storage_class = %q
+  gateway_arn           = "${aws_storagegateway_gateway.test.arn}"
+  location_arn          = "${aws_s3_bucket.test.arn}"
+  role_arn              = "${aws_iam_role.test.arn}"
+}
+`, defaultStorageClass)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_GuessMIMETypeEnabled(rName string, guessMimeTypeEnabled bool) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication          = "GuestAccess"
+  gateway_arn             = "${aws_storagegateway_gateway.test.arn}"
+  guess_mime_type_enabled = %t
+  location_arn            = "${aws_s3_bucket.test.arn}"
+  role_arn                = "${aws_iam_role.test.arn}"
+}
+`, guessMimeTypeEnabled)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_InvalidUserList_Single(rName, invalidUser1 string) string {
+	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Must be ActiveDirectory
+  authentication    = "ActiveDirectory"
+  gateway_arn       = "${aws_storagegateway_gateway.test.arn}"
+  invalid_user_list = [%q]
+  location_arn      = "${aws_s3_bucket.test.arn}"
+  role_arn          = "${aws_iam_role.test.arn}"
+}
+`, invalidUser1)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_InvalidUserList_Multiple(rName, invalidUser1, invalidUser2 string) string {
+	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Must be ActiveDirectory
+  authentication    = "ActiveDirectory"
+  gateway_arn       = "${aws_storagegateway_gateway.test.arn}"
+  invalid_user_list = [%q, %q]
+  location_arn      = "${aws_s3_bucket.test.arn}"
+  role_arn          = "${aws_iam_role.test.arn}"
+}
+`, invalidUser1, invalidUser2)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_KMSEncrypted(rName string, kmsEncrypted bool) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn   = "${aws_storagegateway_gateway.test.arn}"
+  kms_encrypted = %t
+  location_arn  = "${aws_s3_bucket.test.arn}"
+  role_arn      = "${aws_iam_role.test.arn}"
+}
+`, kmsEncrypted)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_KMSKeyArn(rName string) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + `
+resource "aws_kms_key" "test" {
+  count = 2
+
+  deletion_window_in_days = 7
+  description             = "Terraform Acceptance Testing"
+}
+
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  kms_encrypted  = true
+  kms_key_arn    = "${aws_kms_key.test.0.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_KMSKeyArn_Update(rName string) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + `
+resource "aws_kms_key" "test" {
+  count = 2
+
+  deletion_window_in_days = 7
+  description             = "Terraform Acceptance Testing"
+}
+
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  kms_encrypted  = true
+  kms_key_arn    = "${aws_kms_key.test.1.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_ObjectACL(rName, objectACL string) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  object_acl     = %q
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`, objectACL)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_ReadOnly(rName string, readOnly bool) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  read_only      = %t
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`, readOnly)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_RequesterPays(rName string, requesterPays bool) string {
+	return testAccAWSStorageGateway_SmbFileShare_GuestAccessBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Use GuestAccess to simplify testing
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.test.arn}"
+  location_arn   = "${aws_s3_bucket.test.arn}"
+  requester_pays = %t
+  role_arn       = "${aws_iam_role.test.arn}"
+}
+`, requesterPays)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_ValidUserList_Single(rName, validUser1 string) string {
+	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Must be ActiveDirectory
+  authentication    = "ActiveDirectory"
+  gateway_arn     = "${aws_storagegateway_gateway.test.arn}"
+  location_arn    = "${aws_s3_bucket.test.arn}"
+  role_arn        = "${aws_iam_role.test.arn}"
+  valid_user_list = [%q]
+}
+`, validUser1)
+}
+
+func testAccAWSStorageGatewaySmbFileShareConfig_ValidUserList_Multiple(rName, validUser1, validUser2 string) string {
+	return testAccAWSStorageGateway_SmbFileShare_ActiveDirectoryBase(rName) + fmt.Sprintf(`
+resource "aws_storagegateway_smb_file_share" "test" {
+  # Must be ActiveDirectory
+  authentication    = "ActiveDirectory"
+  gateway_arn     = "${aws_storagegateway_gateway.test.arn}"
+  location_arn    = "${aws_s3_bucket.test.arn}"
+  role_arn        = "${aws_iam_role.test.arn}"
+  valid_user_list = [%q, %q]
+}
+`, validUser1, validUser2)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2148,6 +2148,10 @@
                             <a href="/docs/providers/aws/r/storagegateway_nfs_file_share.html">aws_storagegateway_nfs_file_share</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-storagegateway-smb-file-share") %>>
+                            <a href="/docs/providers/aws/r/storagegateway_smb_file_share.html">aws_storagegateway_smb_file_share</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-storagegateway-upload-buffer") %>>
                             <a href="/docs/providers/aws/r/storagegateway_upload_buffer.html">aws_storagegateway_upload_buffer</a>
                         </li>

--- a/website/docs/r/storagegateway_gateway.html.markdown
+++ b/website/docs/r/storagegateway_gateway.html.markdown
@@ -72,7 +72,19 @@ The following arguments are supported:
 * `gateway_ip_address` - (Optional) Gateway IP address to retrieve activation key during resource creation. Conflicts with `activation_key`. Gateway must be accessible on port 80 from where Terraform is running. Additional information is available in the [Storage Gateway User Guide](https://docs.aws.amazon.com/storagegateway/latest/userguide/get-activation-key.html).
 * `gateway_type` - (Optional) Type of the gateway. The default value is `STORED`. Valid values: `CACHED`, `FILE_S3`, `STORED`, `VTL`.
 * `media_changer_type` - (Optional) Type of medium changer to use for tape gateway. Terraform cannot detect drift of this argument. Valid values: `STK-L700`, `AWS-Gateway-VTL`.
+* `smb_active_directory_settings` - (Optional) Nested argument with Active Directory domain join information for Server Message Block (SMB) file shares. Only valid for `FILE_S3` gateway type. Must be set before creating `ActiveDirectory` authentication SMB file shares. More details below.
+* `smb_guest_password` - (Optional) Guest password for Server Message Block (SMB) file shares. Only valid for `FILE_S3` gateway type. Must be set before creating `GuestAccess` authentication SMB file shares. Terraform can only detect drift of the existence of a guest password, not its actual value from the gateway. Terraform can however update the password with changing the argument.
 * `tape_drive_type` - (Optional) Type of tape drive to use for tape gateway. Terraform cannot detect drift of this argument. Valid values: `IBM-ULT3580-TD5`.
+
+### smb_active_directory_settings
+
+Information to join the gateway to an Active Directory domain for Server Message Block (SMB) file shares.
+
+~> **NOTE** It is not possible to unconfigure this setting without recreating the gateway. Also, Terraform can only detect drift of the `domain_name` argument from the gateway.
+
+* `domain_name` - (Required) The name of the domain that you want the gateway to join.
+* `password` - (Required) The password of the user who has permission to add the gateway to the Active Directory domain.
+* `username` - (Required) The user name of user who has permission to add the gateway to the Active Directory domain.
 
 ## Attribute Reference
 

--- a/website/docs/r/storagegateway_smb_file_share.html.markdown
+++ b/website/docs/r/storagegateway_smb_file_share.html.markdown
@@ -1,0 +1,92 @@
+---
+layout: "aws"
+page_title: "AWS: aws_storagegateway_smb_file_share"
+sidebar_current: "docs-aws-resource-storagegateway-smb-file-share"
+description: |-
+  Manages an AWS Storage Gateway SMB File Share
+---
+
+# aws_storagegateway_smb_file_share
+
+Manages an AWS Storage Gateway SMB File Share.
+
+## Example Usage
+
+### Active Directory Authentication
+
+~> **NOTE:** The gateway must have already joined the Active Directory domain prior to SMB file share creation. e.g. via "SMB Settings" in the AWS Storage Gateway console or `smb_active_directory_settings` in the [`aws_storagegateway_gateway` resource](/docs/providers/aws/r/storagegateway_gateway.html).
+
+```hcl
+resource "aws_storagegateway_smb_file_share" "example" {
+  authentication = "ActiveDirectory"
+  gateway_arn    = "${aws_storagegateway_gateway.example.arn}"
+  location_arn   = "${aws_s3_bucket.example.arn}"
+  role_arn       = "${aws_iam_role.example.arn}"
+}
+```
+
+### Guest Authentication
+
+~> **NOTE:** The gateway must have already had the SMB guest password set prior to SMB file share creation. e.g. via "SMB Settings" in the AWS Storage Gateway console or `smb_guest_password` in the [`aws_storagegateway_gateway` resource](/docs/providers/aws/r/storagegateway_gateway.html).
+
+```hcl
+resource "aws_storagegateway_smb_file_share" "example" {
+  authentication = "GuestAccess"
+  gateway_arn    = "${aws_storagegateway_gateway.example.arn}"
+  location_arn   = "${aws_s3_bucket.example.arn}"
+  role_arn       = "${aws_iam_role.example.arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `gateway_arn` - (Required) Amazon Resource Name (ARN) of the file gateway.
+* `location_arn` - (Required) The ARN of the backed storage used for storing file data.
+* `role_arn` - (Required) The ARN of the AWS Identity and Access Management (IAM) role that a file gateway assumes when it accesses the underlying storage.
+* `authentication` - (Optional) The authentication method that users use to access the file share. Defaults to `ActiveDirectory`. Valid values: `ActiveDirectory`, `GuestAccess`.
+* `default_storage_class` - (Optional) The default storage class for objects put into an Amazon S3 bucket by the file gateway. Defaults to `S3_STANDARD`. Valid values: `S3_STANDARD`, `S3_STANDARD_IA`, `S3_ONEZONE_IA`.
+* `guess_mime_type_enabled` - (Optional) Boolean value that enables guessing of the MIME type for uploaded objects based on file extensions. Defaults to `true`.
+* `invalid_user_list` - (Optional) A list of users in the Active Directory that are not allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
+* `kms_encrypted` - (Optional) Boolean value if `true` to use Amazon S3 server side encryption with your own AWS KMS key, or `false` to use a key managed by Amazon S3. Defaults to `false`.
+* `kms_key_arn` - (Optional) Amazon Resource Name (ARN) for KMS key used for Amazon S3 server side encryption. This value can only be set when `kms_encrypted` is true.
+* `smb_file_share_defaults` - (Optional) Nested argument with file share default values. More information below.
+* `object_acl` - (Optional) Access Control List permission for S3 bucket objects. Defaults to `private`.
+* `read_only` - (Optional) Boolean to indicate write status of file share. File share does not accept writes if `true`. Defaults to `false`.
+* `requester_pays` - (Optional) Boolean who pays the cost of the request and the data download from the Amazon S3 bucket. Set this value to `true` if you want the requester to pay instead of the bucket owner. Defaults to `false`.
+* `valid_user_list` - (Optional) A list of users in the Active Directory that are allowed to access the file share. Only valid if `authentication` is set to `ActiveDirectory`.
+
+### smb_file_share_defaults
+
+Files and folders stored as Amazon S3 objects in S3 buckets don't, by default, have Unix file permissions assigned to them. Upon discovery in an S3 bucket by Storage Gateway, the S3 objects that represent files and folders are assigned these default Unix permissions.
+
+* `directory_mode` - (Optional) The Unix directory mode in the string form "nnnn". Defaults to `"0777"`.
+* `file_mode` - (Optional) The Unix file mode in the string form "nnnn". Defaults to `"0666"`.
+* `group_id` - (Optional) The default group ID for the file share (unless the files have another group ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
+* `owner_id` - (Optional) The default owner ID for the file share (unless the files have another owner ID specified). Defaults to `0`. Valid values: `0` through `4294967294`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Amazon Resource Name (ARN) of the SMB File Share.
+* `arn` - Amazon Resource Name (ARN) of the SMB File Share.
+* `fileshare_id` - ID of the SMB File Share.
+* `path` - File share path used by the NFS client to identify the mount point.
+
+## Timeouts
+
+`aws_storagegateway_smb_file_share` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `10m`) How long to wait for file share creation.
+* `update` - (Default `10m`) How long to wait for file share updates.
+* `delete` - (Default `15m`) How long to wait for file share deletion.
+
+## Import
+
+`aws_storagegateway_smb_file_share` can be imported by using the SMB File Share Amazon Resource Name (ARN), e.g.
+
+```
+$ terraform import aws_storagegateway_smb_file_share.example arn:aws:storagegateway:us-east-1:123456789012:share/share-12345678
+```


### PR DESCRIPTION
Built on top of #5269 
Reference #943 

Changes proposed in this pull request:

* New Resource: `aws_storagegateway_smb_file_share`

Output from acceptance testing:

```
11 tests passed (all tests)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_GuestAccess (226.03s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSEncrypted (252.38s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass
--- PASS: TestAccAWSStorageGatewaySmbFileShare_DefaultStorageClass (263.79s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled
--- PASS: TestAccAWSStorageGatewaySmbFileShare_GuessMIMETypeEnabled (264.86s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_ObjectACL
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ObjectACL (285.56s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_RequesterPays
--- PASS: TestAccAWSStorageGatewaySmbFileShare_RequesterPays (294.13s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_ReadOnly
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ReadOnly (297.41s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn
--- PASS: TestAccAWSStorageGatewaySmbFileShare_KMSKeyArn (422.49s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory
--- PASS: TestAccAWSStorageGatewaySmbFileShare_Authentication_ActiveDirectory (632.34s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_InvalidUserList
--- PASS: TestAccAWSStorageGatewaySmbFileShare_InvalidUserList (772.82s)
=== RUN   TestAccAWSStorageGatewaySmbFileShare_ValidUserList
--- PASS: TestAccAWSStorageGatewaySmbFileShare_ValidUserList (862.85s)
```
