### PR TITLE
tests/resource/aws_elasticsearch_domain: Fix ExpectError testing for domain already exists error

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -167,7 +167,7 @@ func TestAccAWSElasticSearchDomain_duplicate(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_elasticsearch_domain.example", "elasticsearch_version", "1.5"),
 				),
-				ExpectError: regexp.MustCompile(`domain "[^"]+" already exists`),
+				ExpectError: regexp.MustCompile(`domain .+ already exists`),
 			},
 		},
 	})


### PR DESCRIPTION
My guess is that a previous code change changed a `%q` to a `%s` without updating the acceptance test.

Found via daily acceptance testing:

```
--- FAIL: TestAccAWSElasticSearchDomain_duplicate (527.70s)
	testing.go:511: Step 0, expected error:

		Error applying: 1 error occurred:
			* aws_elasticsearch_domain.example: 1 error occurred:
			* aws_elasticsearch_domain.example: ElasticSearch domain tf-test-2525576817897572360 already exists

		To match:

		domain "[^"]+" already exists
```

Changes proposed in this pull request:

* Adjust `ExpectError` regex for "already exists" error messaging

Output from acceptance testing:

```
=== RUN   TestAccAWSElasticSearchDomain_duplicate
--- PASS: TestAccAWSElasticSearchDomain_duplicate (455.67s)
```
