### PR TITLE
resource/aws_rds_cluster: Prevent error when restoring cluster from snapshot with tagging enabled

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -1003,10 +1003,13 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
-		return err
-	} else {
-		d.SetPartial("tags")
+	// Tags are set on creation
+	if !d.IsNewResource() && d.HasChange("tags") {
+		if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
 	}
 
 	return resourceAwsRDSClusterRead(d, meta)


### PR DESCRIPTION
Fixes #5450 

Changes proposed in this pull request:

* Adds new `snapshot_identifier` acceptance testing for `aws_rds_cluster` courtesy new `aws_db_cluster_snapshot` resource
* Applies similar fix to `aws_rds_cluster` as #5370 did for `aws_db_instance`

Before code update:

```
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (304.08s)
	testing.go:518: Step 0 error: Error applying: 1 error occurred:
			* aws_rds_cluster.test: 1 error occurred:
			* aws_rds_cluster.test: InvalidParameterValue: The parameter ResourceName must be provided and must not be blank.
```

Output from acceptance testing:

```
22 tests passed (all tests)
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (3.12s)
=== RUN   TestAccAWSRDSCluster_encrypted
--- PASS: TestAccAWSRDSCluster_encrypted (96.39s)
=== RUN   TestAccAWSRDSCluster_EngineVersion
--- PASS: TestAccAWSRDSCluster_EngineVersion (107.47s)
=== RUN   TestAccAWSRDSCluster_generatedName
--- PASS: TestAccAWSRDSCluster_generatedName (109.91s)
=== RUN   TestAccAWSRDSCluster_takeFinalSnapshot
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (116.99s)
=== RUN   TestAccAWSRDSCluster_BacktrackWindow
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (119.67s)
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (136.51s)
=== RUN   TestAccAWSRDSCluster_importBasic
--- PASS: TestAccAWSRDSCluster_importBasic (136.55s)
=== RUN   TestAccAWSRDSCluster_iamAuth
--- PASS: TestAccAWSRDSCluster_iamAuth (136.82s)
=== RUN   TestAccAWSRDSCluster_namePrefix
--- PASS: TestAccAWSRDSCluster_namePrefix (140.23s)
=== RUN   TestAccAWSRDSCluster_backupsUpdate
--- PASS: TestAccAWSRDSCluster_backupsUpdate (149.23s)
=== RUN   TestAccAWSRDSCluster_updateTags
--- PASS: TestAccAWSRDSCluster_updateTags (149.37s)
=== RUN   TestAccAWSRDSCluster_updateIamRoles
--- PASS: TestAccAWSRDSCluster_updateIamRoles (149.69s)
=== RUN   TestAccAWSRDSCluster_updateCloudwatchLogsExports
--- PASS: TestAccAWSRDSCluster_updateCloudwatchLogsExports (149.70s)
=== RUN   TestAccAWSRDSCluster_kmsKey
--- PASS: TestAccAWSRDSCluster_kmsKey (156.69s)
=== RUN   TestAccAWSRDSCluster_Port
--- PASS: TestAccAWSRDSCluster_Port (211.28s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (324.05s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (344.10s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_Tags
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (404.99s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (404.58s)
=== RUN   TestAccAWSRDSCluster_s3Restore
--- PASS: TestAccAWSRDSCluster_s3Restore (1403.30s)
=== RUN   TestAccAWSRDSCluster_EncryptedCrossRegionReplication
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1566.31s)
```
