### PR TITLE
tests: Implement testAccOrganizationsAccountPreCheck function and add to existing AWS Organizations based acceptance tests

### DIFF
--- a/aws/import_aws_organizations_organization_test.go
+++ b/aws/import_aws_organizations_organization_test.go
@@ -10,7 +10,7 @@ func testAccAwsOrganizationsOrganization_importBasic(t *testing.T) {
 	resourceName := "aws_organizations_organization.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsOrganizationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/organizations"
+
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -115,6 +117,19 @@ func testAccMultipleRegionsPreCheck(t *testing.T) {
 			t.Skip("skipping tests; partition only includes a single region")
 		}
 	}
+}
+
+func testAccOrganizationsAccountPreCheck(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).organizationsconn
+	input := &organizations.DescribeOrganizationInput{}
+	_, err := conn.DescribeOrganization(input)
+	if isAWSErr(err, organizations.ErrCodeAWSOrganizationsNotInUseException, "") {
+		return
+	}
+	if err != nil {
+		t.Fatalf("error describing AWS Organization: %s", err)
+	}
+	t.Skip("skipping tests; this AWS account must not be an existing member of an AWS Organization")
 }
 
 func testAccAwsRegionProviderFunc(region string, providers *[]*schema.Provider) func() *schema.Provider {

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -96,7 +96,7 @@ func TestAccAWSConfigConfigurationAggregator_organization(t *testing.T) {
 	expectedName := fmt.Sprintf("tf-%s", rString)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
 		Steps: []resource.TestStep{
@@ -124,7 +124,7 @@ func TestAccAWSConfigConfigurationAggregator_switch(t *testing.T) {
 	rString := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSConfigConfigurationAggregatorDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_organizations_account_test.go
+++ b/aws/resource_aws_organizations_account_test.go
@@ -25,7 +25,7 @@ func testAccAwsOrganizationsAccount_basic(t *testing.T) {
 	email := fmt.Sprintf("tf-acctest+%d@%s", rInt, orgsEmailDomain)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsAccountDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -13,7 +13,7 @@ func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
 	var organization organizations.Organization
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsOrganizationDestroy,
 		Steps: []resource.TestStep{
@@ -38,7 +38,7 @@ func testAccAwsOrganizationsOrganization_consolidatedBilling(t *testing.T) {
 	feature_set := organizations.OrganizationFeatureSetConsolidatedBilling
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsOrganizationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_organizations_policy_attachment_test.go
+++ b/aws/resource_aws_organizations_policy_attachment_test.go
@@ -17,7 +17,7 @@ func TestAccAwsOrganizationsPolicyAttachment_account(t *testing.T) {
 	resourceName := "aws_organizations_policy_attachment.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsPolicyAttachmentDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -20,7 +20,7 @@ func TestAccAwsOrganizationsPolicy_basic(t *testing.T) {
 	resourceName := "aws_organizations_policy.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsPolicyDestroy,
 		Steps: []resource.TestStep{
@@ -57,7 +57,7 @@ func TestAccAwsOrganizationsPolicy_description(t *testing.T) {
 	resourceName := "aws_organizations_policy.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOrganizationsPolicyDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
When testing resources that involve AWS Organizations interaction, usually the acceptance testing needs the ability to create and delete an AWS Organization. When an account is already an existing member of an AWS Organization (e.g. for consolidated billing), it will expectedly throw errors such as these:

```
--- FAIL: TestAccAWSConfigConfigurationAggregator_organization (7.08s)
	testing.go:518: Step 0 error: Error applying: 2 errors occurred:
			* aws_organizations_organization.test: 1 error occurred:
			* aws_organizations_organization.test: Error creating organization: AlreadyInOrganizationException: The AWS account is already a member of an organization.
```

Here we introduce a PreCheck function that ensures the AWS account running the acceptance testing is explicitly not a member of an organization already.

Changes proposed in this pull request:

* Implement `testAccOrganizationsAccountPreCheck` function
* Add `testAccOrganizationsAccountPreCheck` function call to existing acceptance tests that require creating organizations

Verified using an account that is a member of an organization:

```
=== RUN   TestAccAWSConfigConfigurationAggregator_organization
--- SKIP: TestAccAWSConfigConfigurationAggregator_organization (1.37s)
	provider_test.go:132: skipping tests; this AWS account must not be an existing member of an AWS Organization
```

As well as a different account that is not a member of an organization:

```
=== RUN   TestAccAWSConfigConfigurationAggregator_organization
--- PASS: TestAccAWSConfigConfigurationAggregator_organization (15.72s)
```
