### PR TITLE
data-source/aws_storagegateway_local_disk: Add disk_node argument

### DIFF
--- a/aws/data_source_aws_storagegateway_local_disk_test.go
+++ b/aws/data_source_aws_storagegateway_local_disk_test.go
@@ -10,6 +10,29 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAWSStorageGatewayLocalDiskDataSource_DiskNode(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_storagegateway_local_disk.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "disk_id"),
+				),
+			},
+			{
+				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode_NonExistent(rName),
+				ExpectError: regexp.MustCompile(`no results found`),
+			},
+		},
+	})
+}
+
 func TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	dataSourceName := "data.aws_storagegateway_local_disk.test"
@@ -19,15 +42,15 @@ func TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath_NonExistent(rName),
-				ExpectError: regexp.MustCompile(`no results found`),
-			},
-			{
 				Config: testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "disk_id"),
 				),
+			},
+			{
+				Config:      testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath_NonExistent(rName),
+				ExpectError: regexp.MustCompile(`no results found`),
 			},
 		},
 	})
@@ -42,6 +65,58 @@ func testAccAWSStorageGatewayLocalDiskDataSourceExists(dataSourceName string) re
 
 		return nil
 	}
+}
+
+func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = "10"
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/sdb"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_node   = "${aws_volume_attachment.test.device_name}"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+`, rName)
+}
+
+func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskNode_NonExistent(rName string) string {
+	return testAccAWSStorageGatewayGatewayConfig_GatewayType_FileS3(rName) + fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${aws_instance.test.availability_zone}"
+  size              = "10"
+  type              = "gp2"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_volume_attachment" "test" {
+  device_name  = "/dev/sdb"
+  force_detach = true
+  instance_id  = "${aws_instance.test.id}"
+  volume_id    = "${aws_ebs_volume.test.id}"
+}
+
+data "aws_storagegateway_local_disk" "test" {
+  disk_node   = "/dev/sdz"
+  gateway_arn = "${aws_storagegateway_gateway.test.arn}"
+}
+`, rName)
 }
 
 func testAccAWSStorageGatewayLocalDiskDataSourceConfig_DiskPath(rName string) string {

--- a/website/docs/d/storagegateway_local_disk.html.markdown
+++ b/website/docs/d/storagegateway_local_disk.html.markdown
@@ -21,8 +21,9 @@ data "aws_storagegateway_local_disk" "test" {
 
 ## Argument Reference
 
-* `disk_path` - (Required) The device path of the local disk to retrieve. For example, `/dev/sdb` or `/dev/xvdb`.
 * `gateway_arn` - (Required) The Amazon Resource Name (ARN) of the gateway.
+* `disk_node` - (Optional) The device node of the local disk to retrieve. For example, `/dev/sdb`.
+* `disk_path` - (Optional) The device path of the local disk to retrieve. For example, `/dev/xvdb` or `/dev/nvme1n1`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Reference: #5589 

Changes proposed in this pull request:

* Support optional `disk_node` argument, which can represent the device node 
* Mark `disk_path` argument as optional and clarify usage

Output from acceptance testing:

```
--- PASS: TestAccAWSStorageGatewayLocalDiskDataSource_DiskNode (214.08s)
--- PASS: TestAccAWSStorageGatewayLocalDiskDataSource_DiskPath (226.07s)
```
