### PR TITLE
resource/aws_api_gateway_method_response: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_method_response.go
+++ b/aws/resource_aws_api_gateway_method_response.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"sync"
 )
 
 var resourceAwsApiGatewayMethodResponseMutex = &sync.Mutex{}
@@ -23,6 +24,24 @@ func resourceAwsApiGatewayMethodResponse() *schema.Resource {
 		Read:   resourceAwsApiGatewayMethodResponseRead,
 		Update: resourceAwsApiGatewayMethodResponseUpdate,
 		Delete: resourceAwsApiGatewayMethodResponseDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 4 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" || idParts[3] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/RESOURCE-ID/HTTP-METHOD/STATUS-CODE", d.Id())
+				}
+				restApiID := idParts[0]
+				resourceID := idParts[1]
+				httpMethod := idParts[2]
+				statusCode := idParts[3]
+				d.Set("http_method", httpMethod)
+				d.Set("status_code", statusCode)
+				d.Set("resource_id", resourceID)
+				d.Set("rest_api_id", restApiID)
+				d.SetId(fmt.Sprintf("agmr-%s-%s-%s-%s", restApiID, resourceID, httpMethod, statusCode))
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"rest_api_id": &schema.Schema{
@@ -140,10 +159,22 @@ func resourceAwsApiGatewayMethodResponseRead(d *schema.ResourceData, meta interf
 	}
 
 	log.Printf("[DEBUG] Received API Gateway Method Response: %s", methodResponse)
-	d.Set("response_models", aws.StringValueMap(methodResponse.ResponseModels))
-	d.Set("response_parameters", aws.BoolValueMap(methodResponse.ResponseParameters))
-	d.Set("response_parameters_in_json", aws.BoolValueMap(methodResponse.ResponseParameters))
-	d.SetId(fmt.Sprintf("agmr-%s-%s-%s-%s", d.Get("rest_api_id").(string), d.Get("resource_id").(string), d.Get("http_method").(string), d.Get("status_code").(string)))
+
+	if err := d.Set("response_models", aws.StringValueMap(methodResponse.ResponseModels)); err != nil {
+		return fmt.Errorf("error setting response_models: %s", err)
+	}
+
+	if err := d.Set("response_parameters", aws.BoolValueMap(methodResponse.ResponseParameters)); err != nil {
+		return fmt.Errorf("error setting response_parameters: %s", err)
+	}
+
+	// KNOWN ISSUE: This next d.Set() is broken as it should be a JSON string of the map,
+	//              however leaving as-is since this attribute has been deprecated
+	//              for a very long time and will be removed soon in the next major release.
+	//              Not worth the effort of fixing, acceptance testing, and potential JSON equivalence bugs.
+	if _, ok := d.GetOk("response_parameters_in_json"); ok {
+		d.Set("response_parameters_in_json", aws.BoolValueMap(methodResponse.ResponseParameters))
+	}
 
 	return nil
 }

--- a/aws/resource_aws_api_gateway_method_response_test.go
+++ b/aws/resource_aws_api_gateway_method_response_test.go
@@ -42,6 +42,12 @@ func TestAccAWSAPIGatewayMethodResponse_basic(t *testing.T) {
 						"aws_api_gateway_method_response.error", "response_models.application/json", "Empty"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_method_response.error",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayMethodResponseImportStateIdFunc("aws_api_gateway_method_response.error"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -150,6 +156,17 @@ func testAccCheckAWSAPIGatewayMethodResponseDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayMethodResponseImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["resource_id"], rs.Primary.Attributes["http_method"], rs.Primary.Attributes["status_code"]), nil
+	}
 }
 
 const testAccAWSAPIGatewayMethodResponseConfig = `

--- a/website/docs/r/api_gateway_method_response.html.markdown
+++ b/website/docs/r/api_gateway_method_response.html.markdown
@@ -59,3 +59,11 @@ The following arguments are supported:
    For example: `response_parameters = { "method.response.header.X-Some-Header" = true }`
    would define that the header `X-Some-Header` can be provided on the response.
 * `response_parameters_in_json` - **Deprecated**, use `response_parameters` instead.
+
+## Import
+
+`aws_api_gateway_method_response` can be imported using `REST-API-ID/RESOURCE-ID/HTTP-METHOD/STATUS-CODE`, e.g.
+
+```
+$ terraform import aws_api_gateway_method_response.example 12345abcde/67890fghij/GET/200
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayMethodResponse_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayMethodResponse_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayMethodResponse_basic
--- PASS: TestAccAWSAPIGatewayMethodResponse_basic (26.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.152s
```
