### PR TITLE
issue #5412 AWS SSM DoesNotExistException for missing Maintenance Window

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -102,6 +102,11 @@ func resourceAwsSsmMaintenanceWindowUpdate(d *schema.ResourceData, meta interfac
 
 	_, err := ssmconn.UpdateMaintenanceWindow(params)
 	if err != nil {
+		if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
+			log.Printf("[WARN] Maintenance Window %s not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 
@@ -117,6 +122,11 @@ func resourceAwsSsmMaintenanceWindowRead(d *schema.ResourceData, meta interface{
 
 	resp, err := ssmconn.GetMaintenanceWindow(params)
 	if err != nil {
+		if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
+			log.Printf("[WARN] Maintenance Window %s not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes #5412 
Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSSMMaintenanceWindow_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSSSMMaintenanceWindow_basic -timeout 120m
=== RUN   TestAccAWSSSMMaintenanceWindow_basic
--- PASS: TestAccAWSSSMMaintenanceWindow_basic (69.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.112s
...
```
