### PR TITLE
provider: Disable AWS SDK retries faster by default for connection refused errors

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -379,6 +379,12 @@ func (c *Config) Client() (interface{}, error) {
 			log.Printf("[WARN] Disabling retries after next request due to networking issue")
 			r.Retryable = aws.Bool(false)
 		}
+		// RequestError: send request failed
+		// caused by: Post https://FQDN/: dial tcp IPADDRESS:443: connect: connection refused
+		if isAWSErrExtended(r.Error, "RequestError", "send request failed", "connection refused") {
+			log.Printf("[WARN] Disabling retries after next request due to networking issue")
+			r.Retryable = aws.Bool(false)
+		}
 	})
 
 	// This restriction should only be used for Route53 sessions.


### PR DESCRIPTION
When using `resource.Retry()`, this error is sometimes never displayed except for the Terraform debug logs due to the AWS SDK never returning the response before the `resource.Retry()` timeout:

```
* aws_dynamodb_table.mda-table: timeout while waiting for state to become 'success' (timeout: 2m0s)
```

This type of error is more permanent in nature and should be returned quicker than the default MaxRetries configuration of the provider.

Reference: #5599 

Changes proposed in this pull request:

* Disable `Retryable` for `connection refused` errors sooner if using default `MaxRetries` configuration

Output from acceptance testing: Handled via daily acceptance testing
