### PR TITLE
resource/aws_api_gateway_integration_response: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_integration_response_test.go
+++ b/aws/resource_aws_api_gateway_integration_response_test.go
@@ -28,8 +28,8 @@ func TestAccAWSAPIGatewayIntegrationResponse_basic(t *testing.T) {
 						"aws_api_gateway_integration_response.test", "response_templates.application/json", ""),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_integration_response.test", "response_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
-					resource.TestCheckNoResourceAttr(
-						"aws_api_gateway_integration_response.test", "content_handling"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_integration_response.test", "content_handling", ""),
 				),
 			},
 
@@ -45,6 +45,12 @@ func TestAccAWSAPIGatewayIntegrationResponse_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_integration_response.test", "content_handling", "CONVERT_TO_BINARY"),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_integration_response.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayIntegrationResponseImportStateIdFunc("aws_api_gateway_integration_response.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -155,6 +161,17 @@ func testAccCheckAWSAPIGatewayIntegrationResponseDestroy(s *terraform.State) err
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayIntegrationResponseImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["resource_id"], rs.Primary.Attributes["http_method"], rs.Primary.Attributes["status_code"]), nil
+	}
 }
 
 const testAccAWSAPIGatewayIntegrationResponseConfig = `

--- a/website/docs/r/api_gateway_integration_response.html.markdown
+++ b/website/docs/r/api_gateway_integration_response.html.markdown
@@ -84,3 +84,11 @@ The following arguments are supported:
   For example: `response_parameters = { "method.response.header.X-Some-Header" = "integration.response.header.X-Some-Other-Header" }`,
 * `response_parameters_in_json` - **Deprecated**, use `response_parameters` instead.
 * `content_handling` - (Optional) Specifies how to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.
+
+## Import
+
+`aws_api_gateway_integration_response` can be imported using `REST-API-ID/RESOURCE-ID/HTTP-METHOD/STATUS-CODE`, e.g.
+
+```
+$ terraform import aws_api_gateway_integration_response.example 12345abcde/67890fghij/GET/200
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:
* Support, test, and document resource import
* Properly read `content_handling` into Terraform state for drift detection
* Properly read `response_templates` into Terraform state for drift detection

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayIntegrationResponse_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayIntegrationResponse_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayIntegrationResponse_basic
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (28.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	29.523s
```
