### PR TITLE
`sse_kms` is expecting `key_id` and not `kms_id` according to the resource definition 

### DIFF
--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -118,7 +118,7 @@ The `encryption` configuration supports the following:
 
 The `sse_kms` configuration supports the following:
 
-* `kms_id` - (Required) The ARN of the KMS customer master key (CMK) used to encrypt the inventory file.
+* `key_id` - (Required) The ARN of the KMS customer master key (CMK) used to encrypt the inventory file.
 
 ## Import
 


### PR DESCRIPTION
As seen here, https://github.com/terraform-providers/terraform-provider-aws/pull/5019/files
`sse_kms` is expecting 'key_id' and not 'kms_id'