### PR TITLE
resource/aws_ecs_task_definition: Add docker volume configuration 

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -108,6 +108,50 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+
+						"docker_volume_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"scope": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											ecs.ScopeShared,
+											ecs.ScopeTask,
+										}, false),
+									},
+									"autoprovision": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+										Default:  false,
+									},
+									"driver": {
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Optional: true,
+									},
+									"driver_opts": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										ForceNew: true,
+										Optional: true,
+									},
+									"labels": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										ForceNew: true,
+										Optional: true,
+									},
+								},
+							},
+						},
 					},
 				},
 				Set: resourceAwsEcsTaskDefinitionVolumeHash,
@@ -324,6 +368,5 @@ func resourceAwsEcsTaskDefinitionVolumeHash(v interface{}) int {
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["host_path"].(string)))
-
 	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -60,6 +60,78 @@ func TestAccAWSEcsTaskDefinition_withScratchVolume(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsTaskDefinition_withDockerVolume(t *testing.T) {
+	var def ecs.TaskDefinition
+
+	rString := acctest.RandString(8)
+	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsTaskDefinitionWithDockerVolumes(tdName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.scope", "shared"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.autoprovision", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver", "local"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver_opts.%", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver_opts.uid", "1000"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver_opts.device", "tmpfs"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.labels.%", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.labels.stack", "april"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.labels.environment", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig(t *testing.T) {
+	var def ecs.TaskDefinition
+
+	rString := acctest.RandString(8)
+	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsTaskDefinitionWithDockerVolumesMinimalConfig(tdName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.scope", "task"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver", "local"),
+				),
+			},
+		},
+	})
+}
+
 // Regression for https://github.com/hashicorp/terraform/issues/2694
 func TestAccAWSEcsTaskDefinition_withEcsService(t *testing.T) {
 	var def ecs.TaskDefinition
@@ -761,6 +833,70 @@ TASK_DEFINITION
 
   volume {
     name = "database_scratch"
+  }
+}
+`, tdName)
+}
+
+func testAccAWSEcsTaskDefinitionWithDockerVolumes(tdName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "sleep" {
+  family = "%s"
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  volume {
+    name = "database_scratch"
+    docker_volume_configuration {
+        driver = "local"
+        scope  = "shared"
+        driver_opts {
+            device = "tmpfs"
+            uid    = "1000"
+        }
+        labels {
+            environment = "test"
+            stack       = "april"
+        }
+        autoprovision = true
+    }
+  }
+}
+`, tdName)
+}
+
+func testAccAWSEcsTaskDefinitionWithDockerVolumesMinimalConfig(tdName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "sleep" {
+  family = "%s"
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  volume {
+    name = "database_scratch"
+    docker_volume_configuration {
+        autoprovision = true
+    }
   }
 }
 `, tdName)

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -93,6 +93,33 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 * `name` - (Required) The name of the volume. This name is referenced in the `sourceVolume`
 parameter of container definition in the `mountPoints` section.
 * `host_path` - (Optional) The path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
+* `docker_volume_configuration` - (Optional) Used to configure a [docker volume](#docker-volume-configuration-arguments)
+
+#### Docker Volume Configuration Arguments
+
+For more information, see [Specifying a Docker volume in your Task Definition Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-volumes.html#specify-volume-config)
+
+* `scope` - (Optional) The scope for the Docker volume, which determines its lifecycle, either `task` or `shared`.  Docker volumes that are scoped to a `task` are automatically provisioned when the task starts and destroyed when the task stops. Docker volumes that are `scoped` as shared persist after the task stops.
+* `autoprovision` - (Optional) If this value is `true`, the Docker volume is created if it does not already exist. *Note*: This field is only used if the scope is `shared`.
+* `driver` - (Optional) The Docker volume driver to use. The driver value must match the driver name provided by Docker because it is used for task placement.
+* `driver_opts` - (Optional) A map of Docker driver specific options.
+* `labels` - (Optional) A map of custom metadata to add to your Docker volume.
+
+##### Example Usage:
+```hcl
+resource "aws_ecs_task_definition" "service" {
+  family                = "service"
+  container_definitions = "${file("task-definitions/service.json")}"
+
+  volume {
+    name = "service-storage"
+    docker_volume_configuration {
+        scope         = "shared"
+        autoprovision = true
+    }
+  }
+}
+```
 
 #### Placement Constraints Arguments
 


### PR DESCRIPTION
## Todo
- [x] Update schema
- [x] Read resource (update to support new schema)
- [x] Create resource  (update to support new schema)
- [x] Add new test to cover docker volume configuration schema
- [x] Update PR text
- [x] Update documentation
- [x] Manually test new provider

## Description
Adds docker volume support to ECS task definitions

Resolves #5523 

## Testing
I've added a new acceptance test `TestAccAWSEcsTaskDefinition_withDockerVolume` and `TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig`

Here is the output of all the ecs task definition acceptance tests including the new one:
```
GOROOT=/usr/lib/go-1.10 #gosetup
GOPATH=/home/ewilde/data/go #gosetup
/usr/lib/go-1.10/bin/go test -c -i -o /tmp/___resource_aws_ecs_task_definition_test_go github.com/terraform-providers/terraform-provider-aws/aws #gosetup
/usr/lib/go-1.10/bin/go tool test2json -t /tmp/___resource_aws_ecs_task_definition_test_go -test.v -test.run "^TestAccAWSEcsTaskDefinition_basic|TestAccAWSEcsTaskDefinition_withScratchVolume|TestAccAWSEcsTaskDefinition_withDockerVolume|TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig|TestAccAWSEcsTaskDefinition_withEcsService|TestAccAWSEcsTaskDefinition_withTaskRoleArn|TestAccAWSEcsTaskDefinition_withNetworkMode|TestAccAWSEcsTaskDefinition_constraint|TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource|TestAccAWSEcsTaskDefinition_arrays|TestAccAWSEcsTaskDefinition_Fargate|TestAccAWSEcsTaskDefinition_ExecutionRole|TestAccAWSEcsTaskDefinition_Inactive|TestValidateAwsEcsTaskDefinitionContainerDefinitions$" #gosetup
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (35.46s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (19.96s)
=== RUN   TestAccAWSEcsTaskDefinition_withDockerVolume
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (21.30s)
=== RUN   TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (19.54s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (73.59s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (22.05s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (23.36s)
=== RUN   TestAccAWSEcsTaskDefinition_constraint
--- PASS: TestAccAWSEcsTaskDefinition_constraint (19.37s)
=== RUN   TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (34.43s)
=== RUN   TestAccAWSEcsTaskDefinition_arrays
--- PASS: TestAccAWSEcsTaskDefinition_arrays (19.65s)
=== RUN   TestAccAWSEcsTaskDefinition_Fargate
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (20.31s)
=== RUN   TestAccAWSEcsTaskDefinition_ExecutionRole
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (25.31s)
=== RUN   TestAccAWSEcsTaskDefinition_Inactive
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (33.76s)
=== RUN   TestValidateAwsEcsTaskDefinitionContainerDefinitions
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.00s)
PASS

Process finished with exit code 0
```