### PR TITLE
resource/aws_db_instance: During S3 restore, lower retry threshold for IAM eventual consistency from 5 minutes to 2 minutes and retry on additional error

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -616,7 +616,8 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		log.Printf("[DEBUG] DB Instance S3 Restore configuration: %#v", opts)
 		var err error
-		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		// Retry for IAM eventual consistency
+		err = resource.Retry(2*time.Minute, func() *resource.RetryError {
 			_, err = conn.RestoreDBInstanceFromS3(&opts)
 			if err != nil {
 				if isAWSErr(err, "InvalidParameterValue", "ENHANCED_MONITORING") {
@@ -626,6 +627,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 					return resource.RetryableError(err)
 				}
 				if isAWSErr(err, "InvalidParameterValue", "S3 bucket cannot be found") {
+					return resource.RetryableError(err)
+				}
+				// InvalidParameterValue: Files from the specified Amazon S3 bucket cannot be downloaded. Make sure that you have created an AWS Identity and Access Management (IAM) role that lets Amazon RDS access Amazon S3 for you.
+				if isAWSErr(err, "InvalidParameterValue", "Files from the specified Amazon S3 bucket cannot be downloaded") {
 					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)


### PR DESCRIPTION
IAM eventual consistency should only retry to up to 2 minutes instead of potentially retrying on permanent failures like a misconfigured IAM role for 5 minutes.

The additional IAM eventual consistency error was found via daily acceptance testing:

```
--- FAIL: TestAccAWSDBInstance_s3 (16.18s)
	testing.go:518: Step 0 error: Error applying: 1 error occurred:
			* aws_db_instance.s3: 1 error occurred:
			* aws_db_instance.s3: Error creating DB Instance: InvalidParameterValue: Files from the specified Amazon S3 bucket cannot be downloaded. Make sure that you have created an AWS Identity and Access Management (IAM) role that lets Amazon RDS access Amazon S3 for you.
```

Changes proposed in this pull request:

* Lower `RestoreDBInstanceFromS3` IAM eventual consistency retry threshold from 5 minutes to 2 minutes
* Retry `RestoreDBInstanceFromS3` on `InvalidParameterValue: Files from the specified Amazon S3 bucket cannot be downloaded`

Output from acceptance testing:

```
=== RUN   TestAccAWSDBInstance_s3
--- PASS: TestAccAWSDBInstance_s3 (763.92s)
```
