### PR TITLE
[WIP] Add authentication support for lb_listener_rule

### DIFF
--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -265,6 +265,92 @@ func TestAccAWSLBListenerRule_priority(t *testing.T) {
 	})
 }
 
+func TestAccAWSLBListenerRule_cognito(t *testing.T) {
+	var conf elbv2.Rule
+	lbName := fmt.Sprintf("testrule-cognito-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	certificateName := fmt.Sprintf("testcert-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	cognitoPrefix := fmt.Sprintf("testcog-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_listener_rule.cognito",
+		Providers:     testAccProvidersWithTLS,
+		CheckDestroy:  testAccCheckAWSLBListenerRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerRuleConfig_cognito(lbName, targetGroupName, certificateName, cognitoPrefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerRuleExists("aws_lb_listener_rule.cognito", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "listener_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "priority", "100"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.#", "2"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.type", "authenticate-cognito"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.order", "1"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito_config.0.user_pool_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito_config.0.user_pool_client"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito_config.0.user_pool_domain"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito_config.0.authentication_request_extra_params.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito_config.0.authentication_request_extra_params.param", "test"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.1.type", "forward"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.1.order", "2"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.1.target_group_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "condition.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "condition.1366281676.field", "path-pattern"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "condition.1366281676.values.#", "1"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "condition.1366281676.values.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBListenerRule_oidc(t *testing.T) {
+	var conf elbv2.Rule
+	lbName := fmt.Sprintf("testrule-oidc-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	certificateName := fmt.Sprintf("testcert-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_listener_rule.oidc",
+		Providers:     testAccProvidersWithTLS,
+		CheckDestroy:  testAccCheckAWSLBListenerRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerRuleConfig_oidc(lbName, targetGroupName, certificateName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerRuleExists("aws_lb_listener_rule.oidc", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.oidc", "arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.oidc", "listener_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "priority", "100"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.#", "2"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.type", "authenticate-oidc"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.authorization_endpoint", "https://example.com/authorization_endpoint"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.client_id", "s6BhdRkqt3"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.client_secret", "7Fjfp0ZBr1KtDRbnfVdmIw"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.issuer", "https://example.com"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.token_endpoint", "https://example.com/token_endpoint"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.user_info_endpoint", "https://example.com/user_info_endpoint"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.authentication_request_extra_params.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc_config.0.authentication_request_extra_params.param", "test"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.1.type", "forward"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.1.order", "2"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.oidc", "action.1.target_group_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "condition.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "condition.1366281676.field", "path-pattern"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "condition.1366281676.values.#", "1"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.oidc", "condition.1366281676.values.0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLbListenerRuleRecreated(t *testing.T,
 	before, after *elbv2.Rule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -1148,4 +1234,340 @@ resource "aws_lb_listener_rule" "50000_in_use" {
   }
 }
 `)
+}
+
+func testAccAWSLBListenerRuleConfig_cognito(lbName string, targetGroupName string, certificateName string, cognitoPrefix string) string {
+	return fmt.Sprintf(`resource "aws_lb_listener_rule" "cognito" {
+  listener_arn = "${aws_lb_listener.front_end.arn}"
+  priority = 100
+
+  action {
+    order = 1
+    type = "authenticate-cognito"
+    authenticate_cognito_config {
+      user_pool_arn = "${aws_cognito_user_pool.test.arn}"
+      user_pool_client = "${aws_cognito_user_pool_client.test.id}"
+      user_pool_domain = "${aws_cognito_user_pool_domain.test.domain}"
+
+      authentication_request_extra_params {
+        param  = "test"
+      }
+    }
+  }
+
+  action {
+    order = 2
+    type = "forward"
+    target_group_arn = "${aws_lb_target_group.test.arn}"
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/static/*"]
+  }
+}
+
+resource "aws_iam_server_certificate" "test" {
+  name = "terraform-test-cert-%s"
+  certificate_body = "${tls_self_signed_cert.test.cert_pem}"
+  private_key      = "${tls_private_key.test.private_key_pem}"
+}
+
+resource "tls_private_key" "test" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "test" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.test.private_key_pem}"
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_lb_listener" "front_end" {
+   load_balancer_arn = "${aws_lb.alb_test.id}"
+   protocol = "HTTPS"
+   port = "443"
+   ssl_policy = "ELBSecurityPolicy-2015-05"
+   certificate_arn = "${aws_iam_server_certificate.test.arn}"
+
+   default_action {
+     target_group_arn = "${aws_lb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    Name = "TestAccAWSALB_cognito"
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-lb-listener-rule-cognito"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    Name = "tf-acc-lb-listener-rule-cognito-${count.index}"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "TestAccAWSALB_cognito"
+  }
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = "%s-pool"
+}
+
+resource "aws_cognito_user_pool_client" "test" {
+  name = "%s-pool-client"
+  user_pool_id = "${aws_cognito_user_pool.test.id}"
+  generate_secret = true
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows = ["code", "implicit"]
+  allowed_oauth_scopes = ["phone", "email", "openid", "profile", "aws.cognito.signin.user.admin"]
+  callback_urls = ["https://www.example.com/callback", "https://www.example.com/redirect"]
+  default_redirect_uri = "https://www.example.com/redirect"
+  logout_urls = ["https://www.example.com/login"]
+}
+
+resource "aws_cognito_user_pool_domain" "test" {
+  domain = "%s-pool-domain"
+  user_pool_id = "${aws_cognito_user_pool.test.id}"
+}`, lbName, targetGroupName, certificateName, cognitoPrefix, cognitoPrefix, cognitoPrefix)
+}
+
+func testAccAWSLBListenerRuleConfig_oidc(lbName string, targetGroupName string, certificateName string) string {
+	return fmt.Sprintf(`resource "aws_lb_listener_rule" "oidc" {
+  listener_arn = "${aws_lb_listener.front_end.arn}"
+  priority = 100
+
+  action {
+    order = 1
+    type = "authenticate-oidc"
+    authenticate_oidc_config {
+      authorization_endpoint =  "https://example.com/authorization_endpoint"
+      client_id = "s6BhdRkqt3"
+      client_secret = "7Fjfp0ZBr1KtDRbnfVdmIw"
+      issuer = "https://example.com"
+      token_endpoint = "https://example.com/token_endpoint"
+      user_info_endpoint = "https://example.com/user_info_endpoint"
+
+      authentication_request_extra_params {
+        param  = "test"
+      }
+    }
+  }
+
+  action {
+    order = 2
+    type = "forward"
+    target_group_arn = "${aws_lb_target_group.test.arn}"
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/static/*"]
+  }
+}
+
+resource "aws_iam_server_certificate" "test" {
+  name = "terraform-test-cert-%s"
+  certificate_body = "${tls_self_signed_cert.test.cert_pem}"
+  private_key      = "${tls_private_key.test.private_key_pem}"
+}
+
+resource "tls_private_key" "test" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "test" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.test.private_key_pem}"
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_lb_listener" "front_end" {
+   load_balancer_arn = "${aws_lb.alb_test.id}"
+   protocol = "HTTPS"
+   port = "443"
+   ssl_policy = "ELBSecurityPolicy-2015-05"
+   certificate_arn = "${aws_iam_server_certificate.test.arn}"
+
+   default_action {
+     target_group_arn = "${aws_lb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    Name = "TestAccAWSALB_cognito"
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-lb-listener-rule-cognito"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    Name = "tf-acc-lb-listener-rule-cognito-${count.index}"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "TestAccAWSALB_cognito"
+  }
+}`, lbName, targetGroupName, certificateName)
 }

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -67,13 +67,46 @@ The following arguments are supported:
 
 Action Blocks (for `action`) support the following:
 
-* `target_group_arn` - (Required) The ARN of the Target Group to which to route traffic.
-* `type` - (Required) The type of routing action. The only valid value is `forward`.
+* `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic.
+* `type` - (Required) The type of routing action. The valid values are `forward`, `authenticate-oidc` and `authenticate-cognito`.
+* `order` - (Optional) The order for the action.
+* `authenticate_cognito_config` - (Optional) The [authenticate cognito config](#authenticate-cognito-config) configuration.
+* `authenticate_oidc_config` - (Optional) The [authenticate oidc  config](#authenticate-oidc-config) configuration.
 
 Condition Blocks (for `condition`) support the following:
 
 * `field` - (Required) The name of the field. Must be one of `path-pattern` for path based routing or `host-header` for host based routing.
 * `values` - (Required) The path patterns to match. A maximum of 1 can be defined.
+
+### Authenticate Cognito Config
+
+* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10. [See](#authentication-request-extra-params)
+* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
+* `scope` - (Optional) The set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
+* `session_time_out` - (Optional) The maximum duration of the authentication session, in seconds.
+* `user_pool_arn` - (Required) The ARN of the Cognito user pool.
+* `user_pool_client` - (Required) The ID of the Cognito user pool client.
+* `user_pool_domain` - (Required) The domain prefix or fully-qualified domain name of the Cognito user pool.
+
+### Authenticate OIDC Config
+
+* `authentication_request_extra_params` - (Optional) The query parameters to include in the redirect request to the authorization endpoint. Max: 10. [See](#authentication-request-extra-params)
+* `authorization_endpoint` - (Required) The authorization endpoint of the IdP.
+* `client_id` - (Required) The OAuth 2.0 client identifier.
+* `client_secret` - (Required) The OAuth 2.0 client secret.
+* `issuer` - (Required) The OIDC issuer identifier of the IdP.
+* `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
+* `scope` - (Optional) The set of user claims to be requested from the IdP.
+* `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
+* `session_time_out` - (Optional) The maximum duration of the authentication session, in seconds.
+* `token_endpoint` - (Required) The token endpoint of the IdP.
+* `user_info_endpoint` - (Required) The user info endpoint of the IdP.
+
+### Authentication Request Extra Params
+
+* `key` - (Required) The key of query parameter
+* `value` - (Required) The value of query parameter
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/4711

This is based on https://github.com/terraform-providers/terraform-provider-aws/pull/4722 including my suggested changes and requires that to be merged first since it implements common functionality. It implements support for both authenticate-oidc and authenticate-cognito.

Documentation updated and acceptance tests added which passes given that the previous PR is merged with my changes.

```
$ make testacc TESTARGS='-run=TestAccAWSLBListenerRule_oidc'                     telia-divx-common-services-stage-admin-role MFA 59m21s
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSLBListenerRule_oidc -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLBListenerRule_oidc
--- PASS: TestAccAWSLBListenerRule_oidc (298.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	298.998s

$ make testacc TESTARGS='-run=TestAccAWSLBListenerRule_cognito'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSLBListenerRule_cognito -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLBListenerRule_cognito
--- PASS: TestAccAWSLBListenerRule_cognito (299.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	299.048s
```
