### PR TITLE
Issue #5470 aws_cloudwatch_metric_alarm should expsose arn

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -30,6 +30,10 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"comparison_operator": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -163,6 +167,7 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	}
 	d.Set("alarm_description", a.AlarmDescription)
 	d.Set("alarm_name", a.AlarmName)
+	d.Set("arn", a.AlarmArn)
 	d.Set("comparison_operator", a.ComparisonOperator)
 	d.Set("datapoints_to_alarm", a.DatapointsToAlarm)
 	if err := d.Set("dimensions", flattenDimensions(a.Dimensions)); err != nil {

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -328,7 +328,7 @@ func getAwsCloudWatchMetricAlarm(d *schema.ResourceData, meta interface{}) (*clo
 
 	// Find it and return it
 	for idx, ma := range resp.MetricAlarms {
-		if *ma.AlarmName == d.Id() {
+		if aws.StringValue(ma.AlarmName) == d.Id() {
 			return resp.MetricAlarms[idx], nil
 		}
 	}
@@ -339,7 +339,7 @@ func getAwsCloudWatchMetricAlarm(d *schema.ResourceData, meta interface{}) (*clo
 func _strArrPtrToList(strArrPtr []*string) []string {
 	var result []string
 	for _, elem := range strArrPtr {
-		result = append(result, *elem)
+		result = append(result, aws.StringValue(elem))
 	}
 	return result
 }

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -27,7 +27,7 @@ func TestAccAWSCloudWatchMetricAlarm_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_name", "CPUUtilization"),
 					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "statistic", "Average"),
 					resource.TestMatchResourceAttr("aws_cloudwatch_metric_alarm.foobar", "arn",
-						regexp.MustCompile(`^arn:[\w-]+:cloudwatch:[^:]+:\d{12}:alarm/.+$`)),
+						regexp.MustCompile(`^arn:[\w-]+:cloudwatch:[^:]+:\d{12}:alarm:.+$`)),
 					testAccCheckCloudWatchMetricAlarmDimension(
 						"aws_cloudwatch_metric_alarm.foobar", "InstanceId", "i-abc123"),
 				),

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -26,6 +26,8 @@ func TestAccAWSCloudWatchMetricAlarm_basic(t *testing.T) {
 					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
 					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_name", "CPUUtilization"),
 					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "statistic", "Average"),
+					resource.TestMatchResourceAttr("aws_cloudwatch_metric_alarm.foobar", "arn",
+						regexp.MustCompile(`^arn:[\w-]+:cloudwatch:[^:]+:\d{12}:alarm/.+$`)),
 					testAccCheckCloudWatchMetricAlarmDimension(
 						"aws_cloudwatch_metric_alarm.foobar", "InstanceId", "i-abc123"),
 				),

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -68,6 +68,7 @@ for details about valid values.
 The following arguments are supported:
 
 * `alarm_name` - (Required) The descriptive name for the alarm. This name must be unique within the user's AWS account
+* `arn` - The ARN of the cloudwatch metric alarm.
 * `comparison_operator` - (Required) The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: `GreaterThanOrEqualToThreshold`, `GreaterThanThreshold`, `LessThanThreshold`, `LessThanOrEqualToThreshold`.
 * `evaluation_periods` - (Required) The number of periods over which data is compared to the specified threshold.
 * `metric_name` - (Required) The name for the alarm's associated metric.


### PR DESCRIPTION
Fixes #5470 

Changes proposed in this pull request:

* Change 1
added arn attribute

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSCloudWatchMetricAlarm_basic -timeout 120m
=== RUN   TestAccAWSCloudWatchMetricAlarm_basic
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (31.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	(cached)
...
```
