### PR TITLE
docs/resource/aws_cloudfront_distribution: Clarify lambda_function_association configuration placement

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -281,13 +281,30 @@ of several sub-resources - these resources are laid out below.
 Lambda@Edge allows you to associate an AWS Lambda Function with a predefined
 event. You can associate a single function per event type. See [What is
 Lambda@Edge](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/what-is-lambda-at-edge.html)
-for more information
+for more information.
 
-  * `event_type` (Required) - The specific event to trigger this function.
+Example configuration:
+
+```hcl
+resource "aws_cloudfront_distribution" "example" {
+  # ... other configuration ...
+
+  # lambda_function_association is also supported by default_cache_behavior
+  ordered_cache_behavior {
+    # ... other configuration ...
+
+    lambda_function_association {
+      event_type = "viewer-request"
+      lambda_arn = "${aws_lambda_function.example.qualified_arn}"
+    }
+  }
+}
+```
+
+* `event_type` (Required) - The specific event to trigger this function.
   Valid values: `viewer-request`, `origin-request`, `viewer-response`,
   `origin-response`
-
-  * `lambda_arn` (Required) - ARN of the Lambda function.
+* `lambda_arn` (Required) - ARN of the Lambda function.
 
 ##### Cookies Arguments
 


### PR DESCRIPTION
Especially in resources like `aws_cloudfront_distribution` and `aws_kinesis_firehose_delivery_stream`, there are a lot of deeply nested arguments which can be confusing. We might want to consider doing this for the rest of them.

Closes #1720 

Changes proposed in this pull request:

* Add quick example configuration under `lambda_function_association` to help clarify placement

Output from acceptance testing: N/A
