### PR TITLE
[d/aws_lambda_function] Remove default qualifier

### DIFF
--- a/aws/data_source_aws_lambda_function.go
+++ b/aws/data_source_aws_lambda_function.go
@@ -16,7 +16,6 @@ func dataSourceAwsLambdaFunction() *schema.Resource {
 			"qualifier": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "$LATEST",
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -31,7 +31,6 @@ func TestAccDataSourceAWSLambdaFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "invoke_arn"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "function_name", funcName),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "description", funcName),
-					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "qualifier", "$LATEST"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "handler", "exports.example"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "memory_size", "128"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "runtime", "nodejs4.3"),


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove the default qualifier from `aws_lambda_function` data source to make `arn` property consistent.

I spent a few hours trying to debug a problem until I realized that the `aws_lambda_function` data source was appending `:$LATEST` to the arn.

Intuitively, `aws_lambda_function.lambda.arn` and `data.aws_lambda_function.lambda.arn` would return the same value.

```
resource "aws_lambda_function" "lambda" {
  function_name    = "test-lambda"
  filename         = "test-lambda.zip"
  handler          = "test-lambda"
  source_code_hash = "${data.archive_file.test-lambda.output_base64sha256}"
  role             = "${aws_iam_role.test-lambda.arn}"
  runtime          = "go1.x"
  memory_size      = 128
  timeout          = 30
  description      = "Test"
}
```

```
data "aws_lambda_function" "lambda" {
  function_name = "test-lambda"
}
```

But this is required at the moment:

```
data "aws_lambda_function" "lambda" {
  function_name = "test-lambda"
  qualifier     = ""
}
```

In my use case, I was trying to use the data source together with `aws_cloudwatch_log_subscription_filter` before I realized that my `destination_arn` had `:$LATEST` appended. Adding `qualifier=""` solved it.

I have tried to see what difference `$LATEST` does, but I think only the arn changes. I have compared the output from `aws lambda get-function --function-name test-lambda` and `aws lambda get-function --function-name test-lambda --qualifier '$LATEST'` and only `FunctionArn` changes. I have not been able to otherwise identify any reason for the default value.

Thank you!!

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLambdaFunction_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLambdaFunction_basic -timeout 120m
=== RUN   TestAccDataSourceAWSLambdaFunction_basic
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (26.74s)
PASS
ok  	github.com/stefansundin/terraform-provider-aws/aws	26.784s


$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLambdaFunction_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLambdaFunction_basic -timeout 120m
=== RUN   TestAccDataSourceAWSLambdaFunction_basic
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (36.77s)
PASS
ok  	github.com/stefansundin/terraform-provider-aws/aws	36.808s


$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLambdaFunction_version'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLambdaFunction_version -timeout 120m
=== RUN   TestAccDataSourceAWSLambdaFunction_version
--- PASS: TestAccDataSourceAWSLambdaFunction_version (36.27s)
PASS
ok  	github.com/stefansundin/terraform-provider-aws/aws	36.315s


$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLambdaFunction_alias'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLambdaFunction_alias -timeout 120m
=== RUN   TestAccDataSourceAWSLambdaFunction_alias
--- PASS: TestAccDataSourceAWSLambdaFunction_alias (37.04s)
PASS
ok  	github.com/stefansundin/terraform-provider-aws/aws	37.069s


$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLambdaFunction_vpc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLambdaFunction_vpc -timeout 120m
=== RUN   TestAccDataSourceAWSLambdaFunction_vpc
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (36.80s)
PASS
ok  	github.com/stefansundin/terraform-provider-aws/aws	36.832s


$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSLambdaFunction_environment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccDataSourceAWSLambdaFunction_environment -timeout 120m
=== RUN   TestAccDataSourceAWSLambdaFunction_environment
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (28.10s)
PASS
ok  	github.com/stefansundin/terraform-provider-aws/aws	28.139s
```

(by the way, is there an easy way to run a list of acceptance tests? I tried adding multiple `-run` but it didn't work)
