### PR TITLE
New Data Source: aws_storagegateway_local_disk

### DIFF
--- a/aws/data_source_aws_storagegateway_local_disk.go
+++ b/aws/data_source_aws_storagegateway_local_disk.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsStorageGatewayLocalDisk() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsStorageGatewayLocalDiskRead,
+
+		Schema: map[string]*schema.Schema{
+			"disk_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"gateway_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+		},
+	}
+}
+
+func dataSourceAwsStorageGatewayLocalDiskRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.ListLocalDisksInput{
+		GatewayARN: aws.String(d.Get("gateway_arn").(string)),
+	}
+
+	log.Printf("[DEBUG] Reading Storage Gateway Local Disk: %s", input)
+	output, err := conn.ListLocalDisks(input)
+	if err != nil {
+		return fmt.Errorf("error reading Storage Gateway Local Disk: %s", err)
+	}
+
+	if output == nil || len(output.Disks) == 0 {
+		return errors.New("no results found for query, try adjusting your search criteria")
+	}
+
+	diskPath := d.Get("disk_path").(string)
+	var matchingDisks []*storagegateway.Disk
+
+	for _, disk := range output.Disks {
+		if aws.StringValue(disk.DiskPath) == diskPath {
+			matchingDisks = append(matchingDisks, disk)
+		}
+	}
+
+	if len(matchingDisks) == 0 {
+		return errors.New("no results found for query, try adjusting your search criteria")
+	}
+
+	if len(matchingDisks) > 1 {
+		return errors.New("multiple results found for query, try adjusting your search criteria")
+	}
+
+	disk := matchingDisks[0]
+
+	d.SetId(aws.StringValue(disk.DiskId))
+	d.Set("disk_id", disk.DiskId)
+	d.Set("disk_path", disk.DiskPath)
+
+	return nil
+}

--- a/aws/data_source_aws_storagegateway_local_disk_test.go
+++ b/aws/data_source_aws_storagegateway_local_disk_test.go
@@ -1,0 +1,97 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_storagegateway_local_disk.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath_NonExistent(rName),
+				ExpectError: regexp.MustCompile(`no results found`),
+			},
+			{
+				Config: testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "disk_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", dataSourceName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = "10"
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/xvdb"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "${aws_volume_attachment.test.device_name}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+`, rName)
+}
+
+func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath_NonExistent(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = "10"
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/xvdb"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "/dev/xvdz"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+`, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -248,6 +248,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_sns_topic":                        dataSourceAwsSnsTopic(),
 			"aws_sqs_queue":                        dataSourceAwsSqsQueue(),
 			"aws_ssm_parameter":                    dataSourceAwsSsmParameter(),
+			"aws_storagegateway_local_disk":        dataSourceAwsStorageGatewayLocalDisk(),
 			"aws_subnet":                           dataSourceAwsSubnet(),
 			"aws_subnet_ids":                       dataSourceAwsSubnetIDs(),
 			"aws_vpcs":                             dataSourceAwsVpcs(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -328,6 +328,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ssm-parameter") %>>
                          <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-storagegateway-local-disk") %>>
+                         <a href="/docs/providers/aws/d/storagegateway_local_disk.html">aws_storagegateway_local_disk</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-subnet-x") %>>
                             <a href="/docs/providers/aws/d/subnet.html">aws_subnet</a>
                         </li>

--- a/website/docs/d/storagegateway_local_disk.html.markdown
+++ b/website/docs/d/storagegateway_local_disk.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "aws"
+page_title: "AWS: aws_storagegateway_local_disk"
+sidebar_current: "docs-aws-datasource-storagegateway-local-disk"
+description: |-
+  Retrieve information about a Storage Gateway local disk
+---
+
+# Data Source: aws_storagegateway_local_disk
+
+Retrieve information about a Storage Gateway local disk. The disk identifier is useful for adding the disk as a cache or upload buffer to a gateway.
+
+## Example Usage
+
+```hcl
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "${aws_volume_attachment.test.device_name}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+```
+
+## Argument Reference
+
+* `disk_path` - (Required) The device path of the local disk to retrieve. For example, `/dev/sdb` or `/dev/xvdb`.
+* `gateway_arn` - (Required) The Amazon Resource Name (ARN) of the gateway.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `disk_id` - The disk identifier. e.g. `pci-0000:03:00.0-scsi-0:0:0:0`
+* `id` - The disk identifier. e.g. `pci-0000:03:00.0-scsi-0:0:0:0`


### PR DESCRIPTION
Prerequisite for cache and upload buffer resources.

Reference: #943 

Changes proposed in this pull request:

* New Data Source: `aws_storagegateway_local_disk`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath -timeout 120m
=== RUN   TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath
--- PASS: TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath (289.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	290.429s
```
