### PR TITLE
New Resource aws_gamelift_queue

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -427,6 +427,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_gamelift_alias":                               resourceAwsGameliftAlias(),
 			"aws_gamelift_build":                               resourceAwsGameliftBuild(),
 			"aws_gamelift_fleet":                               resourceAwsGameliftFleet(),
+			"aws_gamelift_queue":                               resourceAwsGameliftQueue(),
 			"aws_glacier_vault":                                resourceAwsGlacierVault(),
 			"aws_glue_catalog_database":                        resourceAwsGlueCatalogDatabase(),
 			"aws_glue_catalog_table":                           resourceAwsGlueCatalogTable(),

--- a/aws/resource_aws_gamelift_queue.go
+++ b/aws/resource_aws_gamelift_queue.go
@@ -1,0 +1,200 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"log"
+)
+
+func resourceAwsGameliftQueue() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGameliftQueuesCreate,
+		Read:   resourceAwsGameliftQueuesRead,
+		Update: resourceAwsGameliftQueuesUpdate,
+		Delete: resourceAwsGameliftQueuesDelete,
+
+		Schema: map[string]*schema.Schema{
+			"destinations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 1024),
+			},
+			"player_latency_policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"maximum_individual_player_latency_milliseconds": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+						"policy_duration_seconds": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+					},
+				},
+			},
+			"timeout_in_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsGameliftQueuesCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	input := getFullInputCreate(d)
+	if v, ok := d.GetOk("name"); ok {
+		input.Name = aws.String(v.(string))
+	}
+	log.Printf("[INFO] Creating Gamelift Session Queue: %s", input)
+	out, err := conn.CreateGameSessionQueue(&input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*out.GameSessionQueue.GameSessionQueueArn)
+	d.Set("name", out.GameSessionQueue.Name)
+
+	return resourceAwsGameliftQueuesRead(d, meta)
+}
+
+func resourceAwsGameliftQueuesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+	log.Printf("[INFO] Describing Gamelift Session Queues: %s", d.Get("name"))
+	limit := int64(1)
+	out, err := conn.DescribeGameSessionQueues(&gamelift.DescribeGameSessionQueuesInput{
+		Names: aws.StringSlice([]string{d.Get("name").(string)}),
+		Limit: &limit,
+	})
+	if err != nil {
+		if isAWSErr(err, gamelift.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Gamelift Session Queues (%s) not found, removing from state", d.Get("name"))
+			return nil
+		}
+		return err
+	}
+	sessionQueues := out.GameSessionQueues
+
+	if len(sessionQueues) < 1 {
+		log.Printf("[WARN] Gamelift Session Queue (%s) not found, removing from state", d.Get("name"))
+		return nil
+	}
+	if len(sessionQueues) != 1 {
+		return fmt.Errorf("expected exactly 1 Gamelift Session Queues, found %d under %q",
+			len(sessionQueues), d.Get("name"))
+	}
+	sessionQueue := sessionQueues[0]
+
+	d.Set("destinations", sessionQueue.Destinations)
+	d.Set("name", sessionQueue.Name)
+	d.Set("player_latency_policies", sessionQueue.PlayerLatencyPolicies)
+	d.Set("timeout_in_seconds", sessionQueue.TimeoutInSeconds)
+
+	return nil
+}
+
+func resourceAwsGameliftQueuesUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+
+	name := d.Get("name").(string)
+
+	log.Printf("[INFO] Updating Gamelift Build: %s", name)
+
+	if d.HasChange("name") || d.HasChange("destinations") ||
+		d.HasChange("player_latency_policies") || d.HasChange("timeout_in_seconds") {
+
+		input := getFullInputUpdate(d)
+
+		_, err := conn.UpdateGameSessionQueue(&input)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceAwsGameliftQueuesRead(d, meta)
+}
+
+func resourceAwsGameliftQueuesDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).gameliftconn
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Deleting Gamelift Session Queue: %s", name)
+	_, err := conn.DeleteGameSessionQueue(&gamelift.DeleteGameSessionQueueInput{
+		Name: aws.String(name),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+
+}
+
+func getFullInputCreate(d *schema.ResourceData) gamelift.CreateGameSessionQueueInput {
+	return gamelift.CreateGameSessionQueueInput{
+		Name:                  aws.String(d.Get("name").(string)),
+		Destinations:          getDestinations(d.Get("destinations").([]interface{})),
+		PlayerLatencyPolicies: getPlayerLatencyPolicies(d.Get("player_latency_policies").([]interface{})),
+		TimeoutInSeconds:      aws.Int64(int64(d.Get("timeout_in_seconds").(int))),
+	}
+}
+
+func getFullInputUpdate(d *schema.ResourceData) gamelift.UpdateGameSessionQueueInput {
+	return gamelift.UpdateGameSessionQueueInput{
+		Name:                  aws.String(d.Get("name").(string)),
+		Destinations:          getDestinations(d.Get("destinations").([]interface{})),
+		PlayerLatencyPolicies: getPlayerLatencyPolicies(d.Get("player_latency_policies").([]interface{})),
+		TimeoutInSeconds:      aws.Int64(int64(d.Get("timeout_in_seconds").(int))),
+	}
+}
+
+func getDestinations(destinationsMap []interface{}) []*gamelift.GameSessionQueueDestination {
+	if len(destinationsMap) < 1 {
+		return nil
+	}
+	var destinations []*gamelift.GameSessionQueueDestination
+	for _, destination := range destinationsMap {
+		destinations = append(
+			destinations,
+			&gamelift.GameSessionQueueDestination{
+				DestinationArn: aws.String(destination.(string)),
+			})
+	}
+	return destinations
+}
+
+func getPlayerLatencyPolicies(destinationsPlayerLatencyPolicyMap []interface{}) []*gamelift.PlayerLatencyPolicy {
+	if len(destinationsPlayerLatencyPolicyMap) < 1 {
+		return nil
+	}
+	var playerLatencyPolicies []*gamelift.PlayerLatencyPolicy
+	for _, playerLatencyPolicy := range destinationsPlayerLatencyPolicyMap {
+		item := playerLatencyPolicy.(map[string]interface{})
+		playerLatencyPolicies = append(
+			playerLatencyPolicies,
+			&gamelift.PlayerLatencyPolicy{
+				MaximumIndividualPlayerLatencyMilliseconds: aws.Int64(int64(item["maximum_individual_player_latency_milliseconds"].(int))),
+				PolicyDurationSeconds:                      aws.Int64(int64(item["policy_duration_seconds"].(int))),
+			})
+	}
+	return playerLatencyPolicies
+}

--- a/aws/resource_aws_gamelift_queue_test.go
+++ b/aws/resource_aws_gamelift_queue_test.go
@@ -1,0 +1,264 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"log"
+	"strings"
+)
+
+const testAccGameliftQueuePrefix = "tfAccQueue-"
+
+func init() {
+	resource.AddTestSweepers("aws_gamelift_queue", &resource.Sweeper{
+		Name: "aws_gamelift_queue",
+		F:    testSweepGameliftQueue,
+	})
+}
+
+func testSweepGameliftQueue(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).gameliftconn
+
+	out, err := conn.DescribeGameSessionQueues(&gamelift.DescribeGameSessionQueuesInput{})
+
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Gamelife Queue sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("error listing Gamelift Session Queue: %s", err)
+
+	}
+
+	if len(out.GameSessionQueues) == 0 {
+		log.Print("[DEBUG] No Gamelift Session Queue to sweep")
+		return nil
+	}
+
+	log.Printf("[INFO] Found %d Gamelift Session Queue", len(out.GameSessionQueues))
+
+	for _, queue := range out.GameSessionQueues {
+		if !strings.HasPrefix(*queue.Name, testAccGameliftQueuePrefix) {
+			continue
+		}
+
+		log.Printf("[INFO] Deleting Gamelift Session Queue %q", *queue.Name)
+		_, err := conn.DeleteGameSessionQueue(&gamelift.DeleteGameSessionQueueInput{
+			Name: aws.String(*queue.Name),
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting Gamelift Session Queue (%s): %s",
+				*queue.Name, err)
+		}
+	}
+
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Gamelift Session Queue sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("error listing Gamelift Session Queue: %s", err)
+	}
+
+	return nil
+
+}
+
+func TestAccAWSGameliftQueue_basic(t *testing.T) {
+	var conf gamelift.GameSessionQueue
+
+	rString := acctest.RandString(8)
+	queueName := getComposedQueueName(rString)
+	destinations := gamelift.GameSessionQueueDestination{
+		DestinationArn: aws.String(acctest.RandString(8)),
+	}
+	playerLatencyPolicies := gamelift.PlayerLatencyPolicy{
+		MaximumIndividualPlayerLatencyMilliseconds: aws.Int64(20),
+		PolicyDurationSeconds:                      aws.Int64(30),
+	}
+	timeoutInSeconds := int64(124)
+
+	//uQueueName := getComposedQueueName(fmt.Sprintf("else-%s", rString))
+	uDestinations := gamelift.GameSessionQueueDestination{
+		DestinationArn: aws.String(acctest.RandString(8)),
+	}
+	uPlayerLatencyPolicies := gamelift.PlayerLatencyPolicy{
+		MaximumIndividualPlayerLatencyMilliseconds: aws.Int64(30),
+		PolicyDurationSeconds:                      aws.Int64(40),
+	}
+	uTimeoutInSeconds := int64(600)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGameliftQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGameliftQueueBasicConfig(queueName, destinations,
+					playerLatencyPolicies, timeoutInSeconds),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftQueueExists("aws_gamelift_queue.test", &conf),
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test", "name", queueName),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"destinations.#",
+						"1"),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"destinations.0",
+						fmt.Sprintf("%s", *destinations.DestinationArn)),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"player_latency_policies.#", "1"),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"player_latency_policies.0.maximum_individual_player_latency_milliseconds",
+						fmt.Sprintf("%d", *playerLatencyPolicies.MaximumIndividualPlayerLatencyMilliseconds)),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"player_latency_policies.0.policy_duration_seconds",
+						fmt.Sprintf("%d", *playerLatencyPolicies.PolicyDurationSeconds)),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"timeout_in_seconds", fmt.Sprintf("%d", timeoutInSeconds)),
+				),
+			},
+			{
+				Config: testAccAWSGameliftQueueBasicConfig(queueName, uDestinations,
+					uPlayerLatencyPolicies, uTimeoutInSeconds),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGameliftQueueExists("aws_gamelift_queue.test", &conf),
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test", "name", queueName),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"destinations.#", "1"),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"destinations.0",
+						fmt.Sprintf("%s", *uDestinations.DestinationArn)),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"player_latency_policies.#", "1"),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"player_latency_policies.0.maximum_individual_player_latency_milliseconds",
+						fmt.Sprintf("%d", *uPlayerLatencyPolicies.MaximumIndividualPlayerLatencyMilliseconds)),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"player_latency_policies.0.policy_duration_seconds",
+						fmt.Sprintf("%d", *uPlayerLatencyPolicies.PolicyDurationSeconds)),
+
+					resource.TestCheckResourceAttr("aws_gamelift_queue.test",
+						"timeout_in_seconds", fmt.Sprintf("%d", uTimeoutInSeconds)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGameliftQueueExists(n string, res *gamelift.GameSessionQueue) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no Gamelift Session Queue Name is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+		name := rs.Primary.Attributes["name"]
+		limit := int64(1)
+		out, err := conn.DescribeGameSessionQueues(&gamelift.DescribeGameSessionQueuesInput{
+			Names: aws.StringSlice([]string{name}),
+			Limit: &limit,
+		})
+		if err != nil {
+			return err
+		}
+		attributes := out.GameSessionQueues
+		if len(attributes) < 1 {
+			return fmt.Errorf("gmelift Session Queue %q not found", name)
+		}
+		if len(attributes) != 1 {
+			return fmt.Errorf("expected exactly 1 Gamelift Session Queue, found %d under %q",
+				len(attributes), name)
+		}
+		queue := attributes[0]
+
+		if *queue.Name != name {
+			return fmt.Errorf("gamelift Session Queue not found")
+		}
+
+		*res = *queue
+
+		return nil
+	}
+}
+
+func testAccCheckAWSGameliftQueueDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_gamelift_queue" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		limit := int64(1)
+		out, err := conn.DescribeGameSessionQueues(&gamelift.DescribeGameSessionQueuesInput{
+			Names: aws.StringSlice([]string{name}),
+			Limit: &limit,
+		})
+		if err != nil {
+			return err
+		}
+
+		attributes := out.GameSessionQueues
+
+		if len(attributes) > 0 {
+			return fmt.Errorf("gamelift Session Queue still exists")
+		}
+
+		return nil
+	}
+
+	return nil
+
+}
+
+func testAccAWSGameliftQueueBasicConfig(queueName string, destinations gamelift.GameSessionQueueDestination,
+	playerLatencyPolicies gamelift.PlayerLatencyPolicy, timeoutInSeconds int64) string {
+	return fmt.Sprintf(`
+resource "aws_gamelift_queue" "test" {
+  name = "%s"
+  destinations = ["%s"]
+  player_latency_policies {
+	maximum_individual_player_latency_milliseconds = %d
+	policy_duration_seconds = %d
+  }
+  timeout_in_seconds = %d
+}
+`,
+		queueName,
+		*destinations.DestinationArn,
+		*playerLatencyPolicies.MaximumIndividualPlayerLatencyMilliseconds,
+		*playerLatencyPolicies.PolicyDurationSeconds,
+		timeoutInSeconds)
+}
+
+func getComposedQueueName(name string) string {
+	return fmt.Sprintf("%s%s", testAccGameliftQueuePrefix, name)
+}


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-aws/issues/2546

Changes proposed in this pull request:

* New Resource `aws_gamelift_queue` with `aws_gamelift_queue_test`

```bash
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGameliftQueue_basic'
```

Output from acceptance testing:
```bash
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSGameliftQueue_basic -timeout 120m
=== RUN   TestAccAWSGameliftQueue_basic
--- PASS: TestAccAWSGameliftQueue_basic (46.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.804s
```
