### PR TITLE
Bump AWS SDK to v1.15.9

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go
@@ -158,13 +158,14 @@ func (e *Expiry) SetExpiration(expiration time.Time, window time.Duration) {
 
 // IsExpired returns if the credentials are expired.
 func (e *Expiry) IsExpired() bool {
-	if e.CurrentTime == nil {
-		e.CurrentTime = time.Now
+	curTime := e.CurrentTime
+	if curTime == nil {
+		curTime = time.Now
 	}
-	return e.expiration.Before(e.CurrentTime())
+	return e.expiration.Before(curTime())
 }
 
-// A Credentials provides synchronous safe retrieval of AWS credentials Value.
+// A Credentials provides concurrency safe retrieval of AWS credentials Value.
 // Credentials will cache the credentials value until they expire. Once the value
 // expires the next Get will attempt to retrieve valid credentials.
 //

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.15.8"
+const SDKVersion = "1.15.9"

--- a/vendor/github.com/aws/aws-sdk-go/service/dax/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dax/api.go
@@ -100,6 +100,8 @@ func (c *DAX) CreateClusterRequest(input *CreateClusterInput) (req *request.Requ
 //   * ErrCodeTagQuotaPerResourceExceeded "TagQuotaPerResourceExceeded"
 //   You have exceeded the maximum number of tags for this DAX cluster.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -191,6 +193,8 @@ func (c *DAX) CreateParameterGroupRequest(input *CreateParameterGroupInput) (req
 //
 //   * ErrCodeInvalidParameterGroupStateFault "InvalidParameterGroupStateFault"
 //   One or more parameters in a parameter group are in an invalid state.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
@@ -288,6 +292,8 @@ func (c *DAX) CreateSubnetGroupRequest(input *CreateSubnetGroupInput) (req *requ
 //   * ErrCodeInvalidSubnet "InvalidSubnet"
 //   An invalid subnet identifier was specified.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/CreateSubnetGroup
 func (c *DAX) CreateSubnetGroup(input *CreateSubnetGroupInput) (*CreateSubnetGroupOutput, error) {
 	req, out := c.CreateSubnetGroupRequest(input)
@@ -375,6 +381,8 @@ func (c *DAX) DecreaseReplicationFactorRequest(input *DecreaseReplicationFactorI
 //
 //   * ErrCodeInvalidClusterStateFault "InvalidClusterStateFault"
 //   The requested DAX cluster is not in the available state.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
@@ -467,6 +475,8 @@ func (c *DAX) DeleteClusterRequest(input *DeleteClusterInput) (req *request.Requ
 //   * ErrCodeInvalidClusterStateFault "InvalidClusterStateFault"
 //   The requested DAX cluster is not in the available state.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -555,6 +565,8 @@ func (c *DAX) DeleteParameterGroupRequest(input *DeleteParameterGroupInput) (req
 //
 //   * ErrCodeParameterGroupNotFoundFault "ParameterGroupNotFoundFault"
 //   The specified parameter group does not exist.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
@@ -645,6 +657,8 @@ func (c *DAX) DeleteSubnetGroupRequest(input *DeleteSubnetGroupInput) (req *requ
 //
 //   * ErrCodeSubnetGroupNotFoundFault "SubnetGroupNotFoundFault"
 //   The requested subnet group name does not refer to an existing subnet group.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/DeleteSubnetGroup
 func (c *DAX) DeleteSubnetGroup(input *DeleteSubnetGroupInput) (*DeleteSubnetGroupOutput, error) {
@@ -741,6 +755,8 @@ func (c *DAX) DescribeClustersRequest(input *DescribeClustersInput) (req *reques
 //   * ErrCodeClusterNotFoundFault "ClusterNotFoundFault"
 //   The requested cluster ID does not refer to an existing DAX cluster.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -823,6 +839,8 @@ func (c *DAX) DescribeDefaultParametersRequest(input *DescribeDefaultParametersI
 // API operation DescribeDefaultParameters for usage and error information.
 //
 // Returned Error Codes:
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -910,6 +928,8 @@ func (c *DAX) DescribeEventsRequest(input *DescribeEventsInput) (req *request.Re
 // API operation DescribeEvents for usage and error information.
 //
 // Returned Error Codes:
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -996,6 +1016,8 @@ func (c *DAX) DescribeParameterGroupsRequest(input *DescribeParameterGroupsInput
 //   * ErrCodeParameterGroupNotFoundFault "ParameterGroupNotFoundFault"
 //   The specified parameter group does not exist.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -1080,6 +1102,8 @@ func (c *DAX) DescribeParametersRequest(input *DescribeParametersInput) (req *re
 // Returned Error Codes:
 //   * ErrCodeParameterGroupNotFoundFault "ParameterGroupNotFoundFault"
 //   The specified parameter group does not exist.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
@@ -1166,6 +1190,8 @@ func (c *DAX) DescribeSubnetGroupsRequest(input *DescribeSubnetGroupsInput) (req
 // Returned Error Codes:
 //   * ErrCodeSubnetGroupNotFoundFault "SubnetGroupNotFoundFault"
 //   The requested subnet group name does not refer to an existing subnet group.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/DescribeSubnetGroups
 func (c *DAX) DescribeSubnetGroups(input *DescribeSubnetGroupsInput) (*DescribeSubnetGroupsOutput, error) {
@@ -1262,6 +1288,8 @@ func (c *DAX) IncreaseReplicationFactorRequest(input *IncreaseReplicationFactorI
 //   * ErrCodeNodeQuotaForCustomerExceededFault "NodeQuotaForCustomerExceededFault"
 //   You have attempted to exceed the maximum number of nodes for your AWS account.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -1354,6 +1382,8 @@ func (c *DAX) ListTagsRequest(input *ListTagsInput) (req *request.Request, outpu
 //   * ErrCodeInvalidClusterStateFault "InvalidClusterStateFault"
 //   The requested DAX cluster is not in the available state.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -1445,6 +1475,8 @@ func (c *DAX) RebootNodeRequest(input *RebootNodeInput) (req *request.Request, o
 //
 //   * ErrCodeInvalidClusterStateFault "InvalidClusterStateFault"
 //   The requested DAX cluster is not in the available state.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
@@ -1541,6 +1573,8 @@ func (c *DAX) TagResourceRequest(input *TagResourceInput) (req *request.Request,
 //   * ErrCodeInvalidClusterStateFault "InvalidClusterStateFault"
 //   The requested DAX cluster is not in the available state.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -1635,6 +1669,8 @@ func (c *DAX) UntagResourceRequest(input *UntagResourceInput) (req *request.Requ
 //
 //   * ErrCodeInvalidClusterStateFault "InvalidClusterStateFault"
 //   The requested DAX cluster is not in the available state.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
@@ -1732,6 +1768,8 @@ func (c *DAX) UpdateClusterRequest(input *UpdateClusterInput) (req *request.Requ
 //   * ErrCodeParameterGroupNotFoundFault "ParameterGroupNotFoundFault"
 //   The specified parameter group does not exist.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
 //
@@ -1820,6 +1858,8 @@ func (c *DAX) UpdateParameterGroupRequest(input *UpdateParameterGroupInput) (req
 //
 //   * ErrCodeParameterGroupNotFoundFault "ParameterGroupNotFoundFault"
 //   The specified parameter group does not exist.
+//
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
 //
 //   * ErrCodeInvalidParameterValueException "InvalidParameterValueException"
 //   The value for a parameter is invalid.
@@ -1916,6 +1956,8 @@ func (c *DAX) UpdateSubnetGroupRequest(input *UpdateSubnetGroupInput) (req *requ
 //   * ErrCodeInvalidSubnet "InvalidSubnet"
 //   An invalid subnet identifier was specified.
 //
+//   * ErrCodeServiceLinkedRoleNotFoundFault "ServiceLinkedRoleNotFoundFault"
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/dax-2017-04-19/UpdateSubnetGroup
 func (c *DAX) UpdateSubnetGroup(input *UpdateSubnetGroupInput) (*UpdateSubnetGroupOutput, error) {
 	req, out := c.UpdateSubnetGroupRequest(input)
@@ -1988,6 +2030,10 @@ type Cluster struct {
 	// For example: sun:01:00-sun:09:00. Cluster maintenance normally takes less
 	// than 30 minutes, and is performed automatically within the maintenance window.
 	PreferredMaintenanceWindow *string `type:"string"`
+
+	// The description of the server-side encryption status on the specified DAX
+	// cluster.
+	SSEDescription *SSEDescription `type:"structure"`
 
 	// A list of security groups, and the status of each, for the nodes in the cluster.
 	SecurityGroups []*SecurityGroupMembership `type:"list"`
@@ -2084,6 +2130,12 @@ func (s *Cluster) SetPreferredMaintenanceWindow(v string) *Cluster {
 	return s
 }
 
+// SetSSEDescription sets the SSEDescription field's value.
+func (s *Cluster) SetSSEDescription(v *SSEDescription) *Cluster {
+	s.SSEDescription = v
+	return s
+}
+
 // SetSecurityGroups sets the SecurityGroups field's value.
 func (s *Cluster) SetSecurityGroups(v []*SecurityGroupMembership) *Cluster {
 	s.SecurityGroups = v
@@ -2135,9 +2187,7 @@ type CreateClusterInput struct {
 	// A valid Amazon Resource Name (ARN) that identifies an IAM role. At runtime,
 	// DAX will assume this role and use the role's permissions to access DynamoDB
 	// on your behalf.
-	//
-	// IamRoleArn is a required field
-	IamRoleArn *string `type:"string" required:"true"`
+	IamRoleArn *string `type:"string"`
 
 	// The compute and memory capacity of the nodes in the cluster.
 	//
@@ -2189,6 +2239,9 @@ type CreateClusterInput struct {
 	// ReplicationFactor is a required field
 	ReplicationFactor *int64 `type:"integer" required:"true"`
 
+	// Represents the settings used to enable server-side encryption on the cluster.
+	SSESpecification *SSESpecification `type:"structure"`
+
 	// A list of security group IDs to be assigned to each node in the DAX cluster.
 	// (Each of the security group ID is system-generated.)
 	//
@@ -2222,14 +2275,16 @@ func (s *CreateClusterInput) Validate() error {
 	if s.ClusterName == nil {
 		invalidParams.Add(request.NewErrParamRequired("ClusterName"))
 	}
-	if s.IamRoleArn == nil {
-		invalidParams.Add(request.NewErrParamRequired("IamRoleArn"))
-	}
 	if s.NodeType == nil {
 		invalidParams.Add(request.NewErrParamRequired("NodeType"))
 	}
 	if s.ReplicationFactor == nil {
 		invalidParams.Add(request.NewErrParamRequired("ReplicationFactor"))
+	}
+	if s.SSESpecification != nil {
+		if err := s.SSESpecification.Validate(); err != nil {
+			invalidParams.AddNested("SSESpecification", err.(request.ErrInvalidParams))
+		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -2289,6 +2344,12 @@ func (s *CreateClusterInput) SetPreferredMaintenanceWindow(v string) *CreateClus
 // SetReplicationFactor sets the ReplicationFactor field's value.
 func (s *CreateClusterInput) SetReplicationFactor(v int64) *CreateClusterInput {
 	s.ReplicationFactor = &v
+	return s
+}
+
+// SetSSESpecification sets the SSESpecification field's value.
+func (s *CreateClusterInput) SetSSESpecification(v *SSESpecification) *CreateClusterInput {
+	s.SSESpecification = v
 	return s
 }
 
@@ -3992,6 +4053,79 @@ func (s *RebootNodeOutput) SetCluster(v *Cluster) *RebootNodeOutput {
 	return s
 }
 
+// The description of the server-side encryption status on the specified DAX
+// cluster.
+type SSEDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The current state of server-side encryption:
+	//
+	//    * ENABLING - Server-side encryption is being enabled.
+	//
+	//    * ENABLED - Server-side encryption is enabled.
+	//
+	//    * DISABLING - Server-side encryption is being disabled.
+	//
+	//    * DISABLED - Server-side encryption is disabled.
+	Status *string `type:"string" enum:"SSEStatus"`
+}
+
+// String returns the string representation
+func (s SSEDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SSEDescription) GoString() string {
+	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *SSEDescription) SetStatus(v string) *SSEDescription {
+	s.Status = &v
+	return s
+}
+
+// Represents the settings used to enable server-side encryption.
+type SSESpecification struct {
+	_ struct{} `type:"structure"`
+
+	// Indicates whether server-side encryption is enabled (true) or disabled (false)
+	// on the cluster.
+	//
+	// Enabled is a required field
+	Enabled *bool `type:"boolean" required:"true"`
+}
+
+// String returns the string representation
+func (s SSESpecification) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s SSESpecification) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *SSESpecification) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "SSESpecification"}
+	if s.Enabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("Enabled"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEnabled sets the Enabled field's value.
+func (s *SSESpecification) SetEnabled(v bool) *SSESpecification {
+	s.Enabled = &v
+	return s
+}
+
 // An individual VPC security group and its status.
 type SecurityGroupMembership struct {
 	_ struct{} `type:"structure"`
@@ -4607,6 +4741,20 @@ const (
 
 	// ParameterTypeNodeTypeSpecific is a ParameterType enum value
 	ParameterTypeNodeTypeSpecific = "NODE_TYPE_SPECIFIC"
+)
+
+const (
+	// SSEStatusEnabling is a SSEStatus enum value
+	SSEStatusEnabling = "ENABLING"
+
+	// SSEStatusEnabled is a SSEStatus enum value
+	SSEStatusEnabled = "ENABLED"
+
+	// SSEStatusDisabling is a SSEStatus enum value
+	SSEStatusDisabling = "DISABLING"
+
+	// SSEStatusDisabled is a SSEStatus enum value
+	SSEStatusDisabled = "DISABLED"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/dax/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/dax/errors.go
@@ -108,6 +108,10 @@ const (
 	// You have attempted to exceed the maximum number of parameter groups.
 	ErrCodeParameterGroupQuotaExceededFault = "ParameterGroupQuotaExceededFault"
 
+	// ErrCodeServiceLinkedRoleNotFoundFault for service response error code
+	// "ServiceLinkedRoleNotFoundFault".
+	ErrCodeServiceLinkedRoleNotFoundFault = "ServiceLinkedRoleNotFoundFault"
+
 	// ErrCodeSubnetGroupAlreadyExistsFault for service response error code
 	// "SubnetGroupAlreadyExistsFault".
 	//

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
@@ -531,6 +531,9 @@ func (c *ECS) DeleteServiceRequest(input *DeleteServiceInput) (req *request.Requ
 // up and purged from Amazon ECS record keeping, and DescribeServices API operations
 // on those services return a ServiceNotFoundException error.
 //
+// If you attempt to create a new service with the same name as an existing
+// service in either ACTIVE or DRAINING status, you will receive an error.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -3764,6 +3767,7 @@ type AwsVpcConfiguration struct {
 	_ struct{} `type:"structure"`
 
 	// Whether the task's elastic network interface receives a public IP address.
+	// The default value is DISABLED.
 	AssignPublicIp *string `locationName:"assignPublicIp" type:"string" enum:"AssignPublicIp"`
 
 	// The security groups associated with the task or service. If you do not specify
@@ -3846,7 +3850,8 @@ type Cluster struct {
 	// The number of tasks in the cluster that are in the PENDING state.
 	PendingTasksCount *int64 `locationName:"pendingTasksCount" type:"integer"`
 
-	// The number of container instances registered into the cluster.
+	// The number of container instances registered into the cluster. This includes
+	// container instances in both ACTIVE and DRAINING status.
 	RegisteredContainerInstancesCount *int64 `locationName:"registeredContainerInstancesCount" type:"integer"`
 
 	// The number of tasks in the cluster that are in the RUNNING state.
@@ -4040,16 +4045,16 @@ type ContainerDefinition struct {
 	_ struct{} `type:"structure"`
 
 	// The command that is passed to the container. This parameter maps to Cmd in
-	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the COMMAND parameter to docker run (https://docs.docker.com/engine/reference/run/).
 	// For more information, see https://docs.docker.com/engine/reference/builder/#cmd
 	// (https://docs.docker.com/engine/reference/builder/#cmd).
 	Command []*string `locationName:"command" type:"list"`
 
 	// The number of cpu units reserved for the container. This parameter maps to
-	// CpuShares in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// CpuShares in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --cpu-shares option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// This field is optional for tasks using the Fargate launch type, and the only
@@ -4104,31 +4109,31 @@ type ContainerDefinition struct {
 	Cpu *int64 `locationName:"cpu" type:"integer"`
 
 	// When this parameter is true, networking is disabled within the container.
-	// This parameter maps to NetworkDisabled in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/).
+	// This parameter maps to NetworkDisabled in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/).
 	//
 	// This parameter is not supported for Windows containers.
 	DisableNetworking *bool `locationName:"disableNetworking" type:"boolean"`
 
 	// A list of DNS search domains that are presented to the container. This parameter
-	// maps to DnsSearch in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// maps to DnsSearch in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --dns-search option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// This parameter is not supported for Windows containers.
 	DnsSearchDomains []*string `locationName:"dnsSearchDomains" type:"list"`
 
 	// A list of DNS servers that are presented to the container. This parameter
-	// maps to Dns in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// maps to Dns in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --dns option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// This parameter is not supported for Windows containers.
 	DnsServers []*string `locationName:"dnsServers" type:"list"`
 
 	// A key/value map of labels to add to the container. This parameter maps to
-	// Labels in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// Labels in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --label option to docker run (https://docs.docker.com/engine/reference/run/).
 	// This parameter requires version 1.18 of the Docker Remote API or greater
 	// on your container instance. To check the Docker Remote API version on your
@@ -4140,8 +4145,8 @@ type ContainerDefinition struct {
 	// security systems. This field is not valid for containers in tasks using the
 	// Fargate launch type.
 	//
-	// This parameter maps to SecurityOpt in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// This parameter maps to SecurityOpt in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --security-opt option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// The Amazon ECS container agent running on a container instance must register
@@ -4159,16 +4164,16 @@ type ContainerDefinition struct {
 	// agent or enter your commands and arguments as command array items instead.
 	//
 	// The entry point that is passed to the container. This parameter maps to Entrypoint
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --entrypoint option to docker run (https://docs.docker.com/engine/reference/run/).
 	// For more information, see https://docs.docker.com/engine/reference/builder/#entrypoint
 	// (https://docs.docker.com/engine/reference/builder/#entrypoint).
 	EntryPoint []*string `locationName:"entryPoint" type:"list"`
 
 	// The environment variables to pass to a container. This parameter maps to
-	// Env in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// Env in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --env option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// We do not recommend using plaintext environment variables for sensitive information,
@@ -4192,22 +4197,22 @@ type ContainerDefinition struct {
 	// A list of hostnames and IP address mappings to append to the /etc/hosts file
 	// on the container. If using the Fargate launch type, this may be used to list
 	// non-Fargate hosts to which the container can talk. This parameter maps to
-	// ExtraHosts in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// ExtraHosts in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --add-host option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// This parameter is not supported for Windows containers.
 	ExtraHosts []*HostEntry `locationName:"extraHosts" type:"list"`
 
 	// The health check command and associated configuration parameters for the
-	// container. This parameter maps to HealthCheck in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// container. This parameter maps to HealthCheck in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the HEALTHCHECK parameter of docker run (https://docs.docker.com/engine/reference/run/).
 	HealthCheck *HealthCheck `locationName:"healthCheck" type:"structure"`
 
 	// The hostname to use for your container. This parameter maps to Hostname in
-	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --hostname option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// The hostname parameter is not supported if using the awsvpc networkMode.
@@ -4219,9 +4224,9 @@ type ContainerDefinition struct {
 	// repository-url/image@digest. Up to 255 letters (uppercase and lowercase),
 	// numbers, hyphens, underscores, colons, periods, forward slashes, and number
 	// signs are allowed. This parameter maps to Image in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
-	// and the IMAGE parameter of docker run (https://docs.docker.com/engine/reference/run/).
+	// (https://docs.docker.com/engine/api/v1.35/#create-a-container) section of
+	// the Docker Remote API (https://docs.docker.com/engine/api/v1.35/) and the
+	// IMAGE parameter of docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	//    * When a new task starts, the Amazon ECS container agent pulls the latest
 	//    version of the specified image and tag for the container to use. However,
@@ -4251,8 +4256,8 @@ type ContainerDefinition struct {
 	// numbers, hyphens, and underscores are allowed. For more information about
 	// linking Docker containers, go to https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/
 	// (https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/).
-	// This parameter maps to Links in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// This parameter maps to Links in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --link option to docker run (https://docs.docker.com/engine/reference/commandline/run/).
 	//
 	// This parameter is not supported for Windows containers.
@@ -4273,8 +4278,8 @@ type ContainerDefinition struct {
 	//
 	// If using the Fargate launch type, the only supported value is awslogs.
 	//
-	// This parameter maps to LogConfig in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// This parameter maps to LogConfig in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --log-driver option to docker run (https://docs.docker.com/engine/reference/run/).
 	// By default, containers use the same logging driver that the Docker daemon
 	// uses; however the container may use a different logging driver than the Docker
@@ -4304,8 +4309,8 @@ type ContainerDefinition struct {
 
 	// The hard limit (in MiB) of memory to present to the container. If your container
 	// attempts to exceed the memory specified here, the container is killed. This
-	// parameter maps to Memory in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// parameter maps to Memory in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --memory option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// If your containers are part of a task using the Fargate launch type, this
@@ -4329,8 +4334,8 @@ type ContainerDefinition struct {
 	// it needs to, up to either the hard limit specified with the memory parameter
 	// (if applicable), or all of the available memory on the container instance,
 	// whichever comes first. This parameter maps to MemoryReservation in the Create
-	// a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --memory-reservation option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// You must specify a non-zero integer for one or both of memory or memoryReservation
@@ -4352,8 +4357,8 @@ type ContainerDefinition struct {
 
 	// The mount points for data volumes in your container.
 	//
-	// This parameter maps to Volumes in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// This parameter maps to Volumes in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --volume option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// Windows containers can mount whole directories on the same drive as $env:ProgramData.
@@ -4365,8 +4370,8 @@ type ContainerDefinition struct {
 	// in a task definition, the name of one container can be entered in the links
 	// of another container to connect the containers. Up to 255 letters (uppercase
 	// and lowercase), numbers, hyphens, and underscores are allowed. This parameter
-	// maps to name in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// maps to name in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --name option to docker run (https://docs.docker.com/engine/reference/run/).
 	Name *string `locationName:"name" type:"string"`
 
@@ -4381,8 +4386,8 @@ type ContainerDefinition struct {
 	// There is no loopback for port mappings on Windows, so you cannot access a
 	// container's mapped port from the host itself.
 	//
-	// This parameter maps to PortBindings in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// This parameter maps to PortBindings in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --publish option to docker run (https://docs.docker.com/engine/reference/run/).
 	// If the network mode of a task definition is set to none, then you can't specify
 	// port mappings. If the network mode of a task definition is set to host, then
@@ -4397,8 +4402,8 @@ type ContainerDefinition struct {
 
 	// When this parameter is true, the container is given elevated privileges on
 	// the host container instance (similar to the root user). This parameter maps
-	// to Privileged in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// to Privileged in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --privileged option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// This parameter is not supported for Windows containers or tasks using the
@@ -4407,9 +4412,9 @@ type ContainerDefinition struct {
 
 	// When this parameter is true, the container is given read-only access to its
 	// root file system. This parameter maps to ReadonlyRootfs in the Create a container
-	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
-	// and the --read-only option to docker run.
+	// (https://docs.docker.com/engine/api/v1.35/#create-a-container) section of
+	// the Docker Remote API (https://docs.docker.com/engine/api/v1.35/) and the
+	// --read-only option to docker run.
 	//
 	// This parameter is not supported for Windows containers.
 	ReadonlyRootFilesystem *bool `locationName:"readonlyRootFilesystem" type:"boolean"`
@@ -4418,8 +4423,8 @@ type ContainerDefinition struct {
 	RepositoryCredentials *RepositoryCredentials `locationName:"repositoryCredentials" type:"structure"`
 
 	// A list of ulimits to set in the container. This parameter maps to Ulimits
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --ulimit option to docker run (https://docs.docker.com/engine/reference/run/).
 	// Valid naming values are displayed in the Ulimit data type. This parameter
 	// requires version 1.18 of the Docker Remote API or greater on your container
@@ -4431,22 +4436,22 @@ type ContainerDefinition struct {
 	Ulimits []*Ulimit `locationName:"ulimits" type:"list"`
 
 	// The user name to use inside the container. This parameter maps to User in
-	// the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --user option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// This parameter is not supported for Windows containers.
 	User *string `locationName:"user" type:"string"`
 
 	// Data volumes to mount from another container. This parameter maps to VolumesFrom
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --volumes-from option to docker run (https://docs.docker.com/engine/reference/run/).
 	VolumesFrom []*VolumeFrom `locationName:"volumesFrom" type:"list"`
 
 	// The working directory in which to run commands inside the container. This
-	// parameter maps to WorkingDir in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// parameter maps to WorkingDir in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --workdir option to docker run (https://docs.docker.com/engine/reference/run/).
 	WorkingDirectory *string `locationName:"workingDirectory" type:"string"`
 }
@@ -6406,6 +6411,87 @@ func (s *DiscoverPollEndpointOutput) SetTelemetryEndpoint(v string) *DiscoverPol
 	return s
 }
 
+// The configuration for the Docker volume. This parameter is specified when
+// using Docker volumes.
+type DockerVolumeConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// If this value is true, the Docker volume is created if it does not already
+	// exist.
+	//
+	// This field is only used if the scope is shared.
+	Autoprovision *bool `locationName:"autoprovision" type:"boolean"`
+
+	// The Docker volume driver to use. The driver value must match the driver name
+	// provided by Docker because it is used for task placement. If the driver was
+	// installed using the Docker plugin CLI, use docker plugin ls to retrieve the
+	// driver name from your container instance. If the driver was installed using
+	// another method, use Docker plugin discovery to retrieve the driver name.
+	// For more information, see Docker plugin discovery (https://docs.docker.com/engine/extend/plugin_api/#plugin-discovery).
+	// This parameter maps to Driver in the Create a volume (https://docs.docker.com/engine/api/v1.35/#operation/VolumeCreate)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
+	// and the xxdriver option to docker volume create (https://docs.docker.com/engine/reference/commandline/volume_create/).
+	Driver *string `locationName:"driver" type:"string"`
+
+	// A map of Docker driver specific options passed through. This parameter maps
+	// to DriverOpts in the Create a volume (https://docs.docker.com/engine/api/v1.35/#operation/VolumeCreate)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
+	// and the xxopt option to docker volume create (https://docs.docker.com/engine/reference/commandline/volume_create/).
+	DriverOpts map[string]*string `locationName:"driverOpts" type:"map"`
+
+	// Custom metadata to add to your Docker volume. This parameter maps to Labels
+	// in the Create a volume (https://docs.docker.com/engine/api/v1.35/#operation/VolumeCreate)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
+	// and the xxlabel option to docker volume create (https://docs.docker.com/engine/reference/commandline/volume_create/).
+	Labels map[string]*string `locationName:"labels" type:"map"`
+
+	// The scope for the Docker volume which determines it's lifecycle. Docker volumes
+	// that are scoped to a task are automatically provisioned when the task starts
+	// and destroyed when the task stops. Docker volumes that are scoped as shared
+	// persist after the task stops.
+	Scope *string `locationName:"scope" type:"string" enum:"Scope"`
+}
+
+// String returns the string representation
+func (s DockerVolumeConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DockerVolumeConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetAutoprovision sets the Autoprovision field's value.
+func (s *DockerVolumeConfiguration) SetAutoprovision(v bool) *DockerVolumeConfiguration {
+	s.Autoprovision = &v
+	return s
+}
+
+// SetDriver sets the Driver field's value.
+func (s *DockerVolumeConfiguration) SetDriver(v string) *DockerVolumeConfiguration {
+	s.Driver = &v
+	return s
+}
+
+// SetDriverOpts sets the DriverOpts field's value.
+func (s *DockerVolumeConfiguration) SetDriverOpts(v map[string]*string) *DockerVolumeConfiguration {
+	s.DriverOpts = v
+	return s
+}
+
+// SetLabels sets the Labels field's value.
+func (s *DockerVolumeConfiguration) SetLabels(v map[string]*string) *DockerVolumeConfiguration {
+	s.Labels = v
+	return s
+}
+
+// SetScope sets the Scope field's value.
+func (s *DockerVolumeConfiguration) SetScope(v string) *DockerVolumeConfiguration {
+	s.Scope = &v
+	return s
+}
+
 // A failed resource.
 type Failure struct {
 	_ struct{} `type:"structure"`
@@ -6454,8 +6540,8 @@ type HealthCheck struct {
 	// [ "CMD-SHELL", "curl -f http://localhost/ || exit 1" ]
 	//
 	// An exit code of 0 indicates success, and non-zero exit code indicates failure.
-	// For more information, see HealthCheck in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/).
+	// For more information, see HealthCheck in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/).
 	//
 	// Command is a required field
 	Command []*string `locationName:"command" type:"list" required:"true"`
@@ -6592,17 +6678,18 @@ func (s *HostEntry) SetIpAddress(v string) *HostEntry {
 	return s
 }
 
-// Details on a container instance host volume.
+// Details on a container instance bind mount host volume.
 type HostVolumeProperties struct {
 	_ struct{} `type:"structure"`
 
-	// The path on the host container instance that is presented to the container.
-	// If this parameter is empty, then the Docker daemon has assigned a host path
-	// for you. If the host parameter contains a sourcePath file location, then
-	// the data volume persists at the specified location on the host container
-	// instance until you delete it manually. If the sourcePath value does not exist
-	// on the host container instance, the Docker daemon creates it. If the location
-	// does exist, the contents of the source path folder are exported.
+	// When the host parameter is used, specify a sourcePath to declare the path
+	// on the host container instance that is presented to the container. If this
+	// parameter is empty, then the Docker daemon has assigned a host path for you.
+	// If the host parameter contains a sourcePath file location, then the data
+	// volume persists at the specified location on the host container instance
+	// until you delete it manually. If the sourcePath value does not exist on the
+	// host container instance, the Docker daemon creates it. If the location does
+	// exist, the contents of the source path folder are exported.
 	//
 	// If you are using the Fargate launch type, the sourcePath parameter is not
 	// supported.
@@ -6637,8 +6724,8 @@ type KernelCapabilities struct {
 
 	// The Linux capabilities for the container that have been added to the default
 	// configuration provided by Docker. This parameter maps to CapAdd in the Create
-	// a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --cap-add option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// If you are using tasks that use the Fargate launch type, the add parameter
@@ -6656,8 +6743,8 @@ type KernelCapabilities struct {
 
 	// The Linux capabilities for the container that have been removed from the
 	// default configuration provided by Docker. This parameter maps to CapDrop
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --cap-drop option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// Valid values: "ALL" | "AUDIT_CONTROL" | "AUDIT_WRITE" | "BLOCK_SUSPEND" |
@@ -6740,8 +6827,8 @@ type LinuxParameters struct {
 	Capabilities *KernelCapabilities `locationName:"capabilities" type:"structure"`
 
 	// Any host devices to expose to the container. This parameter maps to Devices
-	// in the Create a container (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/#create-a-container)
-	// section of the Docker Remote API (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.27/)
+	// in the Create a container (https://docs.docker.com/engine/api/v1.35/#create-a-container)
+	// section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
 	// and the --device option to docker run (https://docs.docker.com/engine/reference/run/).
 	//
 	// If you are using tasks that use the Fargate launch type, the devices parameter
@@ -7811,7 +7898,8 @@ type MountPoint struct {
 	// value is false.
 	ReadOnly *bool `locationName:"readOnly" type:"boolean"`
 
-	// The name of the volume to mount.
+	// The name of the volume to mount. Must be a volume name referenced in the
+	// name parameter of task definition volume.
 	SourceVolume *string `locationName:"sourceVolume" type:"string"`
 }
 
@@ -9832,7 +9920,8 @@ type Task struct {
 	// state).
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp"`
 
-	// The desired status of the task.
+	// The desired status of the task. For more information, see Task Lifecycle
+	// (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_life_cycle.html).
 	DesiredStatus *string `locationName:"desiredStatus" type:"string"`
 
 	// The Unix time stamp for when the task execution stopped.
@@ -9854,7 +9943,8 @@ type Task struct {
 	// override any Docker health checks that exist in the container image.
 	HealthStatus *string `locationName:"healthStatus" type:"string" enum:"HealthStatus"`
 
-	// The last known status of the task.
+	// The last known status of the task. For more information, see Task Lifecycle
+	// (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_life_cycle.html).
 	LastStatus *string `locationName:"lastStatus" type:"string"`
 
 	// The launch type on which your task is running.
@@ -10458,6 +10548,7 @@ type Tmpfs struct {
 	// "nomand" | "atime" | "noatime" | "diratime" | "nodiratime" | "bind" | "rbind"
 	// | "unbindable" | "runbindable" | "private" | "rprivate" | "shared" | "rshared"
 	// | "slave" | "rslave" | "relatime" | "norelatime" | "strictatime" | "nostrictatime"
+	// | "mode" | "uid" | "gid" | "nr_inodes" | "nr_blocks" | "mpol"
 	MountOptions []*string `locationName:"mountOptions" type:"list"`
 
 	// The size (in MiB) of the tmpfs volume.
@@ -10956,15 +11047,24 @@ func (s *VersionInfo) SetDockerVersion(v string) *VersionInfo {
 	return s
 }
 
-// A data volume used in a task definition.
+// A data volume used in a task definition. For tasks that use a Docker volume,
+// specify a DockerVolumeConfiguration. For tasks that use a bind mount host
+// volume, specify a host and optional sourcePath. For more information, see
+// Using Data Volumes in Tasks (http://docs.aws.amazon.com/AmazonECS/latest/developerguideusing_data_volumes.html).
 type Volume struct {
 	_ struct{} `type:"structure"`
 
-	// The contents of the host parameter determine whether your data volume persists
-	// on the host container instance and where it is stored. If the host parameter
-	// is empty, then the Docker daemon assigns a host path for your data volume,
-	// but the data is not guaranteed to persist after the containers associated
-	// with it stop running.
+	// The configuration for the Docker volume. This parameter is specified when
+	// using Docker volumes.
+	DockerVolumeConfiguration *DockerVolumeConfiguration `locationName:"dockerVolumeConfiguration" type:"structure"`
+
+	// This parameter is specified when using bind mount host volumes. Bind mount
+	// host volumes are supported when using either the EC2 or Fargate launch types.
+	// The contents of the host parameter determine whether your bind mount host
+	// volume persists on the host container instance and where it is stored. If
+	// the host parameter is empty, then the Docker daemon assigns a host path for
+	// your data volume, but the data is not guaranteed to persist after the containers
+	// associated with it stop running.
 	//
 	// Windows containers can mount whole directories on the same drive as $env:ProgramData.
 	// Windows containers cannot mount directories on a different drive, and mount
@@ -10986,6 +11086,12 @@ func (s Volume) String() string {
 // GoString returns the string representation
 func (s Volume) GoString() string {
 	return s.String()
+}
+
+// SetDockerVolumeConfiguration sets the DockerVolumeConfiguration field's value.
+func (s *Volume) SetDockerVolumeConfiguration(v *DockerVolumeConfiguration) *Volume {
+	s.DockerVolumeConfiguration = v
+	return s
 }
 
 // SetHost sets the Host field's value.
@@ -11196,6 +11302,14 @@ const (
 
 	// SchedulingStrategyDaemon is a SchedulingStrategy enum value
 	SchedulingStrategyDaemon = "DAEMON"
+)
+
+const (
+	// ScopeTask is a Scope enum value
+	ScopeTask = "task"
+
+	// ScopeShared is a Scope enum value
+	ScopeShared = "shared"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -1517,6 +1517,8 @@ func (c *RDS) CreateDBInstanceRequest(input *CreateDBInstanceInput) (req *reques
 //   * ErrCodeDomainNotFoundFault "DomainNotFoundFault"
 //   Domain doesn't refer to an existing Active Directory domain.
 //
+//   * ErrCodeBackupPolicyNotFoundFault "BackupPolicyNotFoundFault"
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/CreateDBInstance
 func (c *RDS) CreateDBInstance(input *CreateDBInstanceInput) (*CreateDBInstanceOutput, error) {
 	req, out := c.CreateDBInstanceRequest(input)
@@ -6792,6 +6794,108 @@ func (c *RDS) ListTagsForResourceWithContext(ctx aws.Context, input *ListTagsFor
 	return out, req.Send()
 }
 
+const opModifyCurrentDBClusterCapacity = "ModifyCurrentDBClusterCapacity"
+
+// ModifyCurrentDBClusterCapacityRequest generates a "aws/request.Request" representing the
+// client's request for the ModifyCurrentDBClusterCapacity operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ModifyCurrentDBClusterCapacity for more information on using the ModifyCurrentDBClusterCapacity
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ModifyCurrentDBClusterCapacityRequest method.
+//    req, resp := client.ModifyCurrentDBClusterCapacityRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ModifyCurrentDBClusterCapacity
+func (c *RDS) ModifyCurrentDBClusterCapacityRequest(input *ModifyCurrentDBClusterCapacityInput) (req *request.Request, output *ModifyCurrentDBClusterCapacityOutput) {
+	op := &request.Operation{
+		Name:       opModifyCurrentDBClusterCapacity,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ModifyCurrentDBClusterCapacityInput{}
+	}
+
+	output = &ModifyCurrentDBClusterCapacityOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ModifyCurrentDBClusterCapacity API operation for Amazon Relational Database Service.
+//
+// Set the capacity of an Aurora Serverless DB cluster to a specific value.
+//
+// Aurora Serverless scales seamlessly based on the workload on the DB cluster.
+// In some cases, the capacity might not scale fast enough to meet a sudden
+// change in workload, such as a large number of new transactions. Call ModifyCurrentDBClusterCapacity
+// to set the capacity explicitly.
+//
+// After this call sets the DB cluster capacity, Aurora Serverless can automatically
+// scale the DB cluster based on the cooldown period for scaling up and the
+// cooldown period for scaling down.
+//
+// For more information about Aurora Serverless, see Using Amazon Aurora Serverless
+// (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/aurora-serverless.html)
+// in the Amazon RDS User Guide.
+//
+// If you call ModifyCurrentDBClusterCapacity with the default TimeoutAction,
+// connections to the DB cluster are dropped when the capacity is set.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Relational Database Service's
+// API operation ModifyCurrentDBClusterCapacity for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeDBClusterNotFoundFault "DBClusterNotFoundFault"
+//   DBClusterIdentifier doesn't refer to an existing DB cluster.
+//
+//   * ErrCodeInvalidDBClusterStateFault "InvalidDBClusterStateFault"
+//   The DB cluster isn't in a valid state.
+//
+//   * ErrCodeInvalidDBClusterCapacityFault "InvalidDBClusterCapacityFault"
+//   Capacity isn't a valid Aurora Serverless DB cluster capacity. Valid capacity
+//   values are 2, 4, 8, 16, 32, 64, 128, and 256.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ModifyCurrentDBClusterCapacity
+func (c *RDS) ModifyCurrentDBClusterCapacity(input *ModifyCurrentDBClusterCapacityInput) (*ModifyCurrentDBClusterCapacityOutput, error) {
+	req, out := c.ModifyCurrentDBClusterCapacityRequest(input)
+	return out, req.Send()
+}
+
+// ModifyCurrentDBClusterCapacityWithContext is the same as ModifyCurrentDBClusterCapacity with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ModifyCurrentDBClusterCapacity for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *RDS) ModifyCurrentDBClusterCapacityWithContext(ctx aws.Context, input *ModifyCurrentDBClusterCapacityInput, opts ...request.Option) (*ModifyCurrentDBClusterCapacityOutput, error) {
+	req, out := c.ModifyCurrentDBClusterCapacityRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opModifyDBCluster = "ModifyDBCluster"
 
 // ModifyDBClusterRequest generates a "aws/request.Request" representing the
@@ -7226,6 +7330,8 @@ func (c *RDS) ModifyDBInstanceRequest(input *ModifyDBInstanceInput) (req *reques
 //
 //   * ErrCodeDomainNotFoundFault "DomainNotFoundFault"
 //   Domain doesn't refer to an existing Active Directory domain.
+//
+//   * ErrCodeBackupPolicyNotFoundFault "BackupPolicyNotFoundFault"
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/ModifyDBInstance
 func (c *RDS) ModifyDBInstance(input *ModifyDBInstanceInput) (*ModifyDBInstanceOutput, error) {
@@ -9176,6 +9282,8 @@ func (c *RDS) RestoreDBInstanceFromDBSnapshotRequest(input *RestoreDBInstanceFro
 //   * ErrCodeDBParameterGroupNotFoundFault "DBParameterGroupNotFound"
 //   DBParameterGroupName doesn't refer to an existing DB parameter group.
 //
+//   * ErrCodeBackupPolicyNotFoundFault "BackupPolicyNotFoundFault"
+//
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/RestoreDBInstanceFromDBSnapshot
 func (c *RDS) RestoreDBInstanceFromDBSnapshot(input *RestoreDBInstanceFromDBSnapshotInput) (*RestoreDBInstanceFromDBSnapshotOutput, error) {
 	req, out := c.RestoreDBInstanceFromDBSnapshotRequest(input)
@@ -9315,6 +9423,8 @@ func (c *RDS) RestoreDBInstanceFromS3Request(input *RestoreDBInstanceFromS3Input
 //
 //   * ErrCodeKMSKeyNotAccessibleFault "KMSKeyNotAccessibleFault"
 //   An error occurred accessing an AWS KMS key.
+//
+//   * ErrCodeBackupPolicyNotFoundFault "BackupPolicyNotFoundFault"
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/RestoreDBInstanceFromS3
 func (c *RDS) RestoreDBInstanceFromS3(input *RestoreDBInstanceFromS3Input) (*RestoreDBInstanceFromS3Output, error) {
@@ -9475,6 +9585,8 @@ func (c *RDS) RestoreDBInstanceToPointInTimeRequest(input *RestoreDBInstanceToPo
 //
 //   * ErrCodeDBParameterGroupNotFoundFault "DBParameterGroupNotFound"
 //   DBParameterGroupName doesn't refer to an existing DB parameter group.
+//
+//   * ErrCodeBackupPolicyNotFoundFault "BackupPolicyNotFoundFault"
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/rds-2014-10-31/RestoreDBInstanceToPointInTime
 func (c *RDS) RestoreDBInstanceToPointInTime(input *RestoreDBInstanceToPointInTimeInput) (*RestoreDBInstanceToPointInTimeOutput, error) {
@@ -10647,6 +10759,12 @@ func (s *CharacterSet) SetCharacterSetName(v string) *CharacterSet {
 
 // The configuration setting for the log types to be enabled for export to CloudWatch
 // Logs for a specific DB instance or DB cluster.
+//
+// The EnableLogTypes and DisableLogTypes arrays determine which logs will be
+// exported (or not exported) to CloudWatch Logs. The values within these arrays
+// depend on the DB engine being used. For more information, see Publishing
+// Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+// in the Amazon Relational Database Service User Guide.
 type CloudwatchLogsExportConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -11571,7 +11689,9 @@ type CreateDBClusterInput struct {
 	DestinationRegion *string `type:"string"`
 
 	// The list of log types that need to be enabled for exporting to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -11587,6 +11707,9 @@ type CreateDBClusterInput struct {
 	//
 	// Engine is a required field
 	Engine *string `type:"string" required:"true"`
+
+	// The DB engine mode of the DB cluster, either provisioned or serverless.
+	EngineMode *string `type:"string"`
 
 	// The version number of the database engine to use.
 	//
@@ -11722,6 +11845,10 @@ type CreateDBClusterInput struct {
 	// this DB cluster is created as a Read Replica.
 	ReplicationSourceIdentifier *string `type:"string"`
 
+	// For DB clusters in serverless DB engine mode, the scaling properties of the
+	// DB cluster.
+	ScalingConfiguration *ScalingConfiguration `type:"structure"`
+
 	// SourceRegion is the source region where the resource exists. This is not
 	// sent over the wire and is only used for presigning. This value should always
 	// have the same region as the source ARN.
@@ -11835,6 +11962,12 @@ func (s *CreateDBClusterInput) SetEngine(v string) *CreateDBClusterInput {
 	return s
 }
 
+// SetEngineMode sets the EngineMode field's value.
+func (s *CreateDBClusterInput) SetEngineMode(v string) *CreateDBClusterInput {
+	s.EngineMode = &v
+	return s
+}
+
 // SetEngineVersion sets the EngineVersion field's value.
 func (s *CreateDBClusterInput) SetEngineVersion(v string) *CreateDBClusterInput {
 	s.EngineVersion = &v
@@ -11892,6 +12025,12 @@ func (s *CreateDBClusterInput) SetPreferredMaintenanceWindow(v string) *CreateDB
 // SetReplicationSourceIdentifier sets the ReplicationSourceIdentifier field's value.
 func (s *CreateDBClusterInput) SetReplicationSourceIdentifier(v string) *CreateDBClusterInput {
 	s.ReplicationSourceIdentifier = &v
+	return s
+}
+
+// SetScalingConfiguration sets the ScalingConfiguration field's value.
+func (s *CreateDBClusterInput) SetScalingConfiguration(v *ScalingConfiguration) *CreateDBClusterInput {
+	s.ScalingConfiguration = v
 	return s
 }
 
@@ -12427,7 +12566,9 @@ type CreateDBInstanceInput struct {
 	DomainIAMRoleName *string `type:"string"`
 
 	// The list of log types that need to be enabled for exporting to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -12804,17 +12945,26 @@ type CreateDBInstanceInput struct {
 	// which resolves to a public IP address. A value of false specifies an internal
 	// instance with a DNS name that resolves to a private IP address.
 	//
-	// Default: The default behavior varies depending on whether a VPC has been
-	// requested or not. The following list shows the default behavior in each case.
+	// Default: The default behavior varies depending on whether DBSubnetGroupName
+	// is specified.
 	//
-	//    * Default VPC: true
+	// If DBSubnetGroupName is not specified, and PubliclyAccessible is not specified,
+	// the following applies:
 	//
-	//    * VPC: false
+	//    * If the default VPC in the target region doesn’t have an Internet gateway
+	//    attached to it, the DB instance is private.
 	//
-	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is publicly accessible. If a specific
-	// DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is private.
+	//    * If the default VPC in the target region has an Internet gateway attached
+	//    to it, the DB instance is public.
+	//
+	// If DBSubnetGroupName is specified, and PubliclyAccessible is not specified,
+	// the following applies:
+	//
+	//    * If the subnets are part of a VPC that doesn’t have an Internet gateway
+	//    attached to it, the DB instance is private.
+	//
+	//    * If the subnets are part of a VPC that has an Internet gateway attached
+	//    to it, the DB instance is public.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// Specifies whether the DB instance is encrypted.
@@ -13246,6 +13396,9 @@ type CreateDBInstanceReadReplicaInput struct {
 	DestinationRegion *string `type:"string"`
 
 	// The list of logs that the new DB instance is to export to CloudWatch Logs.
+	// The values in the list depend on the DB engine being used. For more information,
+	// see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -13386,19 +13539,8 @@ type CreateDBInstanceReadReplicaInput struct {
 	// Specifies the accessibility options for the DB instance. A value of true
 	// specifies an Internet-facing instance with a publicly resolvable DNS name,
 	// which resolves to a public IP address. A value of false specifies an internal
-	// instance with a DNS name that resolves to a private IP address.
-	//
-	// Default: The default behavior varies depending on whether a VPC has been
-	// requested or not. The following list shows the default behavior in each case.
-	//
-	//    * Default VPC:true
-	//
-	//    * VPC:false
-	//
-	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is publicly accessible. If a specific
-	// DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is private.
+	// instance with a DNS name that resolves to a private IP address. For more
+	// information, see CreateDBInstance.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// The identifier of the DB instance that will act as the source for the Read
@@ -14401,6 +14543,8 @@ type DBCluster struct {
 	// Specifies the number of days for which automatic DB snapshots are retained.
 	BackupRetentionPeriod *int64 `type:"integer"`
 
+	Capacity *int64 `type:"integer"`
+
 	// If present, specifies the name of the character set that this cluster is
 	// associated with.
 	CharacterSetName *string `type:"string"`
@@ -14451,6 +14595,10 @@ type DBCluster struct {
 
 	// A list of log types that this DB cluster is configured to export to CloudWatch
 	// Logs.
+	//
+	// Log types vary by DB engine. For information about the log types for each
+	// DB engine, see Amazon RDS Database Log Files (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html)
+	// in the Amazon RDS User Guide.
 	EnabledCloudwatchLogsExports []*string `type:"list"`
 
 	// Specifies the connection endpoint for the primary instance of the DB cluster.
@@ -14458,6 +14606,9 @@ type DBCluster struct {
 
 	// Provides the name of the database engine to be used for this DB cluster.
 	Engine *string `type:"string"`
+
+	// The DB engine mode of the DB cluster, either provisioned or serverless.
+	EngineMode *string `type:"string"`
 
 	// Indicates the database engine version.
 	EngineVersion *string `type:"string"`
@@ -14518,6 +14669,13 @@ type DBCluster struct {
 	// Read Replica.
 	ReplicationSourceIdentifier *string `type:"string"`
 
+	// Shows the scaling configuration for an Aurora DB cluster in serverless DB
+	// engine mode.
+	//
+	// For more information, see Using Amazon Aurora Serverless (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/aurora-serverless.html)
+	// in the Amazon RDS User Guide.
+	ScalingConfigurationInfo *ScalingConfigurationInfo `type:"structure"`
+
 	// Specifies the current state of this DB cluster.
 	Status *string `type:"string"`
 
@@ -14571,6 +14729,12 @@ func (s *DBCluster) SetBacktrackWindow(v int64) *DBCluster {
 // SetBackupRetentionPeriod sets the BackupRetentionPeriod field's value.
 func (s *DBCluster) SetBackupRetentionPeriod(v int64) *DBCluster {
 	s.BackupRetentionPeriod = &v
+	return s
+}
+
+// SetCapacity sets the Capacity field's value.
+func (s *DBCluster) SetCapacity(v int64) *DBCluster {
+	s.Capacity = &v
 	return s
 }
 
@@ -14670,6 +14834,12 @@ func (s *DBCluster) SetEngine(v string) *DBCluster {
 	return s
 }
 
+// SetEngineMode sets the EngineMode field's value.
+func (s *DBCluster) SetEngineMode(v string) *DBCluster {
+	s.EngineMode = &v
+	return s
+}
+
 // SetEngineVersion sets the EngineVersion field's value.
 func (s *DBCluster) SetEngineVersion(v string) *DBCluster {
 	s.EngineVersion = &v
@@ -14751,6 +14921,12 @@ func (s *DBCluster) SetReaderEndpoint(v string) *DBCluster {
 // SetReplicationSourceIdentifier sets the ReplicationSourceIdentifier field's value.
 func (s *DBCluster) SetReplicationSourceIdentifier(v string) *DBCluster {
 	s.ReplicationSourceIdentifier = &v
+	return s
+}
+
+// SetScalingConfigurationInfo sets the ScalingConfigurationInfo field's value.
+func (s *DBCluster) SetScalingConfigurationInfo(v *ScalingConfigurationInfo) *DBCluster {
+	s.ScalingConfigurationInfo = v
 	return s
 }
 
@@ -14954,6 +15130,8 @@ func (s *DBClusterParameterGroupNameMessage) SetDBClusterParameterGroupName(v st
 type DBClusterRole struct {
 	_ struct{} `type:"structure"`
 
+	FeatureName *string `type:"string"`
+
 	// The Amazon Resource Name (ARN) of the IAM role that is associated with the
 	// DB cluster.
 	RoleArn *string `type:"string"`
@@ -14980,6 +15158,12 @@ func (s DBClusterRole) String() string {
 // GoString returns the string representation
 func (s DBClusterRole) GoString() string {
 	return s.String()
+}
+
+// SetFeatureName sets the FeatureName field's value.
+func (s *DBClusterRole) SetFeatureName(v string) *DBClusterRole {
+	s.FeatureName = &v
+	return s
 }
 
 // SetRoleArn sets the RoleArn field's value.
@@ -15318,6 +15502,9 @@ type DBEngineVersion struct {
 	// parameter of the CreateDBInstance action.
 	SupportedCharacterSets []*CharacterSet `locationNameList:"CharacterSet" type:"list"`
 
+	// A list of the supported DB engine modes.
+	SupportedEngineModes []*string `type:"list"`
+
 	// A list of the time zones supported by this engine for the Timezone parameter
 	// of the CreateDBInstance action.
 	SupportedTimezones []*Timezone `locationNameList:"Timezone" type:"list"`
@@ -15389,6 +15576,12 @@ func (s *DBEngineVersion) SetExportableLogTypes(v []*string) *DBEngineVersion {
 // SetSupportedCharacterSets sets the SupportedCharacterSets field's value.
 func (s *DBEngineVersion) SetSupportedCharacterSets(v []*CharacterSet) *DBEngineVersion {
 	s.SupportedCharacterSets = v
+	return s
+}
+
+// SetSupportedEngineModes sets the SupportedEngineModes field's value.
+func (s *DBEngineVersion) SetSupportedEngineModes(v []*string) *DBEngineVersion {
+	s.SupportedEngineModes = v
 	return s
 }
 
@@ -15506,6 +15699,10 @@ type DBInstance struct {
 
 	// A list of log types that this DB instance is configured to export to CloudWatch
 	// Logs.
+	//
+	// Log types vary by DB engine. For information about the log types for each
+	// DB engine, see Amazon RDS Database Log Files (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html)
+	// in the Amazon RDS User Guide.
 	EnabledCloudwatchLogsExports []*string `type:"list"`
 
 	// Specifies the connection endpoint.
@@ -15606,18 +15803,6 @@ type DBInstance struct {
 	// specifies an Internet-facing instance with a publicly resolvable DNS name,
 	// which resolves to a public IP address. A value of false specifies an internal
 	// instance with a DNS name that resolves to a private IP address.
-	//
-	// Default: The default behavior varies depending on whether a VPC has been
-	// requested or not. The following list shows the default behavior in each case.
-	//
-	//    * Default VPC:true
-	//
-	//    * VPC:false
-	//
-	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is publicly accessible. If a specific
-	// DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is private.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// Contains one or more identifiers of Aurora DB clusters that are Read Replicas
@@ -16007,7 +16192,8 @@ type DBInstanceStatusInfo struct {
 	Normal *bool `type:"boolean"`
 
 	// Status of the DB instance. For a StatusType of read replica, the values can
-	// be replicating, error, stopped, or terminated.
+	// be replicating, replication stop point set, replication stop point reached,
+	// error, stopped, or terminated.
 	Status *string `type:"string"`
 
 	// This value is currently "read replication."
@@ -22153,6 +22339,153 @@ func (s *ListTagsForResourceOutput) SetTagList(v []*Tag) *ListTagsForResourceOut
 	return s
 }
 
+type ModifyCurrentDBClusterCapacityInput struct {
+	_ struct{} `type:"structure"`
+
+	// The DB cluster capacity.
+	//
+	// Constraints:
+	//
+	//    * Value must be 2, 4, 8, 16, 32, 64, 128, or 256.
+	Capacity *int64 `type:"integer"`
+
+	// The DB cluster identifier for the cluster being modified. This parameter
+	// is not case-sensitive.
+	//
+	// Constraints:
+	//
+	//    * Must match the identifier of an existing DB cluster.
+	//
+	// DBClusterIdentifier is a required field
+	DBClusterIdentifier *string `type:"string" required:"true"`
+
+	// The amount of time, in seconds, that Aurora Serverless tries to find a scaling
+	// point to perform seamless scaling before enforcing the timeout action. The
+	// default is 300.
+	//
+	//    * Value must be from 10 through 600.
+	SecondsBeforeTimeout *int64 `type:"integer"`
+
+	// The action to take when the timeout is reached, either ForceApplyCapacityChange
+	// or RollbackCapacityChange.
+	//
+	// ForceApplyCapacityChange, the default, drops connections to the DB cluster
+	// and sets the capacity to the specified value as soon as possible.
+	//
+	// RollbackCapacityChange ignores the capacity change if a scaling point is
+	// not found in the timeout period.
+	TimeoutAction *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ModifyCurrentDBClusterCapacityInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyCurrentDBClusterCapacityInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ModifyCurrentDBClusterCapacityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ModifyCurrentDBClusterCapacityInput"}
+	if s.DBClusterIdentifier == nil {
+		invalidParams.Add(request.NewErrParamRequired("DBClusterIdentifier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetCapacity sets the Capacity field's value.
+func (s *ModifyCurrentDBClusterCapacityInput) SetCapacity(v int64) *ModifyCurrentDBClusterCapacityInput {
+	s.Capacity = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *ModifyCurrentDBClusterCapacityInput) SetDBClusterIdentifier(v string) *ModifyCurrentDBClusterCapacityInput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetSecondsBeforeTimeout sets the SecondsBeforeTimeout field's value.
+func (s *ModifyCurrentDBClusterCapacityInput) SetSecondsBeforeTimeout(v int64) *ModifyCurrentDBClusterCapacityInput {
+	s.SecondsBeforeTimeout = &v
+	return s
+}
+
+// SetTimeoutAction sets the TimeoutAction field's value.
+func (s *ModifyCurrentDBClusterCapacityInput) SetTimeoutAction(v string) *ModifyCurrentDBClusterCapacityInput {
+	s.TimeoutAction = &v
+	return s
+}
+
+type ModifyCurrentDBClusterCapacityOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The current capacity of the DB cluster.
+	CurrentCapacity *int64 `type:"integer"`
+
+	// A user-supplied DB cluster identifier. This identifier is the unique key
+	// that identifies a DB cluster.
+	DBClusterIdentifier *string `type:"string"`
+
+	// A value that specifies the capacity that the DB cluster scales to next.
+	PendingCapacity *int64 `type:"integer"`
+
+	// The number of seconds before a call to ModifyCurrentDBClusterCapacity times
+	// out.
+	SecondsBeforeTimeout *int64 `type:"integer"`
+
+	// The timeout action of a call to ModifyCurrentDBClusterCapacity, either ForceApplyCapacityChange
+	// or RollbackCapacityChange.
+	TimeoutAction *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ModifyCurrentDBClusterCapacityOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ModifyCurrentDBClusterCapacityOutput) GoString() string {
+	return s.String()
+}
+
+// SetCurrentCapacity sets the CurrentCapacity field's value.
+func (s *ModifyCurrentDBClusterCapacityOutput) SetCurrentCapacity(v int64) *ModifyCurrentDBClusterCapacityOutput {
+	s.CurrentCapacity = &v
+	return s
+}
+
+// SetDBClusterIdentifier sets the DBClusterIdentifier field's value.
+func (s *ModifyCurrentDBClusterCapacityOutput) SetDBClusterIdentifier(v string) *ModifyCurrentDBClusterCapacityOutput {
+	s.DBClusterIdentifier = &v
+	return s
+}
+
+// SetPendingCapacity sets the PendingCapacity field's value.
+func (s *ModifyCurrentDBClusterCapacityOutput) SetPendingCapacity(v int64) *ModifyCurrentDBClusterCapacityOutput {
+	s.PendingCapacity = &v
+	return s
+}
+
+// SetSecondsBeforeTimeout sets the SecondsBeforeTimeout field's value.
+func (s *ModifyCurrentDBClusterCapacityOutput) SetSecondsBeforeTimeout(v int64) *ModifyCurrentDBClusterCapacityOutput {
+	s.SecondsBeforeTimeout = &v
+	return s
+}
+
+// SetTimeoutAction sets the TimeoutAction field's value.
+func (s *ModifyCurrentDBClusterCapacityOutput) SetTimeoutAction(v string) *ModifyCurrentDBClusterCapacityOutput {
+	s.TimeoutAction = &v
+	return s
+}
+
 type ModifyDBClusterInput struct {
 	_ struct{} `type:"structure"`
 
@@ -22297,6 +22630,10 @@ type ModifyDBClusterInput struct {
 	// Constraints: Minimum 30-minute window.
 	PreferredMaintenanceWindow *string `type:"string"`
 
+	// The scaling properties of the DB cluster. You can only modify scaling properties
+	// for DB clusters in serverless DB engine mode.
+	ScalingConfiguration *ScalingConfiguration `type:"structure"`
+
 	// A list of VPC security groups that the DB cluster will belong to.
 	VpcSecurityGroupIds []*string `locationNameList:"VpcSecurityGroupId" type:"list"`
 }
@@ -22405,6 +22742,12 @@ func (s *ModifyDBClusterInput) SetPreferredBackupWindow(v string) *ModifyDBClust
 // SetPreferredMaintenanceWindow sets the PreferredMaintenanceWindow field's value.
 func (s *ModifyDBClusterInput) SetPreferredMaintenanceWindow(v string) *ModifyDBClusterInput {
 	s.PreferredMaintenanceWindow = &v
+	return s
+}
+
+// SetScalingConfiguration sets the ScalingConfiguration field's value.
+func (s *ModifyDBClusterInput) SetScalingConfiguration(v *ScalingConfiguration) *ModifyDBClusterInput {
+	s.ScalingConfiguration = v
 	return s
 }
 
@@ -24702,6 +25045,9 @@ type OrderableDBInstanceOption struct {
 	// Indicates the storage type for a DB instance.
 	StorageType *string `type:"string"`
 
+	// A list of the supported DB engine modes.
+	SupportedEngineModes []*string `type:"list"`
+
 	// Indicates whether a DB instance supports Enhanced Monitoring at intervals
 	// from 1 to 60 seconds.
 	SupportsEnhancedMonitoring *bool `type:"boolean"`
@@ -24822,6 +25168,12 @@ func (s *OrderableDBInstanceOption) SetStorageType(v string) *OrderableDBInstanc
 	return s
 }
 
+// SetSupportedEngineModes sets the SupportedEngineModes field's value.
+func (s *OrderableDBInstanceOption) SetSupportedEngineModes(v []*string) *OrderableDBInstanceOption {
+	s.SupportedEngineModes = v
+	return s
+}
+
 // SetSupportsEnhancedMonitoring sets the SupportsEnhancedMonitoring field's value.
 func (s *OrderableDBInstanceOption) SetSupportsEnhancedMonitoring(v bool) *OrderableDBInstanceOption {
 	s.SupportsEnhancedMonitoring = &v
@@ -24897,6 +25249,9 @@ type Parameter struct {
 
 	// Indicates the source of the parameter value.
 	Source *string `type:"string"`
+
+	// The valid DB engine modes.
+	SupportedEngineModes []*string `type:"list"`
 }
 
 // String returns the string representation
@@ -24966,6 +25321,12 @@ func (s *Parameter) SetParameterValue(v string) *Parameter {
 // SetSource sets the Source field's value.
 func (s *Parameter) SetSource(v string) *Parameter {
 	s.Source = &v
+	return s
+}
+
+// SetSupportedEngineModes sets the SupportedEngineModes field's value.
+func (s *Parameter) SetSupportedEngineModes(v []*string) *Parameter {
+	s.SupportedEngineModes = v
 	return s
 }
 
@@ -26461,7 +26822,9 @@ type RestoreDBClusterFromS3Input struct {
 	DatabaseName *string `type:"string"`
 
 	// The list of logs that the restored DB cluster is to export to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -26892,7 +27255,9 @@ type RestoreDBClusterFromSnapshotInput struct {
 	DatabaseName *string `type:"string"`
 
 	// The list of logs that the restored DB cluster is to export to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -26909,6 +27274,9 @@ type RestoreDBClusterFromSnapshotInput struct {
 	//
 	// Engine is a required field
 	Engine *string `type:"string" required:"true"`
+
+	// The DB engine mode of the DB cluster, either provisioned or serverless.
+	EngineMode *string `type:"string"`
 
 	// The version of the database engine to use for the new DB cluster.
 	EngineVersion *string `type:"string"`
@@ -26941,6 +27309,10 @@ type RestoreDBClusterFromSnapshotInput struct {
 	//
 	// Default: The same port as the original DB cluster.
 	Port *int64 `type:"integer"`
+
+	// For DB clusters in serverless DB engine mode, the scaling properties of the
+	// DB cluster.
+	ScalingConfiguration *ScalingConfiguration `type:"structure"`
 
 	// The identifier for the DB snapshot or DB cluster snapshot to restore from.
 	//
@@ -27039,6 +27411,12 @@ func (s *RestoreDBClusterFromSnapshotInput) SetEngine(v string) *RestoreDBCluste
 	return s
 }
 
+// SetEngineMode sets the EngineMode field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetEngineMode(v string) *RestoreDBClusterFromSnapshotInput {
+	s.EngineMode = &v
+	return s
+}
+
 // SetEngineVersion sets the EngineVersion field's value.
 func (s *RestoreDBClusterFromSnapshotInput) SetEngineVersion(v string) *RestoreDBClusterFromSnapshotInput {
 	s.EngineVersion = &v
@@ -27060,6 +27438,12 @@ func (s *RestoreDBClusterFromSnapshotInput) SetOptionGroupName(v string) *Restor
 // SetPort sets the Port field's value.
 func (s *RestoreDBClusterFromSnapshotInput) SetPort(v int64) *RestoreDBClusterFromSnapshotInput {
 	s.Port = &v
+	return s
+}
+
+// SetScalingConfiguration sets the ScalingConfiguration field's value.
+func (s *RestoreDBClusterFromSnapshotInput) SetScalingConfiguration(v *ScalingConfiguration) *RestoreDBClusterFromSnapshotInput {
+	s.ScalingConfiguration = v
 	return s
 }
 
@@ -27141,7 +27525,9 @@ type RestoreDBClusterToPointInTimeInput struct {
 	DBSubnetGroupName *string `type:"string"`
 
 	// The list of logs that the restored DB cluster is to export to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -27456,7 +27842,9 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 	DomainIAMRoleName *string `type:"string"`
 
 	// The list of logs that the restored DB instance is to export to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -27551,19 +27939,8 @@ type RestoreDBInstanceFromDBSnapshotInput struct {
 	// Specifies the accessibility options for the DB instance. A value of true
 	// specifies an Internet-facing instance with a publicly resolvable DNS name,
 	// which resolves to a public IP address. A value of false specifies an internal
-	// instance with a DNS name that resolves to a private IP address.
-	//
-	// Default: The default behavior varies depending on whether a VPC has been
-	// requested or not. The following list shows the default behavior in each case.
-	//
-	//    * Default VPC: true
-	//
-	//    * VPC: false
-	//
-	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is publicly accessible. If a specific
-	// DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is private.
+	// instance with a DNS name that resolves to a private IP address. For more
+	// information, see CreateDBInstance.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// Specifies the storage type to be associated with the DB instance.
@@ -27878,7 +28255,9 @@ type RestoreDBInstanceFromS3Input struct {
 	DBSubnetGroupName *string `type:"string"`
 
 	// The list of logs that the restored DB instance is to export to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -28026,7 +28405,10 @@ type RestoreDBInstanceFromS3Input struct {
 	// class of the DB instance.
 	ProcessorFeatures []*ProcessorFeature `locationNameList:"ProcessorFeature" type:"list"`
 
-	// Specifies whether the DB instance is publicly accessible or not. For more
+	// Specifies the accessibility options for the DB instance. A value of true
+	// specifies an Internet-facing instance with a publicly resolvable DNS name,
+	// which resolves to a public IP address. A value of false specifies an internal
+	// instance with a DNS name that resolves to a private IP address. For more
 	// information, see CreateDBInstance.
 	PubliclyAccessible *bool `type:"boolean"`
 
@@ -28450,7 +28832,9 @@ type RestoreDBInstanceToPointInTimeInput struct {
 	DomainIAMRoleName *string `type:"string"`
 
 	// The list of logs that the restored DB instance is to export to CloudWatch
-	// Logs.
+	// Logs. The values in the list depend on the DB engine being used. For more
+	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
+	// in the Amazon Relational Database Service User Guide.
 	EnableCloudwatchLogsExports []*string `type:"list"`
 
 	// True to enable mapping of AWS Identity and Access Management (IAM) accounts
@@ -28540,19 +28924,8 @@ type RestoreDBInstanceToPointInTimeInput struct {
 	// Specifies the accessibility options for the DB instance. A value of true
 	// specifies an Internet-facing instance with a publicly resolvable DNS name,
 	// which resolves to a public IP address. A value of false specifies an internal
-	// instance with a DNS name that resolves to a private IP address.
-	//
-	// Default: The default behavior varies depending on whether a VPC has been
-	// requested or not. The following list shows the default behavior in each case.
-	//
-	//    * Default VPC:true
-	//
-	//    * VPC:false
-	//
-	// If no DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is publicly accessible. If a specific
-	// DB subnet group has been specified as part of the request and the PubliclyAccessible
-	// value has not been set, the DB instance is private.
+	// instance with a DNS name that resolves to a private IP address. For more
+	// information, see CreateDBInstance.
 	PubliclyAccessible *bool `type:"boolean"`
 
 	// The date and time to restore from.
@@ -28942,6 +29315,132 @@ func (s RevokeDBSecurityGroupIngressOutput) GoString() string {
 // SetDBSecurityGroup sets the DBSecurityGroup field's value.
 func (s *RevokeDBSecurityGroupIngressOutput) SetDBSecurityGroup(v *DBSecurityGroup) *RevokeDBSecurityGroupIngressOutput {
 	s.DBSecurityGroup = v
+	return s
+}
+
+// Contains the scaling configuration of an Aurora Serverless DB cluster.
+//
+// For more information, see Using Amazon Aurora Serverless (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/aurora-serverless.html)
+// in the Amazon RDS User Guide.
+type ScalingConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// A value that specifies whether to allow or disallow automatic pause for an
+	// Aurora DB cluster in serverless DB engine mode. A DB cluster can be paused
+	// only when it's idle (it has no connections).
+	//
+	// If a DB cluster is paused for more than seven days, the DB cluster might
+	// be backed up with a snapshot. In this case, the DB cluster is restored when
+	// there is a request to connect to it.
+	AutoPause *bool `type:"boolean"`
+
+	// The maximum capacity for an Aurora DB cluster in serverless DB engine mode.
+	//
+	// Valid capacity values are 2, 4, 8, 16, 32, 64, 128, and 256.
+	//
+	// The maximum capacity must be greater than or equal to the minimum capacity.
+	MaxCapacity *int64 `type:"integer"`
+
+	// The minimum capacity for an Aurora DB cluster in serverless DB engine mode.
+	//
+	// Valid capacity values are 2, 4, 8, 16, 32, 64, 128, and 256.
+	//
+	// The minimum capacity must be less than or equal to the maximum capacity.
+	MinCapacity *int64 `type:"integer"`
+
+	// The time, in seconds, before an Aurora DB cluster in serverless mode is paused.
+	SecondsUntilAutoPause *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s ScalingConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ScalingConfiguration) GoString() string {
+	return s.String()
+}
+
+// SetAutoPause sets the AutoPause field's value.
+func (s *ScalingConfiguration) SetAutoPause(v bool) *ScalingConfiguration {
+	s.AutoPause = &v
+	return s
+}
+
+// SetMaxCapacity sets the MaxCapacity field's value.
+func (s *ScalingConfiguration) SetMaxCapacity(v int64) *ScalingConfiguration {
+	s.MaxCapacity = &v
+	return s
+}
+
+// SetMinCapacity sets the MinCapacity field's value.
+func (s *ScalingConfiguration) SetMinCapacity(v int64) *ScalingConfiguration {
+	s.MinCapacity = &v
+	return s
+}
+
+// SetSecondsUntilAutoPause sets the SecondsUntilAutoPause field's value.
+func (s *ScalingConfiguration) SetSecondsUntilAutoPause(v int64) *ScalingConfiguration {
+	s.SecondsUntilAutoPause = &v
+	return s
+}
+
+// Shows the scaling configuration for an Aurora DB cluster in serverless DB
+// engine mode.
+//
+// For more information, see Using Amazon Aurora Serverless (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/aurora-serverless.html)
+// in the Amazon RDS User Guide.
+type ScalingConfigurationInfo struct {
+	_ struct{} `type:"structure"`
+
+	// A value that indicates whether automatic pause is allowed for the Aurora
+	// DB cluster in serverless DB engine mode.
+	AutoPause *bool `type:"boolean"`
+
+	// The maximum capacity for an Aurora DB cluster in serverless DB engine mode.
+	MaxCapacity *int64 `type:"integer"`
+
+	// The maximum capacity for the Aurora DB cluster in serverless DB engine mode.
+	MinCapacity *int64 `type:"integer"`
+
+	// The remaining amount of time, in seconds, before the Aurora DB cluster in
+	// serverless mode is paused. A DB cluster can be paused only when it's idle
+	// (it has no connections).
+	SecondsUntilAutoPause *int64 `type:"integer"`
+}
+
+// String returns the string representation
+func (s ScalingConfigurationInfo) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ScalingConfigurationInfo) GoString() string {
+	return s.String()
+}
+
+// SetAutoPause sets the AutoPause field's value.
+func (s *ScalingConfigurationInfo) SetAutoPause(v bool) *ScalingConfigurationInfo {
+	s.AutoPause = &v
+	return s
+}
+
+// SetMaxCapacity sets the MaxCapacity field's value.
+func (s *ScalingConfigurationInfo) SetMaxCapacity(v int64) *ScalingConfigurationInfo {
+	s.MaxCapacity = &v
+	return s
+}
+
+// SetMinCapacity sets the MinCapacity field's value.
+func (s *ScalingConfigurationInfo) SetMinCapacity(v int64) *ScalingConfigurationInfo {
+	s.MinCapacity = &v
+	return s
+}
+
+// SetSecondsUntilAutoPause sets the SecondsUntilAutoPause field's value.
+func (s *ScalingConfigurationInfo) SetSecondsUntilAutoPause(v int64) *ScalingConfigurationInfo {
+	s.SecondsUntilAutoPause = &v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/errors.go
@@ -27,6 +27,10 @@ const (
 	// The DB security group authorization quota has been reached.
 	ErrCodeAuthorizationQuotaExceededFault = "AuthorizationQuotaExceeded"
 
+	// ErrCodeBackupPolicyNotFoundFault for service response error code
+	// "BackupPolicyNotFoundFault".
+	ErrCodeBackupPolicyNotFoundFault = "BackupPolicyNotFoundFault"
+
 	// ErrCodeCertificateNotFoundFault for service response error code
 	// "CertificateNotFound".
 	//
@@ -257,6 +261,13 @@ const (
 	// be able to resolve this error by updating your subnet group to use different
 	// Availability Zones that have more storage available.
 	ErrCodeInsufficientStorageClusterCapacityFault = "InsufficientStorageClusterCapacity"
+
+	// ErrCodeInvalidDBClusterCapacityFault for service response error code
+	// "InvalidDBClusterCapacityFault".
+	//
+	// Capacity isn't a valid Aurora Serverless DB cluster capacity. Valid capacity
+	// values are 2, 4, 8, 16, 32, 64, 128, and 256.
+	ErrCodeInvalidDBClusterCapacityFault = "InvalidDBClusterCapacityFault"
 
 	// ErrCodeInvalidDBClusterSnapshotStateFault for service response error code
 	// "InvalidDBClusterSnapshotStateFault".

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,1020 +39,1020 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "Pr3nD0d3ZhGKV0RDBGa9W7m/LeI=",
+			"checksumSHA1": "2GdP8aRMxQ48e+l0/N7587jJeOA=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "EwL79Cq6euk+EV/t/n2E+jzPNmU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
-			"checksumSHA1": "925zPp8gtaXi2gkWrgZ1gAA003A=",
+			"checksumSHA1": "I87y3G8r14yKZQ5NlkupFUJ5jW0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "JTilCBYWVAfhbKSnrxCNhE8IFns=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "eI5TmiOTCFjEUNvWeceFycs9dRU=",
 			"path": "github.com/aws/aws-sdk-go/aws/csm",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "6DRhqSAN7O45gYfRIpwDeuJE8j8=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "uPkjJo+J10vbEukYYXmf0w7Cn4Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "E90Nf2HfcSKYI99ld36ILMXMRKM=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "Ia/AZ2fZp7J4lMO6fpkvfLU/HGY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "zx1mZCdOwgbjBV3jMfb0kyDd//Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "Dj9WOMBPbboyUJV4GB99PwPcO4g=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "tQVg7Sz2zv+KkhbiXxPH0mh9spg=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkuri",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "ZX5QHZb0PrK4UF45um2kaAEiX+8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "stsUCJVnZ5yMrmzSExbjbYp5tZ8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "bOQjEfKXaTqe7dZhDDER/wZUzQc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "CTsp/h3FbFg9QizH4bH1abLwljg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "+O6A945eTP9plLpkEMZB0lwBAcg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "uRvmEPKcEdv7qc0Ep2zn0E3Xumc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "soXVJWQ/xvEB72Mo6FresaQIxLg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "4xFqSOZkwDKot6FJQQgKjhJFoQw=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "3e/4A/8NqTOSXEtJ6KhYAqqWnuY=",
 			"path": "github.com/aws/aws-sdk-go/service/acmpca",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "FjnLIflNek7g0j5NKT3qFkNtdY8=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "K/ynSj/L2OzW+9Zqs2PRe8NzYUc=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "owhfVKeKxjXt4P5KO6PSIjnMLIA=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "3JN52M5wxJMazxQWXB4epL78LNQ=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "O5L1jCrbPe6adyTBIpSnydpToyk=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "42OCpXRErVgOtgPsuTrdg7y++TA=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "kPYTVg109H4HL8CKEf1yQvwKMw4=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "GhANcrglYWrhNSR/NzxNe3jClMk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "HmZRIixQ6u+zMz2Qt0iTU42WVZU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "BXG7bjiNrt222s+bZeimLAXODp4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "iFvc4+KfDeQHigAz2+TmogG1Y7M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudhsmv2",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "1uyTJ/RTr7c8uL2Kbrp+60PE40M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "3q2FBK4CEarGbVeLCuuX+g1E3jk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "o+DFxugR5Cy/Wwlv7GSRRilTW4o=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "7lCMA0KirL9isnwLj87LR2cjipU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "nGSD4idK9hW8o3U4gLGLESYCpwE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "SfdREjSJPmW+OjKCjwD8m07wT+w=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "ysSU5yhqWT4+deQUYZiI8/1tJ2c=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "GvjVVg5btXuEFEHqyoe19BZogGw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "vklitYIK0AiOXA0obSTq0c04pc4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "rL0O6L1zSJ/UQE0kEWUoCOOFDog=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "Zc5M/qyd8bDCYuNRvFnF05gMp5s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "o9WTZk66Jlu+0UdO1wmtO3qp8ps=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "/y7nXSnR9OqMoxlIl1hFcCk5kT8=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
-			"checksumSHA1": "X1TkBdqZ/RWin1tr/FHWOGAFGsI=",
+			"checksumSHA1": "0EzaatOYLyDsPRW0JgbtwdtPeVk=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "eAvb9FYZ6+lM9LhP7TrpNLrNn/Y=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "PBdPTvba1Ci9LrAs0VExIAWtdKQ=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "a02+OXxnVBBBeaZpgs8dXUHj8b0=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "aAw9xutYOwCdzo7p0QwTFVFJr8Y=",
 			"path": "github.com/aws/aws-sdk-go/service/dlm",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "oTvEWASg5Q7pm2LF6FDsFYqg1Ko=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "xNlCk/zwgdNvxnUcdGOhW9K5FJg=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "VD7bAh0n/UgOwRBPe5y38Ow/dHU=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
-			"checksumSHA1": "Or8FcR+N4I0nDl8IU5Y0ek9bBd8=",
+			"checksumSHA1": "Q8RuvleYpFO1hlm/eKRbg5wG/nQ=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "NDrEwIZeUSlHgENwBzVdy0KcCCY=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "5QdblYPoDtRsQ8aczXOesIKTDpc=",
 			"path": "github.com/aws/aws-sdk-go/service/eks",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "kvsll2DfqS1hg97xSWMIcMan5as=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "fx9nf/M9h4DpZY5pEdnh9DeCnsU=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "GdpGQlKFS+BGq90Kc6PboHCW3kM=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "VFjWDQMsGpFMrNfcc//ABRpo6Ew=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "Gp+QZjtg8PCNVi9X8m2SqtFvMas=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "wIiqI9GFAV2AQ32o2kEYHNyqVig=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "oNOLs79R42Vsj/jYTYtrbyTWxcw=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "3hICqVOs1WmluYMZN9fTMbDQSyM=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "tNVmAgvnURWLWibVCL7vIDYU7UM=",
 			"path": "github.com/aws/aws-sdk-go/service/fms",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "J1SHh0J6kX8JBD0+TQCFP+1Kij4=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "BB3/VzUU5Rg4KgrezJ17D4kCnwA=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "p+Nb4OF6gcHREcCKa/tyZ6pWBQ8=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "HNndTio5+fNOiLr23i+QZpPp8HU=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "ae+jhUirSvN0IXPVU7X7xc+EbFE=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "39yMWxFP9XB+8wWWCZX4vkNWmxU=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "JrNTM1HkStbS/DyQXkVokDdB71w=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "q9HZ/0/lBSRKtjHXMegmcRcazPo=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "nUdxsOW9jg+m+sWZYPu7oX9rZo8=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesisanalytics",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "vaMnUnRVDkpHp/e4f3dFX20JblM=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "K4OamITKC7PKo1eHrSl0z8Visg0=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "7rQmR+jAZ4zUIC4upAxyxrbfzNM=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "tX/3xEkl13DuKNIO0v3qYseEIvI=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "+l6bA5aVzmBXH2Isj1xZkd5RKNY=",
 			"path": "github.com/aws/aws-sdk-go/service/macie",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "iRZF/T8Ohr0Thp+d54NYg5QxxEw=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "HoX+EX8JW8kDZxJAs8545YRfjuI=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "CggySAQfK9WXsX37mRI8UqXGkJo=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "9NU6dJOvKvcgnl/4eUdwy4YD5ss=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "qyIVtaN5mzPq4d7BDj9YpYtifKs=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "1jKxCBvS+zKzq6p2i4BqLXYHm48=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "E3i2/WM1kDE7WBOSRnDsZkwmZwI=",
 			"path": "github.com/aws/aws-sdk-go/service/neptune",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "x3PsW91a7fh+Q466y3WM3fdtnGg=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "YCd2EU1DPiO0QTRZk6G1fLZAyg0=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "e5v4Cc9/0H2ngQNuvVyj2Mt0vi0=",
 			"path": "github.com/aws/aws-sdk-go/service/pinpoint",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "j1i1tZ94/kDvvzgpv5xqxwNvgyY=",
 			"path": "github.com/aws/aws-sdk-go/service/pricing",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
-			"checksumSHA1": "Kv8hkh6CxOCAG73xohmft8z4I3g=",
+			"checksumSHA1": "7CqeebyIEswL1HtwHYyrjkh5D8w=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "2eywZb+K9OAw3bZ0gHwOCCdcb/8=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "KlM6azZ5G09MmPg+lzEizW2qaLA=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "DmKatmbYsvm+MoCP01PCdQ6Y6Tk=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "npkvk2UM+YBQi+Zf5gq1BJR12gY=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "VmNRKxSI3CS9RvMT9Zk+y/evy1M=",
 			"path": "github.com/aws/aws-sdk-go/service/secretsmanager",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "Y29bmjwKXcPg0d0WvZNFGdhd4+E=",
 			"path": "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "T8dOJ1jjEBdogUE03oRPRJCOY3k=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "UhJ0RdPXzdMOUEBWREB5Zi9lgmY=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "0vtFXRYnhlCCq8/zPv1O1YWIoSg=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "1rJbvLXRsCzWhTihruRq/i0Zawg=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "hliWYTmov/HswyMpYq93zJtdkk0=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "bW9FW0Qe3VURaSoY305kA/wCFrM=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "ECIZck5xhocpUl8GeUAdeSnCgvg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "lWts5yvTa/92d0U77xSCP7ouO6s=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "TeuakooizAybzyMQyTXllUyhfBg=",
 			"path": "github.com/aws/aws-sdk-go/service/storagegateway",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "UhIVLDgQc19wjrPj8pP7Fu2UwWc=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "zSqEhiGtEK6ll3f1Rlf2tuDKQA8=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "H8Pa7irZ9gpuYGJk3uMK59gxGTs=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "uRMuwxPD/AlpvFpKppgAYzvlC0A=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "oe8l2ibuhzz7fWM3f64cWnHwFy8=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "36aaf21bb9b41f47fdc9b477577d0b604925d489",
-			"revisionTime": "2018-08-08T20:44:34Z",
-			"version": "v1.15.8",
-			"versionExact": "v1.15.8"
+			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
+			"revisionTime": "2018-08-09T22:25:54Z",
+			"version": "v1.15.9",
+			"versionExact": "v1.15.9"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
Required for
* https://github.com/terraform-providers/terraform-provider-aws/issues/5500

```console
$ govendor fetch github.com/aws/aws-sdk-go/...@v1.15.9
```