### PR TITLE
resource/aws_elasticache_cluster: Allow availability_zone to be specified with replication_group_id

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -229,7 +229,6 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		Optional: true,
 		ForceNew: true,
 		ConflictsWith: []string{
-			"availability_zone",
 			"availability_zones",
 			"az_mode",
 			"engine_version",


### PR DESCRIPTION
Fixes #5579 

Changes proposed in this pull request:

* Remove availability_zone from the replication_group_id ConflictsWith

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic -timeout 120m
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic (1084.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1085.065s
```
