### PR TITLE
vendor: hashicorp/terraform@bb37637a139151be0ff9bf00c85c448538e5b3d2

### DIFF
--- a/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
+++ b/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
@@ -1698,7 +1698,7 @@ func interpolationFuncRsaDecrypt() ast.Function {
 
 			b, err := base64.StdEncoding.DecodeString(s)
 			if err != nil {
-				return "", fmt.Errorf("Failed to decode input %q: cipher text must be base64-encoded", key)
+				return "", fmt.Errorf("Failed to decode input %q: cipher text must be base64-encoded", s)
 			}
 
 			block, _ := pem.Decode([]byte(key))

--- a/vendor/github.com/hashicorp/terraform/config/module/storage.go
+++ b/vendor/github.com/hashicorp/terraform/config/module/storage.go
@@ -11,7 +11,6 @@ import (
 	getter "github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/registry"
 	"github.com/hashicorp/terraform/registry/regsrc"
-	"github.com/hashicorp/terraform/svchost/auth"
 	"github.com/hashicorp/terraform/svchost/disco"
 	"github.com/mitchellh/cli"
 )
@@ -64,22 +63,19 @@ type Storage struct {
 	// StorageDir is the full path to the directory where all modules will be
 	// stored.
 	StorageDir string
-	// Services is a required *disco.Disco, which may have services and
-	// credentials pre-loaded.
-	Services *disco.Disco
-	// Creds optionally provides credentials for communicating with service
-	// providers.
-	Creds auth.CredentialsSource
+
 	// Ui is an optional cli.Ui for user output
 	Ui cli.Ui
+
 	// Mode is the GetMode that will be used for various operations.
 	Mode GetMode
 
 	registry *registry.Client
 }
 
-func NewStorage(dir string, services *disco.Disco, creds auth.CredentialsSource) *Storage {
-	regClient := registry.NewClient(services, creds, nil)
+// NewStorage returns a new initialized Storage object.
+func NewStorage(dir string, services *disco.Disco) *Storage {
+	regClient := registry.NewClient(services, nil)
 
 	return &Storage{
 		StorageDir: dir,

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
@@ -266,6 +266,15 @@ type TestStep struct {
 	// below.
 	PreConfig func()
 
+	// Taint is a list of resource addresses to taint prior to the execution of
+	// the step. Be sure to only include this at a step where the referenced
+	// address will be present in state, as it will fail the test if the resource
+	// is missing.
+	//
+	// This option is ignored on ImportState tests, and currently only works for
+	// resources in the root module path.
+	Taint []string
+
 	//---------------------------------------------------------------
 	// Test modes. One of the following groups of settings must be
 	// set to determine what the test step will do. Ideally we would've

--- a/vendor/github.com/hashicorp/terraform/registry/client.go
+++ b/vendor/github.com/hashicorp/terraform/registry/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform/registry/regsrc"
 	"github.com/hashicorp/terraform/registry/response"
 	"github.com/hashicorp/terraform/svchost"
-	"github.com/hashicorp/terraform/svchost/auth"
 	"github.com/hashicorp/terraform/svchost/disco"
 	"github.com/hashicorp/terraform/version"
 )
@@ -37,18 +36,13 @@ type Client struct {
 	// services is a required *disco.Disco, which may have services and
 	// credentials pre-loaded.
 	services *disco.Disco
-
-	// Creds optionally provides credentials for communicating with service
-	// providers.
-	creds auth.CredentialsSource
 }
 
-func NewClient(services *disco.Disco, creds auth.CredentialsSource, client *http.Client) *Client {
+// NewClient returns a new initialized registry client.
+func NewClient(services *disco.Disco, client *http.Client) *Client {
 	if services == nil {
-		services = disco.NewDisco()
+		services = disco.New()
 	}
-
-	services.SetCredentialsSource(creds)
 
 	if client == nil {
 		client = httpclient.New()
@@ -60,7 +54,6 @@ func NewClient(services *disco.Disco, creds auth.CredentialsSource, client *http
 	return &Client{
 		client:   client,
 		services: services,
-		creds:    creds,
 	}
 }
 
@@ -137,11 +130,7 @@ func (c *Client) Versions(module *regsrc.Module) (*response.ModuleVersions, erro
 }
 
 func (c *Client) addRequestCreds(host svchost.Hostname, req *http.Request) {
-	if c.creds == nil {
-		return
-	}
-
-	creds, err := c.creds.ForHost(host)
+	creds, err := c.services.CredentialsForHost(host)
 	if err != nil {
 		log.Printf("[WARN] Failed to get credentials for %s: %s (ignoring)", host, err)
 		return

--- a/vendor/github.com/hashicorp/terraform/svchost/auth/credentials.go
+++ b/vendor/github.com/hashicorp/terraform/svchost/auth/credentials.go
@@ -42,6 +42,9 @@ type HostCredentials interface {
 	// receiving credentials. The usual behavior of this method is to
 	// add some sort of Authorization header to the request.
 	PrepareRequest(req *http.Request)
+
+	// Token returns the authentication token.
+	Token() string
 }
 
 // ForHost iterates over the contained CredentialsSource objects and

--- a/vendor/github.com/hashicorp/terraform/svchost/auth/token_credentials.go
+++ b/vendor/github.com/hashicorp/terraform/svchost/auth/token_credentials.go
@@ -18,3 +18,8 @@ func (tc HostCredentialsToken) PrepareRequest(req *http.Request) {
 	}
 	req.Header.Set("Authorization", "Bearer "+string(tc))
 }
+
+// Token returns the authentication token.
+func (tc HostCredentialsToken) Token() string {
+	return string(tc)
+}

--- a/vendor/github.com/hashicorp/terraform/version/version.go
+++ b/vendor/github.com/hashicorp/terraform/version/version.go
@@ -1,7 +1,7 @@
 // The version package provides a location to set the release versions for all
 // packages to consume, without creating import cycles.
 //
-// This pckage should not import any other terraform packages.
+// This package should not import any other terraform packages.
 package version
 
 import (

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1307,196 +1307,196 @@
 			"revisionTime": "2015-06-09T07:04:31Z"
 		},
 		{
-			"checksumSHA1": "D2qVXjDywJu6wLj/4NCTsFnRrvw=",
+			"checksumSHA1": "MpMvoeVDNxeoOQTI+hUxt+0bHdY=",
 			"path": "github.com/hashicorp/terraform/config",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "WzQP2WfiCYlaALKZVqEFsxZsG1o=",
 			"path": "github.com/hashicorp/terraform/config/configschema",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "3V7300kyZF+AGy/cOKV0+P6M3LY=",
 			"path": "github.com/hashicorp/terraform/config/hcl2shim",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
-			"checksumSHA1": "HayBWvFE+t9aERoz9kpE2MODurk=",
+			"checksumSHA1": "/5UEeukyNbbP/j80Jht10AZ+Law=",
 			"path": "github.com/hashicorp/terraform/config/module",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "mPbjVPD2enEey45bP4M83W2AxlY=",
 			"path": "github.com/hashicorp/terraform/dag",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "P8gNPDuOzmiK4Lz9xG7OBy4Rlm8=",
 			"path": "github.com/hashicorp/terraform/flatmap",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "zx5DLo5aV0xDqxGTzSibXg7HHAA=",
 			"path": "github.com/hashicorp/terraform/helper/acctest",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "uT6Q9RdSRAkDjyUgQlJ2XKJRab4=",
 			"path": "github.com/hashicorp/terraform/helper/config",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "qVmQPoZmJ2w2OnaxIheWfuwun6g=",
 			"path": "github.com/hashicorp/terraform/helper/customdiff",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "FH5eOEHfHgdxPC/JnfmCeSBk66U=",
 			"path": "github.com/hashicorp/terraform/helper/encryption",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "KNvbU1r5jv0CBeQLnEtDoL3dRtc=",
 			"path": "github.com/hashicorp/terraform/helper/hashcode",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "B267stWNQd0/pBTXHfI/tJsxzfc=",
 			"path": "github.com/hashicorp/terraform/helper/hilmapstructure",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "BAXV9ruAyno3aFgwYI2/wWzB2Gc=",
 			"path": "github.com/hashicorp/terraform/helper/logging",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "twkFd4x71kBnDfrdqO5nhs8dMOY=",
 			"path": "github.com/hashicorp/terraform/helper/mutexkv",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "ImyqbHM/xe3eAT2moIjLI8ksuks=",
 			"path": "github.com/hashicorp/terraform/helper/pathorcontents",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
-			"checksumSHA1": "ryCWu7RtMlYrAfSevaI7RtaXe98=",
+			"checksumSHA1": "3ml5nA9mNVoK30lE2W0DxQIPWiw=",
 			"path": "github.com/hashicorp/terraform/helper/resource",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "zA2C6Pg+7DII0K3M0g49R/nRLvc=",
 			"path": "github.com/hashicorp/terraform/helper/schema",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "Fzbv+N7hFXOtrR6E7ZcHT3jEE9s=",
 			"path": "github.com/hashicorp/terraform/helper/structure",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "nEC56vB6M60BJtGPe+N9rziHqLg=",
 			"path": "github.com/hashicorp/terraform/helper/validation",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "kD1ayilNruf2cES1LDfNZjYRscQ=",
 			"path": "github.com/hashicorp/terraform/httpclient",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",
 			"path": "github.com/hashicorp/terraform/moduledeps",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "DqaoG++NXRCfvH/OloneLWrM+3k=",
 			"path": "github.com/hashicorp/terraform/plugin",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "tx5xrdiUWdAHqoRV5aEfALgT1aU=",
 			"path": "github.com/hashicorp/terraform/plugin/discovery",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
-			"checksumSHA1": "f6wDpr0uHKZqQw4ztvxMrtiuvQo=",
+			"checksumSHA1": "dD3uZ27A7V6r2ZcXabXbUwOxD2E=",
 			"path": "github.com/hashicorp/terraform/registry",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "cR87P4V5aiEfvF+1qoBi2JQyQS4=",
 			"path": "github.com/hashicorp/terraform/registry/regsrc",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "y9IXgIJQq9XNy1zIYUV2Kc0KsnA=",
 			"path": "github.com/hashicorp/terraform/registry/response",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "VXlzRRDVOqeMvnnrbUcR9H64OA4=",
 			"path": "github.com/hashicorp/terraform/svchost",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
-			"checksumSHA1": "GzcKNlFL0N77JVjU8qbltXE4R3k=",
+			"checksumSHA1": "o6CMncmy6Q2F+r13sEOeT6R9GF8=",
 			"path": "github.com/hashicorp/terraform/svchost/auth",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
-			"checksumSHA1": "jiDWmQieUE6OoUBMs53hj9P/JDQ=",
+			"checksumSHA1": "uEzjKyPvbd8k5VGdgn4b/2rDDi0=",
 			"path": "github.com/hashicorp/terraform/svchost/disco",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "lHCKONqlaHsn5cEaYltad7dvRq8=",
 			"path": "github.com/hashicorp/terraform/terraform",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "+K+oz9mMTmQMxIA3KVkGRfjvm9I=",
 			"path": "github.com/hashicorp/terraform/tfdiags",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
-			"checksumSHA1": "F1m/rnzqtFsc6PNMv2HWC1KZANY=",
+			"checksumSHA1": "2kPtmuGH9jc0RB/0VkS64UYa1l0=",
 			"path": "github.com/hashicorp/terraform/version",
-			"revision": "ec998a21bc95366269fbd196e09d3a458bba8be7",
-			"revisionTime": "2018-06-20T18:39:08Z"
+			"revision": "bb37637a139151be0ff9bf00c85c448538e5b3d2",
+			"revisionTime": "2018-08-10T18:32:07Z"
 		},
 		{
 			"checksumSHA1": "ft77GtqeZEeCXioGpF/s6DlGm/U=",


### PR DESCRIPTION
We are already using post-0.11.7 upstream code and this brings us up to latest which adds `Taint` action for `TestStep`. It can be used to simplify some existing testing (e.g. `TestAccAWSSQSQueue_queueDeletedRecently`) as well as aid in testing to cover #4467

Changes proposed in this pull request:

* `govendor fetch github.com/hashicorp/terraform/...@bb37637a139151be0ff9bf00c85c448538e5b3d2`

Output from acceptance testing: Handled via daily acceptance testing
