### PR TITLE
tests/resource/aws_lambda_function: Switch removed nodejs4.3-edge runtime usage in TestAccAWSLambdaFunction_updateRuntime

### DIFF
--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -151,7 +151,7 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 				Config: testAccAWSLambdaConfigBasicUpdateRuntime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs4.3-edge"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs6.10"),
 				),
 			},
 		},
@@ -1350,7 +1350,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3-edge"
+    runtime = "nodejs6.10"
 }
 `, funcName)
 }


### PR DESCRIPTION
Starting July 26th, 2018, the `TestAccAWSLambdaFunction_updateRuntime` acceptance test began failing, presumably due to an upstream removal of `nodejs4.3-edge` runtime:

```
--- FAIL: TestAccAWSLambdaFunction_updateRuntime (25.56s)
	testing.go:518: Step 1 error: Error applying: 1 error occurred:
			* aws_lambda_function.lambda_function_test: 1 error occurred:
			* aws_lambda_function.lambda_function_test: Error modifying Lambda Function Configuration tf_acc_lambda_func_update_runtime_wt6y8xtn: InvalidParameterValueException: Value nodejs4.3-edge at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [java8, nodejs6.10, nodejs8.10, python2.7, python3.6, dotnetcore1.0, dotnetcore2.0, dotnetcore2.1, go1.x] or be a valid ARN
			status code: 400, request id: ecac3520-9c77-11e8-bff3-49c8e3f153e9
```

We do not particularly care about which runtime the test Lambda function gets updated to for verification of the Terraform resource ability to update the runtime, so opting for the next stable NodeJS runtime: `nodejs6.10`. I did not find any other usage of the `nodejs4.3-edge` runtime.

Changes proposed in this pull request:

* Use `nodejs6.10` instead of removed `nodejs4.3-edge` in `testAccAWSLambdaConfigBasicUpdateRuntime`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLambdaFunction_updateRuntime'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLambdaFunction_updateRuntime -timeout 120m
=== RUN   TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_updateRuntime (65.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.740s
```
