### PR TITLE
vendor: Pin hashicorp/logutils@v1.0.0

### DIFF
--- a/vendor/github.com/hashicorp/logutils/go.mod
+++ b/vendor/github.com/hashicorp/logutils/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/logutils

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1311,10 +1311,12 @@
 			"revisionTime": "2017-05-12T21:33:05Z"
 		},
 		{
-			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",
+			"checksumSHA1": "v8LPIrksMLyWuVyNVJul0BbQONM=",
 			"path": "github.com/hashicorp/logutils",
-			"revision": "0dc08b1671f34c4250ce212759ebd880f743d883",
-			"revisionTime": "2015-06-09T07:04:31Z"
+			"revision": "a335183dfd075f638afcc820c90591ca3c97eba6",
+			"revisionTime": "2018-08-28T16:12:49Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
 		},
 		{
 			"checksumSHA1": "MpMvoeVDNxeoOQTI+hUxt+0bHdY=",


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/5773

Changes proposed in this pull request:

* Updated via `govendor fetch github.com/hashicorp/logutils/...@v1.0.0`

Output from acceptance testing: No-op change. 😄 
