### PR TITLE
d/Adds a url_suffix attribute to data_source_aws_partition

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -196,7 +196,7 @@ type AWSClient struct {
 	redshiftconn          *redshift.Redshift
 	r53conn               *route53.Route53
 	partition             string
-	urlsuffix             string
+	dnsSuffix             string
 	accountid             string
 	supportedplatforms    []string
 	region                string
@@ -466,12 +466,12 @@ func (c *Config) Client() (interface{}, error) {
 		return nil, fmt.Errorf("Failed to resolve endpoint. Errors: %s", err)
 	}
 
-	urlsuffix, err := parseURLSuffixFromEndpoint(endpoint.URL, client.region)
+	dnsSuffix, err := parseDNSSuffixFromEndpoint(endpoint.URL, client.region)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to resolve URL Suffix. Errors: %s", err)
 	}
 
-	client.urlsuffix = aws.StringValue(urlsuffix)
+	client.dnsSuffix = aws.StringValue(dnsSuffix)
 
 	client.ec2conn = ec2.New(awsEc2Sess)
 
@@ -625,7 +625,7 @@ func (c *Config) Client() (interface{}, error) {
 	return &client, nil
 }
 
-func parseURLSuffixFromEndpoint(endpoint string, region string) (*string, error) {
+func parseDNSSuffixFromEndpoint(endpoint string, region string) (*string, error) {
 	e := strings.Split(endpoint, ".")
 
 	// Expect endpoints with at least three elements

--- a/aws/data_source_aws_partition.go
+++ b/aws/data_source_aws_partition.go
@@ -16,6 +16,10 @@ func dataSourceAwsPartition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"url_suffix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -28,6 +32,9 @@ func dataSourceAwsPartitionRead(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Setting AWS Partition to %s.", client.partition)
 	d.Set("partition", meta.(*AWSClient).partition)
+
+	log.Printf("[DEBUG] Setting AWS URL Suffix to %s.", client.urlsuffix)
+	d.Set("url_suffix", meta.(*AWSClient).urlsuffix)
 
 	return nil
 }

--- a/aws/data_source_aws_partition.go
+++ b/aws/data_source_aws_partition.go
@@ -16,7 +16,7 @@ func dataSourceAwsPartition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"url_suffix": {
+			"dns_suffix": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -33,8 +33,8 @@ func dataSourceAwsPartitionRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Setting AWS Partition to %s.", client.partition)
 	d.Set("partition", meta.(*AWSClient).partition)
 
-	log.Printf("[DEBUG] Setting AWS URL Suffix to %s.", client.urlsuffix)
-	d.Set("url_suffix", meta.(*AWSClient).urlsuffix)
+	log.Printf("[DEBUG] Setting AWS URL Suffix to %s.", client.dnsSuffix)
+	d.Set("dns_suffix", meta.(*AWSClient).dnsSuffix)
 
 	return nil
 }

--- a/aws/data_source_aws_partition_test.go
+++ b/aws/data_source_aws_partition_test.go
@@ -17,6 +17,7 @@ func TestAccAWSPartition_basic(t *testing.T) {
 				Config: testAccCheckAwsPartitionConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsPartition("data.aws_partition.current"),
+					testAccCheckAwsUrlSuffix("data.aws_partition.current"),
 				),
 			},
 		},
@@ -33,6 +34,26 @@ func testAccCheckAwsPartition(n string) resource.TestCheckFunc {
 		expected := testAccProvider.Meta().(*AWSClient).partition
 		if rs.Primary.Attributes["partition"] != expected {
 			return fmt.Errorf("Incorrect Partition: expected %q, got %q", expected, rs.Primary.Attributes["partition"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsUrlSuffix(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find resource: %s", n)
+		}
+
+		expected := testAccProvider.Meta().(*AWSClient).urlsuffix
+		if rs.Primary.Attributes["url_suffix"] != expected {
+			return fmt.Errorf("Incorrect URL Suffix: expected %q, got %q", expected, rs.Primary.Attributes["url_suffix"])
+		}
+
+		if rs.Primary.Attributes["url_suffix"] == "" {
+			return fmt.Errorf("URL Suffix expected to not be nil")
 		}
 
 		return nil

--- a/aws/data_source_aws_partition_test.go
+++ b/aws/data_source_aws_partition_test.go
@@ -17,7 +17,7 @@ func TestAccAWSPartition_basic(t *testing.T) {
 				Config: testAccCheckAwsPartitionConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsPartition("data.aws_partition.current"),
-					testAccCheckAwsUrlSuffix("data.aws_partition.current"),
+					testAccCheckAwsDnsSuffix("data.aws_partition.current"),
 				),
 			},
 		},
@@ -40,20 +40,20 @@ func testAccCheckAwsPartition(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAwsUrlSuffix(n string) resource.TestCheckFunc {
+func testAccCheckAwsDnsSuffix(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Can't find resource: %s", n)
 		}
 
-		expected := testAccProvider.Meta().(*AWSClient).urlsuffix
-		if rs.Primary.Attributes["url_suffix"] != expected {
-			return fmt.Errorf("Incorrect URL Suffix: expected %q, got %q", expected, rs.Primary.Attributes["url_suffix"])
+		expected := testAccProvider.Meta().(*AWSClient).dnsSuffix
+		if rs.Primary.Attributes["dns_suffix"] != expected {
+			return fmt.Errorf("Incorrect DNS Suffix: expected %q, got %q", expected, rs.Primary.Attributes["dns_suffix"])
 		}
 
-		if rs.Primary.Attributes["url_suffix"] == "" {
-			return fmt.Errorf("URL Suffix expected to not be nil")
+		if rs.Primary.Attributes["dns_suffix"] == "" {
+			return fmt.Errorf("DNS Suffix expected to not be nil")
 		}
 
 		return nil

--- a/website/docs/d/partition.html.markdown
+++ b/website/docs/d/partition.html.markdown
@@ -8,7 +8,8 @@ description: |-
 
 # Data Source: aws_partition
 
-Use this data source to lookup current AWS partition in which Terraform is working
+Use this data source to lookup information about the current AWS partition in
+which Terraform is working.
 
 ## Example Usage
 
@@ -37,3 +38,4 @@ There are no arguments available for this data source.
 ## Attributes Reference
 
 `partition` is set to the identifier of the current partition.
+`url_suffix` is set to the URL Suffix associated with the current partition.

--- a/website/docs/d/partition.html.markdown
+++ b/website/docs/d/partition.html.markdown
@@ -37,5 +37,5 @@ There are no arguments available for this data source.
 
 ## Attributes Reference
 
-`partition` is set to the identifier of the current partition.
-`url_suffix` is set to the URL Suffix associated with the current partition.
+* `partition` is set to the identifier of the current partition.
+* `dns_suffix` is set to the base DNS domain name for the current partition (e.g. `amazonaws.com` in AWS Commercial, `amazonaws.com.cn` in AWS China).


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #1960

Changes proposed in this pull request:

* Adds a `urlsuffix` attribute to the `AWSClient` struct
* Infers the urlsuffix value from the STS endpoint associated with the provider region
* Uses the new attribute to add a `url_suffix` attribute to `data_source_aws_partition`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSPartition_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSPartition_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSPartition_basic
--- PASS: TestAccAWSPartition_basic (4.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       4.379s
```
