### PR TITLE
resource/aws_iam_role: Ensure resource recreates when deleted outside Terraform

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -187,12 +187,18 @@ func resourceAwsIamRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	getResp, err := iamconn.GetRole(request)
 	if err != nil {
-		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") { // XXX test me
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 			log.Printf("[WARN] IAM Role %q not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("Error reading IAM Role %s: %s", d.Id(), err)
+	}
+
+	if getResp == nil || getResp.Role == nil {
+		log.Printf("[WARN] IAM Role %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	role := getResp.Role


### PR DESCRIPTION
Changes proposed in this pull request:

* Appropriately tests the line that has `XXX test me` from the resource so we can remove it 😉 
* Also prevent potential panics in case the API not returning the actual response or nested response object

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMRole_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIAMRole_ -timeout 120m
=== RUN   TestAccAWSIAMRole_importBasic
--- PASS: TestAccAWSIAMRole_importBasic (11.45s)
=== RUN   TestAccAWSIAMRole_basic
--- PASS: TestAccAWSIAMRole_basic (9.13s)
=== RUN   TestAccAWSIAMRole_basicWithDescription
--- PASS: TestAccAWSIAMRole_basicWithDescription (24.04s)
=== RUN   TestAccAWSIAMRole_namePrefix
--- PASS: TestAccAWSIAMRole_namePrefix (10.40s)
=== RUN   TestAccAWSIAMRole_testNameChange
--- PASS: TestAccAWSIAMRole_testNameChange (20.12s)
=== RUN   TestAccAWSIAMRole_badJSON
--- PASS: TestAccAWSIAMRole_badJSON (1.44s)
=== RUN   TestAccAWSIAMRole_disappears
--- PASS: TestAccAWSIAMRole_disappears (7.60s)
=== RUN   TestAccAWSIAMRole_force_detach_policies
--- PASS: TestAccAWSIAMRole_force_detach_policies (11.82s)
=== RUN   TestAccAWSIAMRole_MaxSessionDuration
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (18.99s)
=== RUN   TestAccAWSIAMRole_PermissionsBoundary
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (32.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	147.937s
```
