### PR TITLE
credit_specification issues in aws_instance (T3)

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1742,14 +1742,14 @@ func buildAwsInstanceOpts(
 	}
 
 	if v, ok := d.GetOk("credit_specification"); ok {
-		// Only T2 instances support T2 Unlimited
-		if strings.HasPrefix(instanceType, "t2") {
+		// Only T2 and T3 are burstable performance instance types and supports Unlimited
+		if strings.HasPrefix(instanceType, "t2") || strings.HasPrefix(instanceType, "t3") {
 			cs := v.([]interface{})[0].(map[string]interface{})
 			opts.CreditSpecification = &ec2.CreditSpecificationRequest{
 				CpuCredits: aws.String(cs["cpu_credits"].(string)),
 			}
 		} else {
-			log.Print("[WARN] credit_specification is defined but instance type is not T2. Ignoring...")
+			log.Print("[WARN] credit_specification is defined but instance type is not T2/T3. Ignoring...")
 		}
 	}
 

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1602,6 +1602,99 @@ func TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable(t *testin
 	})
 }
 
+func TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited(t *testing.T) {
+	var instance ec2.Instance
+	resName := "aws_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_unspecified_t3(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecificationT3_standardCpuCredits(t *testing.T) {
+	var instance ec2.Instance
+	resName := "aws_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits(t *testing.T) {
+	var instance ec2.Instance
+	resName := "aws_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_creditSpecificationT3_updateCpuCredits(t *testing.T) {
+	var before ec2.Instance
+	var after ec2.Instance
+	resName := "aws_instance.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &before),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "standard"),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(resName, &after),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstance_UserData_EmptyStringToUnspecified(t *testing.T) {
 	var instance ec2.Instance
 	rInt := acctest.RandInt()
@@ -3283,6 +3376,29 @@ resource "aws_instance" "foo" {
 `, rInt)
 }
 
+func testAccInstanceConfig_creditSpecification_unspecified_t3(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "my_vpc" {
+  cidr_block = "172.16.0.0/16"
+  tags {
+    Name = "tf-acctest-%d"
+  }
+}
+
+resource "aws_subnet" "my_subnet" {
+  vpc_id = "${aws_vpc.my_vpc.id}"
+  cidr_block = "172.16.20.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-51537029" # us-west-2
+  instance_type = "t3.micro"
+  subnet_id = "${aws_subnet.my_subnet.id}"
+}
+`, rInt)
+}
+
 func testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
@@ -3309,6 +3425,32 @@ resource "aws_instance" "foo" {
 `, rInt)
 }
 
+func testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "my_vpc" {
+  cidr_block = "172.16.0.0/16"
+  tags {
+    Name = "tf-acctest-%d"
+  }
+}
+
+resource "aws_subnet" "my_subnet" {
+  vpc_id = "${aws_vpc.my_vpc.id}"
+  cidr_block = "172.16.20.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-51537029" # us-west-2
+  instance_type = "t3.micro"
+  subnet_id = "${aws_subnet.my_subnet.id}"
+  credit_specification {
+    cpu_credits = "standard"
+  }
+}
+`, rInt)
+}
+
 func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
@@ -3327,6 +3469,32 @@ resource "aws_subnet" "my_subnet" {
 resource "aws_instance" "foo" {
   ami = "ami-22b9a343" # us-west-2
   instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.my_subnet.id}"
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+}
+`, rInt)
+}
+
+func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "my_vpc" {
+  cidr_block = "172.16.0.0/16"
+  tags {
+    Name = "tf-acctest-%d"
+  }
+}
+
+resource "aws_subnet" "my_subnet" {
+  vpc_id = "${aws_vpc.my_vpc.id}"
+  cidr_block = "172.16.20.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-51537029" # us-west-2
+  instance_type = "t3.micro"
   subnet_id = "${aws_subnet.my_subnet.id}"
   credit_specification {
     cpu_credits = "unlimited"


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5651 
Fixes #5654 

Changes proposed in this pull request:

*Change1
`It doesn't respect the credit_specification attribute for T3 instances`
looks like `credit_specification` will be applied only for t2 instances(during creation) as other type will not support this, included t3 with t2.
* Change 2
 `Even if I didn't change anything or I changed an unrelated resource, it would still update the credit specification on every apply`
added the diffsupress func 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSInstance_creditSpecificationT3'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSInstance_creditSpecificationT3 -timeout 120m
=== RUN   TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (160.55s)
=== RUN   TestAccAWSInstance_creditSpecificationT3_standardCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (149.16s)
=== RUN   TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (157.54s)
=== RUN   TestAccAWSInstance_creditSpecificationT3_updateCpuCredits
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (243.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	711.134s
...
```
