### PR TITLE
[WIP] Issue #4633 retry lambda creation

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -382,6 +382,10 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 				log.Printf("[DEBUG] Received %s, retrying CreateFunction", err)
 				return resource.RetryableError(err)
 			}
+			if isAWSErr(err, "InvalidParameterValueException", "Lambda was unable to configure access to your environment variables because the KMS key is invalid for CreateGrant") {
+				log.Printf("[DEBUG] Received %s, retrying CreateFunction", err)
+				return resource.RetryableError(err)
+			}
 
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
Treat the error 'Lambda was unable to configure access to your
environment variables because the KMS key is invalid for CreateGrant' as
retryable. The root cause seems to be (?) that the required role hasn't
fully been created when the lamdba creation is attmpted (but hard to
know). The failure is intermittent and does not occur on retry.

Fixes #4633

Changes proposed in this pull request:

* Retry lambda creation after receiving error with text 'Lambda was unable to configure access to your environment variables because the KMS key is invalid for CreateGrant'

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

<not run yet>
```
