### PR TITLE
provider: Enable gofmt -s flag

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,7 +29,7 @@ vet:
 	fi
 
 fmt:
-	gofmt -w $(GOFMT_FILES)
+	gofmt -s -w $(GOFMT_FILES)
 
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,7 +2,7 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l)
+gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l -s)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"


### PR DESCRIPTION
Changes proposed in this pull request:

* Add `-s` flag for `gofmt` in `make fmt` and `make fmtcheck`

Output from acceptance testing:

```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.597s
```
