### PR TITLE
vendor: hashicorp/go-version@v1.0.0

### DIFF
--- a/vendor/github.com/hashicorp/go-version/go.mod
+++ b/vendor/github.com/hashicorp/go-version/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/go-version

--- a/vendor/github.com/hashicorp/go-version/version.go
+++ b/vendor/github.com/hashicorp/go-version/version.go
@@ -15,8 +15,8 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-?([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
-	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 	`?`
 
 // Version represents a single version.
@@ -25,6 +25,7 @@ type Version struct {
 	pre      string
 	segments []int64
 	si       int
+	original string
 }
 
 func init() {
@@ -59,11 +60,17 @@ func NewVersion(v string) (*Version, error) {
 		segments = append(segments, 0)
 	}
 
+	pre := matches[7]
+	if pre == "" {
+		pre = matches[4]
+	}
+
 	return &Version{
-		metadata: matches[7],
-		pre:      matches[4],
+		metadata: matches[10],
+		pre:      pre,
 		segments: segments,
 		si:       si,
+		original: v,
 	}, nil
 }
 
@@ -166,24 +173,42 @@ func comparePart(preSelf string, preOther string) int {
 		return 0
 	}
 
+	var selfInt int64
+	selfNumeric := true
+	selfInt, err := strconv.ParseInt(preSelf, 10, 64)
+	if err != nil {
+		selfNumeric = false
+	}
+
+	var otherInt int64
+	otherNumeric := true
+	otherInt, err = strconv.ParseInt(preOther, 10, 64)
+	if err != nil {
+		otherNumeric = false
+	}
+
 	// if a part is empty, we use the other to decide
 	if preSelf == "" {
-		_, notIsNumeric := strconv.ParseInt(preOther, 10, 64)
-		if notIsNumeric == nil {
+		if otherNumeric {
 			return -1
 		}
 		return 1
 	}
 
 	if preOther == "" {
-		_, notIsNumeric := strconv.ParseInt(preSelf, 10, 64)
-		if notIsNumeric == nil {
+		if selfNumeric {
 			return 1
 		}
 		return -1
 	}
 
-	if preSelf > preOther {
+	if selfNumeric && !otherNumeric {
+		return -1
+	} else if !selfNumeric && otherNumeric {
+		return 1
+	} else if !selfNumeric && !otherNumeric && preSelf > preOther {
+		return 1
+	} else if selfInt > otherInt {
 		return 1
 	}
 
@@ -283,11 +308,19 @@ func (v *Version) Segments() []int {
 // for a version "1.2.3-beta", segments will return a slice of
 // 1, 2, 3.
 func (v *Version) Segments64() []int64 {
-	return v.segments
+	result := make([]int64, len(v.segments))
+	copy(result, v.segments)
+	return result
 }
 
 // String returns the full version string included pre-release
 // and metadata information.
+//
+// This value is rebuilt according to the parsed segments and other
+// information. Therefore, ambiguities in the version string such as
+// prefixed zeroes (1.04.0 => 1.4.0), `v` prefix (v1.0.0 => 1.0.0), and
+// missing parts (1.0 => 1.0.0) will be made into a canonicalized form
+// as shown in the parenthesized examples.
 func (v *Version) String() string {
 	var buf bytes.Buffer
 	fmtParts := make([]string, len(v.segments))
@@ -305,4 +338,10 @@ func (v *Version) String() string {
 	}
 
 	return buf.String()
+}
+
+// Original returns the original parsed version as-is, including any
+// potential whitespace, `v` prefix, etc.
+func (v *Version) Original() string {
+	return v.original
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1181,10 +1181,12 @@
 			"revision": "36289988d83ca270bc07c234c36f364b0dd9c9a7"
 		},
 		{
-			"checksumSHA1": "EcZfls6vcqjasWV/nBlu+C+EFmc=",
+			"checksumSHA1": "r0pj5dMHCghpaQZ3f1BRGoKiSWw=",
 			"path": "github.com/hashicorp/go-version",
-			"revision": "e96d3840402619007766590ecea8dd7af1292276",
-			"revisionTime": "2016-10-31T18:26:05Z"
+			"revision": "b5a281d3160aa11950a6182bd9a9dc2cb1e02d50",
+			"revisionTime": "2018-08-24T00:43:55Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
 		},
 		{
 			"checksumSHA1": "o3XZZdOnSnwQSpYw215QV75ZDeI=",


### PR DESCRIPTION
Changes proposed in this pull request:

* `govendor fetch github.com/hashicorp/go-version/...@v1.0.0`

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1124.76s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1129.75s)
```
