### PR TITLE
r/aws_wafregional_xss_match_set: Fix diff between aws_waf_xss_match_set

### DIFF
--- a/aws/resource_aws_wafregional_xss_match_set_test.go
+++ b/aws/resource_aws_wafregional_xss_match_set_test.go
@@ -29,23 +29,23 @@ func TestAccAWSWafRegionalXssMatchSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_xss_match_set.xss_match_set", "name", xssMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.#", "1"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.field_to_match.2316364334.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.text_transformation", "NONE"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.#", "1"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.field_to_match.3756326843.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.field_to_match.3756326843.type", "URI"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.text_transformation", "NONE"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.text_transformation", "NONE"),
 				),
 			},
 		},
@@ -69,7 +69,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_xss_match_set.xss_match_set", "name", xssMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
 				),
 			},
 			{
@@ -79,7 +79,7 @@ func TestAccAWSWafRegionalXssMatchSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_xss_match_set.xss_match_set", "name", xssMatchSetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
 				),
 			},
 		},
@@ -123,23 +123,23 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_xss_match_set.xss_match_set", "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.#", "1"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.data", ""),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.field_to_match.2316364334.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.field_to_match.2316364334.type", "QUERY_STRING"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2018581549.text_transformation", "NONE"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2018581549.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.#", "1"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.data", ""),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.field_to_match.3756326843.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.field_to_match.3756326843.type", "URI"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.field_to_match.3756326843.type", "URI"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2786024938.text_transformation", "NONE"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2786024938.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -149,23 +149,23 @@ func TestAccAWSWafRegionalXssMatchSet_changeTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_xss_match_set.xss_match_set", "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "2"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.field_to_match.#", "1"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2893682529.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.field_to_match.4253810390.data", "GET"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2893682529.field_to_match.4253810390.data", "GET"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.field_to_match.4253810390.type", "METHOD"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2893682529.field_to_match.4253810390.type", "METHOD"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.2893682529.text_transformation", "HTML_ENTITY_DECODE"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.2893682529.text_transformation", "HTML_ENTITY_DECODE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.field_to_match.#", "1"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.4270311415.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.field_to_match.281401076.data", ""),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.4270311415.field_to_match.281401076.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.field_to_match.281401076.type", "BODY"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.4270311415.field_to_match.281401076.type", "BODY"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.4270311415.text_transformation", "CMD_LINE"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.4270311415.text_transformation", "CMD_LINE"),
 				),
 			},
 		},
@@ -188,7 +188,7 @@ func TestAccAWSWafRegionalXssMatchSet_noTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_xss_match_set.xss_match_set", "name", setName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuple.#", "0"),
+						"aws_wafregional_xss_match_set.xss_match_set", "xss_match_tuples.#", "0"),
 				),
 			},
 		},
@@ -299,14 +299,14 @@ func testAccAWSWafRegionalXssMatchSetConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_xss_match_set" "xss_match_set" {
   name = "%s"
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "NONE"
     field_to_match {
       type = "URI"
     }
   }
 
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "NONE"
     field_to_match {
       type = "QUERY_STRING"
@@ -319,14 +319,14 @@ func testAccAWSWafRegionalXssMatchSetConfigChangeName(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_xss_match_set" "xss_match_set" {
   name = "%s"
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "NONE"
     field_to_match {
       type = "URI"
     }
   }
 
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "NONE"
     field_to_match {
       type = "QUERY_STRING"
@@ -339,13 +339,13 @@ func testAccAWSWafRegionalXssMatchSetConfig_changeTuples(name string) string {
 	return fmt.Sprintf(`
 resource "aws_wafregional_xss_match_set" "xss_match_set" {
   name = "%s"
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "CMD_LINE"
     field_to_match {
       type = "BODY"
     }
   }
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "HTML_ENTITY_DECODE"
     field_to_match {
       type = "METHOD"

--- a/website/docs/r/wafregional_xss_match_set.html.markdown
+++ b/website/docs/r/wafregional_xss_match_set.html.markdown
@@ -15,14 +15,14 @@ Provides a WAF Regional XSS Match Set Resource for use with Application Load Bal
 ```
 resource "aws_wafregional_xss_match_set" "xss_match_set" {
   name = "xss_match_set"
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "NONE"
     field_to_match {
       type = "URI"
     }
   }
 
-  xss_match_tuple {
+  xss_match_tuples {
     text_transformation = "NONE"
     field_to_match {
       type = "QUERY_STRING"
@@ -36,11 +36,12 @@ resource "aws_wafregional_xss_match_set" "xss_match_set" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the set
-* `xss_match_tuple` - (Optional) The parts of web requests that you want to inspect for cross-site scripting attacks.
+* `xss_match_tuple` - **Deprecated** use `xss_match_tuples` instead.
+* `xss_match_tuples` - (Optional) The parts of web requests that you want to inspect for cross-site scripting attacks.
 
 ### Nested fields
 
-#### `xss_match_tuple`
+#### `xss_match_tuples`
 
 * `field_to_match` - (Required) Specifies where in a web request to look for cross-site scripting attacks.
 * `text_transformation` - (Required) Which text transformation, if any, to perform on the web request before inspecting the request for cross-site scripting attacks.


### PR DESCRIPTION
Changes proposed in this pull request:

Fix #4137 .
This PR has renamed `xss_match_tuple` to `xss_match_tuples` in aws_wafregional_xss_match_set, because its name is different from the same attribute in aws_waf_xss_match_set.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalXssMatchSet*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalXssMatchSet* -timeout 120m
=== RUN   TestAccAWSWafRegionalXssMatchSet_basic
--- PASS: TestAccAWSWafRegionalXssMatchSet_basic (22.77s)
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeNameForceNew (40.13s)
=== RUN   TestAccAWSWafRegionalXssMatchSet_disappears
--- PASS: TestAccAWSWafRegionalXssMatchSet_disappears (17.96s)
=== RUN   TestAccAWSWafRegionalXssMatchSet_changeTuples
--- PASS: TestAccAWSWafRegionalXssMatchSet_changeTuples (39.22s)
=== RUN   TestAccAWSWafRegionalXssMatchSet_noTuples
--- PASS: TestAccAWSWafRegionalXssMatchSet_noTuples (20.82s)
PASS
ok      github.com/chroju/terraform-provider-aws/aws    140.930s
```
