### PR TITLE
S3 bucket api gateway integration (Issue #5652)

### DIFF
--- a/examples/s3-api-gateway-integration/README.md
+++ b/examples/s3-api-gateway-integration/README.md
@@ -1,1 +1,16 @@
 # S3 Bucket Integration for API Gateway
+
+This example demonstrates how to create an S3 Proxy using AWS API Gateway. It takes you through listing the buckets of the API caller, but provides an example of all of the resources needed to extend the API to manipulating bucket contents. It follows [this article](https://docs.aws.amazon.com/apigateway/latest/developerguide/integrating-api-with-aws-services-s3.html) on AWS.
+
+## Running this Example
+
+*Note: In order to see the API Gateway that this configuration creates you must navigate to the correct region in your AWS console. To ensure the API works as desired, the region you use to create the API should be different than the S3 buckets being queried. If not, you may encounter a 500 Internal Server Error response. This limitation does not apply to any deployed API.*
+
+Only three variables are required to run this example. They can be provided by ```cp terraform.template.tfvars terraform.tfvars```, modifying ```terraform.tfvars``` with your variables, and running ```terraform apply```. Alternatively, the variables can be provided as flags by running:
+```
+terraform apply \
+    -var="aws_access_key=yourawsaccesskey" \
+    -var="aws_secret_key=yourawssecretkey" \
+    -var="aws_region=us-east-1"
+```
+

--- a/examples/s3-api-gateway-integration/README.md
+++ b/examples/s3-api-gateway-integration/README.md
@@ -1,0 +1,1 @@
+# S3 Bucket Integration for API Gateway

--- a/examples/s3-api-gateway-integration/main.tf
+++ b/examples/s3-api-gateway-integration/main.tf
@@ -109,6 +109,8 @@ resource "aws_api_gateway_method_response" "200" {
 }
 
 resource "aws_api_gateway_method_response" "400" {
+  depends_on = ["aws_api_gateway_integration.S3Integration"]
+
   rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
   resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
   http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
@@ -116,6 +118,8 @@ resource "aws_api_gateway_method_response" "400" {
 }
 
 resource "aws_api_gateway_method_response" "500" {
+  depends_on = ["aws_api_gateway_integration.S3Integration"]
+
   rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
   resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
   http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
@@ -123,12 +127,12 @@ resource "aws_api_gateway_method_response" "500" {
 }
 
 resource "aws_api_gateway_integration_response" "200IntegrationResponse" {
+  depends_on = ["aws_api_gateway_integration.S3Integration"]
+
   rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
   resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
   http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
   status_code = "${aws_api_gateway_method_response.200.status_code}"
-
-  selection_pattern = "-"
 
   response_parameters = {
     "method.response.header.Timestamp"      = "integration.response.header.Date"
@@ -138,6 +142,8 @@ resource "aws_api_gateway_integration_response" "200IntegrationResponse" {
 }
 
 resource "aws_api_gateway_integration_response" "400IntegrationResponse" {
+  depends_on = ["aws_api_gateway_integration.S3Integration"]
+
   rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
   resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
   http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
@@ -147,6 +153,8 @@ resource "aws_api_gateway_integration_response" "400IntegrationResponse" {
 }
 
 resource "aws_api_gateway_integration_response" "500IntegrationResponse" {
+  depends_on = ["aws_api_gateway_integration.S3Integration"]
+
   rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
   resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
   http_method = "${aws_api_gateway_method.GetBuckets.http_method}"

--- a/examples/s3-api-gateway-integration/main.tf
+++ b/examples/s3-api-gateway-integration/main.tf
@@ -2,13 +2,13 @@
 provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
-  region     = "us-east-1"
+  region     = "${var.aws_region}"
 }
 
 # Create S3 Full Access Policy
 resource "aws_iam_policy" "s3_policy" {
   name        = "s3-policy"
-  description = "Policy for allowing all S3 Actions."
+  description = "Policy for allowing all S3 Actions"
 
   policy = <<EOF
 {
@@ -52,49 +52,111 @@ resource "aws_iam_role_policy_attachment" "s3_policy_attach" {
   policy_arn = "${aws_iam_policy.s3_policy.arn}"
 }
 
-# resource "aws_api_gateway_rest_api" "MyDemoAPI" {
-#   name        = "MyDemoAPI"
-#   description = "This is my API for demonstration purposes"
-# }
+resource "aws_api_gateway_rest_api" "MyS3" {
+  name        = "MyS3"
+  description = "API for S3 Integration"
+}
 
+resource "aws_api_gateway_resource" "Folder" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  parent_id   = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  path_part   = "{folder}"
+}
 
-# resource "aws_api_gateway_resource" "MyDemoResource" {
-#   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-#   parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
-#   path_part   = "mydemoresource"
-# }
+resource "aws_api_gateway_resource" "Item" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  parent_id   = "${aws_api_gateway_resource.Folder.id}"
+  path_part   = "{item}"
+}
 
+resource "aws_api_gateway_method" "GetBuckets" {
+  rest_api_id   = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id   = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method   = "GET"
+  authorization = "AWS_IAM"
+}
 
-# resource "aws_api_gateway_method" "MyDemoMethod" {
-#   rest_api_id   = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-#   resource_id   = "${aws_api_gateway_resource.MyDemoResource.id}"
-#   http_method   = "GET"
-#   authorization = "NONE"
-# }
+resource "aws_api_gateway_integration" "S3Integration" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
 
+  # Included because of this issue: https://github.com/hashicorp/terraform/issues/10501
+  integration_http_method = "GET"
 
-# resource "aws_api_gateway_integration" "MyDemoIntegration" {
-#   rest_api_id          = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
-#   resource_id          = "${aws_api_gateway_resource.MyDemoResource.id}"
-#   http_method          = "${aws_api_gateway_method.MyDemoMethod.http_method}"
-#   type                 = "MOCK"
-#   cache_key_parameters = ["method.request.path.param"]
-#   cache_namespace      = "foobar"
-#   timeout_milliseconds = 29000
+  type = "AWS"
 
+  # See uri description: https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
+  uri         = "arn:aws:apigateway:${var.aws_region}:s3:path//"
+  credentials = "${aws_iam_role.s3_api_gateyway_role.arn}"
+}
 
-#   request_parameters = {
-#     "integration.request.header.X-Authorization" = "'static'"
-#   }
+resource "aws_api_gateway_method_response" "200" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  status_code = "200"
 
+  response_parameters = {
+    "method.response.header.Timestamp"      = true
+    "method.response.header.Content-Length" = true
+    "method.response.header.Content-Type"   = true
+  }
 
-#   # Transforms the incoming XML request to JSON
-#   request_templates {
-#     "application/xml" = <<EOF
-# {
-#    "body" : $input.json('$')
-# }
-# EOF
-#   }
-# }
+  response_models = {
+    "application/json" = "Empty"
+  }
+}
 
+resource "aws_api_gateway_method_response" "400" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  status_code = "400"
+}
+
+resource "aws_api_gateway_method_response" "500" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  status_code = "500"
+}
+
+resource "aws_api_gateway_integration_response" "200IntegrationResponse" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  status_code = "${aws_api_gateway_method_response.200.status_code}"
+
+  selection_pattern = "-"
+
+  response_parameters = {
+    "method.response.header.Timestamp"      = "integration.response.header.Date"
+    "method.response.header.Content-Length" = "integration.response.header.Content-Length"
+    "method.response.header.Content-Type"   = "integration.response.header.Content-Type"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "400IntegrationResponse" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  status_code = "${aws_api_gateway_method_response.400.status_code}"
+
+  selection_pattern = "4\\d{2}"
+}
+
+resource "aws_api_gateway_integration_response" "500IntegrationResponse" {
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  resource_id = "${aws_api_gateway_rest_api.MyS3.root_resource_id}"
+  http_method = "${aws_api_gateway_method.GetBuckets.http_method}"
+  status_code = "${aws_api_gateway_method_response.500.status_code}"
+
+  selection_pattern = "5\\d{2}"
+}
+
+resource "aws_api_gateway_deployment" "S3APIDeployment" {
+  depends_on  = ["aws_api_gateway_integration.S3Integration"]
+  rest_api_id = "${aws_api_gateway_rest_api.MyS3.id}"
+  stage_name  = "MyS3"
+}

--- a/examples/s3-api-gateway-integration/main.tf
+++ b/examples/s3-api-gateway-integration/main.tf
@@ -1,0 +1,100 @@
+# Provide AWS Credentials
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "us-east-1"
+}
+
+# Create S3 Full Access Policy
+resource "aws_iam_policy" "s3_policy" {
+  name        = "s3-policy"
+  description = "Policy for allowing all S3 Actions."
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+# Create API Gateway Role
+resource "aws_iam_role" "s3_api_gateyway_role" {
+  name = "s3-api-gateyway-role"
+
+  # Create Trust Policy for API Gateway
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "apigateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+} 
+  EOF
+}
+
+# Attach S3 Access Policy to the API Gateway Role
+resource "aws_iam_role_policy_attachment" "s3_policy_attach" {
+  role       = "${aws_iam_role.s3_api_gateyway_role.name}"
+  policy_arn = "${aws_iam_policy.s3_policy.arn}"
+}
+
+# resource "aws_api_gateway_rest_api" "MyDemoAPI" {
+#   name        = "MyDemoAPI"
+#   description = "This is my API for demonstration purposes"
+# }
+
+
+# resource "aws_api_gateway_resource" "MyDemoResource" {
+#   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+#   parent_id   = "${aws_api_gateway_rest_api.MyDemoAPI.root_resource_id}"
+#   path_part   = "mydemoresource"
+# }
+
+
+# resource "aws_api_gateway_method" "MyDemoMethod" {
+#   rest_api_id   = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+#   resource_id   = "${aws_api_gateway_resource.MyDemoResource.id}"
+#   http_method   = "GET"
+#   authorization = "NONE"
+# }
+
+
+# resource "aws_api_gateway_integration" "MyDemoIntegration" {
+#   rest_api_id          = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
+#   resource_id          = "${aws_api_gateway_resource.MyDemoResource.id}"
+#   http_method          = "${aws_api_gateway_method.MyDemoMethod.http_method}"
+#   type                 = "MOCK"
+#   cache_key_parameters = ["method.request.path.param"]
+#   cache_namespace      = "foobar"
+#   timeout_milliseconds = 29000
+
+
+#   request_parameters = {
+#     "integration.request.header.X-Authorization" = "'static'"
+#   }
+
+
+#   # Transforms the incoming XML request to JSON
+#   request_templates {
+#     "application/xml" = <<EOF
+# {
+#    "body" : $input.json('$')
+# }
+# EOF
+#   }
+# }
+

--- a/examples/s3-api-gateway-integration/terraform.template.tfvars
+++ b/examples/s3-api-gateway-integration/terraform.template.tfvars
@@ -1,0 +1,3 @@
+aws_access_key = "aaaaaaaaaaaaaaaa"
+
+aws_secret_key = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/examples/s3-api-gateway-integration/terraform.template.tfvars
+++ b/examples/s3-api-gateway-integration/terraform.template.tfvars
@@ -1,3 +1,5 @@
-aws_access_key = "aaaaaaaaaaaaaaaa"
+aws_access_key = "yourawsaccesskey"
 
-aws_secret_key = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+aws_secret_key = "yourawssecretkey"
+
+aws_region = "us-east-1"

--- a/examples/s3-api-gateway-integration/variables.tf
+++ b/examples/s3-api-gateway-integration/variables.tf
@@ -1,0 +1,7 @@
+variable "aws_access_key" {
+  description = ""
+}
+
+variable "aws_secret_key" {
+  description = ""
+}

--- a/examples/s3-api-gateway-integration/variables.tf
+++ b/examples/s3-api-gateway-integration/variables.tf
@@ -5,3 +5,7 @@ variable "aws_access_key" {
 variable "aws_secret_key" {
   description = ""
 }
+
+variable "aws_region" {
+  description = ""
+}


### PR DESCRIPTION
Fixes #5652 

Example for creating an AWS API Gateway with S3 integration. Follows [this article](https://docs.aws.amazon.com/apigateway/latest/developerguide/integrating-api-with-aws-services-s3.html), but only builds to the point of listing buckets belonging to caller. Article goes on to allow GET, PUT, and DELETE of S3 resources, but this example demonstrates all functionality needed to move forward with the article.
