### PR TITLE
tests/data-source/aws_ami: Filter AMIs in TestAccAWSAmiDataSource_ownersEmpty

### DIFF
--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -285,6 +285,23 @@ const testAccCheckAwsAmiDataSourceEmptyOwnersConfig = `
 data "aws_ami" "amazon_ami" {
   most_recent = true
   owners = [""]
+
+  # we need to test the owners = [""] for regressions but we want to filter the results
+  # beyond all public AWS AMIs :)
+  filter {
+    name = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
 }
 `
 


### PR DESCRIPTION
Previously this acceptance test was attempting to return all public AWS AMIs and occassionally OOMing or would pass with 600MB debug logs (yikes!):

```
=== RUN   TestAccAWSAmiDataSource_ownersEmpty

------- Stderr: -------
fatal error: runtime: out of memory
```

Now, we will continue to test for the owners = [""] regression, but also perform filtering of the AMI result set.

Changes proposed in this pull request:

* Perform filtering in `TestAccAWSAmiDataSource_ownersEmpty` configuration

Output from acceptance testing:

```
=== RUN   TestAccAWSAmiDataSource_ownersEmpty
--- PASS: TestAccAWSAmiDataSource_ownersEmpty (14.57s)
```
