### PR TITLE
r/aws_codebuild_project: Add artifacts encryption_disabled attribute.

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -38,6 +38,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"encryption_disabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"location": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -393,7 +397,8 @@ func expandProjectArtifacts(d *schema.ResourceData) codebuild.ProjectArtifacts {
 	data := configs[0].(map[string]interface{})
 
 	projectArtifacts := codebuild.ProjectArtifacts{
-		Type: aws.String(data["type"].(string)),
+		EncryptionDisabled: aws.Bool(data["encryption_disabled"].(bool)),
+		Type:               aws.String(data["type"].(string)),
 	}
 
 	if data["location"].(string) != "" {
@@ -712,6 +717,7 @@ func flattenAwsCodeBuildProjectArtifacts(artifacts *codebuild.ProjectArtifacts) 
 
 	values := map[string]interface{}{}
 
+	values["encryption_disabled"] = *artifacts.EncryptionDisabled
 	values["type"] = *artifacts.Type
 
 	if artifacts.Location != nil {
@@ -805,9 +811,10 @@ func resourceAwsCodeBuildProjectArtifactsHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	artifactType := m["type"].(string)
-
-	buf.WriteString(fmt.Sprintf("%s-", artifactType))
+	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
+	if v, ok := m["encryption_disabled"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", strconv.FormatBool(v.(bool))))
+	}
 
 	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -812,9 +812,7 @@ func resourceAwsCodeBuildProjectArtifactsHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
-	if v, ok := m["encryption_disabled"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", strconv.FormatBool(v.(bool))))
-	}
+	buf.WriteString(fmt.Sprintf("%t-", m["encryption_disabled"].(bool)))
 
 	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -40,6 +40,7 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifacts.1178773975.encryption_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.1178773975.location", ""),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.1178773975.name", ""),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.1178773975.namespace_type", ""),
@@ -594,7 +595,7 @@ func TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "artifacts.1580844383.encryption_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "artifacts.537882814.encryption_disabled", "true"),
 				),
 			},
 		},

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -578,6 +578,29 @@ func TestAccAWSCodeBuildProject_WindowsContainer(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	bName := acctest.RandomWithPrefix("tf-acc-test-bucket")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodebuildProjectConfig_Artifacts_EncryptionDisabled(rName, bName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "artifacts.0.encryption_disabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAWSCodeBuildProject_nameValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -658,6 +681,14 @@ func testAccCheckAWSCodeBuildProjectDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSCodeBuildProjectConfig_Base_Bucket(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+  force_destroy = true
+}`, rName)
 }
 
 func testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName string) string {
@@ -1239,4 +1270,30 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, rName, testAccAWSCodeBuildGitHubSourceLocationFromEnv())
+}
+
+func testAccAWSCodebuildProjectConfig_Artifacts_EncryptionDisabled(rName string, bName string, encryptionDisabled bool) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name          = "%s"
+  service_role  = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    encryption_disabled = %t
+    location            = "${aws_s3_bucket.test.bucket}"
+    type                = "S3"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/hashicorp/packer.git"
+  }
+}
+`, rName, encryptionDisabled)
 }

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -594,7 +594,7 @@ func TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "artifacts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "artifacts.0.encryption_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "artifacts.1580844383.encryption_disabled", "true"),
 				),
 			},
 		},

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -161,6 +161,7 @@ The following arguments are supported:
 `artifacts` supports the following:
 
 * `type` - (Required) The build output artifact's type. Valid values for this parameter are: `CODEPIPELINE`, `NO_ARTIFACTS` or `S3`.
+* `encryption_disabled` - (Optional) If set to true, output artifacts will not be encrypted. If `type` is set to `NO_ARTIFACTS` then this value will be ignored. Defaults to `false`.
 * `location` - (Optional) Information about the build output artifact location. If `type` is set to `CODEPIPELINE` or `NO_ARTIFACTS` then this value will be ignored. If `type` is set to `S3`, this is the name of the output bucket. If `path` is not also specified, then `location` can also specify the path of the output artifact in the output bucket.
 * `name` - (Optional) The name of the project. If `type` is set to `S3`, this is the name of the output artifact object
 * `namespace_type` - (Optional) The namespace to use in storing build artifacts. If `type` is set to `S3`, then valid values for this parameter are: `BUILD_ID` or `NONE`.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5656 

Changes proposed in this pull request:

* Add an optional boolean attribute to the CodeBuild project resource to control output artifact encryption.

Output from acceptance testing:

```
# make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (32.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       (cached)
```
