### PR TITLE
aws_flow_log - adding support for sending to S3

### DIFF
--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsFlowLog() *schema.Resource {
@@ -22,14 +23,37 @@ func resourceAwsFlowLog() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"iam_role_arn": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
-			"log_group_name": {
+			"log_destination": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"log_group_name"},
+				ValidateFunc:  validateArn,
+			},
+
+			"log_destination_type": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				Default:  ec2.LogDestinationTypeCloudWatchLogs,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.LogDestinationTypeCloudWatchLogs,
+					ec2.LogDestinationTypeS3,
+				}, false),
+			},
+
+			"log_group_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"log_destination"},
+				Deprecated:    "use 'log_destination' argument instead",
 			},
 
 			"vpc_id": {
@@ -89,11 +113,22 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	opts := &ec2.CreateFlowLogsInput{
-		DeliverLogsPermissionArn: aws.String(d.Get("iam_role_arn").(string)),
-		LogGroupName:             aws.String(d.Get("log_group_name").(string)),
-		ResourceIds:              []*string{aws.String(resourceId)},
-		ResourceType:             aws.String(resourceType),
-		TrafficType:              aws.String(d.Get("traffic_type").(string)),
+		LogDestinationType: aws.String(d.Get("log_destination_type").(string)),
+		ResourceIds:        []*string{aws.String(resourceId)},
+		ResourceType:       aws.String(resourceType),
+		TrafficType:        aws.String(d.Get("traffic_type").(string)),
+	}
+
+	if v, ok := d.GetOk("iam_role_arn"); ok && v != "" {
+		opts.DeliverLogsPermissionArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("log_destination"); ok && v != "" {
+		opts.LogDestination = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("log_group_name"); ok && v != "" {
+		opts.LogGroupName = aws.String(v.(string))
 	}
 
 	log.Printf(
@@ -134,6 +169,8 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 
 	fl := resp.FlowLogs[0]
 	d.Set("traffic_type", fl.TrafficType)
+	d.Set("log_destination", fl.LogDestination)
+	d.Set("log_destination_type", fl.LogDestinationType)
 	d.Set("log_group_name", fl.LogGroupName)
 	d.Set("iam_role_arn", fl.DeliverLogsPermissionArn)
 

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -11,10 +11,13 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSFlowLog_importBasic(t *testing.T) {
-	resourceName := "aws_flow_log.test_flow_log"
-
-	rInt := acctest.RandInt()
+func TestAccAWSFlowLog_VPCID(t *testing.T) {
+	var flowLog ec2.FlowLog
+	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_flow_log.test"
+	vpcResourceName := "aws_vpc.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,9 +25,57 @@ func TestAccAWSFlowLog_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_basic(rInt),
+				Config: testAccFlowLogConfig_VPCID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(resourceName, &flowLog),
+					testAccCheckAWSFlowLogAttributes(&flowLog),
+					resource.TestCheckResourceAttrPair(resourceName, "iam_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination", ""),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_type", "cloud-watch-logs"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_name", cloudwatchLogGroupResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_type", "ALL"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
+				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:             testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
 
+func TestAccAWSFlowLog_SubnetID(t *testing.T) {
+	var flowLog ec2.FlowLog
+	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_flow_log.test"
+	subnetResourceName := "aws_subnet.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFlowLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlowLogConfig_SubnetID(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFlowLogExists(resourceName, &flowLog),
+					testAccCheckAWSFlowLogAttributes(&flowLog),
+					resource.TestCheckResourceAttrPair(resourceName, "iam_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination", ""),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_type", "cloud-watch-logs"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_name", cloudwatchLogGroupResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id", subnetResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_type", "ALL"),
+				),
+			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -34,45 +85,61 @@ func TestAccAWSFlowLog_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSFlowLog_basic(t *testing.T) {
+func TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs(t *testing.T) {
 	var flowLog ec2.FlowLog
+	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
+	resourceName := "aws_flow_log.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_flow_log.test_flow_log",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckFlowLogDestroy,
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_basic(rInt),
+				Config: testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFlowLogExists("aws_flow_log.test_flow_log", &flowLog),
+					testAccCheckFlowLogExists(resourceName, &flowLog),
 					testAccCheckAWSFlowLogAttributes(&flowLog),
+					resource.TestCheckResourceAttrPair(resourceName, "log_destination", cloudwatchLogGroupResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_type", "cloud-watch-logs"),
+					resource.TestCheckResourceAttr(resourceName, "log_group_name", fmt.Sprintf("%s:*", rName)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSFlowLog_subnet(t *testing.T) {
+func TestAccAWSFlowLog_LogDestinationType_S3(t *testing.T) {
 	var flowLog ec2.FlowLog
+	s3ResourceName := "aws_s3_bucket.test"
+	resourceName := "aws_flow_log.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_flow_log.test_flow_log_subnet",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckFlowLogDestroy,
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFlowLogDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlowLogConfig_subnet(rInt),
+				Config: testAccFlowLogConfig_LogDestinationType_S3(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFlowLogExists("aws_flow_log.test_flow_log_subnet", &flowLog),
+					testAccCheckFlowLogExists(resourceName, &flowLog),
 					testAccCheckAWSFlowLogAttributes(&flowLog),
+					resource.TestCheckResourceAttrPair(resourceName, "log_destination", s3ResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_destination_type", "s3"),
+					resource.TestCheckResourceAttr(resourceName, "log_group_name", ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -131,27 +198,19 @@ func testAccCheckFlowLogDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccFlowLogConfig_basic(rInt int) string {
+func testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "default" {
-    cidr_block = "10.0.0.0/16"
-    tags {
-        Name = "terraform-testacc-flow-log-basic"
-    }
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = %q
+  }
 }
 
-resource "aws_subnet" "test_subnet" {
-    vpc_id = "${aws_vpc.default.id}"
-    cidr_block = "10.0.1.0/24"
-
-    tags {
-        Name = "tf-acc-flow-log-basic"
-    }
-}
-
-resource "aws_iam_role" "test_role" {
-    name = "tf_test_flow_log_basic_%d"
-    assume_role_policy = <<EOF
+resource "aws_iam_role" "test" {
+  name = %q
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -171,46 +230,66 @@ resource "aws_iam_role" "test_role" {
 EOF
 }
 
-resource "aws_cloudwatch_log_group" "foobar" {
-    name = "tf-test-fl-%d"
-}
-resource "aws_flow_log" "test_flow_log" {
-    log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
-    iam_role_arn = "${aws_iam_role.test_role.arn}"
-    vpc_id = "${aws_vpc.default.id}"
-    traffic_type = "ALL"
+resource "aws_cloudwatch_log_group" "test" {
+  name = %q
 }
 
-resource "aws_flow_log" "test_flow_log_subnet" {
-    log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
-    iam_role_arn = "${aws_iam_role.test_role.arn}"
-    subnet_id = "${aws_subnet.test_subnet.id}"
-    traffic_type = "ALL"
+resource "aws_flow_log" "test" {
+  iam_role_arn         = "${aws_iam_role.test.arn}"
+  log_destination      = "${aws_cloudwatch_log_group.test.arn}"
+  log_destination_type = "cloud-watch-logs"
+  traffic_type         = "ALL"
+  vpc_id               = "${aws_vpc.test.id}"
 }
-`, rInt, rInt)
+`, rName, rName, rName)
 }
 
-func testAccFlowLogConfig_subnet(rInt int) string {
+func testAccFlowLogConfig_LogDestinationType_S3(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "default" {
-    cidr_block = "10.0.0.0/16"
-    tags {
-        Name = "terraform-testacc-flow-log-subnet"
-    }
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = %q
+  }
 }
 
-resource "aws_subnet" "test_subnet" {
-    vpc_id = "${aws_vpc.default.id}"
-    cidr_block = "10.0.1.0/24"
-
-    tags {
-        Name = "tf-acc-flow-log-subnet"
-    }
+resource "aws_s3_bucket" "test" {
+  bucket        = %q
+  force_destroy = true
 }
 
-resource "aws_iam_role" "test_role" {
-    name = "tf_test_flow_log_subnet_%d"
-    assume_role_policy = <<EOF
+resource "aws_flow_log" "test" {
+  log_destination      = "${aws_s3_bucket.test.arn}"
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = "${aws_vpc.test.id}"
+}
+`, rName, rName)
+}
+
+func testAccFlowLogConfig_SubnetID(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.0.1.0/24"
+  vpc_id     = "${aws_vpc.test.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %q
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -229,15 +308,61 @@ resource "aws_iam_role" "test_role" {
 }
 EOF
 }
-resource "aws_cloudwatch_log_group" "foobar" {
-    name = "tf-test-fl-%d"
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %q
 }
 
-resource "aws_flow_log" "test_flow_log_subnet" {
-    log_group_name = "${aws_cloudwatch_log_group.foobar.name}"
-    iam_role_arn = "${aws_iam_role.test_role.arn}"
-    subnet_id = "${aws_subnet.test_subnet.id}"
-    traffic_type = "ALL"
+resource "aws_flow_log" "test" {
+  iam_role_arn   = "${aws_iam_role.test.arn}"
+  log_group_name = "${aws_cloudwatch_log_group.test.name}"
+  subnet_id      = "${aws_subnet.test.id}"
+  traffic_type   = "ALL"
 }
-`, rInt, rInt)
+`, rName, rName, rName, rName)
+}
+
+func testAccFlowLogConfig_VPCID(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = %q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = %q
+}
+
+resource "aws_flow_log" "test" {
+  iam_role_arn   = "${aws_iam_role.test.arn}"
+  log_group_name = "${aws_cloudwatch_log_group.test.name}"
+  traffic_type   = "ALL"
+  vpc_id         = "${aws_vpc.test.id}"
+}
+`, rName, rName, rName)
 }

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -13,20 +13,22 @@ interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group.
 
 ## Example Usage
 
+### CloudWatch Logging
+
 ```hcl
-resource "aws_flow_log" "test_flow_log" {
-  log_group_name = "${aws_cloudwatch_log_group.test_log_group.name}"
-  iam_role_arn   = "${aws_iam_role.test_role.arn}"
-  vpc_id         = "${aws_vpc.default.id}"
-  traffic_type   = "ALL"
+resource "aws_flow_log" "example" {
+  iam_role_arn    = "${aws_iam_role.example.arn}"
+  log_destination = "${aws_cloudwatch_log_group.example.arn}"
+  traffic_type    = "ALL"
+  vpc_id          = "${aws_vpc.example.id}"
 }
 
-resource "aws_cloudwatch_log_group" "test_log_group" {
-  name = "test_log_group"
+resource "aws_cloudwatch_log_group" "example" {
+  name = "example"
 }
 
 resource "aws_iam_role" "test_role" {
-  name = "test_role"
+  name = "example"
 
   assume_role_policy = <<EOF
 {
@@ -45,9 +47,9 @@ resource "aws_iam_role" "test_role" {
 EOF
 }
 
-resource "aws_iam_role_policy" "test_policy" {
-  name = "test_policy"
-  role = "${aws_iam_role.test_role.id}"
+resource "aws_iam_role_policy" "example" {
+  name = "example"
+  role = "${aws_iam_role.example.id}"
 
   policy = <<EOF
 {
@@ -70,18 +72,35 @@ EOF
 }
 ```
 
+### S3 Logging
+
+```hcl
+resource "aws_flow_log" "example" {
+  log_destination      = "${aws_s3_bucket.example.arn}"
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = "${aws_vpc.example.id}"
+}
+
+resource "aws_s3_bucket" "example" {
+  name = "example"
+}
+```
+
 ## Argument Reference
+
+~> **NOTE:** One of `eni_id`, `subnet_id`, or `vpc_id` must be specified.
 
 The following arguments are supported:
 
-* `log_group_name` - (Required) The name of the CloudWatch log group
-* `iam_role_arn` - (Required) The ARN for the IAM role that's used to post flow
-  logs to a CloudWatch Logs log group
-* `vpc_id` - (Optional) VPC ID to attach to
-* `subnet_id` - (Optional) Subnet ID to attach to
+* `traffic_type` - (Required) The type of traffic to capture. Valid values: `ACCEPT`,`REJECT`, `ALL`.
 * `eni_id` - (Optional) Elastic Network Interface ID to attach to
-* `traffic_type` - (Required) The type of traffic to capture. Valid values:
-  `ACCEPT`,`REJECT`, `ALL`
+* `iam_role_arn` - (Optional) The ARN for the IAM role that's used to post flow logs to a CloudWatch Logs log group
+* `log_destination_type` - (Optional) The type of the logging destination. Valid values: `cloud-watch-logs`, `s3`. Default: `cloud-watch-logs`.
+* `log_destination` - (Optional) The ARN of the logging destination.
+* `log_group_name` - (Optional) *Deprecated:* Use `log_destination` instead. The name of the CloudWatch log group.
+* `subnet_id` - (Optional) Subnet ID to attach to
+* `vpc_id` - (Optional) VPC ID to attach to
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5482

Changes proposed in this pull request:

* Updating `aws_flow_log` resource for s3 delivery support, also improving schema validation.
* Adding state migration for `aws_flow_log` resource from v0 to v1
* Adding test for `aws_flow_log` state migration
* Updating docs for new arguments in `aws_flow_log` resource
* Updates to the 1-to-2 upgrade guide for this resource (thanks @ewbankkit)
* Way better tests from @ewbankkit


Output from acceptance testing (from @ewbankkit):

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSFlowLog_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSFlowLog_ -timeout 120m
=== RUN   TestAccAWSFlowLog_VPCID
=== PAUSE TestAccAWSFlowLog_VPCID
=== RUN   TestAccAWSFlowLog_SubnetID
--- PASS: TestAccAWSFlowLog_SubnetID (30.24s)
=== RUN   TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (24.43s)
=== RUN   TestAccAWSFlowLog_LogDestinationType_S3
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (28.18s)
=== CONT  TestAccAWSFlowLog_VPCID
--- PASS: TestAccAWSFlowLog_VPCID (40.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	124.117s
```
