### PR TITLE
tests/resource/aws_config_delivery_channel: Retry on DescribeDeliveryChannels ThrottlingException in testSweepConfigDeliveryChannels

### DIFF
--- a/aws/resource_aws_config_delivery_channel_test.go
+++ b/aws/resource_aws_config_delivery_channel_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/configservice"
@@ -31,7 +32,19 @@ func testSweepConfigDeliveryChannels(region string) error {
 	conn := client.(*AWSClient).configconn
 
 	req := &configservice.DescribeDeliveryChannelsInput{}
-	resp, err := conn.DescribeDeliveryChannels(req)
+	var resp *configservice.DescribeDeliveryChannelsOutput
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+		resp, err = conn.DescribeDeliveryChannels(req)
+		if err != nil {
+			// ThrottlingException: Rate exceeded
+			if isAWSErr(err, "ThrottlingException", "Rate exceeded") {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
 	if err != nil {
 		return fmt.Errorf("Error describing Delivery Channels: %s", err)
 	}


### PR DESCRIPTION
Test sweepers in TeamCity fail quite often with this API call and error, so let's allow automatic retries of the problematic call. We might want to consider having the sweeper client (`sharedClientForRegion`) use the client we build in `aws/config.go` so they can share connection handler functions.

Previously, often:

```
[06:01:22]2018/08/11 06:01:22 [DEBUG] [aws-sdk-go] {"__type":"ThrottlingException","message":"Rate exceeded"}
[06:01:22]2018/08/11 06:01:22 [DEBUG] [aws-sdk-go] DEBUG: Validate Response config/DescribeDeliveryChannels failed, not retrying, error ThrottlingException: Rate exceeded
[06:01:22]	status code: 400, request id: f966f987-9d2b-11e8-b42e-b7d851f1fd3e
[06:01:22]2018/08/11 06:01:22 [ERR] error running (aws_config_delivery_channel): Error describing Delivery Channels: ThrottlingException: Rate exceeded
[06:01:22]	status code: 400, request id: f966f987-9d2b-11e8-b42e-b7d851f1fd3e
```

Changes proposed in this pull request:

* tests/resource/aws_config_delivery_channel: Retry on DescribeDeliveryChannels ThrottlingException in testSweepConfigDeliveryChannels

Output from acceptance testing:

```
$ make sweep SWEEPARGS='-sweep-run=aws_config_delivery_channel'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_config_delivery_channel
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/08/11 19:49:41 [DEBUG] Running Sweepers for region (us-east-1):
2018/08/11 19:49:41 [DEBUG] Sweeper (aws_config_delivery_channel) has dependency (aws_config_configuration_recorder), running..
2018/08/11 19:49:41 [INFO] Building AWS region structure
2018/08/11 19:49:41 [INFO] Building AWS auth structure
2018/08/11 19:49:41 [INFO] Setting AWS metadata API timeout to 100ms
2018/08/11 19:49:42 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/08/11 19:49:42 [INFO] AWS Auth provider used: "EnvProvider"
2018/08/11 19:49:42 [INFO] Initializing DeviceFarm SDK connection
2018/08/11 19:49:42 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/08/11 19:49:43 [DEBUG] No AWS Config Configuration Recorder to sweep
2018/08/11 19:49:43 [INFO] Building AWS region structure
2018/08/11 19:49:43 [INFO] Building AWS auth structure
2018/08/11 19:49:43 [INFO] Setting AWS metadata API timeout to 100ms
2018/08/11 19:49:44 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/08/11 19:49:44 [INFO] AWS Auth provider used: "EnvProvider"
2018/08/11 19:49:44 [INFO] Initializing DeviceFarm SDK connection
2018/08/11 19:49:44 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/08/11 19:49:44 [DEBUG] Waiting for state to become: [success]
2018/08/11 19:49:44 [DEBUG] No AWS Config Delivery Channel to sweep
2018/08/11 19:49:44 Sweeper Tests ran:
	- aws_config_configuration_recorder
	- aws_config_delivery_channel
2018/08/11 19:49:44 [DEBUG] Running Sweepers for region (us-west-2):
2018/08/11 19:49:44 [DEBUG] Sweeper (aws_config_delivery_channel) has dependency (aws_config_configuration_recorder), running..
2018/08/11 19:49:44 [INFO] Building AWS region structure
2018/08/11 19:49:44 [INFO] Building AWS auth structure
2018/08/11 19:49:44 [INFO] Setting AWS metadata API timeout to 100ms
2018/08/11 19:49:45 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/08/11 19:49:45 [INFO] AWS Auth provider used: "EnvProvider"
2018/08/11 19:49:45 [INFO] Initializing DeviceFarm SDK connection
2018/08/11 19:49:45 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/08/11 19:49:46 [DEBUG] No AWS Config Configuration Recorder to sweep
2018/08/11 19:49:46 [INFO] Building AWS region structure
2018/08/11 19:49:46 [INFO] Building AWS auth structure
2018/08/11 19:49:46 [INFO] Setting AWS metadata API timeout to 100ms
2018/08/11 19:49:47 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/08/11 19:49:47 [INFO] AWS Auth provider used: "EnvProvider"
2018/08/11 19:49:47 [INFO] Initializing DeviceFarm SDK connection
2018/08/11 19:49:47 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/08/11 19:49:47 [DEBUG] Waiting for state to become: [success]
2018/08/11 19:49:48 [DEBUG] No AWS Config Delivery Channel to sweep
2018/08/11 19:49:48 Sweeper Tests ran:
	- aws_config_configuration_recorder
	- aws_config_delivery_channel
ok  	github.com/terraform-providers/terraform-provider-aws/aws	7.116s
```
