### PR TITLE
resource/aws_ssm_document: Update SSM Document Permission Updates to Clear Permission Before Updating

### DIFF
--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -108,6 +108,35 @@ func TestAccAWSSSMDocument_permission_private(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMDocument_permission_change(t *testing.T) {
+	name := acctest.RandString(10)
+	initial_ids := "123456789012,123456789013"
+	updated_ids := "123456789012"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, initial_ids),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "permissions.type", "Share"),
+				),
+			},
+			{
+				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, updated_ids),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "permissions.type", "Share"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMDocument_params(t *testing.T) {
 	name := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -110,27 +110,39 @@ func TestAccAWSSSMDocument_permission_private(t *testing.T) {
 
 func TestAccAWSSSMDocument_permission_change(t *testing.T) {
 	name := acctest.RandString(10)
-	initial_ids := "123456789012,123456789013"
-	updated_ids := "123456789012"
+	idsInitial := "123456789012,123456789013"
+	idsRemove := "123456789012"
+	idsAdd := "123456789012,123456789014"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, initial_ids),
+				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, idsInitial),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_document.foo", "permissions.type", "Share"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "permissions.account_ids", idsInitial),
 				),
 			},
 			{
-				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, updated_ids),
+				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, idsRemove),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_document.foo", "permissions.type", "Share"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "permissions.account_ids", idsRemove),
+				),
+			},
+			{
+				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, idsAdd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "permissions.type", "Share"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "permissions.account_ids", idsAdd),
 				),
 			},
 		},


### PR DESCRIPTION
Reference: #5308

Changes proposed in this pull request:

* Update SSM Document Permission Updates to Clear Permission Before Updating

Output from acceptance testing:

```
$  make testacc TESTARGS='-run=TestAccAWSSSMDocument'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSSMDocument -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSSMDocument_basic
--- PASS: TestAccAWSSSMDocument_basic (20.38s)
=== RUN   TestAccAWSSSMDocument_update
--- PASS: TestAccAWSSSMDocument_update (28.27s)
=== RUN   TestAccAWSSSMDocument_permission_public
--- PASS: TestAccAWSSSMDocument_permission_public (15.73s)
=== RUN   TestAccAWSSSMDocument_permission_private
--- PASS: TestAccAWSSSMDocument_permission_private (15.64s)
=== RUN   TestAccAWSSSMDocument_permission_change
--- PASS: TestAccAWSSSMDocument_permission_change (26.85s)
=== RUN   TestAccAWSSSMDocument_params
--- PASS: TestAccAWSSSMDocument_params (15.34s)
=== RUN   TestAccAWSSSMDocument_automation
--- PASS: TestAccAWSSSMDocument_automation (29.21s)
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (27.88s)
=== RUN   TestAccAWSSSMDocument_Tags
--- PASS: TestAccAWSSSMDocument_Tags (38.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	217.371s
```
