### PR TITLE
vendor: hashicorp/go-uuid@v1.0.0

### DIFF
--- a/vendor/github.com/hashicorp/go-uuid/README.md
+++ b/vendor/github.com/hashicorp/go-uuid/README.md
@@ -1,6 +1,6 @@
-# uuid
+# uuid [![Build Status](https://travis-ci.org/hashicorp/go-uuid.svg?branch=master)](https://travis-ci.org/hashicorp/go-uuid)
 
-Generates UUID-format strings using purely high quality random bytes.
+Generates UUID-format strings using high quality, _purely random_ bytes. It is **not** intended to be RFC compliant, merely to use a well-understood string representation of a 128-bit value. It can also parse UUID-format strings into their component bytes.
 
 Documentation
 =============

--- a/vendor/github.com/hashicorp/go-uuid/go.mod
+++ b/vendor/github.com/hashicorp/go-uuid/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/go-uuid

--- a/vendor/github.com/hashicorp/go-uuid/uuid.go
+++ b/vendor/github.com/hashicorp/go-uuid/uuid.go
@@ -6,13 +6,21 @@ import (
 	"fmt"
 )
 
+// GenerateRandomBytes is used to generate random bytes of given size.
+func GenerateRandomBytes(size int) ([]byte, error) {
+	buf := make([]byte, size)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("failed to read random bytes: %v", err)
+	}
+	return buf, nil
+}
+
 // GenerateUUID is used to generate a random UUID
 func GenerateUUID() (string, error) {
-	buf := make([]byte, 16)
-	if _, err := rand.Read(buf); err != nil {
-		return "", fmt.Errorf("failed to read random bytes: %v", err)
+	buf, err := GenerateRandomBytes(16)
+	if err != nil {
+		return "", err
 	}
-
 	return FormatUUID(buf)
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1182,9 +1182,12 @@
 			"revisionTime": "2018-03-26T21:11:50Z"
 		},
 		{
-			"checksumSHA1": "85XUnluYJL7F55ptcwdmN8eSOsk=",
+			"checksumSHA1": "Kjansj6ZDJrWKNS1BJpg+z7OBnI=",
 			"path": "github.com/hashicorp/go-uuid",
-			"revision": "36289988d83ca270bc07c234c36f364b0dd9c9a7"
+			"revision": "de160f5c59f693fed329e73e291bb751fe4ea4dc",
+			"revisionTime": "2018-08-30T03:27:00Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
 		},
 		{
 			"checksumSHA1": "r0pj5dMHCghpaQZ3f1BRGoKiSWw=",


### PR DESCRIPTION
Preparation for converting to Go modules.

Changes proposed in this pull request:

* Updated via: `govendor fetch github.com/hashicorp/go-uuid/...@v1.0.0`

Output from acceptance testing: Handled via daily acceptance testing (although looks very trivial anyways)

