### PR TITLE
provider: Fix and enable ineffassign linting

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -3,6 +3,7 @@
     "Enable": [
         "errcheck",
         "gofmt",
+        "ineffassign",
         "interfacer",
         "structcheck",
         "vet"

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -195,11 +195,10 @@ func expandDefaultCacheBehavior(m map[string]interface{}) *cloudfront.DefaultCac
 }
 
 func flattenDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior) *schema.Set {
-	m := make(map[string]interface{})
 	var cb cloudfront.CacheBehavior
 
 	simpleCopyStruct(dcb, &cb)
-	m = flattenCacheBehaviorDeprecated(&cb)
+	m := flattenCacheBehaviorDeprecated(&cb)
 	return schema.NewSet(defaultCacheBehaviorHash, []interface{}{m})
 }
 

--- a/aws/network_acl_entry.go
+++ b/aws/network_acl_entry.go
@@ -96,8 +96,7 @@ func protocolStrings(protocolIntegers map[string]int) map[int]string {
 }
 
 func protocolIntegers() map[string]int {
-	var protocolIntegers = make(map[string]int)
-	protocolIntegers = map[string]int{
+	return map[string]int{
 		// defined at https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 		"all":             -1,
 		"hopopt":          0,
@@ -245,7 +244,6 @@ func protocolIntegers() map[string]int {
 		"253":             253,
 		"254":             254,
 	}
-	return protocolIntegers
 }
 
 // expectedPortPair stores a pair of ports we expect to see together.

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -156,6 +156,9 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		}
 
 		tagResp, err := acmconn.ListTagsForCertificate(params)
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("error listing tags for certificate (%s): %s", d.Id(), err))
+		}
 		if err := d.Set("tags", tagsToMapACM(tagResp.Tags)); err != nil {
 			return resource.NonRetryableError(err)
 		}

--- a/aws/resource_aws_autoscaling_group_waiting.go
+++ b/aws/resource_aws_autoscaling_group_waiting.go
@@ -46,6 +46,9 @@ func waitForASGCapacity(
 			return nil
 		}
 		elbis, err := getELBInstanceStates(g, meta)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
 		albis, err := getTargetGroupInstanceStates(g, meta)
 		if err != nil {
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_db_parameter_group.go
+++ b/aws/resource_aws_db_parameter_group.go
@@ -276,7 +276,7 @@ func resourceAwsDbParameterGroupUpdate(d *schema.ResourceData, meta interface{})
 			// we've got them all.
 			maxParams := 20
 			for parameters != nil {
-				paramsToModify := make([]*rds.Parameter, 0)
+				var paramsToModify []*rds.Parameter
 				if len(parameters) <= maxParams {
 					paramsToModify, parameters = parameters[:], nil
 				} else {

--- a/aws/resource_aws_elastic_beanstalk_environment_migrate_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_migrate_test.go
@@ -47,7 +47,7 @@ func TestAWSElasticBeanstalkEnvironmentMigrateState(t *testing.T) {
 			ID:         "e-abcde12345",
 			Attributes: tc.Attributes,
 		}
-		is, err := resourceAwsElasticBeanstalkEnvironmentMigrateState(
+		_, err := resourceAwsElasticBeanstalkEnvironmentMigrateState(
 			tc.StateVersion, is, tc.Meta)
 
 		if err != nil {

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -166,7 +166,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 		maxParams := 20
 
 		for len(toRemove) > 0 {
-			paramsToModify := make([]*elasticache.ParameterNameValue, 0)
+			var paramsToModify []*elasticache.ParameterNameValue
 			if len(toRemove) <= maxParams {
 				paramsToModify, toRemove = toRemove[:], nil
 			} else {
@@ -194,7 +194,7 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 		}
 
 		for len(toAdd) > 0 {
-			paramsToModify := make([]*elasticache.ParameterNameValue, 0)
+			var paramsToModify []*elasticache.ParameterNameValue
 			if len(toAdd) <= maxParams {
 				paramsToModify, toAdd = toAdd[:], nil
 			} else {

--- a/aws/resource_aws_elasticache_replication_group_migrate_test.go
+++ b/aws/resource_aws_elasticache_replication_group_migrate_test.go
@@ -65,7 +65,7 @@ func TestAwsElasticacheReplicationGroupMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceAwsElasticacheReplicationGroupMigrateState(0, is, meta)
+	_, err = resourceAwsElasticacheReplicationGroupMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -448,6 +448,9 @@ func flattenAwsELbResource(d *schema.ResourceData, ec2conn *ec2.EC2, elbconn *el
 	resp, err := elbconn.DescribeTags(&elb.DescribeTagsInput{
 		LoadBalancerNames: []*string{lb.LoadBalancerName},
 	})
+	if err != nil {
+		return fmt.Errorf("error describing tags for ELB (%s): %s", d.Id(), err)
+	}
 
 	var et []*elb.Tag
 	if len(resp.TagDescriptions) > 0 {

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1064,6 +1064,9 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		_, err := conn.StopInstances(&ec2.StopInstancesInput{
 			InstanceIds: []*string{aws.String(d.Id())},
 		})
+		if err != nil {
+			return fmt.Errorf("error stopping instance (%s): %s", d.Id(), err)
+		}
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"pending", "running", "shutting-down", "stopped", "stopping"},
@@ -1095,6 +1098,9 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		_, err = conn.StartInstances(&ec2.StartInstancesInput{
 			InstanceIds: []*string{aws.String(d.Id())},
 		})
+		if err != nil {
+			return fmt.Errorf("error starting instance (%s): %s", d.Id(), err)
+		}
 
 		stateConf = &resource.StateChangeConf{
 			Pending:    []string{"pending", "stopped"},

--- a/aws/resource_aws_instance_migrate_test.go
+++ b/aws/resource_aws_instance_migrate_test.go
@@ -151,7 +151,7 @@ func TestAWSInstanceMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceAwsInstanceMigrateState(0, is, meta)
+	_, err = resourceAwsInstanceMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_migrate_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_migrate_test.go
@@ -85,7 +85,7 @@ func TestAWSKinesisFirehoseMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceAwsInstanceMigrateState(0, is, meta)
+	_, err = resourceAwsInstanceMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/aws/resource_aws_load_balancer_policy.go
+++ b/aws/resource_aws_load_balancer_policy.go
@@ -163,6 +163,9 @@ func resourceAwsLoadBalancerPolicyUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	err = resourceAwsLoadBalancerPolicyCreate(d, meta)
+	if err != nil {
+		return err
+	}
 
 	for _, listenerAssignment := range reassignments.listenerPolicies {
 		if _, err := elbconn.SetLoadBalancerPoliciesOfListener(listenerAssignment); err != nil {

--- a/aws/resource_aws_neptune_cluster_parameter_group.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group.go
@@ -206,7 +206,7 @@ func resourceAwsNeptuneClusterParameterGroupUpdate(d *schema.ResourceData, meta 
 			// We can only modify 20 parameters at a time, so walk them until
 			// we've got them all.
 			for parameters != nil {
-				paramsToModify := make([]*neptune.Parameter, 0)
+				var paramsToModify []*neptune.Parameter
 				if len(parameters) <= neptuneClusterParameterGroupMaxParamsBulkEdit {
 					paramsToModify, parameters = parameters[:], nil
 				} else {

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -207,7 +207,7 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 		log.Printf("[DEBUG] Parameters to add: %#v", toAdd)
 
 		for len(toRemove) > 0 {
-			paramsToModify := make([]*neptune.Parameter, 0)
+			var paramsToModify []*neptune.Parameter
 			if len(toRemove) <= maxParams {
 				paramsToModify, toRemove = toRemove[:], nil
 			} else {
@@ -235,7 +235,7 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 		}
 
 		for len(toAdd) > 0 {
-			paramsToModify := make([]*neptune.Parameter, 0)
+			var paramsToModify []*neptune.Parameter
 			if len(toAdd) <= maxParams {
 				paramsToModify, toAdd = toAdd[:], nil
 			} else {

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -214,7 +214,7 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 			// We can only modify 20 parameters at a time, so walk them until
 			// we've got them all.
 			for parameters != nil {
-				paramsToModify := make([]*rds.Parameter, 0)
+				var paramsToModify []*rds.Parameter
 				if len(parameters) <= rdsClusterParameterGroupMaxParamsBulkEdit {
 					paramsToModify, parameters = parameters[:], nil
 				} else {

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -303,6 +303,9 @@ func resourceAwsS3BucketInventoryRead(d *schema.ResourceData, meta interface{}) 
 		}
 		return nil
 	})
+	if err != nil {
+		return fmt.Errorf("error getting S3 Bucket Inventory (%s): %s", d.Id(), err)
+	}
 
 	if output == nil || output.InventoryConfiguration == nil {
 		log.Printf("[WARN] %s S3 bucket inventory configuration not found, removing from state.", d.Id())

--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -1381,14 +1381,12 @@ func protocolForValue(v string) string {
 // Similar to protocolIntegers() used by Network ACLs, but explicitly only
 // supports "tcp", "udp", "icmp", and "all"
 func sgProtocolIntegers() map[string]int {
-	var protocolIntegers = make(map[string]int)
-	protocolIntegers = map[string]int{
+	return map[string]int{
 		"udp":  17,
 		"tcp":  6,
 		"icmp": 1,
 		"all":  -1,
 	}
-	return protocolIntegers
 }
 
 // The AWS Lambda service creates ENIs behind the scenes and keeps these around for a while

--- a/aws/resource_aws_security_group_migrate_test.go
+++ b/aws/resource_aws_security_group_migrate_test.go
@@ -63,7 +63,7 @@ func TestAWSSecurityGroupMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceAwsSecurityGroupMigrateState(0, is, meta)
+	_, err = resourceAwsSecurityGroupMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -454,13 +454,11 @@ func getDocumentPermissions(d *schema.ResourceData, meta interface{}) (map[strin
 		account_ids[i] = *resp.AccountIds[i]
 	}
 
-	var ids = ""
+	ids := ""
 	if len(account_ids) == 1 {
 		ids = account_ids[0]
 	} else if len(account_ids) > 1 {
 		ids = strings.Join(account_ids, ",")
-	} else {
-		ids = ""
 	}
 
 	if ids == "" {

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -72,8 +72,11 @@ func TestAccAWSVolumeAttachment_attachStopped(t *testing.T) {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
 		_, err := conn.StopInstances(&ec2.StopInstancesInput{
-			InstanceIds: []*string{aws.String(*i.InstanceId)},
+			InstanceIds: []*string{i.InstanceId},
 		})
+		if err != nil {
+			t.Fatalf("error stopping instance (%s): %s", aws.StringValue(i.InstanceId), err)
+		}
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"pending", "running", "stopping"},

--- a/aws/resource_aws_waf_regex_match_set_test.go
+++ b/aws/resource_aws_waf_regex_match_set_test.go
@@ -66,11 +66,14 @@ func testSweepWafRegexMatchSet(region string) error {
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.DeleteRegexMatchSetInput{
 				ChangeToken:     token,
-				RegexMatchSetId: aws.String(*set.RegexMatchSetId),
+				RegexMatchSetId: set.RegexMatchSetId,
 			}
 			log.Printf("[INFO] Deleting WAF Regex Match Set: %s", req)
 			return conn.DeleteRegexMatchSet(req)
 		})
+		if err != nil {
+			return fmt.Errorf("error deleting WAF Regex Match Set (%s): %s", aws.StringValue(set.RegexMatchSetId), err)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_waf_rule_group.go
+++ b/aws/resource_aws_waf_rule_group.go
@@ -108,6 +108,9 @@ func resourceAwsWafRuleGroupRead(d *schema.ResourceData, meta interface{}) error
 	rResp, err := conn.ListActivatedRulesInRuleGroup(&waf.ListActivatedRulesInRuleGroupInput{
 		RuleGroupId: aws.String(d.Id()),
 	})
+	if err != nil {
+		return fmt.Errorf("error listing activated rules in WAF Rule Group (%s): %s", d.Id(), err)
+	}
 
 	d.Set("activated_rule", flattenWafActivatedRules(rResp.ActivatedRules))
 	d.Set("name", resp.RuleGroup.Name)

--- a/aws/resource_aws_waf_rule_group_test.go
+++ b/aws/resource_aws_waf_rule_group_test.go
@@ -263,6 +263,9 @@ func testAccCheckAWSWafRuleGroupDisappears(group *waf.RuleGroup) resource.TestCh
 		rResp, err := conn.ListActivatedRulesInRuleGroup(&waf.ListActivatedRulesInRuleGroupInput{
 			RuleGroupId: group.RuleGroupId,
 		})
+		if err != nil {
+			return fmt.Errorf("error listing activated rules in WAF Rule Group (%s): %s", aws.StringValue(group.RuleGroupId), err)
+		}
 
 		wr := newWafRetryer(conn, "global")
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -67,11 +67,14 @@ func testSweepWafRegionalRegexMatchSet(region string) error {
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.DeleteRegexMatchSetInput{
 				ChangeToken:     token,
-				RegexMatchSetId: aws.String(*set.RegexMatchSetId),
+				RegexMatchSetId: set.RegexMatchSetId,
 			}
 			log.Printf("[INFO] Deleting WAF Regional Regex Match Set: %s", req)
 			return conn.DeleteRegexMatchSet(req)
 		})
+		if err != nil {
+			return fmt.Errorf("error deleting WAF Regional Regex Match Set (%s): %s", aws.StringValue(set.RegexMatchSetId), err)
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_wafregional_rule_group.go
+++ b/aws/resource_aws_wafregional_rule_group.go
@@ -110,6 +110,9 @@ func resourceAwsWafRegionalRuleGroupRead(d *schema.ResourceData, meta interface{
 	rResp, err := conn.ListActivatedRulesInRuleGroup(&waf.ListActivatedRulesInRuleGroupInput{
 		RuleGroupId: aws.String(d.Id()),
 	})
+	if err != nil {
+		return fmt.Errorf("error listing activated rules in WAF Regional Rule Group (%s): %s", d.Id(), err)
+	}
 
 	d.Set("activated_rule", flattenWafActivatedRules(rResp.ActivatedRules))
 	d.Set("name", resp.RuleGroup.Name)

--- a/aws/resource_aws_wafregional_rule_group_test.go
+++ b/aws/resource_aws_wafregional_rule_group_test.go
@@ -240,6 +240,9 @@ func testAccCheckAWSWafRegionalRuleGroupDisappears(group *waf.RuleGroup) resourc
 		rResp, err := conn.ListActivatedRulesInRuleGroup(&waf.ListActivatedRulesInRuleGroupInput{
 			RuleGroupId: group.RuleGroupId,
 		})
+		if err != nil {
+			return fmt.Errorf("error listing activated rules in WAF Regional Rule Group (%s): %s", aws.StringValue(group.RuleGroupId), err)
+		}
 
 		wr := newWafRegionalRetryer(conn, region)
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {


### PR DESCRIPTION
Closes #5647 

Changes proposed in this pull request:

* Enable `ineffassign` linting to reduce pull request review comments 😄 

Output from testing: (rest handled via daily acceptance testing)

```
$ make lint
==> Checking source code against linters...
$ make test TEST=./aws
==> Checking that code complies with gofmt requirements...
go test ./aws -timeout=30s -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.444s
```
