### PR TITLE
Issue #5808 aws_iam_policy does not have a description attribute

### DIFF
--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -28,7 +28,6 @@ func resourceAwsIamPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
-				Default:  "Managed by Terraform",
 			},
 			"path": {
 				Type:     schema.TypeString,
@@ -279,12 +278,7 @@ func iamPolicyListVersions(arn string, iamconn *iam.IAM) ([]*iam.PolicyVersion, 
 
 func readIamPolicy(d *schema.ResourceData, policy *iam.Policy) error {
 	d.SetId(*policy.Arn)
-	if policy.Description != nil {
-		// the description isn't present in the response to CreatePolicy.
-		if err := d.Set("description", policy.Description); err != nil {
-			return err
-		}
-	}
+	d.Set("description", policy.Description)
 	if err := d.Set("path", policy.Path); err != nil {
 		return err
 	}

--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -28,6 +28,7 @@ func resourceAwsIamPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
+				Default:  "Managed by Terraform",
 			},
 			"path": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_policy_test.go
+++ b/aws/resource_aws_iam_policy_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -27,6 +26,7 @@ func TestAWSPolicy_namePrefix(t *testing.T) {
 					testAccCheckAWSPolicyExists("aws_iam_policy.policy", &out),
 					testAccCheckAWSPolicyGeneratedNamePrefix(
 						"aws_iam_policy.policy", "test-policy-"),
+					resource.TestCheckResourceAttr("aws_iam_policy.policy", "description", ""),
 				),
 			},
 		},
@@ -42,26 +42,6 @@ func TestAWSPolicy_invalidJson(t *testing.T) {
 			{
 				Config:      testAccAWSPolicyInvalidJsonConfig,
 				ExpectError: regexp.MustCompile("invalid JSON"),
-			},
-		},
-	})
-}
-
-func TestAWSPolicy_checkDescription(t *testing.T) {
-	var out iam.GetPolicyOutput
-	rName := acctest.RandString(10)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSPolicyDescriptionCheckConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSPolicyExists("aws_iam_policy.policy", &out),
-					resource.TestCheckResourceAttrSet("aws_iam_policy.policy", "description"),
-				),
 			},
 		},
 	})
@@ -150,26 +130,3 @@ resource "aws_iam_policy" "policy" {
   EOF
 }
 `
-
-func testAccAWSPolicyDescriptionCheckConfig(rName string) string {
-	return fmt.Sprintf(`
-  resource "aws_iam_policy" "policy" {
-    name_prefix = "test-policy-%s"
-    path = "/"
-    policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:Describe*"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-`, rName)
-}

--- a/aws/resource_aws_iam_policy_test.go
+++ b/aws/resource_aws_iam_policy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -41,6 +42,26 @@ func TestAWSPolicy_invalidJson(t *testing.T) {
 			{
 				Config:      testAccAWSPolicyInvalidJsonConfig,
 				ExpectError: regexp.MustCompile("invalid JSON"),
+			},
+		},
+	})
+}
+
+func TestAWSPolicy_checkDescription(t *testing.T) {
+	var out iam.GetPolicyOutput
+	rName := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPolicyDescriptionCheckConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPolicyExists("aws_iam_policy.policy", &out),
+					resource.TestCheckResourceAttrSet("aws_iam_policy.policy", "description"),
+				),
 			},
 		},
 	})
@@ -129,3 +150,26 @@ resource "aws_iam_policy" "policy" {
   EOF
 }
 `
+
+func testAccAWSPolicyDescriptionCheckConfig(rName string) string {
+	return fmt.Sprintf(`
+  resource "aws_iam_policy" "policy" {
+    name_prefix = "test-policy-%s"
+    path = "/"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+`, rName)
+}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5808 

Changes proposed in this pull request:

* Change 1
 added default value to description attribute.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAWSPolicy_checkDescription'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAWSPolicy_checkDescription -timeout 120m
=== RUN   TestAWSPolicy_checkDescription
--- PASS: TestAWSPolicy_checkDescription (28.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	28.503s
...
```
