### PR TITLE
Add secrets manager resource policy support

### DIFF
--- a/website/docs/r/secretsmanager_secret.html.markdown
+++ b/website/docs/r/secretsmanager_secret.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the friendly name of the new secret. The secret name can consist of uppercase letters, lowercase letters, digits, and any of the following characters: `/_+=.@-` Spaces are not permitted.
 * `description` - (Optional) A description of the secret.
 * `kms_key_id` - (Optional) Specifies the ARN or alias of the AWS KMS customer master key (CMK) to be used to encrypt the secret values in the versions stored in this secret. If you don't specify this value, then Secrets Manager defaults to using the AWS account's default CMK (the one named `aws/secretsmanager`). If the default KMS CMK with that name doesn't yet exist, then AWS Secrets Manager creates it for you automatically the first time.
+* `policy` - (Optional) A valid JSON document representing a [resource policy](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html).
 * `recovery_window_in_days` - (Optional) Specifies the number of days that AWS Secrets Manager waits before it can delete the secret. This value can range from 7 to 30 days. The default value is 30.
 * `rotation_lambda_arn` - (Optional) Specifies the ARN of the Lambda function that can rotate the secret.
 * `rotation_rules` - (Optional) A structure that defines the rotation configuration for this secret. Defined below.


### PR DESCRIPTION
Fixes #4997 

Changes proposed in this pull request:

* Adds support for a `policy` property on aws_secretsmanager_secret
* Adds documentation for property

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsSecretsManagerSecret'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAwsSecretsManagerSecret -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsSecretsManagerSecret_Basic
--- PASS: TestAccAwsSecretsManagerSecret_Basic (17.82s)
=== RUN   TestAccAwsSecretsManagerSecret_Description
--- PASS: TestAccAwsSecretsManagerSecret_Description (27.33s)
=== RUN   TestAccAwsSecretsManagerSecret_KmsKeyID
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (66.27s)
=== RUN   TestAccAwsSecretsManagerSecret_RotationLambdaARN
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (62.74s)
=== RUN   TestAccAwsSecretsManagerSecret_RotationRules
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (60.14s)
=== RUN   TestAccAwsSecretsManagerSecret_Tags
--- PASS: TestAccAwsSecretsManagerSecret_Tags (52.92s)
=== RUN   TestAccAwsSecretsManagerSecret_policy
--- PASS: TestAccAwsSecretsManagerSecret_policy (14.64s)
=== RUN   TestAccAwsSecretsManagerSecretVersion_Basic
--- PASS: TestAccAwsSecretsManagerSecretVersion_Basic (18.10s)
=== RUN   TestAccAwsSecretsManagerSecretVersion_VersionStages
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (43.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	363.216s
```
