### PR TITLE
Allow empty permissions boundary field in AWS role.

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -87,7 +87,7 @@ func resourceAwsIamRole() *schema.Resource {
 			"permissions_boundary": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(20, 2048),
+				ValidateFunc: validateMaxLength(2048),
 			},
 
 			"description": {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5546

Changes proposed in this pull request:

* Allow empty value for the `permissions_boundary` attribute of role, and treat it as absent.
* Add a check in role acceptance tests to verify the permissions boundary field in the API on each test step.

Output from acceptance testing:

```
$ make testacc TESTARGS="-run TestAccAWSIAMRole"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run TestAccAWSIAMRole -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIAMRolePolicy_importBasic
--- PASS: TestAccAWSIAMRolePolicy_importBasic (26.74s)
=== RUN   TestAccAWSIAMRole_importBasic
--- PASS: TestAccAWSIAMRole_importBasic (24.18s)
=== RUN   TestAccAWSIAMRolePolicy_basic
--- PASS: TestAccAWSIAMRolePolicy_basic (42.57s)
=== RUN   TestAccAWSIAMRolePolicy_namePrefix
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (41.43s)
=== RUN   TestAccAWSIAMRolePolicy_generatedName
--- PASS: TestAccAWSIAMRolePolicy_generatedName (41.80s)
=== RUN   TestAccAWSIAMRolePolicy_invalidJSON
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (1.95s)
=== RUN   TestAccAWSIAMRole_basic
--- PASS: TestAccAWSIAMRole_basic (22.15s)
=== RUN   TestAccAWSIAMRole_basicWithDescription
--- PASS: TestAccAWSIAMRole_basicWithDescription (52.90s)
=== RUN   TestAccAWSIAMRole_namePrefix
--- PASS: TestAccAWSIAMRole_namePrefix (22.32s)
=== RUN   TestAccAWSIAMRole_testNameChange
--- PASS: TestAccAWSIAMRole_testNameChange (53.76s)
=== RUN   TestAccAWSIAMRole_badJSON
--- PASS: TestAccAWSIAMRole_badJSON (2.23s)
=== RUN   TestAccAWSIAMRole_disappears
--- PASS: TestAccAWSIAMRole_disappears (15.59s)
=== RUN   TestAccAWSIAMRole_force_detach_policies
--- PASS: TestAccAWSIAMRole_force_detach_policies (32.12s)
=== RUN   TestAccAWSIAMRole_MaxSessionDuration
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (40.68s)
=== RUN   TestAccAWSIAMRole_PermissionsBoundary
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (89.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	510.144s
```
