### PR TITLE
Issue #5774 - Fix the update issues in aws_appsync_datasource

### DIFF
--- a/aws/resource_aws_appsync_datasource.go
+++ b/aws/resource_aws_appsync_datasource.go
@@ -194,18 +194,16 @@ func resourceAwsAppsyncDatasourceUpdate(d *schema.ResourceData, meta interface{}
 	input := &appsync.UpdateDataSourceInput{
 		ApiId: aws.String(d.Get("api_id").(string)),
 		Name:  aws.String(d.Get("name").(string)),
+		Type:  aws.String(d.Get("type").(string)),
+	}
+
+	if v, ok := d.GetOk("service_role_arn"); ok {
+		input.ServiceRoleArn = aws.String(v.(string))
 	}
 
 	if d.HasChange("description") {
 		input.Description = aws.String(d.Get("description").(string))
 	}
-	if d.HasChange("service_role_arn") {
-		input.ServiceRoleArn = aws.String(d.Get("service_role_arn").(string))
-	}
-	if d.HasChange("type") {
-		input.Type = aws.String(d.Get("type").(string))
-	}
-
 	if d.HasChange("dynamodb_config") {
 		ddbconfig := d.Get("dynamodb_config").([]interface{})
 		if len(ddbconfig) > 0 {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5774 

Changes proposed in this pull request:

* Issue 1
```
=== RUN   TestAccAwsAppsyncDatasource_update
--- FAIL: TestAccAwsAppsyncDatasource_update (294.67s)
    testing.go:527: Step 1 error: Error applying: 1 error occurred:
        	* aws_appsync_datasource.test: 1 error occurred:
        	* aws_appsync_datasource.test: InvalidParameter: 1 validation error(s) found.
        - missing required field, UpdateDataSourceInput.Type.
```
`Type` is required field, added in construct.

* Issue 2
```
=== RUN   TestAccAwsAppsyncDatasource_update
--- FAIL: TestAccAwsAppsyncDatasource_update (279.02s)
    testing.go:527: Step 1 error: Error applying: 1 error occurred:
        	* aws_appsync_datasource.test: 1 error occurred:
        	* aws_appsync_datasource.test: BadRequestException: Service role arn not specified
        	status code: 400, request id: ccf048dd-b343-11e8-807f-1d73b8da92e0
```
If the datasource type is either dynamodb, elasticsearch or lambda, it requires `service_role_arn`.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsAppsyncDatasource_update'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsAppsyncDatasource_update -timeout 120m
=== RUN   TestAccAwsAppsyncDatasource_updateType
--- PASS: TestAccAwsAppsyncDatasource_updateType (119.73s)
=== RUN   TestAccAwsAppsyncDatasource_update
--- PASS: TestAccAwsAppsyncDatasource_update (240.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	359.938s
...
```
