### PR TITLE
resource/aws_s3_bucket: Prevent panics with various API read failures and prevent NoSuchBucket error on deletion

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -649,11 +649,8 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			log.Printf("[WARN] S3 Bucket (%s) not found, error code (404)", d.Id())
 			d.SetId("")
 			return nil
-		} else {
-			// some of the AWS SDK's errors can be empty strings, so let's add
-			// some additional context.
-			return fmt.Errorf("error reading S3 bucket \"%s\": %s", d.Id(), err)
 		}
+		return fmt.Errorf("error reading S3 Bucket (%s): %s", d.Id(), err)
 	}
 
 	// In the import case, we won't have this
@@ -697,21 +694,13 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	if err != nil {
-		// An S3 Bucket might not have CORS configuration set.
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() != "NoSuchCORSConfiguration" {
-				return err
-			}
-			log.Printf("[WARN] S3 bucket: %s, no CORS configuration could be found.", d.Id())
-		} else {
-			return err
-		}
+	if err != nil && !isAWSErr(err, "NoSuchCORSConfiguration", "") {
+		return fmt.Errorf("error getting S3 Bucket CORS configuration: %s", err)
 	}
-	cors := corsResponse.(*s3.GetBucketCorsOutput)
-	log.Printf("[DEBUG] S3 bucket: %s, read CORS: %v", d.Id(), cors)
-	if cors.CORSRules != nil {
-		rules := make([]map[string]interface{}, 0, len(cors.CORSRules))
+
+	corsRules := make([]map[string]interface{}, 0)
+	if cors, ok := corsResponse.(*s3.GetBucketCorsOutput); ok && len(cors.CORSRules) > 0 {
+		corsRules = make([]map[string]interface{}, 0, len(cors.CORSRules))
 		for _, ruleObject := range cors.CORSRules {
 			rule := make(map[string]interface{})
 			rule["allowed_headers"] = flattenStringList(ruleObject.AllowedHeaders)
@@ -724,16 +713,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			if ruleObject.MaxAgeSeconds != nil {
 				rule["max_age_seconds"] = int(*ruleObject.MaxAgeSeconds)
 			}
-			rules = append(rules, rule)
+			corsRules = append(corsRules, rule)
 		}
-		if err := d.Set("cors_rule", rules); err != nil {
-			return err
-		}
-	} else {
-		log.Printf("[DEBUG] S3 bucket: %s, read CORS: %v", d.Id(), cors)
-		if err := d.Set("cors_rule", make([]map[string]interface{}, 0)); err != nil {
-			return err
-		}
+	}
+	if err := d.Set("cors_rule", corsRules); err != nil {
+		return fmt.Errorf("error setting cors_rule: %s", err)
 	}
 
 	// Read the website configuration
@@ -742,9 +726,12 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	ws := wsResponse.(*s3.GetBucketWebsiteOutput)
-	var websites []map[string]interface{}
-	if err == nil {
+	if err != nil && !isAWSErr(err, "NotImplemented", "") && !isAWSErr(err, "NoSuchWebsiteConfiguration", "") {
+		return fmt.Errorf("error getting S3 Bucket website configuration: %s", err)
+	}
+
+	websites := make([]map[string]interface{}, 0, 1)
+	if ws, ok := wsResponse.(*s3.GetBucketWebsiteOutput); ok {
 		w := make(map[string]interface{})
 
 		if v := ws.IndexDocument; v != nil {
@@ -789,10 +776,14 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			w["routing_rules"] = rr
 		}
 
-		websites = append(websites, w)
+		// We have special handling for the website configuration,
+		// so only add the configuration if there is any
+		if len(w) > 0 {
+			websites = append(websites, w)
+		}
 	}
 	if err := d.Set("website", websites); err != nil {
-		return err
+		return fmt.Errorf("error setting website: %s", err)
 	}
 
 	// Read the versioning configuration
@@ -802,13 +793,12 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	versioning := versioningResponse.(*s3.GetBucketVersioningOutput)
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] S3 Bucket: %s, versioning: %v", d.Id(), versioning)
-	if versioning != nil {
-		vcl := make([]map[string]interface{}, 0, 1)
+
+	vcl := make([]map[string]interface{}, 0, 1)
+	if versioning, ok := versioningResponse.(*s3.GetBucketVersioningOutput); ok {
 		vc := make(map[string]interface{})
 		if versioning.Status != nil && *versioning.Status == s3.BucketVersioningStatusEnabled {
 			vc["enabled"] = true
@@ -822,9 +812,9 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			vc["mfa_delete"] = false
 		}
 		vcl = append(vcl, vc)
-		if err := d.Set("versioning", vcl); err != nil {
-			return err
-		}
+	}
+	if err := d.Set("versioning", vcl); err != nil {
+		return fmt.Errorf("error setting versioning: %s", err)
 	}
 
 	// Read the acceleration status
@@ -834,25 +824,12 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	accelerate := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput)
-	if err != nil {
-		// Amazon S3 Transfer Acceleration might not be supported in the
-		// given region, for example, China (Beijing) and the Government
-		// Cloud does not support this feature at the moment.
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() != "UnsupportedArgument" {
-			return err
-		}
 
-		var awsRegion string
-		if region, ok := d.GetOk("region"); ok {
-			awsRegion = region.(string)
-		} else {
-			awsRegion = meta.(*AWSClient).region
-		}
-
-		log.Printf("[WARN] S3 bucket: %s, the S3 Transfer Acceleration is not supported in the region: %s", d.Id(), awsRegion)
-	} else {
-		log.Printf("[DEBUG] S3 bucket: %s, read Acceleration: %v", d.Id(), accelerate)
+	// Amazon S3 Transfer Acceleration might not be supported in the region
+	if err != nil && !isAWSErr(err, "UnsupportedArgument", "") {
+		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
+	}
+	if accelerate, ok := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput); ok {
 		d.Set("acceleration_status", accelerate.Status)
 	}
 
@@ -863,15 +840,13 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	payer := payerResponse.(*s3.GetBucketRequestPaymentOutput)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting S3 Bucket request payment: %s", err)
 	}
-	log.Printf("[DEBUG] S3 Bucket: %s, read request payer: %v", d.Id(), payer)
-	if payer.Payer != nil {
-		if err := d.Set("request_payer", *payer.Payer); err != nil {
-			return err
-		}
+
+	if payer, ok := payerResponse.(*s3.GetBucketRequestPaymentOutput); ok {
+		d.Set("request_payer", payer.Payer)
 	}
 
 	// Read the logging configuration
@@ -880,14 +855,14 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	logging := loggingResponse.(*s3.GetBucketLoggingOutput)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting S3 Bucket logging: %s", err)
 	}
 
-	log.Printf("[DEBUG] S3 Bucket: %s, logging: %v", d.Id(), logging)
 	lcl := make([]map[string]interface{}, 0, 1)
-	if v := logging.LoggingEnabled; v != nil {
+	if logging, ok := loggingResponse.(*s3.GetBucketLoggingOutput); ok && logging.LoggingEnabled != nil {
+		v := logging.LoggingEnabled
 		lc := make(map[string]interface{})
 		if *v.TargetBucket != "" {
 			lc["target_bucket"] = *v.TargetBucket
@@ -898,7 +873,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		lcl = append(lcl, lc)
 	}
 	if err := d.Set("logging", lcl); err != nil {
-		return err
+		return fmt.Errorf("error setting logging: %s", err)
 	}
 
 	// Read the lifecycle configuration
@@ -908,14 +883,13 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	if err != nil {
-		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() != 404 {
-			return err
-		}
+	if err != nil && !isAWSErr(err, "NoSuchLifecycleConfiguration", "") {
+		return err
 	}
+
+	lifecycleRules := make([]map[string]interface{}, 0)
 	if lifecycle, ok := lifecycleResponse.(*s3.GetBucketLifecycleConfigurationOutput); ok && len(lifecycle.Rules) > 0 {
-		log.Printf("[DEBUG] S3 Bucket: %s, lifecycle: %v", d.Id(), lifecycle)
-		rules := make([]map[string]interface{}, 0, len(lifecycle.Rules))
+		lifecycleRules = make([]map[string]interface{}, 0, len(lifecycle.Rules))
 
 		for _, lifecycleRule := range lifecycle.Rules {
 			rule := make(map[string]interface{})
@@ -1019,12 +993,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 				rule["noncurrent_version_transition"] = schema.NewSet(transitionHash, transitions)
 			}
 
-			rules = append(rules, rule)
+			lifecycleRules = append(lifecycleRules, rule)
 		}
-
-		if err := d.Set("lifecycle_rule", rules); err != nil {
-			return err
-		}
+	}
+	if err := d.Set("lifecycle_rule", lifecycleRules); err != nil {
+		return fmt.Errorf("error setting lifecycle_rule: %s", err)
 	}
 
 	// Read the bucket replication configuration
@@ -1034,17 +1007,16 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	if err != nil {
-		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() != 404 {
-			return err
-		}
+	if err != nil && !isAWSErr(err, "ReplicationConfigurationNotFoundError", "") {
+		return fmt.Errorf("error getting S3 Bucket replication: %s", err)
 	}
-	replication := replicationResponse.(*s3.GetBucketReplicationOutput)
 
-	log.Printf("[DEBUG] S3 Bucket: %s, read replication configuration: %v", d.Id(), replication)
-	if err := d.Set("replication_configuration", flattenAwsS3BucketReplicationConfiguration(replication.ReplicationConfiguration)); err != nil {
-		log.Printf("[DEBUG] Error setting replication configuration: %s", err)
-		return err
+	replicationConfiguration := make([]map[string]interface{}, 0)
+	if replication, ok := replicationResponse.(*s3.GetBucketReplicationOutput); ok {
+		replicationConfiguration = flattenAwsS3BucketReplicationConfiguration(replication.ReplicationConfiguration)
+	}
+	if err := d.Set("replication_configuration", replicationConfiguration); err != nil {
+		return fmt.Errorf("error setting replication_configuration: %s", err)
 	}
 
 	// Read the bucket server side encryption configuration
@@ -1054,22 +1026,16 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
-	if err != nil {
-		if isAWSErr(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
-			log.Printf("[DEBUG] Default encryption is not enabled for %s", d.Id())
-			d.Set("server_side_encryption_configuration", []map[string]interface{}{})
-		} else {
-			return err
-		}
-	} else {
-		encryption := encryptionResponse.(*s3.GetBucketEncryptionOutput)
-		log.Printf("[DEBUG] S3 Bucket: %s, read encryption configuration: %v", d.Id(), encryption)
-		if c := encryption.ServerSideEncryptionConfiguration; c != nil {
-			if err := d.Set("server_side_encryption_configuration", flattenAwsS3ServerSideEncryptionConfiguration(c)); err != nil {
-				log.Printf("[DEBUG] Error setting server side encryption configuration: %s", err)
-				return err
-			}
-		}
+	if err != nil && !isAWSErr(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
+		return fmt.Errorf("error getting S3 Bucket encryption: %s", err)
+	}
+
+	serverSideEncryptionConfiguration := make([]map[string]interface{}, 0)
+	if encryption, ok := encryptionResponse.(*s3.GetBucketEncryptionOutput); ok && encryption.ServerSideEncryptionConfiguration != nil {
+		serverSideEncryptionConfiguration = flattenAwsS3ServerSideEncryptionConfiguration(encryption.ServerSideEncryptionConfiguration)
+	}
+	if err := d.Set("server_side_encryption_configuration", serverSideEncryptionConfiguration); err != nil {
+		return fmt.Errorf("error setting server_side_encryption_configuration: %s", err)
 	}
 
 	// Add the region as an attribute
@@ -1082,11 +1048,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		)
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting S3 Bucket location: %s", err)
 	}
-	location := locationResponse.(*s3.GetBucketLocationOutput)
+
 	var region string
-	if location.LocationConstraint != nil {
+	if location, ok := locationResponse.(*s3.GetBucketLocationOutput); ok && location.LocationConstraint != nil {
 		region = *location.LocationConstraint
 	}
 	region = normalizeRegion(region)
@@ -1149,64 +1115,70 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 	_, err := s3conn.DeleteBucket(&s3.DeleteBucketInput{
 		Bucket: aws.String(d.Id()),
 	})
-	if err != nil {
-		ec2err, ok := err.(awserr.Error)
-		if ok && ec2err.Code() == "BucketNotEmpty" {
-			if d.Get("force_destroy").(bool) {
-				// bucket may have things delete them
-				log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %+v", err)
 
-				bucket := d.Get("bucket").(string)
-				resp, err := s3conn.ListObjectVersions(
-					&s3.ListObjectVersionsInput{
-						Bucket: aws.String(bucket),
-					},
-				)
-
-				if err != nil {
-					return fmt.Errorf("Error S3 Bucket list Object Versions err: %s", err)
-				}
-
-				objectsToDelete := make([]*s3.ObjectIdentifier, 0)
-
-				if len(resp.DeleteMarkers) != 0 {
-
-					for _, v := range resp.DeleteMarkers {
-						objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
-							Key:       v.Key,
-							VersionId: v.VersionId,
-						})
-					}
-				}
-
-				if len(resp.Versions) != 0 {
-					for _, v := range resp.Versions {
-						objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
-							Key:       v.Key,
-							VersionId: v.VersionId,
-						})
-					}
-				}
-
-				params := &s3.DeleteObjectsInput{
-					Bucket: aws.String(bucket),
-					Delete: &s3.Delete{
-						Objects: objectsToDelete,
-					},
-				}
-
-				_, err = s3conn.DeleteObjects(params)
-
-				if err != nil {
-					return fmt.Errorf("Error S3 Bucket force_destroy error deleting: %s", err)
-				}
-
-				// this line recurses until all objects are deleted or an error is returned
-				return resourceAwsS3BucketDelete(d, meta)
-			}
-		}
-		return fmt.Errorf("Error deleting S3 Bucket: %s %q", err, d.Get("bucket").(string))
+	if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") {
+		return nil
 	}
+
+	if isAWSErr(err, "BucketNotEmpty", "") {
+		if d.Get("force_destroy").(bool) {
+			// bucket may have things delete them
+			log.Printf("[DEBUG] S3 Bucket attempting to forceDestroy %+v", err)
+
+			bucket := d.Get("bucket").(string)
+			resp, err := s3conn.ListObjectVersions(
+				&s3.ListObjectVersionsInput{
+					Bucket: aws.String(bucket),
+				},
+			)
+
+			if err != nil {
+				return fmt.Errorf("Error S3 Bucket list Object Versions err: %s", err)
+			}
+
+			objectsToDelete := make([]*s3.ObjectIdentifier, 0)
+
+			if len(resp.DeleteMarkers) != 0 {
+
+				for _, v := range resp.DeleteMarkers {
+					objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
+						Key:       v.Key,
+						VersionId: v.VersionId,
+					})
+				}
+			}
+
+			if len(resp.Versions) != 0 {
+				for _, v := range resp.Versions {
+					objectsToDelete = append(objectsToDelete, &s3.ObjectIdentifier{
+						Key:       v.Key,
+						VersionId: v.VersionId,
+					})
+				}
+			}
+
+			params := &s3.DeleteObjectsInput{
+				Bucket: aws.String(bucket),
+				Delete: &s3.Delete{
+					Objects: objectsToDelete,
+				},
+			}
+
+			_, err = s3conn.DeleteObjects(params)
+
+			if err != nil {
+				return fmt.Errorf("Error S3 Bucket force_destroy error deleting: %s", err)
+			}
+
+			// this line recurses until all objects are deleted or an error is returned
+			return resourceAwsS3BucketDelete(d, meta)
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting S3 Bucket (%s): %s", d.Id(), err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Rather than continue to piecemeal these interface conversion fixes, this implements them consistently all at once. Prevent panics such as these:

```
panic: interface conversion: interface {} is nil, not *s3.GetBucketLoggingOutput
2018-09-11T18:24:29.493Z [DEBUG] plugin.terraform-provider-aws_v1.22.0_x4: 
2018-09-11T18:24:29.493Z [DEBUG] plugin.terraform-provider-aws_v1.22.0_x4: goroutine 2526 [running]:
2018-09-11T18:24:29.493Z [DEBUG] plugin.terraform-provider-aws_v1.22.0_x4: github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsS3BucketRead(0xc42786ce70, 0x28a1460, 0xc4247fa000, 0xc42786ce70, 0x0)
2018-09-11T18:24:29.493Z [DEBUG] plugin.terraform-provider-aws_v1.22.0_x4: 	/opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_s3_bucket.go:877 +0x5d39
```

Ran across the `NoSuchBucket` error on deletion during testing:

```
--- FAIL: TestAccAWSS3Bucket_Cors_EmptyOrigin (45.32s)
    testing.go:588: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Error applying: 1 error occurred:
        	* aws_s3_bucket.bucket (destroy): 1 error occurred:
        	* aws_s3_bucket.bucket: Error deleting S3 Bucket: NoSuchBucket: The specified bucket does not exist
```

Aside from those cleans up some old issues/PRs as part of the consistency effort:

Closes #3459
Closes #3603
Closes #3620

Changes proposed in this pull request:

* Prevent panic with `GetBucketWebsite` interface conversion
* Prevent panic with `GetBucketVersioning` interface conversion
* Prevent panic with `GetBucketAccelerateConfiguration` interface conversion
* Prevent panic with `GetBucketRequestPayment` interface conversion
* Prevent panic with `GetBucketLogging` interface conversion
* Prevent panic with `GetBucketReplication` interface conversion
* Prevent panic with `GetBucketEncryption` interface conversion
* Prevent panic with `GetBucketLocation` interface conversion
* Return successfully on `NoSuchBucket` error during deletion
* Consistently perform read and error logic
* Split `TestAccAWSS3Bucket_Cors` for testing stability (eventual consistency issues) and best practices (1 `resource.Test` per acceptance test)

Output from acceptance testing:

```
--- PASS: TestAccAWSS3Bucket_namePrefix (5.44s)
--- PASS: TestAccAWSS3Bucket_basic (5.55s)
--- PASS: TestAccAWSS3Bucket_generatedName (5.59s)
--- PASS: TestAccAWSS3Bucket_importWithPolicy (6.36s)
--- PASS: TestAccAWSS3Bucket_importBasic (6.37s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (9.46s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (10.84s)
--- PASS: TestAccAWSS3Bucket_Policy (15.73s)
--- PASS: TestAccAWSS3Bucket_acceleration (20.32s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (12.87s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (14.30s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (6.14s)
--- PASS: TestAccAWSS3Bucket_region (29.96s)
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (4.15s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (11.38s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (22.50s)
--- PASS: TestAccAWSS3Bucket_Versioning (12.68s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (9.86s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (5.56s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (5.47s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (25.40s)
--- PASS: TestAccAWSS3Bucket_Lifecycle (78.61s)
--- PASS: TestAccAWSS3Bucket_Logging (7.32s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (9.55s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (25.98s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (38.67s)
--- PASS: TestAccAWSS3Bucket_Replication (113.15s)
```
