### PR TITLE
provider: Return error instead of WARN log with AWS account ID lookup failure

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -448,13 +448,10 @@ func (c *Config) Client() (interface{}, error) {
 		var err error
 		client.accountid, client.partition, err = GetAccountIDAndPartition(client.iamconn, client.stsconn, cp.ProviderName)
 		if err != nil {
-			// DEPRECATED: Next major version of the provider should return the error instead of logging
-			//             if skip_request_account_id is not enabled.
-			log.Printf("[WARN] %s", fmt.Sprintf(
+			return nil, fmt.Errorf(
 				"AWS account ID not previously found and failed retrieving via all available methods. "+
-					"This will return an error in the next major version of the AWS provider. "+
 					"See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for workaround and implications. "+
-					"Errors: %s", err))
+					"Errors: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Followup to: https://github.com/terraform-providers/terraform-provider-aws/pull/5794

This change is already noted in the Version 2 Upgrade Guide.

Output from acceptance testing: N/A
