### PR TITLE
New Resource: aws_neptune_cluster_snapshot

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -509,6 +509,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_neptune_cluster":                              resourceAwsNeptuneCluster(),
 			"aws_neptune_cluster_instance":                     resourceAwsNeptuneClusterInstance(),
 			"aws_neptune_cluster_parameter_group":              resourceAwsNeptuneClusterParameterGroup(),
+			"aws_neptune_cluster_snapshot":                     resourceAwsNeptuneClusterSnapshot(),
 			"aws_neptune_event_subscription":                   resourceAwsNeptuneEventSubscription(),
 			"aws_neptune_parameter_group":                      resourceAwsNeptuneParameterGroup(),
 			"aws_neptune_subnet_group":                         resourceAwsNeptuneSubnetGroup(),

--- a/aws/resource_aws_neptune_cluster_snapshot.go
+++ b/aws/resource_aws_neptune_cluster_snapshot.go
@@ -1,0 +1,218 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsNeptuneClusterSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsNeptuneClusterSnapshotCreate,
+		Read:   resourceAwsNeptuneClusterSnapshotRead,
+		Delete: resourceAwsNeptuneClusterSnapshotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"db_cluster_snapshot_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"db_cluster_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"allocated_storage": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"db_cluster_snapshot_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"license_model": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"source_db_cluster_snapshot_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"snapshot_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsNeptuneClusterSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	input := &neptune.CreateDBClusterSnapshotInput{
+		DBClusterIdentifier:         aws.String(d.Get("db_cluster_identifier").(string)),
+		DBClusterSnapshotIdentifier: aws.String(d.Get("db_cluster_snapshot_identifier").(string)),
+	}
+
+	log.Printf("[DEBUG] Creating Neptune DB Cluster Snapshot: %s", input)
+	_, err := conn.CreateDBClusterSnapshot(input)
+	if err != nil {
+		return fmt.Errorf("error creating Neptune DB Cluster Snapshot: %s", err)
+	}
+	d.SetId(d.Get("db_cluster_snapshot_identifier").(string))
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"available"},
+		Refresh:    resourceAwsNeptuneClusterSnapshotStateRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		MinTimeout: 10 * time.Second,
+		Delay:      5 * time.Second,
+	}
+
+	// Wait, catching any errors
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for Neptune DB Cluster Snapshot %q to create: %s", d.Id(), err)
+	}
+
+	return resourceAwsNeptuneClusterSnapshotRead(d, meta)
+}
+
+func resourceAwsNeptuneClusterSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	input := &neptune.DescribeDBClusterSnapshotsInput{
+		DBClusterSnapshotIdentifier: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading Neptune DB Cluster Snapshot: %s", input)
+	output, err := conn.DescribeDBClusterSnapshots(input)
+	if err != nil {
+		if isAWSErr(err, neptune.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+			log.Printf("[WARN] Neptune DB Cluster Snapshot %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Neptune DB Cluster Snapshot %q: %s", d.Id(), err)
+	}
+
+	if output == nil || len(output.DBClusterSnapshots) == 0 || output.DBClusterSnapshots[0] == nil || aws.StringValue(output.DBClusterSnapshots[0].DBClusterSnapshotIdentifier) != d.Id() {
+		log.Printf("[WARN] Neptune DB Cluster Snapshot %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	snapshot := output.DBClusterSnapshots[0]
+
+	d.Set("allocated_storage", snapshot.AllocatedStorage)
+	if err := d.Set("availability_zones", flattenStringList(snapshot.AvailabilityZones)); err != nil {
+		return fmt.Errorf("error setting availability_zones: %s", err)
+	}
+	d.Set("db_cluster_identifier", snapshot.DBClusterIdentifier)
+	d.Set("db_cluster_snapshot_arn", snapshot.DBClusterSnapshotArn)
+	d.Set("db_cluster_snapshot_identifier", snapshot.DBClusterSnapshotIdentifier)
+	d.Set("engine_version", snapshot.EngineVersion)
+	d.Set("engine", snapshot.Engine)
+	d.Set("kms_key_id", snapshot.KmsKeyId)
+	d.Set("license_model", snapshot.LicenseModel)
+	d.Set("port", snapshot.Port)
+	d.Set("snapshot_type", snapshot.SnapshotType)
+	d.Set("source_db_cluster_snapshot_arn", snapshot.SourceDBClusterSnapshotArn)
+	d.Set("status", snapshot.Status)
+	d.Set("storage_encrypted", snapshot.StorageEncrypted)
+	d.Set("vpc_id", snapshot.VpcId)
+
+	return nil
+}
+
+func resourceAwsNeptuneClusterSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).neptuneconn
+
+	input := &neptune.DeleteDBClusterSnapshotInput{
+		DBClusterSnapshotIdentifier: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Neptune DB Cluster Snapshot: %s", input)
+	_, err := conn.DeleteDBClusterSnapshot(input)
+	if err != nil {
+		if isAWSErr(err, neptune.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Neptune DB Cluster Snapshot %q: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsNeptuneClusterSnapshotStateRefreshFunc(dbClusterSnapshotIdentifier string, conn *neptune.Neptune) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &neptune.DescribeDBClusterSnapshotsInput{
+			DBClusterSnapshotIdentifier: aws.String(dbClusterSnapshotIdentifier),
+		}
+
+		log.Printf("[DEBUG] Reading Neptune DB Cluster Snapshot: %s", input)
+		output, err := conn.DescribeDBClusterSnapshots(input)
+		if err != nil {
+			if isAWSErr(err, neptune.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+				return nil, "", nil
+			}
+			return nil, "", fmt.Errorf("Error retrieving DB Cluster Snapshots: %s", err)
+		}
+
+		if output == nil || len(output.DBClusterSnapshots) == 0 || output.DBClusterSnapshots[0] == nil {
+			return nil, "", fmt.Errorf("No snapshots returned for %s", dbClusterSnapshotIdentifier)
+		}
+
+		snapshot := output.DBClusterSnapshots[0]
+
+		return output, aws.StringValue(snapshot.Status), nil
+	}
+}

--- a/aws/resource_aws_neptune_cluster_snapshot_test.go
+++ b/aws/resource_aws_neptune_cluster_snapshot_test.go
@@ -1,0 +1,125 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSNeptuneClusterSnapshot_basic(t *testing.T) {
+	var dbClusterSnapshot neptune.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_neptune_cluster_snapshot.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNeptuneClusterSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsNeptuneClusterSnapshotConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNeptuneClusterSnapshotExists(resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttrSet(resourceName, "allocated_storage"),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zones.#"),
+					resource.TestMatchResourceAttr(resourceName, "db_cluster_snapshot_arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-snapshot:.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "engine"),
+					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "license_model"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_type", "manual"),
+					resource.TestCheckResourceAttr(resourceName, "source_db_cluster_snapshot_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
+					resource.TestMatchResourceAttr(resourceName, "vpc_id", regexp.MustCompile(`^vpc-.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckNeptuneClusterSnapshotDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).neptuneconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_neptune_cluster_snapshot" {
+			continue
+		}
+
+		input := &neptune.DescribeDBClusterSnapshotsInput{
+			DBClusterSnapshotIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeDBClusterSnapshots(input)
+		if err != nil {
+			if isAWSErr(err, neptune.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+				continue
+			}
+			return err
+		}
+
+		if output != nil && len(output.DBClusterSnapshots) > 0 && output.DBClusterSnapshots[0] != nil && aws.StringValue(output.DBClusterSnapshots[0].DBClusterSnapshotIdentifier) == rs.Primary.ID {
+			return fmt.Errorf("Neptune DB Cluster Snapshot %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckNeptuneClusterSnapshotExists(resourceName string, dbClusterSnapshot *neptune.DBClusterSnapshot) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set for %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).neptuneconn
+
+		input := &neptune.DescribeDBClusterSnapshotsInput{
+			DBClusterSnapshotIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeDBClusterSnapshots(input)
+		if err != nil {
+			return err
+		}
+
+		if output == nil || len(output.DBClusterSnapshots) == 0 || output.DBClusterSnapshots[0] == nil || aws.StringValue(output.DBClusterSnapshots[0].DBClusterSnapshotIdentifier) != rs.Primary.ID {
+			return fmt.Errorf("Neptune DB Cluster Snapshot %q not found", rs.Primary.ID)
+		}
+
+		*dbClusterSnapshot = *output.DBClusterSnapshots[0]
+
+		return nil
+	}
+}
+
+func testAccAwsNeptuneClusterSnapshotConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_neptune_cluster" "test" {
+  cluster_identifier   = %q
+  skip_final_snapshot  = true
+}
+
+resource "aws_neptune_cluster_snapshot" "test" {
+  db_cluster_identifier          = "${aws_neptune_cluster.test.id}"
+  db_cluster_snapshot_identifier = %q
+}
+`, rName, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1732,6 +1732,10 @@
                             <a href="/docs/providers/aws/r/neptune_cluster_instance.html">aws_neptune_cluster_instance</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-neptune-cluster-snapshot") %>>
+                            <a href="/docs/providers/aws/r/neptune_cluster_snapshot.html">aws_neptune_cluster_snapshot</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-neptune-event-subscription") %>>
                             <a href="/docs/providers/aws/r/neptune_event_subscription.html">aws_neptune_event_subscription</a>
                         </li>

--- a/website/docs/r/neptune_cluster_snapshot.html.markdown
+++ b/website/docs/r/neptune_cluster_snapshot.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "aws"
+page_title: "AWS: aws_neptune_cluster_snapshot"
+sidebar_current: "docs-aws-resource-neptune-cluster-snapshot"
+description: |-
+  Manages a Neptune database cluster snapshot.
+---
+
+# aws_neptune_cluster_snapshot
+
+Manages a Neptune database cluster snapshot.
+
+## Example Usage
+
+```hcl
+resource "aws_neptune_cluster_snapshot" "example" {
+  db_cluster_identifier          = "${aws_neptune_cluster.example.id}"
+  db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `db_cluster_identifier` - (Required) The DB Cluster Identifier from which to take the snapshot.
+* `db_cluster_snapshot_identifier` - (Required) The Identifier for the snapshot.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `allocated_storage` - Specifies the allocated storage size in gigabytes (GB).
+* `availability_zones` - List of EC2 Availability Zones that instances in the DB cluster snapshot can be restored in.
+* `db_cluster_snapshot_arn` - The Amazon Resource Name (ARN) for the DB Cluster Snapshot.
+* `engine` - Specifies the name of the database engine.
+* `engine_version` - Version of the database engine for this DB cluster snapshot.
+* `kms_key_id` - If storage_encrypted is true, the AWS KMS key identifier for the encrypted DB cluster snapshot.
+* `license_model` - License model information for the restored DB cluster.
+* `port` - Port that the DB cluster was listening on at the time of the snapshot.
+* `source_db_cluster_snapshot_identifier` - The DB Cluster Snapshot Arn that the DB Cluster Snapshot was copied from. It only has value in case of cross customer or cross region copy.
+* `storage_encrypted` - Specifies whether the DB cluster snapshot is encrypted.
+* `status` - The status of this DB Cluster Snapshot.
+* `vpc_id` - The VPC ID associated with the DB cluster snapshot.
+
+## Timeouts
+
+`aws_neptune_cluster_snapshot` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `20m`) How long to wait for the snapshot to be available.
+
+## Import
+
+`aws_neptune_cluster_snapshot` can be imported by using the cluster snapshot identifier, e.g.
+
+```
+$ terraform import aws_neptune_cluster_snapshot.example my-cluster-snapshot
+```


### PR DESCRIPTION
For future support of a Neptune cluster snapshot data source and restoring Neptune clusters from snapshot.

Changes proposed in this pull request:

* New Resource: `aws_neptune_cluster_snapshot`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSNeptuneClusterSnapshot_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSNeptuneClusterSnapshot_basic -timeout 120m
=== RUN   TestAccAWSNeptuneClusterSnapshot_basic
--- PASS: TestAccAWSNeptuneClusterSnapshot_basic (188.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	188.877s
```
