### PR TITLE
Issue #3407 aws_ssm_association handles updates incorrectly

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -198,7 +198,7 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 	// AWS creates a new version every time the association is updated, so everything should be passed in the update.
 
 	hasChanges := false
-	
+
 	if d.HasChange("association_name") {
 		hasChanges = true
 	}
@@ -227,22 +227,22 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 		if v, ok := d.GetOk("association_name"); ok {
 			associationInput.AssociationName = aws.String(v.(string))
 		}
-	
+
 		if v, ok := d.GetOk("document_version"); ok {
 			associationInput.DocumentVersion = aws.String(v.(string))
 		}
-	
+
 		if v, ok := d.GetOk("schedule_expression"); ok {
 			associationInput.ScheduleExpression = aws.String(v.(string))
 		}
-	
+
 		if v, ok := d.GetOk("parameters"); ok {
 			associationInput.Parameters = expandSSMDocumentParameters(v.(map[string]interface{}))
 		}
-	
+
 		if _, ok := d.GetOk("targets"); ok {
-		associationInput.Targets = expandAwsSsmTargets(d.Get("targets").([]interface{}))
-	}
+			associationInput.Targets = expandAwsSsmTargets(d.Get("targets").([]interface{}))
+		}
 
 		if v, ok := d.GetOk("output_location"); ok {
 			associationInput.OutputLocation = expandSSMAssociationOutputLocation(v.([]interface{}))

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -97,39 +97,39 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] SSM association create: %s", d.Id())
 
-	assosciationInput := &ssm.CreateAssociationInput{
+	associationInput := &ssm.CreateAssociationInput{
 		Name: aws.String(d.Get("name").(string)),
 	}
 
 	if v, ok := d.GetOk("association_name"); ok {
-		assosciationInput.AssociationName = aws.String(v.(string))
+		associationInput.AssociationName = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("instance_id"); ok {
-		assosciationInput.InstanceId = aws.String(v.(string))
+		associationInput.InstanceId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("document_version"); ok {
-		assosciationInput.DocumentVersion = aws.String(v.(string))
+		associationInput.DocumentVersion = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("schedule_expression"); ok {
-		assosciationInput.ScheduleExpression = aws.String(v.(string))
+		associationInput.ScheduleExpression = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
-		assosciationInput.Parameters = expandSSMDocumentParameters(v.(map[string]interface{}))
+		associationInput.Parameters = expandSSMDocumentParameters(v.(map[string]interface{}))
 	}
 
 	if _, ok := d.GetOk("targets"); ok {
-		assosciationInput.Targets = expandAwsSsmTargets(d.Get("targets").([]interface{}))
+		associationInput.Targets = expandAwsSsmTargets(d.Get("targets").([]interface{}))
 	}
 
 	if v, ok := d.GetOk("output_location"); ok {
-		assosciationInput.OutputLocation = expandSSMAssociationOutputLocation(v.([]interface{}))
+		associationInput.OutputLocation = expandSSMAssociationOutputLocation(v.([]interface{}))
 	}
 
-	resp, err := ssmconn.CreateAssociation(assosciationInput)
+	resp, err := ssmconn.CreateAssociation(associationInput)
 	if err != nil {
 		return fmt.Errorf("[ERROR] Error creating SSM association: %s", err)
 	}
@@ -189,7 +189,7 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
-	log.Printf("[DEBUG] SSM association update: %s", d.Id())
+	log.Printf("[DEBUG] SSM Association update: %s", d.Id())
 
 	associationInput := &ssm.UpdateAssociationInput{
 		AssociationId: aws.String(d.Get("association_id").(string)),
@@ -230,7 +230,7 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsSsmAssociationDelete(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
-	log.Printf("[DEBUG] Deleting SSM Assosciation: %s", d.Id())
+	log.Printf("[DEBUG] Deleting SSM Association: %s", d.Id())
 
 	params := &ssm.DeleteAssociationInput{
 		AssociationId: aws.String(d.Get("association_id").(string)),

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -13,7 +13,7 @@ func resourceAwsSsmAssociation() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsSsmAssociationCreate,
 		Read:   resourceAwsSsmAssociationRead,
-		Update: resourceAwsSsmAssocationUpdate,
+		Update: resourceAwsSsmAssociationUpdate,
 		Delete: resourceAwsSsmAssociationDelete,
 
 		MigrateState:  resourceAwsSsmAssociationMigrateState,
@@ -186,7 +186,7 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsSsmAssociationUpdate(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
 	log.Printf("[DEBUG] SSM Association update: %s", d.Id())

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -203,10 +203,6 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 		hasChanges = true
 	}
 
-	if d.HasChange("instance_id") {
-		hasChange = true
-	}
-
 	if d.HasChange("document_version") {
 		hasChanges = true
 	}
@@ -230,10 +226,6 @@ func resourceAwsSsmAssocationUpdate(d *schema.ResourceData, meta interface{}) er
 	if hasChanges {
 		if v, ok := d.GetOk("association_name"); ok {
 			associationInput.AssociationName = aws.String(v.(string))
-		}
-
-		if v, ok := d.GetOk("instance_id"); ok {
-			associationInput.InstanceId = aws.String(v.(string))
 		}
 	
 		if v, ok := d.GetOk("document_version"); ok {


### PR DESCRIPTION
Fixes #3407

Changes proposed in this pull request:

* Fixed Typo: Corrected Assoscation to Assocation
* resourceAwsSsmAssocationUpdate needs to pass everything to AWS because the AWS API creates a new version of the association rather than updating it in-place. I updated the function to check for any changes and update everything if there are.

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSSMAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSSSMAssociation -timeout 120m
=== RUN   TestAccAWSSSMAssociation_basic
--- PASS: TestAccAWSSSMAssociation_basic (146.89s)
=== RUN   TestAccAWSSSMAssociation_withTargets
--- PASS: TestAccAWSSSMAssociation_withTargets (38.64s)
=== RUN   TestAccAWSSSMAssociation_withParameters
--- PASS: TestAccAWSSSMAssociation_withParameters (26.51s)
=== RUN   TestAccAWSSSMAssociation_withAssociationName
--- PASS: TestAccAWSSSMAssociation_withAssociationName (25.49s)
=== RUN   TestAccAWSSSMAssociation_withDocumentVersion
--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (16.49s)
=== RUN   TestAccAWSSSMAssociation_withOutputLocation
--- PASS: TestAccAWSSSMAssociation_withOutputLocation (68.60s)
=== RUN   TestAccAWSSSMAssociation_withScheduleExpression
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (25.53s)
PASS
ok  	github.com/dpldb/terraform-provider-aws/aws	348.188s
...
```
