### PR TITLE
5731 save key pair fingerprint attribute from response

### DIFF
--- a/aws/resource_aws_key_pair.go
+++ b/aws/resource_aws_key_pair.go
@@ -85,7 +85,8 @@ func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error import KeyPair: %s", err)
 	}
-
+	
+        d.Set("fingerprint", *resp.KeyFingerprint)
 	d.SetId(*resp.KeyName)
 	return nil
 }


### PR DESCRIPTION
5731 save key pair fingerprint attribute from the response to create keypair request.

Fixes #5731

Changes proposed in this pull request:

Save fingerprint to state on the response, change is minimal.