### PR TITLE
Allow empty permissions_boundary attribute on aws_iam_user

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsIamUser() *schema.Resource {
@@ -54,7 +53,7 @@ func resourceAwsIamUser() *schema.Resource {
 			"permissions_boundary": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(20, 2048),
+				ValidateFunc: validateMaxLength(2048),
 			},
 			"force_destroy": {
 				Type:        schema.TypeBool,

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -178,6 +178,7 @@ func TestAccAWSUser_permissionsBoundary(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserExists(resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
+					testAccCheckAWSUserPermissionsBoundary(&user, permissionsBoundary1),
 				),
 			},
 			// Test update
@@ -186,6 +187,7 @@ func TestAccAWSUser_permissionsBoundary(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserExists(resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary2),
+					testAccCheckAWSUserPermissionsBoundary(&user, permissionsBoundary2),
 				),
 			},
 			// Test import
@@ -201,6 +203,7 @@ func TestAccAWSUser_permissionsBoundary(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserExists(resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
+					testAccCheckAWSUserPermissionsBoundary(&user, ""),
 				),
 			},
 			// Test addition
@@ -209,6 +212,16 @@ func TestAccAWSUser_permissionsBoundary(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserExists(resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", permissionsBoundary1),
+					testAccCheckAWSUserPermissionsBoundary(&user, permissionsBoundary1),
+				),
+			},
+			// Test empty value
+			{
+				Config: testAccAWSUserConfig_permissionsBoundary(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSUserExists(resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "permissions_boundary", ""),
+					testAccCheckAWSUserPermissionsBoundary(&user, ""),
 				),
 			},
 		},
@@ -291,6 +304,22 @@ func testAccCheckAWSUserDisappears(getUserOutput *iam.GetUserOutput) resource.Te
 		})
 		if err != nil {
 			return fmt.Errorf("error deleting user %q: %s", userName, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSUserPermissionsBoundary(getUserOutput *iam.GetUserOutput, expectedPermissionsBoundaryArn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		actualPermissionsBoundaryArn := ""
+
+		if getUserOutput.User.PermissionsBoundary != nil {
+			actualPermissionsBoundaryArn = *getUserOutput.User.PermissionsBoundary.PermissionsBoundaryArn
+		}
+
+		if actualPermissionsBoundaryArn != expectedPermissionsBoundaryArn {
+			return fmt.Errorf("PermissionsBoundary: '%q', expected '%q'.", actualPermissionsBoundaryArn, expectedPermissionsBoundaryArn)
 		}
 
 		return nil


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5858

Changes proposed in this pull request:

* Allow empty `permissions_boundary` attribute for `aws_iam_user`, and treat it as an absent value.
* Add `testAccCheckAWSUserPermissionsBoundary` in `aws_iam_user` acceptance tests to check the value of the attribute on the AWS side.

Output from acceptance testing:

```
$ make testacc TESTARGS="-run TestAccAWSUser"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run TestAccAWSUser -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSUser_importBasic
--- PASS: TestAccAWSUser_importBasic (23.48s)
=== RUN   TestAccAWSUserGroupMembership_basic
--- PASS: TestAccAWSUserGroupMembership_basic (107.94s)
=== RUN   TestAccAWSUserLoginProfile_basic
--- PASS: TestAccAWSUserLoginProfile_basic (42.09s)
=== RUN   TestAccAWSUserLoginProfile_keybase
--- PASS: TestAccAWSUserLoginProfile_keybase (31.77s)
=== RUN   TestAccAWSUserLoginProfile_keybaseDoesntExist
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (24.00s)
=== RUN   TestAccAWSUserLoginProfile_notAKey
--- PASS: TestAccAWSUserLoginProfile_notAKey (23.79s)
=== RUN   TestAccAWSUserLoginProfile_PasswordLength
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (33.17s)
=== RUN   TestAccAWSUserPolicyAttachment_basic
--- PASS: TestAccAWSUserPolicyAttachment_basic (47.15s)
=== RUN   TestAccAWSUserSSHKey_basic
--- PASS: TestAccAWSUserSSHKey_basic (25.76s)
=== RUN   TestAccAWSUserSSHKey_pemEncoding
--- PASS: TestAccAWSUserSSHKey_pemEncoding (25.44s)
=== RUN   TestAccAWSUser_basic
--- PASS: TestAccAWSUser_basic (36.87s)
=== RUN   TestAccAWSUser_disappears
--- PASS: TestAccAWSUser_disappears (14.90s)
=== RUN   TestAccAWSUser_nameChange
--- PASS: TestAccAWSUser_nameChange (35.99s)
=== RUN   TestAccAWSUser_pathChange
--- PASS: TestAccAWSUser_pathChange (36.32s)
=== RUN   TestAccAWSUser_permissionsBoundary
--- PASS: TestAccAWSUser_permissionsBoundary (83.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	592.197s
```
