### PR TITLE
resource/aws_api_gateway_stage: Support resource import

### DIFF
--- a/aws/resource_aws_api_gateway_stage.go
+++ b/aws/resource_aws_api_gateway_stage.go
@@ -20,6 +20,20 @@ func resourceAwsApiGatewayStage() *schema.Resource {
 		Read:   resourceAwsApiGatewayStageRead,
 		Update: resourceAwsApiGatewayStageUpdate,
 		Delete: resourceAwsApiGatewayStageDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), "/")
+				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected REST-API-ID/STAGE-NAME", d.Id())
+				}
+				restApiID := idParts[0]
+				stageName := idParts[1]
+				d.Set("stage_name", stageName)
+				d.Set("rest_api_id", restApiID)
+				d.SetId(fmt.Sprintf("ags-%s-%s", restApiID, stageName))
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"access_log_settings": {
@@ -219,8 +233,14 @@ func resourceAwsApiGatewayStageRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("deployment_id", stage.DeploymentId)
 	d.Set("description", stage.Description)
 	d.Set("documentation_version", stage.DocumentationVersion)
-	d.Set("variables", aws.StringValueMap(stage.Variables))
-	d.Set("tags", aws.StringValueMap(stage.Tags))
+
+	if err := d.Set("tags", aws.StringValueMap(stage.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	if err := d.Set("variables", aws.StringValueMap(stage.Variables)); err != nil {
+		return fmt.Errorf("error setting variables: %s", err)
+	}
 
 	region := meta.(*AWSClient).region
 	d.Set("invoke_url", buildApiGatewayInvokeURL(restApiId, region, stageName))

--- a/aws/resource_aws_api_gateway_stage_test.go
+++ b/aws/resource_aws_api_gateway_stage_test.go
@@ -34,6 +34,12 @@ func TestAccAWSAPIGatewayStage_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_api_gateway_stage.test", "invoke_url"),
 				),
 			},
+			{
+				ResourceName:      "aws_api_gateway_stage.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAPIGatewayStageImportStateIdFunc("aws_api_gateway_stage.test"),
+				ImportStateVerify: true,
+			},
 			resource.TestStep{
 				Config: testAccAWSAPIGatewayStageConfig_updated(rName),
 				Check: resource.ComposeTestCheckFunc(
@@ -82,6 +88,7 @@ func TestAccAWSAPIGatewayStage_accessLogSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_stage.test", "access_log_settings.0.format", clf),
 				),
 			},
+
 			{
 				Config: testAccAWSAPIGatewayStageConfig_accessLogSettings(rName, json),
 				Check: resource.ComposeTestCheckFunc(
@@ -177,6 +184,17 @@ func testAccCheckAWSAPIGatewayStageDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAPIGatewayStageImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["rest_api_id"], rs.Primary.Attributes["stage_name"]), nil
+	}
 }
 
 func testAccAWSAPIGatewayStageConfig_base(rName string) string {

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -97,3 +97,11 @@ In addition to all arguments above, the following attributes are exported:
 * `execution_arn` - The execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
   when allowing API Gateway to invoke a Lambda function,
   e.g. `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod`
+
+## Import
+
+`aws_api_gateway_stage` can be imported using `REST-API-ID/STAGE-NAME`, e.g.
+
+```
+$ terraform import aws_api_gateway_stage.example 12345abcde/example
+```


### PR DESCRIPTION
Reference: #558 

Changes proposed in this pull request:

* Support, test, and document resource import

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAPIGatewayStage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAPIGatewayStage_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayStage_basic
--- PASS: TestAccAWSAPIGatewayStage_basic (401.05s)
=== RUN   TestAccAWSAPIGatewayStage_accessLogSettings
--- PASS: TestAccAWSAPIGatewayStage_accessLogSettings (247.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	649.123s
```
