### PR TITLE
resource/aws_api_gateway_integration: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -22,6 +22,22 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 		Read:   resourceAwsApiGatewayIntegrationRead,
 		Update: resourceAwsApiGatewayIntegrationUpdate,
 		Delete: resourceAwsApiGatewayIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/RESOURCE-ID/HTTP-METHOD", d.Id())
+				}
+				restApiID := idParts[0]
+				resourceID := idParts[1]
+				httpMethod := idParts[2]
+				d.Set("http_method", httpMethod)
+				d.Set("resource_id", resourceID)
+				d.Set("rest_api_id", restApiID)
+				d.SetId(fmt.Sprintf("agi-%s-%s-%s", restApiID, resourceID, httpMethod))
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"rest_api_id": {
@@ -271,46 +287,43 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 		return err
 	}
 	log.Printf("[DEBUG] Received API Gateway Integration: %s", integration)
-	d.SetId(fmt.Sprintf("agi-%s-%s-%s", d.Get("rest_api_id").(string), d.Get("resource_id").(string), d.Get("http_method").(string)))
 
-	// AWS converts "" to null on their side, convert it back
-	if v, ok := integration.RequestTemplates["application/json"]; ok && v == nil {
-		integration.RequestTemplates["application/json"] = aws.String("")
+	if err := d.Set("cache_key_parameters", flattenStringList(integration.CacheKeyParameters)); err != nil {
+		return fmt.Errorf("error setting cache_key_parameters: %s", err)
 	}
-
-	d.Set("request_templates", aws.StringValueMap(integration.RequestTemplates))
-	d.Set("type", integration.Type)
-	d.Set("request_parameters", aws.StringValueMap(integration.RequestParameters))
-	d.Set("request_parameters_in_json", aws.StringValueMap(integration.RequestParameters))
-	d.Set("passthrough_behavior", integration.PassthroughBehavior)
+	d.Set("cache_namespace", integration.CacheNamespace)
+	d.Set("connection_id", integration.ConnectionId)
+	d.Set("connection_type", apigateway.ConnectionTypeInternet)
 	if integration.ConnectionType != nil {
 		d.Set("connection_type", integration.ConnectionType)
-	} else {
-		d.Set("connection_type", apigateway.ConnectionTypeInternet)
 	}
-	d.Set("connection_id", integration.ConnectionId)
+	d.Set("content_handling", integration.ContentHandling)
+	d.Set("credentials", integration.Credentials)
+	d.Set("integration_http_method", integration.HttpMethod)
+	d.Set("passthrough_behavior", integration.PassthroughBehavior)
 
-	if integration.Uri != nil {
-		d.Set("uri", integration.Uri)
-	}
-
-	if integration.Credentials != nil {
-		d.Set("credentials", integration.Credentials)
-	}
-
-	if integration.ContentHandling != nil {
-		d.Set("content_handling", integration.ContentHandling)
+	// KNOWN ISSUE: This next d.Set() is broken as it should be a JSON string of the map,
+	//              however leaving as-is since this attribute has been deprecated
+	//              for a very long time and will be removed soon in the next major release.
+	//              Not worth the effort of fixing, acceptance testing, and potential JSON equivalence bugs.
+	if _, ok := d.GetOk("request_parameters_in_json"); ok {
+		d.Set("request_parameters_in_json", aws.StringValueMap(integration.RequestParameters))
 	}
 
-	d.Set("cache_key_parameters", flattenStringList(integration.CacheKeyParameters))
+	d.Set("request_parameters", aws.StringValueMap(integration.RequestParameters))
 
-	if integration.CacheNamespace != nil {
-		d.Set("cache_namespace", integration.CacheNamespace)
+	// We need to explicitly convert key = nil values into key = "", which aws.StringValueMap() removes
+	requestTemplateMap := make(map[string]string)
+	for key, valuePointer := range integration.RequestTemplates {
+		requestTemplateMap[key] = aws.StringValue(valuePointer)
+	}
+	if err := d.Set("request_templates", requestTemplateMap); err != nil {
+		return fmt.Errorf("error setting request_templates: %s", err)
 	}
 
-	if integration.TimeoutInMillis != nil {
-		d.Set("timeout_milliseconds", integration.TimeoutInMillis)
-	}
+	d.Set("timeout_milliseconds", integration.TimeoutInMillis)
+	d.Set("type", integration.Type)
+	d.Set("uri", integration.Uri)
 
 	return nil
 }

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -30,7 +30,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
@@ -50,7 +50,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'updated'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-FooBar", "'Baz'"),
@@ -70,7 +70,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de/updated"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
@@ -90,7 +90,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "0"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "0"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "timeout_milliseconds", "2000"),
@@ -106,7 +106,7 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
@@ -114,6 +114,12 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "timeout_milliseconds", "29000"),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_integration.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayIntegrationImportStateIdFunc("aws_api_gateway_integration.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -136,7 +142,7 @@ func TestAccAWSAPIGatewayIntegration_contentHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
@@ -155,7 +161,7 @@ func TestAccAWSAPIGatewayIntegration_contentHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_BINARY"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
@@ -174,7 +180,7 @@ func TestAccAWSAPIGatewayIntegration_contentHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", ""),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
@@ -182,6 +188,12 @@ func TestAccAWSAPIGatewayIntegration_contentHandling(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_integration.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayIntegrationImportStateIdFunc("aws_api_gateway_integration.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -204,7 +216,7 @@ func TestAccAWSAPIGatewayIntegration_cache_key_parameters(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
-					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "credentials", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "3"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
@@ -216,6 +228,12 @@ func TestAccAWSAPIGatewayIntegration_cache_key_parameters(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_integration.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayIntegrationImportStateIdFunc("aws_api_gateway_integration.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -254,7 +272,14 @@ func TestAccAWSAPIGatewayIntegration_integrationType(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "connection_type", "INTERNET"),
 					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "connection_id", ""),
 				),
-			}},
+			},
+			{
+				ResourceName:      "aws_api_gateway_integration.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayIntegrationImportStateIdFunc("aws_api_gateway_integration.test"),
+				ImportStateVerify: true,
+			},
+		},
 	})
 }
 
@@ -318,6 +343,17 @@ func testAccCheckAWSAPIGatewayIntegrationDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayIntegrationImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["resource_id"], rs.Primary.Attributes["http_method"]), nil
+	}
 }
 
 const testAccAWSAPIGatewayIntegrationConfig = `

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -225,3 +225,11 @@ The following arguments are supported:
 * `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
 * `content_handling` - (Optional) Specifies how to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the passthroughBehaviors is configured to support payload pass-through.
 * `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
+
+## Import
+
+`aws_api_gateway_integration` can be imported using `REST-API-ID/RESOURCE-ID/HTTP-METHOD`, e.g.
+
+```
+$ terraform import aws_api_gateway_integration.example 12345abcde/67890fghij/GET
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import
* Properly read `integration_http_method` into the Terraform state for drift detection

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayIntegration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayIntegration_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayIntegration_basic
--- PASS: TestAccAWSAPIGatewayIntegration_basic (54.97s)
=== RUN   TestAccAWSAPIGatewayIntegration_contentHandling
--- PASS: TestAccAWSAPIGatewayIntegration_contentHandling (35.52s)
=== RUN   TestAccAWSAPIGatewayIntegration_cache_key_parameters
--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (30.47s)
=== RUN   TestAccAWSAPIGatewayIntegration_integrationType
--- PASS: TestAccAWSAPIGatewayIntegration_integrationType (726.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	848.708s
```
