### PR TITLE
Added ForceNew for aws_redshift_cluster on availability_zone change

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -90,6 +90,7 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Computed: true,
 			},
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5757

Changes proposed in this pull request:

* Added "ForceNew: true" for aws_redshift_cluster on availability_zone change
* Added acceptance test: TestAccAWSRedshiftCluster_changeAvailabilityZone
* Added config: testAccAWSRedshiftClusterConfig_updatedAvailabilityZone
* Added simple check: testAccCheckAWSRedshiftClusterAvailabilityZone

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRedshiftCluster_changeAvailabilityZone'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRedshiftCluster_changeAvailabilityZone -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_changeAvailabilityZone
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (2331.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2331.736s
...
```
