### PR TITLE
tests/resource/aws_eip: Fix invalid test configuration

### DIFF
--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -874,12 +874,12 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
   filter {
     name = "root-device-type"
-    values = [%q]
+    values = ["instance-store"]
   }
 }
 
 resource "aws_instance" "foo" {
-	ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
+	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 
@@ -900,12 +900,12 @@ data "aws_ami" "amzn-ami-minimal-pv" {
   }
   filter {
     name = "root-device-type"
-    values = [%q]
+    values = ["instance-store"]
   }
 }
 
 resource "aws_instance" "foo" {
-	ami = "${data.aws_ami.amzn-ami-minimal-hvm.id}"
+	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
 }
 


### PR DESCRIPTION
Found via daily acceptance testing:

```
--- FAIL: TestAccAWSEIPAssociate_not_associated (0.44s)
	testing.go:518: Step 0 error: Error loading configuration: Error parsing /opt/teamcity-agent/temp/buildTmp/tf-test761614874/main.tf: At 14:15: illegal char
FAIL
```

Changes proposed in this pull request:

* Fix copy-paste mistake in `aws_eip` test configuration

Output from acceptance testing:

```
=== RUN   TestAccAWSEIPAssociate_not_associated
--- PASS: TestAccAWSEIPAssociate_not_associated (127.00s)
```
