### PR TITLE
aws_service_discovery_public_dns_namespace name length limit

### DIFF
--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -55,7 +55,7 @@ func resourceAwsServiceDiscoveryPublicDnsNamespaceCreate(d *schema.ResourceData,
 		requestId = resource.PrefixedUniqueId(name)
 	}
 
-	input := &servicediscovery.CreatePublicDnsNamespaceInput {
+	input := &servicediscovery.CreatePublicDnsNamespaceInput{
 		Name:             aws.String(name),
 		CreatorRequestId: aws.String(requestId),
 	}
@@ -69,7 +69,7 @@ func resourceAwsServiceDiscoveryPublicDnsNamespaceCreate(d *schema.ResourceData,
 		return err
 	}
 
-	stateConf := &resource.StateChangeConf {
+	stateConf := &resource.StateChangeConf{
 		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
 		Target:  []string{servicediscovery.OperationStatusSuccess},
 		Refresh: servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),

--- a/aws/resource_aws_service_discovery_public_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace_test.go
@@ -96,7 +96,7 @@ func testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(name string) resour
 }
 
 func testAccAWSServiceDiscoveryPublicDnsNamespace_longname(t *testing.T) {
-	rName := acctest.RandString(64-len("terraform.com"))
+	rName := acctest.RandString(64 - len("terraform.com"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_service_discovery_public_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace_test.go
@@ -95,6 +95,26 @@ func testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists(name string) resour
 	}
 }
 
+func testAccAWSServiceDiscoveryPublicDnsNamespace_longname(t *testing.T) {
+	rName := acctest.RandString(64-len("terraform.com"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryPublicDnsNamespaceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryPublicDnsNamespaceExists("aws_service_discovery_public_dns_namespace.test"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_public_dns_namespace.test", "arn"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_public_dns_namespace.test", "hosted_zone"),
+				),
+			},
+		},
+	})
+}
+
 func testAccServiceDiscoveryPublicDnsNamespaceConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_service_discovery_public_dns_namespace" "test" {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5339

Changes proposed in this pull request:

* Trim name if needed to comply to the 64 character limit to RequestId

Output from acceptance testing:

* Did make acceptance test. Spent a few hours trying to make it run in our company environment, but just wouldn't work.

Basically just does what was done in #4702, and as was suggested by @bflad 

