### PR TITLE
#PR 5191 fix the documentation issue in emr_cluster

### DIFF
--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -196,6 +196,7 @@ flow. Defined below
 	the cluster nodes. Defined below
 * `configurations` - (Optional) List of configurations supplied for the EMR cluster you are creating
 * `configurations_json` - (Optional) A JSON string for supplying list of configurations for the EMR cluster.
+
 ~> **NOTE on configurations_json:** If the `Configurations` value is empty then you should skip
 the `Configurations` field instead of providing empty list as value `"Configurations": []`.
 


### PR DESCRIPTION
@bflad Note added for `configurations_json` looks messed up.
https://www.terraform.io/docs/providers/aws/r/emr_cluster.html#configurations_json

I believe its due to missing line before note, I added that.