### PR TITLE
resource/aws_db_instance: Allow alert, listener, and trace for enabled_cloudwatch_logs_exports

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -396,10 +396,13 @@ func resourceAwsDbInstance() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
+						"alert",
 						"audit",
 						"error",
 						"general",
+						"listener",
 						"slowquery",
+						"trace",
 					}, false),
 				},
 			},

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -91,8 +91,7 @@ with read replicas, it needs to be specified only if the source database
 specifies an instance in another AWS Region. See [DBSubnetGroupName in API
 action CreateDBInstanceReadReplica](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html)
 for additonal read replica contraints.
-* `enabled_cloudwatch_logs_exports` - (Optional) Name list of enable log type for exporting to cloudwatch logs. If omitted, any logs will not be exported to cloudwatch logs.
-   Either of the following is supported: `audit`, `error`, `general`, `slowquery`.
+* `enabled_cloudwatch_logs_exports` - (Optional) List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on `engine`): `alert`, `audit`, `error`, `general`, `listener`, `slowquery`, `trace`.
 * `engine` - (Required unless a `snapshot_identifier` or `replicate_source_db`
 is provided) The database engine to use.  For supported values, see the Engine parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
 Note that for Amazon Aurora instances the engine must match the [DB cluster](/docs/providers/aws/r/rds_cluster.html)'s engine'.


### PR DESCRIPTION
Fixes #5235
Fixes #5253 

Changes proposed in this pull request:

* On the tin

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle -timeout 120m
=== RUN   TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (578.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	579.497s
```
