### PR TITLE
resource/aws_api_gateway_model: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_model.go
+++ b/aws/resource_aws_api_gateway_model.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,6 +19,33 @@ func resourceAwsApiGatewayModel() *schema.Resource {
 		Read:   resourceAwsApiGatewayModelRead,
 		Update: resourceAwsApiGatewayModelUpdate,
 		Delete: resourceAwsApiGatewayModelDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/NAME", d.Id())
+				}
+				restApiID := idParts[0]
+				name := idParts[1]
+				d.Set("name", name)
+				d.Set("rest_api_id", restApiID)
+
+				conn := meta.(*AWSClient).apigateway
+
+				output, err := conn.GetModel(&apigateway.GetModelInput{
+					ModelName: aws.String(name),
+					RestApiId: aws.String(restApiID),
+				})
+
+				if err != nil {
+					return nil, err
+				}
+
+				d.SetId(aws.StringValue(output.Id))
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"rest_api_id": &schema.Schema{
@@ -100,10 +128,10 @@ func resourceAwsApiGatewayModelRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 	log.Printf("[DEBUG] Received API Gateway Model: %s", out)
-	d.SetId(*out.Id)
+
+	d.Set("content_type", out.ContentType)
 	d.Set("description", out.Description)
 	d.Set("schema", out.Schema)
-	d.Set("content_type", out.ContentType)
 
 	return nil
 }

--- a/aws/resource_aws_api_gateway_model_test.go
+++ b/aws/resource_aws_api_gateway_model_test.go
@@ -32,6 +32,12 @@ func TestAccAWSAPIGatewayModel_basic(t *testing.T) {
 						"aws_api_gateway_model.test", "content_type", "application/json"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_model.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayModelImportStateIdFunc("aws_api_gateway_model.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -115,6 +121,17 @@ func testAccCheckAWSAPIGatewayModelDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayModelImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["name"]), nil
+	}
 }
 
 const testAccAWSAPIGatewayModelConfig = `

--- a/website/docs/r/api_gateway_model.html.markdown
+++ b/website/docs/r/api_gateway_model.html.markdown
@@ -47,3 +47,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the model
+
+## Import
+
+`aws_api_gateway_model` can be imported using `REST-API-ID/NAME`, e.g.
+
+```
+$ terraform import aws_api_gateway_model.example 12345abcde/example
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayModel_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayModel_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayModel_basic
--- PASS: TestAccAWSAPIGatewayModel_basic (14.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.981s
```
