### PR TITLE
resource/aws_instance: Ignore change of user_data from omission to empty

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -128,7 +128,8 @@ func resourceAwsInstance() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// Sometimes the EC2 API responds with the equivalent, empty SHA1 sum
 					// echo -n "" | shasum
-					if old == "da39a3ee5e6b4b0d3255bfef95601890afd80709" && new == "" {
+					if (old == "da39a3ee5e6b4b0d3255bfef95601890afd80709" && new == "") ||
+						(old == "" && new == "da39a3ee5e6b4b0d3255bfef95601890afd80709") {
 						return true
 					}
 					return false


### PR DESCRIPTION
Fixes #4954

https://github.com/terraform-providers/terraform-provider-aws/pull/4991/files#r208085096 fixed the issue when changing from empty `user_data` to omitting the field. But the other way is also a valid case that we should ignore, i.e., changing from omitting the `user_data` field to giving it an empty value.

Changes proposed in this pull request:

* Allow aws_instance resource to ignore when EC2 API returns empty string user_data, for changes in both direction: empty value in the field <==> field being omitted.

Did not run acceptance testing. But I've tested it locally.
