### PR TITLE
vendor: Pin apparentlymart/go-textseg@v1.0.0

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -29,8 +29,10 @@
 		{
 			"checksumSHA1": "Ffhtm8iHH7l2ynVVOIGJE3eiuLA=",
 			"path": "github.com/apparentlymart/go-textseg/textseg",
-			"revision": "b836f5c4d331d1945a2fead7188db25432d73b69",
-			"revisionTime": "2017-05-31T20:39:52Z"
+			"revision": "fb01f485ebef760e5ee06d55e1b07534dda2d295",
+			"revisionTime": "2018-08-15T02:43:44Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
 		},
 		{
 			"checksumSHA1": "GCTVJ1J/SGZstNZauuLAnTFOhGA=",


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/5773

Changes proposed in this pull request:

* Updated via: `govendor fetch github.com/apparentlymart/go-textseg/...@v1.0.0`

Output from acceptance testing: No-op change 😄 