### PR TITLE
vendor: aws/aws-sdk-go@v1.15.12

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -50,6 +50,7 @@ const (
 	AcmPcaServiceID                       = "acm-pca"                      // AcmPca.
 	ApiMediatailorServiceID               = "api.mediatailor"              // ApiMediatailor.
 	ApiPricingServiceID                   = "api.pricing"                  // ApiPricing.
+	ApiSagemakerServiceID                 = "api.sagemaker"                // ApiSagemaker.
 	ApigatewayServiceID                   = "apigateway"                   // Apigateway.
 	ApplicationAutoscalingServiceID       = "application-autoscaling"      // ApplicationAutoscaling.
 	Appstream2ServiceID                   = "appstream2"                   // Appstream2.
@@ -146,7 +147,6 @@ const (
 	RuntimeLexServiceID                   = "runtime.lex"                  // RuntimeLex.
 	RuntimeSagemakerServiceID             = "runtime.sagemaker"            // RuntimeSagemaker.
 	S3ServiceID                           = "s3"                           // S3.
-	SagemakerServiceID                    = "sagemaker"                    // Sagemaker.
 	SdbServiceID                          = "sdb"                          // Sdb.
 	SecretsmanagerServiceID               = "secretsmanager"               // Secretsmanager.
 	ServerlessrepoServiceID               = "serverlessrepo"               // Serverlessrepo.
@@ -329,6 +329,19 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-south-1": endpoint{},
 				"us-east-1":  endpoint{},
+			},
+		},
+		"api.sagemaker": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"apigateway": service{
@@ -792,10 +805,11 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
-				"eu-west-1": endpoint{},
-				"us-east-1": endpoint{},
-				"us-east-2": endpoint{},
-				"us-west-2": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
 			},
 		},
 		"config": service{
@@ -1280,6 +1294,7 @@ var awsPartition = partition{
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
@@ -1548,6 +1563,7 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
@@ -1944,19 +1960,6 @@ var awsPartition = partition{
 					Hostname:          "s3.us-west-2.amazonaws.com",
 					SignatureVersions: []string{"s3", "s3v4"},
 				},
-			},
-		},
-		"sagemaker": service{
-
-			Endpoints: endpoints{
-				"ap-northeast-1": endpoint{},
-				"ap-northeast-2": endpoint{},
-				"ap-southeast-2": endpoint{},
-				"eu-central-1":   endpoint{},
-				"eu-west-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-2":      endpoint{},
 			},
 		},
 		"sdb": service{

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.15.9"
+const SDKVersion = "1.15.12"

--- a/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
@@ -61,10 +61,10 @@ func (c *AutoScaling) AttachInstancesRequest(input *AttachInstancesInput) (req *
 //
 // Attaches one or more EC2 instances to the specified Auto Scaling group.
 //
-// When you attach instances, Auto Scaling increases the desired capacity of
-// the group by the number of instances being attached. If the number of instances
-// being attached plus the desired capacity of the group exceeds the maximum
-// size of the group, the operation fails.
+// When you attach instances, Amazon EC2 Auto Scaling increases the desired
+// capacity of the group by the number of instances being attached. If the number
+// of instances being attached plus the desired capacity of the group exceeds
+// the maximum size of the group, the operation fails.
 //
 // If there is a Classic Load Balancer attached to your Auto Scaling group,
 // the instances are also registered with the load balancer. If there are target
@@ -72,8 +72,8 @@ func (c *AutoScaling) AttachInstancesRequest(input *AttachInstancesInput) (req *
 // with the target groups.
 //
 // For more information, see Attach EC2 Instances to Your Auto Scaling Group
-// (http://docs.aws.amazon.com/autoscaling/latest/userguide/attach-instance-asg.html)
-// in the Auto Scaling User Guide.
+// (http://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-instance-asg.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -162,8 +162,8 @@ func (c *AutoScaling) AttachLoadBalancerTargetGroupsRequest(input *AttachLoadBal
 // To detach the target group from the Auto Scaling group, use DetachLoadBalancerTargetGroups.
 //
 // For more information, see Attach a Load Balancer to Your Auto Scaling Group
-// (http://docs.aws.amazon.com/autoscaling/latest/userguide/attach-load-balancer-asg.html)
-// in the Auto Scaling User Guide.
+// (http://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-load-balancer-asg.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -255,8 +255,8 @@ func (c *AutoScaling) AttachLoadBalancersRequest(input *AttachLoadBalancersInput
 // To detach the load balancer from the Auto Scaling group, use DetachLoadBalancers.
 //
 // For more information, see Attach a Load Balancer to Your Auto Scaling Group
-// (http://docs.aws.amazon.com/autoscaling/latest/userguide/attach-load-balancer-asg.html)
-// in the Auto Scaling User Guide.
+// (http://docs.aws.amazon.com/autoscaling/ec2/userguide/attach-load-balancer-asg.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -290,6 +290,177 @@ func (c *AutoScaling) AttachLoadBalancers(input *AttachLoadBalancersInput) (*Att
 // for more information on using Contexts.
 func (c *AutoScaling) AttachLoadBalancersWithContext(ctx aws.Context, input *AttachLoadBalancersInput, opts ...request.Option) (*AttachLoadBalancersOutput, error) {
 	req, out := c.AttachLoadBalancersRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opBatchDeleteScheduledAction = "BatchDeleteScheduledAction"
+
+// BatchDeleteScheduledActionRequest generates a "aws/request.Request" representing the
+// client's request for the BatchDeleteScheduledAction operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See BatchDeleteScheduledAction for more information on using the BatchDeleteScheduledAction
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the BatchDeleteScheduledActionRequest method.
+//    req, resp := client.BatchDeleteScheduledActionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/BatchDeleteScheduledAction
+func (c *AutoScaling) BatchDeleteScheduledActionRequest(input *BatchDeleteScheduledActionInput) (req *request.Request, output *BatchDeleteScheduledActionOutput) {
+	op := &request.Operation{
+		Name:       opBatchDeleteScheduledAction,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &BatchDeleteScheduledActionInput{}
+	}
+
+	output = &BatchDeleteScheduledActionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// BatchDeleteScheduledAction API operation for Auto Scaling.
+//
+// Deletes one or more scheduled actions for the specified Auto Scaling group.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Auto Scaling's
+// API operation BatchDeleteScheduledAction for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeResourceContentionFault "ResourceContention"
+//   You already have a pending update to an Auto Scaling resource (for example,
+//   a group, instance, or load balancer).
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/BatchDeleteScheduledAction
+func (c *AutoScaling) BatchDeleteScheduledAction(input *BatchDeleteScheduledActionInput) (*BatchDeleteScheduledActionOutput, error) {
+	req, out := c.BatchDeleteScheduledActionRequest(input)
+	return out, req.Send()
+}
+
+// BatchDeleteScheduledActionWithContext is the same as BatchDeleteScheduledAction with the addition of
+// the ability to pass a context and additional request options.
+//
+// See BatchDeleteScheduledAction for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AutoScaling) BatchDeleteScheduledActionWithContext(ctx aws.Context, input *BatchDeleteScheduledActionInput, opts ...request.Option) (*BatchDeleteScheduledActionOutput, error) {
+	req, out := c.BatchDeleteScheduledActionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opBatchPutScheduledUpdateGroupAction = "BatchPutScheduledUpdateGroupAction"
+
+// BatchPutScheduledUpdateGroupActionRequest generates a "aws/request.Request" representing the
+// client's request for the BatchPutScheduledUpdateGroupAction operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See BatchPutScheduledUpdateGroupAction for more information on using the BatchPutScheduledUpdateGroupAction
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the BatchPutScheduledUpdateGroupActionRequest method.
+//    req, resp := client.BatchPutScheduledUpdateGroupActionRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/BatchPutScheduledUpdateGroupAction
+func (c *AutoScaling) BatchPutScheduledUpdateGroupActionRequest(input *BatchPutScheduledUpdateGroupActionInput) (req *request.Request, output *BatchPutScheduledUpdateGroupActionOutput) {
+	op := &request.Operation{
+		Name:       opBatchPutScheduledUpdateGroupAction,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &BatchPutScheduledUpdateGroupActionInput{}
+	}
+
+	output = &BatchPutScheduledUpdateGroupActionOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// BatchPutScheduledUpdateGroupAction API operation for Auto Scaling.
+//
+// Creates or updates one or more scheduled scaling actions for an Auto Scaling
+// group. When updating a scheduled scaling action, if you leave a parameter
+// unspecified, the corresponding value remains unchanged.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Auto Scaling's
+// API operation BatchPutScheduledUpdateGroupAction for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeAlreadyExistsFault "AlreadyExists"
+//   You already have an Auto Scaling group or launch configuration with this
+//   name.
+//
+//   * ErrCodeLimitExceededFault "LimitExceeded"
+//   You have already reached a limit for your Auto Scaling resources (for example,
+//   groups, launch configurations, or lifecycle hooks). For more information,
+//   see DescribeAccountLimits.
+//
+//   * ErrCodeResourceContentionFault "ResourceContention"
+//   You already have a pending update to an Auto Scaling resource (for example,
+//   a group, instance, or load balancer).
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/BatchPutScheduledUpdateGroupAction
+func (c *AutoScaling) BatchPutScheduledUpdateGroupAction(input *BatchPutScheduledUpdateGroupActionInput) (*BatchPutScheduledUpdateGroupActionOutput, error) {
+	req, out := c.BatchPutScheduledUpdateGroupActionRequest(input)
+	return out, req.Send()
+}
+
+// BatchPutScheduledUpdateGroupActionWithContext is the same as BatchPutScheduledUpdateGroupAction with the addition of
+// the ability to pass a context and additional request options.
+//
+// See BatchPutScheduledUpdateGroupAction for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *AutoScaling) BatchPutScheduledUpdateGroupActionWithContext(ctx aws.Context, input *BatchPutScheduledUpdateGroupActionInput, opts ...request.Option) (*BatchPutScheduledUpdateGroupActionOutput, error) {
+	req, out := c.BatchPutScheduledUpdateGroupActionRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -346,11 +517,12 @@ func (c *AutoScaling) CompleteLifecycleActionRequest(input *CompleteLifecycleAct
 // Scaling group:
 //
 // (Optional) Create a Lambda function and a rule that allows CloudWatch Events
-// to invoke your Lambda function when Auto Scaling launches or terminates instances.
+// to invoke your Lambda function when Amazon EC2 Auto Scaling launches or terminates
+// instances.
 //
 // (Optional) Create a notification target and an IAM role. The target can be
-// either an Amazon SQS queue or an Amazon SNS topic. The role allows Auto Scaling
-// to publish lifecycle notifications to the target.
+// either an Amazon SQS queue or an Amazon SNS topic. The role allows Amazon
+// EC2 Auto Scaling to publish lifecycle notifications to the target.
 //
 // Create the lifecycle hook. Specify whether the hook is used when the instances
 // launch or terminate.
@@ -360,8 +532,8 @@ func (c *AutoScaling) CompleteLifecycleActionRequest(input *CompleteLifecycleAct
 //
 // If you finish before the timeout period ends, complete the lifecycle action.
 //
-// For more information, see Auto Scaling Lifecycle (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html)
-// in the Auto Scaling User Guide.
+// For more information, see Auto Scaling Lifecycle (http://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroupLifecycle.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -447,11 +619,11 @@ func (c *AutoScaling) CreateAutoScalingGroupRequest(input *CreateAutoScalingGrou
 //
 // If you exceed your maximum limit of Auto Scaling groups, the call fails.
 // For information about viewing this limit, see DescribeAccountLimits. For
-// information about updating this limit, see Auto Scaling Limits (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-account-limits.html)
-// in the Auto Scaling User Guide.
+// information about updating this limit, see Auto Scaling Limits (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-account-limits.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
-// For more information, see Auto Scaling Groups (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroup.html)
-// in the Auto Scaling User Guide.
+// For more information, see Auto Scaling Groups (http://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -549,11 +721,11 @@ func (c *AutoScaling) CreateLaunchConfigurationRequest(input *CreateLaunchConfig
 //
 // If you exceed your maximum limit of launch configurations, the call fails.
 // For information about viewing this limit, see DescribeAccountLimits. For
-// information about updating this limit, see Auto Scaling Limits (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-account-limits.html)
-// in the Auto Scaling User Guide.
+// information about updating this limit, see Auto Scaling Limits (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-account-limits.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
-// For more information, see Launch Configurations (http://docs.aws.amazon.com/autoscaling/latest/userguide/LaunchConfiguration.html)
-// in the Auto Scaling User Guide.
+// For more information, see Launch Configurations (http://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchConfiguration.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -649,8 +821,8 @@ func (c *AutoScaling) CreateOrUpdateTagsRequest(input *CreateOrUpdateTagsInput) 
 // When you specify a tag with a key that already exists, the operation overwrites
 // the previous tag definition, and you do not get an error message.
 //
-// For more information, see Tagging Auto Scaling Groups and Instances (http://docs.aws.amazon.com/autoscaling/latest/userguide/autoscaling-tagging.html)
-// in the Auto Scaling User Guide.
+// For more information, see Tagging Auto Scaling Groups and Instances (http://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-tagging.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -754,7 +926,8 @@ func (c *AutoScaling) DeleteAutoScalingGroupRequest(input *DeleteAutoScalingGrou
 //
 // To remove instances from the Auto Scaling group before deleting it, call
 // DetachInstances with the list of instances and the option to decrement the
-// desired capacity so that Auto Scaling does not launch replacement instances.
+// desired capacity so that Amazon EC2 Auto Scaling does not launch replacement
+// instances.
 //
 // To terminate all instances before deleting the Auto Scaling group, call UpdateAutoScalingGroup
 // and set the minimum size and desired capacity of the Auto Scaling group to
@@ -1357,8 +1530,8 @@ func (c *AutoScaling) DescribeAccountLimitsRequest(input *DescribeAccountLimitsI
 // Describes the current Auto Scaling resource limits for your AWS account.
 //
 // For information about requesting an increase in these limits, see Auto Scaling
-// Limits (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-account-limits.html)
-// in the Auto Scaling User Guide.
+// Limits (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-account-limits.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1796,7 +1969,7 @@ func (c *AutoScaling) DescribeAutoScalingNotificationTypesRequest(input *Describ
 
 // DescribeAutoScalingNotificationTypes API operation for Auto Scaling.
 //
-// Describes the notification types that are supported by Auto Scaling.
+// Describes the notification types that are supported by Amazon EC2 Auto Scaling.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2016,6 +2189,12 @@ func (c *AutoScaling) DescribeLifecycleHookTypesRequest(input *DescribeLifecycle
 // DescribeLifecycleHookTypes API operation for Auto Scaling.
 //
 // Describes the available types of lifecycle hooks.
+//
+// The following hook types are supported:
+//
+//    * autoscaling:EC2_INSTANCE_LAUNCHING
+//
+//    * autoscaling:EC2_INSTANCE_TERMINATING
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2338,7 +2517,7 @@ func (c *AutoScaling) DescribeMetricCollectionTypesRequest(input *DescribeMetric
 
 // DescribeMetricCollectionTypes API operation for Auto Scaling.
 //
-// Describes the available CloudWatch metrics for Auto Scaling.
+// Describes the available CloudWatch metrics for Amazon EC2 Auto Scaling.
 //
 // Note that the GroupStandbyInstances metric is not returned by default. You
 // must explicitly request this metric when calling EnableMetricsCollection.
@@ -3210,7 +3389,7 @@ func (c *AutoScaling) DescribeTerminationPolicyTypesRequest(input *DescribeTermi
 
 // DescribeTerminationPolicyTypes API operation for Auto Scaling.
 //
-// Describes the termination policies supported by Auto Scaling.
+// Describes the termination policies supported by Amazon EC2 Auto Scaling.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3295,8 +3474,8 @@ func (c *AutoScaling) DetachInstancesRequest(input *DetachInstancesInput) (req *
 // After the instances are detached, you can manage them independent of the
 // Auto Scaling group.
 //
-// If you do not specify the option to decrement the desired capacity, Auto
-// Scaling launches instances to replace the ones that are detached.
+// If you do not specify the option to decrement the desired capacity, Amazon
+// EC2 Auto Scaling launches instances to replace the ones that are detached.
 //
 // If there is a Classic Load Balancer attached to the Auto Scaling group, the
 // instances are deregistered from the load balancer. If there are target groups
@@ -3304,8 +3483,8 @@ func (c *AutoScaling) DetachInstancesRequest(input *DetachInstancesInput) (req *
 // target groups.
 //
 // For more information, see Detach EC2 Instances from Your Auto Scaling Group
-// (http://docs.aws.amazon.com/autoscaling/latest/userguide/detach-instance-asg.html)
-// in the Auto Scaling User Guide.
+// (http://docs.aws.amazon.com/autoscaling/ec2/userguide/detach-instance-asg.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3639,8 +3818,8 @@ func (c *AutoScaling) EnableMetricsCollectionRequest(input *EnableMetricsCollect
 // EnableMetricsCollection API operation for Auto Scaling.
 //
 // Enables group metrics for the specified Auto Scaling group. For more information,
-// see Monitoring Your Auto Scaling Groups and Instances (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-monitoring.html)
-// in the Auto Scaling User Guide.
+// see Monitoring Your Auto Scaling Groups and Instances (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-monitoring.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3723,8 +3902,8 @@ func (c *AutoScaling) EnterStandbyRequest(input *EnterStandbyInput) (req *reques
 // Moves the specified instances into the standby state.
 //
 // For more information, see Temporarily Removing Instances from Your Auto Scaling
-// Group (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-enter-exit-standby.html)
-// in the Auto Scaling User Guide.
+// Group (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3893,8 +4072,8 @@ func (c *AutoScaling) ExitStandbyRequest(input *ExitStandbyInput) (req *request.
 // Moves the specified instances out of the standby state.
 //
 // For more information, see Temporarily Removing Instances from Your Auto Scaling
-// Group (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-enter-exit-standby.html)
-// in the Auto Scaling User Guide.
+// Group (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-enter-exit-standby.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3976,19 +4155,20 @@ func (c *AutoScaling) PutLifecycleHookRequest(input *PutLifecycleHookInput) (req
 //
 // Creates or updates a lifecycle hook for the specified Auto Scaling Group.
 //
-// A lifecycle hook tells Auto Scaling that you want to perform an action on
-// an instance that is not actively in service; for example, either when the
-// instance launches or before the instance terminates.
+// A lifecycle hook tells Amazon EC2 Auto Scaling that you want to perform an
+// action on an instance that is not actively in service; for example, either
+// when the instance launches or before the instance terminates.
 //
 // This step is a part of the procedure for adding a lifecycle hook to an Auto
 // Scaling group:
 //
 // (Optional) Create a Lambda function and a rule that allows CloudWatch Events
-// to invoke your Lambda function when Auto Scaling launches or terminates instances.
+// to invoke your Lambda function when Amazon EC2 Auto Scaling launches or terminates
+// instances.
 //
 // (Optional) Create a notification target and an IAM role. The target can be
-// either an Amazon SQS queue or an Amazon SNS topic. The role allows Auto Scaling
-// to publish lifecycle notifications to the target.
+// either an Amazon SQS queue or an Amazon SNS topic. The role allows Amazon
+// EC2 Auto Scaling to publish lifecycle notifications to the target.
 //
 // Create the lifecycle hook. Specify whether the hook is used when the instances
 // launch or terminate.
@@ -3998,8 +4178,8 @@ func (c *AutoScaling) PutLifecycleHookRequest(input *PutLifecycleHookInput) (req
 //
 // If you finish before the timeout period ends, complete the lifecycle action.
 //
-// For more information, see Auto Scaling Lifecycle Hooks (http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html)
-// in the Auto Scaling User Guide.
+// For more information, see Auto Scaling Lifecycle Hooks (http://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // If you exceed your maximum limit of lifecycle hooks, which by default is
 // 50 per Auto Scaling group, the call fails. For information about updating
@@ -4098,7 +4278,7 @@ func (c *AutoScaling) PutNotificationConfigurationRequest(input *PutNotification
 // This configuration overwrites any existing configuration.
 //
 // For more information see Getting SNS Notifications When Your Auto Scaling
-// Group Scales (http://docs.aws.amazon.com/autoscaling/latest/userguide/ASGettingNotifications.html)
+// Group Scales (http://docs.aws.amazon.com/autoscaling/ec2/userguide/ASGettingNotifications.html)
 // in the Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -4289,8 +4469,8 @@ func (c *AutoScaling) PutScheduledUpdateGroupActionRequest(input *PutScheduledUp
 // When updating a scheduled scaling action, if you leave a parameter unspecified,
 // the corresponding value remains unchanged.
 //
-// For more information, see Scheduled Scaling (http://docs.aws.amazon.com/autoscaling/latest/userguide/schedule_time.html)
-// in the Auto Scaling User Guide.
+// For more information, see Scheduled Scaling (http://docs.aws.amazon.com/autoscaling/ec2/userguide/schedule_time.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4387,11 +4567,12 @@ func (c *AutoScaling) RecordLifecycleActionHeartbeatRequest(input *RecordLifecyc
 // Scaling group:
 //
 // (Optional) Create a Lambda function and a rule that allows CloudWatch Events
-// to invoke your Lambda function when Auto Scaling launches or terminates instances.
+// to invoke your Lambda function when Amazon EC2 Auto Scaling launches or terminates
+// instances.
 //
 // (Optional) Create a notification target and an IAM role. The target can be
-// either an Amazon SQS queue or an Amazon SNS topic. The role allows Auto Scaling
-// to publish lifecycle notifications to the target.
+// either an Amazon SQS queue or an Amazon SNS topic. The role allows Amazon
+// EC2 Auto Scaling to publish lifecycle notifications to the target.
 //
 // Create the lifecycle hook. Specify whether the hook is used when the instances
 // launch or terminate.
@@ -4401,8 +4582,8 @@ func (c *AutoScaling) RecordLifecycleActionHeartbeatRequest(input *RecordLifecyc
 //
 // If you finish before the timeout period ends, complete the lifecycle action.
 //
-// For more information, see Auto Scaling Lifecycle (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html)
-// in the Auto Scaling User Guide.
+// For more information, see Auto Scaling Lifecycle (http://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroupLifecycle.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4484,12 +4665,11 @@ func (c *AutoScaling) ResumeProcessesRequest(input *ScalingProcessQuery) (req *r
 
 // ResumeProcesses API operation for Auto Scaling.
 //
-// Resumes the specified suspended Auto Scaling processes, or all suspended
+// Resumes the specified suspended automatic scaling processes, or all suspended
 // process, for the specified Auto Scaling group.
 //
-// For more information, see Suspending and Resuming Auto Scaling Processes
-// (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html)
-// in the Auto Scaling User Guide.
+// For more information, see Suspending and Resuming Scaling Processes (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4576,8 +4756,9 @@ func (c *AutoScaling) SetDesiredCapacityRequest(input *SetDesiredCapacityInput) 
 //
 // Sets the size of the specified Auto Scaling group.
 //
-// For more information about desired capacity, see What Is Auto Scaling? (http://docs.aws.amazon.com/autoscaling/latest/userguide/WhatIsAutoScaling.html)
-// in the Auto Scaling User Guide.
+// For more information about desired capacity, see What Is Amazon EC2 Auto
+// Scaling? (http://docs.aws.amazon.com/autoscaling/ec2/userguide/WhatIsAutoScaling.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4665,8 +4846,8 @@ func (c *AutoScaling) SetInstanceHealthRequest(input *SetInstanceHealthInput) (r
 //
 // Sets the health status of the specified instance.
 //
-// For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html)
-// in the Auto Scaling User Guide.
+// For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4748,8 +4929,8 @@ func (c *AutoScaling) SetInstanceProtectionRequest(input *SetInstanceProtectionI
 //
 // Updates the instance protection settings of the specified instances.
 //
-// For more information, see Instance Protection (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html#instance-protection)
-// in the Auto Scaling User Guide.
+// For more information, see Instance Protection (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#instance-protection)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4836,17 +5017,16 @@ func (c *AutoScaling) SuspendProcessesRequest(input *ScalingProcessQuery) (req *
 
 // SuspendProcesses API operation for Auto Scaling.
 //
-// Suspends the specified Auto Scaling processes, or all processes, for the
-// specified Auto Scaling group.
+// Suspends the specified automatic scaling processes, or all processes, for
+// the specified Auto Scaling group.
 //
 // Note that if you suspend either the Launch or Terminate process types, it
 // can prevent other process types from functioning properly.
 //
 // To resume processes that have been suspended, use ResumeProcesses.
 //
-// For more information, see Suspending and Resuming Auto Scaling Processes
-// (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html)
-// in the Auto Scaling User Guide.
+// For more information, see Suspending and Resuming Scaling Processes (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5203,8 +5383,8 @@ func (s *Activity) SetStatusMessage(v string) *Activity {
 
 // Describes a policy adjustment type.
 //
-// For more information, see Dynamic Scaling (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html)
-// in the Auto Scaling User Guide.
+// For more information, see Dynamic Scaling (http://docs.aws.amazon.com/autoscaling/ec2/DeveloperGuide/as-scale-based-on-demand.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 type AdjustmentType struct {
 	_ struct{} `type:"structure"`
 
@@ -5465,6 +5645,175 @@ func (s AttachLoadBalancersOutput) GoString() string {
 	return s.String()
 }
 
+type BatchDeleteScheduledActionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the Auto Scaling group.
+	//
+	// AutoScalingGroupName is a required field
+	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
+
+	// The names of the scheduled actions to delete. The maximum number allowed
+	// is 50.
+	//
+	// ScheduledActionNames is a required field
+	ScheduledActionNames []*string `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s BatchDeleteScheduledActionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchDeleteScheduledActionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchDeleteScheduledActionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchDeleteScheduledActionInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.ScheduledActionNames == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScheduledActionNames"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *BatchDeleteScheduledActionInput) SetAutoScalingGroupName(v string) *BatchDeleteScheduledActionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetScheduledActionNames sets the ScheduledActionNames field's value.
+func (s *BatchDeleteScheduledActionInput) SetScheduledActionNames(v []*string) *BatchDeleteScheduledActionInput {
+	s.ScheduledActionNames = v
+	return s
+}
+
+type BatchDeleteScheduledActionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The names of the scheduled actions that could not be deleted, including an
+	// error message.
+	FailedScheduledActions []*FailedScheduledUpdateGroupActionRequest `type:"list"`
+}
+
+// String returns the string representation
+func (s BatchDeleteScheduledActionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchDeleteScheduledActionOutput) GoString() string {
+	return s.String()
+}
+
+// SetFailedScheduledActions sets the FailedScheduledActions field's value.
+func (s *BatchDeleteScheduledActionOutput) SetFailedScheduledActions(v []*FailedScheduledUpdateGroupActionRequest) *BatchDeleteScheduledActionOutput {
+	s.FailedScheduledActions = v
+	return s
+}
+
+type BatchPutScheduledUpdateGroupActionInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the Auto Scaling group.
+	//
+	// AutoScalingGroupName is a required field
+	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
+
+	// One or more scheduled actions. The maximum number allowed is 50.
+	//
+	// ScheduledUpdateGroupActions is a required field
+	ScheduledUpdateGroupActions []*ScheduledUpdateGroupActionRequest `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s BatchPutScheduledUpdateGroupActionInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchPutScheduledUpdateGroupActionInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *BatchPutScheduledUpdateGroupActionInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "BatchPutScheduledUpdateGroupActionInput"}
+	if s.AutoScalingGroupName == nil {
+		invalidParams.Add(request.NewErrParamRequired("AutoScalingGroupName"))
+	}
+	if s.AutoScalingGroupName != nil && len(*s.AutoScalingGroupName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AutoScalingGroupName", 1))
+	}
+	if s.ScheduledUpdateGroupActions == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScheduledUpdateGroupActions"))
+	}
+	if s.ScheduledUpdateGroupActions != nil {
+		for i, v := range s.ScheduledUpdateGroupActions {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "ScheduledUpdateGroupActions", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAutoScalingGroupName sets the AutoScalingGroupName field's value.
+func (s *BatchPutScheduledUpdateGroupActionInput) SetAutoScalingGroupName(v string) *BatchPutScheduledUpdateGroupActionInput {
+	s.AutoScalingGroupName = &v
+	return s
+}
+
+// SetScheduledUpdateGroupActions sets the ScheduledUpdateGroupActions field's value.
+func (s *BatchPutScheduledUpdateGroupActionInput) SetScheduledUpdateGroupActions(v []*ScheduledUpdateGroupActionRequest) *BatchPutScheduledUpdateGroupActionInput {
+	s.ScheduledUpdateGroupActions = v
+	return s
+}
+
+type BatchPutScheduledUpdateGroupActionOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The names of the scheduled actions that could not be created or updated,
+	// including an error message.
+	FailedScheduledUpdateGroupActions []*FailedScheduledUpdateGroupActionRequest `type:"list"`
+}
+
+// String returns the string representation
+func (s BatchPutScheduledUpdateGroupActionOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s BatchPutScheduledUpdateGroupActionOutput) GoString() string {
+	return s.String()
+}
+
+// SetFailedScheduledUpdateGroupActions sets the FailedScheduledUpdateGroupActions field's value.
+func (s *BatchPutScheduledUpdateGroupActionOutput) SetFailedScheduledUpdateGroupActions(v []*FailedScheduledUpdateGroupActionRequest) *BatchPutScheduledUpdateGroupActionOutput {
+	s.FailedScheduledUpdateGroupActions = v
+	return s
+}
+
 // Describes a block device mapping.
 type BlockDeviceMapping struct {
 	_ struct{} `type:"structure"`
@@ -5480,8 +5829,8 @@ type BlockDeviceMapping struct {
 	// Suppresses a device mapping.
 	//
 	// If this parameter is true for the root device, the instance might fail the
-	// EC2 health check. Auto Scaling launches a replacement instance if the instance
-	// fails the health check.
+	// EC2 health check. Amazon EC2 Auto Scaling launches a replacement instance
+	// if the instance fails the health check.
 	NoDevice *bool `type:"boolean"`
 
 	// The name of the virtual device (for example, ephemeral0).
@@ -5564,8 +5913,8 @@ type CompleteLifecycleActionInput struct {
 	LifecycleActionResult *string `type:"string" required:"true"`
 
 	// A universally unique identifier (UUID) that identifies a specific lifecycle
-	// action associated with an instance. Auto Scaling sends this token to the
-	// notification target you specified when you created the lifecycle hook.
+	// action associated with an instance. Amazon EC2 Auto Scaling sends this token
+	// to the notification target you specified when you created the lifecycle hook.
 	LifecycleActionToken *string `min:"36" type:"string"`
 
 	// The name of the lifecycle hook.
@@ -5675,8 +6024,8 @@ type CreateAutoScalingGroupInput struct {
 	// The amount of time, in seconds, after a scaling activity completes before
 	// another scaling activity can start. The default is 300.
 	//
-	// For more information, see Auto Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/ec2/userguide/Cooldown.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	DefaultCooldown *int64 `type:"integer"`
 
 	// The number of EC2 instances that should be running in the group. This number
@@ -5685,36 +6034,36 @@ type CreateAutoScalingGroupInput struct {
 	// capacity, the default is the minimum size of the group.
 	DesiredCapacity *int64 `type:"integer"`
 
-	// The amount of time, in seconds, that Auto Scaling waits before checking the
-	// health status of an EC2 instance that has come into service. During this
-	// time, any health check failures for the instance are ignored. The default
-	// is 0.
+	// The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before
+	// checking the health status of an EC2 instance that has come into service.
+	// During this time, any health check failures for the instance are ignored.
+	// The default is 0.
 	//
 	// This parameter is required if you are adding an ELB health check.
 	//
-	// For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	HealthCheckGracePeriod *int64 `type:"integer"`
 
 	// The service to use for the health checks. The valid values are EC2 and ELB.
 	//
 	// By default, health checks use Amazon EC2 instance status checks to determine
-	// the health of an instance. For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html)
-	// in the Auto Scaling User Guide.
+	// the health of an instance. For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	HealthCheckType *string `min:"1" type:"string"`
 
 	// The ID of the instance used to create a launch configuration for the group.
 	// You must specify one of the following: an EC2 instance, a launch configuration,
 	// or a launch template.
 	//
-	// When you specify an ID of an instance, Auto Scaling creates a new launch
-	// configuration and associates it with the group. This launch configuration
+	// When you specify an ID of an instance, Amazon EC2 Auto Scaling creates a
+	// new launch configuration and associates it with the group. This launch configuration
 	// derives its attributes from the specified instance, with the exception of
 	// the block device mapping.
 	//
 	// For more information, see Create an Auto Scaling Group Using an EC2 Instance
-	// (http://docs.aws.amazon.com/autoscaling/latest/userguide/create-asg-from-instance.html)
-	// in the Auto Scaling User Guide.
+	// (http://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-from-instance.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	InstanceId *string `min:"1" type:"string"`
 
 	// The name of the launch configuration. You must specify one of the following:
@@ -5732,8 +6081,8 @@ type CreateAutoScalingGroupInput struct {
 	// use TargetGroupARNs instead.
 	//
 	// For more information, see Using a Load Balancer With an Auto Scaling Group
-	// (http://docs.aws.amazon.com/autoscaling/latest/userguide/create-asg-from-instance.html)
-	// in the Auto Scaling User Guide.
+	// (http://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-from-instance.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	LoadBalancerNames []*string `type:"list"`
 
 	// The maximum size of the group.
@@ -5756,15 +6105,15 @@ type CreateAutoScalingGroupInput struct {
 	PlacementGroup *string `min:"1" type:"string"`
 
 	// The Amazon Resource Name (ARN) of the service-linked role that the Auto Scaling
-	// group uses to call other AWS services on your behalf. By default, Auto Scaling
-	// uses a service-linked role named AWSServiceRoleForAutoScaling, which it creates
-	// if it does not exist.
+	// group uses to call other AWS services on your behalf. By default, Amazon
+	// EC2 Auto Scaling uses a service-linked role named AWSServiceRoleForAutoScaling,
+	// which it creates if it does not exist.
 	ServiceLinkedRoleARN *string `min:"1" type:"string"`
 
 	// One or more tags.
 	//
-	// For more information, see Tagging Auto Scaling Groups and Instances (http://docs.aws.amazon.com/autoscaling/latest/userguide/autoscaling-tagging.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Tagging Auto Scaling Groups and Instances (http://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-tagging.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	Tags []*Tag `type:"list"`
 
 	// The Amazon Resource Names (ARN) of the target groups.
@@ -5774,7 +6123,7 @@ type CreateAutoScalingGroupInput struct {
 	// These policies are executed in the order that they are listed.
 	//
 	// For more information, see Controlling Which Instances Auto Scaling Terminates
-	// During Scale In (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html)
+	// During Scale In (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html)
 	// in the Auto Scaling User Guide.
 	TerminationPolicies []*string `type:"list"`
 
@@ -5784,8 +6133,8 @@ type CreateAutoScalingGroupInput struct {
 	// If you specify subnets and Availability Zones with this call, ensure that
 	// the subnets' Availability Zones match the Availability Zones specified.
 	//
-	// For more information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-in-vpc.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
 }
 
@@ -6006,8 +6355,8 @@ type CreateLaunchConfigurationInput struct {
 
 	// Used for groups that launch instances into a virtual private cloud (VPC).
 	// Specifies whether to assign a public IP address to each instance. For more
-	// information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html)
-	// in the Auto Scaling User Guide.
+	// information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-in-vpc.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	//
 	// If you specify this parameter, be sure to specify at least one subnet when
 	// you create your group.
@@ -6047,11 +6396,11 @@ type CreateLaunchConfigurationInput struct {
 	// with the IAM role for the instance.
 	//
 	// EC2 instances launched with an IAM role will automatically have AWS security
-	// credentials available. You can use IAM roles with Auto Scaling to automatically
-	// enable applications running on your EC2 instances to securely access other
-	// AWS resources. For more information, see Launch Auto Scaling Instances with
-	// an IAM Role (http://docs.aws.amazon.com/autoscaling/latest/userguide/us-iam-role.html)
-	// in the Auto Scaling User Guide.
+	// credentials available. You can use IAM roles with Amazon EC2 Auto Scaling
+	// to automatically enable applications running on your EC2 instances to securely
+	// access other AWS resources. For more information, see Launch Auto Scaling
+	// Instances with an IAM Role (http://docs.aws.amazon.com/autoscaling/ec2/userguide/us-iam-role.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	IamInstanceProfile *string `min:"1" type:"string"`
 
 	// The ID of the Amazon Machine Image (AMI) to use to launch your EC2 instances.
@@ -6072,8 +6421,8 @@ type CreateLaunchConfigurationInput struct {
 	// any other instance attributes, specify them as part of the same request.
 	//
 	// For more information, see Create a Launch Configuration Using an EC2 Instance
-	// (http://docs.aws.amazon.com/autoscaling/latest/userguide/create-lc-with-instanceID.html)
-	// in the Auto Scaling User Guide.
+	// (http://docs.aws.amazon.com/autoscaling/ec2/userguide/create-lc-with-instanceID.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	InstanceId *string `min:"1" type:"string"`
 
 	// Enables detailed monitoring (true) or basic monitoring (false) for the Auto
@@ -6113,8 +6462,8 @@ type CreateLaunchConfigurationInput struct {
 	// If you specify this parameter, be sure to specify at least one subnet when
 	// you create your group.
 	//
-	// For more information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-in-vpc.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	//
 	// Valid values: default | dedicated
 	PlacementTenancy *string `min:"1" type:"string"`
@@ -6137,8 +6486,8 @@ type CreateLaunchConfigurationInput struct {
 	// The maximum hourly price to be paid for any Spot Instance launched to fulfill
 	// the request. Spot Instances are launched when the price you specify exceeds
 	// the current Spot market price. For more information, see Launching Spot Instances
-	// in Your Auto Scaling Group (http://docs.aws.amazon.com/autoscaling/latest/userguide/US-SpotInstances.html)
-	// in the Auto Scaling User Guide.
+	// in Your Auto Scaling Group (http://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-launch-spot-instances.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	SpotPrice *string `min:"1" type:"string"`
 
 	// The user data to make available to the launched EC2 instances. For more information,
@@ -7065,8 +7414,8 @@ func (s *DescribeAdjustmentTypesOutput) SetAdjustmentTypes(v []*AdjustmentType) 
 type DescribeAutoScalingGroupsInput struct {
 	_ struct{} `type:"structure"`
 
-	// The names of the Auto Scaling groups. If you omit this parameter, all Auto
-	// Scaling groups are described.
+	// The names of the Auto Scaling groups. You can specify up to MaxRecords names.
+	// If you omit this parameter, all Auto Scaling groups are described.
 	AutoScalingGroupNames []*string `type:"list"`
 
 	// The maximum number of items to return with this call. The default value is
@@ -7144,9 +7493,9 @@ func (s *DescribeAutoScalingGroupsOutput) SetNextToken(v string) *DescribeAutoSc
 type DescribeAutoScalingInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The instances to describe; up to 50 instance IDs. If you omit this parameter,
-	// all Auto Scaling instances are described. If you specify an ID that does
-	// not exist, it is ignored with no error.
+	// The IDs of the instances. You can specify up to MaxRecords IDs. If you omit
+	// this parameter, all Auto Scaling instances are described. If you specify
+	// an ID that does not exist, it is ignored with no error.
 	InstanceIds []*string `type:"list"`
 
 	// The maximum number of items to return with this call. The default value is
@@ -7871,11 +8220,11 @@ func (s *DescribePoliciesOutput) SetScalingPolicies(v []*ScalingPolicy) *Describ
 type DescribeScalingActivitiesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The activity IDs of the desired scaling activities. If you omit this parameter,
-	// all activities for the past six weeks are described. If you specify an Auto
-	// Scaling group, the results are limited to that group. The list of requested
-	// activities cannot contain more than 50 items. If unknown activities are requested,
-	// they are ignored with no error.
+	// The activity IDs of the desired scaling activities. You can specify up to
+	// 50 IDs. If you omit this parameter, all activities for the past six weeks
+	// are described. If unknown activities are requested, they are ignored with
+	// no error. If you specify an Auto Scaling group, the results are limited to
+	// that group.
 	ActivityIds []*string `type:"list"`
 
 	// The name of the Auto Scaling group.
@@ -8028,13 +8377,9 @@ type DescribeScheduledActionsInput struct {
 	// a previous call.)
 	NextToken *string `type:"string"`
 
-	// Describes one or more scheduled actions. If you omit this parameter, all
-	// scheduled actions are described. If you specify an unknown scheduled action,
-	// it is ignored with no error.
-	//
-	// You can describe up to a maximum of 50 instances with a single call. If there
-	// are more items to return, the call returns a token. To get the next set of
-	// items, repeat the call with the returned token.
+	// The names of one or more scheduled actions. You can specify up to 50 actions.
+	// If you omit this parameter, all scheduled actions are described. If you specify
+	// an unknown scheduled action, it is ignored with no error.
 	ScheduledActionNames []*string `type:"list"`
 
 	// The earliest scheduled start time to return. If scheduled action names are
@@ -8227,8 +8572,9 @@ func (s DescribeTerminationPolicyTypesInput) GoString() string {
 type DescribeTerminationPolicyTypesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The termination policies supported by Auto Scaling (OldestInstance, OldestLaunchConfiguration,
-	// NewestInstance, ClosestToNextInstanceHour, and Default).
+	// The termination policies supported by Amazon EC2 Auto Scaling (OldestInstance,
+	// OldestLaunchConfiguration, NewestInstance, ClosestToNextInstanceHour, and
+	// Default).
 	TerminationPolicyTypes []*string `type:"list"`
 }
 
@@ -8594,8 +8940,6 @@ type Ebs struct {
 	// in the Amazon Elastic Compute Cloud User Guide.
 	//
 	// Valid values: standard | io1 | gp2
-	//
-	// Default: standard
 	VolumeType *string `min:"1" type:"string"`
 }
 
@@ -8915,13 +9259,13 @@ type ExecutePolicyInput struct {
 	// otherwise.
 	BreachThreshold *float64 `type:"double"`
 
-	// Indicates whether Auto Scaling waits for the cooldown period to complete
-	// before executing the policy.
+	// Indicates whether Amazon EC2 Auto Scaling waits for the cooldown period to
+	// complete before executing the policy.
 	//
 	// This parameter is not supported if the policy type is StepScaling.
 	//
-	// For more information, see Auto Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/ec2/userguide/Cooldown.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	HonorCooldown *bool `type:"boolean"`
 
 	// The metric value to compare to BreachThreshold. This enables you to execute
@@ -9089,6 +9433,50 @@ func (s *ExitStandbyOutput) SetActivities(v []*Activity) *ExitStandbyOutput {
 	return s
 }
 
+// Describes a scheduled action that could not be created, updated, or deleted.
+type FailedScheduledUpdateGroupActionRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The error code.
+	ErrorCode *string `min:"1" type:"string"`
+
+	// The error message accompanying the error code.
+	ErrorMessage *string `type:"string"`
+
+	// The name of the scheduled action.
+	//
+	// ScheduledActionName is a required field
+	ScheduledActionName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s FailedScheduledUpdateGroupActionRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FailedScheduledUpdateGroupActionRequest) GoString() string {
+	return s.String()
+}
+
+// SetErrorCode sets the ErrorCode field's value.
+func (s *FailedScheduledUpdateGroupActionRequest) SetErrorCode(v string) *FailedScheduledUpdateGroupActionRequest {
+	s.ErrorCode = &v
+	return s
+}
+
+// SetErrorMessage sets the ErrorMessage field's value.
+func (s *FailedScheduledUpdateGroupActionRequest) SetErrorMessage(v string) *FailedScheduledUpdateGroupActionRequest {
+	s.ErrorMessage = &v
+	return s
+}
+
+// SetScheduledActionName sets the ScheduledActionName field's value.
+func (s *FailedScheduledUpdateGroupActionRequest) SetScheduledActionName(v string) *FailedScheduledUpdateGroupActionRequest {
+	s.ScheduledActionName = &v
+	return s
+}
+
 // Describes a filter.
 type Filter struct {
 	_ struct{} `type:"structure"`
@@ -9159,8 +9547,8 @@ type Group struct {
 	// The metrics enabled for the group.
 	EnabledMetrics []*EnabledMetric `type:"list"`
 
-	// The amount of time, in seconds, that Auto Scaling waits before checking the
-	// health status of an EC2 instance that has come into service.
+	// The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before
+	// checking the health status of an EC2 instance that has come into service.
 	HealthCheckGracePeriod *int64 `type:"integer"`
 
 	// The service to use for the health checks. The valid values are EC2 and ELB.
@@ -9390,7 +9778,8 @@ type Instance struct {
 
 	// The last reported health status of the instance. "Healthy" means that the
 	// instance is healthy and should remain in service. "Unhealthy" means that
-	// the instance is unhealthy and Auto Scaling should terminate and replace it.
+	// the instance is unhealthy and Amazon EC2 Auto Scaling should terminate and
+	// replace it.
 	//
 	// HealthStatus is a required field
 	HealthStatus *string `min:"1" type:"string" required:"true"`
@@ -9412,8 +9801,8 @@ type Instance struct {
 	// LifecycleState is a required field
 	LifecycleState *string `type:"string" required:"true" enum:"LifecycleState"`
 
-	// Indicates whether the instance is protected from termination by Auto Scaling
-	// when scaling in.
+	// Indicates whether the instance is protected from termination by Amazon EC2
+	// Auto Scaling when scaling in.
 	//
 	// ProtectedFromScaleIn is a required field
 	ProtectedFromScaleIn *bool `type:"boolean" required:"true"`
@@ -9487,7 +9876,8 @@ type InstanceDetails struct {
 
 	// The last reported health status of this instance. "Healthy" means that the
 	// instance is healthy and should remain in service. "Unhealthy" means that
-	// the instance is unhealthy and Auto Scaling should terminate and replace it.
+	// the instance is unhealthy and Amazon EC2 Auto Scaling should terminate and
+	// replace it.
 	//
 	// HealthStatus is a required field
 	HealthStatus *string `min:"1" type:"string" required:"true"`
@@ -9505,14 +9895,14 @@ type InstanceDetails struct {
 	LaunchTemplate *LaunchTemplateSpecification `type:"structure"`
 
 	// The lifecycle state for the instance. For more information, see Auto Scaling
-	// Lifecycle (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html)
-	// in the Auto Scaling User Guide.
+	// Lifecycle (http://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroupLifecycle.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	//
 	// LifecycleState is a required field
 	LifecycleState *string `min:"1" type:"string" required:"true"`
 
-	// Indicates whether the instance is protected from termination by Auto Scaling
-	// when scaling in.
+	// Indicates whether the instance is protected from termination by Amazon EC2
+	// Auto Scaling when scaling in.
 	//
 	// ProtectedFromScaleIn is a required field
 	ProtectedFromScaleIn *bool `type:"boolean" required:"true"`
@@ -9816,10 +10206,11 @@ type LaunchTemplateSpecification struct {
 	// or a template ID.
 	LaunchTemplateName *string `min:"3" type:"string"`
 
-	// The version number, $Latest, or $Default. If the value is $Latest, Auto Scaling
-	// selects the latest version of the launch template when launching instances.
-	// If the value is $Default, Auto Scaling selects the default version of the
-	// launch template when launching instances. The default value is $Default.
+	// The version number, $Latest, or $Default. If the value is $Latest, Amazon
+	// EC2 Auto Scaling selects the latest version of the launch template when launching
+	// instances. If the value is $Default, Amazon EC2 Auto Scaling selects the
+	// default version of the launch template when launching instances. The default
+	// value is $Default.
 	Version *string `min:"1" type:"string"`
 }
 
@@ -9870,11 +10261,12 @@ func (s *LaunchTemplateSpecification) SetVersion(v string) *LaunchTemplateSpecif
 	return s
 }
 
-// Describes a lifecycle hook, which tells Auto Scaling that you want to perform
-// an action whenever it launches instances or whenever it terminates instances.
+// Describes a lifecycle hook, which tells Amazon EC2 Auto Scaling that you
+// want to perform an action whenever it launches instances or whenever it terminates
+// instances.
 //
-// For more information, see Auto Scaling Lifecycle Hooks (http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html)
-// in the Auto Scaling User Guide.
+// For more information, see Lifecycle Hooks (http://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 type LifecycleHook struct {
 	_ struct{} `type:"structure"`
 
@@ -9892,24 +10284,29 @@ type LifecycleHook struct {
 	GlobalTimeout *int64 `type:"integer"`
 
 	// The maximum time, in seconds, that can elapse before the lifecycle hook times
-	// out. If the lifecycle hook times out, Auto Scaling performs the default action.
-	// You can prevent the lifecycle hook from timing out by calling RecordLifecycleActionHeartbeat.
+	// out. If the lifecycle hook times out, Amazon EC2 Auto Scaling performs the
+	// default action. You can prevent the lifecycle hook from timing out by calling
+	// RecordLifecycleActionHeartbeat.
 	HeartbeatTimeout *int64 `type:"integer"`
 
 	// The name of the lifecycle hook.
 	LifecycleHookName *string `min:"1" type:"string"`
 
 	// The state of the EC2 instance to which you want to attach the lifecycle hook.
-	// For a list of lifecycle hook types, see DescribeLifecycleHookTypes.
+	// The following are possible values:
+	//
+	//    * autoscaling:EC2_INSTANCE_LAUNCHING
+	//
+	//    * autoscaling:EC2_INSTANCE_TERMINATING
 	LifecycleTransition *string `type:"string"`
 
-	// Additional information that you want to include any time Auto Scaling sends
-	// a message to the notification target.
+	// Additional information that you want to include any time Amazon EC2 Auto
+	// Scaling sends a message to the notification target.
 	NotificationMetadata *string `min:"1" type:"string"`
 
-	// The ARN of the target that Auto Scaling sends notifications to when an instance
-	// is in the transition state for the lifecycle hook. The notification target
-	// can be either an SQS queue or an SNS topic.
+	// The ARN of the target that Amazon EC2 Auto Scaling sends notifications to
+	// when an instance is in the transition state for the lifecycle hook. The notification
+	// target can be either an SQS queue or an SNS topic.
 	NotificationTargetARN *string `min:"1" type:"string"`
 
 	// The ARN of the IAM role that allows the Auto Scaling group to publish to
@@ -9981,11 +10378,12 @@ func (s *LifecycleHook) SetRoleARN(v string) *LifecycleHook {
 	return s
 }
 
-// Describes a lifecycle hook, which tells Auto Scaling that you want to perform
-// an action whenever it launches instances or whenever it terminates instances.
+// Describes a lifecycle hook, which tells Amazon EC2 Auto Scaling that you
+// want to perform an action whenever it launches instances or whenever it terminates
+// instances.
 //
-// For more information, see Auto Scaling Lifecycle Hooks (http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html)
-// in the Auto Scaling User Guide.
+// For more information, see Lifecycle Hooks (http://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html)
+// in the Amazon EC2 Auto Scaling User Guide.
 type LifecycleHookSpecification struct {
 	_ struct{} `type:"structure"`
 
@@ -9995,8 +10393,9 @@ type LifecycleHookSpecification struct {
 	DefaultResult *string `type:"string"`
 
 	// The maximum time, in seconds, that can elapse before the lifecycle hook times
-	// out. If the lifecycle hook times out, Auto Scaling performs the default action.
-	// You can prevent the lifecycle hook from timing out by calling RecordLifecycleActionHeartbeat.
+	// out. If the lifecycle hook times out, Amazon EC2 Auto Scaling performs the
+	// default action. You can prevent the lifecycle hook from timing out by calling
+	// RecordLifecycleActionHeartbeat.
 	HeartbeatTimeout *int64 `type:"integer"`
 
 	// The name of the lifecycle hook.
@@ -10005,18 +10404,22 @@ type LifecycleHookSpecification struct {
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 
 	// The state of the EC2 instance to which you want to attach the lifecycle hook.
-	// For a list of lifecycle hook types, see DescribeLifecycleHookTypes.
+	// The possible values are:
+	//
+	//    * autoscaling:EC2_INSTANCE_LAUNCHING
+	//
+	//    * autoscaling:EC2_INSTANCE_TERMINATING
 	//
 	// LifecycleTransition is a required field
 	LifecycleTransition *string `type:"string" required:"true"`
 
-	// Additional information that you want to include any time Auto Scaling sends
-	// a message to the notification target.
+	// Additional information that you want to include any time Amazon EC2 Auto
+	// Scaling sends a message to the notification target.
 	NotificationMetadata *string `min:"1" type:"string"`
 
-	// The ARN of the target that Auto Scaling sends notifications to when an instance
-	// is in the transition state for the lifecycle hook. The notification target
-	// can be either an SQS queue or an SNS topic.
+	// The ARN of the target that Amazon EC2 Auto Scaling sends notifications to
+	// when an instance is in the transition state for the lifecycle hook. The notification
+	// target can be either an SQS queue or an SNS topic.
 	NotificationTargetARN *string `type:"string"`
 
 	// The ARN of the IAM role that allows the Auto Scaling group to publish to
@@ -10460,8 +10863,8 @@ func (s *PredefinedMetricSpecification) SetResourceLabel(v string) *PredefinedMe
 
 // Describes a process type.
 //
-// For more information, see Auto Scaling Processes (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html#process-types)
-// in the Auto Scaling User Guide.
+// For more information, see Scaling Processes (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html#process-types)
+// in the Amazon EC2 Auto Scaling User Guide.
 type ProcessType struct {
 	_ struct{} `type:"structure"`
 
@@ -10520,8 +10923,8 @@ type PutLifecycleHookInput struct {
 	// out. The range is from 30 to 7200 seconds. The default is 3600 seconds (1
 	// hour).
 	//
-	// If the lifecycle hook times out, Auto Scaling performs the default action.
-	// You can prevent the lifecycle hook from timing out by calling RecordLifecycleActionHeartbeat.
+	// If the lifecycle hook times out, Amazon EC2 Auto Scaling performs the default
+	// action. You can prevent the lifecycle hook from timing out by calling RecordLifecycleActionHeartbeat.
 	HeartbeatTimeout *int64 `type:"integer"`
 
 	// The name of the lifecycle hook.
@@ -10529,29 +10932,33 @@ type PutLifecycleHookInput struct {
 	// LifecycleHookName is a required field
 	LifecycleHookName *string `min:"1" type:"string" required:"true"`
 
-	// The instance state to which you want to attach the lifecycle hook. For a
-	// list of lifecycle hook types, see DescribeLifecycleHookTypes.
+	// The instance state to which you want to attach the lifecycle hook. The possible
+	// values are:
+	//
+	//    * autoscaling:EC2_INSTANCE_LAUNCHING
+	//
+	//    * autoscaling:EC2_INSTANCE_TERMINATING
 	//
 	// This parameter is required for new lifecycle hooks, but optional when updating
 	// existing hooks.
 	LifecycleTransition *string `type:"string"`
 
-	// Contains additional information that you want to include any time Auto Scaling
-	// sends a message to the notification target.
+	// Contains additional information that you want to include any time Amazon
+	// EC2 Auto Scaling sends a message to the notification target.
 	NotificationMetadata *string `min:"1" type:"string"`
 
-	// The ARN of the notification target that Auto Scaling will use to notify you
-	// when an instance is in the transition state for the lifecycle hook. This
-	// target can be either an SQS queue or an SNS topic. If you specify an empty
-	// string, this overrides the current ARN.
+	// The ARN of the notification target that Amazon EC2 Auto Scaling will use
+	// to notify you when an instance is in the transition state for the lifecycle
+	// hook. This target can be either an SQS queue or an SNS topic. If you specify
+	// an empty string, this overrides the current ARN.
 	//
 	// This operation uses the JSON format when sending notifications to an Amazon
 	// SQS queue, and an email key/value pair format when sending notifications
 	// to an Amazon SNS topic.
 	//
-	// When you specify a notification target, Auto Scaling sends it a test message.
-	// Test messages contains the following additional key/value pair: "Event":
-	// "autoscaling:TEST_NOTIFICATION".
+	// When you specify a notification target, Amazon EC2 Auto Scaling sends it
+	// a test message. Test messages contains the following additional key/value
+	// pair: "Event": "autoscaling:TEST_NOTIFICATION".
 	NotificationTargetARN *string `type:"string"`
 
 	// The ARN of the IAM role that allows the Auto Scaling group to publish to
@@ -10671,7 +11078,7 @@ type PutNotificationConfigurationInput struct {
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
 	// The type of event that will cause the notification to be sent. For details
-	// about notification types supported by Auto Scaling, see DescribeAutoScalingNotificationTypes.
+	// about notification types supported by Amazon EC2 Auto Scaling, see DescribeAutoScalingNotificationTypes.
 	//
 	// NotificationTypes is a required field
 	NotificationTypes []*string `type:"list" required:"true"`
@@ -10758,8 +11165,8 @@ type PutScalingPolicyInput struct {
 	//
 	// This parameter is supported if the policy type is SimpleScaling or StepScaling.
 	//
-	// For more information, see Dynamic Scaling (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-scale-based-on-demand.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Dynamic Scaling (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scale-based-on-demand.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	AdjustmentType *string `min:"1" type:"string"`
 
 	// The name of the Auto Scaling group.
@@ -10773,8 +11180,8 @@ type PutScalingPolicyInput struct {
 	//
 	// This parameter is supported if the policy type is SimpleScaling.
 	//
-	// For more information, see Auto Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/ec2/userguide/Cooldown.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	Cooldown *int64 `type:"integer"`
 
 	// The estimated time, in seconds, until a newly launched instance can contribute
@@ -11005,8 +11412,8 @@ type PutScheduledUpdateGroupActionInput struct {
 	// The number of EC2 instances that should be running in the group.
 	DesiredCapacity *int64 `type:"integer"`
 
-	// The time for the recurring schedule to end. Auto Scaling does not perform
-	// the action after this time.
+	// The time for the recurring schedule to end. Amazon EC2 Auto Scaling does
+	// not perform the action after this time.
 	EndTime *time.Time `type:"timestamp"`
 
 	// The maximum size for the Auto Scaling group.
@@ -11016,7 +11423,7 @@ type PutScheduledUpdateGroupActionInput struct {
 	MinSize *int64 `type:"integer"`
 
 	// The recurring schedule for this action, in Unix cron syntax format. For more
-	// information, see Cron (http://en.wikipedia.org/wiki/Cron) in Wikipedia.
+	// information about this format, see Crontab (http://crontab.org).
 	Recurrence *string `min:"1" type:"string"`
 
 	// The name of this scaling action.
@@ -11027,11 +11434,12 @@ type PutScheduledUpdateGroupActionInput struct {
 	// The time for this action to start, in "YYYY-MM-DDThh:mm:ssZ" format in UTC/GMT
 	// only (for example, 2014-06-01T00:00:00Z).
 	//
-	// If you specify Recurrence and StartTime, Auto Scaling performs the action
-	// at this time, and then performs the action based on the specified recurrence.
+	// If you specify Recurrence and StartTime, Amazon EC2 Auto Scaling performs
+	// the action at this time, and then performs the action based on the specified
+	// recurrence.
 	//
-	// If you try to schedule your action in the past, Auto Scaling returns an error
-	// message.
+	// If you try to schedule your action in the past, Amazon EC2 Auto Scaling returns
+	// an error message.
 	StartTime *time.Time `type:"timestamp"`
 
 	// This parameter is deprecated.
@@ -11153,8 +11561,8 @@ type RecordLifecycleActionHeartbeatInput struct {
 	InstanceId *string `min:"1" type:"string"`
 
 	// A token that uniquely identifies a specific lifecycle action associated with
-	// an instance. Auto Scaling sends this token to the notification target you
-	// specified when you created the lifecycle hook.
+	// an instance. Amazon EC2 Auto Scaling sends this token to the notification
+	// target you specified when you created the lifecycle hook.
 	LifecycleActionToken *string `min:"36" type:"string"`
 
 	// The name of the lifecycle hook.
@@ -11471,7 +11879,7 @@ func (s *ScalingProcessQuery) SetScalingProcesses(v []*string) *ScalingProcessQu
 	return s
 }
 
-// Describes a scheduled update to an Auto Scaling group.
+// Describes a scheduled scaling action. Used in response to DescribeScheduledActions.
 type ScheduledUpdateGroupAction struct {
 	_ struct{} `type:"structure"`
 
@@ -11581,6 +11989,119 @@ func (s *ScheduledUpdateGroupAction) SetTime(v time.Time) *ScheduledUpdateGroupA
 	return s
 }
 
+// Describes one or more scheduled scaling action updates for a specified Auto
+// Scaling group. Used in combination with BatchPutScheduledUpdateGroupAction.
+//
+// When updating a scheduled scaling action, all optional parameters are left
+// unchanged if not specified.
+type ScheduledUpdateGroupActionRequest struct {
+	_ struct{} `type:"structure"`
+
+	// The number of EC2 instances that should be running in the group.
+	DesiredCapacity *int64 `type:"integer"`
+
+	// The time for the recurring schedule to end. Amazon EC2 Auto Scaling does
+	// not perform the action after this time.
+	EndTime *time.Time `type:"timestamp"`
+
+	// The maximum size of the group.
+	MaxSize *int64 `type:"integer"`
+
+	// The minimum size of the group.
+	MinSize *int64 `type:"integer"`
+
+	// The recurring schedule for the action, in Unix cron syntax format. For more
+	// information about this format, see Crontab (http://crontab.org).
+	Recurrence *string `min:"1" type:"string"`
+
+	// The name of the scaling action.
+	//
+	// ScheduledActionName is a required field
+	ScheduledActionName *string `min:"1" type:"string" required:"true"`
+
+	// The time for the action to start, in "YYYY-MM-DDThh:mm:ssZ" format in UTC/GMT
+	// only (for example, 2014-06-01T00:00:00Z).
+	//
+	// If you specify Recurrence and StartTime, Amazon EC2 Auto Scaling performs
+	// the action at this time, and then performs the action based on the specified
+	// recurrence.
+	//
+	// If you try to schedule the action in the past, Amazon EC2 Auto Scaling returns
+	// an error message.
+	StartTime *time.Time `type:"timestamp"`
+}
+
+// String returns the string representation
+func (s ScheduledUpdateGroupActionRequest) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ScheduledUpdateGroupActionRequest) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ScheduledUpdateGroupActionRequest) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ScheduledUpdateGroupActionRequest"}
+	if s.Recurrence != nil && len(*s.Recurrence) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Recurrence", 1))
+	}
+	if s.ScheduledActionName == nil {
+		invalidParams.Add(request.NewErrParamRequired("ScheduledActionName"))
+	}
+	if s.ScheduledActionName != nil && len(*s.ScheduledActionName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ScheduledActionName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDesiredCapacity sets the DesiredCapacity field's value.
+func (s *ScheduledUpdateGroupActionRequest) SetDesiredCapacity(v int64) *ScheduledUpdateGroupActionRequest {
+	s.DesiredCapacity = &v
+	return s
+}
+
+// SetEndTime sets the EndTime field's value.
+func (s *ScheduledUpdateGroupActionRequest) SetEndTime(v time.Time) *ScheduledUpdateGroupActionRequest {
+	s.EndTime = &v
+	return s
+}
+
+// SetMaxSize sets the MaxSize field's value.
+func (s *ScheduledUpdateGroupActionRequest) SetMaxSize(v int64) *ScheduledUpdateGroupActionRequest {
+	s.MaxSize = &v
+	return s
+}
+
+// SetMinSize sets the MinSize field's value.
+func (s *ScheduledUpdateGroupActionRequest) SetMinSize(v int64) *ScheduledUpdateGroupActionRequest {
+	s.MinSize = &v
+	return s
+}
+
+// SetRecurrence sets the Recurrence field's value.
+func (s *ScheduledUpdateGroupActionRequest) SetRecurrence(v string) *ScheduledUpdateGroupActionRequest {
+	s.Recurrence = &v
+	return s
+}
+
+// SetScheduledActionName sets the ScheduledActionName field's value.
+func (s *ScheduledUpdateGroupActionRequest) SetScheduledActionName(v string) *ScheduledUpdateGroupActionRequest {
+	s.ScheduledActionName = &v
+	return s
+}
+
+// SetStartTime sets the StartTime field's value.
+func (s *ScheduledUpdateGroupActionRequest) SetStartTime(v time.Time) *ScheduledUpdateGroupActionRequest {
+	s.StartTime = &v
+	return s
+}
+
 type SetDesiredCapacityInput struct {
 	_ struct{} `type:"structure"`
 
@@ -11594,10 +12115,10 @@ type SetDesiredCapacityInput struct {
 	// DesiredCapacity is a required field
 	DesiredCapacity *int64 `type:"integer" required:"true"`
 
-	// Indicates whether Auto Scaling waits for the cooldown period to complete
-	// before initiating a scaling activity to set your Auto Scaling group to its
-	// new capacity. By default, Auto Scaling does not honor the cooldown period
-	// during manual scaling activities.
+	// Indicates whether Amazon EC2 Auto Scaling waits for the cooldown period to
+	// complete before initiating a scaling activity to set your Auto Scaling group
+	// to its new capacity. By default, Amazon EC2 Auto Scaling does not honor the
+	// cooldown period during manual scaling activities.
 	HonorCooldown *bool `type:"boolean"`
 }
 
@@ -11667,7 +12188,8 @@ type SetInstanceHealthInput struct {
 
 	// The health status of the instance. Set to Healthy if you want the instance
 	// to remain in service. Set to Unhealthy if you want the instance to be out
-	// of service. Auto Scaling will terminate and replace the unhealthy instance.
+	// of service. Amazon EC2 Auto Scaling will terminate and replace the unhealthy
+	// instance.
 	//
 	// HealthStatus is a required field
 	HealthStatus *string `min:"1" type:"string" required:"true"`
@@ -11764,8 +12286,8 @@ type SetInstanceProtectionInput struct {
 	// InstanceIds is a required field
 	InstanceIds []*string `type:"list" required:"true"`
 
-	// Indicates whether the instance is protected from termination by Auto Scaling
-	// when scaling in.
+	// Indicates whether the instance is protected from termination by Amazon EC2
+	// Auto Scaling when scaling in.
 	//
 	// ProtectedFromScaleIn is a required field
 	ProtectedFromScaleIn *bool `type:"boolean" required:"true"`
@@ -11946,8 +12468,8 @@ func (s SuspendProcessesOutput) GoString() string {
 	return s.String()
 }
 
-// Describes an Auto Scaling process that has been suspended. For more information,
-// see ProcessType.
+// Describes an automatic scaling process that has been suspended. For more
+// information, see ProcessType.
 type SuspendedProcess struct {
 	_ struct{} `type:"structure"`
 
@@ -12293,8 +12815,8 @@ type UpdateAutoScalingGroupInput struct {
 	// The amount of time, in seconds, after a scaling activity completes before
 	// another scaling activity can start. The default is 300.
 	//
-	// For more information, see Auto Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/latest/userguide/Cooldown.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Scaling Cooldowns (http://docs.aws.amazon.com/autoscaling/ec2/userguide/Cooldown.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	DefaultCooldown *int64 `type:"integer"`
 
 	// The number of EC2 instances that should be running in the Auto Scaling group.
@@ -12302,12 +12824,12 @@ type UpdateAutoScalingGroupInput struct {
 	// and less than or equal to the maximum size of the group.
 	DesiredCapacity *int64 `type:"integer"`
 
-	// The amount of time, in seconds, that Auto Scaling waits before checking the
-	// health status of an EC2 instance that has come into service. The default
-	// is 0.
+	// The amount of time, in seconds, that Amazon EC2 Auto Scaling waits before
+	// checking the health status of an EC2 instance that has come into service.
+	// The default is 0.
 	//
-	// For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/latest/userguide/healthcheck.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Health Checks (http://docs.aws.amazon.com/autoscaling/ec2/userguide/healthcheck.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	HealthCheckGracePeriod *int64 `type:"integer"`
 
 	// The service to use for the health checks. The valid values are EC2 and ELB.
@@ -12345,7 +12867,7 @@ type UpdateAutoScalingGroupInput struct {
 	// that they are listed.
 	//
 	// For more information, see Controlling Which Instances Auto Scaling Terminates
-	// During Scale In (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html)
+	// During Scale In (http://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html)
 	// in the Auto Scaling User Guide.
 	TerminationPolicies []*string `type:"list"`
 
@@ -12355,8 +12877,8 @@ type UpdateAutoScalingGroupInput struct {
 	// When you specify VPCZoneIdentifier with AvailabilityZones, ensure that the
 	// subnets' Availability Zones match the values you specify for AvailabilityZones.
 	//
-	// For more information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/latest/userguide/asg-in-vpc.html)
-	// in the Auto Scaling User Guide.
+	// For more information, see Launching Auto Scaling Instances in a VPC (http://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-in-vpc.html)
+	// in the Amazon EC2 Auto Scaling User Guide.
 	VPCZoneIdentifier *string `min:"1" type:"string"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/restxml"
 )
 
-const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2017_10_30"
+const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2018_06_18"
 
 // CreateCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the CreateCloudFrontOriginAccessIdentity operation. The "output" return
@@ -38,12 +38,12 @@ const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIden
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateCloudFrontOriginAccessIdentity
 func (c *CloudFront) CreateCloudFrontOriginAccessIdentityRequest(input *CreateCloudFrontOriginAccessIdentityInput) (req *request.Request, output *CreateCloudFrontOriginAccessIdentityOutput) {
 	op := &request.Operation{
 		Name:       opCreateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/origin-access-identity/cloudfront",
+		HTTPPath:   "/2018-06-18/origin-access-identity/cloudfront",
 	}
 
 	if input == nil {
@@ -92,7 +92,7 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentityRequest(input *CreateCl
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
 //   The value of Quantity and the size of Items don't match.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateCloudFrontOriginAccessIdentity
 func (c *CloudFront) CreateCloudFrontOriginAccessIdentity(input *CreateCloudFrontOriginAccessIdentityInput) (*CreateCloudFrontOriginAccessIdentityOutput, error) {
 	req, out := c.CreateCloudFrontOriginAccessIdentityRequest(input)
 	return out, req.Send()
@@ -114,7 +114,7 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentityWithContext(ctx aws.Con
 	return out, req.Send()
 }
 
-const opCreateDistribution = "CreateDistribution2017_10_30"
+const opCreateDistribution = "CreateDistribution2018_06_18"
 
 // CreateDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the CreateDistribution operation. The "output" return
@@ -139,12 +139,12 @@ const opCreateDistribution = "CreateDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateDistribution
 func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (req *request.Request, output *CreateDistributionOutput) {
 	op := &request.Operation{
 		Name:       opCreateDistribution,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/distribution",
+		HTTPPath:   "/2018-06-18/distribution",
 	}
 
 	if input == nil {
@@ -298,7 +298,7 @@ func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (
 //   The maximum number of distributions have been associated with the specified
 //   configuration for field-level encryption.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateDistribution
 func (c *CloudFront) CreateDistribution(input *CreateDistributionInput) (*CreateDistributionOutput, error) {
 	req, out := c.CreateDistributionRequest(input)
 	return out, req.Send()
@@ -320,7 +320,7 @@ func (c *CloudFront) CreateDistributionWithContext(ctx aws.Context, input *Creat
 	return out, req.Send()
 }
 
-const opCreateDistributionWithTags = "CreateDistributionWithTags2017_10_30"
+const opCreateDistributionWithTags = "CreateDistributionWithTags2018_06_18"
 
 // CreateDistributionWithTagsRequest generates a "aws/request.Request" representing the
 // client's request for the CreateDistributionWithTags operation. The "output" return
@@ -345,12 +345,12 @@ const opCreateDistributionWithTags = "CreateDistributionWithTags2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateDistributionWithTags
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateDistributionWithTags
 func (c *CloudFront) CreateDistributionWithTagsRequest(input *CreateDistributionWithTagsInput) (req *request.Request, output *CreateDistributionWithTagsOutput) {
 	op := &request.Operation{
 		Name:       opCreateDistributionWithTags,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/distribution?WithTags",
+		HTTPPath:   "/2018-06-18/distribution?WithTags",
 	}
 
 	if input == nil {
@@ -505,7 +505,7 @@ func (c *CloudFront) CreateDistributionWithTagsRequest(input *CreateDistribution
 //   The maximum number of distributions have been associated with the specified
 //   configuration for field-level encryption.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateDistributionWithTags
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateDistributionWithTags
 func (c *CloudFront) CreateDistributionWithTags(input *CreateDistributionWithTagsInput) (*CreateDistributionWithTagsOutput, error) {
 	req, out := c.CreateDistributionWithTagsRequest(input)
 	return out, req.Send()
@@ -527,7 +527,7 @@ func (c *CloudFront) CreateDistributionWithTagsWithContext(ctx aws.Context, inpu
 	return out, req.Send()
 }
 
-const opCreateFieldLevelEncryptionConfig = "CreateFieldLevelEncryptionConfig2017_10_30"
+const opCreateFieldLevelEncryptionConfig = "CreateFieldLevelEncryptionConfig2018_06_18"
 
 // CreateFieldLevelEncryptionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the CreateFieldLevelEncryptionConfig operation. The "output" return
@@ -552,12 +552,12 @@ const opCreateFieldLevelEncryptionConfig = "CreateFieldLevelEncryptionConfig2017
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateFieldLevelEncryptionConfig
 func (c *CloudFront) CreateFieldLevelEncryptionConfigRequest(input *CreateFieldLevelEncryptionConfigInput) (req *request.Request, output *CreateFieldLevelEncryptionConfigOutput) {
 	op := &request.Operation{
 		Name:       opCreateFieldLevelEncryptionConfig,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/field-level-encryption",
+		HTTPPath:   "/2018-06-18/field-level-encryption",
 	}
 
 	if input == nil {
@@ -608,7 +608,7 @@ func (c *CloudFront) CreateFieldLevelEncryptionConfigRequest(input *CreateFieldL
 //   * ErrCodeQueryArgProfileEmpty "QueryArgProfileEmpty"
 //   No profile specified for the field-level encryption query argument.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateFieldLevelEncryptionConfig
 func (c *CloudFront) CreateFieldLevelEncryptionConfig(input *CreateFieldLevelEncryptionConfigInput) (*CreateFieldLevelEncryptionConfigOutput, error) {
 	req, out := c.CreateFieldLevelEncryptionConfigRequest(input)
 	return out, req.Send()
@@ -630,7 +630,7 @@ func (c *CloudFront) CreateFieldLevelEncryptionConfigWithContext(ctx aws.Context
 	return out, req.Send()
 }
 
-const opCreateFieldLevelEncryptionProfile = "CreateFieldLevelEncryptionProfile2017_10_30"
+const opCreateFieldLevelEncryptionProfile = "CreateFieldLevelEncryptionProfile2018_06_18"
 
 // CreateFieldLevelEncryptionProfileRequest generates a "aws/request.Request" representing the
 // client's request for the CreateFieldLevelEncryptionProfile operation. The "output" return
@@ -655,12 +655,12 @@ const opCreateFieldLevelEncryptionProfile = "CreateFieldLevelEncryptionProfile20
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateFieldLevelEncryptionProfile
 func (c *CloudFront) CreateFieldLevelEncryptionProfileRequest(input *CreateFieldLevelEncryptionProfileInput) (req *request.Request, output *CreateFieldLevelEncryptionProfileOutput) {
 	op := &request.Operation{
 		Name:       opCreateFieldLevelEncryptionProfile,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/field-level-encryption-profile",
+		HTTPPath:   "/2018-06-18/field-level-encryption-profile",
 	}
 
 	if input == nil {
@@ -710,7 +710,7 @@ func (c *CloudFront) CreateFieldLevelEncryptionProfileRequest(input *CreateField
 //   The maximum number of field patterns for field-level encryption have been
 //   created.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateFieldLevelEncryptionProfile
 func (c *CloudFront) CreateFieldLevelEncryptionProfile(input *CreateFieldLevelEncryptionProfileInput) (*CreateFieldLevelEncryptionProfileOutput, error) {
 	req, out := c.CreateFieldLevelEncryptionProfileRequest(input)
 	return out, req.Send()
@@ -732,7 +732,7 @@ func (c *CloudFront) CreateFieldLevelEncryptionProfileWithContext(ctx aws.Contex
 	return out, req.Send()
 }
 
-const opCreateInvalidation = "CreateInvalidation2017_10_30"
+const opCreateInvalidation = "CreateInvalidation2018_06_18"
 
 // CreateInvalidationRequest generates a "aws/request.Request" representing the
 // client's request for the CreateInvalidation operation. The "output" return
@@ -757,12 +757,12 @@ const opCreateInvalidation = "CreateInvalidation2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateInvalidation
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateInvalidation
 func (c *CloudFront) CreateInvalidationRequest(input *CreateInvalidationInput) (req *request.Request, output *CreateInvalidationOutput) {
 	op := &request.Operation{
 		Name:       opCreateInvalidation,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/distribution/{DistributionId}/invalidation",
+		HTTPPath:   "/2018-06-18/distribution/{DistributionId}/invalidation",
 	}
 
 	if input == nil {
@@ -808,7 +808,7 @@ func (c *CloudFront) CreateInvalidationRequest(input *CreateInvalidationInput) (
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
 //   The value of Quantity and the size of Items don't match.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateInvalidation
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateInvalidation
 func (c *CloudFront) CreateInvalidation(input *CreateInvalidationInput) (*CreateInvalidationOutput, error) {
 	req, out := c.CreateInvalidationRequest(input)
 	return out, req.Send()
@@ -830,7 +830,7 @@ func (c *CloudFront) CreateInvalidationWithContext(ctx aws.Context, input *Creat
 	return out, req.Send()
 }
 
-const opCreatePublicKey = "CreatePublicKey2017_10_30"
+const opCreatePublicKey = "CreatePublicKey2018_06_18"
 
 // CreatePublicKeyRequest generates a "aws/request.Request" representing the
 // client's request for the CreatePublicKey operation. The "output" return
@@ -855,12 +855,12 @@ const opCreatePublicKey = "CreatePublicKey2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreatePublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreatePublicKey
 func (c *CloudFront) CreatePublicKeyRequest(input *CreatePublicKeyInput) (req *request.Request, output *CreatePublicKeyOutput) {
 	op := &request.Operation{
 		Name:       opCreatePublicKey,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/public-key",
+		HTTPPath:   "/2018-06-18/public-key",
 	}
 
 	if input == nil {
@@ -895,7 +895,7 @@ func (c *CloudFront) CreatePublicKeyRequest(input *CreatePublicKeyInput) (req *r
 //   The maximum number of public keys for field-level encryption have been created.
 //   To create a new public key, delete one of the existing keys.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreatePublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreatePublicKey
 func (c *CloudFront) CreatePublicKey(input *CreatePublicKeyInput) (*CreatePublicKeyOutput, error) {
 	req, out := c.CreatePublicKeyRequest(input)
 	return out, req.Send()
@@ -917,7 +917,7 @@ func (c *CloudFront) CreatePublicKeyWithContext(ctx aws.Context, input *CreatePu
 	return out, req.Send()
 }
 
-const opCreateStreamingDistribution = "CreateStreamingDistribution2017_10_30"
+const opCreateStreamingDistribution = "CreateStreamingDistribution2018_06_18"
 
 // CreateStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the CreateStreamingDistribution operation. The "output" return
@@ -942,12 +942,12 @@ const opCreateStreamingDistribution = "CreateStreamingDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateStreamingDistribution
 func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDistributionInput) (req *request.Request, output *CreateStreamingDistributionOutput) {
 	op := &request.Operation{
 		Name:       opCreateStreamingDistribution,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/streaming-distribution",
+		HTTPPath:   "/2018-06-18/streaming-distribution",
 	}
 
 	if input == nil {
@@ -1034,7 +1034,7 @@ func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDi
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
 //   The value of Quantity and the size of Items don't match.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateStreamingDistribution
 func (c *CloudFront) CreateStreamingDistribution(input *CreateStreamingDistributionInput) (*CreateStreamingDistributionOutput, error) {
 	req, out := c.CreateStreamingDistributionRequest(input)
 	return out, req.Send()
@@ -1056,7 +1056,7 @@ func (c *CloudFront) CreateStreamingDistributionWithContext(ctx aws.Context, inp
 	return out, req.Send()
 }
 
-const opCreateStreamingDistributionWithTags = "CreateStreamingDistributionWithTags2017_10_30"
+const opCreateStreamingDistributionWithTags = "CreateStreamingDistributionWithTags2018_06_18"
 
 // CreateStreamingDistributionWithTagsRequest generates a "aws/request.Request" representing the
 // client's request for the CreateStreamingDistributionWithTags operation. The "output" return
@@ -1081,12 +1081,12 @@ const opCreateStreamingDistributionWithTags = "CreateStreamingDistributionWithTa
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateStreamingDistributionWithTags
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateStreamingDistributionWithTags
 func (c *CloudFront) CreateStreamingDistributionWithTagsRequest(input *CreateStreamingDistributionWithTagsInput) (req *request.Request, output *CreateStreamingDistributionWithTagsOutput) {
 	op := &request.Operation{
 		Name:       opCreateStreamingDistributionWithTags,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/streaming-distribution?WithTags",
+		HTTPPath:   "/2018-06-18/streaming-distribution?WithTags",
 	}
 
 	if input == nil {
@@ -1148,7 +1148,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTagsRequest(input *CreateStr
 //
 //   * ErrCodeInvalidTagging "InvalidTagging"
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/CreateStreamingDistributionWithTags
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/CreateStreamingDistributionWithTags
 func (c *CloudFront) CreateStreamingDistributionWithTags(input *CreateStreamingDistributionWithTagsInput) (*CreateStreamingDistributionWithTagsOutput, error) {
 	req, out := c.CreateStreamingDistributionWithTagsRequest(input)
 	return out, req.Send()
@@ -1170,7 +1170,7 @@ func (c *CloudFront) CreateStreamingDistributionWithTagsWithContext(ctx aws.Cont
 	return out, req.Send()
 }
 
-const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIdentity2017_10_30"
+const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIdentity2018_06_18"
 
 // DeleteCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteCloudFrontOriginAccessIdentity operation. The "output" return
@@ -1195,12 +1195,12 @@ const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIden
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteCloudFrontOriginAccessIdentity
 func (c *CloudFront) DeleteCloudFrontOriginAccessIdentityRequest(input *DeleteCloudFrontOriginAccessIdentityInput) (req *request.Request, output *DeleteCloudFrontOriginAccessIdentityOutput) {
 	op := &request.Operation{
 		Name:       opDeleteCloudFrontOriginAccessIdentity,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2017-10-30/origin-access-identity/cloudfront/{Id}",
+		HTTPPath:   "/2018-06-18/origin-access-identity/cloudfront/{Id}",
 	}
 
 	if input == nil {
@@ -1241,7 +1241,7 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentityRequest(input *DeleteCl
 //
 //   * ErrCodeOriginAccessIdentityInUse "CloudFrontOriginAccessIdentityInUse"
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteCloudFrontOriginAccessIdentity
 func (c *CloudFront) DeleteCloudFrontOriginAccessIdentity(input *DeleteCloudFrontOriginAccessIdentityInput) (*DeleteCloudFrontOriginAccessIdentityOutput, error) {
 	req, out := c.DeleteCloudFrontOriginAccessIdentityRequest(input)
 	return out, req.Send()
@@ -1263,7 +1263,7 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentityWithContext(ctx aws.Con
 	return out, req.Send()
 }
 
-const opDeleteDistribution = "DeleteDistribution2017_10_30"
+const opDeleteDistribution = "DeleteDistribution2018_06_18"
 
 // DeleteDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteDistribution operation. The "output" return
@@ -1288,12 +1288,12 @@ const opDeleteDistribution = "DeleteDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteDistribution
 func (c *CloudFront) DeleteDistributionRequest(input *DeleteDistributionInput) (req *request.Request, output *DeleteDistributionOutput) {
 	op := &request.Operation{
 		Name:       opDeleteDistribution,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2017-10-30/distribution/{Id}",
+		HTTPPath:   "/2018-06-18/distribution/{Id}",
 	}
 
 	if input == nil {
@@ -1334,7 +1334,7 @@ func (c *CloudFront) DeleteDistributionRequest(input *DeleteDistributionInput) (
 //   The precondition given in one or more of the request-header fields evaluated
 //   to false.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteDistribution
 func (c *CloudFront) DeleteDistribution(input *DeleteDistributionInput) (*DeleteDistributionOutput, error) {
 	req, out := c.DeleteDistributionRequest(input)
 	return out, req.Send()
@@ -1356,7 +1356,7 @@ func (c *CloudFront) DeleteDistributionWithContext(ctx aws.Context, input *Delet
 	return out, req.Send()
 }
 
-const opDeleteFieldLevelEncryptionConfig = "DeleteFieldLevelEncryptionConfig2017_10_30"
+const opDeleteFieldLevelEncryptionConfig = "DeleteFieldLevelEncryptionConfig2018_06_18"
 
 // DeleteFieldLevelEncryptionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteFieldLevelEncryptionConfig operation. The "output" return
@@ -1381,12 +1381,12 @@ const opDeleteFieldLevelEncryptionConfig = "DeleteFieldLevelEncryptionConfig2017
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteFieldLevelEncryptionConfig
 func (c *CloudFront) DeleteFieldLevelEncryptionConfigRequest(input *DeleteFieldLevelEncryptionConfigInput) (req *request.Request, output *DeleteFieldLevelEncryptionConfigOutput) {
 	op := &request.Operation{
 		Name:       opDeleteFieldLevelEncryptionConfig,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2017-10-30/field-level-encryption/{Id}",
+		HTTPPath:   "/2018-06-18/field-level-encryption/{Id}",
 	}
 
 	if input == nil {
@@ -1428,7 +1428,7 @@ func (c *CloudFront) DeleteFieldLevelEncryptionConfigRequest(input *DeleteFieldL
 //   * ErrCodeFieldLevelEncryptionConfigInUse "FieldLevelEncryptionConfigInUse"
 //   The specified configuration for field-level encryption is in use.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteFieldLevelEncryptionConfig
 func (c *CloudFront) DeleteFieldLevelEncryptionConfig(input *DeleteFieldLevelEncryptionConfigInput) (*DeleteFieldLevelEncryptionConfigOutput, error) {
 	req, out := c.DeleteFieldLevelEncryptionConfigRequest(input)
 	return out, req.Send()
@@ -1450,7 +1450,7 @@ func (c *CloudFront) DeleteFieldLevelEncryptionConfigWithContext(ctx aws.Context
 	return out, req.Send()
 }
 
-const opDeleteFieldLevelEncryptionProfile = "DeleteFieldLevelEncryptionProfile2017_10_30"
+const opDeleteFieldLevelEncryptionProfile = "DeleteFieldLevelEncryptionProfile2018_06_18"
 
 // DeleteFieldLevelEncryptionProfileRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteFieldLevelEncryptionProfile operation. The "output" return
@@ -1475,12 +1475,12 @@ const opDeleteFieldLevelEncryptionProfile = "DeleteFieldLevelEncryptionProfile20
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteFieldLevelEncryptionProfile
 func (c *CloudFront) DeleteFieldLevelEncryptionProfileRequest(input *DeleteFieldLevelEncryptionProfileInput) (req *request.Request, output *DeleteFieldLevelEncryptionProfileOutput) {
 	op := &request.Operation{
 		Name:       opDeleteFieldLevelEncryptionProfile,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2017-10-30/field-level-encryption-profile/{Id}",
+		HTTPPath:   "/2018-06-18/field-level-encryption-profile/{Id}",
 	}
 
 	if input == nil {
@@ -1522,7 +1522,7 @@ func (c *CloudFront) DeleteFieldLevelEncryptionProfileRequest(input *DeleteField
 //   * ErrCodeFieldLevelEncryptionProfileInUse "FieldLevelEncryptionProfileInUse"
 //   The specified profile for field-level encryption is in use.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteFieldLevelEncryptionProfile
 func (c *CloudFront) DeleteFieldLevelEncryptionProfile(input *DeleteFieldLevelEncryptionProfileInput) (*DeleteFieldLevelEncryptionProfileOutput, error) {
 	req, out := c.DeleteFieldLevelEncryptionProfileRequest(input)
 	return out, req.Send()
@@ -1544,7 +1544,7 @@ func (c *CloudFront) DeleteFieldLevelEncryptionProfileWithContext(ctx aws.Contex
 	return out, req.Send()
 }
 
-const opDeletePublicKey = "DeletePublicKey2017_10_30"
+const opDeletePublicKey = "DeletePublicKey2018_06_18"
 
 // DeletePublicKeyRequest generates a "aws/request.Request" representing the
 // client's request for the DeletePublicKey operation. The "output" return
@@ -1569,12 +1569,12 @@ const opDeletePublicKey = "DeletePublicKey2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeletePublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeletePublicKey
 func (c *CloudFront) DeletePublicKeyRequest(input *DeletePublicKeyInput) (req *request.Request, output *DeletePublicKeyOutput) {
 	op := &request.Operation{
 		Name:       opDeletePublicKey,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2017-10-30/public-key/{Id}",
+		HTTPPath:   "/2018-06-18/public-key/{Id}",
 	}
 
 	if input == nil {
@@ -1616,7 +1616,7 @@ func (c *CloudFront) DeletePublicKeyRequest(input *DeletePublicKeyInput) (req *r
 //   The precondition given in one or more of the request-header fields evaluated
 //   to false.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeletePublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeletePublicKey
 func (c *CloudFront) DeletePublicKey(input *DeletePublicKeyInput) (*DeletePublicKeyOutput, error) {
 	req, out := c.DeletePublicKeyRequest(input)
 	return out, req.Send()
@@ -1638,7 +1638,7 @@ func (c *CloudFront) DeletePublicKeyWithContext(ctx aws.Context, input *DeletePu
 	return out, req.Send()
 }
 
-const opDeleteStreamingDistribution = "DeleteStreamingDistribution2017_10_30"
+const opDeleteStreamingDistribution = "DeleteStreamingDistribution2018_06_18"
 
 // DeleteStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the DeleteStreamingDistribution operation. The "output" return
@@ -1663,12 +1663,12 @@ const opDeleteStreamingDistribution = "DeleteStreamingDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteStreamingDistribution
 func (c *CloudFront) DeleteStreamingDistributionRequest(input *DeleteStreamingDistributionInput) (req *request.Request, output *DeleteStreamingDistributionOutput) {
 	op := &request.Operation{
 		Name:       opDeleteStreamingDistribution,
 		HTTPMethod: "DELETE",
-		HTTPPath:   "/2017-10-30/streaming-distribution/{Id}",
+		HTTPPath:   "/2018-06-18/streaming-distribution/{Id}",
 	}
 
 	if input == nil {
@@ -1744,7 +1744,7 @@ func (c *CloudFront) DeleteStreamingDistributionRequest(input *DeleteStreamingDi
 //   The precondition given in one or more of the request-header fields evaluated
 //   to false.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/DeleteStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/DeleteStreamingDistribution
 func (c *CloudFront) DeleteStreamingDistribution(input *DeleteStreamingDistributionInput) (*DeleteStreamingDistributionOutput, error) {
 	req, out := c.DeleteStreamingDistributionRequest(input)
 	return out, req.Send()
@@ -1766,7 +1766,7 @@ func (c *CloudFront) DeleteStreamingDistributionWithContext(ctx aws.Context, inp
 	return out, req.Send()
 }
 
-const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity2017_10_30"
+const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity2018_06_18"
 
 // GetCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the GetCloudFrontOriginAccessIdentity operation. The "output" return
@@ -1791,12 +1791,12 @@ const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity20
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetCloudFrontOriginAccessIdentity
 func (c *CloudFront) GetCloudFrontOriginAccessIdentityRequest(input *GetCloudFrontOriginAccessIdentityInput) (req *request.Request, output *GetCloudFrontOriginAccessIdentityOutput) {
 	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentity,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/origin-access-identity/cloudfront/{Id}",
+		HTTPPath:   "/2018-06-18/origin-access-identity/cloudfront/{Id}",
 	}
 
 	if input == nil {
@@ -1826,7 +1826,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityRequest(input *GetCloudFro
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetCloudFrontOriginAccessIdentity
 func (c *CloudFront) GetCloudFrontOriginAccessIdentity(input *GetCloudFrontOriginAccessIdentityInput) (*GetCloudFrontOriginAccessIdentityOutput, error) {
 	req, out := c.GetCloudFrontOriginAccessIdentityRequest(input)
 	return out, req.Send()
@@ -1848,7 +1848,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityWithContext(ctx aws.Contex
 	return out, req.Send()
 }
 
-const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIdentityConfig2017_10_30"
+const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIdentityConfig2018_06_18"
 
 // GetCloudFrontOriginAccessIdentityConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetCloudFrontOriginAccessIdentityConfig operation. The "output" return
@@ -1873,12 +1873,12 @@ const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIden
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetCloudFrontOriginAccessIdentityConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetCloudFrontOriginAccessIdentityConfig
 func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfigRequest(input *GetCloudFrontOriginAccessIdentityConfigInput) (req *request.Request, output *GetCloudFrontOriginAccessIdentityConfigOutput) {
 	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentityConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/origin-access-identity/cloudfront/{Id}/config",
+		HTTPPath:   "/2018-06-18/origin-access-identity/cloudfront/{Id}/config",
 	}
 
 	if input == nil {
@@ -1908,7 +1908,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfigRequest(input *GetCl
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetCloudFrontOriginAccessIdentityConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetCloudFrontOriginAccessIdentityConfig
 func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfig(input *GetCloudFrontOriginAccessIdentityConfigInput) (*GetCloudFrontOriginAccessIdentityConfigOutput, error) {
 	req, out := c.GetCloudFrontOriginAccessIdentityConfigRequest(input)
 	return out, req.Send()
@@ -1930,7 +1930,7 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfigWithContext(ctx aws.
 	return out, req.Send()
 }
 
-const opGetDistribution = "GetDistribution2017_10_30"
+const opGetDistribution = "GetDistribution2018_06_18"
 
 // GetDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the GetDistribution operation. The "output" return
@@ -1955,12 +1955,12 @@ const opGetDistribution = "GetDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetDistribution
 func (c *CloudFront) GetDistributionRequest(input *GetDistributionInput) (req *request.Request, output *GetDistributionOutput) {
 	op := &request.Operation{
 		Name:       opGetDistribution,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/distribution/{Id}",
+		HTTPPath:   "/2018-06-18/distribution/{Id}",
 	}
 
 	if input == nil {
@@ -1990,7 +1990,7 @@ func (c *CloudFront) GetDistributionRequest(input *GetDistributionInput) (req *r
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetDistribution
 func (c *CloudFront) GetDistribution(input *GetDistributionInput) (*GetDistributionOutput, error) {
 	req, out := c.GetDistributionRequest(input)
 	return out, req.Send()
@@ -2012,7 +2012,7 @@ func (c *CloudFront) GetDistributionWithContext(ctx aws.Context, input *GetDistr
 	return out, req.Send()
 }
 
-const opGetDistributionConfig = "GetDistributionConfig2017_10_30"
+const opGetDistributionConfig = "GetDistributionConfig2018_06_18"
 
 // GetDistributionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetDistributionConfig operation. The "output" return
@@ -2037,12 +2037,12 @@ const opGetDistributionConfig = "GetDistributionConfig2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetDistributionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetDistributionConfig
 func (c *CloudFront) GetDistributionConfigRequest(input *GetDistributionConfigInput) (req *request.Request, output *GetDistributionConfigOutput) {
 	op := &request.Operation{
 		Name:       opGetDistributionConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/distribution/{Id}/config",
+		HTTPPath:   "/2018-06-18/distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -2072,7 +2072,7 @@ func (c *CloudFront) GetDistributionConfigRequest(input *GetDistributionConfigIn
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetDistributionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetDistributionConfig
 func (c *CloudFront) GetDistributionConfig(input *GetDistributionConfigInput) (*GetDistributionConfigOutput, error) {
 	req, out := c.GetDistributionConfigRequest(input)
 	return out, req.Send()
@@ -2094,7 +2094,7 @@ func (c *CloudFront) GetDistributionConfigWithContext(ctx aws.Context, input *Ge
 	return out, req.Send()
 }
 
-const opGetFieldLevelEncryption = "GetFieldLevelEncryption2017_10_30"
+const opGetFieldLevelEncryption = "GetFieldLevelEncryption2018_06_18"
 
 // GetFieldLevelEncryptionRequest generates a "aws/request.Request" representing the
 // client's request for the GetFieldLevelEncryption operation. The "output" return
@@ -2119,12 +2119,12 @@ const opGetFieldLevelEncryption = "GetFieldLevelEncryption2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryption
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryption
 func (c *CloudFront) GetFieldLevelEncryptionRequest(input *GetFieldLevelEncryptionInput) (req *request.Request, output *GetFieldLevelEncryptionOutput) {
 	op := &request.Operation{
 		Name:       opGetFieldLevelEncryption,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/field-level-encryption/{Id}",
+		HTTPPath:   "/2018-06-18/field-level-encryption/{Id}",
 	}
 
 	if input == nil {
@@ -2154,7 +2154,7 @@ func (c *CloudFront) GetFieldLevelEncryptionRequest(input *GetFieldLevelEncrypti
 //   * ErrCodeNoSuchFieldLevelEncryptionConfig "NoSuchFieldLevelEncryptionConfig"
 //   The specified configuration for field-level encryption doesn't exist.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryption
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryption
 func (c *CloudFront) GetFieldLevelEncryption(input *GetFieldLevelEncryptionInput) (*GetFieldLevelEncryptionOutput, error) {
 	req, out := c.GetFieldLevelEncryptionRequest(input)
 	return out, req.Send()
@@ -2176,7 +2176,7 @@ func (c *CloudFront) GetFieldLevelEncryptionWithContext(ctx aws.Context, input *
 	return out, req.Send()
 }
 
-const opGetFieldLevelEncryptionConfig = "GetFieldLevelEncryptionConfig2017_10_30"
+const opGetFieldLevelEncryptionConfig = "GetFieldLevelEncryptionConfig2018_06_18"
 
 // GetFieldLevelEncryptionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetFieldLevelEncryptionConfig operation. The "output" return
@@ -2201,12 +2201,12 @@ const opGetFieldLevelEncryptionConfig = "GetFieldLevelEncryptionConfig2017_10_30
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryptionConfig
 func (c *CloudFront) GetFieldLevelEncryptionConfigRequest(input *GetFieldLevelEncryptionConfigInput) (req *request.Request, output *GetFieldLevelEncryptionConfigOutput) {
 	op := &request.Operation{
 		Name:       opGetFieldLevelEncryptionConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/field-level-encryption/{Id}/config",
+		HTTPPath:   "/2018-06-18/field-level-encryption/{Id}/config",
 	}
 
 	if input == nil {
@@ -2236,7 +2236,7 @@ func (c *CloudFront) GetFieldLevelEncryptionConfigRequest(input *GetFieldLevelEn
 //   * ErrCodeNoSuchFieldLevelEncryptionConfig "NoSuchFieldLevelEncryptionConfig"
 //   The specified configuration for field-level encryption doesn't exist.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryptionConfig
 func (c *CloudFront) GetFieldLevelEncryptionConfig(input *GetFieldLevelEncryptionConfigInput) (*GetFieldLevelEncryptionConfigOutput, error) {
 	req, out := c.GetFieldLevelEncryptionConfigRequest(input)
 	return out, req.Send()
@@ -2258,7 +2258,7 @@ func (c *CloudFront) GetFieldLevelEncryptionConfigWithContext(ctx aws.Context, i
 	return out, req.Send()
 }
 
-const opGetFieldLevelEncryptionProfile = "GetFieldLevelEncryptionProfile2017_10_30"
+const opGetFieldLevelEncryptionProfile = "GetFieldLevelEncryptionProfile2018_06_18"
 
 // GetFieldLevelEncryptionProfileRequest generates a "aws/request.Request" representing the
 // client's request for the GetFieldLevelEncryptionProfile operation. The "output" return
@@ -2283,12 +2283,12 @@ const opGetFieldLevelEncryptionProfile = "GetFieldLevelEncryptionProfile2017_10_
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryptionProfile
 func (c *CloudFront) GetFieldLevelEncryptionProfileRequest(input *GetFieldLevelEncryptionProfileInput) (req *request.Request, output *GetFieldLevelEncryptionProfileOutput) {
 	op := &request.Operation{
 		Name:       opGetFieldLevelEncryptionProfile,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/field-level-encryption-profile/{Id}",
+		HTTPPath:   "/2018-06-18/field-level-encryption-profile/{Id}",
 	}
 
 	if input == nil {
@@ -2318,7 +2318,7 @@ func (c *CloudFront) GetFieldLevelEncryptionProfileRequest(input *GetFieldLevelE
 //   * ErrCodeNoSuchFieldLevelEncryptionProfile "NoSuchFieldLevelEncryptionProfile"
 //   The specified profile for field-level encryption doesn't exist.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryptionProfile
 func (c *CloudFront) GetFieldLevelEncryptionProfile(input *GetFieldLevelEncryptionProfileInput) (*GetFieldLevelEncryptionProfileOutput, error) {
 	req, out := c.GetFieldLevelEncryptionProfileRequest(input)
 	return out, req.Send()
@@ -2340,7 +2340,7 @@ func (c *CloudFront) GetFieldLevelEncryptionProfileWithContext(ctx aws.Context, 
 	return out, req.Send()
 }
 
-const opGetFieldLevelEncryptionProfileConfig = "GetFieldLevelEncryptionProfileConfig2017_10_30"
+const opGetFieldLevelEncryptionProfileConfig = "GetFieldLevelEncryptionProfileConfig2018_06_18"
 
 // GetFieldLevelEncryptionProfileConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetFieldLevelEncryptionProfileConfig operation. The "output" return
@@ -2365,12 +2365,12 @@ const opGetFieldLevelEncryptionProfileConfig = "GetFieldLevelEncryptionProfileCo
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryptionProfileConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryptionProfileConfig
 func (c *CloudFront) GetFieldLevelEncryptionProfileConfigRequest(input *GetFieldLevelEncryptionProfileConfigInput) (req *request.Request, output *GetFieldLevelEncryptionProfileConfigOutput) {
 	op := &request.Operation{
 		Name:       opGetFieldLevelEncryptionProfileConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/field-level-encryption-profile/{Id}/config",
+		HTTPPath:   "/2018-06-18/field-level-encryption-profile/{Id}/config",
 	}
 
 	if input == nil {
@@ -2400,7 +2400,7 @@ func (c *CloudFront) GetFieldLevelEncryptionProfileConfigRequest(input *GetField
 //   * ErrCodeNoSuchFieldLevelEncryptionProfile "NoSuchFieldLevelEncryptionProfile"
 //   The specified profile for field-level encryption doesn't exist.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetFieldLevelEncryptionProfileConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetFieldLevelEncryptionProfileConfig
 func (c *CloudFront) GetFieldLevelEncryptionProfileConfig(input *GetFieldLevelEncryptionProfileConfigInput) (*GetFieldLevelEncryptionProfileConfigOutput, error) {
 	req, out := c.GetFieldLevelEncryptionProfileConfigRequest(input)
 	return out, req.Send()
@@ -2422,7 +2422,7 @@ func (c *CloudFront) GetFieldLevelEncryptionProfileConfigWithContext(ctx aws.Con
 	return out, req.Send()
 }
 
-const opGetInvalidation = "GetInvalidation2017_10_30"
+const opGetInvalidation = "GetInvalidation2018_06_18"
 
 // GetInvalidationRequest generates a "aws/request.Request" representing the
 // client's request for the GetInvalidation operation. The "output" return
@@ -2447,12 +2447,12 @@ const opGetInvalidation = "GetInvalidation2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetInvalidation
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetInvalidation
 func (c *CloudFront) GetInvalidationRequest(input *GetInvalidationInput) (req *request.Request, output *GetInvalidationOutput) {
 	op := &request.Operation{
 		Name:       opGetInvalidation,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/distribution/{DistributionId}/invalidation/{Id}",
+		HTTPPath:   "/2018-06-18/distribution/{DistributionId}/invalidation/{Id}",
 	}
 
 	if input == nil {
@@ -2485,7 +2485,7 @@ func (c *CloudFront) GetInvalidationRequest(input *GetInvalidationInput) (req *r
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetInvalidation
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetInvalidation
 func (c *CloudFront) GetInvalidation(input *GetInvalidationInput) (*GetInvalidationOutput, error) {
 	req, out := c.GetInvalidationRequest(input)
 	return out, req.Send()
@@ -2507,7 +2507,7 @@ func (c *CloudFront) GetInvalidationWithContext(ctx aws.Context, input *GetInval
 	return out, req.Send()
 }
 
-const opGetPublicKey = "GetPublicKey2017_10_30"
+const opGetPublicKey = "GetPublicKey2018_06_18"
 
 // GetPublicKeyRequest generates a "aws/request.Request" representing the
 // client's request for the GetPublicKey operation. The "output" return
@@ -2532,12 +2532,12 @@ const opGetPublicKey = "GetPublicKey2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetPublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetPublicKey
 func (c *CloudFront) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Request, output *GetPublicKeyOutput) {
 	op := &request.Operation{
 		Name:       opGetPublicKey,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/public-key/{Id}",
+		HTTPPath:   "/2018-06-18/public-key/{Id}",
 	}
 
 	if input == nil {
@@ -2567,7 +2567,7 @@ func (c *CloudFront) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request
 //   * ErrCodeNoSuchPublicKey "NoSuchPublicKey"
 //   The specified public key doesn't exist.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetPublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetPublicKey
 func (c *CloudFront) GetPublicKey(input *GetPublicKeyInput) (*GetPublicKeyOutput, error) {
 	req, out := c.GetPublicKeyRequest(input)
 	return out, req.Send()
@@ -2589,7 +2589,7 @@ func (c *CloudFront) GetPublicKeyWithContext(ctx aws.Context, input *GetPublicKe
 	return out, req.Send()
 }
 
-const opGetPublicKeyConfig = "GetPublicKeyConfig2017_10_30"
+const opGetPublicKeyConfig = "GetPublicKeyConfig2018_06_18"
 
 // GetPublicKeyConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetPublicKeyConfig operation. The "output" return
@@ -2614,12 +2614,12 @@ const opGetPublicKeyConfig = "GetPublicKeyConfig2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetPublicKeyConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetPublicKeyConfig
 func (c *CloudFront) GetPublicKeyConfigRequest(input *GetPublicKeyConfigInput) (req *request.Request, output *GetPublicKeyConfigOutput) {
 	op := &request.Operation{
 		Name:       opGetPublicKeyConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/public-key/{Id}/config",
+		HTTPPath:   "/2018-06-18/public-key/{Id}/config",
 	}
 
 	if input == nil {
@@ -2649,7 +2649,7 @@ func (c *CloudFront) GetPublicKeyConfigRequest(input *GetPublicKeyConfigInput) (
 //   * ErrCodeNoSuchPublicKey "NoSuchPublicKey"
 //   The specified public key doesn't exist.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetPublicKeyConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetPublicKeyConfig
 func (c *CloudFront) GetPublicKeyConfig(input *GetPublicKeyConfigInput) (*GetPublicKeyConfigOutput, error) {
 	req, out := c.GetPublicKeyConfigRequest(input)
 	return out, req.Send()
@@ -2671,7 +2671,7 @@ func (c *CloudFront) GetPublicKeyConfigWithContext(ctx aws.Context, input *GetPu
 	return out, req.Send()
 }
 
-const opGetStreamingDistribution = "GetStreamingDistribution2017_10_30"
+const opGetStreamingDistribution = "GetStreamingDistribution2018_06_18"
 
 // GetStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the GetStreamingDistribution operation. The "output" return
@@ -2696,12 +2696,12 @@ const opGetStreamingDistribution = "GetStreamingDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetStreamingDistribution
 func (c *CloudFront) GetStreamingDistributionRequest(input *GetStreamingDistributionInput) (req *request.Request, output *GetStreamingDistributionOutput) {
 	op := &request.Operation{
 		Name:       opGetStreamingDistribution,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/streaming-distribution/{Id}",
+		HTTPPath:   "/2018-06-18/streaming-distribution/{Id}",
 	}
 
 	if input == nil {
@@ -2732,7 +2732,7 @@ func (c *CloudFront) GetStreamingDistributionRequest(input *GetStreamingDistribu
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetStreamingDistribution
 func (c *CloudFront) GetStreamingDistribution(input *GetStreamingDistributionInput) (*GetStreamingDistributionOutput, error) {
 	req, out := c.GetStreamingDistributionRequest(input)
 	return out, req.Send()
@@ -2754,7 +2754,7 @@ func (c *CloudFront) GetStreamingDistributionWithContext(ctx aws.Context, input 
 	return out, req.Send()
 }
 
-const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2017_10_30"
+const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2018_06_18"
 
 // GetStreamingDistributionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the GetStreamingDistributionConfig operation. The "output" return
@@ -2779,12 +2779,12 @@ const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2017_10_
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetStreamingDistributionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetStreamingDistributionConfig
 func (c *CloudFront) GetStreamingDistributionConfigRequest(input *GetStreamingDistributionConfigInput) (req *request.Request, output *GetStreamingDistributionConfigOutput) {
 	op := &request.Operation{
 		Name:       opGetStreamingDistributionConfig,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/streaming-distribution/{Id}/config",
+		HTTPPath:   "/2018-06-18/streaming-distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -2814,7 +2814,7 @@ func (c *CloudFront) GetStreamingDistributionConfigRequest(input *GetStreamingDi
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/GetStreamingDistributionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/GetStreamingDistributionConfig
 func (c *CloudFront) GetStreamingDistributionConfig(input *GetStreamingDistributionConfigInput) (*GetStreamingDistributionConfigOutput, error) {
 	req, out := c.GetStreamingDistributionConfigRequest(input)
 	return out, req.Send()
@@ -2836,7 +2836,7 @@ func (c *CloudFront) GetStreamingDistributionConfigWithContext(ctx aws.Context, 
 	return out, req.Send()
 }
 
-const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdentities2017_10_30"
+const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdentities2018_06_18"
 
 // ListCloudFrontOriginAccessIdentitiesRequest generates a "aws/request.Request" representing the
 // client's request for the ListCloudFrontOriginAccessIdentities operation. The "output" return
@@ -2861,12 +2861,12 @@ const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdenti
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListCloudFrontOriginAccessIdentities
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListCloudFrontOriginAccessIdentities
 func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesRequest(input *ListCloudFrontOriginAccessIdentitiesInput) (req *request.Request, output *ListCloudFrontOriginAccessIdentitiesOutput) {
 	op := &request.Operation{
 		Name:       opListCloudFrontOriginAccessIdentities,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/origin-access-identity/cloudfront",
+		HTTPPath:   "/2018-06-18/origin-access-identity/cloudfront",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"CloudFrontOriginAccessIdentityList.NextMarker"},
@@ -2899,7 +2899,7 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesRequest(input *ListClou
 //   * ErrCodeInvalidArgument "InvalidArgument"
 //   The argument is invalid.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListCloudFrontOriginAccessIdentities
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListCloudFrontOriginAccessIdentities
 func (c *CloudFront) ListCloudFrontOriginAccessIdentities(input *ListCloudFrontOriginAccessIdentitiesInput) (*ListCloudFrontOriginAccessIdentitiesOutput, error) {
 	req, out := c.ListCloudFrontOriginAccessIdentitiesRequest(input)
 	return out, req.Send()
@@ -2971,7 +2971,7 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesPagesWithContext(ctx aw
 	return p.Err()
 }
 
-const opListDistributions = "ListDistributions2017_10_30"
+const opListDistributions = "ListDistributions2018_06_18"
 
 // ListDistributionsRequest generates a "aws/request.Request" representing the
 // client's request for the ListDistributions operation. The "output" return
@@ -2996,12 +2996,12 @@ const opListDistributions = "ListDistributions2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListDistributions
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListDistributions
 func (c *CloudFront) ListDistributionsRequest(input *ListDistributionsInput) (req *request.Request, output *ListDistributionsOutput) {
 	op := &request.Operation{
 		Name:       opListDistributions,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/distribution",
+		HTTPPath:   "/2018-06-18/distribution",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"DistributionList.NextMarker"},
@@ -3034,7 +3034,7 @@ func (c *CloudFront) ListDistributionsRequest(input *ListDistributionsInput) (re
 //   * ErrCodeInvalidArgument "InvalidArgument"
 //   The argument is invalid.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListDistributions
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListDistributions
 func (c *CloudFront) ListDistributions(input *ListDistributionsInput) (*ListDistributionsOutput, error) {
 	req, out := c.ListDistributionsRequest(input)
 	return out, req.Send()
@@ -3106,7 +3106,7 @@ func (c *CloudFront) ListDistributionsPagesWithContext(ctx aws.Context, input *L
 	return p.Err()
 }
 
-const opListDistributionsByWebACLId = "ListDistributionsByWebACLId2017_10_30"
+const opListDistributionsByWebACLId = "ListDistributionsByWebACLId2018_06_18"
 
 // ListDistributionsByWebACLIdRequest generates a "aws/request.Request" representing the
 // client's request for the ListDistributionsByWebACLId operation. The "output" return
@@ -3131,12 +3131,12 @@ const opListDistributionsByWebACLId = "ListDistributionsByWebACLId2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListDistributionsByWebACLId
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListDistributionsByWebACLId
 func (c *CloudFront) ListDistributionsByWebACLIdRequest(input *ListDistributionsByWebACLIdInput) (req *request.Request, output *ListDistributionsByWebACLIdOutput) {
 	op := &request.Operation{
 		Name:       opListDistributionsByWebACLId,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/distributionsByWebACLId/{WebACLId}",
+		HTTPPath:   "/2018-06-18/distributionsByWebACLId/{WebACLId}",
 	}
 
 	if input == nil {
@@ -3165,7 +3165,7 @@ func (c *CloudFront) ListDistributionsByWebACLIdRequest(input *ListDistributions
 //
 //   * ErrCodeInvalidWebACLId "InvalidWebACLId"
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListDistributionsByWebACLId
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListDistributionsByWebACLId
 func (c *CloudFront) ListDistributionsByWebACLId(input *ListDistributionsByWebACLIdInput) (*ListDistributionsByWebACLIdOutput, error) {
 	req, out := c.ListDistributionsByWebACLIdRequest(input)
 	return out, req.Send()
@@ -3187,7 +3187,7 @@ func (c *CloudFront) ListDistributionsByWebACLIdWithContext(ctx aws.Context, inp
 	return out, req.Send()
 }
 
-const opListFieldLevelEncryptionConfigs = "ListFieldLevelEncryptionConfigs2017_10_30"
+const opListFieldLevelEncryptionConfigs = "ListFieldLevelEncryptionConfigs2018_06_18"
 
 // ListFieldLevelEncryptionConfigsRequest generates a "aws/request.Request" representing the
 // client's request for the ListFieldLevelEncryptionConfigs operation. The "output" return
@@ -3212,12 +3212,12 @@ const opListFieldLevelEncryptionConfigs = "ListFieldLevelEncryptionConfigs2017_1
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListFieldLevelEncryptionConfigs
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListFieldLevelEncryptionConfigs
 func (c *CloudFront) ListFieldLevelEncryptionConfigsRequest(input *ListFieldLevelEncryptionConfigsInput) (req *request.Request, output *ListFieldLevelEncryptionConfigsOutput) {
 	op := &request.Operation{
 		Name:       opListFieldLevelEncryptionConfigs,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/field-level-encryption",
+		HTTPPath:   "/2018-06-18/field-level-encryption",
 	}
 
 	if input == nil {
@@ -3245,7 +3245,7 @@ func (c *CloudFront) ListFieldLevelEncryptionConfigsRequest(input *ListFieldLeve
 //   * ErrCodeInvalidArgument "InvalidArgument"
 //   The argument is invalid.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListFieldLevelEncryptionConfigs
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListFieldLevelEncryptionConfigs
 func (c *CloudFront) ListFieldLevelEncryptionConfigs(input *ListFieldLevelEncryptionConfigsInput) (*ListFieldLevelEncryptionConfigsOutput, error) {
 	req, out := c.ListFieldLevelEncryptionConfigsRequest(input)
 	return out, req.Send()
@@ -3267,7 +3267,7 @@ func (c *CloudFront) ListFieldLevelEncryptionConfigsWithContext(ctx aws.Context,
 	return out, req.Send()
 }
 
-const opListFieldLevelEncryptionProfiles = "ListFieldLevelEncryptionProfiles2017_10_30"
+const opListFieldLevelEncryptionProfiles = "ListFieldLevelEncryptionProfiles2018_06_18"
 
 // ListFieldLevelEncryptionProfilesRequest generates a "aws/request.Request" representing the
 // client's request for the ListFieldLevelEncryptionProfiles operation. The "output" return
@@ -3292,12 +3292,12 @@ const opListFieldLevelEncryptionProfiles = "ListFieldLevelEncryptionProfiles2017
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListFieldLevelEncryptionProfiles
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListFieldLevelEncryptionProfiles
 func (c *CloudFront) ListFieldLevelEncryptionProfilesRequest(input *ListFieldLevelEncryptionProfilesInput) (req *request.Request, output *ListFieldLevelEncryptionProfilesOutput) {
 	op := &request.Operation{
 		Name:       opListFieldLevelEncryptionProfiles,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/field-level-encryption-profile",
+		HTTPPath:   "/2018-06-18/field-level-encryption-profile",
 	}
 
 	if input == nil {
@@ -3325,7 +3325,7 @@ func (c *CloudFront) ListFieldLevelEncryptionProfilesRequest(input *ListFieldLev
 //   * ErrCodeInvalidArgument "InvalidArgument"
 //   The argument is invalid.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListFieldLevelEncryptionProfiles
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListFieldLevelEncryptionProfiles
 func (c *CloudFront) ListFieldLevelEncryptionProfiles(input *ListFieldLevelEncryptionProfilesInput) (*ListFieldLevelEncryptionProfilesOutput, error) {
 	req, out := c.ListFieldLevelEncryptionProfilesRequest(input)
 	return out, req.Send()
@@ -3347,7 +3347,7 @@ func (c *CloudFront) ListFieldLevelEncryptionProfilesWithContext(ctx aws.Context
 	return out, req.Send()
 }
 
-const opListInvalidations = "ListInvalidations2017_10_30"
+const opListInvalidations = "ListInvalidations2018_06_18"
 
 // ListInvalidationsRequest generates a "aws/request.Request" representing the
 // client's request for the ListInvalidations operation. The "output" return
@@ -3372,12 +3372,12 @@ const opListInvalidations = "ListInvalidations2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListInvalidations
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListInvalidations
 func (c *CloudFront) ListInvalidationsRequest(input *ListInvalidationsInput) (req *request.Request, output *ListInvalidationsOutput) {
 	op := &request.Operation{
 		Name:       opListInvalidations,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/distribution/{DistributionId}/invalidation",
+		HTTPPath:   "/2018-06-18/distribution/{DistributionId}/invalidation",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"InvalidationList.NextMarker"},
@@ -3416,7 +3416,7 @@ func (c *CloudFront) ListInvalidationsRequest(input *ListInvalidationsInput) (re
 //   * ErrCodeAccessDenied "AccessDenied"
 //   Access denied.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListInvalidations
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListInvalidations
 func (c *CloudFront) ListInvalidations(input *ListInvalidationsInput) (*ListInvalidationsOutput, error) {
 	req, out := c.ListInvalidationsRequest(input)
 	return out, req.Send()
@@ -3488,7 +3488,7 @@ func (c *CloudFront) ListInvalidationsPagesWithContext(ctx aws.Context, input *L
 	return p.Err()
 }
 
-const opListPublicKeys = "ListPublicKeys2017_10_30"
+const opListPublicKeys = "ListPublicKeys2018_06_18"
 
 // ListPublicKeysRequest generates a "aws/request.Request" representing the
 // client's request for the ListPublicKeys operation. The "output" return
@@ -3513,12 +3513,12 @@ const opListPublicKeys = "ListPublicKeys2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListPublicKeys
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListPublicKeys
 func (c *CloudFront) ListPublicKeysRequest(input *ListPublicKeysInput) (req *request.Request, output *ListPublicKeysOutput) {
 	op := &request.Operation{
 		Name:       opListPublicKeys,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/public-key",
+		HTTPPath:   "/2018-06-18/public-key",
 	}
 
 	if input == nil {
@@ -3545,7 +3545,7 @@ func (c *CloudFront) ListPublicKeysRequest(input *ListPublicKeysInput) (req *req
 //   * ErrCodeInvalidArgument "InvalidArgument"
 //   The argument is invalid.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListPublicKeys
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListPublicKeys
 func (c *CloudFront) ListPublicKeys(input *ListPublicKeysInput) (*ListPublicKeysOutput, error) {
 	req, out := c.ListPublicKeysRequest(input)
 	return out, req.Send()
@@ -3567,7 +3567,7 @@ func (c *CloudFront) ListPublicKeysWithContext(ctx aws.Context, input *ListPubli
 	return out, req.Send()
 }
 
-const opListStreamingDistributions = "ListStreamingDistributions2017_10_30"
+const opListStreamingDistributions = "ListStreamingDistributions2018_06_18"
 
 // ListStreamingDistributionsRequest generates a "aws/request.Request" representing the
 // client's request for the ListStreamingDistributions operation. The "output" return
@@ -3592,12 +3592,12 @@ const opListStreamingDistributions = "ListStreamingDistributions2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListStreamingDistributions
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListStreamingDistributions
 func (c *CloudFront) ListStreamingDistributionsRequest(input *ListStreamingDistributionsInput) (req *request.Request, output *ListStreamingDistributionsOutput) {
 	op := &request.Operation{
 		Name:       opListStreamingDistributions,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/streaming-distribution",
+		HTTPPath:   "/2018-06-18/streaming-distribution",
 		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"StreamingDistributionList.NextMarker"},
@@ -3630,7 +3630,7 @@ func (c *CloudFront) ListStreamingDistributionsRequest(input *ListStreamingDistr
 //   * ErrCodeInvalidArgument "InvalidArgument"
 //   The argument is invalid.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListStreamingDistributions
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListStreamingDistributions
 func (c *CloudFront) ListStreamingDistributions(input *ListStreamingDistributionsInput) (*ListStreamingDistributionsOutput, error) {
 	req, out := c.ListStreamingDistributionsRequest(input)
 	return out, req.Send()
@@ -3702,7 +3702,7 @@ func (c *CloudFront) ListStreamingDistributionsPagesWithContext(ctx aws.Context,
 	return p.Err()
 }
 
-const opListTagsForResource = "ListTagsForResource2017_10_30"
+const opListTagsForResource = "ListTagsForResource2018_06_18"
 
 // ListTagsForResourceRequest generates a "aws/request.Request" representing the
 // client's request for the ListTagsForResource operation. The "output" return
@@ -3727,12 +3727,12 @@ const opListTagsForResource = "ListTagsForResource2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListTagsForResource
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListTagsForResource
 func (c *CloudFront) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
 	op := &request.Operation{
 		Name:       opListTagsForResource,
 		HTTPMethod: "GET",
-		HTTPPath:   "/2017-10-30/tagging",
+		HTTPPath:   "/2018-06-18/tagging",
 	}
 
 	if input == nil {
@@ -3766,7 +3766,7 @@ func (c *CloudFront) ListTagsForResourceRequest(input *ListTagsForResourceInput)
 //
 //   * ErrCodeNoSuchResource "NoSuchResource"
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/ListTagsForResource
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/ListTagsForResource
 func (c *CloudFront) ListTagsForResource(input *ListTagsForResourceInput) (*ListTagsForResourceOutput, error) {
 	req, out := c.ListTagsForResourceRequest(input)
 	return out, req.Send()
@@ -3788,7 +3788,7 @@ func (c *CloudFront) ListTagsForResourceWithContext(ctx aws.Context, input *List
 	return out, req.Send()
 }
 
-const opTagResource = "TagResource2017_10_30"
+const opTagResource = "TagResource2018_06_18"
 
 // TagResourceRequest generates a "aws/request.Request" representing the
 // client's request for the TagResource operation. The "output" return
@@ -3813,12 +3813,12 @@ const opTagResource = "TagResource2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/TagResource
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/TagResource
 func (c *CloudFront) TagResourceRequest(input *TagResourceInput) (req *request.Request, output *TagResourceOutput) {
 	op := &request.Operation{
 		Name:       opTagResource,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/tagging?Operation=Tag",
+		HTTPPath:   "/2018-06-18/tagging?Operation=Tag",
 	}
 
 	if input == nil {
@@ -3854,7 +3854,7 @@ func (c *CloudFront) TagResourceRequest(input *TagResourceInput) (req *request.R
 //
 //   * ErrCodeNoSuchResource "NoSuchResource"
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/TagResource
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/TagResource
 func (c *CloudFront) TagResource(input *TagResourceInput) (*TagResourceOutput, error) {
 	req, out := c.TagResourceRequest(input)
 	return out, req.Send()
@@ -3876,7 +3876,7 @@ func (c *CloudFront) TagResourceWithContext(ctx aws.Context, input *TagResourceI
 	return out, req.Send()
 }
 
-const opUntagResource = "UntagResource2017_10_30"
+const opUntagResource = "UntagResource2018_06_18"
 
 // UntagResourceRequest generates a "aws/request.Request" representing the
 // client's request for the UntagResource operation. The "output" return
@@ -3901,12 +3901,12 @@ const opUntagResource = "UntagResource2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UntagResource
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UntagResource
 func (c *CloudFront) UntagResourceRequest(input *UntagResourceInput) (req *request.Request, output *UntagResourceOutput) {
 	op := &request.Operation{
 		Name:       opUntagResource,
 		HTTPMethod: "POST",
-		HTTPPath:   "/2017-10-30/tagging?Operation=Untag",
+		HTTPPath:   "/2018-06-18/tagging?Operation=Untag",
 	}
 
 	if input == nil {
@@ -3942,7 +3942,7 @@ func (c *CloudFront) UntagResourceRequest(input *UntagResourceInput) (req *reque
 //
 //   * ErrCodeNoSuchResource "NoSuchResource"
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UntagResource
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UntagResource
 func (c *CloudFront) UntagResource(input *UntagResourceInput) (*UntagResourceOutput, error) {
 	req, out := c.UntagResourceRequest(input)
 	return out, req.Send()
@@ -3964,7 +3964,7 @@ func (c *CloudFront) UntagResourceWithContext(ctx aws.Context, input *UntagResou
 	return out, req.Send()
 }
 
-const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIdentity2017_10_30"
+const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIdentity2018_06_18"
 
 // UpdateCloudFrontOriginAccessIdentityRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateCloudFrontOriginAccessIdentity operation. The "output" return
@@ -3989,12 +3989,12 @@ const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIden
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateCloudFrontOriginAccessIdentity
 func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityRequest(input *UpdateCloudFrontOriginAccessIdentityInput) (req *request.Request, output *UpdateCloudFrontOriginAccessIdentityOutput) {
 	op := &request.Operation{
 		Name:       opUpdateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2017-10-30/origin-access-identity/cloudfront/{Id}/config",
+		HTTPPath:   "/2018-06-18/origin-access-identity/cloudfront/{Id}/config",
 	}
 
 	if input == nil {
@@ -4044,7 +4044,7 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityRequest(input *UpdateCl
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
 //   The value of Quantity and the size of Items don't match.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateCloudFrontOriginAccessIdentity
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateCloudFrontOriginAccessIdentity
 func (c *CloudFront) UpdateCloudFrontOriginAccessIdentity(input *UpdateCloudFrontOriginAccessIdentityInput) (*UpdateCloudFrontOriginAccessIdentityOutput, error) {
 	req, out := c.UpdateCloudFrontOriginAccessIdentityRequest(input)
 	return out, req.Send()
@@ -4066,7 +4066,7 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityWithContext(ctx aws.Con
 	return out, req.Send()
 }
 
-const opUpdateDistribution = "UpdateDistribution2017_10_30"
+const opUpdateDistribution = "UpdateDistribution2018_06_18"
 
 // UpdateDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateDistribution operation. The "output" return
@@ -4091,12 +4091,12 @@ const opUpdateDistribution = "UpdateDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateDistribution
 func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (req *request.Request, output *UpdateDistributionOutput) {
 	op := &request.Operation{
 		Name:       opUpdateDistribution,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2017-10-30/distribution/{Id}/config",
+		HTTPPath:   "/2018-06-18/distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -4127,6 +4127,7 @@ func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (
 // Update the XML document that was returned in the response to your GetDistributionConfig
 // request to include the desired changes. You can't change the value of CallerReference.
 // If you try to change this value, CloudFront returns an IllegalUpdate error.
+// Note that you must strip out the ETag parameter that is returned.
 //
 // The new configuration replaces the existing configuration; the values that
 // you specify in an UpdateDistribution request are not merged into the existing
@@ -4295,7 +4296,7 @@ func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (
 //   The maximum number of distributions have been associated with the specified
 //   configuration for field-level encryption.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateDistribution
 func (c *CloudFront) UpdateDistribution(input *UpdateDistributionInput) (*UpdateDistributionOutput, error) {
 	req, out := c.UpdateDistributionRequest(input)
 	return out, req.Send()
@@ -4317,7 +4318,7 @@ func (c *CloudFront) UpdateDistributionWithContext(ctx aws.Context, input *Updat
 	return out, req.Send()
 }
 
-const opUpdateFieldLevelEncryptionConfig = "UpdateFieldLevelEncryptionConfig2017_10_30"
+const opUpdateFieldLevelEncryptionConfig = "UpdateFieldLevelEncryptionConfig2018_06_18"
 
 // UpdateFieldLevelEncryptionConfigRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateFieldLevelEncryptionConfig operation. The "output" return
@@ -4342,12 +4343,12 @@ const opUpdateFieldLevelEncryptionConfig = "UpdateFieldLevelEncryptionConfig2017
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateFieldLevelEncryptionConfig
 func (c *CloudFront) UpdateFieldLevelEncryptionConfigRequest(input *UpdateFieldLevelEncryptionConfigInput) (req *request.Request, output *UpdateFieldLevelEncryptionConfigOutput) {
 	op := &request.Operation{
 		Name:       opUpdateFieldLevelEncryptionConfig,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2017-10-30/field-level-encryption/{Id}/config",
+		HTTPPath:   "/2018-06-18/field-level-encryption/{Id}/config",
 	}
 
 	if input == nil {
@@ -4407,7 +4408,7 @@ func (c *CloudFront) UpdateFieldLevelEncryptionConfigRequest(input *UpdateFieldL
 //   * ErrCodeQueryArgProfileEmpty "QueryArgProfileEmpty"
 //   No profile specified for the field-level encryption query argument.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateFieldLevelEncryptionConfig
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateFieldLevelEncryptionConfig
 func (c *CloudFront) UpdateFieldLevelEncryptionConfig(input *UpdateFieldLevelEncryptionConfigInput) (*UpdateFieldLevelEncryptionConfigOutput, error) {
 	req, out := c.UpdateFieldLevelEncryptionConfigRequest(input)
 	return out, req.Send()
@@ -4429,7 +4430,7 @@ func (c *CloudFront) UpdateFieldLevelEncryptionConfigWithContext(ctx aws.Context
 	return out, req.Send()
 }
 
-const opUpdateFieldLevelEncryptionProfile = "UpdateFieldLevelEncryptionProfile2017_10_30"
+const opUpdateFieldLevelEncryptionProfile = "UpdateFieldLevelEncryptionProfile2018_06_18"
 
 // UpdateFieldLevelEncryptionProfileRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateFieldLevelEncryptionProfile operation. The "output" return
@@ -4454,12 +4455,12 @@ const opUpdateFieldLevelEncryptionProfile = "UpdateFieldLevelEncryptionProfile20
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateFieldLevelEncryptionProfile
 func (c *CloudFront) UpdateFieldLevelEncryptionProfileRequest(input *UpdateFieldLevelEncryptionProfileInput) (req *request.Request, output *UpdateFieldLevelEncryptionProfileOutput) {
 	op := &request.Operation{
 		Name:       opUpdateFieldLevelEncryptionProfile,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2017-10-30/field-level-encryption-profile/{Id}/config",
+		HTTPPath:   "/2018-06-18/field-level-encryption-profile/{Id}/config",
 	}
 
 	if input == nil {
@@ -4522,7 +4523,7 @@ func (c *CloudFront) UpdateFieldLevelEncryptionProfileRequest(input *UpdateField
 //   The maximum number of field patterns for field-level encryption have been
 //   created.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateFieldLevelEncryptionProfile
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateFieldLevelEncryptionProfile
 func (c *CloudFront) UpdateFieldLevelEncryptionProfile(input *UpdateFieldLevelEncryptionProfileInput) (*UpdateFieldLevelEncryptionProfileOutput, error) {
 	req, out := c.UpdateFieldLevelEncryptionProfileRequest(input)
 	return out, req.Send()
@@ -4544,7 +4545,7 @@ func (c *CloudFront) UpdateFieldLevelEncryptionProfileWithContext(ctx aws.Contex
 	return out, req.Send()
 }
 
-const opUpdatePublicKey = "UpdatePublicKey2017_10_30"
+const opUpdatePublicKey = "UpdatePublicKey2018_06_18"
 
 // UpdatePublicKeyRequest generates a "aws/request.Request" representing the
 // client's request for the UpdatePublicKey operation. The "output" return
@@ -4569,12 +4570,12 @@ const opUpdatePublicKey = "UpdatePublicKey2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdatePublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdatePublicKey
 func (c *CloudFront) UpdatePublicKeyRequest(input *UpdatePublicKeyInput) (req *request.Request, output *UpdatePublicKeyOutput) {
 	op := &request.Operation{
 		Name:       opUpdatePublicKey,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2017-10-30/public-key/{Id}/config",
+		HTTPPath:   "/2018-06-18/public-key/{Id}/config",
 	}
 
 	if input == nil {
@@ -4621,7 +4622,7 @@ func (c *CloudFront) UpdatePublicKeyRequest(input *UpdatePublicKeyInput) (req *r
 //   The precondition given in one or more of the request-header fields evaluated
 //   to false.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdatePublicKey
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdatePublicKey
 func (c *CloudFront) UpdatePublicKey(input *UpdatePublicKeyInput) (*UpdatePublicKeyOutput, error) {
 	req, out := c.UpdatePublicKeyRequest(input)
 	return out, req.Send()
@@ -4643,7 +4644,7 @@ func (c *CloudFront) UpdatePublicKeyWithContext(ctx aws.Context, input *UpdatePu
 	return out, req.Send()
 }
 
-const opUpdateStreamingDistribution = "UpdateStreamingDistribution2017_10_30"
+const opUpdateStreamingDistribution = "UpdateStreamingDistribution2018_06_18"
 
 // UpdateStreamingDistributionRequest generates a "aws/request.Request" representing the
 // client's request for the UpdateStreamingDistribution operation. The "output" return
@@ -4668,12 +4669,12 @@ const opUpdateStreamingDistribution = "UpdateStreamingDistribution2017_10_30"
 //        fmt.Println(resp)
 //    }
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateStreamingDistribution
 func (c *CloudFront) UpdateStreamingDistributionRequest(input *UpdateStreamingDistributionInput) (req *request.Request, output *UpdateStreamingDistributionOutput) {
 	op := &request.Operation{
 		Name:       opUpdateStreamingDistribution,
 		HTTPMethod: "PUT",
-		HTTPPath:   "/2017-10-30/streaming-distribution/{Id}/config",
+		HTTPPath:   "/2018-06-18/streaming-distribution/{Id}/config",
 	}
 
 	if input == nil {
@@ -4736,7 +4737,7 @@ func (c *CloudFront) UpdateStreamingDistributionRequest(input *UpdateStreamingDi
 //   * ErrCodeInconsistentQuantities "InconsistentQuantities"
 //   The value of Quantity and the size of Items don't match.
 //
-// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30/UpdateStreamingDistribution
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18/UpdateStreamingDistribution
 func (c *CloudFront) UpdateStreamingDistribution(input *UpdateStreamingDistributionInput) (*UpdateStreamingDistributionOutput, error) {
 	req, out := c.UpdateStreamingDistributionRequest(input)
 	return out, req.Send()
@@ -5030,6 +5031,9 @@ type CacheBehavior struct {
 	// in the Amazon CloudFront Developer Guide.
 	DefaultTTL *int64 `type:"long"`
 
+	// The value of ID for the field-level encryption configuration that you want
+	// CloudFront to use for encrypting specific fields of data for a cache behavior
+	// or for the default cache behavior in your distribution.
 	FieldLevelEncryptionId *string `type:"string"`
 
 	// A complex type that specifies how CloudFront handles query strings and cookies.
@@ -5091,7 +5095,7 @@ type CacheBehavior struct {
 
 	// The value of ID for the origin that you want CloudFront to route requests
 	// to when a request matches the path pattern either for a cache behavior or
-	// for the default cache behavior.
+	// for the default cache behavior in your distribution.
 	//
 	// TargetOriginId is a required field
 	TargetOriginId *string `type:"string" required:"true"`
@@ -5719,7 +5723,7 @@ type CreateCloudFrontOriginAccessIdentityInput struct {
 	// The current configuration information for the identity.
 	//
 	// CloudFrontOriginAccessIdentityConfig is a required field
-	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -5806,7 +5810,7 @@ type CreateDistributionInput struct {
 	// The distribution's configuration information.
 	//
 	// DistributionConfig is a required field
-	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -5893,7 +5897,7 @@ type CreateDistributionWithTagsInput struct {
 	// The distribution's configuration information.
 	//
 	// DistributionConfigWithTags is a required field
-	DistributionConfigWithTags *DistributionConfigWithTags `locationName:"DistributionConfigWithTags" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	DistributionConfigWithTags *DistributionConfigWithTags `locationName:"DistributionConfigWithTags" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -5979,7 +5983,7 @@ type CreateFieldLevelEncryptionConfigInput struct {
 	// The request to create a new field-level encryption configuration.
 	//
 	// FieldLevelEncryptionConfig is a required field
-	FieldLevelEncryptionConfig *FieldLevelEncryptionConfig `locationName:"FieldLevelEncryptionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	FieldLevelEncryptionConfig *FieldLevelEncryptionConfig `locationName:"FieldLevelEncryptionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -6065,7 +6069,7 @@ type CreateFieldLevelEncryptionProfileInput struct {
 	// The request to create a field-level encryption profile.
 	//
 	// FieldLevelEncryptionProfileConfig is a required field
-	FieldLevelEncryptionProfileConfig *FieldLevelEncryptionProfileConfig `locationName:"FieldLevelEncryptionProfileConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	FieldLevelEncryptionProfileConfig *FieldLevelEncryptionProfileConfig `locationName:"FieldLevelEncryptionProfileConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -6156,7 +6160,7 @@ type CreateInvalidationInput struct {
 	// The batch information for the invalidation.
 	//
 	// InvalidationBatch is a required field
-	InvalidationBatch *InvalidationBatch `locationName:"InvalidationBatch" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	InvalidationBatch *InvalidationBatch `locationName:"InvalidationBatch" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -6242,7 +6246,7 @@ type CreatePublicKeyInput struct {
 	// The request to add a public key to CloudFront.
 	//
 	// PublicKeyConfig is a required field
-	PublicKeyConfig *PublicKeyConfig `locationName:"PublicKeyConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	PublicKeyConfig *PublicKeyConfig `locationName:"PublicKeyConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -6328,7 +6332,7 @@ type CreateStreamingDistributionInput struct {
 	// The streaming distribution's configuration information.
 	//
 	// StreamingDistributionConfig is a required field
-	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -6415,7 +6419,7 @@ type CreateStreamingDistributionWithTagsInput struct {
 	// The streaming distribution's configuration information.
 	//
 	// StreamingDistributionConfigWithTags is a required field
-	StreamingDistributionConfigWithTags *StreamingDistributionConfigWithTags `locationName:"StreamingDistributionConfigWithTags" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	StreamingDistributionConfigWithTags *StreamingDistributionConfigWithTags `locationName:"StreamingDistributionConfigWithTags" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -6752,7 +6756,7 @@ func (s *CustomHeaders) SetQuantity(v int64) *CustomHeaders {
 	return s
 }
 
-// A customer origin.
+// A customer origin or an Amazon S3 bucket configured as a website endpoint.
 type CustomOriginConfig struct {
 	_ struct{} `type:"structure"`
 
@@ -6902,6 +6906,9 @@ type DefaultCacheBehavior struct {
 	// in the Amazon CloudFront Developer Guide.
 	DefaultTTL *int64 `type:"long"`
 
+	// The value of ID for the field-level encryption configuration that you want
+	// CloudFront to use for encrypting specific fields of data for a cache behavior
+	// or for the default cache behavior in your distribution.
 	FieldLevelEncryptionId *string `type:"string"`
 
 	// A complex type that specifies how CloudFront handles query strings and cookies.
@@ -6937,7 +6944,7 @@ type DefaultCacheBehavior struct {
 
 	// The value of ID for the origin that you want CloudFront to route requests
 	// to when a request matches the path pattern either for a cache behavior or
-	// for the default cache behavior.
+	// for the default cache behavior in your distribution.
 	//
 	// TargetOriginId is a required field
 	TargetOriginId *string `type:"string" required:"true"`
@@ -7727,9 +7734,6 @@ type DistributionConfig struct {
 
 	// From this field, you can enable or disable the selected distribution.
 	//
-	// If you specify false for Enabled but you specify values for Bucket and Prefix,
-	// the values are automatically deleted.
-	//
 	// Enabled is a required field
 	Enabled *bool `type:"boolean" required:"true"`
 
@@ -7804,8 +7808,10 @@ type DistributionConfig struct {
 	// For more information about price classes, see Choosing the Price Class for
 	// a CloudFront Distribution (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PriceClass.html)
 	// in the Amazon CloudFront Developer Guide. For information about CloudFront
-	// pricing, including how price classes map to CloudFront regions, see Amazon
-	// CloudFront Pricing (https://aws.amazon.com/cloudfront/pricing/).
+	// pricing, including how price classes (such as Price Class 100) map to CloudFront
+	// regions, see Amazon CloudFront Pricing (https://aws.amazon.com/cloudfront/pricing/).
+	// For price class information, scroll down to see the table at the bottom of
+	// the page.
 	PriceClass *string `type:"string" enum:"PriceClass"`
 
 	// A complex type that identifies ways in which you want to restrict distribution
@@ -10802,6 +10808,11 @@ type LambdaFunctionAssociation struct {
 	// EventType is a required field
 	EventType *string `type:"string" required:"true" enum:"EventType"`
 
+	// A flag that allows a Lambda function to have read access to the body content.
+	// For more information, see Accessing Body Content (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/)
+	// in the Amazon CloudFront Developer Guide.
+	IncludeBody *bool `type:"boolean"`
+
 	// The ARN of the Lambda function. You must specify the ARN of a function version;
 	// you can't specify a Lambda alias or $LATEST.
 	//
@@ -10838,6 +10849,12 @@ func (s *LambdaFunctionAssociation) Validate() error {
 // SetEventType sets the EventType field's value.
 func (s *LambdaFunctionAssociation) SetEventType(v string) *LambdaFunctionAssociation {
 	s.EventType = &v
+	return s
+}
+
+// SetIncludeBody sets the IncludeBody field's value.
+func (s *LambdaFunctionAssociation) SetIncludeBody(v bool) *LambdaFunctionAssociation {
+	s.IncludeBody = &v
 	return s
 }
 
@@ -11634,6 +11651,8 @@ type Origin struct {
 
 	// Amazon S3 origins: The DNS name of the Amazon S3 bucket from which you want
 	// CloudFront to get objects for this origin, for example, myawsbucket.s3.amazonaws.com.
+	// If you set up your bucket to be configured as a website endpoint, enter the
+	// Amazon S3 static website hosting endpoint for the bucket.
 	//
 	// Constraints for Amazon S3 origins:
 	//
@@ -13678,7 +13697,7 @@ type TagResourceInput struct {
 	// A complex type that contains zero or more Tag elements.
 	//
 	// Tags is a required field
-	Tags *Tags `locationName:"Tags" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	Tags *Tags `locationName:"Tags" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -13875,7 +13894,7 @@ type UntagResourceInput struct {
 	// A complex type that contains zero or more Tag key elements.
 	//
 	// TagKeys is a required field
-	TagKeys *TagKeys `locationName:"TagKeys" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	TagKeys *TagKeys `locationName:"TagKeys" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -13937,7 +13956,7 @@ type UpdateCloudFrontOriginAccessIdentityInput struct {
 	// The identity's configuration information.
 	//
 	// CloudFrontOriginAccessIdentityConfig is a required field
-	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	CloudFrontOriginAccessIdentityConfig *OriginAccessIdentityConfig `locationName:"CloudFrontOriginAccessIdentityConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 
 	// The identity's id.
 	//
@@ -14038,7 +14057,7 @@ type UpdateDistributionInput struct {
 	// The distribution's configuration information.
 	//
 	// DistributionConfig is a required field
-	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	DistributionConfig *DistributionConfig `locationName:"DistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 
 	// The distribution's id.
 	//
@@ -14138,7 +14157,7 @@ type UpdateFieldLevelEncryptionConfigInput struct {
 	// Request to update a field-level encryption configuration.
 	//
 	// FieldLevelEncryptionConfig is a required field
-	FieldLevelEncryptionConfig *FieldLevelEncryptionConfig `locationName:"FieldLevelEncryptionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	FieldLevelEncryptionConfig *FieldLevelEncryptionConfig `locationName:"FieldLevelEncryptionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 
 	// The ID of the configuration you want to update.
 	//
@@ -14238,7 +14257,7 @@ type UpdateFieldLevelEncryptionProfileInput struct {
 	// Request to update a field-level encryption profile.
 	//
 	// FieldLevelEncryptionProfileConfig is a required field
-	FieldLevelEncryptionProfileConfig *FieldLevelEncryptionProfileConfig `locationName:"FieldLevelEncryptionProfileConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	FieldLevelEncryptionProfileConfig *FieldLevelEncryptionProfileConfig `locationName:"FieldLevelEncryptionProfileConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 
 	// The ID of the field-level encryption profile request.
 	//
@@ -14346,7 +14365,7 @@ type UpdatePublicKeyInput struct {
 	// Request to update public key information.
 	//
 	// PublicKeyConfig is a required field
-	PublicKeyConfig *PublicKeyConfig `locationName:"PublicKeyConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	PublicKeyConfig *PublicKeyConfig `locationName:"PublicKeyConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation
@@ -14446,7 +14465,7 @@ type UpdateStreamingDistributionInput struct {
 	// The streaming distribution's configuration information.
 	//
 	// StreamingDistributionConfig is a required field
-	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2017-10-30/"`
+	StreamingDistributionConfig *StreamingDistributionConfig `locationName:"StreamingDistributionConfig" type:"structure" required:"true" xmlURI:"http://cloudfront.amazonaws.com/doc/2018-06-18/"`
 }
 
 // String returns the string representation

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/doc.go
@@ -8,7 +8,7 @@
 // errors. For detailed information about CloudFront features, see the Amazon
 // CloudFront Developer Guide.
 //
-// See https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2017-10-30 for more information on this service.
+// See https://docs.aws.amazon.com/goto/WebAPI/cloudfront-2018-06-18 for more information on this service.
 //
 // See cloudfront package documentation for more information.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/cloudfront/

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudfront/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudfront/service.go
@@ -60,7 +60,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
 				Endpoint:      endpoint,
-				APIVersion:    "2017-10-30",
+				APIVersion:    "2018-06-18",
 			},
 			handlers,
 		),

--- a/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elasticsearchservice/api.go
@@ -1048,6 +1048,345 @@ func (c *ElasticsearchService) DescribeReservedElasticsearchInstancesPagesWithCo
 	return p.Err()
 }
 
+const opGetCompatibleElasticsearchVersions = "GetCompatibleElasticsearchVersions"
+
+// GetCompatibleElasticsearchVersionsRequest generates a "aws/request.Request" representing the
+// client's request for the GetCompatibleElasticsearchVersions operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetCompatibleElasticsearchVersions for more information on using the GetCompatibleElasticsearchVersions
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetCompatibleElasticsearchVersionsRequest method.
+//    req, resp := client.GetCompatibleElasticsearchVersionsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *ElasticsearchService) GetCompatibleElasticsearchVersionsRequest(input *GetCompatibleElasticsearchVersionsInput) (req *request.Request, output *GetCompatibleElasticsearchVersionsOutput) {
+	op := &request.Operation{
+		Name:       opGetCompatibleElasticsearchVersions,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/compatibleVersions",
+	}
+
+	if input == nil {
+		input = &GetCompatibleElasticsearchVersionsInput{}
+	}
+
+	output = &GetCompatibleElasticsearchVersionsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetCompatibleElasticsearchVersions API operation for Amazon Elasticsearch Service.
+//
+// Returns a list of upgrade compatible Elastisearch versions. You can optionally
+// pass a DomainName to get all upgrade compatible Elasticsearch versions for
+// that specific domain.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation GetCompatibleElasticsearchVersions for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBaseException "BaseException"
+//   An error occurred while processing the request.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeDisabledOperationException "DisabledOperationException"
+//   An error occured because the client wanted to access a not supported operation.
+//   Gives http status code of 409.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+func (c *ElasticsearchService) GetCompatibleElasticsearchVersions(input *GetCompatibleElasticsearchVersionsInput) (*GetCompatibleElasticsearchVersionsOutput, error) {
+	req, out := c.GetCompatibleElasticsearchVersionsRequest(input)
+	return out, req.Send()
+}
+
+// GetCompatibleElasticsearchVersionsWithContext is the same as GetCompatibleElasticsearchVersions with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetCompatibleElasticsearchVersions for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) GetCompatibleElasticsearchVersionsWithContext(ctx aws.Context, input *GetCompatibleElasticsearchVersionsInput, opts ...request.Option) (*GetCompatibleElasticsearchVersionsOutput, error) {
+	req, out := c.GetCompatibleElasticsearchVersionsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opGetUpgradeHistory = "GetUpgradeHistory"
+
+// GetUpgradeHistoryRequest generates a "aws/request.Request" representing the
+// client's request for the GetUpgradeHistory operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetUpgradeHistory for more information on using the GetUpgradeHistory
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetUpgradeHistoryRequest method.
+//    req, resp := client.GetUpgradeHistoryRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *ElasticsearchService) GetUpgradeHistoryRequest(input *GetUpgradeHistoryInput) (req *request.Request, output *GetUpgradeHistoryOutput) {
+	op := &request.Operation{
+		Name:       opGetUpgradeHistory,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/upgradeDomain/{DomainName}/history",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &GetUpgradeHistoryInput{}
+	}
+
+	output = &GetUpgradeHistoryOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetUpgradeHistory API operation for Amazon Elasticsearch Service.
+//
+// Retrieves the complete history of the last 10 upgrades that were performed
+// on the domain.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation GetUpgradeHistory for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBaseException "BaseException"
+//   An error occurred while processing the request.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeDisabledOperationException "DisabledOperationException"
+//   An error occured because the client wanted to access a not supported operation.
+//   Gives http status code of 409.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+func (c *ElasticsearchService) GetUpgradeHistory(input *GetUpgradeHistoryInput) (*GetUpgradeHistoryOutput, error) {
+	req, out := c.GetUpgradeHistoryRequest(input)
+	return out, req.Send()
+}
+
+// GetUpgradeHistoryWithContext is the same as GetUpgradeHistory with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetUpgradeHistory for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) GetUpgradeHistoryWithContext(ctx aws.Context, input *GetUpgradeHistoryInput, opts ...request.Option) (*GetUpgradeHistoryOutput, error) {
+	req, out := c.GetUpgradeHistoryRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// GetUpgradeHistoryPages iterates over the pages of a GetUpgradeHistory operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See GetUpgradeHistory method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a GetUpgradeHistory operation.
+//    pageNum := 0
+//    err := client.GetUpgradeHistoryPages(params,
+//        func(page *GetUpgradeHistoryOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *ElasticsearchService) GetUpgradeHistoryPages(input *GetUpgradeHistoryInput, fn func(*GetUpgradeHistoryOutput, bool) bool) error {
+	return c.GetUpgradeHistoryPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// GetUpgradeHistoryPagesWithContext same as GetUpgradeHistoryPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) GetUpgradeHistoryPagesWithContext(ctx aws.Context, input *GetUpgradeHistoryInput, fn func(*GetUpgradeHistoryOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *GetUpgradeHistoryInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.GetUpgradeHistoryRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*GetUpgradeHistoryOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
+const opGetUpgradeStatus = "GetUpgradeStatus"
+
+// GetUpgradeStatusRequest generates a "aws/request.Request" representing the
+// client's request for the GetUpgradeStatus operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetUpgradeStatus for more information on using the GetUpgradeStatus
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetUpgradeStatusRequest method.
+//    req, resp := client.GetUpgradeStatusRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *ElasticsearchService) GetUpgradeStatusRequest(input *GetUpgradeStatusInput) (req *request.Request, output *GetUpgradeStatusOutput) {
+	op := &request.Operation{
+		Name:       opGetUpgradeStatus,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-01-01/es/upgradeDomain/{DomainName}/status",
+	}
+
+	if input == nil {
+		input = &GetUpgradeStatusInput{}
+	}
+
+	output = &GetUpgradeStatusOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetUpgradeStatus API operation for Amazon Elasticsearch Service.
+//
+// Retrieves the latest status of the last upgrade or upgrade eligibility check
+// that was performed on the domain.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation GetUpgradeStatus for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBaseException "BaseException"
+//   An error occurred while processing the request.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeDisabledOperationException "DisabledOperationException"
+//   An error occured because the client wanted to access a not supported operation.
+//   Gives http status code of 409.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+func (c *ElasticsearchService) GetUpgradeStatus(input *GetUpgradeStatusInput) (*GetUpgradeStatusOutput, error) {
+	req, out := c.GetUpgradeStatusRequest(input)
+	return out, req.Send()
+}
+
+// GetUpgradeStatusWithContext is the same as GetUpgradeStatus with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetUpgradeStatus for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) GetUpgradeStatusWithContext(ctx aws.Context, input *GetUpgradeStatusInput, opts ...request.Option) (*GetUpgradeStatusOutput, error) {
+	req, out := c.GetUpgradeStatusRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListDomainNames = "ListDomainNames"
 
 // ListDomainNamesRequest generates a "aws/request.Request" representing the
@@ -1791,6 +2130,104 @@ func (c *ElasticsearchService) UpdateElasticsearchDomainConfigWithContext(ctx aw
 	return out, req.Send()
 }
 
+const opUpgradeElasticsearchDomain = "UpgradeElasticsearchDomain"
+
+// UpgradeElasticsearchDomainRequest generates a "aws/request.Request" representing the
+// client's request for the UpgradeElasticsearchDomain operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfuly.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpgradeElasticsearchDomain for more information on using the UpgradeElasticsearchDomain
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpgradeElasticsearchDomainRequest method.
+//    req, resp := client.UpgradeElasticsearchDomainRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+func (c *ElasticsearchService) UpgradeElasticsearchDomainRequest(input *UpgradeElasticsearchDomainInput) (req *request.Request, output *UpgradeElasticsearchDomainOutput) {
+	op := &request.Operation{
+		Name:       opUpgradeElasticsearchDomain,
+		HTTPMethod: "POST",
+		HTTPPath:   "/2015-01-01/es/upgradeDomain",
+	}
+
+	if input == nil {
+		input = &UpgradeElasticsearchDomainInput{}
+	}
+
+	output = &UpgradeElasticsearchDomainOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpgradeElasticsearchDomain API operation for Amazon Elasticsearch Service.
+//
+// Allows you to either upgrade your domain or perform an Upgrade eligibility
+// check to a compatible Elasticsearch version.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elasticsearch Service's
+// API operation UpgradeElasticsearchDomain for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBaseException "BaseException"
+//   An error occurred while processing the request.
+//
+//   * ErrCodeResourceNotFoundException "ResourceNotFoundException"
+//   An exception for accessing or deleting a resource that does not exist. Gives
+//   http status code of 400.
+//
+//   * ErrCodeResourceAlreadyExistsException "ResourceAlreadyExistsException"
+//   An exception for creating a resource that already exists. Gives http status
+//   code of 400.
+//
+//   * ErrCodeDisabledOperationException "DisabledOperationException"
+//   An error occured because the client wanted to access a not supported operation.
+//   Gives http status code of 409.
+//
+//   * ErrCodeValidationException "ValidationException"
+//   An exception for missing / invalid input fields. Gives http status code of
+//   400.
+//
+//   * ErrCodeInternalException "InternalException"
+//   The request processing has failed because of an unknown error, exception
+//   or failure (the failure is internal to the service) . Gives http status code
+//   of 500.
+//
+func (c *ElasticsearchService) UpgradeElasticsearchDomain(input *UpgradeElasticsearchDomainInput) (*UpgradeElasticsearchDomainOutput, error) {
+	req, out := c.UpgradeElasticsearchDomainRequest(input)
+	return out, req.Send()
+}
+
+// UpgradeElasticsearchDomainWithContext is the same as UpgradeElasticsearchDomain with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpgradeElasticsearchDomain for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ElasticsearchService) UpgradeElasticsearchDomainWithContext(ctx aws.Context, input *UpgradeElasticsearchDomainInput, opts ...request.Option) (*UpgradeElasticsearchDomainOutput, error) {
+	req, out := c.UpgradeElasticsearchDomainRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 // The configured access rules for the domain's document and search endpoints,
 // and the current status of those rules.
 type AccessPoliciesStatus struct {
@@ -2105,6 +2542,40 @@ func (s *CognitoOptionsStatus) SetOptions(v *CognitoOptions) *CognitoOptionsStat
 // SetStatus sets the Status field's value.
 func (s *CognitoOptionsStatus) SetStatus(v *OptionStatus) *CognitoOptionsStatus {
 	s.Status = v
+	return s
+}
+
+// A map from an ElasticsearchVersion to a list of compatible ElasticsearchVersion
+// s to which the domain can be upgraded.
+type CompatibleVersionsMap struct {
+	_ struct{} `type:"structure"`
+
+	// The current version of Elasticsearch on which a domain is.
+	SourceVersion *string `type:"string"`
+
+	// List of supported elastic search versions.
+	TargetVersions []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s CompatibleVersionsMap) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CompatibleVersionsMap) GoString() string {
+	return s.String()
+}
+
+// SetSourceVersion sets the SourceVersion field's value.
+func (s *CompatibleVersionsMap) SetSourceVersion(v string) *CompatibleVersionsMap {
+	s.SourceVersion = &v
+	return s
+}
+
+// SetTargetVersions sets the TargetVersions field's value.
+func (s *CompatibleVersionsMap) SetTargetVersions(v []*string) *CompatibleVersionsMap {
+	s.TargetVersions = v
 	return s
 }
 
@@ -3257,6 +3728,10 @@ type ElasticsearchDomainStatus struct {
 	// Specifies the status of the SnapshotOptions
 	SnapshotOptions *SnapshotOptions `type:"structure"`
 
+	// The status of an Elasticsearch domain version upgrade. True if Amazon Elasticsearch
+	// Service is undergoing a version upgrade. False if the configuration is active.
+	UpgradeProcessing *bool `type:"boolean"`
+
 	// The VPCOptions for the specified domain. For more information, see VPC Endpoints
 	// for Amazon Elasticsearch Service Domains (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html).
 	VPCOptions *VPCDerivedInfo `type:"structure"`
@@ -3371,6 +3846,12 @@ func (s *ElasticsearchDomainStatus) SetProcessing(v bool) *ElasticsearchDomainSt
 // SetSnapshotOptions sets the SnapshotOptions field's value.
 func (s *ElasticsearchDomainStatus) SetSnapshotOptions(v *SnapshotOptions) *ElasticsearchDomainStatus {
 	s.SnapshotOptions = v
+	return s
+}
+
+// SetUpgradeProcessing sets the UpgradeProcessing field's value.
+func (s *ElasticsearchDomainStatus) SetUpgradeProcessing(v bool) *ElasticsearchDomainStatus {
+	s.UpgradeProcessing = &v
 	return s
 }
 
@@ -3502,6 +3983,266 @@ func (s *EncryptionAtRestOptionsStatus) SetOptions(v *EncryptionAtRestOptions) *
 // SetStatus sets the Status field's value.
 func (s *EncryptionAtRestOptionsStatus) SetStatus(v *OptionStatus) *EncryptionAtRestOptionsStatus {
 	s.Status = v
+	return s
+}
+
+// Container for request parameters to GetCompatibleElasticsearchVersions operation.
+type GetCompatibleElasticsearchVersionsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of an Elasticsearch domain. Domain names are unique across the domains
+	// owned by an account within an AWS region. Domain names start with a letter
+	// or number and can contain the following characters: a-z (lowercase), 0-9,
+	// and - (hyphen).
+	DomainName *string `location:"querystring" locationName:"domainName" min:"3" type:"string"`
+}
+
+// String returns the string representation
+func (s GetCompatibleElasticsearchVersionsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCompatibleElasticsearchVersionsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetCompatibleElasticsearchVersionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetCompatibleElasticsearchVersionsInput"}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetCompatibleElasticsearchVersionsInput) SetDomainName(v string) *GetCompatibleElasticsearchVersionsInput {
+	s.DomainName = &v
+	return s
+}
+
+// Container for response returned by GetCompatibleElasticsearchVersions operation.
+type GetCompatibleElasticsearchVersionsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A map of compatible Elasticsearch versions returned as part of the GetCompatibleElasticsearchVersions
+	// operation.
+	CompatibleElasticsearchVersions []*CompatibleVersionsMap `type:"list"`
+}
+
+// String returns the string representation
+func (s GetCompatibleElasticsearchVersionsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetCompatibleElasticsearchVersionsOutput) GoString() string {
+	return s.String()
+}
+
+// SetCompatibleElasticsearchVersions sets the CompatibleElasticsearchVersions field's value.
+func (s *GetCompatibleElasticsearchVersionsOutput) SetCompatibleElasticsearchVersions(v []*CompatibleVersionsMap) *GetCompatibleElasticsearchVersionsOutput {
+	s.CompatibleElasticsearchVersions = v
+	return s
+}
+
+// Container for request parameters to GetUpgradeHistory operation.
+type GetUpgradeHistoryInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of an Elasticsearch domain. Domain names are unique across the domains
+	// owned by an account within an AWS region. Domain names start with a letter
+	// or number and can contain the following characters: a-z (lowercase), 0-9,
+	// and - (hyphen).
+	//
+	// DomainName is a required field
+	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
+
+	// Set this value to limit the number of results returned.
+	MaxResults *int64 `location:"querystring" locationName:"maxResults" type:"integer"`
+
+	// Paginated APIs accepts NextToken input to returns next page results and provides
+	// a NextToken output in the response which can be used by the client to retrieve
+	// more results.
+	NextToken *string `location:"querystring" locationName:"nextToken" type:"string"`
+}
+
+// String returns the string representation
+func (s GetUpgradeHistoryInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetUpgradeHistoryInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetUpgradeHistoryInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetUpgradeHistoryInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetUpgradeHistoryInput) SetDomainName(v string) *GetUpgradeHistoryInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *GetUpgradeHistoryInput) SetMaxResults(v int64) *GetUpgradeHistoryInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetUpgradeHistoryInput) SetNextToken(v string) *GetUpgradeHistoryInput {
+	s.NextToken = &v
+	return s
+}
+
+// Container for response returned by GetUpgradeHistory operation.
+type GetUpgradeHistoryOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Pagination token that needs to be supplied to the next call to get the next
+	// page of results
+	NextToken *string `type:"string"`
+
+	// A list of UpgradeHistory objects corresponding to each Upgrade or Upgrade
+	// Eligibility Check performed on a domain returned as part of GetUpgradeHistoryResponse
+	// object.
+	UpgradeHistories []*UpgradeHistory `type:"list"`
+}
+
+// String returns the string representation
+func (s GetUpgradeHistoryOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetUpgradeHistoryOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *GetUpgradeHistoryOutput) SetNextToken(v string) *GetUpgradeHistoryOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetUpgradeHistories sets the UpgradeHistories field's value.
+func (s *GetUpgradeHistoryOutput) SetUpgradeHistories(v []*UpgradeHistory) *GetUpgradeHistoryOutput {
+	s.UpgradeHistories = v
+	return s
+}
+
+// Container for request parameters to GetUpgradeStatus operation.
+type GetUpgradeStatusInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of an Elasticsearch domain. Domain names are unique across the domains
+	// owned by an account within an AWS region. Domain names start with a letter
+	// or number and can contain the following characters: a-z (lowercase), 0-9,
+	// and - (hyphen).
+	//
+	// DomainName is a required field
+	DomainName *string `location:"uri" locationName:"DomainName" min:"3" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetUpgradeStatusInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetUpgradeStatusInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetUpgradeStatusInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetUpgradeStatusInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *GetUpgradeStatusInput) SetDomainName(v string) *GetUpgradeStatusInput {
+	s.DomainName = &v
+	return s
+}
+
+// Container for response returned by GetUpgradeStatus operation.
+type GetUpgradeStatusOutput struct {
+	_ struct{} `type:"structure"`
+
+	// One of 4 statuses that a step can go through returned as part of the GetUpgradeStatusResponse
+	// object. The status can take one of the following values: In Progress
+	// Succeeded
+	// Succeeded with Issues
+	// Failed
+	StepStatus *string `type:"string" enum:"UpgradeStatus"`
+
+	// A string that describes the update briefly
+	UpgradeName *string `type:"string"`
+
+	// Represents one of 3 steps that an Upgrade or Upgrade Eligibility Check does
+	// through: PreUpgradeCheck
+	// Snapshot
+	// Upgrade
+	UpgradeStep *string `type:"string" enum:"UpgradeStep"`
+}
+
+// String returns the string representation
+func (s GetUpgradeStatusOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetUpgradeStatusOutput) GoString() string {
+	return s.String()
+}
+
+// SetStepStatus sets the StepStatus field's value.
+func (s *GetUpgradeStatusOutput) SetStepStatus(v string) *GetUpgradeStatusOutput {
+	s.StepStatus = &v
+	return s
+}
+
+// SetUpgradeName sets the UpgradeName field's value.
+func (s *GetUpgradeStatusOutput) SetUpgradeName(v string) *GetUpgradeStatusOutput {
+	s.UpgradeName = &v
+	return s
+}
+
+// SetUpgradeStep sets the UpgradeStep field's value.
+func (s *GetUpgradeStatusOutput) SetUpgradeStep(v string) *GetUpgradeStatusOutput {
+	s.UpgradeStep = &v
 	return s
 }
 
@@ -4841,6 +5582,238 @@ func (s *UpdateElasticsearchDomainConfigOutput) SetDomainConfig(v *Elasticsearch
 	return s
 }
 
+// Container for request parameters to UpgradeElasticsearchDomain operation.
+type UpgradeElasticsearchDomainInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of an Elasticsearch domain. Domain names are unique across the domains
+	// owned by an account within an AWS region. Domain names start with a letter
+	// or number and can contain the following characters: a-z (lowercase), 0-9,
+	// and - (hyphen).
+	//
+	// DomainName is a required field
+	DomainName *string `min:"3" type:"string" required:"true"`
+
+	// This flag, when set to True, indicates that an Upgrade Eligibility Check
+	// needs to be performed. This will not actually perform the Upgrade.
+	PerformCheckOnly *bool `type:"boolean"`
+
+	// The version of Elasticsearch that you intend to upgrade the domain to.
+	//
+	// TargetVersion is a required field
+	TargetVersion *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpgradeElasticsearchDomainInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpgradeElasticsearchDomainInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpgradeElasticsearchDomainInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpgradeElasticsearchDomainInput"}
+	if s.DomainName == nil {
+		invalidParams.Add(request.NewErrParamRequired("DomainName"))
+	}
+	if s.DomainName != nil && len(*s.DomainName) < 3 {
+		invalidParams.Add(request.NewErrParamMinLen("DomainName", 3))
+	}
+	if s.TargetVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("TargetVersion"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpgradeElasticsearchDomainInput) SetDomainName(v string) *UpgradeElasticsearchDomainInput {
+	s.DomainName = &v
+	return s
+}
+
+// SetPerformCheckOnly sets the PerformCheckOnly field's value.
+func (s *UpgradeElasticsearchDomainInput) SetPerformCheckOnly(v bool) *UpgradeElasticsearchDomainInput {
+	s.PerformCheckOnly = &v
+	return s
+}
+
+// SetTargetVersion sets the TargetVersion field's value.
+func (s *UpgradeElasticsearchDomainInput) SetTargetVersion(v string) *UpgradeElasticsearchDomainInput {
+	s.TargetVersion = &v
+	return s
+}
+
+// Container for response returned by UpgradeElasticsearchDomain operation.
+type UpgradeElasticsearchDomainOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of an Elasticsearch domain. Domain names are unique across the domains
+	// owned by an account within an AWS region. Domain names start with a letter
+	// or number and can contain the following characters: a-z (lowercase), 0-9,
+	// and - (hyphen).
+	DomainName *string `min:"3" type:"string"`
+
+	// This flag, when set to True, indicates that an Upgrade Eligibility Check
+	// needs to be performed. This will not actually perform the Upgrade.
+	PerformCheckOnly *bool `type:"boolean"`
+
+	// The version of Elasticsearch that you intend to upgrade the domain to.
+	TargetVersion *string `type:"string"`
+}
+
+// String returns the string representation
+func (s UpgradeElasticsearchDomainOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpgradeElasticsearchDomainOutput) GoString() string {
+	return s.String()
+}
+
+// SetDomainName sets the DomainName field's value.
+func (s *UpgradeElasticsearchDomainOutput) SetDomainName(v string) *UpgradeElasticsearchDomainOutput {
+	s.DomainName = &v
+	return s
+}
+
+// SetPerformCheckOnly sets the PerformCheckOnly field's value.
+func (s *UpgradeElasticsearchDomainOutput) SetPerformCheckOnly(v bool) *UpgradeElasticsearchDomainOutput {
+	s.PerformCheckOnly = &v
+	return s
+}
+
+// SetTargetVersion sets the TargetVersion field's value.
+func (s *UpgradeElasticsearchDomainOutput) SetTargetVersion(v string) *UpgradeElasticsearchDomainOutput {
+	s.TargetVersion = &v
+	return s
+}
+
+// History of the last 10 Upgrades and Upgrade Eligibility Checks.
+type UpgradeHistory struct {
+	_ struct{} `type:"structure"`
+
+	// UTC Timestamp at which the Upgrade API call was made in "yyyy-MM-ddTHH:mm:ssZ"
+	// format.
+	StartTimestamp *time.Time `type:"timestamp"`
+
+	// A list of UpgradeStepItem s representing information about each step performed
+	// as pard of a specific Upgrade or Upgrade Eligibility Check.
+	StepsList []*UpgradeStepItem `type:"list"`
+
+	// A string that describes the update briefly
+	UpgradeName *string `type:"string"`
+
+	// The overall status of the update. The status can take one of the following
+	// values: In Progress
+	// Succeeded
+	// Succeeded with Issues
+	// Failed
+	UpgradeStatus *string `type:"string" enum:"UpgradeStatus"`
+}
+
+// String returns the string representation
+func (s UpgradeHistory) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpgradeHistory) GoString() string {
+	return s.String()
+}
+
+// SetStartTimestamp sets the StartTimestamp field's value.
+func (s *UpgradeHistory) SetStartTimestamp(v time.Time) *UpgradeHistory {
+	s.StartTimestamp = &v
+	return s
+}
+
+// SetStepsList sets the StepsList field's value.
+func (s *UpgradeHistory) SetStepsList(v []*UpgradeStepItem) *UpgradeHistory {
+	s.StepsList = v
+	return s
+}
+
+// SetUpgradeName sets the UpgradeName field's value.
+func (s *UpgradeHistory) SetUpgradeName(v string) *UpgradeHistory {
+	s.UpgradeName = &v
+	return s
+}
+
+// SetUpgradeStatus sets the UpgradeStatus field's value.
+func (s *UpgradeHistory) SetUpgradeStatus(v string) *UpgradeHistory {
+	s.UpgradeStatus = &v
+	return s
+}
+
+// Represents a single step of the Upgrade or Upgrade Eligibility Check workflow.
+type UpgradeStepItem struct {
+	_ struct{} `type:"structure"`
+
+	// A list of strings containing detailed information about the errors encountered
+	// in a particular step.
+	Issues []*string `type:"list"`
+
+	// The Floating point value representing progress percentage of a particular
+	// step.
+	ProgressPercent *float64 `type:"double"`
+
+	// Represents one of 3 steps that an Upgrade or Upgrade Eligibility Check does
+	// through: PreUpgradeCheck
+	// Snapshot
+	// Upgrade
+	UpgradeStep *string `type:"string" enum:"UpgradeStep"`
+
+	// The status of a particular step during an upgrade. The status can take one
+	// of the following values: In Progress
+	// Succeeded
+	// Succeeded with Issues
+	// Failed
+	UpgradeStepStatus *string `type:"string" enum:"UpgradeStatus"`
+}
+
+// String returns the string representation
+func (s UpgradeStepItem) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpgradeStepItem) GoString() string {
+	return s.String()
+}
+
+// SetIssues sets the Issues field's value.
+func (s *UpgradeStepItem) SetIssues(v []*string) *UpgradeStepItem {
+	s.Issues = v
+	return s
+}
+
+// SetProgressPercent sets the ProgressPercent field's value.
+func (s *UpgradeStepItem) SetProgressPercent(v float64) *UpgradeStepItem {
+	s.ProgressPercent = &v
+	return s
+}
+
+// SetUpgradeStep sets the UpgradeStep field's value.
+func (s *UpgradeStepItem) SetUpgradeStep(v string) *UpgradeStepItem {
+	s.UpgradeStep = &v
+	return s
+}
+
+// SetUpgradeStepStatus sets the UpgradeStepStatus field's value.
+func (s *UpgradeStepItem) SetUpgradeStepStatus(v string) *UpgradeStepItem {
+	s.UpgradeStepStatus = &v
+	return s
+}
+
 // Options to specify the subnets and security groups for VPC endpoint. For
 // more information, see  VPC Endpoints for Amazon Elasticsearch Service Domains
 // (http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html).
@@ -5134,6 +6107,31 @@ const (
 
 	// ReservedElasticsearchInstancePaymentOptionNoUpfront is a ReservedElasticsearchInstancePaymentOption enum value
 	ReservedElasticsearchInstancePaymentOptionNoUpfront = "NO_UPFRONT"
+)
+
+const (
+	// UpgradeStatusInProgress is a UpgradeStatus enum value
+	UpgradeStatusInProgress = "IN_PROGRESS"
+
+	// UpgradeStatusSucceeded is a UpgradeStatus enum value
+	UpgradeStatusSucceeded = "SUCCEEDED"
+
+	// UpgradeStatusSucceededWithIssues is a UpgradeStatus enum value
+	UpgradeStatusSucceededWithIssues = "SUCCEEDED_WITH_ISSUES"
+
+	// UpgradeStatusFailed is a UpgradeStatus enum value
+	UpgradeStatusFailed = "FAILED"
+)
+
+const (
+	// UpgradeStepPreUpgradeCheck is a UpgradeStep enum value
+	UpgradeStepPreUpgradeCheck = "PRE_UPGRADE_CHECK"
+
+	// UpgradeStepSnapshot is a UpgradeStep enum value
+	UpgradeStepSnapshot = "SNAPSHOT"
+
+	// UpgradeStepUpgrade is a UpgradeStep enum value
+	UpgradeStepUpgrade = "UPGRADE"
 )
 
 // The type of EBS volume, standard, gp2, or io1. See Configuring EBS-based

--- a/vendor/github.com/aws/aws-sdk-go/service/mediaconvert/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/mediaconvert/api.go
@@ -3991,6 +3991,19 @@ type CmafGroupSettings struct {
 	// playout.
 	MinBufferTime *int64 `locationName:"minBufferTime" type:"integer"`
 
+	// Keep this setting at the default value of 0, unless you are troubleshooting
+	// a problem with how devices play back the end of your video asset. If you
+	// know that player devices are hanging on the final segment of your video because
+	// the length of your final segment is too short, use this setting to specify
+	// a minimum final segment length, in seconds. Choose a value that is greater
+	// than or equal to 1 and less than your segment length. When you specify a
+	// value for this setting, the encoder will combine any final segment that is
+	// shorter than the length that you specify with the previous segment. For example,
+	// your segment length is 3 seconds and your final segment is .5 seconds without
+	// a minimum final segment length; when you set the minimum final segment length
+	// to 1, your final segment is 3.5 seconds.
+	MinFinalSegmentLength *float64 `locationName:"minFinalSegmentLength" type:"double"`
+
 	// When set to SINGLE_FILE, a single output file is generated, which is internally
 	// segmented using the Fragment Length and Segment Length. When set to SEGMENTED_FILES,
 	// separate segment files will be created.
@@ -4107,6 +4120,12 @@ func (s *CmafGroupSettings) SetManifestDurationFormat(v string) *CmafGroupSettin
 // SetMinBufferTime sets the MinBufferTime field's value.
 func (s *CmafGroupSettings) SetMinBufferTime(v int64) *CmafGroupSettings {
 	s.MinBufferTime = &v
+	return s
+}
+
+// SetMinFinalSegmentLength sets the MinFinalSegmentLength field's value.
+func (s *CmafGroupSettings) SetMinFinalSegmentLength(v float64) *CmafGroupSettings {
+	s.MinFinalSegmentLength = &v
 	return s
 }
 
@@ -6531,6 +6550,72 @@ func (s *GetQueueOutput) SetQueue(v *Queue) *GetQueueOutput {
 	return s
 }
 
+// Settings for quality-defined variable bitrate encoding with the H.264 codec.
+// Required when you set Rate control mode to QVBR. Not valid when you set Rate
+// control mode to a value other than QVBR, or when you don't define Rate control
+// mode.
+type H264QvbrSettings struct {
+	_ struct{} `type:"structure"`
+
+	// Use this setting only when Rate control mode is QVBR and Quality tuning level
+	// is Multi-pass HQ. For Max average bitrate values suited to the complexity
+	// of your input video, the service limits the average bitrate of the video
+	// part of this output to the value you choose. That is, the total size of the
+	// video element is less than or equal to the value you set multiplied by the
+	// number of seconds of encoded output.
+	MaxAverageBitrate *int64 `locationName:"maxAverageBitrate" min:"1000" type:"integer"`
+
+	// Required when you use QVBR rate control mode. That is, when you specify qvbrSettings
+	// within h264Settings. Specify the target quality level for this output, from
+	// 1 to 10. Use higher numbers for greater quality. Level 10 results in nearly
+	// lossless compression. The quality level for most broadcast-quality transcodes
+	// is between 6 and 9.
+	//
+	// QvbrQualityLevel is a required field
+	QvbrQualityLevel *int64 `locationName:"qvbrQualityLevel" min:"1" type:"integer" required:"true"`
+}
+
+// String returns the string representation
+func (s H264QvbrSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s H264QvbrSettings) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *H264QvbrSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "H264QvbrSettings"}
+	if s.MaxAverageBitrate != nil && *s.MaxAverageBitrate < 1000 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxAverageBitrate", 1000))
+	}
+	if s.QvbrQualityLevel == nil {
+		invalidParams.Add(request.NewErrParamRequired("QvbrQualityLevel"))
+	}
+	if s.QvbrQualityLevel != nil && *s.QvbrQualityLevel < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("QvbrQualityLevel", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxAverageBitrate sets the MaxAverageBitrate field's value.
+func (s *H264QvbrSettings) SetMaxAverageBitrate(v int64) *H264QvbrSettings {
+	s.MaxAverageBitrate = &v
+	return s
+}
+
+// SetQvbrQualityLevel sets the QvbrQualityLevel field's value.
+func (s *H264QvbrSettings) SetQvbrQualityLevel(v int64) *H264QvbrSettings {
+	s.QvbrQualityLevel = &v
+	return s
+}
+
 // Required when you set (Codec) under (VideoDescription)>(CodecSettings) to
 // the value H_264.
 type H264Settings struct {
@@ -6550,6 +6635,13 @@ type H264Settings struct {
 	// H.264 Profile. High 4:2:2 and 10-bit profiles are only available with the
 	// AVC-I License.
 	CodecProfile *string `locationName:"codecProfile" type:"string" enum:"H264CodecProfile"`
+
+	// Choose Adaptive to improve subjective video quality for high-motion content.
+	// This will cause the service to use fewer B-frames (which infer information
+	// based on other frames) for high-motion portions of the video and more B-frames
+	// for low-motion portions. The maximum number of B-frames is limited by the
+	// value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
+	DynamicSubGop *string `locationName:"dynamicSubGop" type:"string" enum:"H264DynamicSubGop"`
 
 	// Entropy encoding mode. Use CABAC (must be in Main or High profile) or CAVLC.
 	EntropyEncoding *string `locationName:"entropyEncoding" type:"string" enum:"H264EntropyEncoding"`
@@ -6626,7 +6718,7 @@ type H264Settings struct {
 	InterlaceMode *string `locationName:"interlaceMode" type:"string" enum:"H264InterlaceMode"`
 
 	// Maximum bitrate in bits/second. For example, enter five megabits per second
-	// as 5000000.
+	// as 5000000. Required when Rate control mode is QVBR.
 	MaxBitrate *int64 `locationName:"maxBitrate" min:"1000" type:"integer"`
 
 	// Enforces separation between repeated (cadence) I-frames and I-frames inserted
@@ -6661,8 +6753,14 @@ type H264Settings struct {
 	// video encoding.
 	QualityTuningLevel *string `locationName:"qualityTuningLevel" type:"string" enum:"H264QualityTuningLevel"`
 
-	// Use this setting to specify whether this output has a variable bitrate (VBR)
-	// or constant bitrate (CBR).
+	// Settings for quality-defined variable bitrate encoding with the H.264 codec.
+	// Required when you set Rate control mode to QVBR. Not valid when you set Rate
+	// control mode to a value other than QVBR, or when you don't define Rate control
+	// mode.
+	QvbrSettings *H264QvbrSettings `locationName:"qvbrSettings" type:"structure"`
+
+	// Use this setting to specify whether this output has a variable bitrate (VBR),
+	// constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
 	RateControlMode *string `locationName:"rateControlMode" type:"string" enum:"H264RateControlMode"`
 
 	// Places a PPS header on each encoded picture, even if repeated.
@@ -6745,6 +6843,11 @@ func (s *H264Settings) Validate() error {
 	if s.Slices != nil && *s.Slices < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("Slices", 1))
 	}
+	if s.QvbrSettings != nil {
+		if err := s.QvbrSettings.Validate(); err != nil {
+			invalidParams.AddNested("QvbrSettings", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -6773,6 +6876,12 @@ func (s *H264Settings) SetCodecLevel(v string) *H264Settings {
 // SetCodecProfile sets the CodecProfile field's value.
 func (s *H264Settings) SetCodecProfile(v string) *H264Settings {
 	s.CodecProfile = &v
+	return s
+}
+
+// SetDynamicSubGop sets the DynamicSubGop field's value.
+func (s *H264Settings) SetDynamicSubGop(v string) *H264Settings {
+	s.DynamicSubGop = &v
 	return s
 }
 
@@ -6908,6 +7017,12 @@ func (s *H264Settings) SetQualityTuningLevel(v string) *H264Settings {
 	return s
 }
 
+// SetQvbrSettings sets the QvbrSettings field's value.
+func (s *H264Settings) SetQvbrSettings(v *H264QvbrSettings) *H264Settings {
+	s.QvbrSettings = v
+	return s
+}
+
 // SetRateControlMode sets the RateControlMode field's value.
 func (s *H264Settings) SetRateControlMode(v string) *H264Settings {
 	s.RateControlMode = &v
@@ -6974,6 +7089,72 @@ func (s *H264Settings) SetUnregisteredSeiTimecode(v string) *H264Settings {
 	return s
 }
 
+// Settings for quality-defined variable bitrate encoding with the H.265 codec.
+// Required when you set Rate control mode to QVBR. Not valid when you set Rate
+// control mode to a value other than QVBR, or when you don't define Rate control
+// mode.
+type H265QvbrSettings struct {
+	_ struct{} `type:"structure"`
+
+	// Use this setting only when Rate control mode is QVBR and Quality tuning level
+	// is Multi-pass HQ. For Max average bitrate values suited to the complexity
+	// of your input video, the service limits the average bitrate of the video
+	// part of this output to the value you choose. That is, the total size of the
+	// video element is less than or equal to the value you set multiplied by the
+	// number of seconds of encoded output.
+	MaxAverageBitrate *int64 `locationName:"maxAverageBitrate" min:"1000" type:"integer"`
+
+	// Required when you use QVBR rate control mode. That is, when you specify qvbrSettings
+	// within h265Settings. Specify the target quality level for this output, from
+	// 1 to 10. Use higher numbers for greater quality. Level 10 results in nearly
+	// lossless compression. The quality level for most broadcast-quality transcodes
+	// is between 6 and 9.
+	//
+	// QvbrQualityLevel is a required field
+	QvbrQualityLevel *int64 `locationName:"qvbrQualityLevel" min:"1" type:"integer" required:"true"`
+}
+
+// String returns the string representation
+func (s H265QvbrSettings) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s H265QvbrSettings) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *H265QvbrSettings) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "H265QvbrSettings"}
+	if s.MaxAverageBitrate != nil && *s.MaxAverageBitrate < 1000 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxAverageBitrate", 1000))
+	}
+	if s.QvbrQualityLevel == nil {
+		invalidParams.Add(request.NewErrParamRequired("QvbrQualityLevel"))
+	}
+	if s.QvbrQualityLevel != nil && *s.QvbrQualityLevel < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("QvbrQualityLevel", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxAverageBitrate sets the MaxAverageBitrate field's value.
+func (s *H265QvbrSettings) SetMaxAverageBitrate(v int64) *H265QvbrSettings {
+	s.MaxAverageBitrate = &v
+	return s
+}
+
+// SetQvbrQualityLevel sets the QvbrQualityLevel field's value.
+func (s *H265QvbrSettings) SetQvbrQualityLevel(v int64) *H265QvbrSettings {
+	s.QvbrQualityLevel = &v
+	return s
+}
+
 // Settings for H265 codec
 type H265Settings struct {
 	_ struct{} `type:"structure"`
@@ -6997,6 +7178,13 @@ type H265Settings struct {
 	// are grouped as [Profile] / [Tier], so "Main/High" represents Main Profile
 	// with High Tier. 4:2:2 profiles are only available with the HEVC 4:2:2 License.
 	CodecProfile *string `locationName:"codecProfile" type:"string" enum:"H265CodecProfile"`
+
+	// Choose Adaptive to improve subjective video quality for high-motion content.
+	// This will cause the service to use fewer B-frames (which infer information
+	// based on other frames) for high-motion portions of the video and more B-frames
+	// for low-motion portions. The maximum number of B-frames is limited by the
+	// value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
+	DynamicSubGop *string `locationName:"dynamicSubGop" type:"string" enum:"H265DynamicSubGop"`
 
 	// Adjust quantization within each frame to reduce flicker or 'pop' on I-frames.
 	FlickerAdaptiveQuantization *string `locationName:"flickerAdaptiveQuantization" type:"string" enum:"H265FlickerAdaptiveQuantization"`
@@ -7061,7 +7249,8 @@ type H265Settings struct {
 	// on which of the Follow options you chose.
 	InterlaceMode *string `locationName:"interlaceMode" type:"string" enum:"H265InterlaceMode"`
 
-	// Maximum bitrate in bits/second.
+	// Maximum bitrate in bits/second. For example, enter five megabits per second
+	// as 5000000. Required when Rate control mode is QVBR.
 	MaxBitrate *int64 `locationName:"maxBitrate" min:"1000" type:"integer"`
 
 	// Enforces separation between repeated (cadence) I-frames and I-frames inserted
@@ -7096,8 +7285,14 @@ type H265Settings struct {
 	// video encoding.
 	QualityTuningLevel *string `locationName:"qualityTuningLevel" type:"string" enum:"H265QualityTuningLevel"`
 
-	// Use this setting to specify whether this output has a variable bitrate (VBR)
-	// or constant bitrate (CBR).
+	// Settings for quality-defined variable bitrate encoding with the H.265 codec.
+	// Required when you set Rate control mode to QVBR. Not valid when you set Rate
+	// control mode to a value other than QVBR, or when you don't define Rate control
+	// mode.
+	QvbrSettings *H265QvbrSettings `locationName:"qvbrSettings" type:"structure"`
+
+	// Use this setting to specify whether this output has a variable bitrate (VBR),
+	// constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
 	RateControlMode *string `locationName:"rateControlMode" type:"string" enum:"H265RateControlMode"`
 
 	// Specify Sample Adaptive Offset (SAO) filter strength. Adaptive mode dynamically
@@ -7194,6 +7389,11 @@ func (s *H265Settings) Validate() error {
 	if s.Slices != nil && *s.Slices < 1 {
 		invalidParams.Add(request.NewErrParamMinValue("Slices", 1))
 	}
+	if s.QvbrSettings != nil {
+		if err := s.QvbrSettings.Validate(); err != nil {
+			invalidParams.AddNested("QvbrSettings", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -7228,6 +7428,12 @@ func (s *H265Settings) SetCodecLevel(v string) *H265Settings {
 // SetCodecProfile sets the CodecProfile field's value.
 func (s *H265Settings) SetCodecProfile(v string) *H265Settings {
 	s.CodecProfile = &v
+	return s
+}
+
+// SetDynamicSubGop sets the DynamicSubGop field's value.
+func (s *H265Settings) SetDynamicSubGop(v string) *H265Settings {
+	s.DynamicSubGop = &v
 	return s
 }
 
@@ -7348,6 +7554,12 @@ func (s *H265Settings) SetParNumerator(v int64) *H265Settings {
 // SetQualityTuningLevel sets the QualityTuningLevel field's value.
 func (s *H265Settings) SetQualityTuningLevel(v string) *H265Settings {
 	s.QualityTuningLevel = &v
+	return s
+}
+
+// SetQvbrSettings sets the QvbrSettings field's value.
+func (s *H265Settings) SetQvbrSettings(v *H265QvbrSettings) *H265Settings {
+	s.QvbrSettings = v
 	return s
 }
 
@@ -7818,6 +8030,19 @@ type HlsGroupSettings struct {
 	// segment duration.
 	ManifestDurationFormat *string `locationName:"manifestDurationFormat" type:"string" enum:"HlsManifestDurationFormat"`
 
+	// Keep this setting at the default value of 0, unless you are troubleshooting
+	// a problem with how devices play back the end of your video asset. If you
+	// know that player devices are hanging on the final segment of your video because
+	// the length of your final segment is too short, use this setting to specify
+	// a minimum final segment length, in seconds. Choose a value that is greater
+	// than or equal to 1 and less than your segment length. When you specify a
+	// value for this setting, the encoder will combine any final segment that is
+	// shorter than the length that you specify with the previous segment. For example,
+	// your segment length is 3 seconds and your final segment is .5 seconds without
+	// a minimum final segment length; when you set the minimum final segment length
+	// to 1, your final segment is 3.5 seconds.
+	MinFinalSegmentLength *float64 `locationName:"minFinalSegmentLength" type:"double"`
+
 	// When set, Minimum Segment Size is enforced by looking ahead and back within
 	// the specified range for a nearby avail and extending the segment size if
 	// needed.
@@ -7983,6 +8208,12 @@ func (s *HlsGroupSettings) SetManifestCompression(v string) *HlsGroupSettings {
 // SetManifestDurationFormat sets the ManifestDurationFormat field's value.
 func (s *HlsGroupSettings) SetManifestDurationFormat(v string) *HlsGroupSettings {
 	s.ManifestDurationFormat = &v
+	return s
+}
+
+// SetMinFinalSegmentLength sets the MinFinalSegmentLength field's value.
+func (s *HlsGroupSettings) SetMinFinalSegmentLength(v float64) *HlsGroupSettings {
+	s.MinFinalSegmentLength = &v
 	return s
 }
 
@@ -9890,9 +10121,9 @@ func (s *ListQueuesOutput) SetQueues(v []*Queue) *ListQueuesOutput {
 	return s
 }
 
-// List the tags for your MediaConvert resource by sending a request with the
-// Amazon Resource Name (ARN) of the resource. To get the ARN, send a GET request
-// with the resource name.
+// List the tags for your AWS Elemental MediaConvert resource by sending a request
+// with the Amazon Resource Name (ARN) of the resource. To get the ARN, send
+// a GET request with the resource name.
 type ListTagsForResourceInput struct {
 	_ struct{} `type:"structure"`
 
@@ -9932,7 +10163,8 @@ func (s *ListTagsForResourceInput) SetArn(v string) *ListTagsForResourceInput {
 	return s
 }
 
-// Successful list tags for resource requests return a JSON map of tags.
+// A successful request to list the tags for a resource returns a JSON map of
+// tags.
 type ListTagsForResourceOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -10785,6 +11017,13 @@ type Mpeg2Settings struct {
 	// Use Profile (Mpeg2CodecProfile) to set the MPEG-2 profile for the video output.
 	CodecProfile *string `locationName:"codecProfile" type:"string" enum:"Mpeg2CodecProfile"`
 
+	// Choose Adaptive to improve subjective video quality for high-motion content.
+	// This will cause the service to use fewer B-frames (which infer information
+	// based on other frames) for high-motion portions of the video and more B-frames
+	// for low-motion portions. The maximum number of B-frames is limited by the
+	// value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
+	DynamicSubGop *string `locationName:"dynamicSubGop" type:"string" enum:"Mpeg2DynamicSubGop"`
+
 	// If you are using the console, use the Framerate setting to specify the framerate
 	// for this output. If you want to keep the same framerate as the input video,
 	// choose Follow source. If you want to do framerate conversion, choose a framerate
@@ -10970,6 +11209,12 @@ func (s *Mpeg2Settings) SetCodecLevel(v string) *Mpeg2Settings {
 // SetCodecProfile sets the CodecProfile field's value.
 func (s *Mpeg2Settings) SetCodecProfile(v string) *Mpeg2Settings {
 	s.CodecProfile = &v
+	return s
+}
+
+// SetDynamicSubGop sets the DynamicSubGop field's value.
+func (s *Mpeg2Settings) SetDynamicSubGop(v string) *Mpeg2Settings {
+	s.DynamicSubGop = &v
 	return s
 }
 
@@ -12390,24 +12635,24 @@ func (s *Queue) SetType(v string) *Queue {
 type Rectangle struct {
 	_ struct{} `type:"structure"`
 
-	// Height of rectangle in pixels.
+	// Height of rectangle in pixels. Specify only even numbers.
 	//
 	// Height is a required field
-	Height *int64 `locationName:"height" type:"integer" required:"true"`
+	Height *int64 `locationName:"height" min:"2" type:"integer" required:"true"`
 
-	// Width of rectangle in pixels.
+	// Width of rectangle in pixels. Specify only even numbers.
 	//
 	// Width is a required field
-	Width *int64 `locationName:"width" type:"integer" required:"true"`
+	Width *int64 `locationName:"width" min:"2" type:"integer" required:"true"`
 
 	// The distance, in pixels, between the rectangle and the left edge of the video
-	// frame.
+	// frame. Specify only even numbers.
 	//
 	// X is a required field
 	X *int64 `locationName:"x" type:"integer" required:"true"`
 
 	// The distance, in pixels, between the rectangle and the top edge of the video
-	// frame.
+	// frame. Specify only even numbers.
 	//
 	// Y is a required field
 	Y *int64 `locationName:"y" type:"integer" required:"true"`
@@ -12429,26 +12674,20 @@ func (s *Rectangle) Validate() error {
 	if s.Height == nil {
 		invalidParams.Add(request.NewErrParamRequired("Height"))
 	}
-	if s.Height != nil && *s.Height < -2.147483648e+09 {
-		invalidParams.Add(request.NewErrParamMinValue("Height", -2.147483648e+09))
+	if s.Height != nil && *s.Height < 2 {
+		invalidParams.Add(request.NewErrParamMinValue("Height", 2))
 	}
 	if s.Width == nil {
 		invalidParams.Add(request.NewErrParamRequired("Width"))
 	}
-	if s.Width != nil && *s.Width < -2.147483648e+09 {
-		invalidParams.Add(request.NewErrParamMinValue("Width", -2.147483648e+09))
+	if s.Width != nil && *s.Width < 2 {
+		invalidParams.Add(request.NewErrParamMinValue("Width", 2))
 	}
 	if s.X == nil {
 		invalidParams.Add(request.NewErrParamRequired("X"))
 	}
-	if s.X != nil && *s.X < -2.147483648e+09 {
-		invalidParams.Add(request.NewErrParamMinValue("X", -2.147483648e+09))
-	}
 	if s.Y == nil {
 		invalidParams.Add(request.NewErrParamRequired("Y"))
-	}
-	if s.Y != nil && *s.Y < -2.147483648e+09 {
-		invalidParams.Add(request.NewErrParamMinValue("Y", -2.147483648e+09))
 	}
 
 	if invalidParams.Len() > 0 {
@@ -13222,7 +13461,7 @@ func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
 	return s
 }
 
-// Successful untag resource requests return an OK message.
+// A successful request to remove a tag from a resource returns an OK message.
 type UntagResourceOutput struct {
 	_ struct{} `type:"structure"`
 }
@@ -15391,6 +15630,19 @@ const (
 	H264CodecProfileMain = "MAIN"
 )
 
+// Choose Adaptive to improve subjective video quality for high-motion content.
+// This will cause the service to use fewer B-frames (which infer information
+// based on other frames) for high-motion portions of the video and more B-frames
+// for low-motion portions. The maximum number of B-frames is limited by the
+// value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
+const (
+	// H264DynamicSubGopAdaptive is a H264DynamicSubGop enum value
+	H264DynamicSubGopAdaptive = "ADAPTIVE"
+
+	// H264DynamicSubGopStatic is a H264DynamicSubGop enum value
+	H264DynamicSubGopStatic = "STATIC"
+)
+
 // Entropy encoding mode. Use CABAC (must be in Main or High profile) or CAVLC.
 const (
 	// H264EntropyEncodingCabac is a H264EntropyEncoding enum value
@@ -15519,14 +15771,17 @@ const (
 	H264QualityTuningLevelMultiPassHq = "MULTI_PASS_HQ"
 )
 
-// Use this setting to specify whether this output has a variable bitrate (VBR)
-// or constant bitrate (CBR).
+// Use this setting to specify whether this output has a variable bitrate (VBR),
+// constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
 const (
 	// H264RateControlModeVbr is a H264RateControlMode enum value
 	H264RateControlModeVbr = "VBR"
 
 	// H264RateControlModeCbr is a H264RateControlMode enum value
 	H264RateControlModeCbr = "CBR"
+
+	// H264RateControlModeQvbr is a H264RateControlMode enum value
+	H264RateControlModeQvbr = "QVBR"
 )
 
 // Places a PPS header on each encoded picture, even if repeated.
@@ -15719,6 +15974,19 @@ const (
 	H265CodecProfileMain42210bitHigh = "MAIN_422_10BIT_HIGH"
 )
 
+// Choose Adaptive to improve subjective video quality for high-motion content.
+// This will cause the service to use fewer B-frames (which infer information
+// based on other frames) for high-motion portions of the video and more B-frames
+// for low-motion portions. The maximum number of B-frames is limited by the
+// value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
+const (
+	// H265DynamicSubGopAdaptive is a H265DynamicSubGop enum value
+	H265DynamicSubGopAdaptive = "ADAPTIVE"
+
+	// H265DynamicSubGopStatic is a H265DynamicSubGop enum value
+	H265DynamicSubGopStatic = "STATIC"
+)
+
 // Adjust quantization within each frame to reduce flicker or 'pop' on I-frames.
 const (
 	// H265FlickerAdaptiveQuantizationDisabled is a H265FlickerAdaptiveQuantization enum value
@@ -15829,14 +16097,17 @@ const (
 	H265QualityTuningLevelMultiPassHq = "MULTI_PASS_HQ"
 )
 
-// Use this setting to specify whether this output has a variable bitrate (VBR)
-// or constant bitrate (CBR).
+// Use this setting to specify whether this output has a variable bitrate (VBR),
+// constant bitrate (CBR) or quality-defined variable bitrate (QVBR).
 const (
 	// H265RateControlModeVbr is a H265RateControlMode enum value
 	H265RateControlModeVbr = "VBR"
 
 	// H265RateControlModeCbr is a H265RateControlMode enum value
 	H265RateControlModeCbr = "CBR"
+
+	// H265RateControlModeQvbr is a H265RateControlMode enum value
+	H265RateControlModeQvbr = "QVBR"
 )
 
 // Specify Sample Adaptive Offset (SAO) filter strength. Adaptive mode dynamically
@@ -17128,6 +17399,19 @@ const (
 
 	// Mpeg2CodecProfileProfile422 is a Mpeg2CodecProfile enum value
 	Mpeg2CodecProfileProfile422 = "PROFILE_422"
+)
+
+// Choose Adaptive to improve subjective video quality for high-motion content.
+// This will cause the service to use fewer B-frames (which infer information
+// based on other frames) for high-motion portions of the video and more B-frames
+// for low-motion portions. The maximum number of B-frames is limited by the
+// value you provide for the setting B frames between reference frames (numberBFramesBetweenReferenceFrames).
+const (
+	// Mpeg2DynamicSubGopAdaptive is a Mpeg2DynamicSubGop enum value
+	Mpeg2DynamicSubGopAdaptive = "ADAPTIVE"
+
+	// Mpeg2DynamicSubGopStatic is a Mpeg2DynamicSubGop enum value
+	Mpeg2DynamicSubGopStatic = "STATIC"
 )
 
 // If you are using the console, use the Framerate setting to specify the framerate

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -6854,7 +6854,10 @@ func (c *RDS) ModifyCurrentDBClusterCapacityRequest(input *ModifyCurrentDBCluste
 // in the Amazon RDS User Guide.
 //
 // If you call ModifyCurrentDBClusterCapacity with the default TimeoutAction,
-// connections to the DB cluster are dropped when the capacity is set.
+// connections that prevent Aurora Serverless from finding a scaling point might
+// be dropped. For more information about scaling points, see  Autoscaling for
+// Aurora Serverless (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/aurora-serverless.how-it-works.html#aurora-serverless.how-it-works.auto-scaling)
+// in the Amazon RDS User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -22369,8 +22372,8 @@ type ModifyCurrentDBClusterCapacityInput struct {
 	// The action to take when the timeout is reached, either ForceApplyCapacityChange
 	// or RollbackCapacityChange.
 	//
-	// ForceApplyCapacityChange, the default, drops connections to the DB cluster
-	// and sets the capacity to the specified value as soon as possible.
+	// ForceApplyCapacityChange, the default, sets the capacity to the specified
+	// value as soon as possible.
 	//
 	// RollbackCapacityChange ignores the capacity change if a scaling point is
 	// not found in the timeout period.

--- a/vendor/github.com/aws/aws-sdk-go/service/sagemaker/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sagemaker/api.go
@@ -5771,11 +5771,6 @@ type CreateTransformJobInput struct {
 	// means only one record is used per mini-batch. MultiRecord means a mini-batch
 	// is set to contain as many records that can fit within the MaxPayloadInMB
 	// limit.
-	//
-	// Batch transform will automatically split your input data into whatever payload
-	// size is specified if you set SplitType to Line and BatchStrategy to MultiRecord.
-	// There's no need to split the dataset into smaller files or to use larger
-	// payload sizes unless the records in your dataset are very large.
 	BatchStrategy *string `type:"string" enum:"BatchStrategy"`
 
 	// The environment variables to set in the Docker container. We support up to
@@ -7370,22 +7365,21 @@ type DescribeTrainingJobOutput struct {
 	//
 	//    * Stopped - the training job has stopped.
 	//
-	//    * MaxRuntimeExceeded - the training job exceeded the specified max run
-	//    time and has been stopped.
+	//    * MaxRuntimeExceeded - the training exceed the specified the max run time,
+	//    which means the training job is stopping.
 	//
 	//    * Completed - the training job has completed.
 	//
 	//    * Failed - the training job has failed. The failure reason is provided
 	//    in the StatusMessage.
 	//
-	// The valid values for SecondaryStatus are subject to change. They primarily
+	// The valid values for SecondaryStatus are subject to change. They primary
 	// provide information on the progress of the training job.
 	//
 	// SecondaryStatus is a required field
 	SecondaryStatus *string `type:"string" required:"true" enum:"SecondaryStatus"`
 
-	// To give an overview of the training job lifecycle, SecondaryStatusTransitions
-	// is a log of time-ordered secondary statuses that a training job has transitioned.
+	// A log of time-ordered secondary statuses that a training job has transitioned.
 	SecondaryStatusTransitions []*SecondaryStatusTransition `type:"list"`
 
 	// The condition under which to stop the training job.
@@ -11213,8 +11207,7 @@ type SecondaryStatusTransition struct {
 	_ struct{} `type:"structure"`
 
 	// A timestamp that shows when the secondary status has ended and the job has
-	// transitioned into another secondary status. The EndTime timestamp is also
-	// set after the training job has ended.
+	// transitioned into another secondary status.
 	EndTime *time.Time `type:"timestamp"`
 
 	// A timestamp that shows when the training job has entered this secondary status.

--- a/vendor/github.com/aws/aws-sdk-go/service/sagemaker/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sagemaker/service.go
@@ -29,9 +29,9 @@ var initRequest func(*request.Request)
 
 // Service information constants
 const (
-	ServiceName = "sagemaker" // Name of service.
-	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "SageMaker" // ServiceID is a unique identifer of a specific service.
+	ServiceName = "sagemaker"     // Name of service.
+	EndpointsID = "api.sagemaker" // ID to lookup a service endpoint with.
+	ServiceID   = "SageMaker"     // ServiceID is a unique identifer of a specific service.
 )
 
 // New creates a new instance of the SageMaker client with a session.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,1020 +39,1020 @@
 			"revisionTime": "2017-07-27T15:54:43Z"
 		},
 		{
-			"checksumSHA1": "2GdP8aRMxQ48e+l0/N7587jJeOA=",
+			"checksumSHA1": "16RH8b0R92p8l8CoPCB7vbX2WME=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "EwL79Cq6euk+EV/t/n2E+jzPNmU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "vVSUnICaD9IaBQisCfw0n8zLwig=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "I87y3G8r14yKZQ5NlkupFUJ5jW0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "JTilCBYWVAfhbKSnrxCNhE8IFns=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "eI5TmiOTCFjEUNvWeceFycs9dRU=",
 			"path": "github.com/aws/aws-sdk-go/aws/csm",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "6DRhqSAN7O45gYfRIpwDeuJE8j8=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "uPkjJo+J10vbEukYYXmf0w7Cn4Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
-			"checksumSHA1": "E90Nf2HfcSKYI99ld36ILMXMRKM=",
+			"checksumSHA1": "iMbyRn/FOy3AXudhaJHQiwazZxI=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Ia/AZ2fZp7J4lMO6fpkvfLU/HGY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "zx1mZCdOwgbjBV3jMfb0kyDd//Q=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Dj9WOMBPbboyUJV4GB99PwPcO4g=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "tQVg7Sz2zv+KkhbiXxPH0mh9spg=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkuri",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "ZX5QHZb0PrK4UF45um2kaAEiX+8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "stsUCJVnZ5yMrmzSExbjbYp5tZ8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "bOQjEfKXaTqe7dZhDDER/wZUzQc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "CTsp/h3FbFg9QizH4bH1abLwljg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "+O6A945eTP9plLpkEMZB0lwBAcg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "uRvmEPKcEdv7qc0Ep2zn0E3Xumc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "soXVJWQ/xvEB72Mo6FresaQIxLg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "4xFqSOZkwDKot6FJQQgKjhJFoQw=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "3e/4A/8NqTOSXEtJ6KhYAqqWnuY=",
 			"path": "github.com/aws/aws-sdk-go/service/acmpca",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "FjnLIflNek7g0j5NKT3qFkNtdY8=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "K/ynSj/L2OzW+9Zqs2PRe8NzYUc=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "owhfVKeKxjXt4P5KO6PSIjnMLIA=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "3JN52M5wxJMazxQWXB4epL78LNQ=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
-			"checksumSHA1": "O5L1jCrbPe6adyTBIpSnydpToyk=",
+			"checksumSHA1": "P2+Mby00TG2KXcfhiVoNoqIT1Kc=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "42OCpXRErVgOtgPsuTrdg7y++TA=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "kPYTVg109H4HL8CKEf1yQvwKMw4=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "GhANcrglYWrhNSR/NzxNe3jClMk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "HmZRIixQ6u+zMz2Qt0iTU42WVZU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
-			"checksumSHA1": "BXG7bjiNrt222s+bZeimLAXODp4=",
+			"checksumSHA1": "1nPdiFsBAEdm+vd7Kk4+8Lx55jw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "iFvc4+KfDeQHigAz2+TmogG1Y7M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudhsmv2",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "1uyTJ/RTr7c8uL2Kbrp+60PE40M=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "3q2FBK4CEarGbVeLCuuX+g1E3jk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "o+DFxugR5Cy/Wwlv7GSRRilTW4o=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "7lCMA0KirL9isnwLj87LR2cjipU=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "nGSD4idK9hW8o3U4gLGLESYCpwE=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "SfdREjSJPmW+OjKCjwD8m07wT+w=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "ysSU5yhqWT4+deQUYZiI8/1tJ2c=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "GvjVVg5btXuEFEHqyoe19BZogGw=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "vklitYIK0AiOXA0obSTq0c04pc4=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "rL0O6L1zSJ/UQE0kEWUoCOOFDog=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Zc5M/qyd8bDCYuNRvFnF05gMp5s=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "o9WTZk66Jlu+0UdO1wmtO3qp8ps=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "/y7nXSnR9OqMoxlIl1hFcCk5kT8=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "0EzaatOYLyDsPRW0JgbtwdtPeVk=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "eAvb9FYZ6+lM9LhP7TrpNLrNn/Y=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "PBdPTvba1Ci9LrAs0VExIAWtdKQ=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "a02+OXxnVBBBeaZpgs8dXUHj8b0=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "aAw9xutYOwCdzo7p0QwTFVFJr8Y=",
 			"path": "github.com/aws/aws-sdk-go/service/dlm",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "oTvEWASg5Q7pm2LF6FDsFYqg1Ko=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "xNlCk/zwgdNvxnUcdGOhW9K5FJg=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "VD7bAh0n/UgOwRBPe5y38Ow/dHU=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Q8RuvleYpFO1hlm/eKRbg5wG/nQ=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "NDrEwIZeUSlHgENwBzVdy0KcCCY=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "5QdblYPoDtRsQ8aczXOesIKTDpc=",
 			"path": "github.com/aws/aws-sdk-go/service/eks",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "kvsll2DfqS1hg97xSWMIcMan5as=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "fx9nf/M9h4DpZY5pEdnh9DeCnsU=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
-			"checksumSHA1": "GdpGQlKFS+BGq90Kc6PboHCW3kM=",
+			"checksumSHA1": "O++z0DZj/MzSNWgVfV+SYzTS/fM=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "VFjWDQMsGpFMrNfcc//ABRpo6Ew=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Gp+QZjtg8PCNVi9X8m2SqtFvMas=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "wIiqI9GFAV2AQ32o2kEYHNyqVig=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "oNOLs79R42Vsj/jYTYtrbyTWxcw=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "3hICqVOs1WmluYMZN9fTMbDQSyM=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "tNVmAgvnURWLWibVCL7vIDYU7UM=",
 			"path": "github.com/aws/aws-sdk-go/service/fms",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "J1SHh0J6kX8JBD0+TQCFP+1Kij4=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "BB3/VzUU5Rg4KgrezJ17D4kCnwA=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "p+Nb4OF6gcHREcCKa/tyZ6pWBQ8=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "HNndTio5+fNOiLr23i+QZpPp8HU=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "ae+jhUirSvN0IXPVU7X7xc+EbFE=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "39yMWxFP9XB+8wWWCZX4vkNWmxU=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "JrNTM1HkStbS/DyQXkVokDdB71w=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "q9HZ/0/lBSRKtjHXMegmcRcazPo=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "nUdxsOW9jg+m+sWZYPu7oX9rZo8=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesisanalytics",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "vaMnUnRVDkpHp/e4f3dFX20JblM=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "K4OamITKC7PKo1eHrSl0z8Visg0=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "7rQmR+jAZ4zUIC4upAxyxrbfzNM=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "tX/3xEkl13DuKNIO0v3qYseEIvI=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "+l6bA5aVzmBXH2Isj1xZkd5RKNY=",
 			"path": "github.com/aws/aws-sdk-go/service/macie",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
-			"checksumSHA1": "iRZF/T8Ohr0Thp+d54NYg5QxxEw=",
+			"checksumSHA1": "QTsWqalNtwR16n+auzHlg2Vd6HQ=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "HoX+EX8JW8kDZxJAs8545YRfjuI=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "CggySAQfK9WXsX37mRI8UqXGkJo=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "9NU6dJOvKvcgnl/4eUdwy4YD5ss=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "qyIVtaN5mzPq4d7BDj9YpYtifKs=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "1jKxCBvS+zKzq6p2i4BqLXYHm48=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "E3i2/WM1kDE7WBOSRnDsZkwmZwI=",
 			"path": "github.com/aws/aws-sdk-go/service/neptune",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "x3PsW91a7fh+Q466y3WM3fdtnGg=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "YCd2EU1DPiO0QTRZk6G1fLZAyg0=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "e5v4Cc9/0H2ngQNuvVyj2Mt0vi0=",
 			"path": "github.com/aws/aws-sdk-go/service/pinpoint",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "j1i1tZ94/kDvvzgpv5xqxwNvgyY=",
 			"path": "github.com/aws/aws-sdk-go/service/pricing",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
-			"checksumSHA1": "7CqeebyIEswL1HtwHYyrjkh5D8w=",
+			"checksumSHA1": "rkR+yGW3JcvP35fmL5psiRYAZ/M=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "2eywZb+K9OAw3bZ0gHwOCCdcb/8=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "KlM6azZ5G09MmPg+lzEizW2qaLA=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "DmKatmbYsvm+MoCP01PCdQ6Y6Tk=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
-			"checksumSHA1": "npkvk2UM+YBQi+Zf5gq1BJR12gY=",
+			"checksumSHA1": "hqW1N6KXBXppfMH4JR9yXv9xy/M=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "VmNRKxSI3CS9RvMT9Zk+y/evy1M=",
 			"path": "github.com/aws/aws-sdk-go/service/secretsmanager",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "Y29bmjwKXcPg0d0WvZNFGdhd4+E=",
 			"path": "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "T8dOJ1jjEBdogUE03oRPRJCOY3k=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "UhJ0RdPXzdMOUEBWREB5Zi9lgmY=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "0vtFXRYnhlCCq8/zPv1O1YWIoSg=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "1rJbvLXRsCzWhTihruRq/i0Zawg=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "hliWYTmov/HswyMpYq93zJtdkk0=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "bW9FW0Qe3VURaSoY305kA/wCFrM=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "ECIZck5xhocpUl8GeUAdeSnCgvg=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "lWts5yvTa/92d0U77xSCP7ouO6s=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "TeuakooizAybzyMQyTXllUyhfBg=",
 			"path": "github.com/aws/aws-sdk-go/service/storagegateway",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "UhIVLDgQc19wjrPj8pP7Fu2UwWc=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "zSqEhiGtEK6ll3f1Rlf2tuDKQA8=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "H8Pa7irZ9gpuYGJk3uMK59gxGTs=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "uRMuwxPD/AlpvFpKppgAYzvlC0A=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "oe8l2ibuhzz7fWM3f64cWnHwFy8=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "859b69a01f8cb52b639bd8c868b116144bddc74a",
-			"revisionTime": "2018-08-09T22:25:54Z",
-			"version": "v1.15.9",
-			"versionExact": "v1.15.9"
+			"revision": "daed0c76021ea9c4e659e3ec80bcd2d657297100",
+			"revisionTime": "2018-08-14T22:31:59Z",
+			"version": "v1.15.12",
+			"versionExact": "v1.15.12"
 		},
 		{
 			"checksumSHA1": "usT4LCSQItkFvFOQT7cBlkCuGaE=",


### PR DESCRIPTION
Since this includes CloudFront SDK updates and historically those have been problematic, ~~I will kick off acceptance testing for those and ensure~~ they are okay ~~prior to any merge~~.

Changes proposed in this pull request:

* `govendor fetch github.com/aws/aws-sdk-go/...@v1.15.12`

Output from acceptance testing: (the rest handled via daily acceptance testing)

```
15 tests passed (all tests)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.70s)
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.81s)
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_basic
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_basic (7.79s)
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_noComment
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_noComment (8.16s)
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_importBasic
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_importBasic (8.78s)
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (839.15s)
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (840.47s)
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (841.45s)
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (843.01s)
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (845.18s)
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (846.45s)
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (847.36s)
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (847.39s)
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (849.10s)
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (849.11s)
```
