### PR TITLE
Add 'Seperator' property to AWS IoT Firehose Rule

### DIFF
--- a/aws/resource_aws_iot_topic_rule.go
+++ b/aws/resource_aws_iot_topic_rule.go
@@ -190,6 +190,11 @@ func resourceAwsIotTopicRule() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validateArn,
 						},
+						"separator": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validateIoTTopicRuleFirehoseSeparator,
+						},
 					},
 				},
 			},
@@ -413,12 +418,16 @@ func createTopicRulePayload(d *schema.ResourceData) *iot.TopicRulePayload {
 
 	for _, a := range firehoseActions {
 		raw := a.(map[string]interface{})
-		actions[i] = &iot.Action{
+		act := &iot.Action{
 			Firehose: &iot.FirehoseAction{
 				DeliveryStreamName: aws.String(raw["delivery_stream_name"].(string)),
 				RoleArn:            aws.String(raw["role_arn"].(string)),
 			},
 		}
+		if v, ok := raw["separator"].(string); ok && v != "" {
+			act.Firehose.Separator = aws.String(raw["separator"].(string))
+		}
+		actions[i] = act
 		i++
 	}
 

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -387,6 +387,7 @@ resource "aws_iot_topic_rule" "rule" {
   firehose {
     delivery_stream_name = "mystream"
     role_arn             = "${aws_iam_role.iot_role.arn}"
+    separator            = "\n"
   }
 }
 `, rName)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2754,6 +2754,7 @@ func flattenIoTRuleFirehoseActions(actions []*iot.Action) []map[string]interface
 		if v != nil {
 			result["role_arn"] = *v.RoleArn
 			result["delivery_stream_name"] = *v.DeliveryStreamName
+			result["separator"] = *v.Separator
 
 			results = append(results, result)
 		}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1625,6 +1625,19 @@ func validateIoTTopicRuleElasticSearchEndpoint(v interface{}, k string) (ws []st
 	return
 }
 
+func validateIoTTopicRuleFirehoseSeparator(v interface{}, s string) ([]string, []error) {
+	switch v.(string) {
+	case
+		",",
+		"\t",
+		"\n",
+		"\r\n":
+		return nil, nil
+	}
+
+	return nil, []error{fmt.Errorf("Separator must be one of ',' (comma), '\t' (tab) '\n' (newline) or '\r\n' (Windows newline)")}
+}
+
 func validateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(v map[string]interface{}) (errors []error) {
 	t := v["type"].(string)
 	isRequired := t == cognitoidentity.RoleMappingTypeToken || t == cognitoidentity.RoleMappingTypeRules

--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -115,6 +115,7 @@ The `firehose` object takes the following arguments:
 
 * `delivery_stream_name` - (Required) The delivery stream name.
 * `role_arn` - (Required) The IAM role ARN that grants access to the Amazon Kinesis Firehose stream.
+* `separator` - (Optional) A character separator that is used to separate records written to the Firehose stream. Valid values are: '\n' (newline), '\t' (tab), '\r\n' (Windows newline), ',' (comma).
 
 The `kinesis` object takes the following arguments:
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5733

Changes proposed in this pull request:

* Add 'separator' property to AWS IoT Core Firehose topic rule action.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIoTTopicRule_firehose'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSIoTTopicRule_firehose -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIoTTopicRule_firehose
--- PASS: TestAccAWSIoTTopicRule_firehose (29.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	29.698s
```