### PR TITLE
Specify to use security group id in aws instance.

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -77,7 +77,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 
 * `get_password_data` - (Optional) If true, wait for password data to become available and retrieve it. Useful for getting the administrator password for instances running Microsoft Windows. The password data is exported to the `password_data` attribute. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)
-* `security_groups` - (Optional, EC2-Classic and default VPC only) A list of security group names to associate with.
+* `security_groups` - (Optional, EC2-Classic and default VPC only) A list of security group names or IDs to associate with.
 
 -> **NOTE:** If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -77,7 +77,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
 
 * `get_password_data` - (Optional) If true, wait for password data to become available and retrieve it. Useful for getting the administrator password for instances running Microsoft Windows. The password data is exported to the `password_data` attribute. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)
-* `security_groups` - (Optional, EC2-Classic and default VPC only) A list of security group names or IDs to associate with.
+* `security_groups` - (Optional, EC2-Classic and default VPC only) A list of security group names (EC2-Classic) or IDs (default VPC) to associate with.
 
 -> **NOTE:** If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 


### PR DESCRIPTION

I am a total beginner in AWS and Terraform and so as I was playing around I encountered an error when supplying the `security_groups` field under `aws_instance`. I initially used `["${aws_security_group.terraform.name}"]` and this is the error
```
* aws_instance.example: Error launching source instance: InvalidGroup.NotFound: The security group 'terraform_example' does not exist in VPC 'vpc-id'
```
 Changing it to `["${aws_security_group.terraform.id}"]` fixed it.

The changes in this PR will specify in the docs to use the security group ID.

```
$ terraform -v
Terraform v0.11.7
+ provider.aws v1.31.0
```