### PR TITLE
Add dhcp_options_id attribute to vpc data docs

### DIFF
--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -82,6 +82,7 @@ The following attribute is additionally exported:
 * `ipv6_cidr_block` - The IPv6 CIDR block.
 * `enable_dns_support` - Whether or not the VPC has DNS support
 * `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support
+* `dhcp_options_id` - (Optional) The DHCP Options ID
 
 `cidr_block_associations` is also exported with the following attributes:
 


### PR DESCRIPTION
This is missing from the docs.

Defined here: https://github.com/terraform-providers/terraform-provider-aws/blob/8f13308/aws/data_source_aws_vpc.go#L45