### PR TITLE
allow ipv4_address_count to be modifiable

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -319,7 +319,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						},
 						"ipv6_address_count": {
 							Type:     schema.TypeInt,
-							Computed: true,
+							Optional: true,
 						},
 						"ipv6_addresses": {
 							Type:     schema.TypeSet,
@@ -341,7 +341,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						},
 						"ipv4_address_count": {
 							Type:     schema.TypeInt,
-							Computed: true,
+							Optional: true,
 						},
 						"subnet_id": {
 							Type:     schema.TypeString,
@@ -1095,30 +1095,28 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 		}
 	}
 
-	ipv6AddressList := ni["ipv6_addresses"].(*schema.Set).List()
-	for _, address := range ipv6AddressList {
-		ipv6Addresses = append(ipv6Addresses, &ec2.InstanceIpv6AddressRequest{
-			Ipv6Address: aws.String(address.(string)),
-		})
-	}
-	networkInterface.Ipv6Addresses = ipv6Addresses
-
 	if v := ni["ipv6_address_count"].(int); v > 0 {
 		networkInterface.Ipv6AddressCount = aws.Int64(int64(v))
-	}
-
-	ipv4AddressList := ni["ipv4_addresses"].(*schema.Set).List()
-	for _, address := range ipv4AddressList {
-		privateIp := &ec2.PrivateIpAddressSpecification{
-			Primary:          aws.Bool(address.(string) == privateIpAddress),
-			PrivateIpAddress: aws.String(address.(string)),
+	} else if v := ni["ipv6_addresses"].(*schema.Set); v.Len() > 0 {
+		for _, address := range v.List() {
+			ipv6Addresses = append(ipv6Addresses, &ec2.InstanceIpv6AddressRequest{
+				Ipv6Address: aws.String(address.(string)),
+			})
 		}
-		ipv4Addresses = append(ipv4Addresses, privateIp)
+		networkInterface.Ipv6Addresses = ipv6Addresses
 	}
-	networkInterface.PrivateIpAddresses = ipv4Addresses
 
 	if v := ni["ipv4_address_count"].(int); v > 0 {
 		networkInterface.SecondaryPrivateIpAddressCount = aws.Int64(int64(v))
+	} else if v := ni["ipv4_addresses"].(*schema.Set); v.Len() > 0 {
+		for _, address := range v.List() {
+			privateIp := &ec2.PrivateIpAddressSpecification{
+				Primary:          aws.Bool(address.(string) == privateIpAddress),
+				PrivateIpAddress: aws.String(address.(string)),
+			}
+			ipv4Addresses = append(ipv4Addresses, privateIp)
+		}
+		networkInterface.PrivateIpAddresses = ipv4Addresses
 	}
 
 	return networkInterface

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -319,7 +319,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						},
 						"ipv6_address_count": {
 							Type:     schema.TypeInt,
-							Optional: true,
+							Computed: true,
 						},
 						"ipv6_addresses": {
 							Type:     schema.TypeSet,
@@ -1095,15 +1095,16 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 		}
 	}
 
+	ipv6AddressList := ni["ipv6_addresses"].(*schema.Set).List()
+	for _, address := range ipv6AddressList {
+		ipv6Addresses = append(ipv6Addresses, &ec2.InstanceIpv6AddressRequest{
+			Ipv6Address: aws.String(address.(string)),
+		})
+	}
+	networkInterface.Ipv6Addresses = ipv6Addresses
+
 	if v := ni["ipv6_address_count"].(int); v > 0 {
 		networkInterface.Ipv6AddressCount = aws.Int64(int64(v))
-	} else if v := ni["ipv6_addresses"].(*schema.Set); v.Len() > 0 {
-		for _, address := range v.List() {
-			ipv6Addresses = append(ipv6Addresses, &ec2.InstanceIpv6AddressRequest{
-				Ipv6Address: aws.String(address.(string)),
-			})
-		}
-		networkInterface.Ipv6Addresses = ipv6Addresses
 	}
 
 	if v := ni["ipv4_address_count"].(int); v > 0 {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -243,6 +243,8 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
 					resource.TestCheckResourceAttrSet(resName, "network_interfaces.0.network_interface_id"),
 					resource.TestCheckResourceAttr(resName, "network_interfaces.0.associate_public_ip_address", "false"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_address_count", "2"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv6_address_count", "3"),
 				),
 			},
 		},
@@ -525,6 +527,8 @@ resource "aws_launch_template" "test" {
 
   network_interfaces {
     network_interface_id = "${aws_network_interface.test.id}"
+    ipv4_address_count = 2
+    ipv6_address_count = 3
   }
 }
 `

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -244,7 +244,6 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "network_interfaces.0.network_interface_id"),
 					resource.TestCheckResourceAttr(resName, "network_interfaces.0.associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_address_count", "2"),
-					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv6_address_count", "3"),
 				),
 			},
 		},
@@ -528,7 +527,6 @@ resource "aws_launch_template" "test" {
   network_interfaces {
     network_interface_id = "${aws_network_interface.test.id}"
     ipv4_address_count = 2
-    ipv6_address_count = 3
   }
 }
 `

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -211,12 +211,12 @@ Each `network_interfaces` block supports the following:
 * `delete_on_termination` - Whether the network interface should be destroyed on instance termination.
 * `description` - Description of the network interface.
 * `device_index` - The integer index of the network interface attachment.
-* `ipv6_addresses` - One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet.
+* `ipv6_addresses` - One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. Conflicts with `ipv6_address_count`
 * `ipv6_address_count` - The number of IPv6 addresses to assign to a network interface. Conflicts with `ipv6_addresses`
 * `network_interface_id` - The ID of the network interface to attach.
 * `private_ip_address` - The primary private IPv4 address.
-* `ipv4_address_count` - The number of secondary private IPv4 addresses to assign to a network interface.
-* `ipv4_addresses` - One or more private IPv4 addresses to associate.
+* `ipv4_address_count` - The number of secondary private IPv4 addresses to assign to a network interface. Conflicts with `ipv4_address_count`
+* `ipv4_addresses` - One or more private IPv4 addresses to associate. Conflicts with `ipv4_addresses`
 * `security_groups` - A list of security group IDs to associate.
 * `subnet_id` - The VPC Subnet ID to associate.
 


### PR DESCRIPTION
Fixes #5851

Changes proposed in this pull request:

* allow ipv4_address_count to be modifiable

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (12.45s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (12.14s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (11.34s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (47.63s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (48.14s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (11.60s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (45.08s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (20.69s)
=== RUN   TestAccAWSLaunchTemplate_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_nonBurstable (11.49s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_networkInterface (28.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	249.303s
```
