### PR TITLE
resource/aws_config_config_rule: Prevent panic when specifying empty scope

### DIFF
--- a/aws/resource_aws_config_config_rule.go
+++ b/aws/resource_aws_config_config_rule.go
@@ -146,12 +146,8 @@ func resourceAwsConfigConfigRulePut(d *schema.ResourceData, meta interface{}) er
 	name := d.Get("name").(string)
 	ruleInput := configservice.ConfigRule{
 		ConfigRuleName: aws.String(name),
+		Scope:          expandConfigRuleScope(d.Get("scope").([]interface{})),
 		Source:         expandConfigRuleSource(d.Get("source").([]interface{})),
-	}
-
-	scopes := d.Get("scope").([]interface{})
-	if len(scopes) > 0 {
-		ruleInput.Scope = expandConfigRuleScope(scopes[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_config_config_rule_test.go
+++ b/aws/resource_aws_config_config_rule_test.go
@@ -159,6 +159,86 @@ func testAccConfigConfigRule_importLambda(t *testing.T) {
 	})
 }
 
+func testAccConfigConfigRule_Scope_TagKey(t *testing.T) {
+	var configRule configservice.ConfigRule
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_config_rule.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigConfigRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigConfigRuleConfig_Scope_TagKey(rName, "key1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &configRule),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.tag_key", "key1"),
+				),
+			},
+			{
+				Config: testAccConfigConfigRuleConfig_Scope_TagKey(rName, "key2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &configRule),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.tag_key", "key2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigConfigRule_Scope_TagKey_Empty(t *testing.T) {
+	var configRule configservice.ConfigRule
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_config_rule.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigConfigRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigConfigRuleConfig_Scope_TagKey(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &configRule),
+				),
+			},
+		},
+	})
+}
+
+func testAccConfigConfigRule_Scope_TagValue(t *testing.T) {
+	var configRule configservice.ConfigRule
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_config_config_rule.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckConfigConfigRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigConfigRuleConfig_Scope_TagValue(rName, "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &configRule),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.tag_value", "value1"),
+				),
+			},
+			{
+				Config: testAccConfigConfigRuleConfig_Scope_TagValue(rName, "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigConfigRuleExists(resourceName, &configRule),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.tag_value", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckConfigConfigRuleName(n, desired string, obj *configservice.ConfigRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -222,6 +302,42 @@ func testAccCheckConfigConfigRuleDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccConfigConfigRuleConfig_base(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_config_configuration_recorder" "test" {
+  name     = %q
+  role_arn = "${aws_iam_role.test.arn}"
+}
+
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSConfigRole"
+  role       = "${aws_iam_role.test.name}"
+}
+`, rName, rName)
 }
 
 func testAccConfigConfigRuleConfig_basic(randInt int) string {
@@ -470,4 +586,43 @@ resource "aws_iam_role_policy" "p" {
 }
 POLICY
 }`, randInt, path, randInt, randInt, randInt, randInt, randInt, randInt, randInt)
+}
+
+func testAccConfigConfigRuleConfig_Scope_TagKey(rName, tagKey string) string {
+	return testAccConfigConfigRuleConfig_base(rName) + fmt.Sprintf(`
+resource "aws_config_config_rule" "test" {
+  name = %q
+
+  scope {
+    tag_key = %q
+  }
+
+  source {
+    owner = "AWS"
+    source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
+  }
+
+  depends_on = ["aws_config_configuration_recorder.test"]
+}
+`, rName, tagKey)
+}
+
+func testAccConfigConfigRuleConfig_Scope_TagValue(rName, tagValue string) string {
+	return testAccConfigConfigRuleConfig_base(rName) + fmt.Sprintf(`
+resource "aws_config_config_rule" "test" {
+  name = %q
+
+  scope {
+    tag_key   = "key"
+    tag_value = %q
+  }
+
+  source {
+    owner = "AWS"
+    source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
+  }
+
+  depends_on = ["aws_config_configuration_recorder.test"]
+}
+`, rName, tagValue)
 }

--- a/aws/resource_aws_config_test.go
+++ b/aws/resource_aws_config_test.go
@@ -7,11 +7,14 @@ import (
 func TestAccAWSConfig(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Config": {
-			"basic":        testAccConfigConfigRule_basic,
-			"ownerAws":     testAccConfigConfigRule_ownerAws,
-			"customlambda": testAccConfigConfigRule_customlambda,
-			"importAws":    testAccConfigConfigRule_importAws,
-			"importLambda": testAccConfigConfigRule_importLambda,
+			"basic":            testAccConfigConfigRule_basic,
+			"ownerAws":         testAccConfigConfigRule_ownerAws,
+			"customlambda":     testAccConfigConfigRule_customlambda,
+			"importAws":        testAccConfigConfigRule_importAws,
+			"importLambda":     testAccConfigConfigRule_importLambda,
+			"scopeTagKey":      testAccConfigConfigRule_Scope_TagKey,
+			"scopeTagKeyEmpty": testAccConfigConfigRule_Scope_TagKey_Empty,
+			"scopeTagValue":    testAccConfigConfigRule_Scope_TagValue,
 		},
 		"ConfigurationRecorderStatus": {
 			"basic":        testAccConfigConfigurationRecorderStatus_basic,

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2201,7 +2201,11 @@ func flattenConfigRuleScope(scope *configservice.Scope) []interface{} {
 	return items
 }
 
-func expandConfigRuleScope(configured map[string]interface{}) *configservice.Scope {
+func expandConfigRuleScope(l []interface{}) *configservice.Scope {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	configured := l[0].(map[string]interface{})
 	scope := &configservice.Scope{}
 
 	if v, ok := configured["compliance_resource_id"].(string); ok && v != "" {


### PR DESCRIPTION
Previously:

```
=== RUN   TestAccAWSConfig/Config/scopeTagKeyEmpty
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 1709 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsConfigConfigRulePut(0xc0002e8fc0, 0x3c46240, 0xc0000b2600, 0x24, 0x71ead40)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_config_config_rule.go:154 +0x7e6
```

Fixes #5848 

Changes proposed in this pull request:

* Perform `nil` check on first `scope` element to prevent panic

Output from acceptance testing:

```
    --- PASS: TestAccAWSConfig/Config (813.73s)
        --- PASS: TestAccAWSConfig/Config/scopeTagKeyEmpty (92.12s)
        --- PASS: TestAccAWSConfig/Config/scopeTagValue (102.35s)
        --- PASS: TestAccAWSConfig/Config/basic (89.41s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (89.83s)
        --- PASS: TestAccAWSConfig/Config/customlambda (117.45s)
        --- PASS: TestAccAWSConfig/Config/importAws (92.53s)
        --- PASS: TestAccAWSConfig/Config/importLambda (128.34s)
        --- PASS: TestAccAWSConfig/Config/scopeTagKey (101.71s)
```
