### PR TITLE
r/aws_dax_cluster: Support encryption at rest

### DIFF
--- a/aws/resource_aws_dax_parameter_group.go
+++ b/aws/resource_aws_dax_parameter_group.go
@@ -158,34 +158,3 @@ func resourceAwsDaxParameterGroupDelete(d *schema.ResourceData, meta interface{}
 
 	return nil
 }
-
-func expandDaxParameterGroupParameterNameValue(config []interface{}) []*dax.ParameterNameValue {
-	if len(config) == 0 {
-		return nil
-	}
-	results := make([]*dax.ParameterNameValue, 0, len(config))
-	for _, raw := range config {
-		m := raw.(map[string]interface{})
-		pnv := &dax.ParameterNameValue{
-			ParameterName:  aws.String(m["name"].(string)),
-			ParameterValue: aws.String(m["value"].(string)),
-		}
-		results = append(results, pnv)
-	}
-	return results
-}
-
-func flattenDaxParameterGroupParameters(params []*dax.Parameter) []map[string]interface{} {
-	if len(params) == 0 {
-		return nil
-	}
-	results := make([]map[string]interface{}, 0)
-	for _, p := range params {
-		m := map[string]interface{}{
-			"name":  aws.StringValue(p.ParameterName),
-			"value": aws.StringValue(p.ParameterValue),
-		}
-		results = append(results, m)
-	}
-	return results
-}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4516,3 +4516,54 @@ func flattenMacieClassificationType(classificationType *macie.ClassificationType
 	}
 	return []map[string]interface{}{m}
 }
+
+func expandDaxParameterGroupParameterNameValue(config []interface{}) []*dax.ParameterNameValue {
+	if len(config) == 0 {
+		return nil
+	}
+	results := make([]*dax.ParameterNameValue, 0, len(config))
+	for _, raw := range config {
+		m := raw.(map[string]interface{})
+		pnv := &dax.ParameterNameValue{
+			ParameterName:  aws.String(m["name"].(string)),
+			ParameterValue: aws.String(m["value"].(string)),
+		}
+		results = append(results, pnv)
+	}
+	return results
+}
+
+func flattenDaxParameterGroupParameters(params []*dax.Parameter) []map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+	results := make([]map[string]interface{}, 0)
+	for _, p := range params {
+		m := map[string]interface{}{
+			"name":  aws.StringValue(p.ParameterName),
+			"value": aws.StringValue(p.ParameterValue),
+		}
+		results = append(results, m)
+	}
+	return results
+}
+
+func expandDaxEncryptAtRestOptions(m map[string]interface{}) *dax.SSESpecification {
+	options := dax.SSESpecification{}
+
+	if v, ok := m["enabled"]; ok {
+		options.Enabled = aws.Bool(v.(bool))
+	}
+
+	return &options
+}
+
+func flattenDaxEncryptAtRestOptions(options *dax.SSEDescription) []map[string]interface{} {
+	if options == nil {
+		return []map[string]interface{}{}
+	}
+	m := map[string]interface{}{
+		"enabled": aws.StringValue(options.Status) == dax.SSEStatusEnabled,
+	}
+	return []map[string]interface{}{m}
+}

--- a/website/docs/r/dax_cluster.html.markdown
+++ b/website/docs/r/dax_cluster.html.markdown
@@ -59,10 +59,16 @@ maintenance on the cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi`
 * `security_group_ids` – (Optional) One or more VPC security groups associated
 with the cluster
 
+* `server_side_encryption` - (Optional) Encrypt at rest options
+
 * `subnet_group_name` – (Optional) Name of the subnet group to be used for the
 cluster
 
 * `tags` - (Optional) A mapping of tags to assign to the resource
+
+The `server_side_encryption` object supports the following:
+
+* `enabled` - (Required) Whether to enable encryption at rest. If the `server_side_encryption` block is not provided then this defaults to `false`
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/5500.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDAXCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDAXCluster_basic -timeout 120m
=== RUN   TestAccAWSDAXCluster_basic
--- PASS: TestAccAWSDAXCluster_basic (669.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	669.513s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDAXCluster_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDAXCluster_encryption -timeout 120m
=== RUN   TestAccAWSDAXCluster_encryption
--- PASS: TestAccAWSDAXCluster_encryption (596.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	596.203s
```