### PR TITLE
resource/aws_cloudfront_distribution: Import into ordered_cache_behavior instead of deprecated cache_behavior

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -144,10 +144,10 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 		}
 	}
 	if distributionConfig.CacheBehaviors != nil {
-		if _, ok := d.GetOk("ordered_cache_behavior"); ok {
-			err = d.Set("ordered_cache_behavior", flattenCacheBehaviors(distributionConfig.CacheBehaviors))
-		} else {
+		if _, ok := d.GetOk("cache_behavior"); ok {
 			err = d.Set("cache_behavior", flattenCacheBehaviorsDeprecated(distributionConfig.CacheBehaviors))
+		} else {
+			err = d.Set("ordered_cache_behavior", flattenCacheBehaviors(distributionConfig.CacheBehaviors))
 		}
 
 		if err != nil {

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -219,6 +219,11 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ordered_cache_behavior.1.path_pattern", "images2/*.jpg"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes: #5580 
Fixes: #4773

Previously:

```
--- FAIL: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (739.56s)
	testing.go:527: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

		(map[string]string) (len=59) {
		 (string) (len=16) "cache_behavior.#": (string) (len=1) "2",
...
		 (string) (len=48) "cache_behavior.1203603591.viewer_protocol_policy": (string) (len=9) "allow-all"
		}

		(map[string]string) (len=59) {
		 (string) (len=24) "ordered_cache_behavior.#": (string) (len=1) "2",
...
		 (string) (len=47) "ordered_cache_behavior.1.viewer_protocol_policy": (string) (len=9) "allow-all"
		}
```

Changes proposed in this pull request:

* Use `d.GetOk()` against the old attribute during read instead of the new attribute, which defaults imports to the new attribute

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (820.16s)
```
