### PR TITLE
docs/resource/aws_api_gateway_deployment: Additional information about stage_name argument

### DIFF
--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -58,7 +58,7 @@ resource "aws_api_gateway_deployment" "MyDemoDeployment" {
 The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
-* `stage_name` - (Required) The name of the stage
+* `stage_name` - (Required) The name of the stage. If the specified stage already exists, it will be updated to point to the new deployment. If the stage does not exist, a new one will be created and point to this deployment. Use `""` to point at the default stage.
 * `description` - (Optional) The description of the deployment
 * `stage_description` - (Optional) The description of the stage
 * `variables` - (Optional) A map that defines variables for the stage


### PR DESCRIPTION
References:
* https://docs.aws.amazon.com/apigateway/api-reference/link-relation/deployment-create/
* #5723

Changes proposed in this pull request:

* Note behaviors of `stage_name` argument from upstream documentation

Output from acceptance testing: N/A
