### PR TITLE
r/aws_db_parameter_group, r/aws_rds_cluster_parameter_group: Support resetting parameters

### DIFF
--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -295,6 +295,26 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 			}
 			d.SetPartial("parameter")
 		}
+
+		// Reset parameters that have been removed
+		parameters, err = expandParameters(os.Difference(ns).List())
+		if err != nil {
+			return err
+		}
+		if len(parameters) > 0 {
+			parameterGroupName := d.Get("name").(string)
+			resetOpts := rds.ResetDBParameterGroupInput{
+				DBParameterGroupName: aws.String(parameterGroupName),
+				Parameters:           parameters,
+			}
+
+			log.Printf("[DEBUG] Reset DB Parameter Group: %s", resetOpts)
+			_, err = rdsconn.ResetDBParameterGroup(&resetOpts)
+			if err != nil {
+				return fmt.Errorf("Error resetting DB Parameter Group: %s", err)
+			}
+			d.SetPartial("parameter")
+		}
 	}
 
 	if err := setTagsRDS(rdsconn, d, d.Get("arn").(string)); err != nil {

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -234,6 +234,26 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 			}
 			d.SetPartial("parameter")
 		}
+
+		// Reset parameters that have been removed
+		parameters, err = expandParameters(os.Difference(ns).List())
+		if err != nil {
+			return err
+		}
+		if len(parameters) > 0 {
+			parameterGroupName := d.Get("name").(string)
+			resetOpts := rds.ResetDBClusterParameterGroupInput{
+				DBClusterParameterGroupName: aws.String(parameterGroupName),
+				Parameters:                  parameters,
+			}
+
+			log.Printf("[DEBUG] Reset DB Cluster Parameter Group: %s", resetOpts)
+			_, err = rdsconn.ResetDBClusterParameterGroup(&resetOpts)
+			if err != nil {
+				return fmt.Errorf("Error resetting DB Cluster Parameter Group: %s", err)
+			}
+			d.SetPartial("parameter")
+		}
 	}
 
 	if err := setTagsRDS(rdsconn, d, d.Get("arn").(string)); err != nil {


### PR DESCRIPTION
If you create a parameter group like so:

```hcl
resource "aws_rds_cluster_parameter_group" "cluster" {
  name        = "test-cluster"
  family      = "aurora-mysql5.7"

  parameter {
    name         = "binlog_format"
    value        = "MIXED"
    apply_method = "pending-reboot"
  }
}
```

And then uncomment the parameter block and apply again, it doesn't actually do anything. This PR fixes that.

It is sending the parameter value in the reset request, but this doesn't seem to be causing any problems. I inspected a request in the RDS web console, and it also sends the value (and a lot of other stuff).

I tried setting 22 parameters and then resetting them all in one request, and it worked. I was able to re-produce the error of setting more than 20 parameters at the same time.. Is there anywhere else that this limit is documented?

Let me know what you think!! :)

(Relates: #661)