### PR TITLE
resource/aws_db_instance: Prevent is already being deleted error on deletion

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1119,8 +1119,11 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] DB Instance destroy configuration: %v", opts)
-	if _, err := conn.DeleteDBInstance(&opts); err != nil {
-		return err
+	_, err := conn.DeleteDBInstance(&opts)
+
+	// InvalidDBInstanceState: Instance XXX is already being deleted.
+	if err != nil && !isAWSErr(err, rds.ErrCodeInvalidDBInstanceStateFault, "is already being deleted") {
+		return fmt.Errorf("error deleting Database Instance %q: %s", d.Id(), err)
 	}
 
 	log.Println("[INFO] Waiting for DB Instance to be destroyed")


### PR DESCRIPTION
Fixes #5622 

Previously:

```
--- FAIL: TestAccAWSDBInstance_IsAlreadyBeingDeleted (238.05s)
	testing.go:527: Step 1 error: Error applying: 1 error occurred:
			* aws_db_instance.test (destroy): 1 error occurred:
			* aws_db_instance.test: InvalidDBInstanceState: Instance tf-acc-test-1508345143008358561 is already being deleted.
```

Changes proposed in this pull request:

* Ignore InvalidDBInstanceState: Instance XXX is already being deleted error from DeleteDBInstance and continue waiting for deletion


Output from acceptance testing:

```
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (453.66s)
```
