### PR TITLE
[WIP] Add initial container definitions data source.

### DIFF
--- a/aws/data_source_aws_ecs_container_definitions.go
+++ b/aws/data_source_aws_ecs_container_definitions.go
@@ -1,0 +1,106 @@
+package aws
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEcsContainerDefinitions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEcsContainerDefinitionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"container_definitions": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"image": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"memory": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"port_mappings": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"container_port": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+									"host_port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"command": {
+							Type:     schema.TypeList,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Optional: true,
+						},
+					},
+				},
+			},
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEcsContainerDefinitionsRead(d *schema.ResourceData, meta interface{}) error {
+	awsDefinitions := []ecs.ContainerDefinition{}
+	for _, rawDefinition := range d.Get("container_definitions").(*schema.Set).List() {
+		definition := rawDefinition.(map[string]interface{})
+		awsDefinition := ecs.ContainerDefinition{}
+		awsDefinition.Name = aws.String(definition["name"].(string))
+		awsDefinition.Image = aws.String(definition["image"].(string))
+		for _, rawMapping := range definition["port_mappings"].(*schema.Set).List() {
+			mapping := rawMapping.(map[string]interface{})
+			awsMapping := &ecs.PortMapping{}
+			awsMapping.ContainerPort = aws.Int64(int64(mapping["container_port"].(int)))
+			if hostPort, ok := mapping["host_port"].(int); ok {
+				awsMapping.HostPort = aws.Int64(int64(hostPort))
+			}
+			if protocol, ok := mapping["protocol"].(string); ok {
+				awsMapping.Protocol = aws.String(protocol)
+			}
+			awsDefinition.PortMappings = append(awsDefinition.PortMappings, awsMapping)
+		}
+		for _, rawCommand := range definition["command"].([]interface{}) {
+			awsDefinition.Command = append(awsDefinition.Command, aws.String(rawCommand.(string)))
+		}
+		awsDefinitions = append(awsDefinitions, awsDefinition)
+	}
+
+	jsonBytes, err := json.Marshal(awsDefinitions)
+	if err != nil {
+		return err
+	}
+
+	jsonString := string(jsonBytes)
+
+	d.Set("json", jsonString)
+	d.SetId(strconv.Itoa(hashcode.String(jsonString)))
+	return nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -192,6 +192,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ecr_repository":                   dataSourceAwsEcrRepository(),
 			"aws_ecs_cluster":                      dataSourceAwsEcsCluster(),
 			"aws_ecs_container_definition":         dataSourceAwsEcsContainerDefinition(),
+			"aws_ecs_container_definitions":        dataSourceAwsEcsContainerDefinitions(),
 			"aws_ecs_service":                      dataSourceAwsEcsService(),
 			"aws_ecs_task_definition":              dataSourceAwsEcsTaskDefinition(),
 			"aws_efs_file_system":                  dataSourceAwsEfsFileSystem(),


### PR DESCRIPTION
This is an early WIP that I'm submitting for feedback--don't use it yet! I would like to define ecs container definitions in hcl directly, without writing templated json, much like https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html for iam policies. This new resource allows users to define container definitions like so:

```
data "aws_ecs_container_definitions" "test" {
  container_definitions {
    name = "container1"
    image = "image1"
    port_mappings {
      container_port = 5000
    }
  }
  container_definitions {
    name = "container2"
    image = "image2"
  }
}

output "container_json" {
  value = "${data.aws_ecs_container_definitions.test.json}"
}
```

If the use case makes sense, I'll flesh this out, write tests, make the code nicer, etc. WDYT @bflad ?