### PR TITLE
Issue #5160 arn as an attribute for aws_secretsmanager_secret_version

### DIFF
--- a/aws/data_source_aws_secretsmanager_secret_version.go
+++ b/aws/data_source_aws_secretsmanager_secret_version.go
@@ -14,6 +14,10 @@ func dataSourceAwsSecretsManagerSecretVersion() *schema.Resource {
 		Read: dataSourceAwsSecretsManagerSecretVersionRead,
 
 		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"secret_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -78,6 +82,7 @@ func dataSourceAwsSecretsManagerSecretVersionRead(d *schema.ResourceData, meta i
 	d.Set("secret_id", secretID)
 	d.Set("secret_string", output.SecretString)
 	d.Set("version_id", output.VersionId)
+	d.Set("arn", output.ARN)
 
 	if err := d.Set("version_stages", flattenStringList(output.VersionStages)); err != nil {
 		return fmt.Errorf("error setting version_stages: %s", err)

--- a/aws/resource_aws_secretsmanager_secret_version.go
+++ b/aws/resource_aws_secretsmanager_secret_version.go
@@ -21,6 +21,10 @@ func resourceAwsSecretsManagerSecretVersion() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"secret_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -102,6 +106,7 @@ func resourceAwsSecretsManagerSecretVersionRead(d *schema.ResourceData, meta int
 	d.Set("secret_id", secretID)
 	d.Set("secret_string", output.SecretString)
 	d.Set("version_id", output.VersionId)
+	d.Set("arn", output.ARN)
 
 	if err := d.Set("version_stages", flattenStringList(output.VersionStages)); err != nil {
 		return fmt.Errorf("error setting version_stages: %s", err)

--- a/aws/resource_aws_secretsmanager_secret_version_test.go
+++ b/aws/resource_aws_secretsmanager_secret_version_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,6 +30,8 @@ func TestAccAwsSecretsManagerSecretVersion_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.3070137", "AWSCURRENT"),
+					resource.TestMatchResourceAttr(resourceName, "arn",
+						regexp.MustCompile(`^arn:[\w-]+:secretsmanager:[^:]+:\d{12}:secret:.+$`)),
 				),
 			},
 			{

--- a/website/docs/d/secretsmanager_secret_version.html.markdown
+++ b/website/docs/d/secretsmanager_secret_version.html.markdown
@@ -39,6 +39,7 @@ data "aws_secretsmanager_secret_version" "by-version-stage" {
 
 ## Attributes Reference
 
+* `arn` - The ARN of the secret.
 * `id` - The unique identifier of this version of the secret.
 * `secret_string` - The decrypted part of the protected secret information that was originally provided as a string.
 * `version_id` - The unique identifier of this version of the secret.

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -57,7 +57,8 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-* `id` - A pipe delimited combination of secret ID and version ID
+* `arn` - The ARN of the secret.
+* `id` - A pipe delimited combination of secret ID and version ID.
 * `version_id` - The unique identifier of the version of the secret.
 
 ## Import


### PR DESCRIPTION
Fixes #5160 

Changes proposed in this pull request:

* Change 1
added arn for resource aws_secretsmanager_secret_version
* Change 2
added arn for datasource aws_secretsmanager_secret_version
