### PR TITLE
Update aws_launch_template schema(ipv6 addr count)

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -319,7 +319,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						},
 						"ipv6_address_count": {
 							Type:     schema.TypeInt,
-							Computed: true,
+							Optional: true,
 						},
 						"ipv6_addresses": {
 							Type:     schema.TypeSet,

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -313,6 +313,29 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_networkInterface_ipv6_count(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resName := "aws_launch_template.foo"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_ipv6_count(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					resource.TestCheckResourceAttr(resName, "default_version", "1"),
+					resource.TestCheckResourceAttr(resName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -378,6 +401,23 @@ resource "aws_launch_template" "foo" {
 
   tags {
     foo = "bar"
+  }
+}
+`, rInt)
+}
+
+func testAccAWSLaunchTemplateConfig_ipv6_count(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "foo" {
+  name = "set_ipv6_count_foo_%d"
+
+  network_interfaces {
+    ipv6_address_count = 1
+  }
+
+  tags {
+    foo = "bar",
+    ipv6_count = "1",
   }
 }
 `, rInt)


### PR DESCRIPTION
Change ipv6_address_count from computed to optional

Changes proposed in this pull request:

*  Change `ipv6_address_count` from computed to true - aws/resource_aws_launch_template.go 


Output from acceptance testing:

```
make test                                                                                                    
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
ok      github.com/terraform-providers/terraform-provider-aws/aws       6.339s
...
```

Example of this working with the aws cli

```

aws ec2 create-launch-template --launch-template-name example-template --version-description WebVersion1 --launch-template-data '{"NetworkInterfaces":[{"Ipv6AddressCount":1,"SubnetId":"a-subnet"}],"ImageId":"123444","InstanceType":"t2.small","TagSpecifications":[{"ResourceType":"instance","Tags":[{"Key":"Name","Value":"webserver"}]}]}'
```