### PR TITLE
issue #5239 New Data source: aws_network_interfaces

### DIFF
--- a/aws/data_source_aws_network_interfaces.go
+++ b/aws/data_source_aws_network_interfaces.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsNetworkInterfaces() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsNetworkInterfacesRead,
+		Schema: map[string]*schema.Schema{
+
+			"filter": ec2CustomFiltersSchema(),
+
+			"tags": tagsSchemaComputed(),
+
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsNetworkInterfacesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeNetworkInterfacesInput{}
+
+	filters, filtersOk := d.GetOk("filter")
+	tags, tagsOk := d.GetOk("tags")
+
+	if tagsOk {
+		req.Filters = buildEC2TagFilterList(
+			tagsFromMap(tags.(map[string]interface{})),
+		)
+	}
+
+	if filtersOk {
+		req.Filters = append(req.Filters, buildEC2CustomFilterList(
+			filters.(*schema.Set),
+		)...)
+	}
+
+	if len(req.Filters) == 0 {
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] DescribeNetworkInterfaces %s\n", req)
+	resp, err := conn.DescribeNetworkInterfaces(req)
+	if err != nil {
+		return err
+	}
+
+	if resp == nil || len(resp.NetworkInterfaces) == 0 {
+		return errors.New("no matching network interfaces found")
+	}
+
+	networkInterfaces := make([]string, 0)
+
+	for _, networkInterface := range resp.NetworkInterfaces {
+		networkInterfaces = append(networkInterfaces, aws.StringValue(networkInterface.NetworkInterfaceId))
+	}
+
+	d.SetId(resource.UniqueId())
+	if err := d.Set("ids", networkInterfaces); err != nil {
+		return fmt.Errorf("Error setting network interfaces ids: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_network_interfaces_test.go
+++ b/aws/data_source_aws_network_interfaces_test.go
@@ -1,0 +1,96 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsNetworkInterfaces_Filter(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsNetworkInterfacesConfig_Filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_network_interfaces.test", "ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsNetworkInterfaces_Tags(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsNetworkInterfacesConfig_Tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_network_interfaces.test", "ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsNetworkInterfacesConfig_Base(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags {
+    Name = "terraform-testacc-eni-data-source-basic-%s"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.0.0.0/24"
+  availability_zone = "us-west-2a"
+  vpc_id = "${aws_vpc.test.id}"
+  tags {
+    Name = "terraform-testacc-eni-data-source-basic-%s"
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = "${aws_subnet.test.id}"
+}
+
+resource "aws_network_interface" "test1" {
+  subnet_id = "${aws_subnet.test.id}"
+  tags {
+  	Name = "${aws_vpc.test.tags.Name}"
+  }
+}
+
+`, rName, rName)
+}
+
+func testAccDataSourceAwsNetworkInterfacesConfig_Filter(rName string) string {
+	return testAccDataSourceAwsNetworkInterfacesConfig_Base(rName) + `
+data "aws_network_interfaces" "test" {
+  filter {
+    name   = "subnet-id"
+    values = ["${aws_network_interface.test.subnet_id}"]
+  }
+}
+`
+}
+
+func testAccDataSourceAwsNetworkInterfacesConfig_Tags(rName string) string {
+	return testAccDataSourceAwsNetworkInterfacesConfig_Base(rName) + `
+data "aws_network_interfaces" "test" {
+  tags {
+    Name = "${aws_network_interface.test1.tags.Name}"
+  }
+}
+`
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -230,6 +230,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_nat_gateway":                      dataSourceAwsNatGateway(),
 			"aws_network_acls":                     dataSourceAwsNetworkAcls(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
+			"aws_network_interfaces":               dataSourceAwsNetworkInterfaces(),
 			"aws_partition":                        dataSourceAwsPartition(),
 			"aws_prefix_list":                      dataSourceAwsPrefixList(),
 			"aws_pricing_product":                  dataSourceAwsPricingProduct(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -250,6 +250,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-network-interface") %>>
                             <a href="/docs/providers/aws/d/network_interface.html">aws_network_interface</a>
                         </li>
+                         <li<%= sidebar_current("docs-aws-datasource-network-interfaces") %>>
+                            <a href="/docs/providers/aws/d/network_interfaces.html">aws_network_interfaces</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-lambda-function") %>>
                             <a href="/docs/providers/aws/d/lambda_function.html">aws_lambda_function</a>
                         </li>

--- a/website/docs/d/network_interfaces.html.markdown
+++ b/website/docs/d/network_interfaces.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "aws"
+page_title: "AWS: aws_network_interfaces"
+sidebar_current: "docs-aws-datasource-network-interfaces"
+description: |-
+    Provides a list of network interface ids
+---
+
+# Data Source: aws_network_interfaces
+
+## Example Usage
+
+The following shows outputing all network interface ids in a region.
+
+```hcl
+data "aws_network_interfaces" "example" {}
+
+output "example" {
+  value = "${data.aws_network_interfaces.example.ids}"
+}
+```
+
+The following example retrieves a list of all network interface ids with a custom tag of `Name` set to a value of `test`.
+
+```hcl
+data "aws_network_interfaces" "example" {
+  tags {
+    Name = "test"
+  }
+}
+
+output "example1" {
+  value = "${data.aws_network_interfaces.example.ids}"
+}
+```
+
+The following example retrieves a network interface ids which associated
+with specific subnet.
+
+```hcl
+data "aws_network_interfaces" "example" {
+  filter {
+    name = "subnet-id"
+    values = ["${aws_subnet.test.id}"]
+  }
+}
+
+output "example" {
+  value = "${data.aws_network_interfaces.example.ids}"
+}
+```
+
+## Argument Reference
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired network interfaces.
+
+* `filter` - (Optional) Custom filter block as described below.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+
+## Attributes Reference
+
+* `ids` - A list of all the network interface ids found. This data source will fail if none are found.
+


### PR DESCRIPTION

Fixes #5239 

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsNetworkInterfaces_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccDataSourceAwsNetworkInterfaces_ -timeout 120m
=== RUN   TestAccDataSourceAwsNetworkInterfaces_Filter
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Filter (104.71s)
=== RUN   TestAccDataSourceAwsNetworkInterfaces_Tags
--- PASS: TestAccDataSourceAwsNetworkInterfaces_Tags (113.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	218.325s
...
```
