### PR TITLE
Toggling server_side_encryption.enabled should recreate cluster.

### DIFF
--- a/aws/resource_aws_dax_cluster.go
+++ b/aws/resource_aws_dax_cluster.go
@@ -111,6 +111,7 @@ func resourceAwsDaxCluster() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-aws/issues/5662.

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDAXCluster_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDAXCluster_encryption -timeout 120m
=== RUN   TestAccAWSDAXCluster_encryption_disabled
--- PASS: TestAccAWSDAXCluster_encryption_disabled (641.17s)
=== RUN   TestAccAWSDAXCluster_encryption_enabled
--- PASS: TestAccAWSDAXCluster_encryption_enabled (660.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1301.981s
```