### PR TITLE
resource/aws_wafregional_rule: Fix diff between aws_waf_rule

### DIFF
--- a/aws/resource_aws_wafregional_rule_test.go
+++ b/aws/resource_aws_wafregional_rule_test.go
@@ -28,7 +28,7 @@ func TestAccAWSWafRegionalRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_rule.wafrule", "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "1"),
+						"aws_wafregional_rule.wafrule", "predicates.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_rule.wafrule", "metric_name", wafRuleName),
 				),
@@ -54,7 +54,7 @@ func TestAccAWSWafRegionalRule_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_rule.wafrule", "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "1"),
+						"aws_wafregional_rule.wafrule", "predicates.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_rule.wafrule", "metric_name", wafRuleName),
 				),
@@ -66,7 +66,7 @@ func TestAccAWSWafRegionalRule_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_rule.wafrule", "name", wafRuleNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "1"),
+						"aws_wafregional_rule.wafrule", "predicates.#", "1"),
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_rule.wafrule", "metric_name", wafRuleNewName),
 				),
@@ -110,7 +110,7 @@ func TestAccAWSWafRegionalRule_noPredicates(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_rule.wafrule", "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "0"),
+						"aws_wafregional_rule.wafrule", "predicates.#", "0"),
 				),
 			},
 		},
@@ -136,10 +136,10 @@ func TestAccAWSWafRegionalRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &ipset),
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &before),
 					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "predicate.#", "1"),
+					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "predicates.#", "1"),
 					computeWafRegionalRulePredicate(&ipset.IPSetId, false, "IPMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.negated", &idx, "false"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.type", &idx, "IPMatch"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicates.%d.negated", &idx, "false"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicates.%d.type", &idx, "IPMatch"),
 				),
 			},
 			{
@@ -148,13 +148,13 @@ func TestAccAWSWafRegionalRule_changePredicates(t *testing.T) {
 					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &xssMatchSet),
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &after),
 					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "predicate.#", "2"),
+					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "predicates.#", "2"),
 					computeWafRegionalRulePredicate(&xssMatchSet.XssMatchSetId, true, "XssMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.negated", &idx, "true"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.type", &idx, "XssMatch"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicates.%d.negated", &idx, "true"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicates.%d.type", &idx, "XssMatch"),
 					computeWafRegionalRulePredicate(&ipset.IPSetId, true, "IPMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.negated", &idx, "true"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.type", &idx, "IPMatch"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicates.%d.negated", &idx, "true"),
+					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicates.%d.type", &idx, "IPMatch"),
 				),
 			},
 		},
@@ -164,7 +164,7 @@ func TestAccAWSWafRegionalRule_changePredicates(t *testing.T) {
 // Calculates the index which isn't static because dataId is generated as part of the test
 func computeWafRegionalRulePredicate(dataId **string, negated bool, pType string, idx *int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		predicateResource := resourceAwsWafRegionalRule().Schema["predicate"].Elem.(*schema.Resource)
+		predicateResource := resourceAwsWafRegionalRule().Schema["predicates"].Elem.(*schema.Resource)
 		m := map[string]interface{}{
 			"data_id": **dataId,
 			"negated": negated,
@@ -295,7 +295,7 @@ resource "aws_wafregional_rule" "wafrule" {
   name = "%s"
   metric_name = "%s"
 
-  predicate {
+  predicates {
     data_id = "${aws_wafregional_ipset.ipset.id}"
     negated = false
     type = "IPMatch"
@@ -318,7 +318,7 @@ resource "aws_wafregional_rule" "wafrule" {
   name = "%s"
   metric_name = "%s"
 
-  predicate {
+  predicates {
     data_id = "${aws_wafregional_ipset.ipset.id}"
     negated = false
     type = "IPMatch"
@@ -360,13 +360,13 @@ resource "aws_wafregional_rule" "wafrule" {
   name = "%s"
   metric_name = "%s"
 
-  predicate {
+  predicates {
     data_id = "${aws_wafregional_xss_match_set.xss_match_set.id}"
     negated = true
     type = "XssMatch"
   }
 
-  predicate {
+  predicates {
     data_id = "${aws_wafregional_ipset.ipset.id}"
     negated = true
     type = "IPMatch"

--- a/website/docs/r/wafregional_rule.html.markdown
+++ b/website/docs/r/wafregional_rule.html.markdown
@@ -16,7 +16,7 @@ Provides an WAF Regional Rule Resource for use with Application Load Balancer.
 resource "aws_wafregional_ipset" "ipset" {
   name = "tfIPSet"
 
-  ip_set_descriptor {
+  ip_set_descriptors {
     type  = "IPV4"
     value = "192.0.7.0/24"
   }
@@ -26,7 +26,7 @@ resource "aws_wafregional_rule" "wafrule" {
   name        = "tfWAFRule"
   metric_name = "tfWAFRule"
 
-  predicate {
+  predicates {
     type    = "IPMatch"
     data_id = "${aws_wafregional_ipset.ipset.id}"
     negated = false
@@ -40,11 +40,12 @@ The following arguments are supported:
 
 * `name` - (Required) The name or description of the rule.
 * `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this rule.
-* `predicate` - (Optional) The objects to include in a rule.
+* `predicate` - **Deprecated** use `predicates` instead.
+* `predicates` - (Optional) The objects to include in a rule.
 
 ## Nested Fields
 
-### `predicate`
+### `predicates`
 
 See the [WAF Documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_Predicate.html) for more information.
 


### PR DESCRIPTION
Changes proposed in this pull request:

Fix #4137 .
This PR has renamed `predicate` to `predicates` in aws_wafregional_rule, because its name is different from the same attribute in aws_waf_rule.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRule*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalRule* -timeout 120m
=== RUN   TestAccAWSWafRegionalRuleGroup_basic
--- PASS: TestAccAWSWafRegionalRuleGroup_basic (24.75s)
=== RUN   TestAccAWSWafRegionalRuleGroup_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRuleGroup_changeNameForceNew (41.05s)
=== RUN   TestAccAWSWafRegionalRuleGroup_disappears
--- PASS: TestAccAWSWafRegionalRuleGroup_disappears (23.90s)
=== RUN   TestAccAWSWafRegionalRuleGroup_changeActivatedRules
--- PASS: TestAccAWSWafRegionalRuleGroup_changeActivatedRules (43.15s)
=== RUN   TestAccAWSWafRegionalRuleGroup_noActivatedRules
--- PASS: TestAccAWSWafRegionalRuleGroup_noActivatedRules (18.96s)
=== RUN   TestAccAWSWafRegionalRule_basic
--- PASS: TestAccAWSWafRegionalRule_basic (26.99s)
=== RUN   TestAccAWSWafRegionalRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRule_changeNameForceNew (48.27s)
=== RUN   TestAccAWSWafRegionalRule_disappears
--- PASS: TestAccAWSWafRegionalRule_disappears (28.63s)
=== RUN   TestAccAWSWafRegionalRule_noPredicates
--- PASS: TestAccAWSWafRegionalRule_noPredicates (19.59s)
=== RUN   TestAccAWSWafRegionalRule_changePredicates
--- PASS: TestAccAWSWafRegionalRule_changePredicates (43.35s)
PASS
ok      github.com/chroju/terraform-provider-aws/aws    318.690s
```