### PR TITLE
Suppress task definition diffs for equivalent port mappings.

### DIFF
--- a/aws/ecs_task_definition_equivalency_test.go
+++ b/aws/ecs_task_definition_equivalency_test.go
@@ -78,7 +78,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_basic(t *testing.T) {
     }
 ]`
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,57 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_portMappings(t *testing.T) {
     }
 ]`
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equal {
+		t.Fatal("Expected definitions to be equal.")
+	}
+}
+
+func TestAwsEcsContainerDefinitionsAreEquivalent_portMappingsIgnoreHostPort(t *testing.T) {
+	cfgRepresention := `
+[
+    {
+      "name": "wordpress",
+      "image": "wordpress",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80
+        }
+      ]
+    }
+]`
+
+	apiRepresentation := `
+[
+    {
+      "name": "wordpress",
+      "image": "wordpress",
+      "portMappings": [
+        {
+          "containerPort": 80
+        }
+      ]
+    }
+]`
+
+	var (
+		equal bool
+		err   error
+	)
+
+	equal, err = ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal {
+		t.Fatal("Expected definitions to differ.")
+	}
+
+	equal, err = ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +428,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_arrays(t *testing.T) {
 ]
 `
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,7 +466,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_negative(t *testing.T) {
     }
 ]`
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation)
+	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -54,7 +54,9 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 					return json
 				},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					equal, _ := ecsContainerDefinitionsAreEquivalent(old, new)
+					networkMode, ok := d.GetOk("network_mode")
+					isAWSVPC := ok && networkMode.(string) == ecs.NetworkModeAwsvpc
+					equal, _ := ecsContainerDefinitionsAreEquivalent(old, new, isAWSVPC)
 					return equal
 				},
 				ValidateFunc: validateAwsEcsTaskDefinitionContainerDefinitions,


### PR DESCRIPTION
When using the `awsvpc` networking mode, aws assigns the value of
`containerPort` to the `hostPort` for each item in `portMappings`. This
leads to spurious diffs if the user doesn't set `hostPort`. This patch
suppresses diffs when using `awsvpc` networking and the `hostPort` field
is unset.

[Fixes #3401]

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (10.81s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (5.30s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (47.95s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (8.24s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (6.14s)
=== RUN   TestAccAWSEcsTaskDefinition_constraint
--- PASS: TestAccAWSEcsTaskDefinition_constraint (5.36s)
=== RUN   TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (10.78s)
=== RUN   TestAccAWSEcsTaskDefinition_arrays
--- PASS: TestAccAWSEcsTaskDefinition_arrays (4.83s)
=== RUN   TestAccAWSEcsTaskDefinition_Fargate
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (7.27s)
=== RUN   TestAccAWSEcsTaskDefinition_ExecutionRole
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (6.29s)
=== RUN   TestAccAWSEcsTaskDefinition_Inactive
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (11.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       124.882s
...
```