### PR TITLE
vendor: jen20/awspolicyequivalence@v1.0.0

### DIFF
--- a/vendor/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go
+++ b/vendor/github.com/jen20/awspolicyequivalence/aws_policy_equivalence.go
@@ -9,12 +9,11 @@ package awspolicy
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/hashicorp/errwrap"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -31,21 +30,21 @@ import (
 func PoliciesAreEquivalent(policy1, policy2 string) (bool, error) {
 	policy1intermediate := &intermediateAwsPolicyDocument{}
 	if err := json.Unmarshal([]byte(policy1), policy1intermediate); err != nil {
-		return false, errwrap.Wrapf("Error unmarshaling policy: {{err}}", err)
+		return false, fmt.Errorf("Error unmarshaling policy: %s", err)
 	}
 
 	policy2intermediate := &intermediateAwsPolicyDocument{}
 	if err := json.Unmarshal([]byte(policy2), policy2intermediate); err != nil {
-		return false, errwrap.Wrapf("Error unmarshaling policy: {{err}}", err)
+		return false, fmt.Errorf("Error unmarshaling policy: %s", err)
 	}
 
 	policy1Doc, err := policy1intermediate.document()
 	if err != nil {
-		return false, errwrap.Wrapf("Error parsing policy: {{err}}", err)
+		return false, fmt.Errorf("Error parsing policy: %s", err)
 	}
 	policy2Doc, err := policy2intermediate.document()
 	if err != nil {
-		return false, errwrap.Wrapf("Error parsing policy: {{err}}", err)
+		return false, fmt.Errorf("Error parsing policy: %s", err)
 	}
 
 	return policy1Doc.equals(policy2Doc), nil
@@ -63,12 +62,12 @@ func (intermediate *intermediateAwsPolicyDocument) document() (*awsPolicyDocumen
 	switch s := intermediate.Statements.(type) {
 	case []interface{}:
 		if err := mapstructure.Decode(s, &statements); err != nil {
-			return nil, errwrap.Wrapf("Error parsing statement: {{err}}", err)
+			return nil, fmt.Errorf("Error parsing statement: %s", err)
 		}
 	case map[string]interface{}:
 		var singleStatement *awsPolicyStatement
 		if err := mapstructure.Decode(s, &singleStatement); err != nil {
-			return nil, errwrap.Wrapf("Error parsing statement: {{err}}", err)
+			return nil, fmt.Errorf("Error parsing statement: %s", err)
 		}
 		statements = append(statements, singleStatement)
 	default:
@@ -276,16 +275,16 @@ func stringPrincipalsEqual(ours, theirs interface{}) bool {
 	awsAccountIDRegex := regexp.MustCompile(`^[0-9]{12}$`)
 
 	if awsAccountIDRegex.MatchString(ourPrincipal) {
-		if theirArn, err := arn.Parse(theirPrincipal); err == nil {
-			if theirArn.Service == "iam" && theirArn.Resource == "root" && theirArn.AccountID == ourPrincipal {
+		if theirArn, err := parseAwsArnString(theirPrincipal); err == nil {
+			if theirArn.service == "iam" && theirArn.resource == "root" && theirArn.account == ourPrincipal {
 				return true
 			}
 		}
 	}
 
 	if awsAccountIDRegex.MatchString(theirPrincipal) {
-		if ourArn, err := arn.Parse(ourPrincipal); err == nil {
-			if ourArn.Service == "iam" && ourArn.Resource == "root" && ourArn.AccountID == theirPrincipal {
+		if ourArn, err := parseAwsArnString(ourPrincipal); err == nil {
+			if ourArn.service == "iam" && ourArn.resource == "root" && ourArn.account == theirPrincipal {
 				return true
 			}
 		}
@@ -434,4 +433,33 @@ func (ours awsPrincipalStringSet) equals(theirs awsPrincipalStringSet) bool {
 	}
 
 	return true
+}
+
+// awsArn describes an Amazon Resource Name
+// More information: http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+type awsArn struct {
+	account   string
+	partition string
+	region    string
+	resource  string
+	service   string
+}
+
+// parseAwsArnString converts a string into an awsArn
+// Expects string in form of: arn:PARTITION:SERVICE:REGION:ACCOUNT:RESOURCE
+func parseAwsArnString(arn string) (awsArn, error) {
+	if !strings.HasPrefix(arn, "arn:") {
+		return awsArn{}, fmt.Errorf("expected arn: prefix, received: %s", arn)
+	}
+	arnParts := strings.SplitN(arn, ":", 6)
+	if len(arnParts) != 6 {
+		return awsArn{}, fmt.Errorf("expected 6 colon delimited sections, received: %s", arn)
+	}
+	return awsArn{
+		account:   arnParts[4],
+		partition: arnParts[1],
+		region:    arnParts[3],
+		resource:  arnParts[5],
+		service:   arnParts[2],
+	}, nil
 }

--- a/vendor/github.com/jen20/awspolicyequivalence/go.mod
+++ b/vendor/github.com/jen20/awspolicyequivalence/go.mod
@@ -1,0 +1,3 @@
+module github.com/jen20/awspolicyequivalence
+
+require github.com/mitchellh/mapstructure v1.0.0

--- a/vendor/github.com/jen20/awspolicyequivalence/go.sum
+++ b/vendor/github.com/jen20/awspolicyequivalence/go.sum
@@ -1,0 +1,2 @@
+github.com/mitchellh/mapstructure v1.0.0 h1:vVpGvMXJPqSDh2VYHF7gsfQj8Ncx+Xw5Y1KHeTRY+7I=
+github.com/mitchellh/mapstructure v1.0.0/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1603,10 +1603,12 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "77PKgZO4nQy8w8CKOQAc9/vrAmo=",
+			"checksumSHA1": "x+4RAiAczFwq+qsWJUEb9oRpgjM=",
 			"path": "github.com/jen20/awspolicyequivalence",
-			"revision": "9fbcaca9f9f868b9560463d0790aae33b2322945",
-			"revisionTime": "2018-03-16T12:05:52Z"
+			"revision": "9ebbf3c225b2b9da629263e13c3015a5de7965d1",
+			"revisionTime": "2018-08-29T22:45:56Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
 		},
 		{
 			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",


### PR DESCRIPTION
Reference: #5773 

Changes proposed in this pull request:

* Updated via: `govendor fetch github.com/jen20/awspolicyequivalence/...@v1.0.0`

Output from unit testing:

```
$ make test TEST=./aws
==> Checking that code complies with gofmt requirements...
go test ./aws -timeout=30s -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.451s
```

Output from acceptance testing:

```
--- PASS: TestAccAWSKmsKey_policy (39.10s)
--- PASS: TestAccAWSS3BucketPolicy_basic (33.32s)
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (46.38s)
--- PASS: TestAccAwsSecretsManagerSecret_policy (12.56s)
--- PASS: TestAccAWSSNSTopic_policy (9.78s)
--- PASS: TestAccAWSSQSQueuePolicy_basic (15.60s)
--- PASS: TestAccAWSSQSQueuePolicy_import (14.27s)
--- PASS: TestAccAWSSQSQueue_policy (16.14s)
```
