### PR TITLE
Support aurora engine type in performance insights

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -249,7 +249,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		createOpts.MonitoringRoleArn = aws.String(attr.(string))
 	}
 
-	if attr, _ := d.GetOk("engine"); attr == "aurora-postgresql" {
+	if attr, _ := d.GetOk("engine"); attr == "aurora-postgresql" || attr == "aurora" {
 		if attr, ok := d.GetOk("performance_insights_enabled"); ok {
 			createOpts.EnablePerformanceInsights = aws.Bool(attr.(bool))
 		}


### PR DESCRIPTION
Changes proposed in this pull request:

* Allow turning on performance insights for the RDS cluster engine type "aurora"
Since yesterday, performance insights is supported on aurora clusters with mysql version 5.6 (aurora 1.x). 
On AWS API level there is no change, we just have to remove the limitation we implemented in the provider.
Since other engine types are still not supported, we allow the following 2 engines to enable this attribute:
- aurora-postgresql
- aurora
