### PR TITLE
Add ipv6_cidr_blocks attribute to aws_ip_ranges data source

### DIFF
--- a/aws/data_source_aws_ip_ranges.go
+++ b/aws/data_source_aws_ip_ranges.go
@@ -14,15 +14,22 @@ import (
 )
 
 type dataSourceAwsIPRangesResult struct {
-	CreateDate string
-	Prefixes   []dataSourceAwsIPRangesPrefix
-	SyncToken  string
+	CreateDate   string
+	Prefixes     []dataSourceAwsIPRangesPrefix
+	Ipv6Prefixes []dataSourceAwsIPRangesIpv6Prefix `json:"ipv6_prefixes"`
+	SyncToken    string
 }
 
 type dataSourceAwsIPRangesPrefix struct {
 	IpPrefix string `json:"ip_prefix"`
 	Region   string
 	Service  string
+}
+
+type dataSourceAwsIPRangesIpv6Prefix struct {
+	Ipv6Prefix string `json:"ipv6_prefix"`
+	Region     string
+	Service    string
 }
 
 func dataSourceAwsIPRanges() *schema.Resource {
@@ -38,6 +45,11 @@ func dataSourceAwsIPRanges() *schema.Resource {
 			"create_date": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"ipv6_cidr_blocks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"regions": {
 				Type:     schema.TypeSet,
@@ -120,30 +132,42 @@ func dataSourceAwsIPRangesRead(d *schema.ResourceData, meta interface{}) error {
 		regions        = get("regions")
 		services       = get("services")
 		noRegionFilter = regions.Len() == 0
-		prefixes       []string
+		ipPrefixes     []string
+		ipv6Prefixes   []string
 	)
 
+	matchFilter := func(region, service string) bool {
+		matchRegion := noRegionFilter || regions.Contains(strings.ToLower(region))
+		matchService := services.Contains(strings.ToLower(service))
+		return matchRegion && matchService
+	}
+
 	for _, e := range result.Prefixes {
-
-		var (
-			matchRegion  = noRegionFilter || regions.Contains(strings.ToLower(e.Region))
-			matchService = services.Contains(strings.ToLower(e.Service))
-		)
-
-		if matchRegion && matchService {
-			prefixes = append(prefixes, e.IpPrefix)
+		if matchFilter(e.Region, e.Service) {
+			ipPrefixes = append(ipPrefixes, e.IpPrefix)
 		}
-
 	}
 
-	if len(prefixes) == 0 {
-		return fmt.Errorf(" No IP ranges result from filters")
+	for _, e := range result.Ipv6Prefixes {
+		if matchFilter(e.Region, e.Service) {
+			ipv6Prefixes = append(ipv6Prefixes, e.Ipv6Prefix)
+		}
 	}
 
-	sort.Strings(prefixes)
+	if len(ipPrefixes) == 0 && len(ipv6Prefixes) == 0 {
+		return fmt.Errorf("No IP ranges result from filters")
+	}
 
-	if err := d.Set("cidr_blocks", prefixes); err != nil {
-		return fmt.Errorf("Error setting ip ranges: %s", err)
+	sort.Strings(ipPrefixes)
+
+	if err := d.Set("cidr_blocks", ipPrefixes); err != nil {
+		return fmt.Errorf("Error setting cidr_blocks: %s", err)
+	}
+
+	sort.Strings(ipv6Prefixes)
+
+	if err := d.Set("ipv6_cidr_blocks", ipv6Prefixes); err != nil {
+		return fmt.Errorf("Error setting ipv6_cidr_blocks: %s", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_ip_ranges_test.go
+++ b/aws/data_source_aws_ip_ranges_test.go
@@ -21,33 +21,26 @@ func TestAccAWSIPRanges(t *testing.T) {
 			{
 				Config: testAccAWSIPRangesConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSIPRanges("data.aws_ip_ranges.some"),
+					testAccAWSIPRangesCheckAttributes("data.aws_ip_ranges.some"),
+					testAccAWSIPRangesCheckCidrBlocksAttribute("data.aws_ip_ranges.some", "cidr_blocks"),
+					testAccAWSIPRangesCheckCidrBlocksAttribute("data.aws_ip_ranges.some", "ipv6_cidr_blocks"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAWSIPRanges(n string) resource.TestCheckFunc {
+func testAccAWSIPRangesCheckAttributes(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		r := s.RootModule().Resources[n]
 		a := r.Primary.Attributes
 
 		var (
-			cidrBlockSize int
-			createDate    time.Time
-			err           error
-			syncToken     int
+			createDate time.Time
+			err        error
+			syncToken  int
 		)
-
-		if cidrBlockSize, err = strconv.Atoi(a["cidr_blocks.#"]); err != nil {
-			return err
-		}
-
-		if cidrBlockSize < 10 {
-			return fmt.Errorf("cidr_blocks for eu-west-1 seem suspiciously low: %d", cidrBlockSize)
-		}
 
 		if createDate, err = time.Parse("2006-01-02-15-04-05", a["create_date"]); err != nil {
 			return err
@@ -59,24 +52,6 @@ func testAccAWSIPRanges(n string) resource.TestCheckFunc {
 
 		if syncToken != int(createDate.Unix()) {
 			return fmt.Errorf("sync_token %d does not match create_date %s", syncToken, createDate)
-		}
-
-		var cidrBlocks sort.StringSlice = make([]string, cidrBlockSize)
-
-		for i := range make([]string, cidrBlockSize) {
-
-			block := a[fmt.Sprintf("cidr_blocks.%d", i)]
-
-			if _, _, err := net.ParseCIDR(block); err != nil {
-				return fmt.Errorf("malformed CIDR block %s: %s", block, err)
-			}
-
-			cidrBlocks[i] = block
-
-		}
-
-		if !sort.IsSorted(cidrBlocks) {
-			return fmt.Errorf("unexpected order of cidr_blocks: %s", cidrBlocks)
 		}
 
 		var (
@@ -114,6 +89,46 @@ func testAccAWSIPRanges(n string) resource.TestCheckFunc {
 
 		if services != 1 {
 			return fmt.Errorf("unexpected number of services: %d", services)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSIPRangesCheckCidrBlocksAttribute(name, attribute string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[name]
+		a := r.Primary.Attributes
+
+		var (
+			cidrBlockSize int
+			cidrBlocks    sort.StringSlice
+			err           error
+		)
+
+		if cidrBlockSize, err = strconv.Atoi(a[fmt.Sprintf("%s.#", attribute)]); err != nil {
+			return err
+		}
+
+		if cidrBlockSize < 5 {
+			return fmt.Errorf("%s for eu-west-1 seem suspiciously low: %d", attribute, cidrBlockSize)
+		}
+
+		cidrBlocks = make([]string, cidrBlockSize)
+
+		for i := range cidrBlocks {
+			cidrBlock := a[fmt.Sprintf("%s.%d", attribute, i)]
+
+			_, _, err := net.ParseCIDR(cidrBlock)
+			if err != nil {
+				return fmt.Errorf("malformed CIDR block %s in %s: %s", cidrBlock, attribute, err)
+			}
+
+			cidrBlocks[i] = cidrBlock
+		}
+
+		if !sort.IsSorted(cidrBlocks) {
+			return fmt.Errorf("unexpected order of %s: %s", attribute, cidrBlocks)
 		}
 
 		return nil

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -22,10 +22,11 @@ resource "aws_security_group" "from_europe" {
   name = "from_europe"
 
   ingress {
-    from_port   = "443"
-    to_port     = "443"
-    protocol    = "tcp"
-    cidr_blocks = ["${data.aws_ip_ranges.european_ec2.cidr_blocks}"]
+    from_port        = "443"
+    to_port          = "443"
+    protocol         = "tcp"
+    cidr_blocks      = ["${data.aws_ip_ranges.european_ec2.cidr_blocks}"]
+    ipv6_cidr_blocks = ["${data.aws_ip_ranges.european_ec2.ipv6_cidr_blocks}"]
   }
 
   tags {
@@ -50,6 +51,7 @@ CIDR blocks, Terraform will fail.
 ## Attributes Reference
 
 * `cidr_blocks` - The lexically ordered list of CIDR blocks.
+* `ipv6_cidr_blocks` - The lexically ordered list of IPv6 CIDR blocks.
 * `create_date` - The publication time of the IP ranges (e.g. `2016-08-03-23-46-05`).
 * `sync_token` - The publication time of the IP ranges, in Unix epoch time format
   (e.g. `1470267965`).


### PR DESCRIPTION
Changes proposed in this pull request:

* Add `ipv6_cidr_blocks` attribute to `aws_ip_ranges` data source, taken from the `ipv6_prefixes` in https://ip-ranges.amazonaws.com/ip-ranges.json

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIPRanges'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSIPRanges -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIPRanges
--- PASS: TestAccAWSIPRanges (14.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.763s
```
