### PR TITLE
Issue #5513 aws_emr_cluster is not supporting st1 type EBS volumes

### DIFF
--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -95,6 +95,28 @@ func TestAccAWSEMRCluster_instance_group(t *testing.T) {
 	})
 }
 
+func TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1(t *testing.T) {
+	var cluster emr.Cluster
+	r := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEmrDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEmrClusterConfigInstanceGroups_st1(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
+					resource.TestCheckResourceAttr(
+						"aws_emr_cluster.tf-test-cluster", "instance_group.#", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_emr_cluster.tf-test-cluster", "instance_group.0.ebs_config.0.type", "st1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc(t *testing.T) {
 	var cluster emr.Cluster
 	r := acctest.RandInt()
@@ -2448,6 +2470,354 @@ EOT
   }
 
   configurations = "test-fixtures/emr_configurations.json"
+
+  depends_on = ["aws_main_route_table_association.a"]
+
+  service_role = "${aws_iam_role.iam_emr_default_role.arn}"
+  autoscaling_role = "${aws_iam_role.emr-autoscaling-role.arn}"
+}
+
+resource "aws_security_group" "allow_all" {
+  name        = "allow_all_%[1]d"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  depends_on = ["aws_subnet.main"]
+
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+
+  tags {
+    Name = "emr_test"
+  }
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = "168.31.0.0/16"
+  enable_dns_hostnames = true
+
+  tags {
+    Name = "terraform-testacc-emr-cluster-instance-groups"
+  }
+}
+
+resource "aws_subnet" "main" {
+  vpc_id     = "${aws_vpc.main.id}"
+  cidr_block = "168.31.0.0/20"
+
+  tags {
+    Name = "tf-acc-emr-cluster-instance-groups"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.main.id}"
+}
+
+resource "aws_route_table" "r" {
+  vpc_id = "${aws_vpc.main.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
+}
+
+resource "aws_main_route_table_association" "a" {
+  vpc_id         = "${aws_vpc.main.id}"
+  route_table_id = "${aws_route_table.r.id}"
+}
+
+###
+
+# IAM things
+
+###
+
+# IAM role for EMR Service
+resource "aws_iam_role" "iam_emr_default_role" {
+  name = "iam_emr_default_role_%[1]d"
+
+  assume_role_policy = <<EOT
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "elasticmapreduce.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOT
+}
+
+resource "aws_iam_role_policy_attachment" "service-attach" {
+  role       = "${aws_iam_role.iam_emr_default_role.id}"
+  policy_arn = "${aws_iam_policy.iam_emr_default_policy.arn}"
+}
+
+resource "aws_iam_policy" "iam_emr_default_policy" {
+  name = "iam_emr_default_policy_%[1]d"
+
+  policy = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Resource": "*",
+        "Action": [
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CancelSpotInstanceRequests",
+            "ec2:CreateNetworkInterface",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateTags",
+            "ec2:DeleteNetworkInterface",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DeleteTags",
+            "ec2:DescribeAvailabilityZones",
+            "ec2:DescribeAccountAttributes",
+            "ec2:DescribeDhcpOptions",
+            "ec2:DescribeInstanceStatus",
+            "ec2:DescribeInstances",
+            "ec2:DescribeKeyPairs",
+            "ec2:DescribeNetworkAcls",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribePrefixLists",
+            "ec2:DescribeRouteTables",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSpotInstanceRequests",
+            "ec2:DescribeSpotPriceHistory",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcAttribute",
+            "ec2:DescribeVpcEndpoints",
+            "ec2:DescribeVpcEndpointServices",
+            "ec2:DescribeVpcs",
+            "ec2:DetachNetworkInterface",
+            "ec2:ModifyImageAttribute",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:RequestSpotInstances",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances",
+            "ec2:DeleteVolume",
+            "ec2:DescribeVolumeStatus",
+            "ec2:DescribeVolumes",
+            "ec2:DetachVolume",
+            "iam:GetRole",
+            "iam:GetRolePolicy",
+            "iam:ListInstanceProfiles",
+            "iam:ListRolePolicies",
+            "iam:PassRole",
+            "s3:CreateBucket",
+            "s3:Get*",
+            "s3:List*",
+            "sdb:BatchPutAttributes",
+            "sdb:Select",
+            "sqs:CreateQueue",
+            "sqs:Delete*",
+            "sqs:GetQueue*",
+            "sqs:PurgeQueue",
+            "sqs:ReceiveMessage"
+        ]
+    }]
+}
+EOT
+}
+
+# IAM Role for EC2 Instance Profile
+resource "aws_iam_role" "iam_emr_profile_role" {
+  name = "iam_emr_profile_role_%[1]d"
+
+  assume_role_policy = <<EOT
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOT
+}
+
+resource "aws_iam_instance_profile" "emr_profile" {
+  name  = "emr_profile_%[1]d"
+  role = "${aws_iam_role.iam_emr_profile_role.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "profile-attach" {
+  role       = "${aws_iam_role.iam_emr_profile_role.id}"
+  policy_arn = "${aws_iam_policy.iam_emr_profile_policy.arn}"
+}
+
+resource "aws_iam_policy" "iam_emr_profile_policy" {
+  name = "iam_emr_profile_policy_%[1]d"
+
+  policy = <<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Resource": "*",
+        "Action": [
+            "cloudwatch:*",
+            "dynamodb:*",
+            "ec2:Describe*",
+            "elasticmapreduce:Describe*",
+            "elasticmapreduce:ListBootstrapActions",
+            "elasticmapreduce:ListClusters",
+            "elasticmapreduce:ListInstanceGroups",
+            "elasticmapreduce:ListInstances",
+            "elasticmapreduce:ListSteps",
+            "kinesis:CreateStream",
+            "kinesis:DeleteStream",
+            "kinesis:DescribeStream",
+            "kinesis:GetRecords",
+            "kinesis:GetShardIterator",
+            "kinesis:MergeShards",
+            "kinesis:PutRecord",
+            "kinesis:SplitShard",
+            "rds:Describe*",
+            "s3:*",
+            "sdb:*",
+            "sns:*",
+            "sqs:*"
+        ]
+    }]
+}
+EOT
+}
+
+# IAM Role for autoscaling
+resource "aws_iam_role" "emr-autoscaling-role" {
+  name               = "EMR_AutoScaling_DefaultRole_%[1]d"
+  assume_role_policy = "${data.aws_iam_policy_document.emr-autoscaling-role-policy.json}"
+}
+
+data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals = {
+      type        = "Service"
+      identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
+  role       = "${aws_iam_role.emr-autoscaling-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole"
+}
+`, r)
+}
+
+func testAccAWSEmrClusterConfigInstanceGroups_st1(r int) string {
+	return fmt.Sprintf(`
+resource "aws_emr_cluster" "tf-test-cluster" {
+  name          = "emr-test-%[1]d"
+  release_label = "emr-4.6.0"
+  applications  = ["Spark"]
+
+  ec2_attributes {
+    subnet_id                         = "${aws_subnet.main.id}"
+    emr_managed_master_security_group = "${aws_security_group.allow_all.id}"
+    emr_managed_slave_security_group  = "${aws_security_group.allow_all.id}"
+    instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
+  }
+
+  instance_group = [
+    {
+      instance_role = "CORE"
+      instance_type = "c4.large"
+      instance_count = "1"
+      ebs_config {
+        size = "500"
+        type = "st1"
+        volumes_per_instance = 1
+      }
+      bid_price = "0.30"
+      autoscaling_policy = <<EOT
+{
+  "Constraints": {
+    "MinCapacity": 1,
+    "MaxCapacity": 2
+  },
+  "Rules": [
+    {
+      "Name": "ScaleOutMemoryPercentage",
+      "Description": "Scale out if YARNMemoryAvailablePercentage is less than 15",
+      "Action": {
+        "SimpleScalingPolicyConfiguration": {
+          "AdjustmentType": "CHANGE_IN_CAPACITY",
+          "ScalingAdjustment": 1,
+          "CoolDown": 300
+        }
+      },
+      "Trigger": {
+        "CloudWatchAlarmDefinition": {
+          "ComparisonOperator": "LESS_THAN",
+          "EvaluationPeriods": 1,
+          "MetricName": "YARNMemoryAvailablePercentage",
+          "Namespace": "AWS/ElasticMapReduce",
+          "Period": 300,
+          "Statistic": "AVERAGE",
+          "Threshold": 15.0,
+          "Unit": "PERCENT"
+        }
+      }
+    }
+  ]
+}
+EOT
+    },
+    {
+      instance_role = "MASTER"
+      instance_type = "c4.large"
+      instance_count = 1
+    }
+  ]
+
+  tags {
+    role     = "rolename"
+    dns_zone = "env_zone"
+    env      = "env"
+    name     = "name-env"
+  }
+
+  keep_job_flow_alive_when_no_steps = true
+  termination_protection = false
+
+  bootstrap_action {
+    path = "s3://elasticmapreduce/bootstrap-actions/run-if"
+    name = "runif"
+    args = ["instance.isMaster=true", "echo running on master node"]
+  }
 
   depends_on = ["aws_main_route_table_association.a"]
 

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -109,8 +109,6 @@ func TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1(t *testing.T) {
 					testAccCheckAWSEmrClusterExists("aws_emr_cluster.tf-test-cluster", &cluster),
 					resource.TestCheckResourceAttr(
 						"aws_emr_cluster.tf-test-cluster", "instance_group.#", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_emr_cluster.tf-test-cluster", "instance_group.0.ebs_config.0.type", "st1"),
 				),
 			},
 		},

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -800,6 +800,7 @@ func validateAwsEmrEbsVolumeType() schema.SchemaValidateFunc {
 		"gp2",
 		"io1",
 		"standard",
+		"st1",
 	}, false)
 }
 

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -282,7 +282,7 @@ Attributes for each task instance group in the cluster
 Attributes for the EBS volumes attached to each EC2 instance in the `instance_group`
 
 * `size` - (Required) The volume size, in gibibytes (GiB).
-* `type` - (Required) The volume type. Valid options are `gp2`, `io1`, and `standard`.
+* `type` - (Required) The volume type. Valid options are `gp2`, `io1`, `standard` and `st1`. See [EBS Volume Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html).
 * `iops` - (Optional) The number of I/O operations per second (IOPS) that the volume supports
 * `volumes_per_instance` - (Optional) The number of EBS volumes with this configuration to attach to each EC2 instance in the instance group (default is 1)
 


### PR DESCRIPTION
Fixes #5513 

Even though API documentations says volume types supported are gp2, io1, standard (https://docs.aws.amazon.com/emr/latest/APIReference/API_VolumeSpecification.html), looks like it supports `st1` volume type.
https://aws.amazon.com/blogs/aws/amazon-ebs-update-new-cold-storage-and-throughput-options/

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 -timeout 120m
=== RUN   TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
--- PASS: TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 (616.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	616.670s
...
```
