### PR TITLE
Adding more examples of Glue + Firehose usage to docs

### DIFF
--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -51,7 +51,6 @@ resource "aws_glue_catalog_table" "table" {
   storage_descriptor {
     input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
-    location      = "s3://NAME-OF-YOUR-DATA-S3-BUCKET/"
 
     ser_de_info = {
       name                  = "parquet"
@@ -93,7 +92,7 @@ The following arguments are supported:
 ##### storage_descriptor
 
 * `columns` - (Optional) A list of the [Columns](#column) in the table.
-* `location` - (Optional) The physical location of the table. By default this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name.
+* `location` - (Optional) The physical location of the table. By default this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name. Specify this as `s3://name-of-your-s3-bucket/` to ensure the table is usable in Athena.
 * `input_format` - (Optional) The input format: SequenceFileInputFormat (binary), or TextInputFormat, or a custom format.
 * `output_format` - (Optional) The output format: SequenceFileOutputFormat (binary), or IgnoreKeyTextOutputFormat, or a custom format.
 * `compressed` - (Optional) True if the data in the table is compressed, or False if not.

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -12,10 +12,16 @@ Provides a Glue Catalog Table Resource. You can refer to the [Glue Developer Gui
 
 ## Example Usage
 
+### Basic table config
+
 ```hcl
-resource "aws_glue_catalog_table" "aws_glue_catalog_table" {
-  name = "MyCatalogTable"
-  database_name = "MyCatalogDatabase"
+resource "aws_glue_catalog_database" "glue_database" {
+  name = "glue-database"
+}
+
+resource "aws_glue_catalog_table" "glue_table" {
+  name = "glue-table"
+  database_name = "${aws_glue_catalog_database.glue_database.name}"
 }
 ```
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -249,7 +249,6 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   }
 }
 ```
-~> **NOTE:** Kinesis Firehose is currently only supported in us-east-1, us-west-2 and eu-west-1.
 
 ## Argument Reference
 
@@ -266,7 +265,7 @@ is redshift). More details are given below.
 Using `redshift_configuration` requires the user to also specify a
 `s3_configuration` block. More details are given below.
 
-The `kinesis_source_configuration` object supports the following: 
+The `kinesis_source_configuration` object supports the following:
 
 * `kinesis_stream_arn` (Required) The kinesis stream used as the source of the firehose delivery stream.
 * `role_arn` (Required) The ARN of the role that provides access to the source Kinesis stream.


### PR DESCRIPTION
Documentation-only update. This PR adds some additional examples of using Glue databases/tables, as well as integrating them with Kinesis Firehose for Parquet data transformation when writing to S3. 

I spent too much time figuring out how to get all of this wired up against the previous terse examples, so hopefully other people can find these examples useful for what I assume is a common use case (transforming streaming JSON data to Parquet for efficient Athena / Redshift Spectrum querying)