### PR TITLE
tests/resource/aws_dynamodb_table: Remove formatting specific ExpectError conditions

### DIFF
--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -454,7 +454,7 @@ func TestAccAWSDynamoDbTable_streamSpecificationValidation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSDynamoDbConfigStreamSpecification("anything", true, ""),
-				ExpectError: regexp.MustCompile(`stream_view_type is required when stream_enabled = true$`),
+				ExpectError: regexp.MustCompile(`stream_view_type is required when stream_enabled = true`),
 			},
 		},
 	})
@@ -738,11 +738,11 @@ func TestAccAWSDynamoDbTable_attributeUpdateValidation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSDynamoDbConfigOneAttribute(rName, "firstKey", "unusedKey", "S"),
-				ExpectError: regexp.MustCompile(`All attributes must be indexed. Unused attributes: \["unusedKey"\]$`),
+				ExpectError: regexp.MustCompile(`All attributes must be indexed. Unused attributes: \["unusedKey"\]`),
 			},
 			{
 				Config:      testAccAWSDynamoDbConfigTwoAttributes(rName, "firstKey", "secondKey", "firstUnused", "N", "secondUnused", "S"),
-				ExpectError: regexp.MustCompile(`All attributes must be indexed. Unused attributes: \["firstUnused"\ \"secondUnused\"]$`),
+				ExpectError: regexp.MustCompile(`All attributes must be indexed. Unused attributes: \["firstUnused"\ \"secondUnused\"]`),
 			},
 		},
 	})


### PR DESCRIPTION
In https://github.com/terraform-providers/terraform-provider-aws/pull/5442 (vendor: hashicorp/go-multierror@3d5d8f294aa03d8e98859feac328afbdf1ae0703), the output formatting for go-multierror changed which included an additional newline after the final error message. These two acceptance tests were too strict with their `ExpectError` regex validation and extraneously checking whitespace handling outside the returned error.

Previously:

```
--- FAIL: TestAccAWSDynamoDbTable_attributeUpdateValidation (0.93s)
	testing.go:511: Step 0, expected error:

		Error planning: 1 error occurred:
			* aws_dynamodb_table.basic-dynamodb-table: 1 error occurred:
			* aws_dynamodb_table.basic-dynamodb-table: All attributes must be indexed. Unused attributes: ["unusedKey"]

		To match:

		All attributes must be indexed. Unused attributes: \["unusedKey"\]$
--- FAIL: TestAccAWSDynamoDbTable_streamSpecificationValidation (0.86s)
	testing.go:511: Step 0, expected error:

		Error planning: 1 error occurred:
			* aws_dynamodb_table.basic-dynamodb-table: 1 error occurred:
			* aws_dynamodb_table.basic-dynamodb-table: stream_view_type is required when stream_enabled = true

		To match:

		stream_view_type is required when stream_enabled = true$
```

Changes proposed in this pull request:

* Ignore error formatting outside the actual errors in `TestAccAWSDynamoDbTable_streamSpecificationValidation` and `TestAccAWSDynamoDbTable_attributeUpdateValidation`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDynamoDbTable_\(attributeUpdate\|streamSpecification\)Validation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDynamoDbTable_\(attributeUpdate\|streamSpecification\)Validation -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_streamSpecificationValidation
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (2.89s)
=== RUN   TestAccAWSDynamoDbTable_attributeUpdateValidation
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (3.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	7.317s
```
