### PR TITLE
Add arn for aws_subnet and data.aws_subnet

### DIFF
--- a/aws/data_source_aws_subnet.go
+++ b/aws/data_source_aws_subnet.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -71,6 +72,11 @@ func dataSourceAwsSubnet() *schema.Resource {
 			},
 
 			"ipv6_cidr_block_association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -154,6 +160,15 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
 		}
 	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "ec2",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("subnet/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
 
 	return nil
 }

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"regexp"
 )
 
 func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
@@ -115,6 +116,13 @@ func testAccDataSourceAwsSubnetCheck(name string, rInt int) resource.TestCheckFu
 		}
 		if attr["tags.Name"] != "tf-acc-subnet-data-source" {
 			return fmt.Errorf("bad Name tag %s", attr["tags.Name"])
+		}
+
+		arnformat := `^arn:[^:]+:ec2:[^:]+:\d{12}:subnet/subnet-.+`
+		arnregex := regexp.MustCompile(arnformat)
+
+		if !arnregex.MatchString(attr["arn"]) {
+			return fmt.Errorf("arn doesn't match format %s", attr["arn"])
 		}
 
 		return nil

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -64,6 +65,11 @@ func resourceAwsSubnet() *schema.Resource {
 			},
 
 			"ipv6_cidr_block_association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -154,6 +160,16 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("ipv6_cidr_block", "")
 		}
 	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "ec2",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("subnet/%s", d.Id()),
+	}
+	d.Set("arn", arn.String())
+
 	d.Set("tags", tagsToMap(subnet.Tags))
 
 	return nil

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"regexp"
 )
 
 // add sweeper to delete known test subnets
@@ -111,6 +112,10 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 					testAccCheckSubnetExists(
 						"aws_subnet.foo", &v),
 					testCheck,
+					resource.TestMatchResourceAttr(
+						"aws_subnet.foo",
+						"arn",
+						regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:subnet/subnet-.+`)),
 				),
 			},
 		},

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -89,3 +89,7 @@ All of the argument attributes except `filter` blocks are also exported as
 result attributes. This data source will complete the data by populating
 any fields that are not included in the configuration with the data for
 the selected subnet.
+
+In addition the following attributes are exported:
+
+* `arn` - The ARN of the subnet.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -64,6 +64,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the subnet
+* `arn` - The ARN of the subnet.
 * `availability_zone`- The AZ for the subnet.
 * `cidr_block` - The CIDR block for the subnet.
 * `vpc_id` - The VPC ID.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Add ARN attribute to aws_subnet and data.aws_subnet
* Update documentation

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccDataSourceAwsSubnet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceAwsSubnet_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceAwsSubnet_basic
--- PASS: TestAccDataSourceAwsSubnet_basic (63.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	63.640s
```
```
make testacc TESTARGS='-run=TestAccAWSSubnet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSubnet_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (58.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	58.711s

```
