### PR TITLE
Issue #5374 New Datasource: aws_db_event_categories

### DIFF
--- a/aws/data_source_aws_db_event_categories.go
+++ b/aws/data_source_aws_db_event_categories.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsDbEventCategories() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsDbEventCategoriesRead,
+
+		Schema: map[string]*schema.Schema{
+			"source_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_categories": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsDbEventCategoriesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	req := &rds.DescribeEventCategoriesInput{}
+
+	if sourceType := d.Get("source_type").(string); sourceType != "" {
+		req.SourceType = aws.String(sourceType)
+	}
+
+	log.Printf("[DEBUG] Describe Event Categories %s\n", req)
+	resp, err := conn.DescribeEventCategories(req)
+	if err != nil {
+		return err
+	}
+
+	if resp == nil || len(resp.EventCategoriesMapList) == 0 {
+		return fmt.Errorf("Event Categories not found")
+	}
+
+	eventCategories := make([]string, 0)
+
+	for _, eventMap := range resp.EventCategoriesMapList {
+		for _, v := range eventMap.EventCategories {
+			eventCategories = append(eventCategories, aws.StringValue(v))
+		}
+	}
+
+	d.SetId(resource.UniqueId())
+	if err := d.Set("event_categories", eventCategories); err != nil {
+		return fmt.Errorf("Error setting Event Categories: %s", err)
+	}
+
+	return nil
+
+}

--- a/aws/data_source_aws_db_event_categories_test.go
+++ b/aws/data_source_aws_db_event_categories_test.go
@@ -20,14 +20,31 @@ func TestAccAWSDbEventCategories_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsDbEventCategoriesConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccAwsDbEventCategoriesAttrCheck("data.aws_db_event_categories.example"),
+					testAccAwsDbEventCategoriesAttrCheck("data.aws_db_event_categories.example",
+						completeEventCategoriesList),
 				),
 			},
 		},
 	})
 }
 
-func testAccAwsDbEventCategoriesAttrCheck(n string) resource.TestCheckFunc {
+func TestAccAWSDbEventCategories_sourceType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsDbEventCategoriesConfig_sourceType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAwsDbEventCategoriesAttrCheck("data.aws_db_event_categories.example",
+						DbSnapshotEventCategoriesList),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsDbEventCategoriesAttrCheck(n string, expected []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -41,23 +58,6 @@ func testAccAwsDbEventCategoriesAttrCheck(n string) resource.TestCheckFunc {
 		actual, err := testAccCheckAwsDbEventCategoriesBuild(rs.Primary.Attributes)
 		if err != nil {
 			return err
-		}
-
-		expected := []string{
-			"notification",
-			"deletion",
-			"failover",
-			"maintenance",
-			"availability",
-			"read replica",
-			"failure",
-			"configuration change",
-			"recovery",
-			"low storage",
-			"backup",
-			"creation",
-			"backtrack",
-			"restoration",
 		}
 
 		sort.Strings(actual)
@@ -98,3 +98,33 @@ func testAccCheckAwsDbEventCategoriesBuild(attrs map[string]string) ([]string, e
 var testAccCheckAwsDbEventCategoriesConfig = `
 data "aws_db_event_categories" "example" {}
 `
+
+var completeEventCategoriesList = []string{
+	"notification",
+	"deletion",
+	"failover",
+	"maintenance",
+	"availability",
+	"read replica",
+	"failure",
+	"configuration change",
+	"recovery",
+	"low storage",
+	"backup",
+	"creation",
+	"backtrack",
+	"restoration",
+}
+
+var testAccCheckAwsDbEventCategoriesConfig_sourceType = `
+data "aws_db_event_categories" "example" {
+	source_type = "db-snapshot"
+}
+`
+
+var DbSnapshotEventCategoriesList = []string{
+	"notification",
+	"deletion",
+	"creation",
+	"restoration",
+}

--- a/aws/data_source_aws_db_event_categories_test.go
+++ b/aws/data_source_aws_db_event_categories_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"testing"
@@ -19,14 +20,14 @@ func TestAccAWSDbEventCategories_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsDbEventCategoriesConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDbEventCategoriesAttr("data.aws_db_event_categories.example"),
+					testAccAwsDbEventCategoriesAttrCheck("data.aws_db_event_categories.example"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckAwsDbEventCategoriesAttr(n string) resource.TestCheckFunc {
+func testAccAwsDbEventCategoriesAttrCheck(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -82,16 +83,16 @@ func testAccCheckAwsDbEventCategoriesBuild(attrs map[string]string) ([]string, e
 	if qty < 1 {
 		return nil, fmt.Errorf("No DB Event Categories found.")
 	}
-	eventCategories := make([]string, qty)
-	for n := range eventCategories {
-		eventCategory, ok := attrs["event_categories."+strconv.Itoa(n)]
-		if !ok {
-			return nil, fmt.Errorf("DB Event Categories list is corrupted.")
-		}
-		eventCategories[n] = eventCategory
-	}
-	return eventCategories, nil
 
+	var eventCategories []string
+	for k, v := range attrs {
+		matched, _ := regexp.MatchString("event_categories.[0-9]+", k)
+		if matched {
+			eventCategories = append(eventCategories, v)
+		}
+	}
+
+	return eventCategories, nil
 }
 
 var testAccCheckAwsDbEventCategoriesConfig = `

--- a/aws/data_source_aws_db_event_categories_test.go
+++ b/aws/data_source_aws_db_event_categories_test.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDbEventCategories_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsDbEventCategoriesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDbEventCategoriesAttr("data.aws_db_event_categories.example"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDbEventCategoriesAttr(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find DB Event Categories: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("DB Event Categories resource ID not set.")
+		}
+
+		actual, err := testAccCheckAwsDbEventCategoriesBuild(rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		expected := []string{
+			"notification",
+			"deletion",
+			"failover",
+			"maintenance",
+			"availability",
+			"read replica",
+			"failure",
+			"configuration change",
+			"recovery",
+			"low storage",
+			"backup",
+			"creation",
+			"backtrack",
+			"restoration",
+		}
+
+		sort.Strings(actual)
+		sort.Strings(expected)
+		if reflect.DeepEqual(expected, actual) != true {
+			return fmt.Errorf("DB Event Categories not matched: expected %v, got %v", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsDbEventCategoriesBuild(attrs map[string]string) ([]string, error) {
+	v, ok := attrs["event_categories.#"]
+	if !ok {
+		return nil, fmt.Errorf("DB Event Categories list is missing.")
+	}
+
+	qty, err := strconv.Atoi(v)
+	if err != nil {
+		return nil, err
+	}
+	if qty < 1 {
+		return nil, fmt.Errorf("No DB Event Categories found.")
+	}
+	eventCategories := make([]string, qty)
+	for n := range eventCategories {
+		eventCategory, ok := attrs["event_categories."+strconv.Itoa(n)]
+		if !ok {
+			return nil, fmt.Errorf("DB Event Categories list is corrupted.")
+		}
+		eventCategories[n] = eventCategory
+	}
+	return eventCategories, nil
+
+}
+
+var testAccCheckAwsDbEventCategoriesConfig = `
+data "aws_db_event_categories" "example" {}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -181,6 +181,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cognito_user_pools":               dataSourceAwsCognitoUserPools(),
 			"aws_codecommit_repository":            dataSourceAwsCodeCommitRepository(),
 			"aws_db_cluster_snapshot":              dataSourceAwsDbClusterSnapshot(),
+			"aws_db_event_categories":              dataSourceAwsDbEventCategories(),
 			"aws_db_instance":                      dataSourceAwsDbInstance(),
 			"aws_db_snapshot":                      dataSourceAwsDbSnapshot(),
 			"aws_dx_gateway":                       dataSourceAwsDxGateway(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -116,6 +116,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-db-cluster-snapshot") %>>
                           <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-db-event-categories") %>>
+                          <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-db-instance") %>>
                             <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
                         </li>

--- a/website/docs/d/db_event_categories.html.markdown
+++ b/website/docs/d/db_event_categories.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "aws"
+page_title: "AWS: aws_db_event_categories"
+sidebar_current: "docs-aws-datasource-db-event-categories"
+description: |-
+    Provides a list of DB Event Categories which can be used to pass values into DB Event Subscription.
+---
+
+# Data Source: aws_db_event_categories
+
+## Example Usage
+
+List the event categories of all the RDS resources. 
+
+```hcl
+data "aws_db_event_categories" "example" {}
+
+output "example" {
+  value = "${data.aws_db_event_categories.example.event_categories}"
+}
+```
+
+List the event categories specific to the RDS resource `db-snapshot`.
+
+```hcl
+data "aws_db_event_categories" "example" {
+  source_type = "db-snapshot"
+}
+
+output "example" {
+  value = "${data.aws_db_event_categories.example.event_categories}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `source_type` - (Optional) The type of source that will be generating the events. Valid options are db-instance, db-security-group, db-parameter-group, db-snapshot, db-cluster or db-cluster-snapshot.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `event_categories` - A list of the event categories.


### PR DESCRIPTION
Fixes #5374

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDbEventCategories_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDbEventCategories_ -timeout 120m
=== RUN   TestAccAWSDbEventCategories_basic
--- PASS: TestAccAWSDbEventCategories_basic (31.83s)
=== RUN   TestAccAWSDbEventCategories_sourceType
--- PASS: TestAccAWSDbEventCategories_sourceType (30.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	62.069s
...
```
