### PR TITLE
Allow WAF web ACL rule import

### DIFF
--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -17,6 +17,9 @@ func resourceAwsWafWebAcl() *schema.Resource {
 		Read:   resourceAwsWafWebAclRead,
 		Update: resourceAwsWafWebAclUpdate,
 		Delete: resourceAwsWafWebAclDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -16,27 +16,35 @@ import (
 func TestAccAWSWafWebAcl_basic(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_waf_web_acl.waf_acl"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWafWebAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSWafWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafWebAclExists("aws_waf_web_acl.waf_acl", &v),
+					testAccCheckAWSWafWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.4234791575.type", "ALLOW"),
+						resourceName, "default_action.4234791575.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "rules.#", "1"),
+						resourceName, "rules.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The WAF ACL rule resource doesn't GET rules
+				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -45,6 +53,7 @@ func TestAccAWSWafWebAcl_basic(t *testing.T) {
 func TestAccAWSWafWebAcl_group(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafaclgroup%s", acctest.RandString(5))
+	resourceName := "aws_waf_web_acl.waf_acl"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -54,18 +63,25 @@ func TestAccAWSWafWebAcl_group(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSWafWebAclGroupConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafWebAclExists("aws_waf_web_acl.waf_acl", &v),
+					testAccCheckAWSWafWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.4234791575.type", "ALLOW"),
+						resourceName, "default_action.4234791575.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "rules.#", "1"),
+						resourceName, "rules.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The WAF ACL rule resource doesn't GET rules
+				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -75,6 +91,7 @@ func TestAccAWSWafWebAcl_changeNameForceNew(t *testing.T) {
 	var before, after waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
 	wafAclNewName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_waf_web_acl.waf_acl"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -84,34 +101,41 @@ func TestAccAWSWafWebAcl_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafWebAclExists("aws_waf_web_acl.waf_acl", &before),
+					testAccCheckAWSWafWebAclExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.4234791575.type", "ALLOW"),
+						resourceName, "default_action.4234791575.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "rules.#", "1"),
+						resourceName, "rules.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
 			},
 			{
 				Config: testAccAWSWafWebAclConfigChangeName(wafAclNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafWebAclExists("aws_waf_web_acl.waf_acl", &after),
+					testAccCheckAWSWafWebAclExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.4234791575.type", "ALLOW"),
+						resourceName, "default_action.4234791575.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "name", wafAclNewName),
+						resourceName, "name", wafAclNewName),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "rules.#", "1"),
+						resourceName, "rules.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "metric_name", wafAclNewName),
+						resourceName, "metric_name", wafAclNewName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The WAF ACL rule resource doesn't GET rules
+				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -121,6 +145,7 @@ func TestAccAWSWafWebAcl_changeDefaultAction(t *testing.T) {
 	var before, after waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
 	wafAclNewName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_waf_web_acl.waf_acl"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -130,34 +155,41 @@ func TestAccAWSWafWebAcl_changeDefaultAction(t *testing.T) {
 			{
 				Config: testAccAWSWafWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafWebAclExists("aws_waf_web_acl.waf_acl", &before),
+					testAccCheckAWSWafWebAclExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.4234791575.type", "ALLOW"),
+						resourceName, "default_action.4234791575.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "rules.#", "1"),
+						resourceName, "rules.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
 			},
 			{
 				Config: testAccAWSWafWebAclConfigDefaultAction(wafAclNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafWebAclExists("aws_waf_web_acl.waf_acl", &after),
+					testAccCheckAWSWafWebAclExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "default_action.2267395054.type", "BLOCK"),
+						resourceName, "default_action.2267395054.type", "BLOCK"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "name", wafAclNewName),
+						resourceName, "name", wafAclNewName),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "rules.#", "1"),
+						resourceName, "rules.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_waf_web_acl.waf_acl", "metric_name", wafAclNewName),
+						resourceName, "metric_name", wafAclNewName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The WAF ACL rule resource doesn't GET rules
+				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -166,6 +198,7 @@ func TestAccAWSWafWebAcl_changeDefaultAction(t *testing.T) {
 func TestAccAWSWafWebAcl_disappears(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_waf_web_acl.waf_acl"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -175,7 +208,7 @@ func TestAccAWSWafWebAcl_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafWebAclExists("aws_waf_web_acl.waf_acl", &v),
+					testAccCheckAWSWafWebAclExists(resourceName, &v),
 					testAccCheckAWSWafWebAclDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,

--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -92,3 +92,13 @@ See [docs](http://docs.aws.amazon.com/waf/latest/APIReference/API_ActivatedRule.
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF WebACL.
+
+## Import
+
+WAF Web ACL can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_waf_web_acl.main 0c8e583e-18f3-4c13-9e2a-67c4805d2f94
+```
+
+~> **Note:** The `rules` will not be imported.


### PR DESCRIPTION
Fixes #4589

Changes proposed in this pull request:

* Title says it all
* The WAF web ACL resource doesn't get rules and I'm guessing if it did, that would conflict with the rule resource so I excluded it from the import test.

Output from acceptance testing:

```
TESTARGS='-run=TestAccAWSWafWebAcl'  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSWafWebAcl -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSWafWebAcl_basic
--- PASS: TestAccAWSWafWebAcl_basic (36.13s)
=== RUN   TestAccAWSWafWebAcl_group
--- PASS: TestAccAWSWafWebAcl_group (34.00s)
=== RUN   TestAccAWSWafWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (66.05s)
=== RUN   TestAccAWSWafWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafWebAcl_changeDefaultAction (65.58s)
=== RUN   TestAccAWSWafWebAcl_disappears
--- PASS: TestAccAWSWafWebAcl_disappears (38.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       239.855s
```
