### PR TITLE
provider: Ensure schema.TypeMap Elem are schema.Schema

### DIFF
--- a/aws/data_source_aws_lambda_function.go
+++ b/aws/data_source_aws_lambda_function.go
@@ -122,7 +122,7 @@ func dataSourceAwsLambdaFunction() *schema.Resource {
 						"variables": {
 							Type:     schema.TypeMap,
 							Computed: true,
-							Elem:     schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -74,14 +74,14 @@ func resourceAwsKmsGrant() *schema.Resource {
 							Type:     schema.TypeMap,
 							Optional: true,
 							ForceNew: true,
-							Elem:     schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 							// ConflictsWith encryption_context_subset handled in Create, see kmsGrantConstraintsIsValid
 						},
 						"encryption_context_subset": {
 							Type:     schema.TypeMap,
 							Optional: true,
 							ForceNew: true,
-							Elem:     schema.TypeString,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 							// ConflictsWith encryption_context_equals handled in Create, see kmsGrantConstraintsIsValid
 						},
 					},


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/issues/18544

Changes proposed in this pull request:

* Manually caught until the provider validation is fixed

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAWSKmsGrant_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAWSKmsGrant_ -timeout 120m
=== RUN   TestAWSKmsGrant_Basic
--- PASS: TestAWSKmsGrant_Basic (51.52s)
=== RUN   TestAWSKmsGrant_withConstraints
--- PASS: TestAWSKmsGrant_withConstraints (72.59s)
=== RUN   TestAWSKmsGrant_withRetiringPrincipal
--- PASS: TestAWSKmsGrant_withRetiringPrincipal (51.72s)
=== RUN   TestAWSKmsGrant_bare
--- PASS: TestAWSKmsGrant_bare (52.66s)
=== RUN   TestAWSKmsGrant_ARN
--- PASS: TestAWSKmsGrant_ARN (60.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	289.994s

$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLambdaFunction_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLambdaFunction_ -timeout 120m
=== RUN   TestAccDataSourceAWSLambdaFunction_basic
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (40.38s)
=== RUN   TestAccDataSourceAWSLambdaFunction_version
--- PASS: TestAccDataSourceAWSLambdaFunction_version (37.81s)
=== RUN   TestAccDataSourceAWSLambdaFunction_alias
--- PASS: TestAccDataSourceAWSLambdaFunction_alias (31.02s)
=== RUN   TestAccDataSourceAWSLambdaFunction_vpc
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (36.79s)
=== RUN   TestAccDataSourceAWSLambdaFunction_environment
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (38.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	184.680s
```
