### PR TITLE
elbv2: Prevent panics from unsafe * nil dereferences

### DIFF
--- a/aws/data_source_aws_lb.go
+++ b/aws/data_source_aws_lb.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -140,12 +139,12 @@ func dataSourceAwsLbRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Load Balancer: %s", describeLbOpts)
 	describeResp, err := elbconn.DescribeLoadBalancers(describeLbOpts)
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving LB: {{err}}", err)
+		return fmt.Errorf("Error retrieving LB: %s", err)
 	}
 	if len(describeResp.LoadBalancers) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(describeResp.LoadBalancers))
 	}
-	d.SetId(*describeResp.LoadBalancers[0].LoadBalancerArn)
+	d.SetId(aws.StringValue(describeResp.LoadBalancers[0].LoadBalancerArn))
 
 	return flattenAwsLbResource(d, meta, describeResp.LoadBalancers[0])
 }

--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -147,7 +146,7 @@ func dataSourceAwsLbTargetGroupRead(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Reading Load Balancer Target Group: %s", describeTgOpts)
 	describeResp, err := elbconn.DescribeTargetGroups(describeTgOpts)
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving LB Target Group: {{err}}", err)
+		return fmt.Errorf("Error retrieving LB Target Group: %s", err)
 	}
 	if len(describeResp.TargetGroups) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(describeResp.TargetGroups))
@@ -155,6 +154,6 @@ func dataSourceAwsLbTargetGroupRead(d *schema.ResourceData, meta interface{}) er
 
 	targetGroup := describeResp.TargetGroups[0]
 
-	d.SetId(*targetGroup.TargetGroupArn)
+	d.SetId(aws.StringValue(targetGroup.TargetGroupArn))
 	return flattenAwsLbTargetGroupResource(d, meta, targetGroup)
 }

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -495,10 +494,10 @@ func testAccCheckAWSALBTargetGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		if isTargetGroupNotFound(err) {
+		if isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {
 			return nil
 		} else {
-			return errwrap.Wrapf("Unexpected error checking ALB destroyed: {{err}}", err)
+			return fmt.Errorf("Unexpected error checking ALB destroyed: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_lb_listener_certificate.go
+++ b/aws/resource_aws_lb_listener_certificate.go
@@ -6,10 +6,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/resource"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -141,11 +140,11 @@ func findAwsLbListenerCertificate(certificateArn, listenerArn string, skipDefaul
 	}
 
 	for _, cert := range resp.Certificates {
-		if skipDefault && *cert.IsDefault {
+		if skipDefault && aws.BoolValue(cert.IsDefault) {
 			continue
 		}
 
-		if *cert.CertificateArn == certificateArn {
+		if aws.StringValue(cert.CertificateArn) == certificateArn {
 			return cert, nil
 		}
 	}

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -187,7 +187,7 @@ func resourceAwsLbListenerRuleRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("priority", 99999)
 	} else {
 		if priority, err := strconv.Atoi(aws.StringValue(rule.Priority)); err != nil {
-			return fmt.Errorf("Cannot convert rule priority %q to int: %s", err)
+			return fmt.Errorf("Cannot convert rule priority %q to int: %s", aws.StringValue(rule.Priority), err)
 		} else {
 			d.Set("priority", priority)
 		}

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -326,10 +325,10 @@ func testAccCheckAWSLBListenerRuleDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		if isRuleNotFound(err) {
+		if isAWSErr(err, elbv2.ErrCodeRuleNotFoundException, "") {
 			return nil
 		} else {
-			return errwrap.Wrapf("Unexpected error checking LB Listener Rule destroyed: {{err}}", err)
+			return fmt.Errorf("Unexpected error checking LB Listener Rule destroyed: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -153,7 +152,7 @@ func testAccCheckAWSLBListenerDestroy(s *terraform.State) error {
 		if isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
 			return nil
 		} else {
-			return errwrap.Wrapf("Unexpected error checking LB Listener destroyed: {{err}}", err)
+			return fmt.Errorf("Unexpected error checking LB Listener destroyed: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -9,9 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -65,10 +63,14 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 			},
 
 			"protocol": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateLbListenerProtocol(),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					elbv2.ProtocolEnumHttp,
+					elbv2.ProtocolEnumHttps,
+					elbv2.ProtocolEnumTcp,
+				}, true),
 			},
 
 			"vpc_id": {
@@ -167,7 +169,11 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 							StateFunc: func(v interface{}) string {
 								return strings.ToUpper(v.(string))
 							},
-							ValidateFunc: validateLbListenerProtocol(),
+							ValidateFunc: validation.StringInSlice([]string{
+								elbv2.ProtocolEnumHttp,
+								elbv2.ProtocolEnumHttps,
+								elbv2.ProtocolEnumTcp,
+							}, true),
 						},
 
 						"timeout": {
@@ -255,15 +261,14 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := elbconn.CreateTargetGroup(params)
 	if err != nil {
-		return errwrap.Wrapf("Error creating LB Target Group: {{err}}", err)
+		return fmt.Errorf("Error creating LB Target Group: %s", err)
 	}
 
 	if len(resp.TargetGroups) == 0 {
 		return errors.New("Error creating LB Target Group: no groups returned in response")
 	}
 
-	targetGroupArn := resp.TargetGroups[0].TargetGroupArn
-	d.SetId(*targetGroupArn)
+	d.SetId(aws.StringValue(resp.TargetGroups[0].TargetGroupArn))
 
 	return resourceAwsLbTargetGroupUpdate(d, meta)
 }
@@ -275,12 +280,12 @@ func resourceAwsLbTargetGroupRead(d *schema.ResourceData, meta interface{}) erro
 		TargetGroupArns: []*string{aws.String(d.Id())},
 	})
 	if err != nil {
-		if isTargetGroupNotFound(err) {
+		if isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {
 			log.Printf("[DEBUG] DescribeTargetGroups - removing %s from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return errwrap.Wrapf("Error retrieving Target Group: {{err}}", err)
+		return fmt.Errorf("Error retrieving Target Group: %s", err)
 	}
 
 	if len(resp.TargetGroups) != 1 {
@@ -294,7 +299,7 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	elbconn := meta.(*AWSClient).elbv2conn
 
 	if err := setElbV2Tags(elbconn, d); err != nil {
-		return errwrap.Wrapf("Error Modifying Tags on LB Target Group: {{err}}", err)
+		return fmt.Errorf("Error Modifying Tags on LB Target Group: %s", err)
 	}
 
 	if d.HasChange("health_check") {
@@ -333,7 +338,7 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		if params != nil {
 			_, err := elbconn.ModifyTargetGroup(params)
 			if err != nil {
-				return errwrap.Wrapf("Error modifying Target Group: {{err}}", err)
+				return fmt.Errorf("Error modifying Target Group: %s", err)
 			}
 		}
 	}
@@ -399,7 +404,7 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 
 		_, err := elbconn.ModifyTargetGroupAttributes(params)
 		if err != nil {
-			return errwrap.Wrapf("Error modifying Target Group Attributes: {{err}}", err)
+			return fmt.Errorf("Error modifying Target Group Attributes: %s", err)
 		}
 	}
 
@@ -413,15 +418,10 @@ func resourceAwsLbTargetGroupDelete(d *schema.ResourceData, meta interface{}) er
 		TargetGroupArn: aws.String(d.Id()),
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error deleting Target Group: {{err}}", err)
+		return fmt.Errorf("Error deleting Target Group: %s", err)
 	}
 
 	return nil
-}
-
-func isTargetGroupNotFound(err error) bool {
-	elberr, ok := err.(awserr.Error)
-	return ok && elberr.Code() == "TargetGroupNotFound"
 }
 
 func validateAwsLbTargetGroupHealthCheckPath(v interface{}, k string) (ws []string, errors []error) {
@@ -496,37 +496,37 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	d.Set("target_type", targetGroup.TargetType)
 
 	healthCheck := make(map[string]interface{})
-	healthCheck["interval"] = *targetGroup.HealthCheckIntervalSeconds
-	healthCheck["port"] = *targetGroup.HealthCheckPort
-	healthCheck["protocol"] = *targetGroup.HealthCheckProtocol
-	healthCheck["timeout"] = *targetGroup.HealthCheckTimeoutSeconds
-	healthCheck["healthy_threshold"] = *targetGroup.HealthyThresholdCount
-	healthCheck["unhealthy_threshold"] = *targetGroup.UnhealthyThresholdCount
+	healthCheck["interval"] = int(aws.Int64Value(targetGroup.HealthCheckIntervalSeconds))
+	healthCheck["port"] = aws.StringValue(targetGroup.HealthCheckPort)
+	healthCheck["protocol"] = aws.StringValue(targetGroup.HealthCheckProtocol)
+	healthCheck["timeout"] = int(aws.Int64Value(targetGroup.HealthCheckTimeoutSeconds))
+	healthCheck["healthy_threshold"] = int(aws.Int64Value(targetGroup.HealthyThresholdCount))
+	healthCheck["unhealthy_threshold"] = int(aws.Int64Value(targetGroup.UnhealthyThresholdCount))
 
 	if targetGroup.HealthCheckPath != nil {
-		healthCheck["path"] = *targetGroup.HealthCheckPath
+		healthCheck["path"] = aws.StringValue(targetGroup.HealthCheckPath)
 	}
 	if targetGroup.Matcher != nil && targetGroup.Matcher.HttpCode != nil {
-		healthCheck["matcher"] = *targetGroup.Matcher.HttpCode
+		healthCheck["matcher"] = aws.StringValue(targetGroup.Matcher.HttpCode)
 	}
 
 	if err := d.Set("health_check", []interface{}{healthCheck}); err != nil {
-		log.Printf("[WARN] Error setting health check: %s", err)
+		return fmt.Errorf("error setting health_check: %s", err)
 	}
 
 	attrResp, err := elbconn.DescribeTargetGroupAttributes(&elbv2.DescribeTargetGroupAttributesInput{
 		TargetGroupArn: aws.String(d.Id()),
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving Target Group Attributes: {{err}}", err)
+		return fmt.Errorf("Error retrieving Target Group Attributes: %s", err)
 	}
 
 	for _, attr := range attrResp.Attributes {
-		switch *attr.Key {
+		switch aws.StringValue(attr.Key) {
 		case "proxy_protocol_v2.enabled":
-			enabled, err := strconv.ParseBool(*attr.Value)
+			enabled, err := strconv.ParseBool(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("Error converting proxy_protocol_v2.enabled to bool: %s", *attr.Value)
+				return fmt.Errorf("Error converting proxy_protocol_v2.enabled to bool: %s", aws.StringValue(attr.Value))
 			}
 			d.Set("proxy_protocol_v2", enabled)
 		case "slow_start.duration_seconds":
@@ -547,13 +547,13 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 	// This is a workaround to support module design where the module needs to
 	// support HTTP and TCP target groups.
 	switch {
-	case *targetGroup.Protocol != "TCP":
+	case aws.StringValue(targetGroup.Protocol) != "TCP":
 		if err = flattenAwsLbTargetGroupStickiness(d, attrResp.Attributes); err != nil {
 			return err
 		}
-	case *targetGroup.Protocol == "TCP" && len(d.Get("stickiness").([]interface{})) < 1:
+	case aws.StringValue(targetGroup.Protocol) == "TCP" && len(d.Get("stickiness").([]interface{})) < 1:
 		if err = d.Set("stickiness", []interface{}{}); err != nil {
-			return err
+			return fmt.Errorf("error setting stickiness: %s", err)
 		}
 	}
 
@@ -561,12 +561,12 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 		ResourceArns: []*string{aws.String(d.Id())},
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving Target Group Tags: {{err}}", err)
+		return fmt.Errorf("Error retrieving Target Group Tags: %s", err)
 	}
 	for _, t := range tagsResp.TagDescriptions {
-		if *t.ResourceArn == d.Id() {
+		if aws.StringValue(t.ResourceArn) == d.Id() {
 			if err := d.Set("tags", tagsToMapELBv2(t.Tags)); err != nil {
-				return err
+				return fmt.Errorf("error setting tags: %s", err)
 			}
 		}
 	}
@@ -577,25 +577,25 @@ func flattenAwsLbTargetGroupResource(d *schema.ResourceData, meta interface{}, t
 func flattenAwsLbTargetGroupStickiness(d *schema.ResourceData, attributes []*elbv2.TargetGroupAttribute) error {
 	stickinessMap := map[string]interface{}{}
 	for _, attr := range attributes {
-		switch *attr.Key {
+		switch aws.StringValue(attr.Key) {
 		case "stickiness.enabled":
-			enabled, err := strconv.ParseBool(*attr.Value)
+			enabled, err := strconv.ParseBool(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("Error converting stickiness.enabled to bool: %s", *attr.Value)
+				return fmt.Errorf("Error converting stickiness.enabled to bool: %s", aws.StringValue(attr.Value))
 			}
 			stickinessMap["enabled"] = enabled
 		case "stickiness.type":
-			stickinessMap["type"] = *attr.Value
+			stickinessMap["type"] = aws.StringValue(attr.Value)
 		case "stickiness.lb_cookie.duration_seconds":
-			duration, err := strconv.Atoi(*attr.Value)
+			duration, err := strconv.Atoi(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("Error converting stickiness.lb_cookie.duration_seconds to int: %s", *attr.Value)
+				return fmt.Errorf("Error converting stickiness.lb_cookie.duration_seconds to int: %s", aws.StringValue(attr.Value))
 			}
 			stickinessMap["cookie_duration"] = duration
 		case "deregistration_delay.timeout_seconds":
-			timeout, err := strconv.Atoi(*attr.Value)
+			timeout, err := strconv.Atoi(aws.StringValue(attr.Value))
 			if err != nil {
-				return fmt.Errorf("Error converting deregistration_delay.timeout_seconds to int: %s", *attr.Value)
+				return fmt.Errorf("Error converting deregistration_delay.timeout_seconds to int: %s", aws.StringValue(attr.Value))
 			}
 			d.Set("deregistration_delay", timeout)
 		}

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -161,10 +160,10 @@ func testAccCheckAWSLBTargetGroupAttachmentDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		if isTargetGroupNotFound(err) || isInvalidTarget(err) {
+		if isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") || isAWSErr(err, elbv2.ErrCodeInvalidTargetException, "") {
 			return nil
 		} else {
-			return errwrap.Wrapf("Unexpected error checking LB destroyed: {{err}}", err)
+			return fmt.Errorf("Unexpected error checking LB destroyed: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -949,10 +948,10 @@ func testAccCheckAWSLBTargetGroupDestroy(s *terraform.State) error {
 		}
 
 		// Verify the error
-		if isTargetGroupNotFound(err) {
+		if isAWSErr(err, elbv2.ErrCodeTargetGroupNotFoundException, "") {
 			return nil
 		} else {
-			return errwrap.Wrapf("Unexpected error checking ALB destroyed: {{err}}", err)
+			return fmt.Errorf("Unexpected error checking ALB destroyed: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Sorry for the cross-resource pull request but it seemed better to fix this across all the ELBv2 resources instead of just the specific case.

Fixes #5357 

Changes proposed in this pull request:

* Prevent all potential `*` nil dereference panics by using SDK provided functions (e.g. `aws.StringValue()`)
* Other minor refactoring while I'm touching all these files:
  * Replace `errwrap.Wrapf()` usage with `fmt.Errorf()`
  * Directly use `isAWSErr()` instead of custom `isInvalidTarget()`/`isTargetGroupNotFound()` functions
  * Split out `validateLbListenerActionType()` usage in preparation for #5344 
  * Split out `validateLbListenerProtocol()` usage in preparation for potential ELBv2 resource split

Output from acceptance testing:

```
57 tests passed (all tests)
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (2.57s)
=== RUN   TestAccAWSALBTargetGroup_generatedName
--- PASS: TestAccAWSALBTargetGroup_generatedName (22.68s)
=== RUN   TestAccAWSALBTargetGroup_namePrefix
--- PASS: TestAccAWSALBTargetGroup_namePrefix (23.96s)
=== RUN   TestAccAWSALBTargetGroup_setAndUpdateSlowStart
--- PASS: TestAccAWSALBTargetGroup_setAndUpdateSlowStart (36.79s)
=== RUN   TestAccAWSALBTargetGroup_changePortForceNew
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (36.93s)
=== RUN   TestAccAWSALBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (38.41s)
=== RUN   TestAccAWSALBTargetGroup_tags
--- PASS: TestAccAWSALBTargetGroup_tags (43.37s)
=== RUN   TestAccAWSALBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (43.52s)
=== RUN   TestAccAWSALBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (44.37s)
=== RUN   TestAccAWSALBTargetGroup_basic
--- PASS: TestAccAWSALBTargetGroup_basic (49.61s)
=== RUN   TestAccAWSALBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (50.33s)
=== RUN   TestAccAWSLBTargetGroup_basic
--- PASS: TestAccAWSLBTargetGroup_basic (14.25s)
=== RUN   TestAccAWSALBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (53.55s)
=== RUN   TestAccAWSLBTargetGroup_namePrefix
--- PASS: TestAccAWSLBTargetGroup_namePrefix (9.16s)
=== RUN   TestAccAWSLBTargetGroup_generatedName
--- PASS: TestAccAWSLBTargetGroup_generatedName (16.34s)
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (26.92s)
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (33.78s)
=== RUN   TestAccAWSLBTargetGroup_changePortForceNew
--- PASS: TestAccAWSLBTargetGroup_changePortForceNew (22.40s)
=== RUN   TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck
--- PASS: TestAccAWSLBTargetGroup_TCP_HTTPHealthCheck (33.90s)
=== RUN   TestAccAWSLBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSLBTargetGroup_changeNameForceNew (28.23s)
=== RUN   TestAccAWSLBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSLBTargetGroup_changeProtocolForceNew (30.84s)
=== RUN   TestAccAWSLBTargetGroup_stickinessWithTCPEnabledShouldError
--- PASS: TestAccAWSLBTargetGroup_stickinessWithTCPEnabledShouldError (1.51s)
=== RUN   TestAccAWSLBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSLBTargetGroup_changeVpcForceNew (35.95s)
=== RUN   TestAccAWSLBTargetGroup_stickinessWithTCPDisabled
--- PASS: TestAccAWSLBTargetGroup_stickinessWithTCPDisabled (17.33s)
=== RUN   TestAccAWSLBTargetGroup_defaults_application
--- PASS: TestAccAWSLBTargetGroup_defaults_application (22.19s)
=== RUN   TestAccAWSLBTargetGroup_tags
--- PASS: TestAccAWSLBTargetGroup_tags (32.60s)
=== RUN   TestAccAWSLBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSLBTargetGroup_updateHealthCheck (36.71s)
=== RUN   TestAccAWSLBTargetGroup_defaults_network
--- PASS: TestAccAWSLBTargetGroup_defaults_network (30.11s)
=== RUN   TestAccAWSLBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSLBTargetGroup_updateSticknessEnabled (41.00s)
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (102.24s)
=== RUN   TestAccAWSLBTargetGroupAttachment_withoutPort
--- PASS: TestAccAWSLBTargetGroupAttachment_withoutPort (120.71s)
=== RUN   TestAccDataSourceAWSLB_basic
--- PASS: TestAccDataSourceAWSLB_basic (191.93s)
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (205.13s)
=== RUN   TestAccDataSourceAWSLBListener_basic
--- PASS: TestAccDataSourceAWSLBListener_basic (208.61s)
=== RUN   TestAccAWSLBListener_basic
--- PASS: TestAccAWSLBListener_basic (209.01s)
=== RUN   TestAccAWSLBListener_https
--- PASS: TestAccAWSLBListener_https (199.02s)
=== RUN   TestAccDataSourceAWSLBListener_https
--- PASS: TestAccDataSourceAWSLBListener_https (232.94s)
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (234.05s)
=== RUN   TestAccDataSourceAWSALBTargetGroup_basic
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (255.68s)
=== RUN   TestAccAWSLBListenerRule_basic
--- PASS: TestAccAWSLBListenerRule_basic (266.43s)
=== RUN   TestAccAWSLB_generatedName
--- PASS: TestAccAWSLB_generatedName (190.17s)
=== RUN   TestAccAWSLB_generatesNameForZeroValue
--- PASS: TestAccAWSLB_generatesNameForZeroValue (193.02s)
=== RUN   TestAccAWSLBListenerRule_priority
--- PASS: TestAccAWSLBListenerRule_priority (293.95s)
=== RUN   TestAccAWSLB_basic
--- PASS: TestAccAWSLB_basic (213.61s)
=== RUN   TestAccAWSLB_namePrefix
--- PASS: TestAccAWSLB_namePrefix (200.51s)
=== RUN   TestAccAWSLB_networkLoadbalancerEIP
--- PASS: TestAccAWSLB_networkLoadbalancerEIP (215.04s)
=== RUN   TestAccAWSLB_networkLoadbalancerBasic
--- PASS: TestAccAWSLB_networkLoadbalancerBasic (236.63s)
=== RUN   TestAccAWSLB_tags
--- PASS: TestAccAWSLB_tags (245.96s)
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateHttp2
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (278.89s)
=== RUN   TestAccAWSLB_networkLoadbalancer_updateCrossZone
--- PASS: TestAccAWSLB_networkLoadbalancer_updateCrossZone (295.13s)
=== RUN   TestAccAWSLB_updatedSecurityGroups
--- PASS: TestAccAWSLB_updatedSecurityGroups (216.58s)
=== RUN   TestAccAWSLB_noSecurityGroup
--- PASS: TestAccAWSLB_noSecurityGroup (207.78s)
=== RUN   TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (270.64s)
=== RUN   TestAccAWSLB_updatedSubnets
--- PASS: TestAccAWSLB_updatedSubnets (235.69s)
=== RUN   TestAccAWSLB_updatedIpAddressType
--- PASS: TestAccAWSLB_updatedIpAddressType (232.76s)
=== RUN   TestAccAWSLB_networkLoadbalancer_subnet_change
--- PASS: TestAccAWSLB_networkLoadbalancer_subnet_change (247.36s)
=== RUN   TestAccAWSLB_accesslogs
--- PASS: TestAccAWSLB_accesslogs (333.41s)
```
