### PR TITLE
resource/aws_wafregional_ipset: Fix diff between aws_waf_ipset

### DIFF
--- a/aws/resource_aws_wafregional_ipset_test.go
+++ b/aws/resource_aws_wafregional_ipset_test.go
@@ -32,9 +32,9 @@ func TestAccAWSWafRegionalIPSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "name", ipsetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
 					resource.TestMatchResourceAttr("aws_wafregional_ipset.ipset", "arn",
 						regexp.MustCompile(`^arn:[\w-]+:waf-regional:[^:]+:\d{12}:ipset/.+$`)),
 				),
@@ -80,9 +80,9 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "name", ipsetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
@@ -92,9 +92,9 @@ func TestAccAWSWafRegionalIPSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "name", ipsetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 		},
@@ -117,11 +117,11 @@ func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "name", ipsetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.type", "IPV4"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.type", "IPV4"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.4037960608.value", "192.0.7.0/24"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.4037960608.value", "192.0.7.0/24"),
 				),
 			},
 			{
@@ -131,11 +131,11 @@ func TestAccAWSWafRegionalIPSet_changeDescriptors(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "name", ipsetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "1"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.type", "IPV4"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.115741513.type", "IPV4"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.115741513.value", "192.0.8.0/24"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.115741513.value", "192.0.8.0/24"),
 				),
 			},
 		},
@@ -158,7 +158,7 @@ func TestAccAWSWafRegionalIPSet_noDescriptors(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_ipset.ipset", "name", ipsetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_ipset.ipset", "ip_set_descriptor.#", "0"),
+						"aws_wafregional_ipset.ipset", "ip_set_descriptors.#", "0"),
 				),
 			},
 		},
@@ -371,7 +371,7 @@ func testAccAWSWafRegionalIPSetConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_ipset" "ipset" {
   name = "%s"
-  ip_set_descriptor {
+  ip_set_descriptors {
     type = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -381,7 +381,7 @@ resource "aws_wafregional_ipset" "ipset" {
 func testAccAWSWafRegionalIPSetConfigChangeName(name string) string {
 	return fmt.Sprintf(`resource "aws_wafregional_ipset" "ipset" {
   name = "%s"
-  ip_set_descriptor {
+  ip_set_descriptors {
     type = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -391,7 +391,7 @@ func testAccAWSWafRegionalIPSetConfigChangeName(name string) string {
 func testAccAWSWafRegionalIPSetConfigChangeIPSetDescriptors(name string) string {
 	return fmt.Sprintf(`resource "aws_wafregional_ipset" "ipset" {
   name = "%s"
-  ip_set_descriptor {
+  ip_set_descriptors {
     type = "IPV4"
     value = "192.0.8.0/24"
   }

--- a/website/docs/r/wafregional_ipset.html.markdown
+++ b/website/docs/r/wafregional_ipset.html.markdown
@@ -16,12 +16,12 @@ Provides a WAF Regional IPSet Resource for use with Application Load Balancer.
 resource "aws_wafregional_ipset" "ipset" {
   name = "tfIPSet"
 
-  ip_set_descriptor {
+  ip_set_descriptors {
     type = "IPV4"
     value = "192.0.7.0/24"
   }
 
-  ip_set_descriptor {
+  ip_set_descriptors {
     type  = "IPV4"
     value = "10.16.16.0/16"
   }
@@ -33,11 +33,12 @@ resource "aws_wafregional_ipset" "ipset" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the IPSet.
-* `ip_set_descriptor` - (Optional) One or more pairs specifying the IP address type (IPV4 or IPV6) and the IP address range (in CIDR notation) from which web requests originate.
+* `ip_set_descriptor` - **Deprecated**, use `ip_set_descriptors` instead.
+* `ip_set_descriptors` - (Optional) One or more pairs specifying the IP address type (IPV4 or IPV6) and the IP address range (in CIDR notation) from which web requests originate.
 
 ## Nested Blocks
 
-### `ip_set_descriptor`
+### `ip_set_descriptors`
 
 #### Arguments
 


### PR DESCRIPTION
Changes proposed in this pull request:

Fix #4137 .
This PR has renamed `ip_set_descriptor` to `ip_set_descriptors` in aws_wafregional_ip_set, because its name is different from the same attribute in aws_waf_ip_set.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalIPSet*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalIPSet* -timeout 120m
=== RUN   TestAccAWSWafRegionalIPSet_basic
--- PASS: TestAccAWSWafRegionalIPSet_basic (22.67s)
=== RUN   TestAccAWSWafRegionalIPSet_disappears
--- PASS: TestAccAWSWafRegionalIPSet_disappears (16.83s)
=== RUN   TestAccAWSWafRegionalIPSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalIPSet_changeNameForceNew (36.32s)
=== RUN   TestAccAWSWafRegionalIPSet_changeDescriptors
--- PASS: TestAccAWSWafRegionalIPSet_changeDescriptors (35.96s)
=== RUN   TestAccAWSWafRegionalIPSet_noDescriptors
--- PASS: TestAccAWSWafRegionalIPSet_noDescriptors (20.14s)
PASS
ok      github.com/chroju/terraform-provider-aws/aws    131.970s
```
