### PR TITLE
data-source/aws_ami: Add note that owners argument will be required in next major version

### DIFF
--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -11,6 +11,8 @@ description: |-
 Use this data source to get the ID of a registered AMI for use in other
 resources.
 
+~> **NOTE:** The `owners` argument will be **required** in the next major version.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/d/ami_ids.html.markdown
+++ b/website/docs/d/ami_ids.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to get a list of AMI IDs matching the specified criteria.
 
+~> **NOTE:** The `owners` argument will be **required** in the next major version.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -19,6 +19,8 @@ Upgrade topics:
 <!-- TOC depthFrom:2 depthTo:2 -->
 
 - [Provider Version Configuration](#provider-version-configuration)
+- [Data Source: aws_ami](#data-source-aws_ami)
+- [Data Source: aws_ami_ids](#data-source-aws_ami_ids)
 - [Data Source: aws_iam_role](#data-source-aws_iam_role)
 - [Data Source: aws_kms_secret](#data-source-aws_kms_secret)
 - [Data Source: aws_region](#data-source-aws_region)
@@ -69,6 +71,18 @@ provider "aws" {
   version = "~> 2.0.0"
 }
 ```
+
+## Data Source: aws_ami
+
+### owners Argument Now Required
+
+The `owners` argument is now required. Specifying `owner-id` or `owner-alias` under `filter` does not satisfy this requirement.
+
+## Data Source: aws_ami_ids
+
+### owners Argument Now Required
+
+The `owners` argument is now required. Specifying `owner-id` or `owner-alias` under `filter` does not satisfy this requirement.
 
 ## Data Source: aws_iam_role
 


### PR DESCRIPTION
Reference: #5576 

Changes proposed in this pull request:

* data-source/aws_ami: Add note that `owners` argument will be required in next major version
* data-source/aws_ami_ids: Add note that `owners` argument will be required in next major version

Output from acceptance testing: N/A