### PR TITLE
Fix bug: Update of rate_limit in aws_wafregional_rate_based_rule is n…

### DIFF
--- a/aws/resource_aws_wafregional_rate_based_rule.go
+++ b/aws/resource_aws_wafregional_rate_based_rule.go
@@ -130,7 +130,7 @@ func resourceAwsWafRegionalRateBasedRuleUpdate(d *schema.ResourceData, meta inte
 	conn := meta.(*AWSClient).wafregionalconn
 	region := meta.(*AWSClient).region
 
-	if d.HasChange("predicate") {
+	if d.HasChange("predicate") || d.HasChange("rate_limit") {
 		o, n := d.GetChange("predicate")
 		oldP, newP := o.(*schema.Set).List(), n.(*schema.Set).List()
 		rateLimit := d.Get("rate_limit")

--- a/aws/resource_aws_wafregional_rate_based_rule_test.go
+++ b/aws/resource_aws_wafregional_rate_based_rule_test.go
@@ -137,6 +137,37 @@ func TestAccAWSWafRegionalRateBasedRule_changePredicates(t *testing.T) {
 	})
 }
 
+func TestAccAWSWafRegionalRateBasedRule_changeRateLimit(t *testing.T) {
+	var before, after waf.RateBasedRule
+	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	rateLimitBefore := "2000"
+	rateLimitAfter := "2001"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalRateBasedRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleWithRateLimitConfig(ruleName, rateLimitBefore),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &before),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "rate_limit", rateLimitBefore),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalRateBasedRuleWithRateLimitConfig(ruleName, rateLimitAfter),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRegionalRateBasedRuleExists("aws_wafregional_rate_based_rule.wafrule", &after),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr("aws_wafregional_rate_based_rule.wafrule", "rate_limit", rateLimitAfter),
+				),
+			},
+		},
+	})
+}
+
 // computeWafRegionalRateBasedRulePredicateWithIpSet calculates index
 // which isn't static because dataId is generated as part of the test
 func computeWafRegionalRateBasedRulePredicateWithIpSet(ipSet *waf.IPSet, negated bool, pType string, idx *int) resource.TestCheckFunc {
@@ -401,4 +432,14 @@ resource "aws_wafregional_rate_based_rule" "wafrule" {
   rate_key = "IP"
   rate_limit = 2000
 }`, name, name)
+}
+
+func testAccAWSWafRegionalRateBasedRuleWithRateLimitConfig(name string, limit string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_rate_based_rule" "wafrule" {
+  name = "%s"
+  metric_name = "%s"
+  rate_key = "IP"
+  rate_limit = %s
+}`, name, name, limit)
 }


### PR DESCRIPTION
This fixes the issue I introduced in #5355 

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRate*

TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegionalRate* -timeout 120m
=== RUN   TestAccAWSWafRegionalRateBasedRule_basic
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (67.37s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (103.42s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (55.50s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changePredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (97.69s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeRateLimit
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (63.22s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_noPredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (37.56s)
PASS
...
```
