### PR TITLE
Fixing aws_dax_cluster example usage.

### DIFF
--- a/website/docs/r/dax_cluster.html.markdown
+++ b/website/docs/r/dax_cluster.html.markdown
@@ -14,7 +14,7 @@ Provides a DAX Cluster resource.
 
 ```hcl
 resource "aws_dax_cluster" "bar" {
-  cluster_id         = "cluster-example"
+  cluster_name       = "cluster-example"
   iam_role_arn       = "${data.aws_iam_role.example.arn}"
   node_type          = "dax.r3.large"
   replication_factor = 1


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix aws_dax_cluster example usage as it shows using `cluster_id` (which does not exist) instead of `cluster_name`
