### PR TITLE
Data source aws_db_instance: Add enabled_cloudwatch_logs_exports

### DIFF
--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -87,6 +87,12 @@ func dataSourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"enabled_cloudwatch_logs_exports": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -271,6 +277,10 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("port", dbInstance.Endpoint.Port)
 	d.Set("hosted_zone_id", dbInstance.Endpoint.HostedZoneId)
 	d.Set("endpoint", fmt.Sprintf("%s:%d", *dbInstance.Endpoint.Address, *dbInstance.Endpoint.Port))
+
+	if err := d.Set("enabled_cloudwatch_logs_exports", aws.StringValueSlice(dbInstance.EnabledCloudwatchLogsExports)); err != nil {
+		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %#v", err)
+	}
 
 	var optionGroups []string
 	for _, v := range dbInstance.OptionGroupMemberships {

--- a/aws/data_source_aws_db_instance_test.go
+++ b/aws/data_source_aws_db_instance_test.go
@@ -28,6 +28,8 @@ func TestAccAWSDbInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "hosted_zone_id"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "master_username"),
 					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "port"),
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "enabled_cloudwatch_logs_exports.0"),
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "enabled_cloudwatch_logs_exports.1"),
 				),
 			},
 		},
@@ -69,6 +71,11 @@ resource "aws_db_instance" "bar" {
 
 	backup_retention_period = 0
 	skip_final_snapshot = true
+
+	enabled_cloudwatch_logs_exports = [
+		"audit",
+		"error",
+	]
 }
 
 data "aws_db_instance" "bar" {

--- a/website/docs/d/db_instance.html.markdown
+++ b/website/docs/d/db_instance.html.markdown
@@ -41,6 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 * `db_security_groups` - Provides List of DB security groups associated to this DB instance.
 * `db_subnet_group` - Specifies the name of the subnet group associated with the DB instance.
 * `db_instance_port` - Specifies the port that the DB instance listens on.
+* `enabled_cloudwatch_logs_exports` - List of log types to export to cloudwatch.
 * `endpoint` - The connection endpoint in `address:port` format.
 * `engine` - Provides the name of the database engine to be used for this DB instance.
 * `engine_version` - Indicates the database engine version.


### PR DESCRIPTION
Changes proposed in this pull request:

* Add enabled_cloudwatch_logs_exports attribute to aws_db_instance
* Update Data Source aws_db_instance Document

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDbInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSDbInstanceDataSource_basic -timeout 120m
=== RUN   TestAccAWSDbInstanceDataSource_basic
--- PASS: TestAccAWSDbInstanceDataSource_basic (474.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws    474.689s
```
