### PR TITLE
vendor: aws/aws-sdk-go@v1.14.33

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.14.31"
+const SDKVersion = "1.14.33"

--- a/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dynamodb/api.go
@@ -4191,6 +4191,394 @@ func (s *AttributeValueUpdate) SetValue(v *AttributeValue) *AttributeValueUpdate
 	return s
 }
 
+// Represents the properties of the scaling policy.
+type AutoScalingPolicyDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the scaling policy.
+	PolicyName *string `min:"1" type:"string"`
+
+	// Represents a target tracking scaling policy configuration.
+	TargetTrackingScalingPolicyConfiguration *AutoScalingTargetTrackingScalingPolicyConfigurationDescription `type:"structure"`
+}
+
+// String returns the string representation
+func (s AutoScalingPolicyDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingPolicyDescription) GoString() string {
+	return s.String()
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AutoScalingPolicyDescription) SetPolicyName(v string) *AutoScalingPolicyDescription {
+	s.PolicyName = &v
+	return s
+}
+
+// SetTargetTrackingScalingPolicyConfiguration sets the TargetTrackingScalingPolicyConfiguration field's value.
+func (s *AutoScalingPolicyDescription) SetTargetTrackingScalingPolicyConfiguration(v *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) *AutoScalingPolicyDescription {
+	s.TargetTrackingScalingPolicyConfiguration = v
+	return s
+}
+
+// Represents the autoscaling policy to be modified.
+type AutoScalingPolicyUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the scaling policy.
+	PolicyName *string `min:"1" type:"string"`
+
+	// Represents a target tracking scaling policy configuration.
+	//
+	// TargetTrackingScalingPolicyConfiguration is a required field
+	TargetTrackingScalingPolicyConfiguration *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s AutoScalingPolicyUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingPolicyUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AutoScalingPolicyUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AutoScalingPolicyUpdate"}
+	if s.PolicyName != nil && len(*s.PolicyName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("PolicyName", 1))
+	}
+	if s.TargetTrackingScalingPolicyConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetTrackingScalingPolicyConfiguration"))
+	}
+	if s.TargetTrackingScalingPolicyConfiguration != nil {
+		if err := s.TargetTrackingScalingPolicyConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("TargetTrackingScalingPolicyConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPolicyName sets the PolicyName field's value.
+func (s *AutoScalingPolicyUpdate) SetPolicyName(v string) *AutoScalingPolicyUpdate {
+	s.PolicyName = &v
+	return s
+}
+
+// SetTargetTrackingScalingPolicyConfiguration sets the TargetTrackingScalingPolicyConfiguration field's value.
+func (s *AutoScalingPolicyUpdate) SetTargetTrackingScalingPolicyConfiguration(v *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) *AutoScalingPolicyUpdate {
+	s.TargetTrackingScalingPolicyConfiguration = v
+	return s
+}
+
+// Represents the autoscaling settings for a global table or global secondary
+// index.
+type AutoScalingSettingsDescription struct {
+	_ struct{} `type:"structure"`
+
+	// Disabled autoscaling for this global table or global secondary index.
+	AutoScalingDisabled *bool `type:"boolean"`
+
+	// Role ARN used for configuring autoScaling policy.
+	AutoScalingRoleArn *string `type:"string"`
+
+	// The maximum capacity units that a global table or global secondary index
+	// should be scaled up to.
+	MaximumUnits *int64 `min:"1" type:"long"`
+
+	// The minimum capacity units that a global table or global secondary index
+	// should be scaled down to.
+	MinimumUnits *int64 `min:"1" type:"long"`
+
+	// Information about the scaling policies.
+	ScalingPolicies []*AutoScalingPolicyDescription `type:"list"`
+}
+
+// String returns the string representation
+func (s AutoScalingSettingsDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingSettingsDescription) GoString() string {
+	return s.String()
+}
+
+// SetAutoScalingDisabled sets the AutoScalingDisabled field's value.
+func (s *AutoScalingSettingsDescription) SetAutoScalingDisabled(v bool) *AutoScalingSettingsDescription {
+	s.AutoScalingDisabled = &v
+	return s
+}
+
+// SetAutoScalingRoleArn sets the AutoScalingRoleArn field's value.
+func (s *AutoScalingSettingsDescription) SetAutoScalingRoleArn(v string) *AutoScalingSettingsDescription {
+	s.AutoScalingRoleArn = &v
+	return s
+}
+
+// SetMaximumUnits sets the MaximumUnits field's value.
+func (s *AutoScalingSettingsDescription) SetMaximumUnits(v int64) *AutoScalingSettingsDescription {
+	s.MaximumUnits = &v
+	return s
+}
+
+// SetMinimumUnits sets the MinimumUnits field's value.
+func (s *AutoScalingSettingsDescription) SetMinimumUnits(v int64) *AutoScalingSettingsDescription {
+	s.MinimumUnits = &v
+	return s
+}
+
+// SetScalingPolicies sets the ScalingPolicies field's value.
+func (s *AutoScalingSettingsDescription) SetScalingPolicies(v []*AutoScalingPolicyDescription) *AutoScalingSettingsDescription {
+	s.ScalingPolicies = v
+	return s
+}
+
+// Represents the autoscaling settings to be modified for a global table or
+// global secondary index.
+type AutoScalingSettingsUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// Disabled autoscaling for this global table or global secondary index.
+	AutoScalingDisabled *bool `type:"boolean"`
+
+	// Role ARN used for configuring autoscaling policy.
+	AutoScalingRoleArn *string `min:"1" type:"string"`
+
+	// The maximum capacity units that a global table or global secondary index
+	// should be scaled up to.
+	MaximumUnits *int64 `min:"1" type:"long"`
+
+	// The minimum capacity units that a global table or global secondary index
+	// should be scaled down to.
+	MinimumUnits *int64 `min:"1" type:"long"`
+
+	// The scaling policy to apply for scaling target global table or global secondary
+	// index capacity units.
+	ScalingPolicyUpdate *AutoScalingPolicyUpdate `type:"structure"`
+}
+
+// String returns the string representation
+func (s AutoScalingSettingsUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingSettingsUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AutoScalingSettingsUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AutoScalingSettingsUpdate"}
+	if s.AutoScalingRoleArn != nil && len(*s.AutoScalingRoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingRoleArn", 1))
+	}
+	if s.MaximumUnits != nil && *s.MaximumUnits < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaximumUnits", 1))
+	}
+	if s.MinimumUnits != nil && *s.MinimumUnits < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MinimumUnits", 1))
+	}
+	if s.ScalingPolicyUpdate != nil {
+		if err := s.ScalingPolicyUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ScalingPolicyUpdate", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAutoScalingDisabled sets the AutoScalingDisabled field's value.
+func (s *AutoScalingSettingsUpdate) SetAutoScalingDisabled(v bool) *AutoScalingSettingsUpdate {
+	s.AutoScalingDisabled = &v
+	return s
+}
+
+// SetAutoScalingRoleArn sets the AutoScalingRoleArn field's value.
+func (s *AutoScalingSettingsUpdate) SetAutoScalingRoleArn(v string) *AutoScalingSettingsUpdate {
+	s.AutoScalingRoleArn = &v
+	return s
+}
+
+// SetMaximumUnits sets the MaximumUnits field's value.
+func (s *AutoScalingSettingsUpdate) SetMaximumUnits(v int64) *AutoScalingSettingsUpdate {
+	s.MaximumUnits = &v
+	return s
+}
+
+// SetMinimumUnits sets the MinimumUnits field's value.
+func (s *AutoScalingSettingsUpdate) SetMinimumUnits(v int64) *AutoScalingSettingsUpdate {
+	s.MinimumUnits = &v
+	return s
+}
+
+// SetScalingPolicyUpdate sets the ScalingPolicyUpdate field's value.
+func (s *AutoScalingSettingsUpdate) SetScalingPolicyUpdate(v *AutoScalingPolicyUpdate) *AutoScalingSettingsUpdate {
+	s.ScalingPolicyUpdate = v
+	return s
+}
+
+// Represents the properties of a target tracking scaling policy.
+type AutoScalingTargetTrackingScalingPolicyConfigurationDescription struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether scale in by the target tracking policy is disabled. If
+	// the value is true, scale in is disabled and the target tracking policy won't
+	// remove capacity from the scalable resource. Otherwise, scale in is enabled
+	// and the target tracking policy can remove capacity from the scalable resource.
+	// The default value is false.
+	DisableScaleIn *bool `type:"boolean"`
+
+	// The amount of time, in seconds, after a scale in activity completes before
+	// another scale in activity can start. The cooldown period is used to block
+	// subsequent scale in requests until it has expired. You should scale in conservatively
+	// to protect your application's availability. However, if another alarm triggers
+	// a scale out policy during the cooldown period after a scale-in, application
+	// autoscaling scales out your scalable target immediately.
+	ScaleInCooldown *int64 `type:"integer"`
+
+	// The amount of time, in seconds, after a scale out activity completes before
+	// another scale out activity can start. While the cooldown period is in effect,
+	// the capacity that has been added by the previous scale out event that initiated
+	// the cooldown is calculated as part of the desired capacity for the next scale
+	// out. You should continuously (but not excessively) scale out.
+	ScaleOutCooldown *int64 `type:"integer"`
+
+	// The target value for the metric. The range is 8.515920e-109 to 1.174271e+108
+	// (Base 10) or 2e-360 to 2e360 (Base 2).
+	//
+	// TargetValue is a required field
+	TargetValue *float64 `type:"double" required:"true"`
+}
+
+// String returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationDescription) GoString() string {
+	return s.String()
+}
+
+// SetDisableScaleIn sets the DisableScaleIn field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetDisableScaleIn(v bool) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.DisableScaleIn = &v
+	return s
+}
+
+// SetScaleInCooldown sets the ScaleInCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetScaleInCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.ScaleInCooldown = &v
+	return s
+}
+
+// SetScaleOutCooldown sets the ScaleOutCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetScaleOutCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.ScaleOutCooldown = &v
+	return s
+}
+
+// SetTargetValue sets the TargetValue field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationDescription) SetTargetValue(v float64) *AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
+	s.TargetValue = &v
+	return s
+}
+
+// Represents the settings of a target tracking scaling policy that will be
+// modified.
+type AutoScalingTargetTrackingScalingPolicyConfigurationUpdate struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether scale in by the target tracking policy is disabled. If
+	// the value is true, scale in is disabled and the target tracking policy won't
+	// remove capacity from the scalable resource. Otherwise, scale in is enabled
+	// and the target tracking policy can remove capacity from the scalable resource.
+	// The default value is false.
+	DisableScaleIn *bool `type:"boolean"`
+
+	// The amount of time, in seconds, after a scale in activity completes before
+	// another scale in activity can start. The cooldown period is used to block
+	// subsequent scale in requests until it has expired. You should scale in conservatively
+	// to protect your application's availability. However, if another alarm triggers
+	// a scale out policy during the cooldown period after a scale-in, application
+	// autoscaling scales out your scalable target immediately.
+	ScaleInCooldown *int64 `type:"integer"`
+
+	// The amount of time, in seconds, after a scale out activity completes before
+	// another scale out activity can start. While the cooldown period is in effect,
+	// the capacity that has been added by the previous scale out event that initiated
+	// the cooldown is calculated as part of the desired capacity for the next scale
+	// out. You should continuously (but not excessively) scale out.
+	ScaleOutCooldown *int64 `type:"integer"`
+
+	// The target value for the metric. The range is 8.515920e-109 to 1.174271e+108
+	// (Base 10) or 2e-360 to 2e360 (Base 2).
+	//
+	// TargetValue is a required field
+	TargetValue *float64 `type:"double" required:"true"`
+}
+
+// String returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AutoScalingTargetTrackingScalingPolicyConfigurationUpdate"}
+	if s.TargetValue == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetValue"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDisableScaleIn sets the DisableScaleIn field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetDisableScaleIn(v bool) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.DisableScaleIn = &v
+	return s
+}
+
+// SetScaleInCooldown sets the ScaleInCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetScaleInCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.ScaleInCooldown = &v
+	return s
+}
+
+// SetScaleOutCooldown sets the ScaleOutCooldown field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetScaleOutCooldown(v int64) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.ScaleOutCooldown = &v
+	return s
+}
+
+// SetTargetValue sets the TargetValue field's value.
+func (s *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate) SetTargetValue(v float64) *AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
+	s.TargetValue = &v
+	return s
+}
+
 // Contains the description of the backup created for the table.
 type BackupDescription struct {
 	_ struct{} `type:"structure"`
@@ -7556,6 +7944,10 @@ type GlobalTableGlobalSecondaryIndexSettingsUpdate struct {
 	// IndexName is a required field
 	IndexName *string `min:"3" type:"string" required:"true"`
 
+	// AutoScaling settings for managing a global secondary index's write capacity
+	// units.
+	ProvisionedWriteCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
+
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException.
 	ProvisionedWriteCapacityUnits *int64 `min:"1" type:"long"`
@@ -7583,6 +7975,11 @@ func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) Validate() error {
 	if s.ProvisionedWriteCapacityUnits != nil && *s.ProvisionedWriteCapacityUnits < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ProvisionedWriteCapacityUnits", 1))
 	}
+	if s.ProvisionedWriteCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.ProvisionedWriteCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedWriteCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7593,6 +7990,12 @@ func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) Validate() error {
 // SetIndexName sets the IndexName field's value.
 func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) SetIndexName(v string) *GlobalTableGlobalSecondaryIndexSettingsUpdate {
 	s.IndexName = &v
+	return s
+}
+
+// SetProvisionedWriteCapacityAutoScalingSettingsUpdate sets the ProvisionedWriteCapacityAutoScalingSettingsUpdate field's value.
+func (s *GlobalTableGlobalSecondaryIndexSettingsUpdate) SetProvisionedWriteCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *GlobalTableGlobalSecondaryIndexSettingsUpdate {
+	s.ProvisionedWriteCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 
@@ -9745,9 +10148,17 @@ type ReplicaGlobalSecondaryIndexSettingsDescription struct {
 	//    * ACTIVE - The global secondary index is ready for use.
 	IndexStatus *string `type:"string" enum:"IndexStatus"`
 
+	// Autoscaling settings for a global secondary index replica's read capacity
+	// units.
+	ProvisionedReadCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
+
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException.
 	ProvisionedReadCapacityUnits *int64 `min:"1" type:"long"`
+
+	// AutoScaling settings for a global secondary index replica's write capacity
+	// units.
+	ProvisionedWriteCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
 
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException.
@@ -9776,9 +10187,21 @@ func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetIndexStatus(v string
 	return s
 }
 
+// SetProvisionedReadCapacityAutoScalingSettings sets the ProvisionedReadCapacityAutoScalingSettings field's value.
+func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetProvisionedReadCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaGlobalSecondaryIndexSettingsDescription {
+	s.ProvisionedReadCapacityAutoScalingSettings = v
+	return s
+}
+
 // SetProvisionedReadCapacityUnits sets the ProvisionedReadCapacityUnits field's value.
 func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetProvisionedReadCapacityUnits(v int64) *ReplicaGlobalSecondaryIndexSettingsDescription {
 	s.ProvisionedReadCapacityUnits = &v
+	return s
+}
+
+// SetProvisionedWriteCapacityAutoScalingSettings sets the ProvisionedWriteCapacityAutoScalingSettings field's value.
+func (s *ReplicaGlobalSecondaryIndexSettingsDescription) SetProvisionedWriteCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaGlobalSecondaryIndexSettingsDescription {
+	s.ProvisionedWriteCapacityAutoScalingSettings = v
 	return s
 }
 
@@ -9798,6 +10221,10 @@ type ReplicaGlobalSecondaryIndexSettingsUpdate struct {
 	//
 	// IndexName is a required field
 	IndexName *string `min:"3" type:"string" required:"true"`
+
+	// Autoscaling settings for managing a global secondary index replica's read
+	// capacity units.
+	ProvisionedReadCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
 
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException.
@@ -9826,6 +10253,11 @@ func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) Validate() error {
 	if s.ProvisionedReadCapacityUnits != nil && *s.ProvisionedReadCapacityUnits < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("ProvisionedReadCapacityUnits", 1))
 	}
+	if s.ProvisionedReadCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.ProvisionedReadCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ProvisionedReadCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9836,6 +10268,12 @@ func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) Validate() error {
 // SetIndexName sets the IndexName field's value.
 func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) SetIndexName(v string) *ReplicaGlobalSecondaryIndexSettingsUpdate {
 	s.IndexName = &v
+	return s
+}
+
+// SetProvisionedReadCapacityAutoScalingSettingsUpdate sets the ProvisionedReadCapacityAutoScalingSettingsUpdate field's value.
+func (s *ReplicaGlobalSecondaryIndexSettingsUpdate) SetProvisionedReadCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *ReplicaGlobalSecondaryIndexSettingsUpdate {
+	s.ProvisionedReadCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 
@@ -9857,11 +10295,17 @@ type ReplicaSettingsDescription struct {
 	// Replica global secondary index settings for the global table.
 	ReplicaGlobalSecondaryIndexSettings []*ReplicaGlobalSecondaryIndexSettingsDescription `type:"list"`
 
+	// Autoscaling settings for a global table replica's read capacity units.
+	ReplicaProvisionedReadCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
+
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException. For more information, see Specifying
 	// Read and Write Requirements (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput)
 	// in the Amazon DynamoDB Developer Guide.
 	ReplicaProvisionedReadCapacityUnits *int64 `min:"1" type:"long"`
+
+	// AutoScaling settings for a global table replica's write capacity units.
+	ReplicaProvisionedWriteCapacityAutoScalingSettings *AutoScalingSettingsDescription `type:"structure"`
 
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException. For more information, see Specifying Read and Write
@@ -9903,9 +10347,21 @@ func (s *ReplicaSettingsDescription) SetReplicaGlobalSecondaryIndexSettings(v []
 	return s
 }
 
+// SetReplicaProvisionedReadCapacityAutoScalingSettings sets the ReplicaProvisionedReadCapacityAutoScalingSettings field's value.
+func (s *ReplicaSettingsDescription) SetReplicaProvisionedReadCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaSettingsDescription {
+	s.ReplicaProvisionedReadCapacityAutoScalingSettings = v
+	return s
+}
+
 // SetReplicaProvisionedReadCapacityUnits sets the ReplicaProvisionedReadCapacityUnits field's value.
 func (s *ReplicaSettingsDescription) SetReplicaProvisionedReadCapacityUnits(v int64) *ReplicaSettingsDescription {
 	s.ReplicaProvisionedReadCapacityUnits = &v
+	return s
+}
+
+// SetReplicaProvisionedWriteCapacityAutoScalingSettings sets the ReplicaProvisionedWriteCapacityAutoScalingSettings field's value.
+func (s *ReplicaSettingsDescription) SetReplicaProvisionedWriteCapacityAutoScalingSettings(v *AutoScalingSettingsDescription) *ReplicaSettingsDescription {
+	s.ReplicaProvisionedWriteCapacityAutoScalingSettings = v
 	return s
 }
 
@@ -9933,6 +10389,10 @@ type ReplicaSettingsUpdate struct {
 	// Represents the settings of a global secondary index for a global table that
 	// will be modified.
 	ReplicaGlobalSecondaryIndexSettingsUpdate []*ReplicaGlobalSecondaryIndexSettingsUpdate `min:"1" type:"list"`
+
+	// Autoscaling settings for managing a global table replica's read capacity
+	// units.
+	ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
 
 	// The maximum number of strongly consistent reads consumed per second before
 	// DynamoDB returns a ThrottlingException. For more information, see Specifying
@@ -9973,6 +10433,11 @@ func (s *ReplicaSettingsUpdate) Validate() error {
 			}
 		}
 	}
+	if s.ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -9989,6 +10454,12 @@ func (s *ReplicaSettingsUpdate) SetRegionName(v string) *ReplicaSettingsUpdate {
 // SetReplicaGlobalSecondaryIndexSettingsUpdate sets the ReplicaGlobalSecondaryIndexSettingsUpdate field's value.
 func (s *ReplicaSettingsUpdate) SetReplicaGlobalSecondaryIndexSettingsUpdate(v []*ReplicaGlobalSecondaryIndexSettingsUpdate) *ReplicaSettingsUpdate {
 	s.ReplicaGlobalSecondaryIndexSettingsUpdate = v
+	return s
+}
+
+// SetReplicaProvisionedReadCapacityAutoScalingSettingsUpdate sets the ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate field's value.
+func (s *ReplicaSettingsUpdate) SetReplicaProvisionedReadCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *ReplicaSettingsUpdate {
+	s.ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 
@@ -11955,6 +12426,10 @@ type UpdateGlobalTableSettingsInput struct {
 	// GlobalTableName is a required field
 	GlobalTableName *string `min:"3" type:"string" required:"true"`
 
+	// AutoScaling settings for managing provisioned write capacity for the global
+	// table.
+	GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate *AutoScalingSettingsUpdate `type:"structure"`
+
 	// The maximum number of writes consumed per second before DynamoDB returns
 	// a ThrottlingException.
 	GlobalTableProvisionedWriteCapacityUnits *int64 `min:"1" type:"long"`
@@ -12001,6 +12476,11 @@ func (s *UpdateGlobalTableSettingsInput) Validate() error {
 			}
 		}
 	}
+	if s.GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate != nil {
+		if err := s.GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate.Validate(); err != nil {
+			invalidParams.AddNested("GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate", err.(request.ErrInvalidParams))
+		}
+	}
 	if s.ReplicaSettingsUpdate != nil {
 		for i, v := range s.ReplicaSettingsUpdate {
 			if v == nil {
@@ -12027,6 +12507,12 @@ func (s *UpdateGlobalTableSettingsInput) SetGlobalTableGlobalSecondaryIndexSetti
 // SetGlobalTableName sets the GlobalTableName field's value.
 func (s *UpdateGlobalTableSettingsInput) SetGlobalTableName(v string) *UpdateGlobalTableSettingsInput {
 	s.GlobalTableName = &v
+	return s
+}
+
+// SetGlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate sets the GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate field's value.
+func (s *UpdateGlobalTableSettingsInput) SetGlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate(v *AutoScalingSettingsUpdate) *UpdateGlobalTableSettingsInput {
+	s.GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/api.go
@@ -70485,6 +70485,60 @@ const (
 	// InstanceTypeR416xlarge is a InstanceType enum value
 	InstanceTypeR416xlarge = "r4.16xlarge"
 
+	// InstanceTypeR5Large is a InstanceType enum value
+	InstanceTypeR5Large = "r5.large"
+
+	// InstanceTypeR5Xlarge is a InstanceType enum value
+	InstanceTypeR5Xlarge = "r5.xlarge"
+
+	// InstanceTypeR52xlarge is a InstanceType enum value
+	InstanceTypeR52xlarge = "r5.2xlarge"
+
+	// InstanceTypeR54xlarge is a InstanceType enum value
+	InstanceTypeR54xlarge = "r5.4xlarge"
+
+	// InstanceTypeR58xlarge is a InstanceType enum value
+	InstanceTypeR58xlarge = "r5.8xlarge"
+
+	// InstanceTypeR512xlarge is a InstanceType enum value
+	InstanceTypeR512xlarge = "r5.12xlarge"
+
+	// InstanceTypeR516xlarge is a InstanceType enum value
+	InstanceTypeR516xlarge = "r5.16xlarge"
+
+	// InstanceTypeR524xlarge is a InstanceType enum value
+	InstanceTypeR524xlarge = "r5.24xlarge"
+
+	// InstanceTypeR5Metal is a InstanceType enum value
+	InstanceTypeR5Metal = "r5.metal"
+
+	// InstanceTypeR5dLarge is a InstanceType enum value
+	InstanceTypeR5dLarge = "r5d.large"
+
+	// InstanceTypeR5dXlarge is a InstanceType enum value
+	InstanceTypeR5dXlarge = "r5d.xlarge"
+
+	// InstanceTypeR5d2xlarge is a InstanceType enum value
+	InstanceTypeR5d2xlarge = "r5d.2xlarge"
+
+	// InstanceTypeR5d4xlarge is a InstanceType enum value
+	InstanceTypeR5d4xlarge = "r5d.4xlarge"
+
+	// InstanceTypeR5d8xlarge is a InstanceType enum value
+	InstanceTypeR5d8xlarge = "r5d.8xlarge"
+
+	// InstanceTypeR5d12xlarge is a InstanceType enum value
+	InstanceTypeR5d12xlarge = "r5d.12xlarge"
+
+	// InstanceTypeR5d16xlarge is a InstanceType enum value
+	InstanceTypeR5d16xlarge = "r5d.16xlarge"
+
+	// InstanceTypeR5d24xlarge is a InstanceType enum value
+	InstanceTypeR5d24xlarge = "r5d.24xlarge"
+
+	// InstanceTypeR5dMetal is a InstanceType enum value
+	InstanceTypeR5dMetal = "r5d.metal"
+
 	// InstanceTypeX116xlarge is a InstanceType enum value
 	InstanceTypeX116xlarge = "x1.16xlarge"
 
@@ -70727,6 +70781,24 @@ const (
 
 	// InstanceTypeH116xlarge is a InstanceType enum value
 	InstanceTypeH116xlarge = "h1.16xlarge"
+
+	// InstanceTypeZ1dLarge is a InstanceType enum value
+	InstanceTypeZ1dLarge = "z1d.large"
+
+	// InstanceTypeZ1dXlarge is a InstanceType enum value
+	InstanceTypeZ1dXlarge = "z1d.xlarge"
+
+	// InstanceTypeZ1d2xlarge is a InstanceType enum value
+	InstanceTypeZ1d2xlarge = "z1d.2xlarge"
+
+	// InstanceTypeZ1d3xlarge is a InstanceType enum value
+	InstanceTypeZ1d3xlarge = "z1d.3xlarge"
+
+	// InstanceTypeZ1d6xlarge is a InstanceType enum value
+	InstanceTypeZ1d6xlarge = "z1d.6xlarge"
+
+	// InstanceTypeZ1d12xlarge is a InstanceType enum value
+	InstanceTypeZ1d12xlarge = "z1d.12xlarge"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
@@ -248,7 +248,7 @@ func (c *ECS) CreateServiceRequest(input *CreateServiceInput) (req *request.Requ
 //   The specified platform version does not exist.
 //
 //   * ErrCodePlatformTaskDefinitionIncompatibilityException "PlatformTaskDefinitionIncompatibilityException"
-//   The specified platform version does not satisfy the task definition’s required
+//   The specified platform version does not satisfy the task definition's required
 //   capabilities.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -2572,7 +2572,7 @@ func (c *ECS) RegisterTaskDefinitionRequest(input *RegisterTaskDefinitionInput) 
 // definition with the networkMode parameter. The available network modes correspond
 // to those described in Network settings (https://docs.docker.com/engine/reference/run/#/network-settings)
 // in the Docker run reference. If you specify the awsvpc network mode, the
-// task is allocated an Elastic Network Interface, and you must specify a NetworkConfiguration
+// task is allocated an elastic network interface, and you must specify a NetworkConfiguration
 // when you create a service or run a task with the task definition. For more
 // information, see Task Networking (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
 // in the Amazon Elastic Container Service Developer Guide.
@@ -2686,7 +2686,7 @@ func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *request.Request, output 
 //    it. Run the DescribeTasks command using an exponential backoff algorithm
 //    to ensure that you allow enough time for the previous command to propagate
 //    through the system. To do this, run the DescribeTasks command repeatedly,
-//    starting with a couple of seconds of wait time, and increasing gradually
+//    starting with a couple of seconds of wait time and increasing gradually
 //    up to five minutes of wait time.
 //
 //    * Add wait time between subsequent commands, even if the DescribeTasks
@@ -2725,7 +2725,7 @@ func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *request.Request, output 
 //   The specified platform version does not exist.
 //
 //   * ErrCodePlatformTaskDefinitionIncompatibilityException "PlatformTaskDefinitionIncompatibilityException"
-//   The specified platform version does not satisfy the task definition’s required
+//   The specified platform version does not satisfy the task definition's required
 //   capabilities.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3549,7 +3549,7 @@ func (c *ECS) UpdateServiceRequest(input *UpdateServiceInput) (req *request.Requ
 //   The specified platform version does not exist.
 //
 //   * ErrCodePlatformTaskDefinitionIncompatibilityException "PlatformTaskDefinitionIncompatibilityException"
-//   The specified platform version does not satisfy the task definition’s required
+//   The specified platform version does not satisfy the task definition's required
 //   capabilities.
 //
 //   * ErrCodeAccessDeniedException "AccessDeniedException"
@@ -3581,7 +3581,7 @@ func (c *ECS) UpdateServiceWithContext(ctx aws.Context, input *UpdateServiceInpu
 type Attachment struct {
 	_ struct{} `type:"structure"`
 
-	// Details of the attachment. For Elastic Network Interfaces, this includes
+	// Details of the attachment. For elastic network interfaces, this includes
 	// the network interface ID, the MAC address, the subnet ID, and the private
 	// IPv4 address.
 	Details []*KeyValuePair `locationName:"details" type:"list"`
@@ -3769,10 +3769,14 @@ type AwsVpcConfiguration struct {
 	// The security groups associated with the task or service. If you do not specify
 	// a security group, the default security group for the VPC is used. There is
 	// a limit of 5 security groups able to be specified per AwsVpcConfiguration.
+	//
+	// All specified security groups must be from the same VPC.
 	SecurityGroups []*string `locationName:"securityGroups" type:"list"`
 
 	// The subnets associated with the task or service. There is a limit of 10 subnets
 	// able to be specified per AwsVpcConfiguration.
+	//
+	// All specified subnets must be from the same VPC.
 	//
 	// Subnets is a required field
 	Subnets []*string `locationName:"subnets" type:"list" required:"true"`
@@ -3831,7 +3835,7 @@ type Cluster struct {
 	ActiveServicesCount *int64 `locationName:"activeServicesCount" type:"integer"`
 
 	// The Amazon Resource Name (ARN) that identifies the cluster. The ARN contains
-	// the arn:aws:ecs namespace, followed by the region of the cluster, the AWS
+	// the arn:aws:ecs namespace, followed by the Region of the cluster, the AWS
 	// account ID of the cluster owner, the cluster namespace, and then the cluster
 	// name. For example, arn:aws:ecs:region:012345678910:cluster/test..
 	ClusterArn *string `locationName:"clusterArn" type:"string"`
@@ -4187,8 +4191,8 @@ type ContainerDefinition struct {
 
 	// A list of hostnames and IP address mappings to append to the /etc/hosts file
 	// on the container. If using the Fargate launch type, this may be used to list
-	// non-Fargate hosts you want the container to talk to. This parameter maps
-	// to ExtraHosts in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
+	// non-Fargate hosts to which the container can talk. This parameter maps to
+	// ExtraHosts in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
 	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
 	// and the --add-host option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
@@ -4387,8 +4391,8 @@ type ContainerDefinition struct {
 	//
 	// After a task reaches the RUNNING status, manual and automatic host and container
 	// port assignments are visible in the Network Bindings section of a container
-	// description for a selected task in the Amazon ECS console, or the networkBindings
-	// section DescribeTasks responses.
+	// description for a selected task in the Amazon ECS console. The assignments
+	// are also visible in the networkBindings section DescribeTasks responses.
 	PortMappings []*PortMapping `locationName:"portMappings" type:"list"`
 
 	// When this parameter is true, the container is given elevated privileges on
@@ -4409,6 +4413,9 @@ type ContainerDefinition struct {
 	//
 	// This parameter is not supported for Windows containers.
 	ReadonlyRootFilesystem *bool `locationName:"readonlyRootFilesystem" type:"boolean"`
+
+	// The private repository authentication credentials to use.
+	RepositoryCredentials *RepositoryCredentials `locationName:"repositoryCredentials" type:"structure"`
 
 	// A list of ulimits to set in the container. This parameter maps to Ulimits
 	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
@@ -4480,6 +4487,11 @@ func (s *ContainerDefinition) Validate() error {
 	if s.LogConfiguration != nil {
 		if err := s.LogConfiguration.Validate(); err != nil {
 			invalidParams.AddNested("LogConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.RepositoryCredentials != nil {
+		if err := s.RepositoryCredentials.Validate(); err != nil {
+			invalidParams.AddNested("RepositoryCredentials", err.(request.ErrInvalidParams))
 		}
 	}
 	if s.Ulimits != nil {
@@ -4643,6 +4655,12 @@ func (s *ContainerDefinition) SetReadonlyRootFilesystem(v bool) *ContainerDefini
 	return s
 }
 
+// SetRepositoryCredentials sets the RepositoryCredentials field's value.
+func (s *ContainerDefinition) SetRepositoryCredentials(v *RepositoryCredentials) *ContainerDefinition {
+	s.RepositoryCredentials = v
+	return s
+}
+
 // SetUlimits sets the Ulimits field's value.
 func (s *ContainerDefinition) SetUlimits(v []*Ulimit) *ContainerDefinition {
 	s.Ulimits = v
@@ -4673,15 +4691,15 @@ type ContainerInstance struct {
 	_ struct{} `type:"structure"`
 
 	// This parameter returns true if the agent is connected to Amazon ECS. Registered
-	// instances with an agent that may be unhealthy or stopped return false. Instances
-	// without a connected agent can't accept placement requests.
+	// instances with an agent that may be unhealthy or stopped return false. Only
+	// instances connected to an agent can accept placement requests.
 	AgentConnected *bool `locationName:"agentConnected" type:"boolean"`
 
 	// The status of the most recent agent update. If an update has never been requested,
 	// this value is NULL.
 	AgentUpdateStatus *string `locationName:"agentUpdateStatus" type:"string" enum:"AgentUpdateStatus"`
 
-	// The Elastic Network Interfaces associated with the container instance.
+	// The elastic network interfaces associated with the container instance.
 	Attachments []*Attachment `locationName:"attachments" type:"list"`
 
 	// The attributes set for the container instance, either by the Amazon ECS container
@@ -4689,7 +4707,7 @@ type ContainerInstance struct {
 	Attributes []*Attribute `locationName:"attributes" type:"list"`
 
 	// The Amazon Resource Name (ARN) of the container instance. The ARN contains
-	// the arn:aws:ecs namespace, followed by the region of the container instance,
+	// the arn:aws:ecs namespace, followed by the Region of the container instance,
 	// the AWS account ID of the container instance owner, the container-instance
 	// namespace, and then the container instance ID. For example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
 	ContainerInstanceArn *string `locationName:"containerInstanceArn" type:"string"`
@@ -5055,7 +5073,7 @@ type CreateServiceInput struct {
 	// has first started. This is only valid if your service is configured to use
 	// a load balancer. If your service's tasks take a while to start and respond
 	// to Elastic Load Balancing health checks, you can specify a health check grace
-	// period of up to 1,800 seconds during which the ECS service scheduler ignores
+	// period of up to 7,200 seconds during which the ECS service scheduler ignores
 	// health check status. This grace period can prevent the ECS service scheduler
 	// from marking tasks as unhealthy and stopping them before they have time to
 	// come up.
@@ -5154,13 +5172,13 @@ type CreateServiceInput struct {
 	// The name of your service. Up to 255 letters (uppercase and lowercase), numbers,
 	// hyphens, and underscores are allowed. Service names must be unique within
 	// a cluster, but you can have similarly named services in multiple clusters
-	// within a region or across multiple regions.
+	// within a Region or across multiple Regions.
 	//
 	// ServiceName is a required field
 	ServiceName *string `locationName:"serviceName" type:"string" required:"true"`
 
-	// The details of the service discovery registries you want to assign to this
-	// service. For more information, see Service Discovery (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html).
+	// The details of the service discovery registries to assign to this service.
+	// For more information, see Service Discovery (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html).
 	//
 	// Service discovery is supported for Fargate tasks if using platform version
 	// v1.1.0 or later. For more information, see AWS Fargate Platform Versions
@@ -5572,7 +5590,7 @@ type Deployment struct {
 	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
 
 	// The VPC subnet and security group configuration for tasks that receive their
-	// own Elastic Network Interface by using the awsvpc networking mode.
+	// own elastic network interface by using the awsvpc networking mode.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
 	// The number of tasks in the deployment that are in the PENDING status.
@@ -5723,7 +5741,7 @@ type DeregisterContainerInstanceInput struct {
 	Cluster *string `locationName:"cluster" type:"string"`
 
 	// The container instance ID or full ARN of the container instance to deregister.
-	// The ARN contains the arn:aws:ecs namespace, followed by the region of the
+	// The ARN contains the arn:aws:ecs namespace, followed by the Region of the
 	// container instance, the AWS account ID of the container instance owner, the
 	// container-instance namespace, and then the container instance ID. For example,
 	// arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
@@ -6328,7 +6346,7 @@ type DiscoverPollEndpointInput struct {
 	Cluster *string `locationName:"cluster" type:"string"`
 
 	// The container instance ID or full ARN of the container instance. The ARN
-	// contains the arn:aws:ecs namespace, followed by the region of the container
+	// contains the arn:aws:ecs namespace, followed by the Region of the container
 	// instance, the AWS account ID of the container instance owner, the container-instance
 	// namespace, and then the container instance ID. For example, arn:aws:ecs:region:aws_account_id:container-instance/container_instance_ID.
 	ContainerInstance *string `locationName:"containerInstance" type:"string"`
@@ -6448,7 +6466,7 @@ type HealthCheck struct {
 
 	// The number of times to retry a failed health check before the container is
 	// considered unhealthy. You may specify between 1 and 10 retries. The default
-	// value is 3 retries.
+	// value is 3.
 	Retries *int64 `locationName:"retries" type:"integer"`
 
 	// The optional grace period within which to provide containers time to bootstrap
@@ -6463,7 +6481,7 @@ type HealthCheck struct {
 
 	// The time period in seconds to wait for a health check to succeed before it
 	// is considered a failure. You may specify between 2 and 60 seconds. The default
-	// value is 5 seconds.
+	// value is 5.
 	Timeout *int64 `locationName:"timeout" type:"integer"`
 }
 
@@ -7160,7 +7178,7 @@ type ListServicesInput struct {
 	// is assumed.
 	Cluster *string `locationName:"cluster" type:"string"`
 
-	// The launch type for services you want to list.
+	// The launch type for the services to list.
 	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
 
 	// The maximum number of service results returned by ListServices in paginated
@@ -7515,7 +7533,7 @@ type ListTasksInput struct {
 	// a family limits the results to tasks that belong to that family.
 	Family *string `locationName:"family" type:"string"`
 
-	// The launch type for services you want to list.
+	// The launch type for services to list.
 	LaunchType *string `locationName:"launchType" type:"string" enum:"LaunchType"`
 
 	// The maximum number of task results returned by ListTasks in paginated output.
@@ -7884,6 +7902,8 @@ type NetworkConfiguration struct {
 	_ struct{} `type:"structure"`
 
 	// The VPC subnets and security groups associated with a task.
+	//
+	// All specified subnets and security groups must be from the same VPC.
 	AwsvpcConfiguration *AwsVpcConfiguration `locationName:"awsvpcConfiguration" type:"structure"`
 }
 
@@ -7918,7 +7938,7 @@ func (s *NetworkConfiguration) SetAwsvpcConfiguration(v *AwsVpcConfiguration) *N
 	return s
 }
 
-// An object representing the Elastic Network Interface for tasks that use the
+// An object representing the elastic network interface for tasks that use the
 // awsvpc network mode.
 type NetworkInterface struct {
 	_ struct{} `type:"structure"`
@@ -7967,9 +7987,9 @@ func (s *NetworkInterface) SetPrivateIpv4Address(v string) *NetworkInterface {
 type PlacementConstraint struct {
 	_ struct{} `type:"structure"`
 
-	// A cluster query language expression to apply to the constraint. Note you
-	// cannot specify an expression if the constraint type is distinctInstance.
-	// For more information, see Cluster Query Language (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html)
+	// A cluster query language expression to apply to the constraint. You cannot
+	// specify an expression if the constraint type is distinctInstance. For more
+	// information, see Cluster Query Language (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html)
 	// in the Amazon Elastic Container Service Developer Guide.
 	Expression *string `locationName:"expression" type:"string"`
 
@@ -8360,8 +8380,8 @@ type RegisterTaskDefinitionInput struct {
 
 	// The number of CPU units used by the task. It can be expressed as an integer
 	// using CPU units, for example 1024, or as a string using vCPUs, for example
-	// 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer
-	// indicating the CPU units when the task definition is registered.
+	// 1 vCPU or 1 vcpu, in a task definition. String values are converted to an
+	// integer indicating the CPU units when the task definition is registered.
 	//
 	// Task-level CPU and memory parameters are ignored for Windows containers.
 	// We recommend specifying container-level resources for Windows containers.
@@ -8403,8 +8423,8 @@ type RegisterTaskDefinitionInput struct {
 
 	// The amount of memory (in MiB) used by the task. It can be expressed as an
 	// integer using MiB, for example 1024, or as a string using GB, for example
-	// 1GB or 1 GB, in a task definition but will be converted to an integer indicating
-	// the MiB when the task definition is registered.
+	// 1GB or 1 GB, in a task definition. String values are converted to an integer
+	// indicating the MiB when the task definition is registered.
 	//
 	// Task-level CPU and memory parameters are ignored for Windows containers.
 	// We recommend specifying container-level resources for Windows containers.
@@ -8600,6 +8620,46 @@ func (s RegisterTaskDefinitionOutput) GoString() string {
 // SetTaskDefinition sets the TaskDefinition field's value.
 func (s *RegisterTaskDefinitionOutput) SetTaskDefinition(v *TaskDefinition) *RegisterTaskDefinitionOutput {
 	s.TaskDefinition = v
+	return s
+}
+
+// The repository credentials for private registry authentication.
+type RepositoryCredentials struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) or name of the secret containing the private
+	// repository credentials.
+	//
+	// CredentialsParameter is a required field
+	CredentialsParameter *string `locationName:"credentialsParameter" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RepositoryCredentials) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RepositoryCredentials) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RepositoryCredentials) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RepositoryCredentials"}
+	if s.CredentialsParameter == nil {
+		invalidParams.Add(request.NewErrParamRequired("CredentialsParameter"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCredentialsParameter sets the CredentialsParameter field's value.
+func (s *RepositoryCredentials) SetCredentialsParameter(v string) *RepositoryCredentials {
+	s.CredentialsParameter = &v
 	return s
 }
 
@@ -8919,7 +8979,7 @@ type Service struct {
 	LoadBalancers []*LoadBalancer `locationName:"loadBalancers" type:"list"`
 
 	// The VPC subnet and security group configuration for tasks that receive their
-	// own Elastic Network Interface by using the awsvpc networking mode.
+	// own elastic network interface by using the awsvpc networking mode.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
 	// The number of tasks in the cluster that are in the PENDING state.
@@ -8962,14 +9022,14 @@ type Service struct {
 	SchedulingStrategy *string `locationName:"schedulingStrategy" type:"string" enum:"SchedulingStrategy"`
 
 	// The ARN that identifies the service. The ARN contains the arn:aws:ecs namespace,
-	// followed by the region of the service, the AWS account ID of the service
+	// followed by the Region of the service, the AWS account ID of the service
 	// owner, the service namespace, and then the service name. For example, arn:aws:ecs:region:012345678910:service/my-service.
 	ServiceArn *string `locationName:"serviceArn" type:"string"`
 
 	// The name of your service. Up to 255 letters (uppercase and lowercase), numbers,
 	// hyphens, and underscores are allowed. Service names must be unique within
 	// a cluster, but you can have similarly named services in multiple clusters
-	// within a region or across multiple regions.
+	// within a Region or across multiple Regions.
 	ServiceName *string `locationName:"serviceName" type:"string"`
 
 	ServiceRegistries []*ServiceRegistry `locationName:"serviceRegistries" type:"list"`
@@ -9254,7 +9314,7 @@ type StartTaskInput struct {
 	Group *string `locationName:"group" type:"string"`
 
 	// The VPC subnet and security group configuration for tasks that receive their
-	// own Elastic Network Interface by using the awsvpc networking mode.
+	// own elastic network interface by using the awsvpc networking mode.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
 	// A list of container overrides in JSON format that specify the name of a container
@@ -9721,7 +9781,7 @@ func (s *SubmitTaskStateChangeOutput) SetAcknowledgment(v string) *SubmitTaskSta
 type Task struct {
 	_ struct{} `type:"structure"`
 
-	// The Elastic Network Adapter associated with the task if the task uses the
+	// The elastic network adapter associated with the task if the task uses the
 	// awsvpc network mode.
 	Attachments []*Attachment `locationName:"attachments" type:"list"`
 
@@ -9742,8 +9802,8 @@ type Task struct {
 
 	// The number of CPU units used by the task. It can be expressed as an integer
 	// using CPU units, for example 1024, or as a string using vCPUs, for example
-	// 1 vCPU or 1 vcpu, in a task definition but is converted to an integer indicating
-	// the CPU units when the task definition is registered.
+	// 1 vCPU or 1 vcpu, in a task definition. String values are converted to an
+	// integer indicating the CPU units when the task definition is registered.
 	//
 	// If using the EC2 launch type, this field is optional. Supported values are
 	// between 128 CPU units (0.125 vCPUs) and 10240 CPU units (10 vCPUs).
@@ -9802,8 +9862,8 @@ type Task struct {
 
 	// The amount of memory (in MiB) used by the task. It can be expressed as an
 	// integer using MiB, for example 1024, or as a string using GB, for example
-	// 1GB or 1 GB, in a task definition but is converted to an integer indicating
-	// the MiB when the task definition is registered.
+	// 1GB or 1 GB, in a task definition. String values are converted to an integer
+	// indicating the MiB when the task definition is registered.
 	//
 	// If using the EC2 launch type, this field is optional.
 	//
@@ -9857,7 +9917,7 @@ type Task struct {
 	// The reason the task was stopped.
 	StoppedReason *string `locationName:"stoppedReason" type:"string"`
 
-	// The Unix time stamp for when the task will stop (transitions from the RUNNING
+	// The Unix time stamp for when the task stops (transitions from the RUNNING
 	// state to STOPPED).
 	StoppingAt *time.Time `locationName:"stoppingAt" type:"timestamp"`
 
@@ -10386,7 +10446,7 @@ func (s *TaskOverride) SetTaskRoleArn(v string) *TaskOverride {
 type Tmpfs struct {
 	_ struct{} `type:"structure"`
 
-	// The absolute file path where the tmpfs volume will be mounted.
+	// The absolute file path where the tmpfs volume is to be mounted.
 	//
 	// ContainerPath is a required field
 	ContainerPath *string `locationName:"containerPath" type:"string" required:"true"`
@@ -10731,7 +10791,7 @@ type UpdateServiceInput struct {
 	// network configuration, this does not trigger a new service deployment.
 	NetworkConfiguration *NetworkConfiguration `locationName:"networkConfiguration" type:"structure"`
 
-	// The platform version you want to update your service to run.
+	// The platform version that your service should run.
 	PlatformVersion *string `locationName:"platformVersion" type:"string"`
 
 	// The name of the service to update.

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/errors.go
@@ -89,7 +89,7 @@ const (
 	// ErrCodePlatformTaskDefinitionIncompatibilityException for service response error code
 	// "PlatformTaskDefinitionIncompatibilityException".
 	//
-	// The specified platform version does not satisfy the task definition’s required
+	// The specified platform version does not satisfy the task definition's required
 	// capabilities.
 	ErrCodePlatformTaskDefinitionIncompatibilityException = "PlatformTaskDefinitionIncompatibilityException"
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,1012 +39,1012 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "36e2OadMiTAbRp58Y0oBAuxJT2Y=",
+			"checksumSHA1": "Nb4M8Xc8+19Dg8GNV1WlzKGx1HQ=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "EwL79Cq6euk+EV/t/n2E+jzPNmU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "925zPp8gtaXi2gkWrgZ1gAA003A=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "JTilCBYWVAfhbKSnrxCNhE8IFns=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "eI5TmiOTCFjEUNvWeceFycs9dRU=",
 			"path": "github.com/aws/aws-sdk-go/aws/csm",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "6DRhqSAN7O45gYfRIpwDeuJE8j8=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "uPkjJo+J10vbEukYYXmf0w7Cn4Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Q1co3y5Y8rRIEjEXEfUZ9SwTmic=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Ia/AZ2fZp7J4lMO6fpkvfLU/HGY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "zx1mZCdOwgbjBV3jMfb0kyDd//Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Dj9WOMBPbboyUJV4GB99PwPcO4g=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "tQVg7Sz2zv+KkhbiXxPH0mh9spg=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkuri",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "ZX5QHZb0PrK4UF45um2kaAEiX+8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "stsUCJVnZ5yMrmzSExbjbYp5tZ8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "bOQjEfKXaTqe7dZhDDER/wZUzQc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "CTsp/h3FbFg9QizH4bH1abLwljg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "+O6A945eTP9plLpkEMZB0lwBAcg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "uRvmEPKcEdv7qc0Ep2zn0E3Xumc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "4dWtH/HkBpS7TnTf21+HOrE1zFc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "4xFqSOZkwDKot6FJQQgKjhJFoQw=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "3e/4A/8NqTOSXEtJ6KhYAqqWnuY=",
 			"path": "github.com/aws/aws-sdk-go/service/acmpca",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "FjnLIflNek7g0j5NKT3qFkNtdY8=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "K/ynSj/L2OzW+9Zqs2PRe8NzYUc=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "owhfVKeKxjXt4P5KO6PSIjnMLIA=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "3JN52M5wxJMazxQWXB4epL78LNQ=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "O5L1jCrbPe6adyTBIpSnydpToyk=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "42OCpXRErVgOtgPsuTrdg7y++TA=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "kPYTVg109H4HL8CKEf1yQvwKMw4=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "GhANcrglYWrhNSR/NzxNe3jClMk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "HmZRIixQ6u+zMz2Qt0iTU42WVZU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "BXG7bjiNrt222s+bZeimLAXODp4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "WqtP2Q4z15vT4i/TLix/kcsK91w=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudhsmv2",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "1uyTJ/RTr7c8uL2Kbrp+60PE40M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "3q2FBK4CEarGbVeLCuuX+g1E3jk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "o+DFxugR5Cy/Wwlv7GSRRilTW4o=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "7lCMA0KirL9isnwLj87LR2cjipU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "ciAsJhe41ygl47dhStzMJfGVFPQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "PV8Gt5eOyMFCT/+Y63CUrrY4V5k=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "ysSU5yhqWT4+deQUYZiI8/1tJ2c=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "GvjVVg5btXuEFEHqyoe19BZogGw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "vklitYIK0AiOXA0obSTq0c04pc4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "rL0O6L1zSJ/UQE0kEWUoCOOFDog=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Zc5M/qyd8bDCYuNRvFnF05gMp5s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "o9WTZk66Jlu+0UdO1wmtO3qp8ps=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "/y7nXSnR9OqMoxlIl1hFcCk5kT8=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "X1TkBdqZ/RWin1tr/FHWOGAFGsI=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "eAvb9FYZ6+lM9LhP7TrpNLrNn/Y=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "9AU0+8dys0VKkN4NT1N/wwhnLIU=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "a02+OXxnVBBBeaZpgs8dXUHj8b0=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "aAw9xutYOwCdzo7p0QwTFVFJr8Y=",
 			"path": "github.com/aws/aws-sdk-go/service/dlm",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
-			"checksumSHA1": "iCV19HfLlnGxp/WQXnf1j0WrSNk=",
+			"checksumSHA1": "iCy9zIjgDqNGBx0BLKNgY/4YV88=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
-			"checksumSHA1": "xSjeyAlY8+CyJ9nwDJ/3maeF9G4=",
+			"checksumSHA1": "a4Kb3tBW4zaoS8UFrkfU8MNHE8o=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "VD7bAh0n/UgOwRBPe5y38Ow/dHU=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
-			"checksumSHA1": "xOm3N99bh70t1mP96ttlgnj/CNc=",
+			"checksumSHA1": "Or8FcR+N4I0nDl8IU5Y0ek9bBd8=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "tkcjBjsY0K9byl1c0XZupuafZVQ=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "5QdblYPoDtRsQ8aczXOesIKTDpc=",
 			"path": "github.com/aws/aws-sdk-go/service/eks",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "kvsll2DfqS1hg97xSWMIcMan5as=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "fx9nf/M9h4DpZY5pEdnh9DeCnsU=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "BcT1GzSQ5j/x9A3OsFZWVBLnsxc=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "VFjWDQMsGpFMrNfcc//ABRpo6Ew=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Gp+QZjtg8PCNVi9X8m2SqtFvMas=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
-			"checksumSHA1": "aenp73UfqiJbl1sw3Yx3fGASNjc=",
+			"checksumSHA1": "wIiqI9GFAV2AQ32o2kEYHNyqVig=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "oNOLs79R42Vsj/jYTYtrbyTWxcw=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "3hICqVOs1WmluYMZN9fTMbDQSyM=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "tNVmAgvnURWLWibVCL7vIDYU7UM=",
 			"path": "github.com/aws/aws-sdk-go/service/fms",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "J1SHh0J6kX8JBD0+TQCFP+1Kij4=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "FEfr6yYlSRWsIV0M0kxm0/jOw0E=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "20er3HEJYcoJ1z0UumeaAkfOtpw=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "HNndTio5+fNOiLr23i+QZpPp8HU=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "ae+jhUirSvN0IXPVU7X7xc+EbFE=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "+KOm0n6lqwE3KWV4Kid2CFxmdRk=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "AIq7YTfZFlbyPUpv7fyjfB9k2sM=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "7PMjfoyDLrnS2N09LgR6syWP8Gk=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "TqLWVx6OQ+VqSMlzvokkC+IEv/k=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "K4OamITKC7PKo1eHrSl0z8Visg0=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "7rQmR+jAZ4zUIC4upAxyxrbfzNM=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "tX/3xEkl13DuKNIO0v3qYseEIvI=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "+l6bA5aVzmBXH2Isj1xZkd5RKNY=",
 			"path": "github.com/aws/aws-sdk-go/service/macie",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "7PCXsr+LBF9Hvjo7ZphC/xelGMs=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "HoX+EX8JW8kDZxJAs8545YRfjuI=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "CggySAQfK9WXsX37mRI8UqXGkJo=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "9NU6dJOvKvcgnl/4eUdwy4YD5ss=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "qyIVtaN5mzPq4d7BDj9YpYtifKs=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "p/+jOAMB5MSAnPloxJIFy77Hfck=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "E3i2/WM1kDE7WBOSRnDsZkwmZwI=",
 			"path": "github.com/aws/aws-sdk-go/service/neptune",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "x3PsW91a7fh+Q466y3WM3fdtnGg=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "YCd2EU1DPiO0QTRZk6G1fLZAyg0=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "RfTumx3C/ryCRp8ACLwhfnF+Cw0=",
 			"path": "github.com/aws/aws-sdk-go/service/pinpoint",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "j1i1tZ94/kDvvzgpv5xqxwNvgyY=",
 			"path": "github.com/aws/aws-sdk-go/service/pricing",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Kv8hkh6CxOCAG73xohmft8z4I3g=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "rwMv5M8vL6WvdvupGF5y+xOvFuQ=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "KlM6azZ5G09MmPg+lzEizW2qaLA=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "DmKatmbYsvm+MoCP01PCdQ6Y6Tk=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "TnYnywRdKZQ1uRVgUdeqpWO2+78=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "vv32189Rin9Nq5GrmwmpLziJsvU=",
 			"path": "github.com/aws/aws-sdk-go/service/secretsmanager",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "Y29bmjwKXcPg0d0WvZNFGdhd4+E=",
 			"path": "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "T8dOJ1jjEBdogUE03oRPRJCOY3k=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "UhJ0RdPXzdMOUEBWREB5Zi9lgmY=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "0vtFXRYnhlCCq8/zPv1O1YWIoSg=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "1rJbvLXRsCzWhTihruRq/i0Zawg=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "hliWYTmov/HswyMpYq93zJtdkk0=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "bW9FW0Qe3VURaSoY305kA/wCFrM=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "ECIZck5xhocpUl8GeUAdeSnCgvg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "UfgmCQjT787z6llIfGM9ZHzuydM=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "baQQigT2uBO5p8GwjjoYnO0xMDw=",
 			"path": "github.com/aws/aws-sdk-go/service/storagegateway",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "UhIVLDgQc19wjrPj8pP7Fu2UwWc=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "zSqEhiGtEK6ll3f1Rlf2tuDKQA8=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "H8Pa7irZ9gpuYGJk3uMK59gxGTs=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "uRMuwxPD/AlpvFpKppgAYzvlC0A=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "oe8l2ibuhzz7fWM3f64cWnHwFy8=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "bc3f534c19ffdf835e524e11f0f825b3eaf541c3",
-			"revisionTime": "2018-07-20T20:35:14Z",
-			"version": "v1.14.31",
-			"versionExact": "v1.14.31"
+			"revision": "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4",
+			"revisionTime": "2018-07-25T21:41:52Z",
+			"version": "v1.14.33",
+			"versionExact": "v1.14.33"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
Includes:
* New DynamoDB autoscaling APIs
* ECS private repository credentials fields
* ELBv2 redirect/fixed response fields

Changes proposed in this pull request:

* `govendor fetch github.com/aws/aws-sdk-go/...@v1.14.33`

Output from acceptance testing: Handled via daily acceptance testing
