### PR TITLE
r/aws_wafregional_sql_injection_match_set: Fix diff between aws_waf_sql_injection_match_set

### DIFF
--- a/aws/resource_aws_wafregional_sql_injection_match_set_test.go
+++ b/aws/resource_aws_wafregional_sql_injection_match_set_test.go
@@ -28,15 +28,15 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.data", ""),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.type", "QUERY_STRING"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.field_to_match.0.type", "QUERY_STRING"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.text_transformation", "URL_DECODE"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.text_transformation", "URL_DECODE"),
 				),
 			},
 		},
@@ -60,7 +60,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew(t *testing.T) 
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
 				),
 			},
 			{
@@ -70,7 +70,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew(t *testing.T) 
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
 				),
 			},
 		},
@@ -114,15 +114,15 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.data", ""),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.field_to_match.0.type", "QUERY_STRING"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.field_to_match.0.type", "QUERY_STRING"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.1913782288.text_transformation", "URL_DECODE"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.1913782288.text_transformation", "URL_DECODE"),
 				),
 			},
 			{
@@ -132,15 +132,15 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.field_to_match.#", "1"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3961339938.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.field_to_match.0.data", "user-agent"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3961339938.field_to_match.0.data", "user-agent"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.field_to_match.0.type", "HEADER"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3961339938.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.3961339938.text_transformation", "NONE"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3961339938.text_transformation", "NONE"),
 				),
 			},
 		},
@@ -163,7 +163,7 @@ func TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuple.#", "0"),
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "0"),
 				),
 			},
 		},
@@ -273,7 +273,7 @@ func testAccAWSWafRegionalSqlInjectionMatchSetConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
   name = "%s"
-  sql_injection_match_tuple {
+  sql_injection_match_tuples {
     text_transformation = "URL_DECODE"
     field_to_match {
       type = "QUERY_STRING"
@@ -286,7 +286,7 @@ func testAccAWSWafRegionalSqlInjectionMatchSetConfig_changeTuples(name string) s
 	return fmt.Sprintf(`
 resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
   name = "%s"
-  sql_injection_match_tuple {
+  sql_injection_match_tuples {
     text_transformation = "NONE"
     field_to_match {
       type = "HEADER"

--- a/website/docs/r/wafregional_sql_injection_match_set.html.markdown
+++ b/website/docs/r/wafregional_sql_injection_match_set.html.markdown
@@ -15,7 +15,7 @@ Provides a WAF Regional SQL Injection Match Set Resource for use with Applicatio
 ```hcl
 resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
   name = "tf-sql_injection_match_set"
-  sql_injection_match_tuple {
+  sql_injection_match_tuples {
     text_transformation = "URL_DECODE"
     field_to_match {
       type = "QUERY_STRING"
@@ -29,11 +29,12 @@ resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the SizeConstraintSet.
-* `sql_injection_match_tuple` - (Optional) The parts of web requests that you want AWS WAF to inspect for malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header.
+* `sql_injection_match_tuple` - **Deprecated**, use `sql_injection_match_tuples` instead.
+* `sql_injection_match_tuples` - (Optional) The parts of web requests that you want AWS WAF to inspect for malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header.
 
 ### Nested fields
 
-### `sql_injection_match_tuple`
+### `sql_injection_match_tuples`
 
 * `field_to_match` - (Required) Specifies where in a web request to look for snippets of malicious SQL code.
 * `text_transformation` - (Required) Text transformations used to eliminate unusual formatting that attackers use in web requests in an effort to bypass AWS WAF.


### PR DESCRIPTION
Changes proposed in this pull request:

Fix #4137 .
This PR has renamed `sql_injection_match_tuple` to `sql_injection_match_tuples` in aws_wafregional_sql_injection_match_set, because its name is different from the same attribute in aws_waf_sql_injection_match_set.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalSqlInjectionMatchSet*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalSqlInjectionMatchSet* -timeout 120m
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_basic (23.69s)
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew (39.70s)
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_disappears
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_disappears (19.80s)
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_changeTuples (38.82s)
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_noTuples (19.57s)
PASS
ok      github.com/chroju/terraform-provider-aws/aws    141.615s
```