### PR TITLE
docs/resource/aws_elasticsearch_domain: Add missing comma in IAM policy

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -39,7 +39,7 @@ resource "aws_elasticsearch_domain" "es" {
 			"Action": "es:*",
 			"Principal": "*",
 			"Effect": "Allow",
-			"Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"
+			"Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*",
 			"Condition": {
 				"IpAddress": {"aws:SourceIp": ["66.193.100.22/32"]}
 			}


### PR DESCRIPTION
Fixes #5232 

Changes proposed in this pull request:

* On the tin

Output from acceptance testing: N/A -- documentation fix
