### PR TITLE
resource/aws_api_gateway_base_path_mapping: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_base_path_mapping.go
+++ b/aws/resource_aws_api_gateway_base_path_mapping.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,6 +20,9 @@ func resourceAwsApiGatewayBasePathMapping() *schema.Resource {
 		Create: resourceAwsApiGatewayBasePathMappingCreate,
 		Read:   resourceAwsApiGatewayBasePathMappingRead,
 		Delete: resourceAwsApiGatewayBasePathMappingDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"api_id": {
@@ -82,15 +86,9 @@ func resourceAwsApiGatewayBasePathMappingCreate(d *schema.ResourceData, meta int
 func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigateway
 
-	domainName := d.Get("domain_name").(string)
-	basePath := d.Get("base_path").(string)
-
-	if domainName == "" {
-		return nil
-	}
-
-	if basePath == "" {
-		basePath = emptyBasePathMappingValue
+	domainName, basePath, err := decodeApiGatewayBasePathMappingId(d.Id())
+	if err != nil {
+		return err
 	}
 
 	mapping, err := conn.GetBasePathMapping(&apigateway.GetBasePathMappingInput{
@@ -114,6 +112,7 @@ func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta inter
 	}
 
 	d.Set("base_path", mappingBasePath)
+	d.Set("domain_name", domainName)
 	d.Set("api_id", mapping.RestApiId)
 	d.Set("stage_name", mapping.Stage)
 
@@ -123,14 +122,13 @@ func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta inter
 func resourceAwsApiGatewayBasePathMappingDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigateway
 
-	basePath := d.Get("base_path").(string)
-
-	if basePath == "" {
-		basePath = emptyBasePathMappingValue
+	domainName, basePath, err := decodeApiGatewayBasePathMappingId(d.Id())
+	if err != nil {
+		return err
 	}
 
-	_, err := conn.DeleteBasePathMapping(&apigateway.DeleteBasePathMappingInput{
-		DomainName: aws.String(d.Get("domain_name").(string)),
+	_, err = conn.DeleteBasePathMapping(&apigateway.DeleteBasePathMappingInput{
+		DomainName: aws.String(domainName),
 		BasePath:   aws.String(basePath),
 	})
 
@@ -143,4 +141,26 @@ func resourceAwsApiGatewayBasePathMappingDelete(d *schema.ResourceData, meta int
 	}
 
 	return nil
+}
+
+func decodeApiGatewayBasePathMappingId(id string) (string, string, error) {
+	idFormatErr := fmt.Errorf("Unexpected format of ID (%q), expected DOMAIN/BASEPATH", id)
+
+	parts := strings.SplitN(id, "/", 2)
+	if len(parts) != 2 {
+		return "", "", idFormatErr
+	}
+
+	domainName := parts[0]
+	basePath := parts[1]
+
+	if domainName == "" {
+		return "", "", idFormatErr
+	}
+
+	if basePath == "" {
+		basePath = emptyBasePathMappingValue
+	}
+
+	return domainName, basePath, nil
 }

--- a/website/docs/r/api_gateway_base_path_mapping.html.markdown
+++ b/website/docs/r/api_gateway_base_path_mapping.html.markdown
@@ -45,3 +45,19 @@ The following arguments are supported:
 * `api_id` - (Required) The id of the API to connect.
 * `stage_name` - (Optional) The name of a specific deployment stage to expose at the given path. If omitted, callers may select any stage by including its name as a path element after the base path.
 * `base_path` - (Optional) Path segment that must be prepended to the path when accessing the API via this mapping. If omitted, the API is exposed at the root of the given domain.
+
+## Import
+
+`aws_api_gateway_base_path_mapping` can be imported by using the domain name and base path, e.g.
+
+For empty `base_path` (e.g. root path (`/`)):
+
+```
+$ terraform import aws_api_gateway_base_path_mapping.example example.com/
+```
+
+Otherwise:
+
+```
+$ terraform import aws_api_gateway_base_path_mapping.example example.com/base-path
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import via ID
* Fix CheckDestroy function handling to check `aws_api_gateway_base_path_mapping` resources

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayBasePathMapping_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayBasePathMapping_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayBasePathMapping_basic
--- PASS: TestAccAWSAPIGatewayBasePathMapping_basic (24.58s)
=== RUN   TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty
--- PASS: TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty (34.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	60.000s
```
