### PR TITLE
Firehose docs - Remove outdated supported regions

### DIFF
--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -249,7 +249,6 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   }
 }
 ```
-~> **NOTE:** Kinesis Firehose is currently only supported in us-east-1, us-west-2 and eu-west-1.
 
 ## Argument Reference
 


### PR DESCRIPTION
Kinesis Firehose is now supported in nearly all regions (per https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/ Firehose is not available in govcloud, Osaka, and Chinese regions).

This proposed change removes the note that Firehose is only available in us-east-1, us-west-2 and eu-west-1.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
