### PR TITLE
tests/data-source/aws_cloudformation_stack: Fix outputs.VPCId handling for longer VPC IDs

### DIFF
--- a/aws/data_source_aws_cloudformation_stack_test.go
+++ b/aws/data_source_aws_cloudformation_stack_test.go
@@ -22,7 +22,7 @@ func TestAccAWSCloudFormationStack_dataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.network", "outputs.%", "1"),
 					resource.TestMatchResourceAttr("data.aws_cloudformation_stack.network", "outputs.VPCId",
-						regexp.MustCompile("^vpc-[a-z0-9]{8}$")),
+						regexp.MustCompile("^vpc-[a-z0-9]+")),
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.network", "capabilities.#", "0"),
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.network", "disable_rollback", "false"),
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.network", "notification_arns.#", "0"),
@@ -97,7 +97,7 @@ func TestAccAWSCloudFormationStack_dataSource_yaml(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.yaml", "outputs.%", "1"),
 					resource.TestMatchResourceAttr("data.aws_cloudformation_stack.yaml", "outputs.VPCId",
-						regexp.MustCompile("^vpc-[a-z0-9]{8}$")),
+						regexp.MustCompile("^vpc-[a-z0-9]+")),
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.yaml", "capabilities.#", "0"),
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.yaml", "disable_rollback", "false"),
 					resource.TestCheckResourceAttr("data.aws_cloudformation_stack.yaml", "notification_arns.#", "0"),


### PR DESCRIPTION
AWS switched to longer IDs at some point and we don't particularly care how long they are.

Previously:

```
--- FAIL: TestAccAWSCloudFormationStack_dataSource_basic (64.08s)
    testing.go:527: Step 0 error: Check failed: Check 2/11 error: data.aws_cloudformation_stack.network: Attribute 'outputs.VPCId' didn't match "^vpc-[a-z0-9]{8}$", got "vpc-06a0f633be3839442"
--- FAIL: TestAccAWSCloudFormationStack_dataSource_yaml (54.21s)
    testing.go:527: Step 0 error: Check failed: Check 2/11 error: data.aws_cloudformation_stack.yaml: Attribute 'outputs.VPCId' didn't match "^vpc-[a-z0-9]{8}$", got "vpc-05022ffdfe3c092f8"
```

Changes proposed in this pull request:

* Adjust regex for `outputs.VPCId` to handle longer VPC IDs

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (72.94s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (72.08s)
```
