### PR TITLE
Update kubectl install link to current location in EKS documentation

### DIFF
--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -84,7 +84,7 @@ and configuration of these applications, see their official documentation.
 
 Relevant Links:
 
-* [Kubernetes Client Downloads](https://kubernetes.io/docs/imported/release/notes/#client-binaries)
+* [Kubernetes Client Install Guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * [AWS IAM Authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator)
 
 ## Create Sample Architecture in AWS


### PR DESCRIPTION
The previous link is throwing a 404, so going ahead and updating to the current installation docs for `kubectl`.

Changes proposed in this pull request:

* Fixes the `kubectl` install link in the EKS Getting Started guide.