### PR TITLE
Require Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: go
 go:
-- 1.9.1
+- "1.11"
 
 git:
   depth: 1

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Terraform Provider
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.9 (to build the provider plugin)
+- [Terraform](https://www.terraform.io/downloads.html) 0.10+
+- [Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
 
 Building The Provider
 ---------------------
@@ -37,7 +37,7 @@ If you're building the provider, follow the instructions to [install it as a plu
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.9+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 

--- a/aws/data_source_aws_cloudformation_export_test.go
+++ b/aws/data_source_aws_cloudformation_export_test.go
@@ -17,7 +17,7 @@ func TestAccAWSCloudformationExportDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsCloudformationExportConfig(rName),
+				Config:                    testAccCheckAwsCloudformationExportConfig(rName),
 				PreventPostDestroyRefresh: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_cloudformation_export.waiter", "value", "waiter"),

--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -345,13 +345,13 @@ func (lt *opsworksLayerType) Create(d *schema.ResourceData, client *opsworks.Ops
 		EnableAutoHealing:           aws.Bool(d.Get("auto_healing").(bool)),
 		InstallUpdatesOnBoot:        aws.Bool(d.Get("install_updates_on_boot").(bool)),
 		LifecycleEventConfiguration: lt.LifecycleEventConfiguration(d),
-		Name:                     aws.String(d.Get("name").(string)),
-		Packages:                 expandStringSet(d.Get("system_packages").(*schema.Set)),
-		Type:                     aws.String(lt.TypeName),
-		StackId:                  aws.String(d.Get("stack_id").(string)),
-		UseEbsOptimizedInstances: aws.Bool(d.Get("use_ebs_optimized_instances").(bool)),
-		Attributes:               lt.AttributeMap(d),
-		VolumeConfigurations:     lt.VolumeConfigurations(d),
+		Name:                        aws.String(d.Get("name").(string)),
+		Packages:                    expandStringSet(d.Get("system_packages").(*schema.Set)),
+		Type:                        aws.String(lt.TypeName),
+		StackId:                     aws.String(d.Get("stack_id").(string)),
+		UseEbsOptimizedInstances:    aws.Bool(d.Get("use_ebs_optimized_instances").(bool)),
+		Attributes:                  lt.AttributeMap(d),
+		VolumeConfigurations:        lt.VolumeConfigurations(d),
 	}
 
 	if lt.CustomShortName {
@@ -399,11 +399,11 @@ func (lt *opsworksLayerType) Update(d *schema.ResourceData, client *opsworks.Ops
 		EnableAutoHealing:           aws.Bool(d.Get("auto_healing").(bool)),
 		InstallUpdatesOnBoot:        aws.Bool(d.Get("install_updates_on_boot").(bool)),
 		LifecycleEventConfiguration: lt.LifecycleEventConfiguration(d),
-		Name:                     aws.String(d.Get("name").(string)),
-		Packages:                 expandStringSet(d.Get("system_packages").(*schema.Set)),
-		UseEbsOptimizedInstances: aws.Bool(d.Get("use_ebs_optimized_instances").(bool)),
-		Attributes:               lt.AttributeMap(d),
-		VolumeConfigurations:     lt.VolumeConfigurations(d),
+		Name:                        aws.String(d.Get("name").(string)),
+		Packages:                    expandStringSet(d.Get("system_packages").(*schema.Set)),
+		UseEbsOptimizedInstances:    aws.Bool(d.Get("use_ebs_optimized_instances").(bool)),
+		Attributes:                  lt.AttributeMap(d),
+		VolumeConfigurations:        lt.VolumeConfigurations(d),
 	}
 
 	if lt.CustomShortName {

--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -90,7 +90,7 @@ func resourceAwsAcmCertificateCheckValidationRecords(validationRecordFqdns []int
 			CertificateArn: cert.CertificateArn,
 		}
 		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			log.Printf("[DEBUG] Certificate domain validation options empty for %q, retrying", cert.CertificateArn)
+			log.Printf("[DEBUG] Certificate domain validation options empty for %q, retrying", *cert.CertificateArn)
 			output, err := conn.DescribeCertificate(input)
 			if err != nil {
 				return resource.NonRetryableError(err)

--- a/aws/resource_aws_acmpca_certificate_authority.go
+++ b/aws/resource_aws_acmpca_certificate_authority.go
@@ -284,7 +284,7 @@ func resourceAwsAcmpcaCertificateAuthorityCreate(d *schema.ResourceData, meta in
 	if v, ok := d.GetOk("tags"); ok {
 		input := &acmpca.TagCertificateAuthorityInput{
 			CertificateAuthorityArn: aws.String(d.Id()),
-			Tags: tagsFromMapACMPCA(v.(map[string]interface{})),
+			Tags:                    tagsFromMapACMPCA(v.(map[string]interface{})),
 		}
 
 		log.Printf("[DEBUG] Tagging ACMPCA Certificate Authority: %s", input)
@@ -458,7 +458,7 @@ func resourceAwsAcmpcaCertificateAuthorityUpdate(d *schema.ResourceData, meta in
 			log.Printf("[DEBUG] Removing ACMPCA Certificate Authority %q tags: %#v", d.Id(), remove)
 			_, err := conn.UntagCertificateAuthority(&acmpca.UntagCertificateAuthorityInput{
 				CertificateAuthorityArn: aws.String(d.Id()),
-				Tags: remove,
+				Tags:                    remove,
 			})
 			if err != nil {
 				return fmt.Errorf("error updating ACMPCA Certificate Authority %q tags: %s", d.Id(), err)
@@ -468,7 +468,7 @@ func resourceAwsAcmpcaCertificateAuthorityUpdate(d *schema.ResourceData, meta in
 			log.Printf("[DEBUG] Creating ACMPCA Certificate Authority %q tags: %#v", d.Id(), create)
 			_, err := conn.TagCertificateAuthority(&acmpca.TagCertificateAuthorityInput{
 				CertificateAuthorityArn: aws.String(d.Id()),
-				Tags: create,
+				Tags:                    create,
 			})
 			if err != nil {
 				return fmt.Errorf("error updating ACMPCA Certificate Authority %q tags: %s", d.Id(), err)

--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -243,22 +243,22 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 	}
 
 	_, err := conn.PutIntegration(&apigateway.PutIntegrationInput{
-		HttpMethod: aws.String(d.Get("http_method").(string)),
-		ResourceId: aws.String(d.Get("resource_id").(string)),
-		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
-		Type:       aws.String(d.Get("type").(string)),
+		HttpMethod:            aws.String(d.Get("http_method").(string)),
+		ResourceId:            aws.String(d.Get("resource_id").(string)),
+		RestApiId:             aws.String(d.Get("rest_api_id").(string)),
+		Type:                  aws.String(d.Get("type").(string)),
 		IntegrationHttpMethod: integrationHttpMethod,
-		Uri:                 uri,
-		RequestParameters:   aws.StringMap(parameters),
-		RequestTemplates:    aws.StringMap(templates),
-		Credentials:         credentials,
-		CacheNamespace:      cacheNamespace,
-		CacheKeyParameters:  cacheKeyParameters,
-		PassthroughBehavior: passthroughBehavior,
-		ContentHandling:     contentHandling,
-		ConnectionType:      connectionType,
-		ConnectionId:        connectionId,
-		TimeoutInMillis:     timeoutInMillis,
+		Uri:                   uri,
+		RequestParameters:     aws.StringMap(parameters),
+		RequestTemplates:      aws.StringMap(templates),
+		Credentials:           credentials,
+		CacheNamespace:        cacheNamespace,
+		CacheKeyParameters:    cacheKeyParameters,
+		PassthroughBehavior:   passthroughBehavior,
+		ContentHandling:       contentHandling,
+		ConnectionType:        connectionType,
+		ConnectionId:          connectionId,
+		TimeoutInMillis:       timeoutInMillis,
 	})
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Integration: %s", err)

--- a/aws/resource_aws_api_gateway_resource_test.go
+++ b/aws/resource_aws_api_gateway_resource_test.go
@@ -84,7 +84,7 @@ func TestAccAWSAPIGatewayResource_update(t *testing.T) {
 func testAccCheckAWSAPIGatewayResourceAttributes(conf *apigateway.Resource, path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *conf.Path != path {
-			return fmt.Errorf("Wrong Path: %q", conf.Path)
+			return fmt.Errorf("Wrong Path: %q", *conf.Path)
 		}
 
 		return nil

--- a/aws/resource_aws_cloudfront_origin_access_identity.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity.go
@@ -95,9 +95,9 @@ func resourceAwsCloudFrontOriginAccessIdentityRead(d *schema.ResourceData, meta 
 func resourceAwsCloudFrontOriginAccessIdentityUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudfrontconn
 	params := &cloudfront.UpdateCloudFrontOriginAccessIdentityInput{
-		Id: aws.String(d.Id()),
+		Id:                                   aws.String(d.Id()),
 		CloudFrontOriginAccessIdentityConfig: expandOriginAccessIdentityConfig(d),
-		IfMatch: aws.String(d.Get("etag").(string)),
+		IfMatch:                              aws.String(d.Get("etag").(string)),
 	}
 	_, err := conn.UpdateCloudFrontOriginAccessIdentity(params)
 	if err != nil {

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1568,7 +1568,7 @@ func TestAWSCodeDeployDeploymentGroup_expandBlueGreenDeploymentConfig(t *testing
 
 			"terminate_blue_instances_on_deployment_success": []interface{}{
 				map[string]interface{}{
-					"action": "TERMINATE",
+					"action":                           "TERMINATE",
 					"termination_wait_time_in_minutes": 90,
 				},
 			},
@@ -1586,7 +1586,7 @@ func TestAWSCodeDeployDeploymentGroup_expandBlueGreenDeploymentConfig(t *testing
 		},
 
 		TerminateBlueInstancesOnDeploymentSuccess: &codedeploy.BlueInstanceTerminationOption{
-			Action: aws.String("TERMINATE"),
+			Action:                       aws.String("TERMINATE"),
 			TerminationWaitTimeInMinutes: aws.Int64(90),
 		},
 	}
@@ -1611,7 +1611,7 @@ func TestAWSCodeDeployDeploymentGroup_flattenBlueGreenDeploymentConfig(t *testin
 		},
 
 		TerminateBlueInstancesOnDeploymentSuccess: &codedeploy.BlueInstanceTerminationOption{
-			Action: aws.String("KEEP_ALIVE"),
+			Action:                       aws.String("KEEP_ALIVE"),
 			TerminationWaitTimeInMinutes: aws.Int64(90),
 		},
 	}
@@ -1632,7 +1632,7 @@ func TestAWSCodeDeployDeploymentGroup_flattenBlueGreenDeploymentConfig(t *testin
 
 		"terminate_blue_instances_on_deployment_success": []map[string]interface{}{
 			{
-				"action": "KEEP_ALIVE",
+				"action":                           "KEEP_ALIVE",
 				"termination_wait_time_in_minutes": 90,
 			},
 		},

--- a/aws/resource_aws_db_security_group.go
+++ b/aws/resource_aws_db_security_group.go
@@ -91,7 +91,7 @@ func resourceAwsDbSecurityGroupCreate(d *schema.ResourceData, meta interface{}) 
 	opts := rds.CreateDBSecurityGroupInput{
 		DBSecurityGroupName:        aws.String(d.Get("name").(string)),
 		DBSecurityGroupDescription: aws.String(d.Get("description").(string)),
-		Tags: tags,
+		Tags:                       tags,
 	}
 
 	log.Printf("[DEBUG] DB Security Group create configuration: %#v", opts)

--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -136,7 +136,7 @@ func resourceAwsDmsReplicationInstanceCreate(d *schema.ResourceData, meta interf
 		PubliclyAccessible:            aws.Bool(d.Get("publicly_accessible").(bool)),
 		ReplicationInstanceClass:      aws.String(d.Get("replication_instance_class").(string)),
 		ReplicationInstanceIdentifier: aws.String(d.Get("replication_instance_id").(string)),
-		Tags: dmsTagsFromMap(d.Get("tags").(map[string]interface{})),
+		Tags:                          dmsTagsFromMap(d.Get("tags").(map[string]interface{})),
 	}
 
 	// WARNING: GetOk returns the zero value for the type if the key is omitted in config. This means for optional

--- a/aws/resource_aws_elasticache_replication_group_migrate_test.go
+++ b/aws/resource_aws_elasticache_replication_group_migrate_test.go
@@ -16,7 +16,7 @@ func TestAwsElasticacheReplicationGroupMigrateState(t *testing.T) {
 		"v0Tov1": {
 			StateVersion: 0,
 			Attributes: map[string]string{
-				"cluster_mode.#":                                  "1",
+				"cluster_mode.#": "1",
 				"cluster_mode.4170186206.num_node_groups":         "2",
 				"cluster_mode.4170186206.replicas_per_node_group": "1",
 			},

--- a/aws/resource_aws_emr_security_configuration.go
+++ b/aws/resource_aws_emr_security_configuration.go
@@ -65,7 +65,7 @@ func resourceAwsEmrSecurityConfigurationCreate(d *schema.ResourceData, meta inte
 	}
 
 	resp, err := conn.CreateSecurityConfiguration(&emr.CreateSecurityConfigurationInput{
-		Name: aws.String(emrSCName),
+		Name:                  aws.String(emrSCName),
 		SecurityConfiguration: aws.String(d.Get("configuration").(string)),
 	})
 

--- a/aws/resource_aws_gamelift_fleet.go
+++ b/aws/resource_aws_gamelift_fleet.go
@@ -301,10 +301,10 @@ func resourceAwsGameliftFleetUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("description") || d.HasChange("metric_groups") || d.HasChange("name") ||
 		d.HasChange("new_game_session_protection_policy") || d.HasChange("resource_creation_limit_policy") {
 		_, err := conn.UpdateFleetAttributes(&gamelift.UpdateFleetAttributesInput{
-			Description:  aws.String(d.Get("description").(string)),
-			FleetId:      aws.String(d.Id()),
-			MetricGroups: expandStringList(d.Get("metric_groups").([]interface{})),
-			Name:         aws.String(d.Get("name").(string)),
+			Description:                    aws.String(d.Get("description").(string)),
+			FleetId:                        aws.String(d.Id()),
+			MetricGroups:                   expandStringList(d.Get("metric_groups").([]interface{})),
+			Name:                           aws.String(d.Get("name").(string)),
 			NewGameSessionProtectionPolicy: aws.String(d.Get("new_game_session_protection_policy").(string)),
 			ResourceCreationLimitPolicy:    expandGameliftResourceCreationLimitPolicy(d.Get("resource_creation_limit_policy").([]interface{})),
 		})
@@ -318,7 +318,7 @@ func resourceAwsGameliftFleetUpdate(d *schema.ResourceData, meta interface{}) er
 		authorizations, revocations := diffGameliftPortSettings(oldPerms.([]interface{}), newPerms.([]interface{}))
 
 		_, err := conn.UpdateFleetPortSettings(&gamelift.UpdateFleetPortSettingsInput{
-			FleetId: aws.String(d.Id()),
+			FleetId:                         aws.String(d.Id()),
 			InboundPermissionAuthorizations: authorizations,
 			InboundPermissionRevocations:    revocations,
 		})

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -505,12 +505,12 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Build the creation struct
 	runOpts := &ec2.RunInstancesInput{
-		BlockDeviceMappings:   instanceOpts.BlockDeviceMappings,
-		DisableApiTermination: instanceOpts.DisableAPITermination,
-		EbsOptimized:          instanceOpts.EBSOptimized,
-		Monitoring:            instanceOpts.Monitoring,
-		IamInstanceProfile:    instanceOpts.IAMInstanceProfile,
-		ImageId:               instanceOpts.ImageID,
+		BlockDeviceMappings:               instanceOpts.BlockDeviceMappings,
+		DisableApiTermination:             instanceOpts.DisableAPITermination,
+		EbsOptimized:                      instanceOpts.EBSOptimized,
+		Monitoring:                        instanceOpts.Monitoring,
+		IamInstanceProfile:                instanceOpts.IAMInstanceProfile,
+		ImageId:                           instanceOpts.ImageID,
 		InstanceInitiatedShutdownBehavior: instanceOpts.InstanceInitiatedShutdownBehavior,
 		InstanceType:                      instanceOpts.InstanceType,
 		Ipv6AddressCount:                  instanceOpts.Ipv6AddressCount,

--- a/aws/resource_aws_instance_migrate_test.go
+++ b/aws/resource_aws_instance_migrate_test.go
@@ -17,7 +17,7 @@ func TestAWSInstanceMigrateState(t *testing.T) {
 			StateVersion: 0,
 			Attributes: map[string]string{
 				// EBS
-				"block_device.#":                                "2",
+				"block_device.#": "2",
 				"block_device.3851383343.delete_on_termination": "true",
 				"block_device.3851383343.device_name":           "/dev/sdx",
 				"block_device.3851383343.encrypted":             "false",
@@ -42,7 +42,7 @@ func TestAWSInstanceMigrateState(t *testing.T) {
 				"block_device.56575650.volume_type":           "standard",
 			},
 			Expected: map[string]string{
-				"ebs_block_device.#":                                 "1",
+				"ebs_block_device.#": "1",
 				"ebs_block_device.3851383343.delete_on_termination":  "true",
 				"ebs_block_device.3851383343.device_name":            "/dev/sdx",
 				"ebs_block_device.3851383343.encrypted":              "false",
@@ -64,7 +64,7 @@ func TestAWSInstanceMigrateState(t *testing.T) {
 			StateVersion: 0,
 			Attributes: map[string]string{
 				// EBS
-				"block_device.#":                                "2",
+				"block_device.#": "2",
 				"block_device.3851383343.delete_on_termination": "true",
 				"block_device.3851383343.device_name":           "/dev/sdx",
 				"block_device.3851383343.encrypted":             "false",
@@ -92,7 +92,7 @@ func TestAWSInstanceMigrateState(t *testing.T) {
 				"root_block_device.3018388612.iops":                  "1000",
 			},
 			Expected: map[string]string{
-				"ebs_block_device.#":                                 "1",
+				"ebs_block_device.#": "1",
 				"ebs_block_device.3851383343.delete_on_termination":  "true",
 				"ebs_block_device.3851383343.device_name":            "/dev/sdx",
 				"ebs_block_device.3851383343.encrypted":              "false",

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -228,11 +228,11 @@ func flattenFirehoseExtendedS3Configuration(description *firehose.ExtendedS3Dest
 		"cloudwatch_logging_options":           flattenCloudwatchLoggingOptions(description.CloudWatchLoggingOptions),
 		"compression_format":                   aws.StringValue(description.CompressionFormat),
 		"data_format_conversion_configuration": flattenFirehoseDataFormatConversionConfiguration(description.DataFormatConversionConfiguration),
-		"prefix":                   aws.StringValue(description.Prefix),
-		"processing_configuration": flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),
-		"role_arn":                 aws.StringValue(description.RoleARN),
-		"s3_backup_configuration":  flattenFirehoseS3Configuration(description.S3BackupDescription),
-		"s3_backup_mode":           aws.StringValue(description.S3BackupMode),
+		"prefix":                               aws.StringValue(description.Prefix),
+		"processing_configuration":             flattenProcessingConfiguration(description.ProcessingConfiguration, aws.StringValue(description.RoleARN)),
+		"role_arn":                             aws.StringValue(description.RoleARN),
+		"s3_backup_configuration":              flattenFirehoseS3Configuration(description.S3BackupDescription),
+		"s3_backup_mode":                       aws.StringValue(description.S3BackupMode),
 	}
 
 	if description.BufferingHints != nil {

--- a/aws/resource_aws_neptune_cluster_instance.go
+++ b/aws/resource_aws_neptune_cluster_instance.go
@@ -196,7 +196,7 @@ func resourceAwsNeptuneClusterInstanceCreate(d *schema.ResourceData, meta interf
 		PubliclyAccessible:      aws.Bool(d.Get("publicly_accessible").(bool)),
 		PromotionTier:           aws.Int64(int64(d.Get("promotion_tier").(int))),
 		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
-		Tags: tags,
+		Tags:                    tags,
 	}
 
 	if attr, ok := d.GetOk("availability_zone"); ok {

--- a/aws/resource_aws_neptune_cluster_parameter_group.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group.go
@@ -154,7 +154,7 @@ func resourceAwsNeptuneClusterParameterGroupRead(d *schema.ResourceData, meta in
 	// Only include user customized parameters as there's hundreds of system/default ones
 	describeParametersOpts := neptune.DescribeDBClusterParametersInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
-		Source: aws.String("user"),
+		Source:                      aws.String("user"),
 	}
 
 	describeParametersResp, err := conn.DescribeDBClusterParameters(&describeParametersOpts)

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -216,7 +216,7 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		PubliclyAccessible:      aws.Bool(d.Get("publicly_accessible").(bool)),
 		PromotionTier:           aws.Int64(int64(d.Get("promotion_tier").(int))),
 		AutoMinorVersionUpgrade: aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
-		Tags: tags,
+		Tags:                    tags,
 	}
 
 	if attr, ok := d.GetOk("availability_zone"); ok {

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -161,7 +161,7 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 	// Only include user customized parameters as there's hundreds of system/default ones
 	describeParametersOpts := rds.DescribeDBClusterParametersInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
-		Source: aws.String("user"),
+		Source:                      aws.String("user"),
 	}
 
 	describeParametersResp, err := rdsconn.DescribeDBClusterParameters(&describeParametersOpts)

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -415,7 +415,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 			AllowVersionUpgrade:              aws.Bool(d.Get("allow_version_upgrade").(bool)),
 			PubliclyAccessible:               aws.Bool(d.Get("publicly_accessible").(bool)),
 			AutomatedSnapshotRetentionPeriod: aws.Int64(int64(d.Get("automated_snapshot_retention_period").(int))),
-			Tags: tags,
+			Tags:                             tags,
 		}
 
 		if v := d.Get("number_of_nodes").(int); v > 1 {

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -541,8 +541,8 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 		name := normalizeAwsAliasName(*alias.DNSName)
 		d.Set("alias", []interface{}{
 			map[string]interface{}{
-				"zone_id": *alias.HostedZoneId,
-				"name":    name,
+				"zone_id":                *alias.HostedZoneId,
+				"name":                   name,
 				"evaluate_target_health": *alias.EvaluateTargetHealth,
 			},
 		})

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1700,7 +1700,7 @@ func resourceAwsS3BucketServerSideEncryptionConfigurationUpdate(s3conn *s3.S3, d
 
 	rc.Rules = rules
 	i := &s3.PutBucketEncryptionInput{
-		Bucket: aws.String(bucket),
+		Bucket:                            aws.String(bucket),
 		ServerSideEncryptionConfiguration: rc,
 	}
 	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)
@@ -1807,7 +1807,7 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 
 	rc.Rules = rules
 	i := &s3.PutBucketReplicationInput{
-		Bucket: aws.String(bucket),
+		Bucket:                   aws.String(bucket),
 		ReplicationConfiguration: rc,
 	}
 	log.Printf("[DEBUG] S3 put bucket replication configuration: %#v", i)

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -221,8 +221,8 @@ func resourceAwsS3BucketInventoryPut(d *schema.ResourceData, meta interface{}) e
 	}
 
 	input := &s3.PutBucketInventoryConfigurationInput{
-		Bucket: aws.String(bucket),
-		Id:     aws.String(name),
+		Bucket:                 aws.String(bucket),
+		Id:                     aws.String(name),
 		InventoryConfiguration: inventoryConfiguration,
 	}
 

--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -304,7 +304,7 @@ func resourceAwsS3BucketNotificationPut(d *schema.ResourceData, meta interface{}
 		notificationConfiguration.TopicConfigurations = topicConfigs
 	}
 	i := &s3.PutBucketNotificationConfigurationInput{
-		Bucket: aws.String(bucket),
+		Bucket:                    aws.String(bucket),
 		NotificationConfiguration: notificationConfiguration,
 	}
 
@@ -336,7 +336,7 @@ func resourceAwsS3BucketNotificationDelete(d *schema.ResourceData, meta interfac
 	s3conn := meta.(*AWSClient).s3conn
 
 	i := &s3.PutBucketNotificationConfigurationInput{
-		Bucket: aws.String(d.Id()),
+		Bucket:                    aws.String(d.Id()),
 		NotificationConfiguration: &s3.NotificationConfiguration{},
 	}
 

--- a/aws/resource_aws_security_group_migrate_test.go
+++ b/aws/resource_aws_security_group_migrate_test.go
@@ -19,7 +19,7 @@ func TestAWSSecurityGroupMigrateState(t *testing.T) {
 				"name": "test",
 			},
 			Expected: map[string]string{
-				"name": "test",
+				"name":                   "test",
 				"revoke_rules_on_delete": "false",
 			},
 		},

--- a/aws/resource_aws_service_discovery_service_migrate_test.go
+++ b/aws/resource_aws_service_discovery_service_migrate_test.go
@@ -24,7 +24,7 @@ func TestAwsServiceDiscoveryServiceMigrateState(t *testing.T) {
 				"dns_config.0.dns_records.#":      "1",
 				"dns_config.0.dns_records.0.ttl":  "10",
 				"dns_config.0.dns_records.0.type": "A",
-				"arn": "arn",
+				"arn":                             "arn",
 			},
 			Expected: map[string]string{
 				"name":                            "test-name",
@@ -34,7 +34,7 @@ func TestAwsServiceDiscoveryServiceMigrateState(t *testing.T) {
 				"dns_config.0.dns_records.#":      "1",
 				"dns_config.0.dns_records.0.ttl":  "10",
 				"dns_config.0.dns_records.0.type": "A",
-				"arn": "arn",
+				"arn":                             "arn",
 			},
 		},
 	}

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -27,10 +27,10 @@ var SNSAttributeMap = map[string]string{
 	"lambda_failure_feedback_role_arn":    "LambdaFailureFeedbackRoleArn",
 	"lambda_success_feedback_role_arn":    "LambdaSuccessFeedbackRoleArn",
 	"lambda_success_feedback_sample_rate": "LambdaSuccessFeedbackSampleRate",
-	"policy":                           "Policy",
-	"sqs_failure_feedback_role_arn":    "SQSFailureFeedbackRoleArn",
-	"sqs_success_feedback_role_arn":    "SQSSuccessFeedbackRoleArn",
-	"sqs_success_feedback_sample_rate": "SQSSuccessFeedbackSampleRate",
+	"policy":                              "Policy",
+	"sqs_failure_feedback_role_arn":       "SQSFailureFeedbackRoleArn",
+	"sqs_success_feedback_role_arn":       "SQSSuccessFeedbackRoleArn",
+	"sqs_success_feedback_sample_rate":    "SQSSuccessFeedbackSampleRate",
 }
 
 func resourceAwsSnsTopic() *schema.Resource {

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -610,7 +610,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
 		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
 		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behaviour").(string)),
-		Type: aws.String(d.Get("fleet_type").(string)),
+		Type:                             aws.String(d.Get("fleet_type").(string)),
 	}
 
 	if v, ok := d.GetOk("excess_capacity_termination_policy"); ok {

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -622,7 +622,7 @@ func testAccCheckAWSSpotFleetRequest_PlacementAttributes(
 			return fmt.Errorf("Expected placement to be set, got nil")
 		}
 		if *placement.Tenancy != "dedicated" {
-			return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", placement.Tenancy)
+			return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", *placement.Tenancy)
 		}
 
 		return nil

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -118,8 +118,8 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	}
 
 	spotOpts := &ec2.RequestSpotInstancesInput{
-		SpotPrice: aws.String(d.Get("spot_price").(string)),
-		Type:      aws.String(d.Get("spot_type").(string)),
+		SpotPrice:                    aws.String(d.Get("spot_price").(string)),
+		Type:                         aws.String(d.Get("spot_type").(string)),
 		InstanceInterruptionBehavior: aws.String(d.Get("instance_interruption_behaviour").(string)),
 
 		// Though the AWS API supports creating spot instance requests for multiple

--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -55,10 +55,10 @@ func resourceAwsSsmMaintenanceWindowCreate(d *schema.ResourceData, meta interfac
 	ssmconn := meta.(*AWSClient).ssmconn
 
 	params := &ssm.CreateMaintenanceWindowInput{
-		Name:     aws.String(d.Get("name").(string)),
-		Schedule: aws.String(d.Get("schedule").(string)),
-		Duration: aws.Int64(int64(d.Get("duration").(int))),
-		Cutoff:   aws.Int64(int64(d.Get("cutoff").(int))),
+		Name:                     aws.String(d.Get("name").(string)),
+		Schedule:                 aws.String(d.Get("schedule").(string)),
+		Duration:                 aws.Int64(int64(d.Get("duration").(int))),
+		Cutoff:                   aws.Int64(int64(d.Get("cutoff").(int))),
 		AllowUnassociatedTargets: aws.Bool(d.Get("allow_unassociated_targets").(bool)),
 	}
 

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -147,7 +147,7 @@ func resourceAwsSsmPatchBaselineCreate(d *schema.ResourceData, meta interface{})
 	ssmconn := meta.(*AWSClient).ssmconn
 
 	params := &ssm.CreatePatchBaselineInput{
-		Name: aws.String(d.Get("name").(string)),
+		Name:                           aws.String(d.Get("name").(string)),
 		ApprovedPatchesComplianceLevel: aws.String(d.Get("approved_patches_compliance_level").(string)),
 		OperatingSystem:                aws.String(d.Get("operating_system").(string)),
 	}

--- a/aws/resource_aws_swf_domain.go
+++ b/aws/resource_aws_swf_domain.go
@@ -70,7 +70,7 @@ func resourceAwsSwfDomainCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	input := &swf.RegisterDomainInput{
-		Name: aws.String(name),
+		Name:                                   aws.String(name),
 		WorkflowExecutionRetentionPeriodInDays: aws.String(d.Get("workflow_execution_retention_period_in_days").(string)),
 	}
 

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -411,7 +411,7 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		if toAssign {
 			modifyOpts := &ec2.AssociateVpcCidrBlockInput{
-				VpcId: &vpcid,
+				VpcId:                       &vpcid,
 				AmazonProvidedIpv6CidrBlock: aws.Bool(toAssign),
 			}
 			log.Printf("[INFO] Enabling assign_generated_ipv6_cidr_block vpc attribute for %s: %#v",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2232,23 +2232,23 @@ func TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(t *testin
 	}{
 		{
 			AmbiguousRoleResolution: nil,
-			Type:     cognitoidentity.RoleMappingTypeToken,
-			ErrCount: 1,
+			Type:                    cognitoidentity.RoleMappingTypeToken,
+			ErrCount:                1,
 		},
 		{
 			AmbiguousRoleResolution: "foo",
-			Type:     cognitoidentity.RoleMappingTypeToken,
-			ErrCount: 0, // 0 as it should be defined, the value isn't validated here
+			Type:                    cognitoidentity.RoleMappingTypeToken,
+			ErrCount:                0, // 0 as it should be defined, the value isn't validated here
 		},
 		{
 			AmbiguousRoleResolution: cognitoidentity.AmbiguousRoleResolutionTypeAuthenticatedRole,
-			Type:     cognitoidentity.RoleMappingTypeToken,
-			ErrCount: 0,
+			Type:                    cognitoidentity.RoleMappingTypeToken,
+			ErrCount:                0,
 		},
 		{
 			AmbiguousRoleResolution: cognitoidentity.AmbiguousRoleResolutionTypeDeny,
-			Type:     cognitoidentity.RoleMappingTypeToken,
-			ErrCount: 0,
+			Type:                    cognitoidentity.RoleMappingTypeToken,
+			ErrCount:                0,
 		},
 	}
 


### PR DESCRIPTION
Builds on #5679 by updating the README documentation and TravisCI configuration. 

Changes proposed in this pull request:

* Add Go 1.11 requirement in README
* Update TravisCI to use Go 1.11 instead of Go 1.9

Output from acceptance testing: A full acceptance test run was completed without new issues: `Tests failed: 75, passed: 1970, ignored: 39` (omitted for brevity)
