### PR TITLE
r/aws_lambda_event_source_mapping: Infer enabled status from State atttribute

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -191,6 +191,14 @@ func resourceAwsLambdaEventSourceMappingRead(d *schema.ResourceData, meta interf
 	d.Set("uuid", eventSourceMappingConfiguration.UUID)
 	d.Set("function_name", eventSourceMappingConfiguration.FunctionArn)
 
+	if *eventSourceMappingConfiguration.State == "Enabled" {
+		d.Set("enabled", true)
+	} else if *eventSourceMappingConfiguration.State == "Disabled" {
+		d.Set("enabled", false)
+	} else {
+		log.Printf("[DEBUG] Lambda event source mapping is neither enabled nor disabled but %s", *eventSourceMappingConfiguration.State)
+	}
+
 	return nil
 }
 

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -191,11 +191,14 @@ func resourceAwsLambdaEventSourceMappingRead(d *schema.ResourceData, meta interf
 	d.Set("uuid", eventSourceMappingConfiguration.UUID)
 	d.Set("function_name", eventSourceMappingConfiguration.FunctionArn)
 
-	if *eventSourceMappingConfiguration.State == "Enabled" {
+	state := aws.StringValue(eventSourceMappingConfiguration.State)
+
+	switch state {
+	case "Enabled", "Enabling":
 		d.Set("enabled", true)
-	} else if *eventSourceMappingConfiguration.State == "Disabled" {
+	case "Disabled", "Disabling":
 		d.Set("enabled", false)
-	} else {
+	default:
 		log.Printf("[DEBUG] Lambda event source mapping is neither enabled nor disabled but %s", *eventSourceMappingConfiguration.State)
 	}
 

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -270,8 +270,7 @@ func testAccCheckAWSLambdaEventSourceMappingIsBeingDisabled(conf *lambda.EventSo
 			_, err := conn.UpdateEventSourceMapping(params)
 
 			if err != nil {
-				cgw, ok := err.(awserr.Error)
-				if ok && cgw.Code() == lambda.ErrCodeResourceInUseException {
+				if isAWSErr(err, lambda.ErrCodeResourceInUseException, "") {
 					return resource.RetryableError(fmt.Errorf(
 						"Waiting for Lambda Event Source Mapping to be ready to be updated: %v", conf.UUID))
 				}


### PR DESCRIPTION
Fixes #498

Changes proposed in this pull request:
* This PR adds logic to map LambdaEventSourceMappings `State` attribute to the resources `enabled` parameter to allow terraform to detect if the enabled parameter was changed outside of terraforms control and change it back.

Open question: 
* `State` can have lots of values, [_Creating, Enabled, Disabled, Enabling, Disabling, Updating, or Deleting_](https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html#SSS-GetEventSourceMapping-response-State). Currently, this PR only handles the clear cases `Enabled` and `Disabled`. In all other cases we just ignore the output and keep the terraform state as it is. 
Is this a problem that should be adressed in this PR? If yes, does it make more sense to "guess" the future state (e.g. `Enabling` will become `Enabled`) or wait and retry until the state has converged?

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaEventSourceMapping'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLambdaEventSourceMapping -timeout 120m
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (156.59s)
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (147.12s)
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_basic
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (156.78s)
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_import
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_import (120.90s)
=== RUN   TestAccAWSLambdaEventSourceMapping_kinesis_disappears
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_disappears (118.96s)
=== RUN   TestAccAWSLambdaEventSourceMapping_sqsDisappears
--- PASS: TestAccAWSLambdaEventSourceMapping_sqsDisappears (154.77s)
=== RUN   TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected
--- PASS: TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected (184.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1039.497s
```
 