### PR TITLE
resource/aws_api_gateway_method: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_method.go
+++ b/aws/resource_aws_api_gateway_method.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,6 +21,22 @@ func resourceAwsApiGatewayMethod() *schema.Resource {
 		Read:   resourceAwsApiGatewayMethodRead,
 		Update: resourceAwsApiGatewayMethodUpdate,
 		Delete: resourceAwsApiGatewayMethodDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/RESOURCE-ID/HTTP-METHOD", d.Id())
+				}
+				restApiID := idParts[0]
+				resourceID := idParts[1]
+				httpMethod := idParts[2]
+				d.Set("http_method", httpMethod)
+				d.Set("resource_id", resourceID)
+				d.Set("rest_api_id", restApiID)
+				d.SetId(fmt.Sprintf("agm-%s-%s-%s", restApiID, resourceID, httpMethod))
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"rest_api_id": &schema.Schema{
@@ -170,18 +187,33 @@ func resourceAwsApiGatewayMethodRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	log.Printf("[DEBUG] Received API Gateway Method: %s", out)
-	d.SetId(fmt.Sprintf("agm-%s-%s-%s", d.Get("rest_api_id").(string), d.Get("resource_id").(string), d.Get("http_method").(string)))
-	d.Set("request_parameters", aws.BoolValueMap(out.RequestParameters))
-	d.Set("request_parameters_in_json", aws.BoolValueMap(out.RequestParameters))
+
 	d.Set("api_key_required", out.ApiKeyRequired)
-	d.Set("authorization", out.AuthorizationType)
-	d.Set("authorizer_id", out.AuthorizerId)
-	d.Set("request_models", aws.StringValueMap(out.RequestModels))
-	d.Set("request_validator_id", out.RequestValidatorId)
 
 	if err := d.Set("authorization_scopes", flattenStringList(out.AuthorizationScopes)); err != nil {
 		return fmt.Errorf("error setting authorization_scopes: %s", err)
 	}
+
+	d.Set("authorization", out.AuthorizationType)
+	d.Set("authorizer_id", out.AuthorizerId)
+
+	if err := d.Set("request_models", aws.StringValueMap(out.RequestModels)); err != nil {
+		return fmt.Errorf("error setting request_models: %s", err)
+	}
+
+	// KNOWN ISSUE: This next d.Set() is broken as it should be a JSON string of the map,
+	//              however leaving as-is since this attribute has been deprecated
+	//              for a very long time and will be removed soon in the next major release.
+	//              Not worth the effort of fixing, acceptance testing, and potential JSON equivalence bugs.
+	if _, ok := d.GetOk("request_parameters_in_json"); ok {
+		d.Set("request_parameters_in_json", aws.BoolValueMap(out.RequestParameters))
+	}
+
+	if err := d.Set("request_parameters", aws.BoolValueMap(out.RequestParameters)); err != nil {
+		return fmt.Errorf("error setting request_models: %s", err)
+	}
+
+	d.Set("request_validator_id", out.RequestValidatorId)
 
 	return nil
 }

--- a/aws/resource_aws_api_gateway_method_test.go
+++ b/aws/resource_aws_api_gateway_method_test.go
@@ -35,6 +35,12 @@ func TestAccAWSAPIGatewayMethod_basic(t *testing.T) {
 						"aws_api_gateway_method.test", "request_models.application/json", "Error"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_method.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayMethodImportStateIdFunc("aws_api_gateway_method.test"),
+				ImportStateVerify: true,
+			},
 
 			{
 				Config: testAccAWSAPIGatewayMethodConfigUpdate(rInt),
@@ -70,6 +76,12 @@ func TestAccAWSAPIGatewayMethod_customauthorizer(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_method.test", "request_models.application/json", "Error"),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_method.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayMethodImportStateIdFunc("aws_api_gateway_method.test"),
+				ImportStateVerify: true,
 			},
 
 			{
@@ -129,6 +141,12 @@ func TestAccAWSAPIGatewayMethod_cognitoauthorizer(t *testing.T) {
 						"aws_api_gateway_method.test", "authorization_scopes.#", "3"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_method.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayMethodImportStateIdFunc("aws_api_gateway_method.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -156,6 +174,12 @@ func TestAccAWSAPIGatewayMethod_customrequestvalidator(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_api_gateway_method.test", "request_validator_id", regexp.MustCompile("^[a-z0-9]{6}$")),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_method.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayMethodImportStateIdFunc("aws_api_gateway_method.test"),
+				ImportStateVerify: true,
 			},
 
 			{
@@ -279,6 +303,17 @@ func testAccCheckAWSAPIGatewayMethodDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayMethodImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["resource_id"], rs.Primary.Attributes["http_method"]), nil
+	}
 }
 
 func testAccAWSAPIGatewayMethodConfigWithCustomAuthorizer(rInt int) string {

--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -95,3 +95,11 @@ request_parameters = {
 ```
 would define that the header `X-Some-Header` and the query string `some-query-param` must be provided on the request, or
 * `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
+
+## Import
+
+`aws_api_gateway_method` can be imported using `REST-API-ID/RESOURCE-ID/HTTP-METHOD`, e.g.
+
+```
+$ terraform import aws_api_gateway_method.example 12345abcde/67890fghij/GET
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayMethod_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayMethod_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayMethod_basic
--- PASS: TestAccAWSAPIGatewayMethod_basic (23.34s)
=== RUN   TestAccAWSAPIGatewayMethod_customauthorizer
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (42.91s)
=== RUN   TestAccAWSAPIGatewayMethod_cognitoauthorizer
--- PASS: TestAccAWSAPIGatewayMethod_cognitoauthorizer (25.09s)
=== RUN   TestAccAWSAPIGatewayMethod_customrequestvalidator
--- PASS: TestAccAWSAPIGatewayMethod_customrequestvalidator (30.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	122.264s
```
