### PR TITLE
resource/aws_ses_identity_notification_topic: Prevent panic when API returns no attributes

### DIFF
--- a/aws/resource_aws_ses_identity_notification_topic.go
+++ b/aws/resource_aws_ses_identity_notification_topic.go
@@ -91,7 +91,16 @@ func resourceAwsSesNotificationTopicRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error reading SES Identity Notification Topic: %s", err)
 	}
 
-	notificationAttributes := response.NotificationAttributes[identity]
+	d.Set("topic_arn", "")
+	if response == nil {
+		return nil
+	}
+
+	notificationAttributes, notificationAttributesOk := response.NotificationAttributes[identity]
+	if !notificationAttributesOk {
+		return nil
+	}
+
 	switch notificationType {
 	case ses.NotificationTypeBounce:
 		d.Set("topic_arn", notificationAttributes.BounceTopic)


### PR DESCRIPTION
Fixes #5326 

Changes proposed in this pull request:

* Add `nil`/`map` checks for `GetIdentityNotificationAttributes` API call

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsSESIdentityNotificationTopic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsSESIdentityNotificationTopic -timeout 120m
=== RUN   TestAccAwsSESIdentityNotificationTopic_basic
--- PASS: TestAccAwsSESIdentityNotificationTopic_basic (23.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.573s
```
