### PR TITLE
Update vpc region in route 53 zone association

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -200,6 +200,9 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		if associatedVPC == nil {
 			return fmt.Errorf("[DEBUG] VPC: %v is not associated with Zone: %v", d.Get("vpc_id"), d.Id())
 		}
+
+		// update vpc region in tf state to match
+		d.Set("vpc_region", *associatedVPC.VPCRegion)
 	}
 
 	if zone.DelegationSet != nil && zone.DelegationSet.Id != nil {

--- a/aws/resource_aws_route53_zone_association.go
+++ b/aws/resource_aws_route53_zone_association.go
@@ -104,6 +104,9 @@ func resourceAwsRoute53ZoneAssociationRead(d *schema.ResourceData, meta interfac
 
 	for _, vpc := range zone.VPCs {
 		if vpc_id == *vpc.VPCId {
+			// update vpc region in tf state to match
+			d.Set("vpc_region", *vpc.VPCRegion)
+
 			// association is there, return
 			return nil
 		}


### PR DESCRIPTION
Changes proposed in this pull request:

* Update vpc region in route 53 zone association

Output from acceptance testing (too afraid to run on our internal infrastructure)

All unit tests passed though:
```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.807s
```

This addresses a bug when new VPCs are inserted into the associated VPC list of a route 53 zone.

#### The Setup
- A Route 53 zone which have 2+ VPCs associated
- Then a new VPC is inserted into the list of associated VPCs

Module "zone"
```
# Input
variable "name" {
  description = "The name of the internal zone"
}

variable "associated_vpc_ids" {
  description = "The list of VPC IDs to associate with this zone"
  type        = "list"
}

variable "associated_vpc_regions" {
  description = "The list of VPC regions for the aforementioned VPC IDs"
  type        = "list"
}

# Resources
resource "aws_route53_zone" "primary" {
  name       = "${var.name}"
  comment    = "${var.comment}"
  vpc_id     = "${var.associated_vpc_ids[0]}"
  vpc_region = "${var.associated_vpc_regions[0]}"
}

resource "aws_route53_zone_association" "additional" {
  count      = "${length(var.associated_vpc_ids) - 1}"
  zone_id    = "${aws_route53_zone.primary.zone_id}"
  vpc_id     = "${element(var.associated_vpc_ids, count.index + 1)}"
  vpc_region = "${element(var.associated_vpc_regions, count.index + 1)}"
}
```

Zone "Foo" - Version 1
```
module "zone-foo" {
  source = "zone"

  name                   = "foo.com."
  associated_vpc_ids     = ["vpc1", "vpc2"]
  associated_vpc_regions = "["us-west-1", "us-east-1"]
}
```

Zone "Foo" - Version 2
```
module "zone-foo" {
  source = "zone"

  name                   = "foo.com."
  associated_vpc_ids     = ["vpc1", "vpc-new", "vpc2"]
  associated_vpc_regions = "["us-west-1", "us-west-2", "us-east-1"]
}
```

#### The Problem
After version 2 is applied, the terraform state does have `vpc-new`, but its vpc region is `us-east-1`, instead of `us-west-2`, because terraform thinks the second associated VPC has changed from `vpc2` to `vpc-new`, but it does not update vpc region in this update.