### PR TITLE
resource/aws_db_instance: Prevent double apply with replicate_source_db, prevent pending-reboot on creation with parameter_group_name

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -414,6 +414,23 @@ func resourceAwsDbInstance() *schema.Resource {
 
 func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
+
+	// Some API calls (e.g. CreateDBInstanceReadReplica and
+	// RestoreDBInstanceFromDBSnapshot do not support all parameters to
+	// correctly apply all settings in one pass. For missing parameters or
+	// unsupported configurations, we may need to call ModifyDBInstance
+	// afterwards to prevent Terraform operators from API errors or needing
+	// to double apply.
+	var requiresModifyDbInstance bool
+	modifyDbInstanceInput := &rds.ModifyDBInstanceInput{
+		ApplyImmediately: aws.Bool(true),
+	}
+
+	// Some ModifyDBInstance parameters (e.g. DBParameterGroupName) require
+	// a database instance reboot to take affect. During resource creation,
+	// we expect everything to be in sync before returning completion.
+	var requiresRebootDbInstance bool
+
 	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
 	var identifier string
@@ -437,27 +454,32 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("replicate_source_db"); ok {
 		opts := rds.CreateDBInstanceReadReplicaInput{
-			SourceDBInstanceIdentifier: aws.String(v.(string)),
+			AutoMinorVersionUpgrade:    aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 			CopyTagsToSnapshot:         aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBInstanceClass:            aws.String(d.Get("instance_class").(string)),
 			DBInstanceIdentifier:       aws.String(identifier),
 			PubliclyAccessible:         aws.Bool(d.Get("publicly_accessible").(bool)),
-			Tags:                       tags,
-		}
-		if attr, ok := d.GetOk("iops"); ok {
-			opts.Iops = aws.Int64(int64(attr.(int)))
+			SourceDBInstanceIdentifier: aws.String(v.(string)),
+			Tags: tags,
 		}
 
-		if attr, ok := d.GetOk("port"); ok {
-			opts.Port = aws.Int64(int64(attr.(int)))
+		if attr, ok := d.GetOk("allocated_storage"); ok {
+			modifyDbInstanceInput.AllocatedStorage = aws.Int64(int64(attr.(int)))
+			requiresModifyDbInstance = true
 		}
 
 		if attr, ok := d.GetOk("availability_zone"); ok {
 			opts.AvailabilityZone = aws.String(attr.(string))
 		}
 
-		if attr, ok := d.GetOk("storage_type"); ok {
-			opts.StorageType = aws.String(attr.(string))
+		if attr, ok := d.GetOk("backup_retention_period"); ok {
+			modifyDbInstanceInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
+			requiresModifyDbInstance = true
+		}
+
+		if attr, ok := d.GetOk("backup_window"); ok {
+			modifyDbInstanceInput.PreferredBackupWindow = aws.String(attr.(string))
+			requiresModifyDbInstance = true
 		}
 
 		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
@@ -468,6 +490,14 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
 		}
 
+		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
+			opts.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
+		}
+
+		if attr, ok := d.GetOk("iops"); ok {
+			opts.Iops = aws.Int64(int64(attr.(int)))
+		}
+
 		if attr, ok := d.GetOk("kms_key_id"); ok {
 			opts.KmsKeyId = aws.String(attr.(string))
 			if arnParts := strings.Split(v.(string), ":"); len(arnParts) >= 4 {
@@ -475,16 +505,54 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			}
 		}
 
-		if attr, ok := d.GetOk("monitoring_role_arn"); ok {
-			opts.MonitoringRoleArn = aws.String(attr.(string))
+		if attr, ok := d.GetOk("maintenance_window"); ok {
+			modifyDbInstanceInput.PreferredMaintenanceWindow = aws.String(attr.(string))
+			requiresModifyDbInstance = true
 		}
 
 		if attr, ok := d.GetOk("monitoring_interval"); ok {
 			opts.MonitoringInterval = aws.Int64(int64(attr.(int)))
 		}
 
+		if attr, ok := d.GetOk("monitoring_role_arn"); ok {
+			opts.MonitoringRoleArn = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("multi_az"); ok {
+			opts.MultiAZ = aws.Bool(attr.(bool))
+		}
+
 		if attr, ok := d.GetOk("option_group_name"); ok {
 			opts.OptionGroupName = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("parameter_group_name"); ok {
+			modifyDbInstanceInput.DBParameterGroupName = aws.String(attr.(string))
+			requiresModifyDbInstance = true
+			requiresRebootDbInstance = true
+		}
+
+		if attr, ok := d.GetOk("password"); ok {
+			modifyDbInstanceInput.MasterUserPassword = aws.String(attr.(string))
+			requiresModifyDbInstance = true
+		}
+
+		if attr, ok := d.GetOk("port"); ok {
+			opts.Port = aws.Int64(int64(attr.(int)))
+		}
+
+		if attr := d.Get("security_group_names").(*schema.Set); attr.Len() > 0 {
+			modifyDbInstanceInput.DBSecurityGroups = expandStringSet(attr)
+			requiresModifyDbInstance = true
+		}
+
+		if attr, ok := d.GetOk("storage_type"); ok {
+			opts.StorageType = aws.String(attr.(string))
+		}
+
+		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			modifyDbInstanceInput.VpcSecurityGroupIds = expandStringSet(attr)
+			requiresModifyDbInstance = true
 		}
 
 		log.Printf("[DEBUG] DB Instance Replica create configuration: %#v", opts)
@@ -665,12 +733,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		return resourceAwsDbInstanceRead(d, meta)
 	} else if _, ok := d.GetOk("snapshot_identifier"); ok {
-		// RestoreDBInstanceFromDBSnapshot does not support all parameters
-		// correctly apply in one pass. For missing parameters or unsupported
-		// configurations, we need to call ModifyDBInstance afterwards to
-		// prevent Terraform operators from API errors or double apply.
-		var requiresModifyDbInstance bool
-
 		opts := rds.RestoreDBInstanceFromDBSnapshotInput{
 			AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 			CopyTagsToSnapshot:      aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
@@ -692,15 +754,22 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			}
 		}
 
+		if attr, ok := d.GetOk("allocated_storage"); ok {
+			modifyDbInstanceInput.AllocatedStorage = aws.Int64(int64(attr.(int)))
+			requiresModifyDbInstance = true
+		}
+
 		if attr, ok := d.GetOk("availability_zone"); ok {
 			opts.AvailabilityZone = aws.String(attr.(string))
 		}
 
-		if _, ok := d.GetOk("backup_retention_period"); ok {
+		if attr, ok := d.GetOk("backup_retention_period"); ok {
+			modifyDbInstanceInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
 			requiresModifyDbInstance = true
 		}
 
-		if _, ok := d.GetOk("backup_window"); ok {
+		if attr, ok := d.GetOk("backup_window"); ok {
+			modifyDbInstanceInput.PreferredBackupWindow = aws.String(attr.(string))
 			requiresModifyDbInstance = true
 		}
 
@@ -716,8 +785,8 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.Engine = aws.String(attr.(string))
 		}
 
-		if _, ok := d.GetOk("iam_database_authentication_enabled"); ok {
-			requiresModifyDbInstance = true
+		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
+			opts.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
 		}
 
 		if attr, ok := d.GetOk("iops"); ok {
@@ -728,15 +797,18 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.LicenseModel = aws.String(attr.(string))
 		}
 
-		if _, ok := d.GetOk("maintenance_window"); ok {
+		if attr, ok := d.GetOk("maintenance_window"); ok {
+			modifyDbInstanceInput.PreferredMaintenanceWindow = aws.String(attr.(string))
 			requiresModifyDbInstance = true
 		}
 
-		if _, ok := d.GetOk("monitoring_interval"); ok {
+		if attr, ok := d.GetOk("monitoring_interval"); ok {
+			modifyDbInstanceInput.MonitoringInterval = aws.Int64(int64(attr.(int)))
 			requiresModifyDbInstance = true
 		}
 
-		if _, ok := d.GetOk("monitoring_role_arn"); ok {
+		if attr, ok := d.GetOk("monitoring_role_arn"); ok {
+			modifyDbInstanceInput.MonitoringRoleArn = aws.String(attr.(string))
 			requiresModifyDbInstance = true
 		}
 
@@ -748,6 +820,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			// InvalidParameterValue: Mirroring cannot be applied to instances with backup retention set to zero.
 			// If we know the engine, prevent the error upfront.
 			if v, ok := d.GetOk("engine"); ok && strings.HasPrefix(strings.ToLower(v.(string)), "sqlserver") {
+				modifyDbInstanceInput.MultiAZ = aws.Bool(attr.(bool))
 				requiresModifyDbInstance = true
 			} else {
 				opts.MultiAZ = aws.Bool(attr.(bool))
@@ -758,11 +831,14 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.OptionGroupName = aws.String(attr.(string))
 		}
 
-		if _, ok := d.GetOk("parameter_group_name"); ok {
+		if attr, ok := d.GetOk("parameter_group_name"); ok {
+			modifyDbInstanceInput.DBParameterGroupName = aws.String(attr.(string))
 			requiresModifyDbInstance = true
+			requiresRebootDbInstance = true
 		}
 
-		if _, ok := d.GetOk("password"); ok {
+		if attr, ok := d.GetOk("password"); ok {
+			modifyDbInstanceInput.MasterUserPassword = aws.String(attr.(string))
 			requiresModifyDbInstance = true
 		}
 
@@ -771,6 +847,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("security_group_names").(*schema.Set); attr.Len() > 0 {
+			modifyDbInstanceInput.DBSecurityGroups = expandStringSet(attr)
 			requiresModifyDbInstance = true
 		}
 
@@ -783,6 +860,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			modifyDbInstanceInput.VpcSecurityGroupIds = expandStringSet(attr)
 			requiresModifyDbInstance = true
 		}
 
@@ -799,40 +877,13 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		// and remove the invalid configuration for it to be fixed afterwards.
 		if isAWSErr(err, "InvalidParameterValue", "Mirroring cannot be applied to instances with backup retention set to zero") {
 			opts.MultiAZ = aws.Bool(false)
+			modifyDbInstanceInput.MultiAZ = aws.Bool(true)
 			requiresModifyDbInstance = true
 			_, err = conn.RestoreDBInstanceFromDBSnapshot(&opts)
 		}
 
 		if err != nil {
 			return fmt.Errorf("Error creating DB Instance: %s", err)
-		}
-
-		if requiresModifyDbInstance {
-			d.SetId(d.Get("identifier").(string))
-
-			log.Printf("[INFO] DB Instance %q configuration requires ModifyDBInstance after RestoreDBInstanceFromDBSnapshot", d.Id())
-			log.Printf("[INFO] Waiting for DB Instance %q to be available", d.Id())
-
-			stateConf := &resource.StateChangeConf{
-				Pending:    resourceAwsDbInstanceCreatePendingStates,
-				Target:     []string{"available", "storage-optimization"},
-				Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
-				Timeout:    d.Timeout(schema.TimeoutCreate),
-				MinTimeout: 10 * time.Second,
-				Delay:      30 * time.Second, // Wait 30 secs before starting
-			}
-
-			// Wait, catching any errors
-			_, err := stateConf.WaitForState()
-			if err != nil {
-				return err
-			}
-
-			err = resourceAwsDbInstanceUpdate(d, meta)
-			if err != nil {
-				return err
-			}
-
 		}
 	} else {
 		if _, ok := d.GetOk("allocated_storage"); !ok {
@@ -975,11 +1026,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(d.Get("identifier").(string))
 
-	log.Printf("[INFO] DB Instance ID: %s", d.Id())
-
-	log.Println(
-		"[INFO] Waiting for DB Instance to be available")
-
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceAwsDbInstanceCreatePendingStates,
 		Target:     []string{"available", "storage-optimization"},
@@ -989,10 +1035,44 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
 
-	// Wait, catching any errors
+	log.Printf("[INFO] Waiting for DB Instance (%s) to be available", d.Id())
 	_, err := stateConf.WaitForState()
 	if err != nil {
 		return err
+	}
+
+	if requiresModifyDbInstance {
+		modifyDbInstanceInput.DBInstanceIdentifier = aws.String(d.Id())
+
+		log.Printf("[INFO] DB Instance (%s) configuration requires ModifyDBInstance: %s", d.Id(), modifyDbInstanceInput)
+		_, err := conn.ModifyDBInstance(modifyDbInstanceInput)
+		if err != nil {
+			return fmt.Errorf("error modifying DB Instance (%s): %s", d.Id(), err)
+		}
+
+		log.Printf("[INFO] Waiting for DB Instance (%s) to be available", d.Id())
+		err = waitUntilAwsDbInstanceIsAvailableAfterUpdate(d.Id(), conn, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("error waiting for DB Instance (%s) to be available: %s", d.Id(), err)
+		}
+	}
+
+	if requiresRebootDbInstance {
+		rebootDbInstanceInput := &rds.RebootDBInstanceInput{
+			DBInstanceIdentifier: aws.String(d.Id()),
+		}
+
+		log.Printf("[INFO] DB Instance (%s) configuration requires RebootDBInstance: %s", d.Id(), rebootDbInstanceInput)
+		_, err := conn.RebootDBInstance(rebootDbInstanceInput)
+		if err != nil {
+			return fmt.Errorf("error rebooting DB Instance (%s): %s", d.Id(), err)
+		}
+
+		log.Printf("[INFO] Waiting for DB Instance (%s) to be available", d.Id())
+		err = waitUntilAwsDbInstanceIsAvailableAfterUpdate(d.Id(), conn, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("error waiting for DB Instance (%s) to be available: %s", d.Id(), err)
+		}
 	}
 
 	return resourceAwsDbInstanceRead(d, meta)
@@ -1157,6 +1237,19 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 	return waitUntilAwsDbInstanceIsDeleted(d.Id(), conn, d.Timeout(schema.TimeoutDelete))
 }
 
+func waitUntilAwsDbInstanceIsAvailableAfterUpdate(id string, conn *rds.RDS, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    resourceAwsDbInstanceUpdatePendingStates,
+		Target:     []string{"available", "storage-optimization"},
+		Refresh:    resourceAwsDbInstanceStateRefreshFunc(id, conn),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second, // Wait 30 secs before starting
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}
+
 func waitUntilAwsDbInstanceIsDeleted(id string, conn *rds.RDS, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    resourceAwsDbInstanceDeletePendingStates,
@@ -1180,13 +1273,6 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		DBInstanceIdentifier: aws.String(d.Id()),
 	}
 
-	// ModifyDBInstance might be called during resource creation
-	// to fix unsupported configurations, e.g. missing parameters
-	// from RestoreDBInstanceFromDBSnapshot. In this case, we should
-	// always apply immediately.
-	if d.IsNewResource() {
-		req.ApplyImmediately = aws.Bool(true)
-	}
 	d.SetPartial("apply_immediately")
 
 	if !aws.BoolValue(req.ApplyImmediately) {
@@ -1286,22 +1372,14 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("vpc_security_group_ids") {
 		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
-			var s []*string
-			for _, v := range attr.List() {
-				s = append(s, aws.String(v.(string)))
-			}
-			req.VpcSecurityGroupIds = s
+			req.VpcSecurityGroupIds = expandStringSet(attr)
 		}
 		requestUpdate = true
 	}
 
 	if d.HasChange("security_group_names") {
 		if attr := d.Get("security_group_names").(*schema.Set); attr.Len() > 0 {
-			var s []*string
-			for _, v := range attr.List() {
-				s = append(s, aws.String(v.(string)))
-			}
-			req.DBSecurityGroups = s
+			req.DBSecurityGroups = expandStringSet(attr)
 		}
 		requestUpdate = true
 	}
@@ -1317,13 +1395,13 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		req.DBPortNumber = aws.Int64(int64(d.Get("port").(int)))
 		requestUpdate = true
 	}
-	if d.HasChange("db_subnet_group_name") && !d.IsNewResource() {
+	if d.HasChange("db_subnet_group_name") {
 		d.SetPartial("db_subnet_group_name")
 		req.DBSubnetGroupName = aws.String(d.Get("db_subnet_group_name").(string))
 		requestUpdate = true
 	}
 
-	if d.HasChange("enabled_cloudwatch_logs_exports") && !d.IsNewResource() {
+	if d.HasChange("enabled_cloudwatch_logs_exports") {
 		d.SetPartial("enabled_cloudwatch_logs_exports")
 		req.CloudwatchLogsExportConfiguration = buildCloudwatchLogsExportConfiguration(d)
 		requestUpdate = true
@@ -1342,21 +1420,10 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Error modifying DB Instance %s: %s", d.Id(), err)
 		}
 
-		log.Println("[INFO] Waiting for DB Instance to be available")
-
-		stateConf := &resource.StateChangeConf{
-			Pending:    resourceAwsDbInstanceUpdatePendingStates,
-			Target:     []string{"available", "storage-optimization"},
-			Refresh:    resourceAwsDbInstanceStateRefreshFunc(d.Id(), conn),
-			Timeout:    d.Timeout(schema.TimeoutUpdate),
-			MinTimeout: 10 * time.Second,
-			Delay:      30 * time.Second, // Wait 30 secs before starting
-		}
-
-		// Wait, catching any errors
-		_, dbStateErr := stateConf.WaitForState()
-		if dbStateErr != nil {
-			return dbStateErr
+		log.Printf("[DEBUG] Waiting for DB Instance (%s) to be available", d.Id())
+		err = waitUntilAwsDbInstanceIsAvailableAfterUpdate(d.Id(), conn, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("error waiting for DB Instance (%s) to be available: %s", d.Id(), err)
 		}
 	}
 
@@ -1382,8 +1449,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	// Tags are set on creation
-	if !d.IsNewResource() && d.HasChange("tags") {
+	if d.HasChange("tags") {
 		if err := setTagsRDS(conn, d, d.Get("arn").(string)); err != nil {
 			return err
 		} else {


### PR DESCRIPTION
Fixes #218
Fixes #263
Fixes #1329
Fixes #1494
Fixes #1510
Fixes #2909

Previously:

```
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1160.55s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'allocated_storage' expected "10", got "5"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1433.85s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'allocated_storage' expected "10", got "5"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1707.73s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'auto_minor_version_upgrade' expected "false", got "true"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1336.28s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'backup_retention_period' expected "1", got "0"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1451.16s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'backup_window' expected "00:00-08:00", got "08:31-09:01"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1525.07s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'iam_database_authentication_enabled' expected "true", got "false"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1695.94s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'maintenance_window' expected "sun:01:00-sun:01:30", got "sat:07:22-sat:07:52"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (1802.71s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'multi_az' expected "true", got "false"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1624.64s)
	testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'parameter_group_name' expected "tf-acc-test-2677194822897355379", got "default.mysql5.7"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1479.95s)
	testing.go:527: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: aws_db_instance.test
		  vpc_security_group_ids.1493394302: "" => "sg-0202c4194da544ffb"
		  vpc_security_group_ids.81746784:   "sg-1ca59078" => ""
```

Before RebootDBInstance addition:

```
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1256.87s)
	testing.go:527: Step 0 error: Check failed: Check 5/5 error: expected DB Instance (tf-acc-test-8132994030462245505) Parameter Group (tf-acc-test-8132994030462245505) apply status to be: "in-sync", got: "pending-reboot"
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1761.14s)
	testing.go:527: Step 0 error: Check failed: Check 5/5 error: expected DB Instance (tf-acc-test-632112102194298217) Parameter Group (tf-acc-test-632112102194298217) apply status to be: "in-sync", got: "pending-reboot"
```

Changes proposed in this pull request:

* Add `ModifyDBInstance` call to `CreateDBInstanceReadReplica` if necessary
* Add `RebootDBInstance` call after `ModifyDBInstance` if necessary
* Refactor to not call update function during create function
* Additional acceptance testing with `snapshot_identifier` and `allocated_storage`, `availability_zone`, `auto_minor_version_upgrade`, and `port`

Output from acceptance testing:

```
51 tests passed (all tests)
--- PASS: TestAccAWSDBInstance_namePrefix (450.90s)
--- PASS: TestAccAWSDBInstance_iamAuth (470.49s)
--- PASS: TestAccAWSDBInstance_generatedName (491.28s)
--- PASS: TestAccAWSDBInstance_importBasic (501.34s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (501.44s)
--- PASS: TestAccAWSDBInstance_basic (520.82s)
--- PASS: TestAccAWSDBInstance_kmsKey (550.28s)
--- PASS: TestAccAWSDBInstance_optionGroup (592.18s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (733.31s)
--- PASS: TestAccAWSDBInstance_subnetGroup (935.85s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (956.10s)
--- PASS: TestAccAWSDBInstance_S3Import (784.56s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1381.45s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1533.10s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1604.60s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1644.87s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1654.63s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1661.31s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1705.38s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1289.00s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1258.32s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1531.50s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1298.63s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1156.87s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (2148.84s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1675.46s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (2279.75s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1761.78s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1450.02s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1935.97s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1228.25s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1137.73s)
--- PASS: TestAccAWSDBInstance_MinorVersion (459.25s)
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (626.51s)
--- PASS: TestAccAWSDBInstance_portUpdate (542.92s)
--- PASS: TestAccAWSDBInstance_separate_iops_update (633.42s)
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (459.22s)
--- PASS: TestAccAWSDBInstance_ec2Classic (449.74s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1280.71s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2389.66s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (514.97s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1248.17s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1277.75s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (559.38s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1298.67s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1209.14s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1380.50s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (823.13s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1944.08s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1530.48s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (3841.77s)
```
