### PR TITLE
Fix read for non-pending aws_acm_certificate

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -216,7 +216,7 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 				for _, validationEmail := range o.ValidationEmails {
 					emailValidationResult = append(emailValidationResult, *validationEmail)
 				}
-			} else {
+			} else if *o.ValidationStatus == acm.DomainStatusPendingValidation {
 				log.Printf("[DEBUG] No validation options need to retry: %#v", o)
 				return nil, nil, fmt.Errorf("No validation options need to retry: %#v", o)
 			}


### PR DESCRIPTION
If a DomainValidation indicates a validation status of success or failed there is no reason for it to be re-queried, even if no ResourceRecord or ValidationEmails are present. Re-querying in either of these cases will cause the import of the resource to fail and prevent the certificate from being imported.

Now the certificate is only re-queried if the DomainValidation is in a pending state.

This bug was encountered while attempting to import older, but still in-use, certificates that no longer include domain validation data, preventing us from importing these certificates into Terraform.
