### PR TITLE
aws_vpc: Add arn as an attribute for aws_vpc

### DIFF
--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -92,6 +93,11 @@ func dataSourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchemaComputed(),
 		},
 	}
@@ -161,6 +167,15 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("default", vpc.IsDefault)
 	d.Set("state", vpc.State)
 	d.Set("tags", tagsToMap(vpc.Tags))
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ec2",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("vpc/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 
 	cidrAssociations := []interface{}{}
 	for _, associationSet := range vpc.CidrBlockAssociationSet {

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -30,6 +30,8 @@ func TestAccDataSourceAwsVpc_basic(t *testing.T) {
 						"data.aws_vpc.by_id", "enable_dns_support", "true"),
 					resource.TestCheckResourceAttr(
 						"data.aws_vpc.by_id", "enable_dns_hostnames", "false"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_vpc.by_id", "arn"),
 				),
 			},
 		},

--- a/aws/resource_aws_default_vpc_test.go
+++ b/aws/resource_aws_default_vpc_test.go
@@ -27,6 +27,8 @@ func TestAccAWSDefaultVpc_basic(t *testing.T) {
 						"aws_default_vpc.foo", "tags.%", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_default_vpc.foo", "tags.Name", "Default VPC"),
+					resource.TestCheckResourceAttrSet(
+						"aws_default_vpc.foo", "arn"),
 					resource.TestCheckNoResourceAttr(
 						"aws_default_vpc.foo", "assign_generated_ipv6_cidr_block"),
 					resource.TestCheckNoResourceAttr(

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -107,6 +108,11 @@ func resourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -176,6 +182,16 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", vpc.CidrBlock)
 	d.Set("dhcp_options_id", vpc.DhcpOptionsId)
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
+
+	// ARN
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ec2",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("vpc/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 
 	// Tags
 	d.Set("tags", tagsToMap(vpc.Tags))

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -95,6 +95,8 @@ func TestAccAWSVpc_basic(t *testing.T) {
 						"aws_vpc.foo", "default_route_table_id"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc.foo", "enable_dns_support", "true"),
+					resource.TestCheckResourceAttrSet(
+						"aws_vpc.foo", "arn"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes #5027

Changes proposed in this pull request:

* Add arn attribute to aws_default_vpc resource, aws_vpc resource and data source

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=\(TestAccAWS\(Default\)?Vpc\|TestAccDataSourceAwsVpc\)_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=\(TestAccAWS\(Default\)?Vpc\|TestAccDataSourceAwsVpc\)_ -timeout 120m
=== RUN   TestAccAWSVpc_coreMismatchedDiffs
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (68.49s)
=== RUN   TestAccDataSourceAwsVpc_basic
--- PASS: TestAccDataSourceAwsVpc_basic (131.73s)
=== RUN   TestAccDataSourceAwsVpc_ipv6Associated
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (95.52s)
=== RUN   TestAccDataSourceAwsVpc_multipleCidr
--- PASS: TestAccDataSourceAwsVpc_multipleCidr (115.77s)
=== RUN   TestAccAWSVpc_importBasic
--- PASS: TestAccAWSVpc_importBasic (79.07s)
=== RUN   TestAccAWSDefaultVpc_basic
--- PASS: TestAccAWSDefaultVpc_basic (40.26s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (43.60s)
=== RUN   TestAccAWSVpc_enableIpv6
--- PASS: TestAccAWSVpc_enableIpv6 (124.12s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (46.50s)
=== RUN   TestAccAWSVpc_modifyTenancy
--- PASS: TestAccAWSVpc_modifyTenancy (119.07s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (78.43s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (79.10s)
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (20.37s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (41.94s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (44.46s)
=== RUN   TestAccAWSVpc_classiclinkDnsSupportOptionSet
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (43.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1172.322s
```

Output from Terraform test:
```
$ cat main.tf
provider "aws" {
  profile = "personal"
  region  = "eu-west-1"
}

# Externally created VPC to test data source
data "aws_vpc" "external" {
  id = "vpc-4ce9b52a"
}
output "data_source" {
  value = "${data.aws_vpc.external.arn}"
}

# Default VPC
resource "aws_default_vpc" "default" {}
output "default_vpc" {
  value = "${aws_default_vpc.default.arn}"
}

# Terraform managed
resource "aws_vpc" "foo" {
  cidr_block = "11.0.0.0/16"
}
output "terraform_vpc" {
  value = "${aws_vpc.foo.arn}"
}

...

data_source = arn:aws:ec2:eu-west-1:328265934943:vpc/vpc-4ce9b52a
default_vpc = arn:aws:ec2:eu-west-1:328265934943:vpc/vpc-93510cf7
terraform_vpc = arn:aws:ec2:eu-west-1:328265934943:vpc/vpc-63e8b405
```