### PR TITLE
Fix typo in Glue docs

### DIFF
--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws_glue_crawler
 
-Manages a Glue Crawler. More information can be found in the [AWS Glue Develeper Guide](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html)
+Manages a Glue Crawler. More information can be found in the [AWS Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/add-crawler.html)
 
 ## Example Usage
 


### PR DESCRIPTION
"Developer" was misspelled. Documentation-only update.