### PR TITLE
Fix aws_lambda_event_source_mapping function name flapping

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -40,7 +40,7 @@ func resourceAwsLambdaEventSourceMapping() *schema.Resource {
 					// Using function name or ARN should not be shown as a diff.
 					// Try to convert the old and new values from ARN to function name
 					oldFunctionName, oldFunctionNameErr := getFunctionNameFromLambdaArn(old)
-					newFunctionName, newFunctionNameErr := getFunctionNameFromLambdaArn(old)
+					newFunctionName, newFunctionNameErr := getFunctionNameFromLambdaArn(new)
 					return (oldFunctionName == new && oldFunctionNameErr == nil) || (newFunctionName == old && newFunctionNameErr == nil)
 				},
 			},

--- a/aws/resource_aws_lambda_event_source_mapping.go
+++ b/aws/resource_aws_lambda_event_source_mapping.go
@@ -36,6 +36,13 @@ func resourceAwsLambdaEventSourceMapping() *schema.Resource {
 			"function_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Using function name or ARN should not be shown as a diff.
+					// Try to convert the old and new values from ARN to function name
+					oldFunctionName, oldFunctionNameErr := getFunctionNameFromLambdaArn(old)
+					newFunctionName, newFunctionNameErr := getFunctionNameFromLambdaArn(old)
+					return (oldFunctionName == new && oldFunctionNameErr == nil) || (newFunctionName == old && newFunctionNameErr == nil)
+				},
 			},
 			"starting_position": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -18,6 +18,8 @@ import (
 func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
+
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_esm_basic_%s", rString)
 	policyName := fmt.Sprintf("tf_acc_policy_lambda_esm_basic_%s", rString)
@@ -35,22 +37,18 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_basic(t *testing.T) {
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
 				),
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"batch_size", strconv.Itoa(200)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"enabled", strconv.FormatBool(false)),
-					resource.TestMatchResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"function_arn", uFuncArnRe),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"starting_position", "TRIM_HORIZON"),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(200)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(false)),
+					resource.TestMatchResourceAttr(resourceName, "function_arn", uFuncArnRe),
+					resource.TestCheckResourceAttr(resourceName, "starting_position", "TRIM_HORIZON"),
 				),
 			},
 		},
@@ -63,6 +61,8 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 	// a diff.
 
 	var conf lambda.EventSourceMappingConfiguration
+
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_esm_basic_%s", rString)
@@ -80,20 +80,17 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
 				),
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_kinesis_removeBatchSize(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"batch_size", strconv.Itoa(100)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"starting_position", "TRIM_HORIZON"),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(100)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr(resourceName, "starting_position", "TRIM_HORIZON"),
 				),
 			},
 		},
@@ -102,6 +99,8 @@ func TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize(t *testing.T) {
 
 func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
+
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
 
 	rString := acctest.RandString(8)
 	roleName := fmt.Sprintf("tf_acc_role_lambda_sqs_basic_%s", rString)
@@ -120,24 +119,52 @@ func TestAccAWSLambdaEventSourceMapping_sqs_basic(t *testing.T) {
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfig_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
-					resource.TestCheckNoResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
+					resource.TestCheckNoResourceAttr(resourceName,
 						"starting_position"),
 				),
 			},
 			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate_sqs(roleName, policyName, attName, streamName, funcName, uFuncName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"batch_size", strconv.Itoa(5)),
-					resource.TestCheckResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"enabled", strconv.FormatBool(false)),
-					resource.TestMatchResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"function_arn", uFuncArnRe),
-					resource.TestCheckNoResourceAttr("aws_lambda_event_source_mapping.lambda_event_source_mapping_test",
-						"starting_position"),
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "batch_size", strconv.Itoa(5)),
+					resource.TestCheckResourceAttr(resourceName, "enabled", strconv.FormatBool(false)),
+					resource.TestMatchResourceAttr(resourceName, "function_arn", uFuncArnRe),
+					resource.TestCheckNoResourceAttr(resourceName, "starting_position"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName(t *testing.T) {
+	var conf lambda.EventSourceMappingConfiguration
+
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
+
+	rString := acctest.RandString(8)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_sqs_basic_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_sqs_basic_%s", rString)
+	attName := fmt.Sprintf("tf_acc_att_lambda_sqs_basic_%s", rString)
+	streamName := fmt.Sprintf("tf_acc_stream_lambda_sqs_basic_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_sqs_basic_%s", rString)
+	funcArnRe := regexp.MustCompile(":" + funcName + "$")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfig_sqs_testWithFunctionName(roleName, policyName, attName, streamName, funcName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
+					resource.TestMatchResourceAttr(resourceName, "function_arn", funcArnRe),
+					resource.TestMatchResourceAttr(resourceName, "function_name", funcArnRe),
+					resource.TestCheckNoResourceAttr(resourceName, "starting_position"),
 				),
 			},
 		},
@@ -839,4 +866,73 @@ resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
     depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
     function_name = "${aws_lambda_function.lambda_function_test_update.arn}"
 }`, roleName, policyName, attName, streamName, funcName, uFuncName)
+}
+
+func testAccAWSLambdaEventSourceMappingConfig_sqs_testWithFunctionName(roleName, policyName, attName, streamName, funcName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "iam_for_lambda" {
+    name = "%[1]s"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "policy_for_role" {
+    name = "%[2]s"
+    path = "/"
+    description = "IAM policy for Lambda event mapping testing"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+            "sqs:*"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "policy_attachment_for_role" {
+    name = "%[3]s"
+    roles = ["${aws_iam_role.iam_for_lambda.name}"]
+    policy_arn = "${aws_iam_policy.policy_for_role.arn}"
+}
+
+resource "aws_sqs_queue" "sqs_queue_test" {
+    name = "%[4]s"
+}
+
+resource "aws_lambda_function" "lambda_function_test_create" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%[5]s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+}
+
+
+resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
+    batch_size = 5
+    event_source_arn = "${aws_sqs_queue.sqs_queue_test.arn}"
+    depends_on = ["aws_iam_policy_attachment.policy_attachment_for_role"]
+    enabled = false
+    function_name = "%[5]s"
+}`, roleName, policyName, attName, streamName, funcName)
 }


### PR DESCRIPTION
Went with DiffSupressFunc finally. I thought it was a bit weird to deprecate an argument just to prevent some flapping. Also, there's already a function implemented to get the function name from a lambda ARN

Changes proposed in this pull request:

* Add DiffSupressFunc to the `function_name` argument that tries to convert the old value from ARN to name as well as the new one. This prevents flapping from name to ARN.

Output from acceptance testing:

```
TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName'  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName (431.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       431.717s
```
