### PR TITLE
Remove required strings for outputs

### DIFF
--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -38,6 +38,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the parameter.
-* `name` - (Required) The name of the parameter.
-* `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
-* `value` - (Required) The value of the parameter.
+* `name` - The name of the parameter.
+* `type` - The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
+* `value` - The value of the parameter.


### PR DESCRIPTION
- Outputs can't be "required". Fixed.


Changes proposed in this pull request: Remove 'required' strings from exported outputs section in doc.

Testing done: None.