### PR TITLE
resource/aws_api_gateway_rest_api: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -106,6 +106,11 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "endpoint_configuration.#", "1"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_rest_api.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 
 			{
 				Config: testAccAWSAPIGatewayRestAPIUpdateConfig,
@@ -153,6 +158,11 @@ func TestAccAWSAPIGatewayRestApi_EndpointConfiguration(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "endpoint_configuration.0.types.#", "1"),
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "endpoint_configuration.0.types.0", "REGIONAL"),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_rest_api.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			// For backwards compatibility, test removing endpoint_configuration, which should do nothing
 			{
@@ -248,6 +258,11 @@ func TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "endpoint_configuration.0.types.0", "PRIVATE"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_rest_api.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -265,6 +280,11 @@ func TestAccAWSAPIGatewayRestApi_api_key_source(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "api_key_source", expectedAPIKeySource),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_rest_api.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSAPIGatewayRestAPIConfigWithUpdateAPIKeySource,
@@ -295,6 +315,11 @@ func TestAccAWSAPIGatewayRestApi_policy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aws_api_gateway_rest_api.test", "policy", expectedPolicyText),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_rest_api.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSAPIGatewayRestAPIConfigUpdatePolicy,
@@ -333,7 +358,12 @@ func TestAccAWSAPIGatewayRestApi_openapi(t *testing.T) {
 					resource.TestCheckNoResourceAttr("aws_api_gateway_rest_api.test", "binary_media_types"),
 				),
 			},
-
+			{
+				ResourceName:            "aws_api_gateway_rest_api.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"body"},
+			},
 			{
 				Config: testAccAWSAPIGatewayRestAPIUpdateConfigOpenAPI,
 				Check: resource.ComposeTestCheckFunc(

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -71,3 +71,13 @@ In addition to all arguments above, the following attributes are exported:
 * `execution_arn` - The execution ARN part to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
   when allowing API Gateway to invoke a Lambda function,
   e.g. `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j`, which can be concatenated with allowed stage, method and resource path.
+
+## Import
+
+`aws_api_gateway_rest_api` can be imported by using the REST API ID, e.g.
+
+```
+$ terraform import aws_api_gateway_rest_api.example 12345abcde
+```
+
+~> **NOTE:** Resource import does not currently support the `body` attribute.


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Supports, tests, and documents `aws_api_gateway_rest_api` resource import via ID
* Ensure `root_resource_id` attribute has proper drift detection
* Minor refactoring to remove usage of awserr and errwrap

Output from acceptance testing:

```
=== RUN   TestAccAWSAPIGatewayRestApi_basic
--- PASS: TestAccAWSAPIGatewayRestApi_basic (30.63s)
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration (67.79s)
=== RUN   TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private
--- PASS: TestAccAWSAPIGatewayRestApi_EndpointConfiguration_Private (39.44s)
=== RUN   TestAccAWSAPIGatewayRestApi_api_key_source
--- PASS: TestAccAWSAPIGatewayRestApi_api_key_source (41.51s)
=== RUN   TestAccAWSAPIGatewayRestApi_policy
--- PASS: TestAccAWSAPIGatewayRestApi_policy (31.04s)
=== RUN   TestAccAWSAPIGatewayRestApi_openapi
--- PASS: TestAccAWSAPIGatewayRestApi_openapi (21.74s)
```
