### PR TITLE
Update acm_certificate_validation.html.markdown

### DIFF
--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -43,7 +43,7 @@ resource "aws_route53_record" "cert_validation" {
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  validation_record_fqdns = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"]
 }
 
 resource "aws_lb_listener" "front_end" {


### PR DESCRIPTION
Replacing `aws_route53_record.cert_validation.fqdn` with `resource_record_name` as fqdn errors our with `FATAL problem: DomainLabelEmpty (Domain label is empty). `

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
