### PR TITLE
Update Example Runtime for Node.js Lambdas

### DIFF
--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -92,7 +92,7 @@ resource "aws_lambda_function" "lambda_processor" {
   function_name = "firehose_lambda_processor"
   role = "${aws_iam_role.lambda_iam.arn}"
   handler = "exports.handler"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
 }
 ```
 

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "test_lambda" {
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.test"
   source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
-  runtime          = "nodejs4.3"
+  runtime          = "nodejs8.10"
 
   environment {
     variables = {


### PR DESCRIPTION

Changes proposed in this pull request:

* Change example for Lambda functions to be the latest version of Node AWS currently supports. 

While this is a really small edit, I think it is important because if someone just copy and pastes the example without reading the details, they will set up their project with a [deprecated version of Node.js](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).

> _The Node Foundation declared End-of-Life (EOL) for Node.js v4 on April 30, 2018_ 
  ...
> _Code updates to existing functions using Node.js v4.3 will be disabled on October 31, 2018_
