### PR TITLE
vendor: hashicorp/go-cleanhttp@v0.5.0

### DIFF
--- a/vendor/github.com/hashicorp/go-cleanhttp/cleanhttp.go
+++ b/vendor/github.com/hashicorp/go-cleanhttp/cleanhttp.go
@@ -26,6 +26,7 @@ func DefaultPooledTransport() *http.Transport {
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
+			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,

--- a/vendor/github.com/hashicorp/go-cleanhttp/go.mod
+++ b/vendor/github.com/hashicorp/go-cleanhttp/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/go-cleanhttp

--- a/vendor/github.com/hashicorp/go-cleanhttp/handlers.go
+++ b/vendor/github.com/hashicorp/go-cleanhttp/handlers.go
@@ -1,0 +1,43 @@
+package cleanhttp
+
+import (
+	"net/http"
+	"strings"
+	"unicode"
+)
+
+// HandlerInput provides input options to cleanhttp's handlers
+type HandlerInput struct {
+	ErrStatus int
+}
+
+// PrintablePathCheckHandler is a middleware that ensures the request path
+// contains only printable runes.
+func PrintablePathCheckHandler(next http.Handler, input *HandlerInput) http.Handler {
+	// Nil-check on input to make it optional
+	if input == nil {
+		input = &HandlerInput{
+			ErrStatus: http.StatusBadRequest,
+		}
+	}
+
+	// Default to http.StatusBadRequest on error
+	if input.ErrStatus == 0 {
+		input.ErrStatus = http.StatusBadRequest
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check URL path for non-printable characters
+		idx := strings.IndexFunc(r.URL.Path, func(c rune) bool {
+			return !unicode.IsPrint(c)
+		})
+
+		if idx != -1 {
+			w.WriteHeader(input.ErrStatus)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+		return
+	})
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1140,10 +1140,12 @@
 			"revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 		},
 		{
-			"checksumSHA1": "b8F628srIitj5p7Y130xc9k0QWs=",
+			"checksumSHA1": "Ihile6rE76J6SivxECovHgMROxw=",
 			"path": "github.com/hashicorp/go-cleanhttp",
-			"revision": "3573b8b52aa7b37b9358d966a898feb387f62437",
-			"revisionTime": "2017-02-11T01:34:15Z"
+			"revision": "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18",
+			"revisionTime": "2018-08-30T03:37:06Z",
+			"version": "v0.5.0",
+			"versionExact": "v0.5.0"
 		},
 		{
 			"checksumSHA1": "fvjFEz5PBN1m9ALWf9UuLgTFWLg=",


### PR DESCRIPTION
Preparation for migrating to Go modules. Notable change: `net.Dialer` has `DualStack` enabled. Documentation: https://golang.org/pkg/net/#Dialer

```
        // DualStack enables RFC 6555-compliant "Happy Eyeballs"
        // dialing when the network is "tcp" and the host in the
        // address parameter resolves to both IPv4 and IPv6 addresses.
        // This allows a client to tolerate networks where one address
        // family is silently broken.
        DualStack bool
```

Changes proposed in this pull request:

* Updated via `govendor fetch github.com/hashicorp/go-cleanhttp/...@v0.5.0`

Output from acceptance testing: Handled via daily acceptance testing
