### PR TITLE
Fixes typo on debug info of datasource aws_security_groups

### DIFF
--- a/aws/data_source_aws_security_groups.go
+++ b/aws/data_source_aws_security_groups.go
@@ -77,7 +77,7 @@ func dataSourceAwsSecurityGroupsRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 
-	log.Printf("[DEBUG] Found %d securuity groups via given filter: %s", len(ids), req)
+	log.Printf("[DEBUG] Found %d security groups via given filter: %s", len(ids), req)
 
 	d.SetId(resource.UniqueId())
 	err := d.Set("ids", ids)


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Fixes typo in datasource aws_security_groups debug info

This tiny issue prevented me to identify the found datasource debug info programmatically (using grep).