### PR TITLE
resource/aws_db_instance: Prevent double apply for snapshot_identifier with multiple other arguments

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -365,6 +365,141 @@ func TestAccAWSDBInstance_SnapshotIdentifier(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var dbSnapshot rds.DBSnapshot
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceDbResourceName := "aws_db_instance.source"
+	snapshotResourceName := "aws_db_snapshot.test"
+	resourceName := "aws_db_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupRetentionPeriod(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
+					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "backup_retention_period", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var dbSnapshot rds.DBSnapshot
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceDbResourceName := "aws_db_instance.source"
+	snapshotResourceName := "aws_db_snapshot.test"
+	resourceName := "aws_db_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupWindow(rName, "00:00-08:00"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
+					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "backup_window", "00:00-08:00"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var dbSnapshot rds.DBSnapshot
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceDbResourceName := "aws_db_instance.source"
+	snapshotResourceName := "aws_db_snapshot.test"
+	resourceName := "aws_db_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_IamDatabaseAuthenticationEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
+					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "iam_database_authentication_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var dbSnapshot rds.DBSnapshot
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceDbResourceName := "aws_db_instance.source"
+	snapshotResourceName := "aws_db_snapshot.test"
+	resourceName := "aws_db_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_MaintenanceWindow(rName, "sun:01:00-sun:01:30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
+					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "sun:01:00-sun:01:30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_SnapshotIdentifier_Monitoring(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var dbSnapshot rds.DBSnapshot
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceDbResourceName := "aws_db_instance.source"
+	snapshotResourceName := "aws_db_snapshot.test"
+	resourceName := "aws_db_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_Monitoring(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
+					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_interval", "5"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ(t *testing.T) {
 	var dbInstance, sourceDbInstance rds.DBInstance
 	var dbSnapshot rds.DBSnapshot
@@ -413,6 +548,33 @@ func TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer(t *testing.T) {
 					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					resource.TestCheckResourceAttr(resourceName, "multi_az", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName(t *testing.T) {
+	var dbInstance, sourceDbInstance rds.DBInstance
+	var dbSnapshot rds.DBSnapshot
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	sourceDbResourceName := "aws_db_instance.source"
+	snapshotResourceName := "aws_db_snapshot.test"
+	resourceName := "aws_db_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_ParameterGroupName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
+					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
+					resource.TestCheckResourceAttr(resourceName, "parameter_group_name", rName),
 				),
 			},
 		},
@@ -2155,6 +2317,168 @@ resource "aws_db_instance" "test" {
 `, rName, rName, rName)
 }
 
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupRetentionPeriod(rName string, backupRetentionPeriod int) string {
+	return fmt.Sprintf(`
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = "mariadb"
+  identifier          = "%s-source"
+  instance_class      = "db.t2.micro"
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = "${aws_db_instance.source.id}"
+  db_snapshot_identifier = %q
+}
+
+resource "aws_db_instance" "test" {
+  backup_retention_period = %d
+  identifier              = %q
+  instance_class          = "${aws_db_instance.source.instance_class}"
+  snapshot_identifier     = "${aws_db_snapshot.test.id}"
+  skip_final_snapshot     = true
+}
+`, rName, rName, backupRetentionPeriod, rName)
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_BackupWindow(rName, backupWindow string) string {
+	return fmt.Sprintf(`
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = "mariadb"
+  identifier          = "%s-source"
+  instance_class      = "db.t2.micro"
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = "${aws_db_instance.source.id}"
+  db_snapshot_identifier = %q
+}
+
+resource "aws_db_instance" "test" {
+  backup_window       = %q
+  identifier          = %q
+  instance_class      = "${aws_db_instance.source.instance_class}"
+  snapshot_identifier = "${aws_db_snapshot.test.id}"
+  skip_final_snapshot = true
+}
+`, rName, rName, backupWindow, rName)
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_IamDatabaseAuthenticationEnabled(rName string, iamDatabaseAuthenticationEnabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = "mysql"
+  identifier          = "%s-source"
+  instance_class      = "db.t2.micro"
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = "${aws_db_instance.source.id}"
+  db_snapshot_identifier = %q
+}
+
+resource "aws_db_instance" "test" {
+  iam_database_authentication_enabled = %t
+  identifier                          = %q
+  instance_class                      = "${aws_db_instance.source.instance_class}"
+  snapshot_identifier                 = "${aws_db_snapshot.test.id}"
+  skip_final_snapshot                 = true
+}
+`, rName, rName, iamDatabaseAuthenticationEnabled, rName)
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_MaintenanceWindow(rName, maintenanceWindow string) string {
+	return fmt.Sprintf(`
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = "mariadb"
+  identifier          = "%s-source"
+  instance_class      = "db.t2.micro"
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = "${aws_db_instance.source.id}"
+  db_snapshot_identifier = %q
+}
+
+resource "aws_db_instance" "test" {
+  identifier          = %q
+  instance_class      = "${aws_db_instance.source.instance_class}"
+  maintenance_window  = %q
+  snapshot_identifier = "${aws_db_snapshot.test.id}"
+  skip_final_snapshot = true
+}
+`, rName, rName, rName, maintenanceWindow)
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_Monitoring(rName string, monitoringInterval int) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "monitoring.rds.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  role       = "${aws_iam_role.test.id}"
+}
+
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = "mariadb"
+  identifier          = "%s-source"
+  instance_class      = "db.t2.micro"
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = "${aws_db_instance.source.id}"
+  db_snapshot_identifier = %q
+}
+
+resource "aws_db_instance" "test" {
+  identifier          = %q
+  instance_class      = "${aws_db_instance.source.instance_class}"
+  monitoring_interval = %d
+  monitoring_role_arn = "${aws_iam_role.test.arn}"
+  snapshot_identifier = "${aws_db_snapshot.test.id}"
+  skip_final_snapshot = true
+}
+`, rName, rName, rName, rName, monitoringInterval)
+}
+
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_MultiAZ(rName string, multiAz bool) string {
 	return fmt.Sprintf(`
 resource "aws_db_instance" "source" {
@@ -2210,6 +2534,44 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot     = true
 }
 `, rName, rName, rName, multiAz)
+}
+
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_ParameterGroupName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_db_parameter_group" "test" {
+  family = "mariadb10.2"
+  name   = %q
+
+  parameter {
+    name = "sync_binlog"
+    value = 0
+  }
+}
+
+resource "aws_db_instance" "source" {
+  allocated_storage   = 5
+  engine              = "mariadb"
+  engine_version      = "10.2.15"
+  identifier          = "%s-source"
+  instance_class      = "db.t2.micro"
+  password            = "avoid-plaintext-passwords"
+  username            = "tfacctest"
+  skip_final_snapshot = true
+}
+
+resource "aws_db_snapshot" "test" {
+  db_instance_identifier = "${aws_db_instance.source.id}"
+  db_snapshot_identifier = %q
+}
+
+resource "aws_db_instance" "test" {
+  identifier           = %q
+  instance_class       = "${aws_db_instance.source.instance_class}"
+  parameter_group_name = "${aws_db_parameter_group.test.id}"
+  snapshot_identifier  = "${aws_db_snapshot.test.id}"
+  skip_final_snapshot  = true
+}
+`, rName, rName, rName, rName)
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_Tags(rName string) string {


### PR DESCRIPTION
Closes #2869
Fixes #2859
Reference (this is the first half of these issues -- `pending-reboot` issue to be fixed after): #218, #1494, #1510

Previously:

```
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1154.50s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'backup_retention_period' expected "1", got "0"
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1195.82s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'backup_window' expected "00:00-08:00", got "06:13-06:43"
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1113.22s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'iam_database_authentication_enabled' expected "true", got "false"
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1259.26s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'maintenance_window' expected "Sun:01:00-Sun:01:30", got "wed:10:33-wed:11:03"
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1214.60s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'monitoring_interval' expected "5", got "0"
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1134.54s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'parameter_group_name' expected "tf-acc-test-4546585708384390733", got "default.mariadb10.2"
```

Changes proposed in this pull request:

* Ensure the following Terraform arguments trigger `ModifyDBInstance` when using `RestoreDBInstanceFromDBSnapshot`
  * `backup_retention_period`
  * `backup_window`
  * `iam_database_authentication_enabled`
  * `maintenance_window`
  * `monitoring_interval`
  * `monitoring_role_arn`
  * `parameter_group_name`

Output from acceptance testing:

```
34 tests passed (all tests)
--- PASS: TestAccAWSDBInstance_importBasic (441.25s)
--- PASS: TestAccAWSDBInstance_iamAuth (451.00s)
--- PASS: TestAccAWSDBInstance_generatedName (471.69s)
--- PASS: TestAccAWSDBInstance_basic (511.88s)
--- PASS: TestAccAWSDBInstance_namePrefix (512.04s)
--- PASS: TestAccAWSDBInstance_kmsKey (520.80s)
--- PASS: TestAccAWSDBInstance_optionGroup (542.32s)
--- PASS: TestAccAWSDBInstance_noSnapshot (663.43s)
--- PASS: TestAccAWSDBInstance_s3 (837.33s)
--- PASS: TestAccAWSDBInstance_subnetGroup (905.89s)
--- PASS: TestAccAWSDBInstance_snapshot (986.80s)
--- PASS: TestAccAWSDBInstance_portUpdate (552.60s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1159.29s)
--- PASS: TestAccAWSDBInstance_separate_iops_update (664.15s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1209.77s)
--- PASS: TestAccAWSDBInstance_MinorVersion (449.18s)
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (777.38s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1329.91s)
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (448.94s)
--- PASS: TestAccAWSDBInstance_replica (1372.02s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1491.56s)
--- PASS: TestAccAWSDBInstance_ec2Classic (523.50s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1524.52s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (453.37s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1664.06s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (577.94s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1309.21s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1348.55s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1350.06s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1380.31s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1936.30s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (782.88s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (3030.58s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (3984.31s)
```
