### PR TITLE
tests/resource/aws_eip: Remove hardcoded AMI IDs

### DIFF
--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -186,13 +186,17 @@ func TestAccAWSEIP_associated_user_private_ip(t *testing.T) {
 // Regression test for https://github.com/hashicorp/terraform/issues/3429 (now
 // https://github.com/terraform-providers/terraform-provider-aws/issues/42)
 func TestAccAWSEIP_classic_disassociate(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccEC2ClassicPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEIPDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSEIP_classic_disassociate("ami-408c7f28"),
+				Config: testAccAWSEIP_classic_disassociate("instance-store"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"aws_eip.ip.0",
@@ -203,7 +207,7 @@ func TestAccAWSEIP_classic_disassociate(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAWSEIP_classic_disassociate("ami-8c6ea9e4"),
+				Config: testAccAWSEIP_classic_disassociate("ebs"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"aws_eip.ip.0",
@@ -454,8 +458,25 @@ const testAccAWSEIPInstanceEc2Classic = `
 provider "aws" {
 	region = "us-east-1"
 }
+
+data "aws_ami" "amzn-ami-minimal-pv" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-pv-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["instance-store"]
+  }
+}
+
 resource "aws_instance" "foo" {
-	ami = "ami-5469ae3c"
+	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 	tags {
 		Name = "testAccAWSEIPInstanceEc2Classic"
@@ -468,9 +489,24 @@ resource "aws_eip" "bar" {
 `
 
 const testAccAWSEIPInstanceConfig = `
+data "aws_ami" "amzn-ami-minimal-pv" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-pv-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["instance-store"]
+  }
+}
+
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
+	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 
@@ -480,9 +516,24 @@ resource "aws_eip" "bar" {
 `
 
 const testAccAWSEIPInstanceConfig2 = `
+data "aws_ami" "amzn-ami-minimal-pv" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-pv-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["instance-store"]
+  }
+}
+
 resource "aws_instance" "bar" {
-	# us-west-2
-	ami = "ami-4fccb37f"
+	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 
@@ -492,6 +543,22 @@ resource "aws_eip" "bar" {
 `
 
 const testAccAWSEIPInstanceConfig_associated = `
+data "aws_ami" "amzn-ami-minimal-hvm" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 resource "aws_vpc" "default" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
@@ -522,8 +589,7 @@ resource "aws_subnet" "tf_test_subnet" {
 }
 
 resource "aws_instance" "foo" {
-  # us-west-2
-  ami           = "ami-5189a661"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
   instance_type = "t2.micro"
 
   private_ip = "10.0.0.12"
@@ -535,9 +601,7 @@ resource "aws_instance" "foo" {
 }
 
 resource "aws_instance" "bar" {
-  # us-west-2
-
-  ami = "ami-5189a661"
+  ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
 
   instance_type = "t2.micro"
 
@@ -557,6 +621,22 @@ resource "aws_eip" "bar" {
 }
 `
 const testAccAWSEIPInstanceConfig_associated_switch = `
+data "aws_ami" "amzn-ami-minimal-hvm" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 resource "aws_vpc" "default" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
@@ -587,8 +667,7 @@ resource "aws_subnet" "tf_test_subnet" {
 }
 
 resource "aws_instance" "foo" {
-  # us-west-2
-  ami           = "ami-5189a661"
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
   instance_type = "t2.micro"
 
   private_ip = "10.0.0.12"
@@ -600,9 +679,7 @@ resource "aws_instance" "foo" {
 }
 
 resource "aws_instance" "bar" {
-  # us-west-2
-
-  ami = "ami-5189a661"
+  ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
 
   instance_type = "t2.micro"
 
@@ -619,18 +696,6 @@ resource "aws_eip" "bar" {
 
   instance                  = "${aws_instance.foo.id}"
   associate_with_private_ip = "10.0.0.12"
-}
-`
-
-const testAccAWSEIPInstanceConfig_associated_update = `
-resource "aws_instance" "bar" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-}
-
-resource "aws_eip" "bar" {
-	instance = "${aws_instance.bar.id}"
 }
 `
 
@@ -710,7 +775,7 @@ resource "aws_eip" "two" {
 }
 `
 
-func testAccAWSEIP_classic_disassociate(ami string) string {
+func testAccAWSEIP_classic_disassociate(rootDeviceType string) string {
 	return fmt.Sprintf(`
 provider "aws" {
   region = "us-east-1"
@@ -718,6 +783,22 @@ provider "aws" {
 
 variable "server_count" {
   default = 2
+}
+
+data "aws_ami" "amzn-ami-minimal-pv" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-pv-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = [%q]
+  }
 }
 
 resource "aws_eip" "ip" {
@@ -729,7 +810,7 @@ resource "aws_eip" "ip" {
 resource "aws_instance" "example" {
   count = "${var.server_count}"
 
-  ami                         = "%s"
+  ami                         = "${data.aws_ami.amzn-ami-minimal-pv.id}"
   instance_type               = "m1.small"
   associate_public_ip_address = true
   subnet_id                   = "${aws_subnet.us-east-1b-public.id}"
@@ -777,13 +858,28 @@ resource "aws_route_table" "us-east-1-public" {
 resource "aws_route_table_association" "us-east-1b-public" {
   subnet_id      = "${aws_subnet.us-east-1b-public.id}"
   route_table_id = "${aws_route_table.us-east-1-public.id}"
-}`, ami)
+}`, rootDeviceType)
 }
 
 const testAccAWSEIPAssociate_not_associated = `
+data "aws_ami" "amzn-ami-minimal-pv" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-pv-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = [%q]
+  }
+}
+
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
 	instance_type = "m1.small"
 }
 
@@ -792,9 +888,24 @@ resource "aws_eip" "bar" {
 `
 
 const testAccAWSEIPAssociate_associated = `
+data "aws_ami" "amzn-ami-minimal-pv" {
+  most_recent = true
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-pv-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = [%q]
+  }
+}
+
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
+	ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
 	instance_type = "m1.small"
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Switch to `aws_ami` data source for future partition/region agnostic testing

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEIP_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEIP_ -timeout 120m
=== RUN   TestAccAWSEIP_importEc2Classic
--- PASS: TestAccAWSEIP_importEc2Classic (114.69s)
=== RUN   TestAccAWSEIP_importVpc
--- PASS: TestAccAWSEIP_importVpc (47.15s)
=== RUN   TestAccAWSEIP_basic
--- PASS: TestAccAWSEIP_basic (14.62s)
=== RUN   TestAccAWSEIP_instance
--- PASS: TestAccAWSEIP_instance (311.68s)
=== RUN   TestAccAWSEIP_network_interface
--- PASS: TestAccAWSEIP_network_interface (44.91s)
=== RUN   TestAccAWSEIP_twoEIPsOneNetworkInterface
--- PASS: TestAccAWSEIP_twoEIPsOneNetworkInterface (45.62s)
=== RUN   TestAccAWSEIP_associated_user_private_ip
--- PASS: TestAccAWSEIP_associated_user_private_ip (172.49s)
=== RUN   TestAccAWSEIP_classic_disassociate
--- PASS: TestAccAWSEIP_classic_disassociate (318.51s)
=== RUN   TestAccAWSEIP_disappears
--- PASS: TestAccAWSEIP_disappears (8.65s)
=== RUN   TestAccAWSEIP_tags
--- PASS: TestAccAWSEIP_tags (22.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1101.317s
```
