### PR TITLE
Fix update behavior for Cognito User Pool Clients

### DIFF
--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -270,48 +270,48 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 		UserPoolId: aws.String(d.Get("user_pool_id").(string)),
 	}
 
-	if d.HasChange("explicit_auth_flows") {
-		params.ExplicitAuthFlows = expandStringList(d.Get("explicit_auth_flows").(*schema.Set).List())
+	if v, ok := d.GetOk("explicit_auth_flows"); ok {
+		params.ExplicitAuthFlows = expandStringList(v.(*schema.Set).List())
 	}
 
-	if d.HasChange("read_attributes") {
-		params.ReadAttributes = expandStringList(d.Get("read_attributes").(*schema.Set).List())
+	if v, ok := d.GetOk("read_attributes"); ok {
+		params.ReadAttributes = expandStringList(v.(*schema.Set).List())
 	}
 
-	if d.HasChange("write_attributes") {
-		params.WriteAttributes = expandStringList(d.Get("write_attributes").(*schema.Set).List())
+	if v, ok := d.GetOk("write_attributes"); ok {
+		params.WriteAttributes = expandStringList(v.(*schema.Set).List())
 	}
 
-	if d.HasChange("refresh_token_validity") {
-		params.RefreshTokenValidity = aws.Int64(int64(d.Get("refresh_token_validity").(int)))
+	if v, ok := d.GetOk("refresh_token_validity"); ok {
+		params.RefreshTokenValidity = aws.Int64(int64(v.(int)))
 	}
 
-	if d.HasChange("allowed_oauth_flows") {
-		params.AllowedOAuthFlows = expandStringList(d.Get("allowed_oauth_flows").(*schema.Set).List())
+	if v, ok := d.GetOk("allowed_oauth_flows"); ok {
+		params.AllowedOAuthFlows = expandStringList(v.(*schema.Set).List())
 	}
 
-	if d.HasChange("allowed_oauth_flows_user_pool_client") {
-		params.AllowedOAuthFlowsUserPoolClient = aws.Bool(d.Get("allowed_oauth_flows_user_pool_client").(bool))
+	if v, ok := d.GetOk("allowed_oauth_flows_user_pool_client"); ok {
+		params.AllowedOAuthFlowsUserPoolClient = aws.Bool(v.(bool))
 	}
 
-	if d.HasChange("allowed_oauth_scopes") {
-		params.AllowedOAuthScopes = expandStringList(d.Get("allowed_oauth_scopes").(*schema.Set).List())
+	if v, ok := d.GetOk("allowed_oauth_scopes"); ok {
+		params.AllowedOAuthScopes = expandStringList(v.(*schema.Set).List())
 	}
 
-	if d.HasChange("callback_urls") {
-		params.CallbackURLs = expandStringList(d.Get("callback_urls").([]interface{}))
+	if v, ok := d.GetOk("callback_urls"); ok {
+		params.CallbackURLs = expandStringList(v.([]interface{}))
 	}
 
-	if d.HasChange("default_redirect_uri") {
-		params.DefaultRedirectURI = aws.String(d.Get("default_redirect_uri").(string))
+	if v, ok := d.GetOk("default_redirect_uri"); ok {
+		params.DefaultRedirectURI = aws.String(v.(string))
 	}
 
-	if d.HasChange("logout_urls") {
-		params.LogoutURLs = expandStringList(d.Get("logout_urls").([]interface{}))
+	if v, ok := d.GetOk("logout_urls"); ok {
+		params.LogoutURLs = expandStringList(v.([]interface{}))
 	}
 
-	if d.HasChange("supported_identity_providers") {
-		params.SupportedIdentityProviders = expandStringList(d.Get("supported_identity_providers").([]interface{}))
+	if v, ok := d.GetOk("supported_identity_providers"); ok {
+		params.SupportedIdentityProviders = expandStringList(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Updating Cognito User Pool Client: %s", params)

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -124,7 +124,7 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName),
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", clientName),
@@ -138,6 +138,55 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.#", "1"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.881205744", "email"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "refresh_token_validity", "300"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.#", "2"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.2645166319", "code"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.3465961881", "implicit"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows_user_pool_client", "true"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.#", "5"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2517049750", "openid"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.2603607895", "phone"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.380129571", "aws.cognito.signin.user.admin"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_scopes.4080487570", "profile"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.#", "2"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.0", "https://www.example.com/callback"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "callback_urls.1", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "default_redirect_uri", "https://www.example.com/redirect"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "logout_urls.#", "1"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "logout_urls.0", "https://www.example.com/login"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
+	userPoolName := fmt.Sprintf("tf-acc-cognito-user-pool-%s", acctest.RandString(7))
+	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 300),
+			},
+			{
+				Config: testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName, 299),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolClientExists("aws_cognito_user_pool_client.client"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "name", clientName),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.#", "3"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1728632605", "CUSTOM_AUTH_FLOW_ONLY"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.1860959087", "USER_PASSWORD_AUTH"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "explicit_auth_flows.245201344", "ADMIN_NO_SRP_AUTH"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "generate_secret", "true"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "read_attributes.#", "1"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "read_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.#", "1"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "write_attributes.881205744", "email"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "refresh_token_validity", "299"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.#", "2"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.2645166319", "code"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_client.client", "allowed_oauth_flows.3465961881", "implicit"),
@@ -242,7 +291,7 @@ resource "aws_cognito_user_pool_client" "client" {
 `, rName, rName, refreshTokenValidity)
 }
 
-func testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName string) string {
+func testAccAWSCognitoUserPoolClientConfig_allFields(userPoolName, clientName string, refreshTokenValidity int) string {
 	return fmt.Sprintf(`
 resource "aws_cognito_user_pool" "pool" {
   name = "%s"
@@ -259,7 +308,7 @@ resource "aws_cognito_user_pool_client" "client" {
   read_attributes = ["email"]
   write_attributes = ["email"]
 
-  refresh_token_validity = 300
+  refresh_token_validity = %d
 
   allowed_oauth_flows = ["code", "implicit"]
   allowed_oauth_flows_user_pool_client = "true"
@@ -269,5 +318,5 @@ resource "aws_cognito_user_pool_client" "client" {
   default_redirect_uri = "https://www.example.com/redirect"
   logout_urls = ["https://www.example.com/login"]
 }
-`, userPoolName, clientName)
+`, userPoolName, clientName, refreshTokenValidity)
 }


### PR DESCRIPTION
Fixes #5029 

Changes proposed in this pull request:

* The `UpdateUserPoolClient` API call appears to require a full specification of the client. Currently the provider sends a partial specification, including only the fields that have changed. As a result, any fields that aren't being updated are wiped out by `terraform apply`. This PR changes the provider to always send a full specification based on the Terraform config.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPoolClient_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserPoolClient_ -timeout 120m
=== RUN   TestAccAWSCognitoUserPoolClient_basic
--- PASS: TestAccAWSCognitoUserPoolClient_basic (15.03s)
=== RUN   TestAccAWSCognitoUserPoolClient_importBasic
--- PASS: TestAccAWSCognitoUserPoolClient_importBasic (16.81s)
=== RUN   TestAccAWSCognitoUserPoolClient_RefreshTokenValidity
--- PASS: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (24.37s)
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (14.49s)
=== RUN   TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
--- PASS: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (24.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	94.979s
```

The newly added acceptance test `TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField` passes here but fails on the master branch. The failure on master looks ilke:

```
(Note: failure from master branch. The issue is fixed in this PR)

make testacc TEST=./aws TESTARGS='-run=TestAccAWSCognitoUserPoolClient_allFields'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCognitoUserPoolClient_allFields -timeout 120m
=== RUN   TestAccAWSCognitoUserPoolClient_allFields
--- PASS: TestAccAWSCognitoUserPoolClient_allFields (15.28s)
=== RUN   TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField
--- FAIL: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (19.63s)
	testing.go:518: Step 1 error: Check failed: 24 errors occurred:
			* Check 3/28 error: aws_cognito_user_pool_client.client: Attribute 'explicit_auth_flows.#' expected "3", got "0"
			* Check 4/28 error: aws_cognito_user_pool_client.client: Attribute 'explicit_auth_flows.1728632605' not found
			* Check 5/28 error: aws_cognito_user_pool_client.client: Attribute 'explicit_auth_flows.1860959087' not found
			* Check 6/28 error: aws_cognito_user_pool_client.client: Attribute 'explicit_auth_flows.245201344' not found
			* Check 8/28 error: aws_cognito_user_pool_client.client: Attribute 'read_attributes.#' expected "1", got "0"
			* Check 9/28 error: aws_cognito_user_pool_client.client: Attribute 'read_attributes.881205744' not found
			* Check 10/28 error: aws_cognito_user_pool_client.client: Attribute 'write_attributes.#' expected "1", got "0"
			* Check 11/28 error: aws_cognito_user_pool_client.client: Attribute 'write_attributes.881205744' not found
			* Check 13/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_flows.#' expected "2", got "0"
			* Check 14/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_flows.2645166319' not found
			* Check 15/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_flows.3465961881' not found
			* Check 16/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_flows_user_pool_client' expected "true", got "false"
			* Check 17/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_scopes.#' expected "5", got "0"
			* Check 18/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_scopes.2517049750' not found
			* Check 19/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_scopes.881205744' not found
			* Check 20/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_scopes.2603607895' not found
			* Check 21/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_scopes.380129571' not found
			* Check 22/28 error: aws_cognito_user_pool_client.client: Attribute 'allowed_oauth_scopes.4080487570' not found
			* Check 23/28 error: aws_cognito_user_pool_client.client: Attribute 'callback_urls.#' expected "2", got "0"
			* Check 24/28 error: aws_cognito_user_pool_client.client: Attribute 'callback_urls.0' not found
			* Check 25/28 error: aws_cognito_user_pool_client.client: Attribute 'callback_urls.1' not found
			* Check 26/28 error: aws_cognito_user_pool_client.client: Attribute 'default_redirect_uri' expected "https://www.example.com/redirect", got ""
			* Check 27/28 error: aws_cognito_user_pool_client.client: Attribute 'logout_urls.#' expected "1", got "0"
			* Check 28/28 error: aws_cognito_user_pool_client.client: Attribute 'logout_urls.0' not found
		
		
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	34.930s
```
