### PR TITLE
fix config_configuration_recorder_status example code

### DIFF
--- a/website/docs/r/config_configuration_recorder_status.html.markdown
+++ b/website/docs/r/config_configuration_recorder_status.html.markdown
@@ -59,6 +59,29 @@ resource "aws_iam_role" "r" {
 }
 POLICY
 }
+
+resource "aws_iam_role_policy" "p" {
+  name = "awsconfig-example"
+  role = "${aws_iam_role.r.id}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.b.arn}",
+        "${aws_s3_bucket.b.arn}/*"
+      ]
+    }
+  ]
+}
+POLICY
+}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
This example code does not fully work -- it needs a policy to be able to write to the s3 bucket. I copied the aws_iam_role_policy from the config_delivery_channel resource documentation.
