### PR TITLE
tests/resource/aws_instance: Add sweeper

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1185,7 +1185,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if err := awsTerminateInstance(conn, d.Id(), d); err != nil {
+	if err := awsTerminateInstance(conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return err
 	}
 
@@ -1880,7 +1880,7 @@ func buildAwsInstanceOpts(
 	return opts, nil
 }
 
-func awsTerminateInstance(conn *ec2.EC2, id string, d *schema.ResourceData) error {
+func awsTerminateInstance(conn *ec2.EC2, id string, timeout time.Duration) error {
 	log.Printf("[INFO] Terminating instance: %s", id)
 	req := &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(id)},
@@ -1895,7 +1895,7 @@ func awsTerminateInstance(conn *ec2.EC2, id string, d *schema.ResourceData) erro
 		Pending:    []string{"pending", "running", "shutting-down", "stopped", "stopping"},
 		Target:     []string{"terminated"},
 		Refresh:    InstanceStateRefreshFunc(conn, id, []string{}),
-		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Timeout:    timeout,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -396,7 +396,7 @@ func resourceAwsSpotInstanceRequestDelete(d *schema.ResourceData, meta interface
 
 	if instanceId := d.Get("spot_instance_id").(string); instanceId != "" {
 		log.Printf("[INFO] Terminating instance: %s", instanceId)
-		if err := awsTerminateInstance(conn, instanceId, d); err != nil {
+		if err := awsTerminateInstance(conn, instanceId, d.Timeout(schema.TimeoutDelete)); err != nil {
 			return fmt.Errorf("Error terminating spot instance: %s", err)
 		}
 	}

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 // add sweeper to delete known test subnets
@@ -30,6 +30,7 @@ func init() {
 			"aws_elasticache_replication_group",
 			"aws_elasticsearch_domain",
 			"aws_elb",
+			"aws_instance",
 			"aws_lambda_function",
 			"aws_lb",
 			"aws_mq_broker",


### PR DESCRIPTION
The new Storage Gateway testing that involves spinning up EC2 instances is especially flakey, often leaving behind the EC2 instances, which then cause the following issues during the TeamCity CI pre-sweeper step:

```
[07:25:01][Step 2/4] 2018/09/05 07:25:01 [ERR] error running (aws_subnet): Error deleting Subnet (subnet-0616668e81903e7ce): DependencyViolation: The subnet 'subnet-0616668e81903e7ce' has dependencies and cannot be deleted.
[07:25:01][Step 2/4] 	status code: 400, request id: aad34408-124f-49a1-a509-02ef00d652e5
[07:25:01][Step 2/4] FAIL	github.com/terraform-providers/terraform-provider-aws/aws	97.874s
[07:25:01][Step 2/4] Process exited with code 1
[07:25:01][Step 2/4] Process exited with code 1 (Step: Pre-Sweeper (Command Line))
[07:25:01][Step 2/4] Step Pre-Sweeper (Command Line) failed
```

For now this sweeps `tf-acc-test-` Name tag prefixed EC2 instances (used by the Storage Gateway acceptance test configurations), but later we'll fix up the rest of the EC2 instances in test configurations to include that Name tag.

Changes proposed in this pull request:

* Add `aws_instance` sweeper
* Add `aws_instance` as dependency for `aws_subnet` sweeper

Output from acceptance testing:
```
$ make sweep SWEEPARGS='-sweep-run=aws_instance'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_instance
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/09/10 12:55:39 [DEBUG] Running Sweepers for region (us-east-1):
2018/09/10 12:55:39 [INFO] Building AWS region structure
2018/09/10 12:55:39 [INFO] Building AWS auth structure
2018/09/10 12:55:39 [INFO] Setting AWS metadata API timeout to 100ms
2018/09/10 12:55:40 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/09/10 12:55:40 [INFO] AWS Auth provider used: "EnvProvider"
2018/09/10 12:55:40 [INFO] Initializing DeviceFarm SDK connection
2018/09/10 12:55:40 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/09/10 12:55:41 [INFO] Skipping EC2 Instance: i-02021584d9b372d65
2018/09/10 12:55:41 Sweeper Tests ran:
	- aws_instance
2018/09/10 12:55:41 [DEBUG] Running Sweepers for region (us-west-2):
2018/09/10 12:55:41 [INFO] Building AWS region structure
2018/09/10 12:55:41 [INFO] Building AWS auth structure
2018/09/10 12:55:41 [INFO] Setting AWS metadata API timeout to 100ms
2018/09/10 12:55:41 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/09/10 12:55:41 [INFO] AWS Auth provider used: "EnvProvider"
2018/09/10 12:55:41 [INFO] Initializing DeviceFarm SDK connection
2018/09/10 12:55:41 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/09/10 12:55:43 [INFO] Terminating EC2 Instance: i-0e1108b3f5fe4f5f9
2018/09/10 12:55:43 [INFO] Terminating instance: i-0e1108b3f5fe4f5f9
2018/09/10 12:55:44 [DEBUG] Waiting for instance (i-0e1108b3f5fe4f5f9) to become terminated
2018/09/10 12:55:44 [DEBUG] Waiting for state to become: [terminated]
2018/09/10 12:55:54 [TRACE] Waiting 3s before next try
2018/09/10 12:55:58 [TRACE] Waiting 6s before next try
2018/09/10 12:56:04 [TRACE] Waiting 10s before next try
2018/09/10 12:56:15 [TRACE] Waiting 10s before next try
2018/09/10 12:56:25 [TRACE] Waiting 10s before next try
2018/09/10 12:56:36 [INFO] Terminating EC2 Instance: i-03b969954c3865b1a
2018/09/10 12:56:36 [INFO] Terminating instance: i-03b969954c3865b1a
2018/09/10 12:56:36 [DEBUG] Waiting for instance (i-03b969954c3865b1a) to become terminated
2018/09/10 12:56:36 [DEBUG] Waiting for state to become: [terminated]
2018/09/10 12:56:47 [INFO] Skipping EC2 Instance: i-0170bc5bbcc73ea04
2018/09/10 12:56:47 [INFO] Terminating EC2 Instance: i-0fc2d51082859b075
2018/09/10 12:56:47 [INFO] Terminating instance: i-0fc2d51082859b075
2018/09/10 12:56:47 [DEBUG] Waiting for instance (i-0fc2d51082859b075) to become terminated
2018/09/10 12:56:47 [DEBUG] Waiting for state to become: [terminated]
2018/09/10 12:56:57 [INFO] Skipping EC2 Instance: i-0eaa10dec1c06e18c
2018/09/10 12:56:57 [INFO] Skipping EC2 Instance: i-02034867a7389cbaf
2018/09/10 12:56:57 Sweeper Tests ran:
	- aws_instance
ok  	github.com/terraform-providers/terraform-provider-aws/aws	79.107s
```
