### PR TITLE
Note the lowest r53 record ttl is 1 in terraform

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 * `zone_id` - (Required) The ID of the hosted zone to contain this record.
 * `name` - (Required) The name of the record.
 * `type` - (Required) The record type. Valid values are `A`, `AAAA`, `CAA`, `CNAME`, `MX`, `NAPTR`, `NS`, `PTR`, `SOA`, `SPF`, `SRV` and `TXT`.
-* `ttl` - (Required for non-alias records) The TTL of the record.
+* `ttl` - (Required for non-alias records) The TTL of the record. Terraform considers `0` as `false`, therefore the lowest TTL is `1`.
 * `records` - (Required for non-alias records) A string list of records. To specify a single record value longer than 255 characters such as a TXT record for DKIM, add `\"\"` inside the Terraform configuration string (e.g. `"first255characters\"\"morecharacters"`).
 * `set_identifier` - (Optional) Unique identifier to differentiate records with routing policies from one another. Required if using `failover`, `geolocation`, `latency`, or `weighted` routing policies documented below.
 * `health_check_id` - (Optional) The health check the record should be associated with.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #332

Changes proposed in this pull request:

* Note in the doc the lowest possible ttl is 1.

Output from acceptance testing:
N/A

```
