### PR TITLE
provider: WARN log instead of returning error with AWS account ID lookup logic

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -448,8 +448,18 @@ func (c *Config) Client() (interface{}, error) {
 		var err error
 		client.accountid, client.partition, err = GetAccountIDAndPartition(client.iamconn, client.stsconn, cp.ProviderName)
 		if err != nil {
-			return nil, fmt.Errorf("Failed getting account information via all available methods. Errors: %s", err)
+			// DEPRECATED: Next major version of the provider should return the error instead of logging
+			//             if skip_request_account_id is not enabled.
+			log.Printf("[WARN] %s", fmt.Sprintf(
+				"AWS account ID not previously found and failed retrieving via all available methods. "+
+					"This will return an error in the next major version of the AWS provider. "+
+					"See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for workaround and implications. "+
+					"Errors: %s", err))
 		}
+	}
+
+	if client.accountid == "" {
+		log.Printf("[WARN] AWS account ID not found for provider. See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for implications.")
 	}
 
 	authErr := c.ValidateAccountId(client.accountid)

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -19,6 +19,7 @@ Upgrade topics:
 <!-- TOC depthFrom:2 depthTo:2 -->
 
 - [Provider Version Configuration](#provider-version-configuration)
+- [Provider: Configuration](#provider-configuration)
 - [Data Source: aws_ami](#data-source-aws_ami)
 - [Data Source: aws_ami_ids](#data-source-aws_ami_ids)
 - [Data Source: aws_iam_role](#data-source-aws_iam_role)
@@ -70,6 +71,24 @@ provider "aws" {
   # ... other configuration ...
 
   version = "~> 2.0.0"
+}
+```
+
+## Provider: Configuration
+
+### skip_requesting_account_id Argument Now Required to Skip Account ID Lookup Errors
+
+If the provider is unable to determine the AWS account ID from a provider assume role configuration or the STS GetCallerIdentity call used to verify the credentials (if `skip_credentials_validation = false`), it will attempt to lookup the AWS account ID via EC2 metadata, IAM GetUser, IAM ListRoles, and STS GetCallerIdentity. Previously, the provider would silently allow the failure of all the above methods.
+
+The provider will now return an error to ensure operators understand the implications of the missing AWS account ID in the provider.
+
+If necessary, the AWS account ID lookup logic can be skipped via:
+
+```hcl
+provider "aws" {
+  # ... other configuration ...
+
+  skip_requesting_account_id = true
 }
 ```
 


### PR DESCRIPTION
Reinstates provider behavior previous to version 1.31.0 which silently allowed AWS account ID lookup failures during initialization. Since missing the AWS account ID in the provider has implications for quite a few data sources and resources, we will return the error in the next major version of the provider.

Fixes #5584
Fixes #5496

Changes proposed in this pull request:

* Replace error from provider AWS account ID lookup with WARN log message
* Add information about change in behavior to Version 2 Upgrade Guide

Output from acceptance testing: (provided as a smoke test)

```
--- PASS: TestAccAWSAvailabilityZones_basic (10.39s)
```
