### PR TITLE
AWS SSM DoesNotExistException for missing Patch Baseline

### DIFF
--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -218,6 +218,11 @@ func resourceAwsSsmPatchBaselineUpdate(d *schema.ResourceData, meta interface{})
 
 	_, err := ssmconn.UpdatePatchBaseline(params)
 	if err != nil {
+		if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
+			log.Printf("[WARN] Patch Baseline %s not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 
@@ -232,6 +237,11 @@ func resourceAwsSsmPatchBaselineRead(d *schema.ResourceData, meta interface{}) e
 
 	resp, err := ssmconn.GetPatchBaseline(params)
 	if err != nil {
+		if isAWSErr(err, ssm.ErrCodeDoesNotExistException, "") {
+			log.Printf("[WARN] Patch Baseline %s not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -63,6 +63,28 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMPatchBaseline_disappears(t *testing.T) {
+	var identity ssm.PatchBaselineIdentity
+	name := acctest.RandString(10)
+	resourceName := "aws_ssm_patch_baseline.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMPatchBaselineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMPatchBaselineBasicConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMPatchBaselineExists(resourceName, &identity),
+					testAccCheckAWSSSMPatchBaselineDisappears(&identity),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMPatchBaselineWithOperatingSystem(t *testing.T) {
 	var before, after ssm.PatchBaselineIdentity
 	name := acctest.RandString(10)
@@ -153,6 +175,24 @@ func testAccCheckAWSSSMPatchBaselineExists(n string, patch *ssm.PatchBaselineIde
 		}
 
 		return fmt.Errorf("No AWS SSM Patch Baseline found")
+	}
+}
+
+func testAccCheckAWSSSMPatchBaselineDisappears(patch *ssm.PatchBaselineIdentity) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ssmconn
+
+		id := aws.StringValue(patch.BaselineId)
+		params := &ssm.DeletePatchBaselineInput{
+			BaselineId: aws.String(id),
+		}
+
+		_, err := conn.DeletePatchBaseline(params)
+		if err != nil {
+			return fmt.Errorf("error deleting Patch Baseline %s: %s", id, err)
+		}
+
+		return nil
 	}
 }
 


### PR DESCRIPTION

Fixes #4612 

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSSMPatchBaseline_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSSSMPatchBaseline_ -timeout 120m
=== RUN   TestAccAWSSSMPatchBaseline_basic
--- PASS: TestAccAWSSSMPatchBaseline_basic (51.81s)
=== RUN   TestAccAWSSSMPatchBaseline_disappears
--- PASS: TestAccAWSSSMPatchBaseline_disappears (22.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	74.349s
...
```
