### PR TITLE
vendor: Pin hashicorp/go-safetemp@v1.0.0

### DIFF
--- a/vendor/github.com/hashicorp/go-safetemp/go.mod
+++ b/vendor/github.com/hashicorp/go-safetemp/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/go-safetemp

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1178,10 +1178,12 @@
 			"revisionTime": "2017-08-16T15:18:19Z"
 		},
 		{
-			"checksumSHA1": "CduvzBFfTv77nhjtXPGdIjQQLMI=",
+			"checksumSHA1": "0daDqRBckum49dBVYduwjaoObgU=",
 			"path": "github.com/hashicorp/go-safetemp",
-			"revision": "b1a1dbde6fdc11e3ae79efd9039009e22d4ae240",
-			"revisionTime": "2018-03-26T21:11:50Z"
+			"revision": "c9a55de4fe06c920a71964b53cfe3dd293a3c743",
+			"revisionTime": "2018-08-28T16:41:30Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
 		},
 		{
 			"checksumSHA1": "85XUnluYJL7F55ptcwdmN8eSOsk=",


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/5773

Changes proposed in this pull request:

* Updated via: `govendor fetch github.com/hashicorp/go-safetemp/...@v1.0.0`

Output from acceptance testing: No-op change 😄 