### PR TITLE
resource/aws_route_table: Add documentation/warnings for import behavior

### DIFF
--- a/aws/import_aws_route_table.go
+++ b/aws/import_aws_route_table.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -30,6 +31,9 @@ func resourceAwsRouteTableImportState(
 	results := make([]*schema.ResourceData, 1,
 		2+len(table.Associations)+len(table.Routes))
 	results[0] = d
+	log.Print("[WARN] RouteTable imports will be handled differently in a future version.")
+	log.Printf("[WARN] This import will create %d resources (aws_route_table, aws_route, aws_route_table_association).", len(results))
+	log.Print("[WARN] In the future, only 1 aws_route_table resource will be created with inline routes.")
 
 	{
 		// Construct the routes

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -40,6 +40,7 @@ Upgrade topics:
 - [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_network_acl](#resource-aws_network_acl)
 - [Resource: aws_redshift_cluster](#resource-aws_redshift_cluster)
+- [Resource: aws_route_table](#resource-aws_route_table)
 - [Resource: aws_wafregional_byte_match_set](#resource-aws_wafregional_byte_match_set)
 
 <!-- /TOC -->
@@ -590,6 +591,14 @@ resource "aws_redshift_cluster" "example" {
   }
 }
 ```
+
+## Resource: aws_route_table
+
+### Import Change
+
+Previously, importing this resource resulted in an `aws_route` resource for each route, in
+addition to the `aws_route_table`, in the Terraform state. Support for importing `aws_route` resources has been added and importing this resource only adds the `aws_route_table` 
+resource, with in-line routes, to the state.
 
 ## Resource: aws_wafregional_byte_match_set
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -85,8 +85,11 @@ attribute once the route resource is created.
 
 ## Import
 
-Route Tables can be imported using the `route table id`, e.g.
+~> **NOTE:** Importing this resource currently adds an `aws_route` resource to the state for each route, in addition to adding the `aws_route_table` resource. If you plan to apply the imported state, avoid the deletion of actual routes by not using in-line routes in your configuration and by naming `aws_route` resources after the `aws_route_table`. For example, if your route table is `aws_route_table.rt`, name routes as `aws_route.rt`, `aws_route.rt-1` and so forth. The behavior of adding `aws_route` resources with the `aws_route_table` resource will be removed in the next major version.
+
+Route Tables can be imported using the route table `id`. For example, to import
+route table `rtb-4e616f6d69`, use this command:
 
 ```
-$ terraform import aws_route_table.public_rt rtb-22574640
+$ terraform import aws_route_table.public_rt rtb-4e616f6d69
 ```


### PR DESCRIPTION
This adds warnings and work around information related to the bug
detailed in #5631.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* resource/aws_route_table: `[WARN]` on importing that import behavior may change in the future.
* Version 2 Upgrade Guide: Add documentation about import of `aws_route_table` changing.
* resource/aws_route_table documentation: Add information about bug #5631 and a workaround.

Related #5657