### PR TITLE
resource/aws_waf(regional)_web_acl: Properly read rules into Terraform state

### DIFF
--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
@@ -43,8 +42,6 @@ func TestAccAWSWafWebAcl_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				// The WAF ACL rule resource doesn't GET rules
-				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -80,8 +77,6 @@ func TestAccAWSWafWebAcl_group(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				// The WAF ACL rule resource doesn't GET rules
-				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -134,8 +129,6 @@ func TestAccAWSWafWebAcl_changeNameForceNew(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				// The WAF ACL rule resource doesn't GET rules
-				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -188,8 +181,6 @@ func TestAccAWSWafWebAcl_changeDefaultAction(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				// The WAF ACL rule resource doesn't GET rules
-				ImportStateVerifyIgnore: []string{"rules"},
 			},
 		},
 	})
@@ -279,10 +270,8 @@ func testAccCheckAWSWafWebAclDestroy(s *terraform.State) error {
 		}
 
 		// Return nil if the WebACL is already destroyed
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "WAFNonexistentItemException" {
-				return nil
-			}
+		if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
+			continue
 		}
 
 		return err

--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -100,5 +100,3 @@ WAF Web ACL can be imported using the `id`, e.g.
 ```
 $ terraform import aws_waf_web_acl.main 0c8e583e-18f3-4c13-9e2a-67c4805d2f94
 ```
-
-~> **Note:** The `rules` will not be imported.


### PR DESCRIPTION
Reference: #4589 

Changes proposed in this pull request:

* Ensure `rules` argument is properly read into Terraform state for import and drift detection
* Other minor refactoring

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafWebAcl'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafWebAcl -timeout 120m
=== RUN   TestAccAWSWafWebAcl_basic
--- PASS: TestAccAWSWafWebAcl_basic (17.33s)
=== RUN   TestAccAWSWafWebAcl_group
--- PASS: TestAccAWSWafWebAcl_group (13.71s)
=== RUN   TestAccAWSWafWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (32.09s)
=== RUN   TestAccAWSWafWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafWebAcl_changeDefaultAction (30.88s)
=== RUN   TestAccAWSWafWebAcl_disappears
--- PASS: TestAccAWSWafWebAcl_disappears (21.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	115.665s

$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalWebAcl_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalWebAcl_ -timeout 120m
=== RUN   TestAccAWSWafRegionalWebAcl_basic
--- PASS: TestAccAWSWafRegionalWebAcl_basic (18.86s)
=== RUN   TestAccAWSWafRegionalWebAcl_createRateBased
--- PASS: TestAccAWSWafRegionalWebAcl_createRateBased (19.89s)
=== RUN   TestAccAWSWafRegionalWebAcl_createGroup
--- PASS: TestAccAWSWafRegionalWebAcl_createGroup (20.51s)
=== RUN   TestAccAWSWafRegionalWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafRegionalWebAcl_changeNameForceNew (33.72s)
=== RUN   TestAccAWSWafRegionalWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafRegionalWebAcl_changeDefaultAction (32.38s)
=== RUN   TestAccAWSWafRegionalWebAcl_disappears
--- PASS: TestAccAWSWafRegionalWebAcl_disappears (17.65s)
=== RUN   TestAccAWSWafRegionalWebAcl_noRules
--- PASS: TestAccAWSWafRegionalWebAcl_noRules (13.05s)
=== RUN   TestAccAWSWafRegionalWebAcl_changeRules
--- PASS: TestAccAWSWafRegionalWebAcl_changeRules (28.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	185.234s
```
