### PR TITLE
data-source/aws_ami: Print warning log messages for missing owners argument and missing owners filtering

### DIFF
--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -200,6 +201,27 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 
 		if len(o) > 0 {
 			params.Owners = o
+		}
+	}
+
+	// Deprecated: pre-2.0.0 warning logging
+	if !ownersOk {
+		log.Print("[WARN] The \"owners\" argument will become required in the next major version.")
+		log.Print("[WARN] Documentation can be found at: https://www.terraform.io/docs/providers/aws/d/ami.html#owners")
+
+		missingOwnerFilter := true
+
+		if filtersOk {
+			for _, filter := range params.Filters {
+				if aws.StringValue(filter.Name) == "owner-alias" || aws.StringValue(filter.Name) == "owner-id" {
+					missingOwnerFilter = false
+					break
+				}
+			}
+		}
+
+		if missingOwnerFilter {
+			log.Print("[WARN] Potential security issue: missing \"owners\" filtering for AMI. Check AMI to ensure it came from trusted source.")
 		}
 	}
 

--- a/aws/data_source_aws_ami_ids.go
+++ b/aws/data_source_aws_ami_ids.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -69,6 +70,27 @@ func dataSourceAwsAmiIdsRead(d *schema.ResourceData, meta interface{}) error {
 
 		if len(o) > 0 {
 			params.Owners = o
+		}
+	}
+
+	// Deprecated: pre-2.0.0 warning logging
+	if !ownersOk {
+		log.Print("[WARN] The \"owners\" argument will become required in the next major version.")
+		log.Print("[WARN] Documentation can be found at: https://www.terraform.io/docs/providers/aws/d/ami.html#owners")
+
+		missingOwnerFilter := true
+
+		if filtersOk {
+			for _, filter := range params.Filters {
+				if aws.StringValue(filter.Name) == "owner-alias" || aws.StringValue(filter.Name) == "owner-id" {
+					missingOwnerFilter = false
+					break
+				}
+			}
+		}
+
+		if missingOwnerFilter {
+			log.Print("[WARN] Potential security issue: missing \"owners\" filtering for AMI. Check AMI to ensure it came from trusted source.")
 		}
 	}
 


### PR DESCRIPTION
Reference: #5576 

Changes proposed in this pull request:

* Print warning log message for missing `owners` argument
* Print warning log message for missing owners filtering completely

Verified manually:

```
2018/08/22 13:33:17 [WARN] The "owners" argument will become required in the next major version.
2018/08/22 13:33:17 [WARN] Documentation can be found at: https://www.terraform.io/docs/providers/aws/d/ami.html#owners
2018/08/22 13:33:17 [WARN] Potential security issue: missing "owners" filtering for AMI. Check AMI to ensure it came from trusted source.
2018/08/22 13:33:17 [DEBUG] Reading AMI: {
  Filters: [{
      Name: "name",
      Values: ["ubuntu/images/hvm-instance/ubuntu-trusty-14.04-amd64-server*"]
    },{
      Name: "root-device-type",
      Values: ["instance-store"]
    },{
      Name: "virtualization-type",
      Values: ["hvm"]
    }]
}
```
