### PR TITLE
docs/resource/cloudwatch_event_target: Fix broken link for resource based policies

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -244,7 +244,7 @@ DOC
    SNS topic invoked by a CloudWatch Events rule, you must setup the right permissions
    using [`aws_lambda_permission`](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)
    or [`aws_sns_topic.policy`](https://www.terraform.io/docs/providers/aws/r/sns_topic.html#policy).
-   More info [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/EventsResourceBasedPermissions.html).
+   More info [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/resource-based-policies-cwe.html).
 
 The following arguments are supported:
 


### PR DESCRIPTION
The previous link for [EventsResourceBasedPermissions](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/EventsResourceBasedPermissions.html) redirected to the [What is Amazon CloudWatch Events?](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/WhatIsCloudWatchEvents.html) documentation. This fixes that to point to what seems to be the right documentation page [resource-based-policies-cwe](http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/resource-based-policies-cwe.html).