### PR TITLE
storagegateway: Add cached iSCSI volume resource, retry on busy connection, fix cache resource updating disk ID

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -600,6 +600,13 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	})
 
+	client.storagegatewayconn.Handlers.Retry.PushBack(func(r *request.Request) {
+		// InvalidGatewayRequestException: The specified gateway proxy network connection is busy.
+		if isAWSErr(r.Error, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified gateway proxy network connection is busy") {
+			r.Retryable = aws.Bool(true)
+		}
+	})
+
 	return &client, nil
 }
 

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -591,6 +591,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ssm_parameter":                                resourceAwsSsmParameter(),
 			"aws_ssm_resource_data_sync":                       resourceAwsSsmResourceDataSync(),
 			"aws_storagegateway_cache":                         resourceAwsStorageGatewayCache(),
+			"aws_storagegateway_cached_iscsi_volume":           resourceAwsStorageGatewayCachedIscsiVolume(),
 			"aws_storagegateway_gateway":                       resourceAwsStorageGatewayGateway(),
 			"aws_storagegateway_nfs_file_share":                resourceAwsStorageGatewayNfsFileShare(),
 			"aws_storagegateway_smb_file_share":                resourceAwsStorageGatewaySmbFileShare(),

--- a/aws/resource_aws_storagegateway_cache.go
+++ b/aws/resource_aws_storagegateway_cache.go
@@ -53,6 +53,8 @@ func resourceAwsStorageGatewayCacheCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error adding Storage Gateway cache: %s", err)
 	}
 
+	d.SetId(fmt.Sprintf("%s:%s", gatewayARN, diskID))
+
 	// Depending on the Storage Gateway software, it will sometimes relabel a local DiskId
 	// with a UUID if previously unlabeled, e.g.
 	//   Before conn.AddCache(): "DiskId": "/dev/xvdb",

--- a/aws/resource_aws_storagegateway_cached_iscsi_volume.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume.go
@@ -1,0 +1,236 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsStorageGatewayCachedIscsiVolume() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsStorageGatewayCachedIscsiVolumeCreate,
+		Read:   resourceAwsStorageGatewayCachedIscsiVolumeRead,
+		Delete: resourceAwsStorageGatewayCachedIscsiVolumeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"chap_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"gateway_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"lun_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			// Poor API naming: this accepts the IP address of the network interface
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"network_interface_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_volume_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+			"target_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"volume_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_size_in_bytes": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsStorageGatewayCachedIscsiVolumeCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.CreateCachediSCSIVolumeInput{
+		ClientToken:        aws.String(resource.UniqueId()),
+		GatewayARN:         aws.String(d.Get("gateway_arn").(string)),
+		NetworkInterfaceId: aws.String(d.Get("network_interface_id").(string)),
+		TargetName:         aws.String(d.Get("target_name").(string)),
+		VolumeSizeInBytes:  aws.Int64(int64(d.Get("volume_size_in_bytes").(int))),
+	}
+
+	if v, ok := d.GetOk("snapshot_id"); ok {
+		input.SnapshotId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("source_volume_arn"); ok {
+		input.SourceVolumeARN = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating Storage Gateway cached iSCSI volume: %s", input)
+	output, err := conn.CreateCachediSCSIVolume(input)
+	if err != nil {
+		return fmt.Errorf("error creating Storage Gateway cached iSCSI volume: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.VolumeARN))
+
+	return resourceAwsStorageGatewayCachedIscsiVolumeRead(d, meta)
+}
+
+func resourceAwsStorageGatewayCachedIscsiVolumeRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.DescribeCachediSCSIVolumesInput{
+		VolumeARNs: []*string{aws.String(d.Id())},
+	}
+
+	log.Printf("[DEBUG] Reading Storage Gateway cached iSCSI volume: %s", input)
+	output, err := conn.DescribeCachediSCSIVolumes(input)
+
+	if err != nil {
+		if isAWSErr(err, storagegateway.ErrorCodeVolumeNotFound, "") {
+			log.Printf("[WARN] Storage Gateway cached iSCSI volume %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Storage Gateway cached iSCSI volume %q: %s", d.Id(), err)
+	}
+
+	if output == nil || len(output.CachediSCSIVolumes) == 0 || output.CachediSCSIVolumes[0] == nil || aws.StringValue(output.CachediSCSIVolumes[0].VolumeARN) != d.Id() {
+		log.Printf("[WARN] Storage Gateway cached iSCSI volume %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	volume := output.CachediSCSIVolumes[0]
+
+	d.Set("arn", aws.StringValue(volume.VolumeARN))
+	d.Set("snapshot_id", aws.StringValue(volume.SourceSnapshotId))
+	d.Set("volume_arn", aws.StringValue(volume.VolumeARN))
+	d.Set("volume_id", aws.StringValue(volume.VolumeId))
+	d.Set("volume_size_in_bytes", int(aws.Int64Value(volume.VolumeSizeInBytes)))
+
+	if volume.VolumeiSCSIAttributes != nil {
+		d.Set("chap_enabled", aws.BoolValue(volume.VolumeiSCSIAttributes.ChapEnabled))
+		d.Set("lun_number", int(aws.Int64Value(volume.VolumeiSCSIAttributes.LunNumber)))
+		d.Set("network_interface_id", aws.StringValue(volume.VolumeiSCSIAttributes.NetworkInterfaceId))
+		d.Set("network_interface_port", int(aws.Int64Value(volume.VolumeiSCSIAttributes.NetworkInterfacePort)))
+
+		targetARN := aws.StringValue(volume.VolumeiSCSIAttributes.TargetARN)
+		d.Set("target_arn", targetARN)
+
+		gatewayARN, targetName, err := parseStorageGatewayVolumeGatewayARNAndTargetNameFromARN(targetARN)
+		if err != nil {
+			return fmt.Errorf("error parsing Storage Gateway volume gateway ARN and target name from target ARN %q: %s", targetARN, err)
+		}
+		d.Set("gateway_arn", gatewayARN)
+		d.Set("target_name", targetName)
+	}
+
+	return nil
+}
+
+func resourceAwsStorageGatewayCachedIscsiVolumeDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).storagegatewayconn
+
+	input := &storagegateway.DeleteVolumeInput{
+		VolumeARN: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Storage Gateway cached iSCSI volume: %s", input)
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteVolume(input)
+		if err != nil {
+			if isAWSErr(err, storagegateway.ErrorCodeVolumeNotFound, "") {
+				return nil
+			}
+			// InvalidGatewayRequestException: The specified gateway is not connected.
+			// Can occur during concurrent DeleteVolume operations
+			if isAWSErr(err, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified gateway is not connected") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error deleting Storage Gateway cached iSCSI volume %q: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func parseStorageGatewayVolumeGatewayARNAndTargetNameFromARN(inputARN string) (string, string, error) {
+	// inputARN = arn:aws:storagegateway:us-east-2:111122223333:gateway/sgw-12A3456B/target/iqn.1997-05.com.amazon:TargetName
+	targetARN, err := arn.Parse(inputARN)
+	if err != nil {
+		return "", "", err
+	}
+	// We need to get:
+	//  * The Gateway ARN portion of the target ARN resource (gateway/sgw-12A3456B)
+	//  * The target name portion of the target ARN resource (TargetName)
+	// First, let's split up the resource of the target ARN
+	// targetARN.Resource = gateway/sgw-12A3456B/target/iqn.1997-05.com.amazon:TargetName
+	expectedFormatErr := fmt.Errorf("expected resource format gateway/sgw-12A3456B/target/iqn.1997-05.com.amazon:TargetName, received: %s", targetARN.Resource)
+	resourceParts := strings.SplitN(targetARN.Resource, "/", 4)
+	if len(resourceParts) != 4 {
+		return "", "", expectedFormatErr
+	}
+	gatewayARN := arn.ARN{
+		AccountID: targetARN.AccountID,
+		Partition: targetARN.Partition,
+		Region:    targetARN.Region,
+		Resource:  fmt.Sprintf("%s/%s", resourceParts[0], resourceParts[1]),
+		Service:   targetARN.Service,
+	}.String()
+	// Second, let's split off the target name from the initiator name
+	// resourceParts[3] = iqn.1997-05.com.amazon:TargetName
+	initiatorParts := strings.SplitN(resourceParts[3], ":", 2)
+	if len(initiatorParts) != 2 {
+		return "", "", expectedFormatErr
+	}
+	targetName := initiatorParts[1]
+	return gatewayARN, targetName, nil
+}

--- a/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
@@ -1,0 +1,429 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/storagegateway"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestParseStorageGatewayVolumeGatewayARNAndTargetNameFromARN(t *testing.T) {
+	var testCases = []struct {
+		Input              string
+		ExpectedGatewayARN string
+		ExpectedTargetName string
+		ErrCount           int
+	}{
+		{
+			Input:              "arn:aws:storagegateway:us-east-2:111122223333:gateway/sgw-12A3456B/target/iqn.1997-05.com.amazon:TargetName",
+			ExpectedGatewayARN: "arn:aws:storagegateway:us-east-2:111122223333:gateway/sgw-12A3456B",
+			ExpectedTargetName: "TargetName",
+			ErrCount:           0,
+		},
+		{
+			Input:    "gateway/sgw-12A3456B/target/iqn.1997-05.com.amazon:TargetName",
+			ErrCount: 1,
+		},
+		{
+			Input:    "arn:aws:storagegateway:us-east-2:111122223333:target/iqn.1997-05.com.amazon:TargetName",
+			ErrCount: 1,
+		},
+		{
+			Input:    "arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678",
+			ErrCount: 1,
+		},
+		{
+			Input:    "TargetName",
+			ErrCount: 1,
+		},
+		{
+			Input:    "gateway/sgw-12345678",
+			ErrCount: 1,
+		},
+		{
+			Input:    "sgw-12345678",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		gatewayARN, targetName, err := parseStorageGatewayVolumeGatewayARNAndTargetNameFromARN(tc.Input)
+		if tc.ErrCount == 0 && err != nil {
+			t.Fatalf("expected %q not to trigger an error, received: %s", tc.Input, err)
+		}
+		if tc.ErrCount > 0 && err == nil {
+			t.Fatalf("expected %q to trigger an error", tc.Input)
+		}
+		if gatewayARN != tc.ExpectedGatewayARN {
+			t.Fatalf("expected %q to return Gateway ARN %q, received: %s", tc.Input, tc.ExpectedGatewayARN, gatewayARN)
+		}
+		if targetName != tc.ExpectedTargetName {
+			t.Fatalf("expected %q to return Disk ID %q, received: %s", tc.Input, tc.ExpectedTargetName, targetName)
+		}
+	}
+}
+
+func TestAccAWSStorageGatewayCachedIscsiVolume_Basic(t *testing.T) {
+	var cachedIscsiVolume storagegateway.CachediSCSIVolume
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_cached_iscsi_volume.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayCachedIscsiVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayCachedIscsiVolumeConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayCachedIscsiVolumeExists(resourceName, &cachedIscsiVolume),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+/volume/vol-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "chap_enabled", "false"),
+					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "lun_number", "0"),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_id", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_port", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_id", ""),
+					resource.TestMatchResourceAttr(resourceName, "target_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:storagegateway:[^:]+:\\d{12}:gateway/sgw-.+/target/iqn.1997-05.com.amazon:%s$", rName))),
+					resource.TestCheckResourceAttr(resourceName, "target_name", rName),
+					resource.TestMatchResourceAttr(resourceName, "volume_id", regexp.MustCompile(`^vol-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "volume_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+/volume/vol-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "volume_size_in_bytes", "5368709120"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId(t *testing.T) {
+	var cachedIscsiVolume storagegateway.CachediSCSIVolume
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_cached_iscsi_volume.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayCachedIscsiVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayCachedIscsiVolumeConfig_SnapshotId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayCachedIscsiVolumeExists(resourceName, &cachedIscsiVolume),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+/volume/vol-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "chap_enabled", "false"),
+					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "lun_number", "0"),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_id", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_port", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "snapshot_id", regexp.MustCompile(`^snap-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "target_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:storagegateway:[^:]+:\\d{12}:gateway/sgw-.+/target/iqn.1997-05.com.amazon:%s$", rName))),
+					resource.TestCheckResourceAttr(resourceName, "target_name", rName),
+					resource.TestMatchResourceAttr(resourceName, "volume_id", regexp.MustCompile(`^vol-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "volume_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+/volume/vol-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "volume_size_in_bytes", "5368709120"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn(t *testing.T) {
+	t.Skip("This test can cause Storage Gateway 2.0.10.0 to enter an irrecoverable state during volume deletion.")
+	var cachedIscsiVolume storagegateway.CachediSCSIVolume
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_storagegateway_cached_iscsi_volume.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSStorageGatewayCachedIscsiVolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayCachedIscsiVolumeConfig_SourceVolumeArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSStorageGatewayCachedIscsiVolumeExists(resourceName, &cachedIscsiVolume),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+/volume/vol-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "gateway_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_id", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "network_interface_port", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_id", ""),
+					resource.TestMatchResourceAttr(resourceName, "source_volume_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+/volume/vol-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "target_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:storagegateway:[^:]+:\\d{12}:gateway/sgw-.+/target/iqn.1997-05.com.amazon:%s$", rName))),
+					resource.TestCheckResourceAttr(resourceName, "target_name", rName),
+					resource.TestMatchResourceAttr(resourceName, "volume_id", regexp.MustCompile(`^vol-.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "volume_arn", regexp.MustCompile(`^arn:[^:]+:storagegateway:[^:]+:\d{12}:gateway/sgw-.+/volume/vol-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "volume_size_in_bytes", "1073741824"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source_volume_arn"},
+			},
+		},
+	})
+}
+
+func testAccCheckAWSStorageGatewayCachedIscsiVolumeExists(resourceName string, cachedIscsiVolume *storagegateway.CachediSCSIVolume) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+
+		input := &storagegateway.DescribeCachediSCSIVolumesInput{
+			VolumeARNs: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.DescribeCachediSCSIVolumes(input)
+
+		if err != nil {
+			return fmt.Errorf("error reading Storage Gateway cached iSCSI volume: %s", err)
+		}
+
+		if output == nil || len(output.CachediSCSIVolumes) == 0 || output.CachediSCSIVolumes[0] == nil || aws.StringValue(output.CachediSCSIVolumes[0].VolumeARN) != rs.Primary.ID {
+			return fmt.Errorf("Storage Gateway cached iSCSI volume %q not found", rs.Primary.ID)
+		}
+
+		*cachedIscsiVolume = *output.CachediSCSIVolumes[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAWSStorageGatewayCachedIscsiVolumeDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).storagegatewayconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_storagegateway_cached_iscsi_volume" {
+			continue
+		}
+
+		input := &storagegateway.DescribeCachediSCSIVolumesInput{
+			VolumeARNs: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		output, err := conn.DescribeCachediSCSIVolumes(input)
+
+		if err != nil {
+			if isAWSErrStorageGatewayGatewayNotFound(err) {
+				return nil
+			}
+			if isAWSErr(err, storagegateway.ErrorCodeVolumeNotFound, "") {
+				return nil
+			}
+			return err
+		}
+
+		if output != nil && len(output.CachediSCSIVolumes) > 0 && output.CachediSCSIVolumes[0] != nil && aws.StringValue(output.CachediSCSIVolumes[0].VolumeARN) == rs.Primary.ID {
+			return fmt.Errorf("Storage Gateway cached iSCSI volume %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSStorageGatewayCachedIscsiVolumeConfig_Basic(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_Cached(rName) + fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = 10
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/xvdc"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "${aws_volume_attachment.test.device_name}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_cache" "test" {
+  # ACCEPTANCE TESTING WORKAROUND:
+  # Data sources are not refreshed before plan after apply in TestStep
+  # Step 0 error: After applying this step, the plan was not empty:
+  #   disk_id:     "0b68f77a-709b-4c79-ad9d-d7728014b291" => "/dev/xvdc" (forces new resource)
+  # We expect this data source value to change due to how Storage Gateway works.
+  lifecycle {
+    ignore_changes = ["disk_id"]
+  }
+
+  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_cached_iscsi_volume" "test" {
+  gateway_arn          = "${aws_storagegateway_cache.test.gateway_arn}"
+  network_interface_id = "${aws_instance.test.private_ip}"
+  target_name          = %q
+  volume_size_in_bytes = 5368709120
+}
+`, rName, rName)
+}
+
+func testAccAWSStorageGatewayCachedIscsiVolumeConfig_SnapshotId(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_Cached(rName) + fmt.Sprintf(`
+resource "aws_ebs_volume" "cachevolume" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = 10
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/xvdc"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.cachevolume.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "${aws_volume_attachment.test.device_name}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_cache" "test" {
+  # ACCEPTANCE TESTING WORKAROUND:
+  # Data sources are not refreshed before plan after apply in TestStep
+  # Step 0 error: After applying this step, the plan was not empty:
+  #   disk_id:     "0b68f77a-709b-4c79-ad9d-d7728014b291" => "/dev/xvdc" (forces new resource)
+  # We expect this data source value to change due to how Storage Gateway works.
+  lifecycle {
+    ignore_changes = ["disk_id"]
+  }
+
+  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_ebs_volume" "snapvolume" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = 5
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_ebs_snapshot" "test" {
+  volume_id = "${aws_ebs_volume.snapvolume.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_storagegateway_cached_iscsi_volume" "test" {
+  gateway_arn          = "${aws_storagegateway_cache.test.gateway_arn}"
+  network_interface_id = "${aws_instance.test.private_ip}"
+  snapshot_id          = "${aws_ebs_snapshot.test.id}"
+  target_name          = %q
+  volume_size_in_bytes = "${aws_ebs_snapshot.test.volume_size * 1024 * 1024 * 1024}"
+}
+`, rName, rName, rName, rName)
+}
+
+func testAccAWSStorageGatewayCachedIscsiVolumeConfig_SourceVolumeArn(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_Cached(rName) + fmt.Sprintf(`
+data "aws_storagegateway_local_disk" "uploadbuffer" {
+  disk_path   = "/dev/xvdb"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_upload_buffer" "test" {
+  # ACCEPTANCE TESTING WORKAROUND:
+  # Data sources are not refreshed before plan after apply in TestStep
+  # Step 0 error: After applying this step, the plan was not empty:
+  #   disk_id:     "0b68f77a-709b-4c79-ad9d-d7728014b291" => "/dev/xvdc" (forces new resource)
+  # We expect this data source value to change due to how Storage Gateway works.
+  lifecycle {
+    ignore_changes = ["disk_id"]
+  }
+
+  disk_id     = "${data.aws_storagegateway_local_disk.uploadbuffer.id}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = 10
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/xvdc"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_path   = "${aws_volume_attachment.test.device_name}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_cache" "test" {
+  # ACCEPTANCE TESTING WORKAROUND:
+  # Data sources are not refreshed before plan after apply in TestStep
+  # Step 0 error: After applying this step, the plan was not empty:
+  #   disk_id:     "0b68f77a-709b-4c79-ad9d-d7728014b291" => "/dev/xvdc" (forces new resource)
+  # We expect this data source value to change due to how Storage Gateway works.
+  lifecycle {
+    ignore_changes = ["disk_id"]
+  }
+
+  disk_id     = "${data.aws_storagegateway_local_disk.test.id}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+
+resource "aws_storagegateway_cached_iscsi_volume" "source" {
+  gateway_arn          = "${aws_storagegateway_cache.test.gateway_arn}"
+  network_interface_id = "${aws_instance.test.private_ip}"
+  target_name          = "%s-source"
+  volume_size_in_bytes = 1073741824
+}
+
+resource "aws_storagegateway_cached_iscsi_volume" "test" {
+  gateway_arn          = "${aws_storagegateway_cache.test.gateway_arn}"
+  network_interface_id = "${aws_instance.test.private_ip}"
+  source_volume_arn    = "${aws_storagegateway_cached_iscsi_volume.source.arn}"
+  target_name          = %q
+  volume_size_in_bytes = "${aws_storagegateway_cached_iscsi_volume.source.volume_size_in_bytes}"
+}
+`, rName, rName, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2148,8 +2148,12 @@
                     <a href="#">Storage Gateway Resources</a>
                     <ul class="nav nav-visible">
 
-                        <li<%= sidebar_current("docs-aws-resource-storagegateway-cache") %>>
+                        <li<%= sidebar_current("docs-aws-resource-storagegateway-cache-x") %>>
                             <a href="/docs/providers/aws/r/storagegateway_cache.html">aws_storagegateway_cache</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-storagegateway-cached-iscsi-volume") %>>
+                            <a href="/docs/providers/aws/r/storagegateway_cached_iscsi_volume.html">aws_storagegateway_cached_iscsi_volume</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-storagegateway-gateway") %>>

--- a/website/docs/r/storagegateway_cache.html.markdown
+++ b/website/docs/r/storagegateway_cache.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_storagegateway_cache"
-sidebar_current: "docs-aws-resource-storagegateway-cache"
+sidebar_current: "docs-aws-resource-storagegateway-cache-x"
 description: |-
   Manages an AWS Storage Gateway cache
 ---

--- a/website/docs/r/storagegateway_cached_iscsi_volume.html.markdown
+++ b/website/docs/r/storagegateway_cached_iscsi_volume.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "aws"
+page_title: "AWS: aws_storagegateway_cached_iscsi_volume"
+sidebar_current: "docs-aws-resource-storagegateway-cached-iscsi-volume"
+description: |-
+  Manages an AWS Storage Gateway cached iSCSI volume
+---
+
+# aws_storagegateway_cached_iscsi_volume
+
+Manages an AWS Storage Gateway cached iSCSI volume.
+
+~> **NOTE:** The gateway must have cache added (e.g. via the [`aws_storagegateway_cache`](/docs/providers/aws/r/storagegateway_cache.html) resource) before creating volumes otherwise the Storage Gateway API will return an error.
+
+~> **NOTE:** The gateway must have an upload buffer added (e.g. via the [`aws_storagegateway_upload_buffer`](/docs/providers/aws/r/storagegateway_upload_buffer.html) resource) before the volume is operational to clients, however the Storage Gateway API will allow volume creation without error in that case and return volume status as `UPLOAD BUFFER NOT CONFIGURED`.
+
+## Example Usage
+
+~> **NOTE:** These examples are referencing the [`aws_storagegateway_cache`](/docs/providers/aws/r/storagegateway_cache.html) resource `gateway_arn` attribute to ensure Terraform properly adds cache before creating the volume. If you are not using this method, you may need to declare an expicit dependency (e.g. via `depends_on = ["aws_storagegateway_cache.example"]`) to ensure proper ordering.
+
+### Create Empty Cached iSCSI Volume
+
+```hcl
+resource "aws_storagegateway_cached_iscsi_volume" "example" {
+  gateway_arn          = "${aws_storagegateway_cache.example.gateway_arn}"
+  network_interface_id = "${aws_instance.example.private_ip}"
+  target_name          = "example"
+  volume_size_in_bytes = 5368709120 # 5 GB
+}
+```
+
+### Create Cached iSCSI Volume From Snapshot
+
+```hcl
+resource "aws_storagegateway_cached_iscsi_volume" "example" {
+  gateway_arn          = "${aws_storagegateway_cache.example.gateway_arn}"
+  network_interface_id = "${aws_instance.example.private_ip}"
+  snapshot_id          = "${aws_ebs_snapshot.example.id}"
+  target_name          = "example"
+  volume_size_in_bytes = "${aws_ebs_snapshot.example.volume_size * 1024 * 1024 * 1024}"
+}
+```
+
+### Create Cached iSCSI Volume From Source Volume
+
+```hcl
+resource "aws_storagegateway_cached_iscsi_volume" "example" {
+  gateway_arn          = "${aws_storagegateway_cache.example.gateway_arn}"
+  network_interface_id = "${aws_instance.example.private_ip}"
+  source_volume_arn    = "${aws_storagegateway_cached_iscsi_volume.existing.arn}"
+  target_name          = "example"
+  volume_size_in_bytes = "${aws_storagegateway_cached_iscsi_volume.existing.volume_size_in_bytes}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `gateway_arn` - (Required) The Amazon Resource Name (ARN) of the gateway.
+* `network_interface_id` - (Required) The network interface of the gateway on which to expose the iSCSI target. Only IPv4 addresses are accepted.
+* `target_name` - (Required) The name of the iSCSI target used by initiators to connect to the target and as a suffix for the target ARN. The target name must be unique across all volumes of a gateway.
+* `volume_size_in_bytes` - (Required) The size of the volume in bytes.
+* `snapshot_id` - (Optional) The snapshot ID of the snapshot to restore as the new cached volume. e.g. `snap-1122aabb`.
+* `source_volume_arn` - (Optional) The ARN for an existing volume. Specifying this ARN makes the new volume into an exact copy of the specified existing volume's latest recovery point. The `volume_size_in_bytes` value for this new volume must be equal to or larger than the size of the existing volume, in bytes.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Volume Amazon Resource Name (ARN), e.g. `arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678/volume/vol-12345678`.
+* `chap_enabled` - Whether mutual CHAP is enabled for the iSCSI target.
+* `id` - Volume Amazon Resource Name (ARN), e.g. `arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678/volume/vol-12345678`.
+* `lun_number` - Logical disk number.
+* `network_interface_port` - The port used to communicate with iSCSI targets.
+* `target_arn` - Target Amazon Resource Name (ARN), e.g. `arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678/target/iqn.1997-05.com.amazon:TargetName`.
+* `volume_arn` - Volume Amazon Resource Name (ARN), e.g. `arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678/volume/vol-12345678`.
+* `volume_id` - Volume ID, e.g. `vol-12345678`.
+
+## Import
+
+`aws_storagegateway_cached_iscsi_volume` can be imported by using the volume Amazon Resource Name (ARN), e.g.
+
+```
+$ terraform import aws_storagegateway_cache.example arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12345678/volume/vol-12345678
+```


### PR DESCRIPTION
Reference #943 

Sorry for bundling these changes together, but it was the creation of this resource and its acceptance testing that highlighted these Storage Gateway API issues.

Changes proposed in this pull request:

* New Resource: `aws_storagegateway_cached_iscsi_disk`
* storagegatewayconn: Retry on `InvalidGatewayRequestException: The specified gateway proxy network connection is busy.` which occurs when (near) concurrent operations are performed on a gateway
* resource/aws_storagegateway_cache: Ensure resource updates disk ID after creation due to disk ID relabeling (exhibited by `aws-storage-gateway-2.0.10.0` AMI for tape/volume gateways, but not `aws-thinstaller` AMI for file gateways)

Before `aws_storagegateway_cache` code update:

```
=== RUN   TestAccAWSStorageGatewayCache_TapeAndVolumeGateway
--- FAIL: TestAccAWSStorageGatewayCache_TapeAndVolumeGateway (301.11s)
	testing.go:518: Step 0 error: Check failed: Check 1/3 error: Not found: aws_storagegateway_cache.test
```

Output from acceptance testing:

```
=== RUN   TestAccAWSStorageGatewayCache_TapeAndVolumeGateway
--- PASS: TestAccAWSStorageGatewayCache_TapeAndVolumeGateway (302.07s)

=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_Basic
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_Basic (306.42s)
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId
--- PASS: TestAccAWSStorageGatewayCachedIscsiVolume_SnapshotId (301.38s)
=== RUN   TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn
--- SKIP: TestAccAWSStorageGatewayCachedIscsiVolume_SourceVolumeArn (0.00s)
	resource_aws_storagegateway_cached_iscsi_volume_test.go:146: This test can cause Storage Gateway 2.0.10.0 to enter an irrecoverable state during volume deletion.
```
