### PR TITLE
Add support for 'redirect' and 'fixed-response' into lb_listener and lb_listener_rule

### DIFF
--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -54,13 +54,77 @@ func dataSourceAwsLbListener() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"target_group_arn": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"type": {
-							Type:     schema.TypeString,
+
+						"redirect": {
+							Type:     schema.TypeList,
 							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"host": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"port": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"query": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"status_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"fixed_response": {
+							Type:     schema.TypeList,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"content_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"message_body": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"status_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
 						},
 					},
 				},

--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -54,77 +54,13 @@ func dataSourceAwsLbListener() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
 						"target_group_arn": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-
-						"redirect": {
-							Type:     schema.TypeList,
+						"type": {
+							Type:     schema.TypeString,
 							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"host": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-
-									"path": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-
-									"port": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-
-									"protocol": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-
-									"query": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-
-									"status_code": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
-						},
-
-						"fixed_response": {
-							Type:     schema.TypeList,
-							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"content_type": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-
-									"message_body": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-
-									"status_code": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
 						},
 					},
 				},

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -81,51 +81,84 @@ func resourceAwsLbListener() *schema.Resource {
 								elbv2.ActionTypeEnumRedirect,
 							}, true),
 						},
-						"target_group_arn": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"forward"}),
+						"forward": {
+							Type: schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target_group_arn": {
+										Type:             schema.TypeString,
+										Required:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("forward"),
+									},
+								},
+							},
 						},
-						"status_code": {
-							Type:             schema.TypeInt,
-							Optional:         true,
-							Computed:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"fixed-response", "redirect"}),
+						"redirect": {
+							Type: schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"status_code": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+									},
+									"host": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+									},
+									"query": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+									},
+									"path": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+									},
+									"port": {
+										Type:             schema.TypeInt,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+									},
+								},
+							},
 						},
-						"host": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
-						},
-						"query": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
-						},
-						"path": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
-						},
-						"port": {
-							Type:             schema.TypeInt,
-							Optional:         true,
-							Computed:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
-						},
-						"content_type": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"fixed-response"}),
-						},
-						"message_body": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"fixed-response"}),
+						"fixed_response": {
+							Type: schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"status_code": {
+										Type:             schema.TypeInt,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("fixed-response"),
+									},
+									"content_type": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("fixed-response"),
+									},
+									"message_body": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										DiffSuppressFunc: suppressIfDefaultActionTypeNot("fixed-response"),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -134,14 +167,9 @@ func resourceAwsLbListener() *schema.Resource {
 	}
 }
 
-func suppressIfDefaultActionTypeNotInSlice(valid []string) schema.SchemaDiffSuppressFunc {
+func suppressIfDefaultActionTypeNot(t string) schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
-		for _, t := range valid {
-			if d.Get("default_action.type").(string) == t {
-				return true
-			}
-		}
-		return false
+		return d.Get("default_action.type").(string) != t
 	}
 }
 

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -72,21 +72,76 @@ func resourceAwsLbListener() *schema.Resource {
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"target_group_arn": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
+								elbv2.ActionTypeEnumFixedResponse,
 								elbv2.ActionTypeEnumForward,
+								elbv2.ActionTypeEnumRedirect,
 							}, true),
+						},
+						"target_group_arn": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"forward"}),
+						},
+						"status_code": {
+							Type:             schema.TypeInt,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"fixed-response", "redirect"}),
+						},
+						"host": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
+						},
+						"query": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
+						},
+						"path": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
+						},
+						"port": {
+							Type:             schema.TypeInt,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"redirect"}),
+						},
+						"content_type": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"fixed-response"}),
+						},
+						"message_body": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNotInSlice([]string{"fixed-response"}),
 						},
 					},
 				},
 			},
 		},
+	}
+}
+
+func suppressIfDefaultActionTypeNotInSlice(valid []string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		for _, t := range valid {
+			if d.Get("default_action.type").(string) == t {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -189,7 +189,6 @@ func suppressIfDefaultActionTypeNot(t string) schema.SchemaDiffSuppressFunc {
 			return false
 		})
 		at := k[:i+1] + "type"
-		log.Printf("[DEBUG] at %s %s", k, at)
 		return d.Get(at).(string) != t
 	}
 }

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -153,8 +153,14 @@ func resourceAwsLbListener() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"content_type": {
 										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"text/plain",
+											"text/css",
+											"text/html",
+											"application/javascript",
+											"application/json",
+										}, false),
 									},
 
 									"message_body": {

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"regexp"
 )
 
 func resourceAwsLbListener() *schema.Resource {
@@ -250,7 +250,7 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 						StatusCode: aws.String(redirectMap["status_code"].(string)),
 					}
 				} else {
-					return errors.New("for actions of type 'redirect', you must specify a 'redirect_config'")
+					return errors.New("for actions of type 'redirect', you must specify a 'redirect' block")
 				}
 
 			case "fixed-response":
@@ -265,7 +265,7 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 						StatusCode:  aws.String(fixedResponseMap["status_code"].(string)),
 					}
 				} else {
-					return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response'")
+					return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response' block")
 				}
 			}
 
@@ -420,7 +420,7 @@ func resourceAwsLbListenerUpdate(d *schema.ResourceData, meta interface{}) error
 						StatusCode: aws.String(redirectMap["status_code"].(string)),
 					}
 				} else {
-					return errors.New("for actions of type 'redirect', you must specify a 'redirect_config'")
+					return errors.New("for actions of type 'redirect', you must specify a 'redirect' block")
 				}
 
 			case "fixed-response":
@@ -435,7 +435,7 @@ func resourceAwsLbListenerUpdate(d *schema.ResourceData, meta interface{}) error
 						StatusCode:  aws.String(fixedResponseMap["status_code"].(string)),
 					}
 				} else {
-					return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response'")
+					return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response' block")
 				}
 			}
 

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -100,25 +100,25 @@ func resourceAwsLbListener() *schema.Resource {
 									"host": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{host}",
+										Default:  "#{host}",
 									},
 
 									"path": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "/#{path}",
+										Default:  "/#{path}",
 									},
 
 									"port": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{port}",
+										Default:  "#{port}",
 									},
 
 									"protocol": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{protocol}",
+										Default:  "#{protocol}",
 										ValidateFunc: validation.StringInSlice([]string{
 											"#{protocol}",
 											"HTTP",
@@ -129,7 +129,7 @@ func resourceAwsLbListener() *schema.Resource {
 									"query": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{query}",
+										Default:  "#{query}",
 									},
 
 									"status_code": {
@@ -163,9 +163,9 @@ func resourceAwsLbListener() *schema.Resource {
 									},
 
 									"status_code": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[245]\d\d$`), ""),
 									},
 								},

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -70,6 +70,7 @@ func resourceAwsLbListener() *schema.Resource {
 			"default_action": {
 				Type:     schema.TypeList,
 				Required: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -81,81 +82,70 @@ func resourceAwsLbListener() *schema.Resource {
 								elbv2.ActionTypeEnumRedirect,
 							}, true),
 						},
-						"forward": {
-							Type: schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"target_group_arn": {
-										Type:             schema.TypeString,
-										Required:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("forward"),
-									},
-								},
-							},
+
+						"target_group_arn": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNot("forward"),
 						},
+
 						"redirect": {
-							Type: schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+							MaxItems:         1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"status_code": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
-									},
 									"host": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
-									},
-									"query": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+										Type:     schema.TypeString,
+										Required: true,
 									},
 									"path": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+										Type:     schema.TypeString,
+										Required: true,
 									},
 									"port": {
-										Type:             schema.TypeInt,
-										Optional:         true,
-										Computed:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("redirect"),
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"query": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"status_code": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
 									},
 								},
 							},
 						},
+
 						"fixed_response": {
-							Type: schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressIfDefaultActionTypeNot("fixed-response"),
+							MaxItems:         1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"status_code": {
-										Type:             schema.TypeInt,
-										Optional:         true,
-										Computed:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("fixed-response"),
-									},
 									"content_type": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										Computed:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("fixed-response"),
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
 									},
 									"message_body": {
-										Type:             schema.TypeString,
-										Optional:         true,
-										DiffSuppressFunc: suppressIfDefaultActionTypeNot("fixed-response"),
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"status_code": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
 									},
 								},
 							},
@@ -169,7 +159,17 @@ func resourceAwsLbListener() *schema.Resource {
 
 func suppressIfDefaultActionTypeNot(t string) schema.SchemaDiffSuppressFunc {
 	return func(k, old, new string, d *schema.ResourceData) bool {
-		return d.Get("default_action.type").(string) != t
+		take := 2
+		i := strings.IndexFunc(k, func(r rune) bool {
+			if r == '.' {
+				take -= 1
+				return take == 0
+			}
+			return false
+		})
+		at := k[:i+1] + "type"
+		log.Printf("[DEBUG] at %s %s", k, at)
+		return d.Get(at).(string) != t
 	}
 }
 
@@ -201,10 +201,45 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 		for i, defaultAction := range defaultActions {
 			defaultActionMap := defaultAction.(map[string]interface{})
 
-			params.DefaultActions[i] = &elbv2.Action{
-				TargetGroupArn: aws.String(defaultActionMap["target_group_arn"].(string)),
-				Type:           aws.String(defaultActionMap["type"].(string)),
+			action := &elbv2.Action{
+				Type: aws.String(defaultActionMap["type"].(string)),
 			}
+
+			switch defaultActionMap["type"].(string) {
+			case "forward":
+				action.TargetGroupArn = aws.String(defaultActionMap["target_group_arn"].(string))
+
+			case "redirect":
+				redirectList := defaultActionMap["redirect"].([]interface{})
+
+				if len(redirectList) == 1 {
+					redirectMap := redirectList[0].(map[string]interface{})
+
+					action.RedirectConfig = &elbv2.RedirectActionConfig{
+						Host:       aws.String(redirectMap["host"].(string)),
+						Path:       aws.String(redirectMap["path"].(string)),
+						Port:       aws.String(redirectMap["port"].(string)),
+						Protocol:   aws.String(redirectMap["protocol"].(string)),
+						Query:      aws.String(redirectMap["query"].(string)),
+						StatusCode: aws.String(redirectMap["status_code"].(string)),
+					}
+				}
+
+			case "fixed-response":
+				fixedResponseList := defaultActionMap["fixed_response"].([]interface{})
+
+				if len(fixedResponseList) == 1 {
+					fixedResponseMap := fixedResponseList[0].(map[string]interface{})
+
+					action.FixedResponseConfig = &elbv2.FixedResponseActionConfig{
+						ContentType: aws.String(fixedResponseMap["content_type"].(string)),
+						MessageBody: aws.String(fixedResponseMap["message_body"].(string)),
+						StatusCode:  aws.String(fixedResponseMap["status_code"].(string)),
+					}
+				}
+			}
+
+			params.DefaultActions[i] = action
 		}
 	}
 
@@ -271,9 +306,35 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 	if listener.DefaultActions != nil && len(listener.DefaultActions) > 0 {
 		for _, defaultAction := range listener.DefaultActions {
 			action := map[string]interface{}{
-				"target_group_arn": aws.StringValue(defaultAction.TargetGroupArn),
-				"type":             aws.StringValue(defaultAction.Type),
+				"type": aws.StringValue(defaultAction.Type),
 			}
+
+			switch aws.StringValue(defaultAction.Type) {
+			case "forward":
+				action["target_group_arn"] = aws.StringValue(defaultAction.TargetGroupArn)
+
+			case "redirect":
+				action["redirect"] = []map[string]interface{}{
+					{
+						"host":        aws.StringValue(defaultAction.RedirectConfig.Host),
+						"path":        aws.StringValue(defaultAction.RedirectConfig.Path),
+						"port":        aws.StringValue(defaultAction.RedirectConfig.Port),
+						"protocol":    aws.StringValue(defaultAction.RedirectConfig.Protocol),
+						"query":       aws.StringValue(defaultAction.RedirectConfig.Query),
+						"status_code": aws.StringValue(defaultAction.RedirectConfig.StatusCode),
+					},
+				}
+
+			case "fixed-response":
+				action["fixed_response"] = []map[string]interface{}{
+					{
+						"content_type": aws.StringValue(defaultAction.FixedResponseConfig.ContentType),
+						"message_body": aws.StringValue(defaultAction.FixedResponseConfig.MessageBody),
+						"status_code":  aws.StringValue(defaultAction.FixedResponseConfig.StatusCode),
+					},
+				}
+			}
+
 			defaultActions = append(defaultActions, action)
 		}
 	}
@@ -308,10 +369,45 @@ func resourceAwsLbListenerUpdate(d *schema.ResourceData, meta interface{}) error
 		for i, defaultAction := range defaultActions {
 			defaultActionMap := defaultAction.(map[string]interface{})
 
-			params.DefaultActions[i] = &elbv2.Action{
-				TargetGroupArn: aws.String(defaultActionMap["target_group_arn"].(string)),
-				Type:           aws.String(defaultActionMap["type"].(string)),
+			action := &elbv2.Action{
+				Type: aws.String(defaultActionMap["type"].(string)),
 			}
+
+			switch defaultActionMap["type"].(string) {
+			case "forward":
+				action.TargetGroupArn = aws.String(defaultActionMap["target_group_arn"].(string))
+
+			case "redirect":
+				redirectList := defaultActionMap["redirect"].([]interface{})
+
+				if len(redirectList) == 1 {
+					redirectMap := redirectList[0].(map[string]interface{})
+
+					action.RedirectConfig = &elbv2.RedirectActionConfig{
+						Host:       aws.String(redirectMap["host"].(string)),
+						Path:       aws.String(redirectMap["path"].(string)),
+						Port:       aws.String(redirectMap["port"].(string)),
+						Protocol:   aws.String(redirectMap["protocol"].(string)),
+						Query:      aws.String(redirectMap["query"].(string)),
+						StatusCode: aws.String(redirectMap["status_code"].(string)),
+					}
+				}
+
+			case "fixed-response":
+				fixedResponseList := defaultActionMap["fixed_response"].([]interface{})
+
+				if len(fixedResponseList) == 1 {
+					fixedResponseMap := fixedResponseList[0].(map[string]interface{})
+
+					action.FixedResponseConfig = &elbv2.FixedResponseActionConfig{
+						ContentType: aws.String(fixedResponseMap["content_type"].(string)),
+						MessageBody: aws.String(fixedResponseMap["message_body"].(string)),
+						StatusCode:  aws.String(fixedResponseMap["status_code"].(string)),
+					}
+				}
+			}
+
+			params.DefaultActions[i] = action
 		}
 	}
 

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -74,25 +74,25 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 									"host": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{host}",
+										Default:  "#{host}",
 									},
 
 									"path": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "/#{path}",
+										Default:  "/#{path}",
 									},
 
 									"port": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{port}",
+										Default:  "#{port}",
 									},
 
 									"protocol": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{protocol}",
+										Default:  "#{protocol}",
 										ValidateFunc: validation.StringInSlice([]string{
 											"#{protocol}",
 											"HTTP",
@@ -103,7 +103,7 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 									"query": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Default: "#{query}",
+										Default:  "#{query}",
 									},
 
 									"status_code": {
@@ -137,9 +137,9 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 									},
 
 									"status_code": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[245]\d\d$`), ""),
 									},
 								},

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -128,8 +128,14 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"content_type": {
 										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"text/plain",
+											"text/css",
+											"text/html",
+											"application/javascript",
+											"application/json",
+										}, false),
 									},
 
 									"message_body": {

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -14,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"strings"
 )
 
 func resourceAwsLbbListenerRule() *schema.Resource {
@@ -228,7 +228,7 @@ func resourceAwsLbListenerRuleCreate(d *schema.ResourceData, meta interface{}) e
 					StatusCode: aws.String(redirectMap["status_code"].(string)),
 				}
 			} else {
-				return errors.New("for actions of type 'redirect', you must specify a 'redirect_config'")
+				return errors.New("for actions of type 'redirect', you must specify a 'redirect' block")
 			}
 
 		case "fixed-response":
@@ -243,7 +243,7 @@ func resourceAwsLbListenerRuleCreate(d *schema.ResourceData, meta interface{}) e
 					StatusCode:  aws.String(fixedResponseMap["status_code"].(string)),
 				}
 			} else {
-				return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response'")
+				return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response' block")
 			}
 		}
 
@@ -447,7 +447,7 @@ func resourceAwsLbListenerRuleUpdate(d *schema.ResourceData, meta interface{}) e
 						StatusCode: aws.String(redirectMap["status_code"].(string)),
 					}
 				} else {
-					return errors.New("for actions of type 'redirect', you must specify a 'redirect_config'")
+					return errors.New("for actions of type 'redirect', you must specify a 'redirect' block")
 				}
 
 			case "fixed-response":
@@ -462,7 +462,7 @@ func resourceAwsLbListenerRuleUpdate(d *schema.ResourceData, meta interface{}) e
 						StatusCode:  aws.String(fixedResponseMap["status_code"].(string)),
 					}
 				} else {
-					return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response'")
+					return errors.New("for actions of type 'fixed-response', you must specify a 'fixed_response' block")
 				}
 			}
 

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -75,6 +75,8 @@ func TestAccAWSLBListenerRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.#", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "action.0.target_group_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.#", "0"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.fixed_response.#", "0"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.#", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.1366281676.field", "path-pattern"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.1366281676.values.#", "1"),
@@ -106,10 +108,85 @@ func TestAccAWSLBListenerRuleBackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "action.0.target_group_arn"),
+					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.redirect.#", "0"),
+					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.fixed_response.#", "0"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "condition.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "condition.1366281676.field", "path-pattern"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "condition.1366281676.values.#", "1"),
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "condition.1366281676.values.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBListenerRule_redirect(t *testing.T) {
+	var conf elbv2.Rule
+	lbName := fmt.Sprintf("testrule-redirect-%s", acctest.RandStringFromCharSet(14, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_listener_rule.static",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBListenerRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerRuleConfig_redirect(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerRuleExists("aws_lb_listener_rule.static", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "listener_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "priority", "100"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.type", "redirect"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.target_group_arn", ""),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.0.host", "#{host}"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.0.path", "/#{path}"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.0.port", "443"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.0.query", "#{query}"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.0.status_code", "HTTP_301"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.fixed_response.#", "0"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.1366281676.field", "path-pattern"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.1366281676.values.#", "1"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "condition.1366281676.values.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBListenerRule_fixedResponse(t *testing.T) {
+	var conf elbv2.Rule
+	lbName := fmt.Sprintf("testrule-fixedresponse-%s", acctest.RandStringFromCharSet(9, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_listener_rule.static",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBListenerRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerRuleConfig_fixedResponse(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerRuleExists("aws_lb_listener_rule.static", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "listener_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "priority", "100"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.type", "fixed-response"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.target_group_arn", ""),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.#", "0"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.fixed_response.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.fixed_response.0.content_type", "text/plain"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.fixed_response.0.message_body", "Fixed response content"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.fixed_response.0.status_code", "200"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.1366281676.field", "path-pattern"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "condition.1366281676.values.#", "1"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "condition.1366281676.values.0"),
 				),
 			},
 		},
@@ -666,6 +743,208 @@ resource "aws_security_group" "alb_test" {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
+}
+
+func testAccAWSLBListenerRuleConfig_redirect(lbName string) string {
+	return fmt.Sprintf(`resource "aws_lb_listener_rule" "static" {
+  listener_arn = "${aws_lb_listener.front_end.arn}"
+  priority = 100
+
+  action {
+    type = "redirect"
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/static/*"]
+  }
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.alb_test.id}"
+  protocol = "HTTP"
+  port = "80"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    Name = "TestAccAWSALB_redirect"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-lb-listener-rule-redirect"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    Name = "tf-acc-lb-listener-rule-redirect-${count.index}"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "TestAccAWSALB_redirect"
+  }
+}`, lbName)
+}
+
+func testAccAWSLBListenerRuleConfig_fixedResponse(lbName string) string {
+	return fmt.Sprintf(`resource "aws_lb_listener_rule" "static" {
+  listener_arn = "${aws_lb_listener.front_end.arn}"
+  priority = 100
+
+  action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Fixed response content"
+      status_code = "200"
+    }
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/static/*"]
+  }
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.alb_test.id}"
+  protocol = "HTTP"
+  port = "80"
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Fixed response content"
+      status_code = "200"
+    }
+  }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    Name = "TestAccAWSALB_fixedResponse"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-lb-listener-rule-fixedresponse"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    Name = "tf-acc-lb-listener-rule-fixedresponse-${count.index}"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "TestAccAWSALB_fixedresponse"
+  }
+}`, lbName)
 }
 
 func testAccAWSLBListenerRuleConfig_updateRulePriority(lbName, targetGroupName string) string {

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -34,6 +34,8 @@ func TestAccAWSLBListener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "0"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.fixed_response.#", "0"),
 				),
 			},
 		},
@@ -62,6 +64,8 @@ func TestAccAWSLBListenerBackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.redirect.#", "0"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.fixed_response.#", "0"),
 				),
 			},
 		},
@@ -90,8 +94,77 @@ func TestAccAWSLBListener_https(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "0"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.fixed_response.#", "0"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "certificate_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "ssl_policy", "ELBSecurityPolicy-2015-05"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBListener_redirect(t *testing.T) {
+	var conf elbv2.Listener
+	lbName := fmt.Sprintf("testlistener-redirect-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_listener.front_end",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerConfig_redirect(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerExists("aws_lb_listener.front_end", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "protocol", "HTTP"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "port", "80"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "redirect"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.target_group_arn", ""),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.0.host", "#{host}"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.0.path", "/#{path}"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.0.port", "443"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.0.query", "#{query}"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.0.status_code", "HTTP_301"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.fixed_response.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBListener_fixedResponse(t *testing.T) {
+	var conf elbv2.Listener
+	lbName := fmt.Sprintf("testlistener-fixedresponse-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_listener.front_end",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerConfig_fixedResponse(lbName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerExists("aws_lb_listener.front_end", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "protocol", "HTTP"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "port", "80"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "fixed-response"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.target_group_arn", ""),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "0"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.fixed_response.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.fixed_response.0.content_type", "text/plain"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.fixed_response.0.message_body", "Fixed response content"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.fixed_response.0.status_code", "200"),
 				),
 			},
 		},
@@ -486,4 +559,168 @@ resource "tls_self_signed_cert" "example" {
   ]
 }
 `, lbName, targetGroupName, acctest.RandInt())
+}
+
+func testAccAWSLBListenerConfig_redirect(lbName string) string {
+	return fmt.Sprintf(`resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.alb_test.id}"
+  protocol = "HTTP"
+  port = "80"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    Name = "TestAccAWSALB_redirect"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-lb-listener-redirect"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    Name = "tf-acc-lb-listener-redirect-${count.index}"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "TestAccAWSALB_redirect"
+  }
+}`, lbName)
+}
+
+func testAccAWSLBListenerConfig_fixedResponse(lbName string) string {
+	return fmt.Sprintf(`resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.alb_test.id}"
+  protocol = "HTTP"
+  port = "80"
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Fixed response content"
+      status_code = "200"
+    }
+  }
+}
+
+resource "aws_lb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    Name = "TestAccAWSALB_fixedresponse"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-lb-listener-fixedresponse"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    Name = "tf-acc-lb-listener-fixedresponse-${count.index}"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "TestAccAWSALB_fixedresponse"
+  }
+}`, lbName)
 }


### PR DESCRIPTION
Fixes #5344.

Changes proposed in this pull request:

* Add support for `redirect` and `fixed-response` into `lb_listener`.
* Add support for `redirect` and `fixed-response` into `lb_listener_rule`.
* Updated docs.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLBListener\(Rule\)?'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLBListener\(Rule\)? -timeout 120m
=== RUN   TestAccAWSLBListenerRule_basic
--- PASS: TestAccAWSLBListenerRule_basic (223.11s)
=== RUN   TestAccAWSLBListenerRuleBackwardsCompatibility
--- PASS: TestAccAWSLBListenerRuleBackwardsCompatibility (250.42s)
=== RUN   TestAccAWSLBListenerRule_redirect
--- PASS: TestAccAWSLBListenerRule_redirect (234.50s)
=== RUN   TestAccAWSLBListenerRule_fixedResponse
--- PASS: TestAccAWSLBListenerRule_fixedResponse (221.45s)
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (338.63s)
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (265.98s)
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (1.53s)
=== RUN   TestAccAWSLBListenerRule_priority
--- PASS: TestAccAWSLBListenerRule_priority (429.05s)
=== RUN   TestAccAWSLBListener_basic
--- PASS: TestAccAWSLBListener_basic (233.51s)
=== RUN   TestAccAWSLBListenerBackwardsCompatibility
--- PASS: TestAccAWSLBListenerBackwardsCompatibility (230.56s)
=== RUN   TestAccAWSLBListener_https
--- PASS: TestAccAWSLBListener_https (243.43s)
=== RUN   TestAccAWSLBListener_redirect
--- PASS: TestAccAWSLBListener_redirect (232.45s)
=== RUN   TestAccAWSLBListener_fixedResponse
--- PASS: TestAccAWSLBListener_fixedResponse (236.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3140.836s

```
