### PR TITLE
Add missing policies to EKS example

### DIFF
--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -34,6 +34,33 @@ resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSServicePolicy" 
   role       = "${aws_iam_role.demo-cluster.name}"
 }
 
+resource "aws_iam_policy" "extra-policy" {
+  name = "eks-extra-policy"
+  description = "Allow for NLB creation"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeInternetGateways",
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "extra-policy-attach" {
+    role       = "${aws_iam_role.demo-cluster.name}"
+    policy_arn = "${aws_iam_policy.extra-policy.arn}"
+}
+
+
 resource "aws_security_group" "demo-cluster" {
   name        = "terraform-eks-demo-cluster"
   description = "Cluster communication with worker nodes"

--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -60,7 +60,6 @@ resource "aws_iam_role_policy_attachment" "extra-policy-attach" {
     policy_arn = "${aws_iam_policy.extra-policy.arn}"
 }
 
-
 resource "aws_security_group" "demo-cluster" {
   name        = "terraform-eks-demo-cluster"
   description = "Cluster communication with worker nodes"


### PR DESCRIPTION
These three policies seem to be required for provisioning an NLB (following [this](https://kubernetes.github.io/ingress-nginx/deploy/#aws) guide, deploying [this](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/provider/aws/service-nlb.yaml) service)

  * ec2:DescribeAccountAttributes
  * ec2:DescribeInternetGateways
  * iam:CreateServiceLinkedRole

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5669

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
