### PR TITLE
This addresses the oddity of the configuration 

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -166,11 +166,7 @@ func resourceAwsCodePipeline() *schema.Resource {
 }
 
 func validateAwsCodePipelineStageActionConfiguration(v interface{}, k string) (ws []string, errors []error) {
-	for k := range v.(map[string]interface{}) {
-		if k == "OAuthToken" {
-			errors = append(errors, fmt.Errorf("CodePipeline: OAuthToken should be set as environment variable 'GITHUB_TOKEN'"))
-		}
-	}
+
 	return
 }
 
@@ -339,11 +335,6 @@ func flattenAwsCodePipelineStageActions(actions []*codepipeline.ActionDeclaratio
 		}
 		if action.Configuration != nil {
 			config := flattenAwsCodePipelineStageActionConfiguration(action.Configuration)
-			_, ok := config["OAuthToken"]
-			actionProvider := *action.ActionTypeId.Provider
-			if ok && actionProvider == "GitHub" {
-				delete(config, "OAuthToken")
-			}
 			values["configuration"] = config
 		}
 


### PR DESCRIPTION
This addresses the oddity of the configuration in #2796. This simply removes the code that deletes the OAuthToken passed in and arbitrary validation condition looking for GITHUB_TOKEN env variable. This behavior goes against Terraform convention, and was absolutely NOT well documented, it also drove me insane for a few days until I found an off-hand mention and code reference. There was also no rationale provided for why the code should delete what was provided and replace it with the value of arbitrary ENV variable. 

A much better way to address this is to improve the schema of the in the project definition to mark OAuthToken as sensitive.

Fixes #2796

Changes proposed in this pull request:

* Remove validation code requiring GITHUB_TOKEN env var
* Remove code that deletes the value provided in the configuration per [AWS official documentation](https://docs.aws.amazon.com/codepipeline/latest/userguide/GitHub-rotate-personal-token-CLI.html)

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
I can't get it to run, never worked with Go.
...
```
