### PR TITLE
resource/aws_api_gateway_domain_name: support import

### DIFF
--- a/aws/resource_aws_api_gateway_domain_name.go
+++ b/aws/resource_aws_api_gateway_domain_name.go
@@ -19,6 +19,9 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 		Read:   resourceAwsApiGatewayDomainNameRead,
 		Update: resourceAwsApiGatewayDomainNameUpdate,
 		Delete: resourceAwsApiGatewayDomainNameDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 

--- a/aws/resource_aws_api_gateway_domain_name_test.go
+++ b/aws/resource_aws_api_gateway_domain_name_test.go
@@ -94,6 +94,12 @@ func TestAccAWSAPIGatewayDomainName_CertificateName(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_api_gateway_domain_name.test", "certificate_upload_date"),
 				),
 			},
+			{
+				ResourceName:            "aws_api_gateway_domain_name.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate_body", "certificate_chain", "certificate_private_key"},
+			},
 		},
 	})
 }

--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -100,3 +100,11 @@ In addition to the arguments, the following attributes are exported:
   that can be used to create a Route53 alias record for the distribution.
 * `regional_domain_name` - The hostname for the custom domain's regional endpoint.
 * `regional_zone_id` - The hosted zone ID that can be used to create a Route53 alias record for the regional endpoint.
+
+## Import
+
+API Gateway domain names can be imported using their `name`, e.g.
+
+```
+$ terraform import aws_api_gateway_domain_name.example dev.example.com
+```


### PR DESCRIPTION
Fixes part of  #558

Changes proposed in this pull request:

* Support import of the `aws_api_gateway_domain_name` resource via `name`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayDomainName_CertificateName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayDomainName_CertificateName -timeout 120m
=== RUN   TestAccAWSAPIGatewayDomainName_CertificateName
--- PASS: TestAccAWSAPIGatewayDomainName_CertificateName (65.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	(cached)
```
