### PR TITLE
resource/aws_secretsmanager_secret: Support ForceDeleteWithoutRecovery and recreation after immediate deletion

### DIFF
--- a/website/docs/r/secretsmanager_secret.html.markdown
+++ b/website/docs/r/secretsmanager_secret.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `description` - (Optional) A description of the secret.
 * `kms_key_id` - (Optional) Specifies the ARN or alias of the AWS KMS customer master key (CMK) to be used to encrypt the secret values in the versions stored in this secret. If you don't specify this value, then Secrets Manager defaults to using the AWS account's default CMK (the one named `aws/secretsmanager`). If the default KMS CMK with that name doesn't yet exist, then AWS Secrets Manager creates it for you automatically the first time.
 * `policy` - (Optional) A valid JSON document representing a [resource policy](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html).
-* `recovery_window_in_days` - (Optional) Specifies the number of days that AWS Secrets Manager waits before it can delete the secret. This value can range from 7 to 30 days. The default value is 30.
+* `recovery_window_in_days` - (Optional) Specifies the number of days that AWS Secrets Manager waits before it can delete the secret. This value can be `0` to force deletion without recovery or range from `7` to `30` days. The default value is `30`.
 * `rotation_lambda_arn` - (Optional) Specifies the ARN of the Lambda function that can rotate the secret.
 * `rotation_rules` - (Optional) A structure that defines the rotation configuration for this secret. Defined below.
 * `tags` - (Optional) Specifies a key-value map of user-defined tags that are attached to the secret.


### PR DESCRIPTION
Closes #5521 
Closes #5445 
Closes #5127 
Closes #4467

Changes proposed in this pull request:

* When `recovery_window_in_days` is set to 0, use `ForceDeleteWithoutRecovery` with `DeleteSecret`
* On creation, allow two minutes of retry for `InvalidRequestException: You can’t perform this operation on the secret because it was deleted.`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsSecretsManagerSecret_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsSecretsManagerSecret_ -timeout 120m
=== RUN   TestAccAwsSecretsManagerSecret_Basic
--- PASS: TestAccAwsSecretsManagerSecret_Basic (13.95s)
=== RUN   TestAccAwsSecretsManagerSecret_Description
--- PASS: TestAccAwsSecretsManagerSecret_Description (22.19s)
=== RUN   TestAccAwsSecretsManagerSecret_KmsKeyID
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (53.60s)
=== RUN   TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (51.11s)
=== RUN   TestAccAwsSecretsManagerSecret_RotationLambdaARN
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (51.04s)
=== RUN   TestAccAwsSecretsManagerSecret_RotationRules
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (52.66s)
=== RUN   TestAccAwsSecretsManagerSecret_Tags
--- PASS: TestAccAwsSecretsManagerSecret_Tags (40.70s)
=== RUN   TestAccAwsSecretsManagerSecret_policy
--- PASS: TestAccAwsSecretsManagerSecret_policy (11.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	297.680s
```
