### PR TITLE
tests/resource/aws_sqs_queue: Cleanup refactoring and utilize TestStep Taint in TestAccAWSSQSQueue_queueDeletedRecently

### DIFF
--- a/aws/resource_aws_sqs_queue_policy_test.go
+++ b/aws/resource_aws_sqs_queue_policy_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
+	var queueAttributes map[string]*string
+
 	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,7 +21,8 @@ func TestAccAWSSQSQueuePolicy_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAWSSQSPolicyConfig_basic(queueName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.q"),
+					testAccCheckAWSSQSQueueExists("aws_sqs_queue.q", &queueAttributes),
+					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
 					resource.TestMatchResourceAttr("aws_sqs_queue_policy.test", "policy",
 						regexp.MustCompile("^{\"Version\":\"2012-10-17\".+")),
 				),


### PR DESCRIPTION
This started as a simple refactor of `TestAccAWSSQSQueue_queueDeletedRecently` to use the new `Taint` functionality instead of an extraneous `TestStep`, however I noticed some of the file was utilizing older acceptance testing coding styles so went ahead and did some refactoring here for future travelers.

Changes proposed in this pull request:

* Ensure check function names begin with `testAccCheckAWSSQSQueue`
* Return queue attributes as part of existenence check function and simplify queue attribute checking functions
* Utilize `TestStep` `Taint` in `TestAccAWSSQSQueue_queueDeletedRecently`

Output from acceptance testing:

```
16 tests passed (all tests)
=== RUN   TestAccAWSSQSQueue_FIFOExpectNameError
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (2.65s)
=== RUN   TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (2.81s)
=== RUN   TestAccAWSSQSQueue_Encryption
--- PASS: TestAccAWSSQSQueue_Encryption (8.62s)
=== RUN   TestAccAWSSQSQueue_FIFO
--- PASS: TestAccAWSSQSQueue_FIFO (8.70s)
=== RUN   TestAccAWSSQSQueue_importBasic
--- PASS: TestAccAWSSQSQueue_importBasic (9.11s)
=== RUN   TestAccAWSSQSQueue_namePrefix
--- PASS: TestAccAWSSQSQueue_namePrefix (9.22s)
=== RUN   TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (9.20s)
=== RUN   TestAccAWSSQSQueue_namePrefix_fifo
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (9.39s)
=== RUN   TestAccAWSSQSQueue_importFifo
--- PASS: TestAccAWSSQSQueue_importFifo (9.82s)
=== RUN   TestAccAWSSQSQueue_redrivePolicy
--- PASS: TestAccAWSSQSQueue_redrivePolicy (9.84s)
=== RUN   TestAccAWSSQSQueue_Policybasic
--- PASS: TestAccAWSSQSQueue_Policybasic (10.30s)
=== RUN   TestAccAWSSQSQueue_importEncryption
--- PASS: TestAccAWSSQSQueue_importEncryption (11.89s)
=== RUN   TestAccAWSSQSQueue_basic
--- PASS: TestAccAWSSQSQueue_basic (14.45s)
=== RUN   TestAccAWSSQSQueue_policy
--- PASS: TestAccAWSSQSQueue_policy (16.92s)
=== RUN   TestAccAWSSQSQueue_tags
--- PASS: TestAccAWSSQSQueue_tags (28.35s)
=== RUN   TestAccAWSSQSQueue_queueDeletedRecently
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (87.22s)
```
