### PR TITLE
resource/aws_lambda_function: Properly handle `vpc_config` removal

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -305,32 +305,12 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if v, ok := d.GetOk("vpc_config"); ok {
+	if v, ok := d.GetOk("vpc_config"); ok && len(v.([]interface{})) > 0 {
+		config := v.([]interface{})[0].(map[string]interface{})
 
-		configs := v.([]interface{})
-		if len(configs) == 1 {
-			config, ok := configs[0].(map[string]interface{})
-
-			if !ok {
-				return errors.New("vpc_config is <nil>")
-			}
-
-			if config != nil {
-				var subnetIds []*string
-				for _, id := range config["subnet_ids"].(*schema.Set).List() {
-					subnetIds = append(subnetIds, aws.String(id.(string)))
-				}
-
-				var securityGroupIds []*string
-				for _, id := range config["security_group_ids"].(*schema.Set).List() {
-					securityGroupIds = append(securityGroupIds, aws.String(id.(string)))
-				}
-
-				params.VpcConfig = &lambda.VpcConfig{
-					SubnetIds:        subnetIds,
-					SecurityGroupIds: securityGroupIds,
-				}
-			}
+		params.VpcConfig = &lambda.VpcConfig{
+			SecurityGroupIds: expandStringSet(config["security_group_ids"].(*schema.Set)),
+			SubnetIds:        expandStringSet(config["subnet_ids"].(*schema.Set)),
 		}
 	}
 
@@ -682,31 +662,16 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 	if d.HasChange("vpc_config") {
-		vpcConfigRaw := d.Get("vpc_config").([]interface{})
-		if len(vpcConfigRaw) == 1 { // Schema guarantees either 0 or 1
-			vpcConfig, ok := vpcConfigRaw[0].(map[string]interface{})
-			if !ok {
-				return errors.New("vpc_config is <nil>")
-			}
-
-			if vpcConfig != nil {
-				var subnetIds []*string
-				for _, id := range vpcConfig["subnet_ids"].(*schema.Set).List() {
-					subnetIds = append(subnetIds, aws.String(id.(string)))
-				}
-
-				var securityGroupIds []*string
-				for _, id := range vpcConfig["security_group_ids"].(*schema.Set).List() {
-					securityGroupIds = append(securityGroupIds, aws.String(id.(string)))
-				}
-
-				configReq.VpcConfig = &lambda.VpcConfig{
-					SubnetIds:        subnetIds,
-					SecurityGroupIds: securityGroupIds,
-				}
-				configUpdate = true
-			}
+		configReq.VpcConfig = &lambda.VpcConfig{
+			SecurityGroupIds: []*string{},
+			SubnetIds:        []*string{},
 		}
+		if v, ok := d.GetOk("vpc_config"); ok && len(v.([]interface{})) > 0 {
+			vpcConfig := v.([]interface{})[0].(map[string]interface{})
+			configReq.VpcConfig.SecurityGroupIds = expandStringSet(vpcConfig["security_group_ids"].(*schema.Set))
+			configReq.VpcConfig.SubnetIds = expandStringSet(vpcConfig["subnet_ids"].(*schema.Set))
+		}
+		configUpdate = true
 	}
 
 	if d.HasChange("runtime") {

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -534,6 +534,35 @@ func TestAccAWSLambdaFunction_VPC(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaFunction_VPCRemoval(t *testing.T) {
+	var conf lambda.GetFunctionOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lambda_function.lambda_function_test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaConfigWithVPC(rName, rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists(resourceName, rName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLambdaConfigBasic(rName, rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists(resourceName, rName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLambdaFunction_VPCUpdate(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 


### PR DESCRIPTION
Includes preventing panics as started by #5792 

Fixes #5791
Fixes #3784
Fixes #2509

Changes proposed in this pull request:

* Adds acceptance test (`TestAccAWSLambdaFunction_VPCRemoval`) to cover `vpc_config` removal
* Prevents panic when removing `vpc_config`
* Properly handles `vpc_config` removal to prevent perpetual difference

Previously:

```
--- FAIL: TestAccAWSLambdaFunction_VPCRemoval (42.52s)
    testing.go:527: Step 1 error: Check failed: Check 2/2 error: aws_lambda_function.lambda_function_test: Attribute 'vpc_config.#' expected "0", got "1"
```

Output from acceptance testing: (others pending in TeamCity)

```
31 tests passed (all tests)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (17.96s)
--- PASS: TestAccAWSLambdaFunction_importS3 (21.54s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (27.06s)
--- PASS: TestAccAWSLambdaFunction_versioned (30.83s)
--- PASS: TestAccAWSLambdaFunction_basic (37.09s)
--- PASS: TestAccAWSLambdaFunction_importLocalFile (37.63s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (0.48s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (39.90s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (48.67s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (50.55s)
--- PASS: TestAccAWSLambdaFunction_VPC (51.22s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (30.33s)
--- PASS: TestAccAWSLambdaFunction_s3 (35.32s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (32.29s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (62.81s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (29.28s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (66.61s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (37.50s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (69.89s)
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (76.53s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs43 (38.74s)
--- PASS: TestAccAWSLambdaFunction_concurrency (77.12s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (40.97s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (30.25s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (81.65s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (35.09s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (88.68s)
--- PASS: TestAccAWSLambdaFunction_envVariables (89.78s)
--- PASS: TestAccAWSLambdaFunction_tags (40.89s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (94.16s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (119.74s)
```
