### PR TITLE
Use ParameterFilters instead of regular Filters on SSM parameter

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -118,6 +118,12 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error describing SSM parameter: %s", err)
 	}
 
+	if describeResp == nil || len(describeResp.Parameters) == 0 || describeResp.Parameters[0] == nil {
+		log.Printf("[WARN] SSM Parameter %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	detail := describeResp.Parameters[0]
 	d.Set("key_id", detail.KeyId)
 	d.Set("description", detail.Description)

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -105,30 +105,20 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("value", param.Value)
 
 	describeParamsInput := &ssm.DescribeParametersInput{
-		Filters: []*ssm.ParametersFilter{
-			&ssm.ParametersFilter{
+		ParameterFilters: []*ssm.ParameterStringFilter{
+			&ssm.ParameterStringFilter{
 				Key:    aws.String("Name"),
+				Option: aws.String("Equals"),
 				Values: []*string{aws.String(d.Get("name").(string))},
 			},
 		},
-		MaxResults: aws.Int64(50),
 	}
-	detailedParameters := []*ssm.ParameterMetadata{}
-	err = ssmconn.DescribeParametersPages(describeParamsInput,
-		func(page *ssm.DescribeParametersOutput, lastPage bool) bool {
-			detailedParameters = append(detailedParameters, page.Parameters...)
-			return !lastPage
-		})
+	describeResp, err := ssmconn.DescribeParameters(describeParamsInput)
 	if err != nil {
 		return fmt.Errorf("error describing SSM parameter: %s", err)
 	}
-	if len(detailedParameters) == 0 {
-		log.Printf("[WARN] SSM Param %q not found, removing from state", d.Id())
-		d.SetId("")
-		return nil
-	}
 
-	detail := detailedParameters[0]
+	detail := describeResp.Parameters[0]
 	d.Set("key_id", detail.KeyId)
 	d.Set("description", detail.Description)
 	d.Set("allowed_pattern", detail.AllowedPattern)


### PR DESCRIPTION
Fixes #5281 

Changes proposed in this pull request:

* No need to paginate calls. DescribeParameters always returns the parameters asked for in the first page when using the `ParameterFilters` with the `Equals` option.

Output from acceptance testing:

```
TESTARGS='-run=TestAccAWSSSMParameter'  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSSMParameter -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMParameter_importBasic
--- PASS: TestAccAWSSSMParameter_importBasic (29.13s)
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (24.64s)
=== RUN   TestAccAWSSSMParameter_disappears
--- PASS: TestAccAWSSSMParameter_disappears (15.99s)
=== RUN   TestAccAWSSSMParameter_update
--- PASS: TestAccAWSSSMParameter_update (43.75s)
=== RUN   TestAccAWSSSMParameter_updateDescription
--- PASS: TestAccAWSSSMParameter_updateDescription (42.34s)
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (43.64s)
=== RUN   TestAccAWSSSMParameter_fullPath
--- PASS: TestAccAWSSSMParameter_fullPath (50.61s)
=== RUN   TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_secure (28.46s)
=== RUN   TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_secure_with_key (57.85s)
=== RUN   TestAccAWSSSMParameter_secure_keyUpdate
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (78.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       415.196s
```
