### PR TITLE
Created data source `aws_api_gateway_resource`

### DIFF
--- a/aws/data_source_aws_api_gateway_resource.go
+++ b/aws/data_source_aws_api_gateway_resource.go
@@ -1,0 +1,68 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsApiGatewayResource() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsApiGatewayResourceRead,
+		Schema: map[string]*schema.Schema{
+			"rest_api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path_part": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parent_id": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsApiGatewayResourceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+
+	restApiId := d.Get("rest_api_id").(string)
+	target := d.Get("path").(string)
+	params := &apigateway.GetResourcesInput{RestApiId: aws.String(restApiId)}
+
+	var matches []*apigateway.Resource
+	log.Printf("[DEBUG] Reading API Gateway Resources: %s", params)
+	err := conn.GetResourcesPages(params,func(page *apigateway.GetResourcesOutput, lastPage bool) bool {
+		for _, resource := range page.Items {
+			if aws.StringValue(resource.Path) == target {
+				matches = append(matches, resource)
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("error describing API Gateway Resources: %s", err)
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("no Resources with path %q found for rest api %q", target, restApiId)
+	}
+	if len(matches) > 1 {
+		return fmt.Errorf("multiple Resources with path %q found for rest api %q", target, restApiId)
+	}
+
+	match := matches[0]
+	d.SetId(*match.Id)
+
+	return nil
+}

--- a/aws/data_source_aws_api_gateway_resource.go
+++ b/aws/data_source_aws_api_gateway_resource.go
@@ -63,6 +63,8 @@ func dataSourceAwsApiGatewayResourceRead(d *schema.ResourceData, meta interface{
 
 	match := matches[0]
 	d.SetId(*match.Id)
+	d.Set("path_part", match.PathPart)
+	d.Set("parent_id", match.ParentId)
 
 	return nil
 }

--- a/aws/data_source_aws_api_gateway_resource.go
+++ b/aws/data_source_aws_api_gateway_resource.go
@@ -26,7 +26,7 @@ func dataSourceAwsApiGatewayResource() *schema.Resource {
 				Computed: true,
 			},
 			"parent_id": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -42,7 +42,7 @@ func dataSourceAwsApiGatewayResourceRead(d *schema.ResourceData, meta interface{
 
 	var matches []*apigateway.Resource
 	log.Printf("[DEBUG] Reading API Gateway Resources: %s", params)
-	err := conn.GetResourcesPages(params,func(page *apigateway.GetResourcesOutput, lastPage bool) bool {
+	err := conn.GetResourcesPages(params, func(page *apigateway.GetResourcesOutput, lastPage bool) bool {
 		for _, resource := range page.Items {
 			if aws.StringValue(resource.Path) == target {
 				matches = append(matches, resource)

--- a/aws/data_source_aws_api_gateway_resource_test.go
+++ b/aws/data_source_aws_api_gateway_resource_test.go
@@ -89,12 +89,12 @@ resource "aws_api_gateway_resource" "example_v1_endpoint" {
 
 data "aws_api_gateway_resource" "example_v1" {
   rest_api_id = "${aws_api_gateway_rest_api.example.id}"
-  path        = "/v1"
+  path        = "/${aws_api_gateway_resource.example_v1.path_part}"
 }
 
 data "aws_api_gateway_resource" "example_v1_endpoint" {
   rest_api_id = "${aws_api_gateway_rest_api.example.id}"
-  path        = "/v1/endpoint"
+  path        = "/${aws_api_gateway_resource.example_v1.path_part}/${aws_api_gateway_resource.example_v1_endpoint.path_part}"
 }
 `, r)
 }

--- a/aws/data_source_aws_api_gateway_resource_test.go
+++ b/aws/data_source_aws_api_gateway_resource_test.go
@@ -1,0 +1,100 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestDataSourceAwsApiGatewayResource(t *testing.T) {
+	rName := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsApiGatewayResourceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsApiGatewayResourceCheck("aws_api_gateway_resource.example_v1"),
+					testAccDataSourceAwsApiGatewayResourceCheck("aws_api_gateway_resource.example_v1_endpoint"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsApiGatewayResourceCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		created, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		datasource, ok := s.RootModule().Resources[fmt.Sprintf("data.%s", name)]
+		if !ok {
+			return fmt.Errorf("root modules has no datasource called data.%s", name)
+		}
+
+		rattr := created.Primary.Attributes
+		dattr := datasource.Primary.Attributes
+
+		if got, want := rattr["id"], dattr["id"]; got != want {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				got,
+				want,
+			)
+		}
+
+		if got, want := rattr["path_part"], dattr["path_part"]; got != want {
+			return fmt.Errorf(
+				"path_part is %s; want %s",
+				got,
+				want,
+			)
+		}
+
+		if got, want := rattr["parent_id"], dattr["parent_id"]; got != want {
+			return fmt.Errorf(
+				"parent_id is %s; want %s",
+				got,
+				want,
+			)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsApiGatewayResourceConfig(r string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "example" {
+	name = "%s_example"
+}
+
+resource "aws_api_gateway_resource" "example_v1" {
+	rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+    parent_id   = "${aws_api_gateway_rest_api.example.root_resource_id}"
+	path_part   = "v1"
+}
+
+resource "aws_api_gateway_resource" "example_v1_endpoint" {
+	rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+    parent_id   = "${aws_api_gateway_resource.example_v1.id}"
+	path_part   = "endpoint"
+}
+
+data "aws_api_gateway_resource" "example_v1" {
+  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+  path        = "/v1"
+}
+
+data "aws_api_gateway_resource" "example_v1_endpoint" {
+  rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+  path        = "/v1/endpoint"
+}
+`, r)
+}

--- a/aws/data_source_aws_api_gateway_resource_test.go
+++ b/aws/data_source_aws_api_gateway_resource_test.go
@@ -6,11 +6,15 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestDataSourceAwsApiGatewayResource(t *testing.T) {
+func TestAccDataSourceAwsApiGatewayResource(t *testing.T) {
 	rName := acctest.RandString(8)
+	resourceName1 := "aws_api_gateway_resource.example_v1"
+	dataSourceName1 := "data.aws_api_gateway_resource.example_v1"
+	resourceName2 := "aws_api_gateway_resource.example_v1_endpoint"
+	dataSourceName2 := "data.aws_api_gateway_resource.example_v1_endpoint"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -18,55 +22,16 @@ func TestDataSourceAwsApiGatewayResource(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsApiGatewayResourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsApiGatewayResourceCheck("aws_api_gateway_resource.example_v1"),
-					testAccDataSourceAwsApiGatewayResourceCheck("aws_api_gateway_resource.example_v1_endpoint"),
+					resource.TestCheckResourceAttrPair(resourceName1, "id", dataSourceName1, "id"),
+					resource.TestCheckResourceAttrPair(resourceName1, "parent_id", dataSourceName1, "parent_id"),
+					resource.TestCheckResourceAttrPair(resourceName1, "path_part", dataSourceName1, "path_part"),
+					resource.TestCheckResourceAttrPair(resourceName2, "id", dataSourceName2, "id"),
+					resource.TestCheckResourceAttrPair(resourceName2, "parent_id", dataSourceName2, "parent_id"),
+					resource.TestCheckResourceAttrPair(resourceName2, "path_part", dataSourceName2, "path_part"),
 				),
 			},
 		},
 	})
-}
-
-func testAccDataSourceAwsApiGatewayResourceCheck(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		created, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		datasource, ok := s.RootModule().Resources[fmt.Sprintf("data.%s", name)]
-		if !ok {
-			return fmt.Errorf("root modules has no datasource called data.%s", name)
-		}
-
-		rattr := created.Primary.Attributes
-		dattr := datasource.Primary.Attributes
-
-		if got, want := rattr["id"], dattr["id"]; got != want {
-			return fmt.Errorf(
-				"id is %s; want %s",
-				got,
-				want,
-			)
-		}
-
-		if got, want := rattr["path_part"], dattr["path_part"]; got != want {
-			return fmt.Errorf(
-				"path_part is %s; want %s",
-				got,
-				want,
-			)
-		}
-
-		if got, want := rattr["parent_id"], dattr["parent_id"]; got != want {
-			return fmt.Errorf(
-				"parent_id is %s; want %s",
-				got,
-				want,
-			)
-		}
-
-		return nil
-	}
 }
 
 func testAccDataSourceAwsApiGatewayResourceConfig(r string) string {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -164,6 +164,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_acmpca_certificate_authority":     dataSourceAwsAcmpcaCertificateAuthority(),
 			"aws_ami":                              dataSourceAwsAmi(),
 			"aws_ami_ids":                          dataSourceAwsAmiIds(),
+			"aws_api_gateway_resource":             dataSourceAwsApiGatewayResource(),
 			"aws_api_gateway_rest_api":             dataSourceAwsApiGatewayRestApi(),
 			"aws_arn":                              dataSourceAwsArn(),
 			"aws_autoscaling_groups":               dataSourceAwsAutoscalingGroups(),

--- a/website/docs/d/api_gateway_resource.html.markdown
+++ b/website/docs/d/api_gateway_resource.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_resource"
+sidebar_current: "docs-aws_api_gateway_resource"
+description: |-
+  Get information on a API Gateway Resource
+---
+
+# Data Source: aws_api_gateway_resource
+
+Use this data source to get the id of a Resource in API Gateway. 
+To fetch the Resource, you must provide the REST API id as well as the full path.  
+
+## Example Usage
+
+```hcl
+data "aws_api_gateway_rest_api" "my_rest_api" {
+  name = "my-rest-api"
+}
+
+data "aws_api_gateway_resource" "my_resource" {
+  rest_api_id = "${aws_api_gateway_rest_api.my_rest_api.id}"
+  path        = "/endpoint/path"
+}
+```
+
+## Argument Reference
+
+ * `rest_api_id` - (Required) The REST API id that owns the resource. If no REST API is found, an error will be returned.
+ * `path` - (Required) The full path of the resource.  If no path is found, an error will be returned.
+
+## Attributes Reference
+
+ * `id` - Set to the ID of the found Resource.
+ * `parent_id` - Set to the ID of the parent Resource.
+ * `path_part` - Set to the path relative to the parent Resource.


### PR DESCRIPTION
Changes proposed in this pull request:

* Create `data.aws_api_gateway_resource`.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsApiGatewayResource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestDataSourceAwsApiGatewayResource -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestDataSourceAwsApiGatewayResource
--- PASS: TestDataSourceAwsApiGatewayResource (17.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       (cached)

```
