### PR TITLE
resource/aws_route: Support route import

### DIFF
--- a/aws/data_source_aws_route.go
+++ b/aws/data_source_aws_route.go
@@ -98,7 +98,7 @@ func dataSourceAwsRouteRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	route := results[0]
 
-	d.SetId(routeIDHash(d, route)) // using function from "resource_aws_route.go"
+	d.SetId(resourceAwsRouteID(d, route)) // using function from "resource_aws_route.go"
 	d.Set("destination_cidr_block", route.DestinationCidrBlock)
 	d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
 	d.Set("egress_only_gateway_id", route.EgressOnlyInternetGatewayId)

--- a/aws/import_aws_route_table.go
+++ b/aws/import_aws_route_table.go
@@ -56,7 +56,7 @@ func resourceAwsRouteTableImportState(
 			d.Set("route_table_id", id)
 			d.Set("destination_cidr_block", route.DestinationCidrBlock)
 			d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
-			d.SetId(routeIDHash(d, route))
+			d.SetId(resourceAwsRouteID(d, route))
 			results = append(results, d)
 		}
 	}

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -392,7 +392,7 @@ func testAccCheckAWSRouteExists(n string, res *ec2.Route) resource.TestCheckFunc
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		r, err := findResourceRoute(
+		r, err := resourceAwsRouteFindRoute(
 			conn,
 			rs.Primary.Attributes["route_table_id"],
 			rs.Primary.Attributes["destination_cidr_block"],
@@ -420,7 +420,7 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		route, err := findResourceRoute(
+		route, err := resourceAwsRouteFindRoute(
 			conn,
 			rs.Primary.Attributes["route_table_id"],
 			rs.Primary.Attributes["destination_cidr_block"],

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -45,6 +45,12 @@ func TestAccAWSRoute_basic(t *testing.T) {
 					testCheck,
 				),
 			},
+			{
+				ResourceName:      "aws_route.bar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -82,6 +88,12 @@ func TestAccAWSRoute_ipv6Support(t *testing.T) {
 					testCheck,
 				),
 			},
+			{
+				ResourceName:      "aws_route.bar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -101,6 +113,12 @@ func TestAccAWSRoute_ipv6ToInternetGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists("aws_route.igw", &route),
 				),
+			},
+			{
+				ResourceName:      "aws_route.igw",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.igw"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -122,6 +140,12 @@ func TestAccAWSRoute_ipv6ToInstance(t *testing.T) {
 					testAccCheckAWSRouteExists("aws_route.internal-default-route-ipv6", &route),
 				),
 			},
+			{
+				ResourceName:      "aws_route.internal-default-route-ipv6",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.internal-default-route-ipv6"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -142,6 +166,12 @@ func TestAccAWSRoute_ipv6ToNetworkInterface(t *testing.T) {
 					testAccCheckAWSRouteExists("aws_route.internal-default-route-ipv6", &route),
 				),
 			},
+			{
+				ResourceName:      "aws_route.internal-default-route-ipv6",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.internal-default-route-ipv6"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -161,6 +191,12 @@ func TestAccAWSRoute_ipv6ToPeeringConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists("aws_route.pc", &route),
 				),
+			},
+			{
+				ResourceName:      "aws_route.pc",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.pc"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -188,6 +224,12 @@ func TestAccAWSRoute_changeRouteTable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists("aws_route.bar", &after),
 				),
+			},
+			{
+				ResourceName:      "aws_route.bar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -260,6 +302,12 @@ func TestAccAWSRoute_changeCidr(t *testing.T) {
 					testCheckChange,
 				),
 			},
+			{
+				ResourceName:      "aws_route.bar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -298,6 +346,12 @@ func TestAccAWSRoute_noopdiff(t *testing.T) {
 					testCheckChange,
 				),
 			},
+			{
+				ResourceName:      "aws_route.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -315,6 +369,12 @@ func TestAccAWSRoute_doesNotCrashWithVPCEndpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRouteExists("aws_route.bar", &route),
 				),
+			},
+			{
+				ResourceName:      "aws_route.bar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteImportStateIdFunc("aws_route.bar"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -373,6 +433,22 @@ func testAccCheckAWSRouteDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSRouteImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		destination := rs.Primary.Attributes["destination_cidr_block"]
+		if _, ok := rs.Primary.Attributes["destination_ipv6_cidr_block"]; ok {
+			destination = rs.Primary.Attributes["destination_ipv6_cidr_block"]
+		}
+
+		return fmt.Sprintf("%s_%s", rs.Primary.Attributes["route_table_id"], destination), nil
+	}
 }
 
 var testAccAWSRouteBasicConfig = fmt.Sprint(`

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -89,3 +89,19 @@ will be exported as an attribute once the resource is created.
 
 - `create` - (Default `2 minutes`) Used for route creation
 - `delete` - (Default `5 minutes`) Used for route deletion
+
+## Import
+
+Individual routes can be imported using `ROUTETABLEID_DESTINATION`.
+
+For example, import a route in route table `rtb-656C65616E6F72` with an IPv4 destination CIDR of `10.42.0.0/16` like this:
+
+```console
+$ terraform import aws_route.my_route rtb-656C65616E6F72_10.42.0.0/16
+```
+
+Import a route in route table `rtb-656C65616E6F72` with an IPv6 destination CIDR of `2620:0:2d0:200::8/125` similarly:
+
+```console
+$ terraform import aws_route.my_route rtb-656C65616E6F72_2620:0:2d0:200::8/125
+```


### PR DESCRIPTION
* Fixes #5689 
* Fixes #2270
* (Originally part of PR #5657)

Changes proposed in this pull request:

* Support importing AWS_ROUTE resources

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSRoute_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSRoute_import -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRoute_importBasic
--- PASS: TestAccAWSRoute_importBasic (51.13s)
=== RUN   TestAccAWSRoute_importIPv6IGW
--- PASS: TestAccAWSRoute_importIPv6IGW (51.61s)
=== RUN   TestAccAWSRoute_importIPv6NetworkInterface
--- PASS: TestAccAWSRoute_importIPv6NetworkInterface (192.53s)
=== RUN   TestAccAWSRoute_importWithMultipleRTs
--- PASS: TestAccAWSRoute_importWithMultipleRTs (45.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	340.554s
```