### PR TITLE
resource/aws_api_gateway_resource: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_resource.go
+++ b/aws/resource_aws_api_gateway_resource.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,6 +19,20 @@ func resourceAwsApiGatewayResource() *schema.Resource {
 		Read:   resourceAwsApiGatewayResourceRead,
 		Update: resourceAwsApiGatewayResourceUpdate,
 		Delete: resourceAwsApiGatewayResourceDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/RESOURCE-ID", d.Id())
+				}
+				restApiID := idParts[0]
+				resourceID := idParts[1]
+				d.Set("request_validator_id", resourceID)
+				d.Set("rest_api_id", restApiID)
+				d.SetId(resourceID)
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"rest_api_id": &schema.Schema{

--- a/aws/resource_aws_api_gateway_resource_test.go
+++ b/aws/resource_aws_api_gateway_resource_test.go
@@ -30,6 +30,12 @@ func TestAccAWSAPIGatewayResource_basic(t *testing.T) {
 						"aws_api_gateway_resource.test", "path", "/test"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_resource.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayResourceImportStateIdFunc("aws_api_gateway_resource.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -64,6 +70,12 @@ func TestAccAWSAPIGatewayResource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_resource.test", "path", "/test_changed"),
 				),
+			},
+			{
+				ResourceName:      "aws_api_gateway_resource.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayResourceImportStateIdFunc("aws_api_gateway_resource.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -143,6 +155,17 @@ func testAccCheckAWSAPIGatewayResourceDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayResourceImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.ID), nil
+	}
 }
 
 const testAccAWSAPIGatewayResourceConfig = `

--- a/website/docs/r/api_gateway_resource.html.markdown
+++ b/website/docs/r/api_gateway_resource.html.markdown
@@ -39,3 +39,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource's identifier.
 * `path` - The complete path for this API resource, including all parent paths.
+
+## Import
+
+`aws_api_gateway_resource` can be imported using `REST-API-ID/RESOURCE-ID`, e.g.
+
+```
+$ terraform import aws_api_gateway_resource.example 12345abcde/67890fghij
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayResource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayResource_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayResource_basic
--- PASS: TestAccAWSAPIGatewayResource_basic (14.57s)
=== RUN   TestAccAWSAPIGatewayResource_update
--- PASS: TestAccAWSAPIGatewayResource_update (33.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.778s
```
