### PR TITLE
Provide example of getting multiple KMS secrets

### DIFF
--- a/website/docs/d/kms_secrets.html.markdown
+++ b/website/docs/d/kms_secrets.html.markdown
@@ -29,6 +29,7 @@ That encrypted output can now be inserted into Terraform configurations without 
 ```hcl
 data "aws_kms_secrets" "example" {
   secret {
+    # ... potentially other configuration ...
     name    = "master_password"
     payload = "AQECAHgaPa0J8WadplGCqqVAr4HNvDaFSQ+NaiwIBhmm6qDSFwAAAGIwYAYJKoZIhvcNAQcGoFMwUQIBADBMBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDI+LoLdvYv8l41OhAAIBEIAfx49FFJCLeYrkfMfAw6XlnxP23MmDBdqP8dPp28OoAQ=="
 
@@ -36,11 +37,20 @@ data "aws_kms_secrets" "example" {
       foo = "bar"
     }
   }
+
+  secret {
+    # ... potentially other configuration ...
+    name    = "master_username"
+    payload = "AQECAHgaPa0J8WadplGCqqVAr4HNvDaFSQ+NaiwIBhmm6qDSFwAAAGIwYAYJKoZI
+               hvcNAQcGoFMwUQIBADBMBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDI+LoLdvYv8l41OhAAIBEIAf
+               x49FFJCLeYrkfMfAw6XlnxP23MmDBdqP8dPp28OoAQ=="
+  }
 }
 
 resource "aws_rds_cluster" "example" {
   # ... other configuration ...
   master_password = "${data.aws_kms_secrets.example.plaintext["master_password"]}"
+  master_username = "${data.aws_kms_secrets.example.plaintext["master_username"]}"
 }
 ```
 

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -102,13 +102,13 @@ As an example, lets take the below sample configuration and migrate it.
 
 data "aws_kms_secret" "example" {
   secret {
-    # ... potentially other configration ...
+    # ... potentially other configuration ...
     name    = "master_password"
     payload = "AQEC..."
   }
 
   secret {
-    # ... potentially other configration ...
+    # ... potentially other configuration ...
     name    = "master_username"
     payload = "AQEC..."
   }
@@ -128,13 +128,13 @@ Updating the sample configuration from above:
 ```hcl
 data "aws_kms_secrets" "example" {
   secret {
-    # ... potentially other configration ...
+    # ... potentially other configuration ...
     name    = "master_password"
     payload = "AQEC..."
   }
 
   secret {
-    # ... potentially other configration ...
+    # ... potentially other configuration ...
     name    = "master_username"
     payload = "AQEC..."
   }


### PR DESCRIPTION
This example was already given in the version-2-upgrade guide.

Noticed after seeing [this StackOverflow question](https://stackoverflow.com/q/51543968/2291321) having previously read the upgrade guide docs and was surprised that the data source docs didn't include an example with multiple secrets.