### PR TITLE
vendor: blang/semver@v3.5.1

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1076,7 +1076,9 @@
 			"checksumSHA1": "OT4XN9z5k69e2RsMSpwW74B+yk4=",
 			"path": "github.com/blang/semver",
 			"revision": "2ee87856327ba09384cabd113bc6b5d174e9ec0f",
-			"revisionTime": "2017-07-27T06:48:18Z"
+			"revisionTime": "2017-07-27T06:48:18Z",
+			"version": "v3.5.1",
+			"versionExact": "v3.5.1"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",


### PR DESCRIPTION
Point to same tag as revision.

Changes proposed in this pull request:

* `govendor fetch github.com/blang/semver/...@v3.5.1`

Output from acceptance testing: N/A
