### PR TITLE
data-source/aws_iam_policy_document: Add version argument

### DIFF
--- a/aws/data_source_aws_iam_policy_document.go
+++ b/aws/data_source_aws_iam_policy_document.go
@@ -84,6 +84,15 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 					},
 				},
 			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "2012-10-17",
+				ValidateFunc: validation.StringInSlice([]string{
+					"2008-10-17",
+					"2012-10-17",
+				}, false),
+			},
 			"json": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -103,9 +112,9 @@ func dataSourceAwsIamPolicyDocumentRead(d *schema.ResourceData, meta interface{}
 	}
 
 	// process the current document
-	doc := &IAMPolicyDoc{}
-
-	doc.Version = "2012-10-17"
+	doc := &IAMPolicyDoc{
+		Version: d.Get("version").(string),
+	}
 
 	if policyId, hasPolicyId := d.GetOk("policy_id"); hasPolicyId {
 		doc.Id = policyId.(string)

--- a/aws/data_source_aws_iam_policy_document_test.go
+++ b/aws/data_source_aws_iam_policy_document_test.go
@@ -1,11 +1,9 @@
 package aws
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSDataSourceIAMPolicyDocument_basic(t *testing.T) {
@@ -19,9 +17,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_basic(t *testing.T) {
 			{
 				Config: testAccAWSIAMPolicyDocumentConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStateValue("data.aws_iam_policy_document.test", "json",
-						testAccAWSIAMPolicyDocumentExpectedJSON,
-					),
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json", testAccAWSIAMPolicyDocumentExpectedJSON),
 				),
 			},
 		},
@@ -39,17 +35,13 @@ func TestAccAWSDataSourceIAMPolicyDocument_source(t *testing.T) {
 			{
 				Config: testAccAWSIAMPolicyDocumentSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStateValue("data.aws_iam_policy_document.test_source", "json",
-						testAccAWSIAMPolicyDocumentSourceExpectedJSON,
-					),
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test_source", "json", testAccAWSIAMPolicyDocumentSourceExpectedJSON),
 				),
 			},
 			{
 				Config: testAccAWSIAMPolicyDocumentSourceBlankConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStateValue("data.aws_iam_policy_document.test_source_blank", "json",
-						testAccAWSIAMPolicyDocumentSourceBlankExpectedJSON,
-					),
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test_source_blank", "json", testAccAWSIAMPolicyDocumentSourceBlankExpectedJSON),
 				),
 			},
 		},
@@ -64,9 +56,7 @@ func TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting(t *testing.T) {
 			{
 				Config: testAccAWSIAMPolicyDocumentSourceConflictingConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStateValue("data.aws_iam_policy_document.test_source_conflicting", "json",
-						testAccAWSIAMPolicyDocumentSourceConflictingExpectedJSON,
-					),
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test_source_conflicting", "json", testAccAWSIAMPolicyDocumentSourceConflictingExpectedJSON),
 				),
 			},
 		},
@@ -81,33 +71,26 @@ func TestAccAWSDataSourceIAMPolicyDocument_override(t *testing.T) {
 			{
 				Config: testAccAWSIAMPolicyDocumentOverrideConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStateValue("data.aws_iam_policy_document.test_override", "json",
-						testAccAWSIAMPolicyDocumentOverrideExpectedJSON,
-					),
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test_override", "json", testAccAWSIAMPolicyDocumentOverrideExpectedJSON),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckStateValue(id, name, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[id]
-		if !ok {
-			return fmt.Errorf("Not found: %s", id)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		v := rs.Primary.Attributes[name]
-		if v != value {
-			return fmt.Errorf(
-				"Value for %s is %s, not %s", name, v, value)
-		}
-
-		return nil
-	}
+func TestAccAWSDataSourceIAMPolicyDocument_Version_20081017(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMPolicyDocumentDataSourceConfig_Version_20081017,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_iam_policy_document.test", "json", testAccAWSIAMPolicyDocumentDataSourceConfig_Version_20081017_ExpectedJSON),
+				),
+			},
+		},
+	})
 }
 
 var testAccAWSIAMPolicyDocumentConfig = `
@@ -516,6 +499,29 @@ var testAccAWSIAMPolicyDocumentOverrideExpectedJSON = `{
       "Sid": "SidToOverwrite",
       "Effect": "Allow",
       "Action": "s3:*",
+      "Resource": "*"
+    }
+  ]
+}`
+
+const testAccAWSIAMPolicyDocumentDataSourceConfig_Version_20081017 = `
+data "aws_iam_policy_document" "test" {
+  version = "2008-10-17"
+
+  statement {
+    actions   = ["ec2:*"]
+    resources = ["*"]
+  }
+}
+`
+
+const testAccAWSIAMPolicyDocumentDataSourceConfig_Version_20081017_ExpectedJSON = `{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "ec2:*",
       "Resource": "*"
     }
   ]

--- a/website/docs/d/iam_policy_document.html.markdown
+++ b/website/docs/d/iam_policy_document.html.markdown
@@ -77,17 +77,13 @@ valid to use literal JSON strings within your configuration, or to use the
 
 The following arguments are supported:
 
+* `statement` (Required) - A nested configuration block (described below) configuring one *statement* to be included in the policy document.
+* `override_json` (Optional) - An IAM policy document to import and override the current policy document. Statements with non-blank `sid`s in the override document will overwrite statements with the same `sid` in the current document. Statements without an `sid` cannot be overwritten.
 * `policy_id` (Optional) - An ID for the policy document.
-* `source_json` (Optional) - An IAM policy document to import as a base for the
-  current policy document.  Statements with non-blank `sid`s in the current
-  policy document will overwrite statements with the same `sid` in the source
-  json.  Statements without an `sid` cannot be overwritten.
-* `override_json` (Optional) - An IAM policy document to import and override the
-  current policy document.  Statements with non-blank `sid`s in the override
-  document will overwrite statements with the same `sid` in the current document.
-  Statements without an `sid` cannot be overwritten.
-* `statement` (Required) - A nested configuration block (described below)
-  configuring one *statement* to be included in the policy document.
+* `source_json` (Optional) - An IAM policy document to import as a base for the current policy document. Statements with non-blank `sid`s in the current policy document will overwrite statements with the same `sid` in the source JSON. Statements without an `sid` cannot be overwritten.
+* `version` (Optional) - IAM policy document version. Defaults to `2012-10-17`. Valid values: `2008-10-17`, `2012-10-17`. For more information, see the [AWS IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html).
+
+### statement
 
 Each document configuration must have one or more `statement` blocks, which
 each accept the following arguments:
@@ -113,12 +109,16 @@ each accept the following arguments:
   that defines a further, possibly-service-specific condition that constrains
   whether this statement applies.
 
+#### principals
+
 Each policy may have either zero or more `principals` blocks or zero or more
 `not_principals` blocks, both of which each accept the following arguments:
 
 * `type` (Required) The type of principal. For AWS accounts this is "AWS".
 * `identifiers` (Required) List of identifiers for principals. When `type`
   is "AWS", these are IAM user or role ARNs.
+
+#### condition
 
 Each policy statement may have zero or more `condition` blocks, which each
 accept the following arguments:
@@ -159,7 +159,7 @@ like `type = "AWS"` and `identifiers = ["*"]` will be rendered as `"Principal": 
 
 ## Attributes Reference
 
-The following attribute is exported:
+In addition to the arguments above, the following attributes are exported:
 
 * `json` - The above arguments serialized as a standard JSON policy document.
 


### PR DESCRIPTION
Closes #744 

Changes proposed in this pull request:

* Supports creating `2008-10-17` version IAM policy documents as the structure is the same as `2012-10-17`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMPolicyDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDataSourceIAMPolicyDocument -timeout 120m
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_basic
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_basic (9.57s)
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_source
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_source (12.37s)
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_sourceConflicting (9.17s)
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_override
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_override (7.61s)
=== RUN   TestAccAWSDataSourceIAMPolicyDocument_Version_20081017
--- PASS: TestAccAWSDataSourceIAMPolicyDocument_Version_20081017 (7.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.194s
```
