### PR TITLE
resource/aws_ecs_task_definition: Treat INACTIVE task definitions as removed

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -244,9 +244,16 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Received task definition %s", out)
+	log.Printf("[DEBUG] Received task definition %s, status:%s\n %s", aws.StringValue(out.TaskDefinition.Family),
+		aws.StringValue(out.TaskDefinition.Status), out)
 
 	taskDefinition := out.TaskDefinition
+
+	if aws.StringValue(taskDefinition.Status) == "INACTIVE" {
+		log.Printf("[DEBUG] Removing ECS task definition %s because it's INACTIVE", aws.StringValue(out.TaskDefinition.Family))
+		d.SetId("")
+		return nil
+	}
 
 	d.SetId(*taskDefinition.Family)
 	d.Set("arn", taskDefinition.TaskDefinitionArn)


### PR DESCRIPTION
## Todo
- [ ] Create acceptance test to verify deleting resource when task definition is `INACTIVE`

## Description
If a task definition is marked as INACTIVE in ECS then terraform should
treat it as a deleted resource

Fixes https://github.com/hashicorp/terraform/issues/3582

Output from acceptance testing:

```
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (40.59s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (24.57s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (74.65s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (28.97s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (25.93s)
=== RUN   TestAccAWSEcsTaskDefinition_constraint
--- PASS: TestAccAWSEcsTaskDefinition_constraint (26.89s)
=== RUN   TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (49.10s)
=== RUN   TestAccAWSEcsTaskDefinition_arrays
--- PASS: TestAccAWSEcsTaskDefinition_arrays (27.20s)
=== RUN   TestAccAWSEcsTaskDefinition_Fargate
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (26.15s)
=== RUN   TestAccAWSEcsTaskDefinition_ExecutionRole
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (37.77s)
=== RUN   TestValidateAwsEcsTaskDefinitionContainerDefinitions
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.00s)
PASS

Process finished with exit code 0
```

New acceptance test
```
=== RUN   TestAccAWSEcsTaskDefinition_Inactive
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (37.50s)
```