### PR TITLE
resource/aws_route53_record: Prevent DomainLabelEmpty errors when expanding record names with trailing period

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -929,7 +929,7 @@ func expandRecordName(name, zone string) string {
 		if len(name) == 0 {
 			rn = zone
 		} else {
-			rn = strings.Join([]string{name, zone}, ".")
+			rn = strings.Join([]string{rn, zone}, ".")
 		}
 	}
 	return rn

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -40,6 +40,7 @@ func TestExpandRecordName(t *testing.T) {
 		Input, Output string
 	}{
 		{"www", "www.nonexample.com"},
+		{"www.", "www.nonexample.com"},
 		{"dev.www", "dev.www.nonexample.com"},
 		{"*", "*.nonexample.com"},
 		{"nonexample.com", "nonexample.com"},


### PR DESCRIPTION
Reference: #5237

Changes proposed in this pull request:

* Prepend sanitized record name (lowercase and trimmed of trailing period) instead of raw record name when expanding

Before code change:

```
--- FAIL: TestExpandRecordName (0.00s)
  resource_aws_route53_record_test.go:55: input: www.
    output: www..nonexample.com
```

Output from unit testing:

```
$ make test TEST=./aws
==> Checking that code complies with gofmt requirements...
go test ./aws -timeout=30s -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.426s
```

Output from acceptance testing:

```
Pending in TeamCity
```
