### PR TITLE
resource/aws_api_gateway_gateway_response: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_gateway_response.go
+++ b/aws/resource_aws_api_gateway_gateway_response.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,6 +19,20 @@ func resourceAwsApiGatewayGatewayResponse() *schema.Resource {
 		Read:   resourceAwsApiGatewayGatewayResponseRead,
 		Update: resourceAwsApiGatewayGatewayResponsePut,
 		Delete: resourceAwsApiGatewayGatewayResponseDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/RESPONSE-TYPE", d.Id())
+				}
+				restApiID := idParts[0]
+				responseType := idParts[1]
+				d.Set("response_type", responseType)
+				d.Set("rest_api_id", restApiID)
+				d.SetId(fmt.Sprintf("aggr-%s-%s", restApiID, responseType))
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"rest_api_id": {

--- a/aws/resource_aws_api_gateway_gateway_response_test.go
+++ b/aws/resource_aws_api_gateway_gateway_response_test.go
@@ -43,6 +43,12 @@ func TestAccAWSAPIGatewayGatewayResponse_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("aws_api_gateway_gateway_response.test", "response_parameters.gatewayresponse.header.Authorization"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_gateway_response.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayGatewayResponseImportStateIdFunc("aws_api_gateway_gateway_response.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -105,6 +111,17 @@ func testAccCheckAWSAPIGatewayGatewayResponseDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayGatewayResponseImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["response_type"]), nil
+	}
 }
 
 func testAccAWSAPIGatewayGatewayResponseConfig(rName string) string {

--- a/website/docs/r/api_gateway_gateway_response.markdown
+++ b/website/docs/r/api_gateway_gateway_response.markdown
@@ -41,3 +41,11 @@ The following arguments are supported:
 * `status_code` - (Optional) The HTTP status code of the Gateway Response.
 * `response_parameters` - (Optional) A map specifying the templates used to transform the response body.
 * `response_templates` - (Optional) A map specifying the parameters (paths, query strings and headers) of the Gateway Response.
+
+## Import
+
+`aws_api_gateway_gateway_response` can be imported using `REST-API-ID/RESPONSE-TYPE`, e.g.
+
+```
+$ terraform import aws_api_gateway_gateway_response.example 12345abcde/UNAUTHORIZED
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayGatewayResponse_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayGatewayResponse_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayGatewayResponse_basic
--- PASS: TestAccAWSAPIGatewayGatewayResponse_basic (21.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.291s
```
