### PR TITLE
provider: Fix and enable misspell linting for source code and website

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -4,6 +4,7 @@
         "errcheck",
         "gofmt",
         "interfacer",
+        "misspell",
         "structcheck",
         "vet"
     ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
 - make lint
 - make test
 - make vendor-status
+- make website-lint
 - make website-test
 
 branches:

--- a/aws/import_aws_security_group.go
+++ b/aws/import_aws_security_group.go
@@ -51,7 +51,7 @@ func resourceAwsSecurityGroupImportState(
 
 func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType string, perm *ec2.IpPermission) ([]*schema.ResourceData, error) {
 	/*
-	   Create a seperate Security Group Rule for:
+	   Create a separate Security Group Rule for:
 	   * The collection of IpRanges (cidr_blocks)
 	   * The collection of Ipv6Ranges (ipv6_cidr_blocks)
 	   * Each individual UserIdGroupPair (source_security_group_id)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -671,7 +671,7 @@ func Provider() terraform.ResourceProvider {
 			// ALBs are actually LBs because they can be type `network` or `application`
 			// To avoid regressions, we will add a new resource for each and they both point
 			// back to the old ALB version. IF the Terraform supported aliases for resources
-			// this would be a whole lot simplier
+			// this would be a whole lot simpler
 			"aws_alb":                         resourceAwsLb(),
 			"aws_lb":                          resourceAwsLb(),
 			"aws_alb_listener":                resourceAwsLbListener(),

--- a/aws/resource_aws_autoscaling_attachment.go
+++ b/aws/resource_aws_autoscaling_attachment.go
@@ -78,7 +78,7 @@ func resourceAwsAutoscalingAttachmentRead(d *schema.ResourceData, meta interface
 	asgconn := meta.(*AWSClient).autoscalingconn
 	asgName := d.Get("autoscaling_group_name").(string)
 
-	// Retrieve the ASG properites to get list of associated ELBs
+	// Retrieve the ASG properties to get list of associated ELBs
 	asg, err := getAwsAutoscalingGroup(asgName, asgconn)
 
 	if err != nil {
@@ -101,7 +101,7 @@ func resourceAwsAutoscalingAttachmentRead(d *schema.ResourceData, meta interface
 		}
 
 		if !found {
-			log.Printf("[WARN] Association for %s was not found in ASG assocation", v.(string))
+			log.Printf("[WARN] Association for %s was not found in ASG association", v.(string))
 			d.SetId("")
 		}
 	}
@@ -117,7 +117,7 @@ func resourceAwsAutoscalingAttachmentRead(d *schema.ResourceData, meta interface
 		}
 
 		if !found {
-			log.Printf("[WARN] Association for %s was not found in ASG assocation", v.(string))
+			log.Printf("[WARN] Association for %s was not found in ASG association", v.(string))
 			d.SetId("")
 		}
 	}

--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -136,7 +136,7 @@ func testAccCheckAWSAutocalingAlbAttachmentExists(asgname string, targetGroupCou
 		})
 
 		if err != nil {
-			return fmt.Errorf("Recieved an error when attempting to load %s:  %s", asg, err)
+			return fmt.Errorf("Received an error when attempting to load %s:  %s", asg, err)
 		}
 
 		if targetGroupCount != len(actual.AutoScalingGroups[0].TargetGroupARNs) {

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -321,7 +321,7 @@ func testAccCheckBatchComputeEnvironmentDestroy(s *terraform.State) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error occured when get compute environment information.")
+			return fmt.Errorf("Error occurred when get compute environment information.")
 		}
 		if len(result.ComputeEnvironments) == 1 {
 			return fmt.Errorf("Compute environment still exists.")
@@ -348,7 +348,7 @@ func testAccCheckAwsBatchComputeEnvironmentExists() resource.TestCheckFunc {
 			})
 
 			if err != nil {
-				return fmt.Errorf("Error occured when get compute environment information.")
+				return fmt.Errorf("Error occurred when get compute environment information.")
 			}
 			if len(result.ComputeEnvironments) == 0 {
 				return fmt.Errorf("Compute environment doesn't exists.")

--- a/aws/resource_aws_codecommit_trigger.go
+++ b/aws/resource_aws_codecommit_trigger.go
@@ -134,7 +134,7 @@ func resourceAwsCodeCommitTriggerDelete(d *schema.ResourceData, meta interface{}
 func expandAwsCodeCommitTriggers(configured []interface{}) []*codecommit.RepositoryTrigger {
 	triggers := make([]*codecommit.RepositoryTrigger, 0, len(configured))
 	// Loop over our configured triggers and create
-	// an array of aws-sdk-go compatabile objects
+	// an array of aws-sdk-go compatible objects
 	for _, lRaw := range configured {
 		data := lRaw.(map[string]interface{})
 		t := &codecommit.RepositoryTrigger{

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -882,7 +882,7 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 }
 
 // Without "Computed: true" on load_balancer_info, removing the resource
-// from configuration causes an error, becuase the remote resource still exists.
+// from configuration causes an error, because the remote resource still exists.
 func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
@@ -1186,7 +1186,7 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 }
 
 // Without "Computed: true" on blue_green_deployment_config, removing the resource
-// from configuration causes an error, becuase the remote resource still exists.
+// from configuration causes an error, because the remote resource still exists.
 func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -1097,7 +1097,7 @@ resource "aws_cognito_user_pool" "pool" {
   sms_verification_message   = "{####} Baz"
 
   # Setting Verification template attributes like EmailMessage, EmailSubject or SmsMessage
-  # will implicitely set EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage
+  # will implicitly set EmailVerificationMessage, EmailVerificationSubject and SmsVerificationMessage
   # attributes.
   verification_message_template {
     default_email_option  = "CONFIRM_WITH_LINK"

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -111,7 +111,7 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 			Optional: true,
 			ForceNew: true,
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// Supress default memcached/redis ports when not defined
+				// Suppress default memcached/redis ports when not defined
 				if !d.IsNewResource() && new == "0" && (old == "6379" || old == "11211") {
 					return true
 				}

--- a/aws/resource_aws_emr_security_configuration.go
+++ b/aws/resource_aws_emr_security_configuration.go
@@ -85,7 +85,7 @@ func resourceAwsEmrSecurityConfigurationRead(d *schema.ResourceData, meta interf
 	})
 	if err != nil {
 		if isAWSErr(err, "InvalidRequestException", "does not exist") {
-			log.Printf("[WARN] EMR Security Configuraiton (%s) not found, removing from state", d.Id())
+			log.Printf("[WARN] EMR Security Configuration (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_iam_account_alias_test.go
+++ b/aws/resource_aws_iam_account_alias_test.go
@@ -59,7 +59,7 @@ func testAccAWSIAMAccountAlias_basic_with_datasource(t *testing.T) {
 				// We expect a non-empty plan due to the way data sources and depends_on
 				// work, or don't work. See https://github.com/hashicorp/terraform/issues/11139#issuecomment-275121893
 				// We accept this limitation and feel this test is OK because of the
-				// explicity check above
+				// explicitly check above
 				ExpectNonEmptyPlan: true,
 			},
 		},

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -71,7 +71,7 @@ func generateIAMPassword(length int) string {
 	result := make([]byte, length)
 	charsetSize := big.NewInt(int64(len(charset)))
 
-	// rather than trying to artifically add specific characters from each
+	// rather than trying to artificially add specific characters from each
 	// class to the password to match the policy, we generate passwords
 	// randomly and reject those that don't match.
 	//

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -988,7 +988,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		// Because we're calling Update prior to Read, and the default value of `source_dest_check` is `true`,
 		// HasChange() thinks there is a diff between what is set on the instance and what is set in state. We need to ensure that
-		// if a diff has occured, it's not because it's a new instance.
+		// if a diff has occurred, it's not because it's a new instance.
 		if d.HasChange("source_dest_check") && !d.IsNewResource() || d.IsNewResource() && !sourceDestCheck {
 			// SourceDestCheck can only be set on VPC instances
 			// AWS will return an error of InvalidParameterCombination if we attempt

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -163,7 +163,7 @@ func resourceAwsKmsGrantCreate(d *schema.ResourceData, meta interface{}) error {
 					fmt.Errorf("[WARN] Error adding new KMS Grant for key: %s, retrying %s",
 						*input.KeyId, err))
 			}
-			log.Printf("[ERROR] An error occured creating new AWS KMS Grant: %s", err)
+			log.Printf("[ERROR] An error occurred creating new AWS KMS Grant: %s", err)
 			return resource.NonRetryableError(err)
 		}
 		return nil

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -257,7 +257,7 @@ func resourceAwsLambdaPermissionRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("action", statement.Action)
-	// Check if the pricipal is a cross-account IAM role
+	// Check if the principal is a cross-account IAM role
 	if _, ok := statement.Principal["AWS"]; ok {
 		d.Set("principal", statement.Principal["AWS"])
 	} else {

--- a/aws/resource_aws_lightsail_instance.go
+++ b/aws/resource_aws_lightsail_instance.go
@@ -149,7 +149,7 @@ func resourceAwsLightsailInstanceCreate(d *schema.ResourceData, meta interface{}
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		// We don't return an error here because the Create call succeded
+		// We don't return an error here because the Create call succeeded
 		log.Printf("[ERR] Error waiting for instance (%s) to become ready: %s", d.Id(), err)
 	}
 

--- a/aws/resource_aws_lightsail_key_pair.go
+++ b/aws/resource_aws_lightsail_key_pair.go
@@ -160,7 +160,7 @@ func resourceAwsLightsailKeyPairCreate(d *schema.ResourceData, meta interface{})
 
 	_, err := stateConf.WaitForState()
 	if err != nil {
-		// We don't return an error here because the Create call succeded
+		// We don't return an error here because the Create call succeeded
 		log.Printf("[ERR] Error waiting for KeyPair (%s) to become ready: %s", d.Id(), err)
 	}
 

--- a/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/aws/resource_aws_opsworks_rds_db_instance.go
@@ -135,7 +135,7 @@ func resourceAwsOpsworksRdsDbInstanceRead(d *schema.ResourceData, meta interface
 		StackId: aws.String(d.Get("stack_id").(string)),
 	}
 
-	log.Printf("[DEBUG] Reading OpsWorks registerd rds db instances for stack: %s", d.Get("stack_id"))
+	log.Printf("[DEBUG] Reading OpsWorks registered rds db instances for stack: %s", d.Get("stack_id"))
 
 	resp, err := client.DescribeRdsDbInstances(req)
 	if err != nil {

--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -339,7 +339,7 @@ func resourceAwsRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	switch setTarget {
-	//instance_id is a special case due to the fact that AWS will "discover" the network_interace_id
+	//instance_id is a special case due to the fact that AWS will "discover" the network_interface_id
 	//when it creates the route and return that data.  In the case of an update, we should ignore the
 	//existing network_interface_id
 	case "instance_id":

--- a/aws/resource_aws_security_group_rules_matching_test.go
+++ b/aws/resource_aws_security_group_rules_matching_test.go
@@ -636,11 +636,11 @@ func TestRulesMixedMatching(t *testing.T) {
 
 				// skip early
 				if numExpectedSGs != numRemoteSGs {
-					log.Printf("\n\ncontinuning on numRemoteSGs \n\n")
+					log.Printf("\n\ncontinuing on numRemoteSGs \n\n")
 					continue
 				}
 				if numExpectedCidrs != numRemoteCidrs {
-					log.Printf("\n\ncontinuning numRemoteCidrs\n\n")
+					log.Printf("\n\ncontinuing numRemoteCidrs\n\n")
 					continue
 				}
 

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -770,7 +770,7 @@ func testRemoveRuleCycle(primary, secondary *ec2.SecurityGroup) resource.TestChe
 }
 
 // This test should fail to destroy the Security Groups and VPC, due to a
-// dependency cycle added outside of terraform's managment. There is a sweeper
+// dependency cycle added outside of terraform's management. There is a sweeper
 // 'aws_vpc' and 'aws_security_group' that cleans these up, however, the test is
 // written to allow Terraform to clean it up because we do go and revoke the
 // cyclic rules that were added.
@@ -837,7 +837,7 @@ func TestAccAWSSecurityGroup_forceRevokeRules_true(t *testing.T) {
 				),
 			},
 			// Again try to apply the config with the sgs removed; it should work,
-			// because we've told the SGs to forecfully revoke their rules first
+			// because we've told the SGs to forcefully revoke their rules first
 			{
 				Config: testAccAWSSecurityGroupConfig_revoke_base_removed,
 			},

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1811,7 +1811,7 @@ func flattenBeanstalkTrigger(list []*elasticbeanstalk.Trigger) []string {
 }
 
 // There are several parts of the AWS API that will sort lists of strings,
-// causing diffs inbetween resources that use lists. This avoids a bit of
+// causing diffs between resources that use lists. This avoids a bit of
 // code duplication for pre-sorts that can be used for things like hash
 // functions, etc.
 func sortInterfaceSlice(in []interface{}) []interface{} {
@@ -4205,7 +4205,7 @@ func expandDynamoDbAttributes(cfg []interface{}) []*dynamodb.AttributeDefinition
 	return attributes
 }
 
-// TODO: Get rid of keySchemaM - the user should just explicitely define
+// TODO: Get rid of keySchemaM - the user should just explicitly define
 // this in the config, we shouldn't magically be setting it like this.
 // Removal will however require config change, hence BC. :/
 func expandDynamoDbLocalSecondaryIndexes(cfg []interface{}, keySchemaM map[string]interface{}) []*dynamodb.LocalSecondaryIndex {

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -234,7 +234,7 @@ You can configure how instances will be added to the replacement environment in 
 * `action` - (Optional) The method used to add instances to a replacement environment.
 
   * `DISCOVER_EXISTING`: Use instances that already exist or will be created manually.
-  * `COPY_AUTO_SCALING_GROUP`: Use settings from a specified **Auto Scaling** group to define and create instances in a new Auto Scaling group. _Exactly one Auto Scaling group must be specifed_ when selecting `COPY_AUTO_SCALING_GROUP`. Use `autoscaling_groups` to specify the Auto Scaling group.
+  * `COPY_AUTO_SCALING_GROUP`: Use settings from a specified **Auto Scaling** group to define and create instances in a new Auto Scaling group. _Exactly one Auto Scaling group must be specified_ when selecting `COPY_AUTO_SCALING_GROUP`. Use `autoscaling_groups` to specify the Auto Scaling group.
 
 You can configure how instances in the original environment are terminated when a blue/green deployment is successful. `terminate_blue_instances_on_deployment_success` supports the following:
 

--- a/website/docs/r/config_configuration_aggregator.html.markdown
+++ b/website/docs/r/config_configuration_aggregator.html.markdown
@@ -89,7 +89,7 @@ Either `regions` or `all_regions` (as true) must be specified.
 
 * `all_regions` - (Optional) If true, aggregate existing AWS Config regions and future regions.
 * `regions` - (Optional) List of source regions being aggregated.
-* `role_arn` - (Required) ARN of the IAM role used to retreive AWS Organization details associated with the aggregator account.
+* `role_arn` - (Required) ARN of the IAM role used to retrieve AWS Organization details associated with the aggregator account.
 
 Either `regions` or `all_regions` (as true) must be specified.
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -90,7 +90,7 @@ be created in the `default` VPC, or in EC2 Classic, if available. When working
 with read replicas, it needs to be specified only if the source database
 specifies an instance in another AWS Region. See [DBSubnetGroupName in API
 action CreateDBInstanceReadReplica](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html)
-for additonal read replica contraints.
+for additional read replica contraints.
 * `domain` - (Optional) The ID of the Directory Service Active Directory domain to create the instance in.
 * `domain_iam_role_name` - (Optional, but required if domain is provided) The name of the IAM role to be used when making API calls to the Directory Service.
 * `enabled_cloudwatch_logs_exports` - (Optional) List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on `engine`): `alert`, `audit`, `error`, `general`, `listener`, `slowquery`, `trace`.

--- a/website/docs/r/emr_security_configuration.html.markdown
+++ b/website/docs/r/emr_security_configuration.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_emr_security_configuraiton"
+page_title: "AWS: aws_emr_security_configuration"
 sidebar_current: "docs-aws-resource-emr-security-configuration"
 description: |-
   Provides a resource to manage AWS EMR Security Configurations

--- a/website/docs/r/lightsail_key_pair.html.markdown
+++ b/website/docs/r/lightsail_key_pair.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # aws_lightsail_key_pair
 
 Provides a Lightsail Key Pair, for use with Lightsail Instances. These key pairs
-are seperate from EC2 Key Pairs, and must be created or imported for use with
+are separate from EC2 Key Pairs, and must be created or imported for use with
 Lightsail.
 
 ~> **Note:** Lightsail is currently only supported in a limited number of AWS Regions, please see ["Regions and Availability Zones in Amazon Lightsail"](https://lightsail.aws.amazon.com/ls/docs/overview/article/understanding-regions-and-availability-zones-in-amazon-lightsail) for more details

--- a/website/docs/r/ssm_activation.html.markdown
+++ b/website/docs/r/ssm_activation.html.markdown
@@ -46,7 +46,7 @@ resource "aws_ssm_activation" "foo" {
 
 The following arguments are supported:
 
-* `name` - (Optional) The default name of the registerd managed instance.
+* `name` - (Optional) The default name of the registered managed instance.
 * `description` - (Optional) The description of the resource that you want to register.
 * `expiration_date` - (Optional) A timestamp in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) by which this activation request should expire. The default value is 24 hours from resource creation time.
 * `iam_role` - (Required) The IAM Role to attach to the managed instance.
@@ -57,7 +57,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `activation_code` - The code the system generates when it processes the activation.
-* `name` - The default name of the registerd managed instance.
+* `name` - The default name of the registered managed instance.
 * `description` - The description of the resource that was registered.
 * `expired` - If the current activation has expired.
 * `expiration_date` - The date by which this activation request should expire. The default value is 24 hours.


### PR DESCRIPTION
Closes #5644 

Changes proposed in this pull request:

* Enable `misspell` to reduce pull request review comments 😄 

Output from acceptance testing:

```
$ make lint
==> Checking source code against linters...
$ make website-lint
==> Checking website against linters...
$
```
