### PR TITLE
resource/aws_ssm_document: Fix Deletion of Privately Shared Documents

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -448,10 +448,19 @@ func deleteDocumentPermissions(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] Removing permissions from document: %s", d.Id())
 
+	permission := d.Get("permissions").(map[string]interface{})
+	var accountsToRemove []*string
+	if permission["account_ids"] != nil {
+		accountsToRemove = aws.StringSlice([]string{permission["account_ids"].(string)})
+		if strings.Contains(permission["account_ids"].(string), ",") {
+			accountsToRemove = aws.StringSlice(strings.Split(permission["account_ids"].(string), ","))
+		}
+	}
+
 	permInput := &ssm.ModifyDocumentPermissionInput{
 		Name:               aws.String(d.Get("name").(string)),
 		PermissionType:     aws.String("Share"),
-		AccountIdsToRemove: aws.StringSlice(strings.Split("all", ",")),
+		AccountIdsToRemove: accountsToRemove,
 	}
 
 	_, err := ssmconn.ModifyDocumentPermission(permInput)


### PR DESCRIPTION
~~Partially Fixes~~ Reference: #5308

Changes proposed in this pull request:

* Fix Deletion of Privately Shared Documents

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSSMDocument_permission'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSSMDocument_permission -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMDocument_permission_public
--- PASS: TestAccAWSSSMDocument_permission_public (120.00s)
=== RUN   TestAccAWSSSMDocument_permission_private
--- PASS: TestAccAWSSSMDocument_permission_private (137.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       257.630s
```
