### PR TITLE
use correct admin username

### DIFF
--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -97,7 +97,7 @@ resource "aws_directory_service_directory" "connector" {
 
   connect_settings {
     customer_dns_ips  = ["A.B.C.D"]
-    customer_username = "Administrator"
+    customer_username = "Admin"
     subnet_ids        = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
     vpc_id            = "${aws_vpc.main.id}"
   }


### PR DESCRIPTION
The `customer_username` example within `connect_settings` for ADConnector should be `Admin` as auto-generated by AWS.

Using a value of `Administrator` as shown in the current documentation results in the following error:

```
Configuration issues detected: Invalid credentials (bad username/password) for IP: 10.0.1.149. Please verify existing configuration and retry the operation.
```