### PR TITLE
resource/aws_dynamodb_table: Allow simultaneous region deletion retry of 5 minutes to better handle global table deletions

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -580,7 +580,7 @@ func deleteAwsDynamoDbTable(tableName string, conn *dynamodb.DynamoDB) error {
 		TableName: aws.String(tableName),
 	}
 
-	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteTable(input)
 		if err != nil {
 			// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously


### PR DESCRIPTION
When DynamoDB is deleting multiple regions of a global table, the deletion call can get stuck waiting for another deletion call to finish. This can be seen with the very consistently failing acceptance test:

```
--- FAIL: TestAccAWSDynamoDbGlobalTable_multipleRegions (284.43s)
	testing.go:579: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error applying: 2 errors occurred:
			* aws_dynamodb_table.us-east-1 (destroy): 1 error occurred:
			* aws_dynamodb_table.us-east-1: ResourceInUseException: Attempt to change a resource which is still in use: Table is being deleted: tf-acc-test-bavzb
			status code: 400, request id: 8UEJN22QSQF434KNQF9IJ63J1NVV4KQNSO5AEMVJF66Q9ASUAAJG

			* aws_dynamodb_table.us-west-2 (destroy): 1 error occurred:
			* aws_dynamodb_table.us-west-2: ResourceInUseException: Attempt to change a resource which is still in use: Table is being deleted: tf-acc-test-bavzb
			status code: 400, request id: T73SL4E6R3EUUE7E2012Q11DCJVV4KQNSO5AEMVJF66Q9ASUAAJG
```

Changes proposed in this pull request:

* Increase the retry threshold in `aws_dynamodb_table` resource deletion function to allow DynamoDB to get around to deleting other regions simultaneously. Increasing the threshold to 2 minutes still was flakey with our empty DynamoDB global table, so decided on 5 minutes as the retry threshold since the retry conditions are fairly safe. In some regards this _guess_ that it shouldn't instead be `d.Timeout(schema.TimeoutDelete)`, which is already used with the wait for deletion `StateChangeConf`.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDynamoDbGlobalTable_multipleRegions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDynamoDbGlobalTable_multipleRegions -timeout 120m
=== RUN   TestAccAWSDynamoDbGlobalTable_multipleRegions
--- PASS: TestAccAWSDynamoDbGlobalTable_multipleRegions (301.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	302.214s
```
