### PR TITLE
fix: added check to remove quotes from payload

### DIFF
--- a/aws/data_source_aws_lambda_invocation.go
+++ b/aws/data_source_aws_lambda_invocation.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -81,7 +82,13 @@ func dataSourceAwsLambdaInvocationRead(d *schema.ResourceData, meta interface{})
 	var result map[string]interface{}
 
 	if err = json.Unmarshal(res.Payload, &result); err != nil {
-		return err
+		unquotedPayload, err := strconv.Unquote(string(res.Payload))
+		if err != nil {
+			return err
+		}
+		if err = json.Unmarshal([]byte(unquotedPayload), &result); err != nil {
+			return err
+		}
 	}
 
 	if err = d.Set("result_map", result); err != nil {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5403 #4808 

Changes proposed in this pull request:

* Add check where if unmarshaling fails it attempts to unquote the payload and unmarshal again.  If that fails it then returns the error.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsLambdaInvocation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceAwsLambdaInvocation_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAwsLambdaInvocation_basic
--- PASS: TestAccDataSourceAwsLambdaInvocation_basic (45.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       45.205s

$ make testacc TESTARGS='-run=TestAccDataSourceAwsLambdaInvocation_complex'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceAwsLambdaInvocation_complex -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAwsLambdaInvocation_complex
--- PASS: TestAccDataSourceAwsLambdaInvocation_complex (43.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       43.651s
...
```
