### PR TITLE
resource/aws_cloudtrail: Increase IAM retry threshold from 15 seconds to 1 minute

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -165,7 +165,7 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	var t *cloudtrail.CreateTrailOutput
-	err := resource.Retry(15*time.Second, func() *resource.RetryError {
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		var err error
 		t, err = conn.CreateTrail(&input)
 		if err != nil {

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -332,7 +332,7 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] Updating CloudTrail: %s", input)
 	var t *cloudtrail.UpdateTrailOutput
-	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		var err error
 		t, err = conn.UpdateTrail(&input)
 		if err != nil {


### PR DESCRIPTION
IAM can take upwards of a minute to fully propagate changes due to its eventually consistent nature. Found via daily acceptance testing:

```
        --- FAIL: TestAccAWSCloudTrail/Trail/cloudwatch (21.00s)
        	testing.go:518: Step 0 error: Error applying: 1 error occurred:
        			* aws_cloudtrail.test: 1 error occurred:
        			* aws_cloudtrail.test: InvalidCloudWatchLogsLogGroupArnException: Access denied. Check the permissions for your role.
        			status code: 400, request id: 7ce4eabc-65dc-4cd6-9e87-4240a5dde616
```

Changes proposed in this pull request:

* Increase IAM retry threshold from 15 seconds to 1 minute during creation and update

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudTrail'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudTrail -timeout 120m
=== RUN   TestAccAWSCloudTrailServiceAccount_basic
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (14.58s)
=== RUN   TestAccAWSCloudTrail_importBasic
--- PASS: TestAccAWSCloudTrail_importBasic (49.68s)
=== RUN   TestAccAWSCloudTrail
=== RUN   TestAccAWSCloudTrail/Trail
=== RUN   TestAccAWSCloudTrail/Trail/kmsKey
=== RUN   TestAccAWSCloudTrail/Trail/tags
=== RUN   TestAccAWSCloudTrail/Trail/eventSelector
=== RUN   TestAccAWSCloudTrail/Trail/basic
=== RUN   TestAccAWSCloudTrail/Trail/cloudwatch
=== RUN   TestAccAWSCloudTrail/Trail/enableLogging
=== RUN   TestAccAWSCloudTrail/Trail/isMultiRegion
=== RUN   TestAccAWSCloudTrail/Trail/logValidation
--- PASS: TestAccAWSCloudTrail (702.12s)
    --- PASS: TestAccAWSCloudTrail/Trail (702.12s)
        --- PASS: TestAccAWSCloudTrail/Trail/kmsKey (68.54s)
        --- PASS: TestAccAWSCloudTrail/Trail/tags (100.72s)
        --- PASS: TestAccAWSCloudTrail/Trail/eventSelector (91.26s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (74.80s)
        --- PASS: TestAccAWSCloudTrail/Trail/cloudwatch (93.76s)
        --- PASS: TestAccAWSCloudTrail/Trail/enableLogging (101.92s)
        --- PASS: TestAccAWSCloudTrail/Trail/isMultiRegion (96.86s)
        --- PASS: TestAccAWSCloudTrail/Trail/logValidation (74.27s)
=== RUN   TestAccAWSCloudTrail_include_global_service_events
--- PASS: TestAccAWSCloudTrail_include_global_service_events (45.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	812.286s
```
