### PR TITLE
Fixed Throttling Lambda Invocations Through Reserved Concurrency 

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -413,7 +413,7 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(d.Get("function_name").(string))
 
-	if reservedConcurrentExecutions > 0 {
+	if reservedConcurrentExecutions >= 0 {
 
 		log.Printf("[DEBUG] Setting Concurrency to %d for the Lambda Function %s", reservedConcurrentExecutions, functionName)
 


### PR DESCRIPTION
This PR addresses the issue here (terraform-providers#5287) where setting a value of 0 for the reserved_concurrent_executions will not properly enable Reserved Concurrency for the Lambda.

Using the test Terraform code in the referenced issue, I get the expected output:

```
$ aws lambda get-function --function-name lambda_function_name
{
    "Configuration": {
        "FunctionName": "lambda_function_name",
        "FunctionArn": "arn:aws:lambda:us-east-1:XXXXXXXXXXXX:function:lambda_function_name",
        "Runtime": "go1.x",
        "Role": "arn:aws:iam::XXXXXXXXXXXX:role/iam_for_lambda",
        "Handler": "main",
        "CodeSize": 2661873,
        "Description": "",
        "Timeout": 3,
        "MemorySize": 128,
        "LastModified": "2018-07-21T01:41:36.494+0000",
        "CodeSha256": "VBK96LKeV2/y/h38A2P8yXhiaVGy52e05yxfJcEi4GI=",
        "Version": "$LATEST",
        "TracingConfig": {
            "Mode": "PassThrough"
        }
    },
    "Code": {
        "RepositoryType": "S3",
        "Location": "REDACTED"
    },
    "Concurrency": {
        "ReservedConcurrentExecutions": 0
    }
}
```