### PR TITLE
add data source for organizations_organization

### DIFF
--- a/aws/data_source_aws_organizations_organization.go
+++ b/aws/data_source_aws_organizations_organization.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"log"
+
+	organizations "github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsOrganizationsOrganization() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOrganizationsOrganizationRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_email": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"feature_set": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"available_policy_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+
+	log.Printf("[INFO] Reading Organization")
+	org, err := conn.DescribeOrganization(&organizations.DescribeOrganizationInput{})
+	if err != nil {
+		if isAWSErr(err, organizations.ErrCodeAWSOrganizationsNotInUseException, "") {
+			log.Printf("[WARN] Organization does not exist, removing from state: %s", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	d.SetId(*org.Organization.Id)
+	d.Set("arn", org.Organization.Arn)
+	d.Set("feature_set", org.Organization.FeatureSet)
+	d.Set("master_account_arn", org.Organization.MasterAccountArn)
+	d.Set("master_account_email", org.Organization.MasterAccountEmail)
+	d.Set("master_account_id", org.Organization.MasterAccountId)
+	availablePolicyTypes := availablePolicyTypeListToMap(org.Organization.AvailablePolicyTypes)
+	d.Set("available_policy_types", availablePolicyTypes)
+	return nil
+}
+
+func availablePolicyTypeListToMap(list []*organizations.PolicyTypeSummary) []map[string]interface{} {
+	var output []map[string]interface{}
+	for _, o := range list {
+		policyTypeSummary := map[string]interface{}{
+			"status": *o.Status,
+			"type":   *o.Type,
+		}
+		output = append(output, policyTypeSummary)
+	}
+	return output
+}

--- a/aws/data_source_aws_organizations_organization_test.go
+++ b/aws/data_source_aws_organizations_organization_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAwsDataSourceOrganizationsOrganization_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAccAwsOrganizationsOrganizationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "master_account_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "master_account_email"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "feature_set"),
+					resource.TestCheckResourceAttrSet("data.aws_organizations_organization.test", "available_policy_types.#"),
+				),
+			},
+		},
+	})
+}
+
+const testDataSourceAccAwsOrganizationsOrganizationConfig = `data "aws_organizations_organization" "test" {}`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -232,6 +232,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_network_acls":                     dataSourceAwsNetworkAcls(),
 			"aws_network_interface":                dataSourceAwsNetworkInterface(),
 			"aws_network_interfaces":               dataSourceAwsNetworkInterfaces(),
+			"aws_organizations_organization":       dataSourceAwsOrganizationsOrganization(),
 			"aws_partition":                        dataSourceAwsPartition(),
 			"aws_prefix_list":                      dataSourceAwsPrefixList(),
 			"aws_pricing_product":                  dataSourceAwsPricingProduct(),

--- a/website/docs/d/organizations_organization.html.markdown
+++ b/website/docs/d/organizations_organization.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aws"
+page_title: "AWS: aws_organizations_organization"
+sidebar_current: "docs-aws-datasource-organizations-organization"
+description: |-
+  Provides details about an organization.
+---
+
+# Data Source: aws_organizations_organization
+
+Retrieves information about the organization that the user's account belongs to.
+
+## Example Usage:
+
+```hcl
+data "aws_organizations_organization" "org" {}
+```
+
+## Argument Reference
+
+N/A
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - ARN of the organization
+* `id` - Identifier of the organization
+* `master_account_arn` - ARN of the master account
+* `master_account_email` - Email address of the master account
+* `master_account_id` - Identifier of the master account
+* `available_policy_types` - A list of policy type objects that are enabed for this organization
+
+The policy type object contains the following attributes:
+
+* `type` - The name of the policy type
+* `status` - The status of the policy type as it relates to the associated root.


### PR DESCRIPTION
Changes proposed in this pull request:

* New data resource for organizations_organization. Compliments the existing resource for organizations_organization.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsDataSourceOrganizationsOrganization_basic'

=== RUN   TestAccAwsDataSourceOrganizationsOrganization_basic
--- PASS: TestAccAwsDataSourceOrganizationsOrganization_basic (10.70s)
PASS
ok  	github.com/scottwinkler/terraform-provider-aws/aws	10.763s
```
