### PR TITLE
resource/aws_api_gateway_request_validator: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_request_validator_test.go
+++ b/aws/resource_aws_api_gateway_request_validator_test.go
@@ -43,6 +43,12 @@ func TestAccAWSAPIGatewayRequestValidator_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_request_validator.test", "validate_request_parameters", "true"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_request_validator.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayRequestValidatorImportStateIdFunc("aws_api_gateway_request_validator.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -141,6 +147,17 @@ func testAccCheckAWSAPIGatewayRequestValidatorDestroy(s *terraform.State) error 
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayRequestValidatorImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.ID), nil
+	}
 }
 
 const testAccAWSAPIGatewayRequestValidatorConfig_base = `

--- a/website/docs/r/api_gateway_request_validator.html.markdown
+++ b/website/docs/r/api_gateway_request_validator.html.markdown
@@ -35,3 +35,11 @@ The following argument is supported:
 The following attribute is exported in addition to the arguments listed above:
 
 * `id` - The unique ID of the request validator
+
+## Import
+
+`aws_api_gateway_request_validator` can be imported using `REST-API-ID/REQUEST-VALIDATOR-ID`, e.g.
+
+```
+$ terraform import aws_api_gateway_request_validator.example 12345abcde/67890fghij
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayRequestValidator_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayRequestValidator_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayRequestValidator_basic
--- PASS: TestAccAWSAPIGatewayRequestValidator_basic (20.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	21.568s
```
