### PR TITLE
resource/aws_neptune_event_subscription: Support resource import

### DIFF
--- a/aws/resource_aws_neptune_event_subscription.go
+++ b/aws/resource_aws_neptune_event_subscription.go
@@ -17,6 +17,9 @@ func resourceAwsNeptuneEventSubscription() *schema.Resource {
 		Read:   resourceAwsNeptuneEventSubscriptionRead,
 		Update: resourceAwsNeptuneEventSubscriptionUpdate,
 		Delete: resourceAwsNeptuneEventSubscriptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(40 * time.Minute),

--- a/aws/resource_aws_neptune_event_subscription_test.go
+++ b/aws/resource_aws_neptune_event_subscription_test.go
@@ -45,6 +45,11 @@ func TestAccAWSNeptuneEventSubscription_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_neptune_event_subscription.bar", "tags.Name", "tf-acc-test1"),
 				),
 			},
+			{
+				ResourceName:      "aws_neptune_event_subscription.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -66,6 +71,12 @@ func TestAccAWSNeptuneEventSubscription_withPrefix(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_neptune_event_subscription.bar", "name", startsWithPrefix),
 				),
+			},
+			{
+				ResourceName:            "aws_neptune_event_subscription.bar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})
@@ -100,6 +111,11 @@ func TestAccAWSNeptuneEventSubscription_withSourceIds(t *testing.T) {
 						"aws_neptune_event_subscription.bar", "source_ids.#", "2"),
 				),
 			},
+			{
+				ResourceName:      "aws_neptune_event_subscription.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -132,6 +148,11 @@ func TestAccAWSNeptuneEventSubscription_withCategories(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_neptune_event_subscription.bar", "event_categories.#", "1"),
 				),
+			},
+			{
+				ResourceName:      "aws_neptune_event_subscription.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/neptune_event_subscription.html.markdown
+++ b/website/docs/r/neptune_event_subscription.html.markdown
@@ -90,3 +90,11 @@ configuration options:
 - `create` - (Default `40m`) How long to wait for creating event subscription to become available.
 - `delete` - (Default `40m`) How long to wait for deleting event subscription to become fully deleted.
 - `update` - (Default `40m`) How long to wait for updating event subscription to complete updates.
+
+## Import
+
+`aws_neptune_event_subscription` can be imported by using the event subscription name, e.g.
+
+```
+$ terraform import aws_neptune_event_subscription.example my-event-subscription
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Support, document, and acceptance test `aws_neptune_event_subscription` resource import

Output from acceptance testing:

```
4 tests passed (all tests)
=== RUN   TestAccAWSNeptuneEventSubscription_withSourceIds
--- PASS: TestAccAWSNeptuneEventSubscription_withSourceIds (440.18s)
=== RUN   TestAccAWSNeptuneEventSubscription_withPrefix
--- PASS: TestAccAWSNeptuneEventSubscription_withPrefix (456.03s)
=== RUN   TestAccAWSNeptuneEventSubscription_withCategories
--- PASS: TestAccAWSNeptuneEventSubscription_withCategories (779.61s)
=== RUN   TestAccAWSNeptuneEventSubscription_basic
--- PASS: TestAccAWSNeptuneEventSubscription_basic (779.95s)
```
