### PR TITLE
tests/resource/aws_lb: Ensure testacc prefix load balancers are included in sweeper

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -34,6 +34,7 @@ func testSweepLBs(region string) error {
 		"tf-test-",
 		"tf-acc-test-",
 		"test-",
+		"testacc",
 	}
 
 	err = conn.DescribeLoadBalancersPages(&elbv2.DescribeLoadBalancersInput{}, func(page *elbv2.DescribeLoadBalancersOutput, isLast bool) bool {


### PR DESCRIPTION
Until we have time to cleanup all the test configurations to use a consistent prefix.

Changes proposed in this pull request:

* On the tin

Previously we could get stuck with the following during sweeper runs until manual deletion:

```
2018/09/10 13:37:14 [ERR] error running (aws_vpc): Error deleting Subnet (subnet-0edfe07fd8c68bee8): DependencyViolation: The subnet 'subnet-0edfe07fd8c68bee8' has dependencies and cannot be deleted.
	status code: 400, request id: e4d38f4e-578a-4be1-a99c-511b8ebc6431
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	49.477s
```

Output from acceptance testing:

```
$ make sweep SWEEPARGS='-sweep-run=aws_lb'
WARNING: This will destroy infrastructure. Use only in development accounts.
go test ./... -v -sweep=us-east-1,us-west-2 -sweep-run=aws_lb
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
2018/09/10 13:48:24 [DEBUG] Running Sweepers for region (us-east-1):
2018/09/10 13:48:24 [INFO] Building AWS region structure
2018/09/10 13:48:24 [INFO] Building AWS auth structure
2018/09/10 13:48:24 [INFO] Setting AWS metadata API timeout to 100ms
2018/09/10 13:48:25 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/09/10 13:48:25 [INFO] AWS Auth provider used: "EnvProvider"
2018/09/10 13:48:25 [INFO] Initializing DeviceFarm SDK connection
2018/09/10 13:48:25 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/09/10 13:48:25 [DEBUG] No LBs to sweep
2018/09/10 13:48:25 [DEBUG] Sweeper (aws_lb_target_group) has dependency (aws_lb), running..
2018/09/10 13:48:25 [DEBUG] Sweeper (aws_lb) already ran in region (us-east-1)
2018/09/10 13:48:25 [INFO] Building AWS region structure
2018/09/10 13:48:25 [INFO] Building AWS auth structure
2018/09/10 13:48:25 [INFO] Setting AWS metadata API timeout to 100ms
2018/09/10 13:48:26 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/09/10 13:48:26 [INFO] AWS Auth provider used: "EnvProvider"
2018/09/10 13:48:26 [INFO] Initializing DeviceFarm SDK connection
2018/09/10 13:48:26 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/09/10 13:48:26 [DEBUG] No LB Target Groups to sweep
2018/09/10 13:48:26 Sweeper Tests ran:
	- aws_lb
	- aws_lb_target_group
2018/09/10 13:48:26 [DEBUG] Running Sweepers for region (us-west-2):
2018/09/10 13:48:26 [INFO] Building AWS region structure
2018/09/10 13:48:26 [INFO] Building AWS auth structure
2018/09/10 13:48:26 [INFO] Setting AWS metadata API timeout to 100ms
2018/09/10 13:48:27 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/09/10 13:48:27 [INFO] AWS Auth provider used: "EnvProvider"
2018/09/10 13:48:27 [INFO] Initializing DeviceFarm SDK connection
2018/09/10 13:48:27 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/09/10 13:48:28 [INFO] Deleting LB: testaccawslbaccesslog-wghk
2018/09/10 13:48:29 [DEBUG] Sweeper (aws_lb_target_group) has dependency (aws_lb), running..
2018/09/10 13:48:29 [DEBUG] Sweeper (aws_lb) already ran in region (us-west-2)
2018/09/10 13:48:29 [INFO] Building AWS region structure
2018/09/10 13:48:29 [INFO] Building AWS auth structure
2018/09/10 13:48:29 [INFO] Setting AWS metadata API timeout to 100ms
2018/09/10 13:48:29 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2018/09/10 13:48:29 [INFO] AWS Auth provider used: "EnvProvider"
2018/09/10 13:48:29 [INFO] Initializing DeviceFarm SDK connection
2018/09/10 13:48:29 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2018/09/10 13:48:30 [DEBUG] No LB Target Groups to sweep
2018/09/10 13:48:30 Sweeper Tests ran:
	- aws_lb
	- aws_lb_target_group
ok  	github.com/terraform-providers/terraform-provider-aws/aws	7.003s
```
