### PR TITLE
docs/resource/aws_instance: Further clarify usage of security_groups versus vpc_security_group_ids

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -77,11 +77,11 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 
 * `get_password_data` - (Optional) If true, wait for password data to become available and retrieve it. Useful for getting the administrator password for instances running Microsoft Windows. The password data is exported to the `password_data` attribute. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)
-* `security_groups` - (Optional) A list of security group names to associate with.
+* `security_groups` - (Optional, EC2-Classic and default VPC only) A list of security group names to associate with.
 
 -> **NOTE:** If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 
-* `vpc_security_group_ids` - (Optional) A list of security group IDs to associate with.
+* `vpc_security_group_ids` - (Optional, VPC only) A list of security group IDs to associate with.
 * `subnet_id` - (Optional) The VPC Subnet ID to launch in.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.  Boolean value.
 * `private_ip` - (Optional) Private IP address to associate with the


### PR DESCRIPTION
Reference: #5302 

Changes proposed in this pull request:

* On the tin, based on https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#RunInstancesInput

Output from acceptance testing: N/A