### PR TITLE
New resource: aws_iot_policy_attachment

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -473,6 +473,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_internet_gateway":                             resourceAwsInternetGateway(),
 			"aws_iot_certificate":                              resourceAwsIotCertificate(),
 			"aws_iot_policy":                                   resourceAwsIotPolicy(),
+			"aws_iot_policy_attachment":                        resourceAwsIotPolicyAttachment(),
 			"aws_iot_thing":                                    resourceAwsIotThing(),
 			"aws_iot_thing_type":                               resourceAwsIotThingType(),
 			"aws_iot_topic_rule":                               resourceAwsIotTopicRule(),

--- a/aws/resource_aws_iot_policy_attachment.go
+++ b/aws/resource_aws_iot_policy_attachment.go
@@ -116,6 +116,7 @@ func resourceAwsIotPolicyAttachmentDelete(d *schema.ResourceData, meta interface
 
 	if err != nil {
 		log.Printf("[ERROR] Error detaching policy %s from target %s: %s", policyName, target, err)
+		return err
 	}
 
 	return nil

--- a/aws/resource_aws_iot_policy_attachment.go
+++ b/aws/resource_aws_iot_policy_attachment.go
@@ -1,0 +1,122 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsIotPolicyAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIotPolicyAttachmentCreate,
+		Read:   resourceAwsIotPolicyAttachmentRead,
+		Delete: resourceAwsIotPolicyAttachmentDelete,
+		Schema: map[string]*schema.Schema{
+			"policy": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"target": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsIotPolicyAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	policyName := d.Get("policy").(string)
+	target := d.Get("target").(string)
+
+	_, err := conn.AttachPolicy(&iot.AttachPolicyInput{
+		PolicyName: aws.String(policyName),
+		Target:     aws.String(target),
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Error attaching policy %s to target %s: %s", policyName, target, err)
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s|%s", policyName, target))
+	return resourceAwsIotPolicyAttachmentRead(d, meta)
+}
+
+func listIotPolicyAttachmentPages(c *iot.IoT, input *iot.ListAttachedPoliciesInput,
+	fn func(out *iot.ListAttachedPoliciesOutput, lastPage bool) bool) error {
+	for {
+		page, err := c.ListAttachedPolicies(input)
+		if err != nil {
+			return err
+		}
+		lastPage := page.NextMarker == nil
+
+		shouldContinue := fn(page, lastPage)
+		if !shouldContinue || lastPage {
+			break
+		}
+		input.Marker = page.NextMarker
+	}
+	return nil
+}
+
+func resourceAwsIotPolicyAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	policyName := d.Get("policy").(string)
+	target := d.Get("target").(string)
+
+	var policy *iot.Policy
+
+	err := listIotPolicyAttachmentPages(conn, &iot.ListAttachedPoliciesInput{
+		PageSize:  aws.Int64(250),
+		Recursive: aws.Bool(false),
+		Target:    aws.String(target),
+	}, func(out *iot.ListAttachedPoliciesOutput, lastPage bool) bool {
+		for _, att := range out.Policies {
+			name := aws.StringValue(att.PolicyName)
+			if name == policyName {
+				policy = att
+				return false
+			}
+		}
+		return true
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Error listing policy attachments for target %s: %s", target, err)
+		return err
+	}
+
+	if policy == nil {
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceAwsIotPolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	policyName := d.Get("policy").(string)
+	target := d.Get("target").(string)
+
+	_, err := conn.DetachPolicy(&iot.DetachPolicyInput{
+		PolicyName: aws.String(policyName),
+		Target:     aws.String(target),
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Error detaching policy %s from target %s: %s", policyName, target, err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_iot_policy_attachment_test.go
+++ b/aws/resource_aws_iot_policy_attachment_test.go
@@ -11,18 +11,44 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIoTPolicyAttachment_basic(t *testing.T) {
+func TestAccAWSIotPolicyAttachment_basic(t *testing.T) {
 	policyName := acctest.RandomWithPrefix("PolicyName-")
+	policyName2 := acctest.RandomWithPrefix("PolicyName2-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSIoTPolicyAttchmentDestroy_basic,
+		CheckDestroy: testAccCheckAWSIotPolicyAttchmentDestroy_basic,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSIoTPolicyAttachmentConfig(policyName),
+				Config: testAccAWSIotPolicyAttachmentConfig(policyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIoTPolicyAttachmentExists("aws_iot_policy_attachment.att"),
+					testAccCheckAWSIotPolicyAttachmentExists("aws_iot_policy_attachment.att", 1),
+					testAccCheckAWSIotPolicyAttachmentCertStatus("aws_iot_certificate.cert", []string{policyName}),
+				),
+			},
+			{
+				Config: testAccAWSIotPolicyAttachmentConfigUpdate1(policyName, policyName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotPolicyAttachmentExists("aws_iot_policy_attachment.att", 2),
+					testAccCheckAWSIotPolicyAttachmentExists("aws_iot_policy_attachment.att2", 2),
+					testAccCheckAWSIotPolicyAttachmentCertStatus("aws_iot_certificate.cert", []string{policyName, policyName2}),
+				),
+			},
+			{
+				Config: testAccAWSIotPolicyAttachmentConfigUpdate2(policyName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotPolicyAttachmentExists("aws_iot_policy_attachment.att2", 1),
+					testAccCheckAWSIotPolicyAttachmentCertStatus("aws_iot_certificate.cert", []string{policyName2}),
+				),
+			},
+			{
+				Config: testAccAWSIotPolicyAttachmentConfigUpdate3(policyName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotPolicyAttachmentExists("aws_iot_policy_attachment.att2", 1),
+					testAccCheckAWSIotPolicyAttachmentExists("aws_iot_policy_attachment.att3", 1),
+					testAccCheckAWSIotPolicyAttachmentCertStatus("aws_iot_certificate.cert", []string{policyName2}),
+					testAccCheckAWSIotPolicyAttachmentCertStatus("aws_iot_certificate.cert2", []string{policyName2}),
 				),
 			},
 		},
@@ -30,11 +56,11 @@ func TestAccAWSIoTPolicyAttachment_basic(t *testing.T) {
 
 }
 
-func testAccCheckAWSIoTPolicyAttchmentDestroy_basic(s *terraform.State) error {
+func testAccCheckAWSIotPolicyAttchmentDestroy_basic(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSIoTPolicyAttachmentExists(n string) resource.TestCheckFunc {
+func testAccCheckAWSIotPolicyAttachmentExists(n string, c int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -57,21 +83,76 @@ func testAccCheckAWSIoTPolicyAttachmentExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("Error: Failed to get attached policies for target %s (%s)", target, n)
 		}
-		if len(out.Policies) != 1 {
+		if len(out.Policies) != c {
 			return fmt.Errorf("Error: Target (%s) has wrong number of policies attached on initial creation", target)
 		}
 
-		attPolicyName := aws.StringValue(out.Policies[0].PolicyName)
+		found := false
+		for _, p := range out.Policies {
+			if policyName == aws.StringValue(p.PolicyName) {
+				found = true
+				break
+			}
+		}
 
-		if policyName != attPolicyName {
-			return fmt.Errorf("Error: Target (%s) has wrong policy attached, expected %s, got %s", target, policyName, attPolicyName)
+		if !found {
+			return fmt.Errorf("Error: Policy %s is not attached to target (%s)", policyName, target)
 		}
 
 		return nil
 	}
 }
 
-func testAccAWSIoTPolicyAttachmentConfig(policyName string) string {
+func testAccCheckAWSIotPolicyAttachmentCertStatus(n string, policies []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		certARN := rs.Primary.Attributes["arn"]
+
+		out, err := conn.ListAttachedPolicies(&iot.ListAttachedPoliciesInput{
+			Target:   aws.String(certARN),
+			PageSize: aws.Int64(250),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error: Cannot list attached policies for target %s: %s", certARN, err)
+		}
+
+		if len(out.Policies) != len(policies) {
+			return fmt.Errorf("Error: Invalid attached policies count for target %s, expected %d, got %d",
+				certARN,
+				len(policies),
+				len(out.Policies))
+		}
+
+		for _, p1 := range policies {
+			found := false
+			for _, p2 := range out.Policies {
+				if p1 == aws.StringValue(p2.PolicyName) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("Error: Policy %s is not attached to target %s", p1, certARN)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSIotPolicyAttachmentConfig(policyName string) string {
 	return fmt.Sprintf(`
 resource "aws_iot_certificate" "cert" {
   csr = "${file("test-fixtures/iot-csr.pem")}"
@@ -97,4 +178,117 @@ resource "aws_iot_policy_attachment" "att" {
   target = "${aws_iot_certificate.cert.arn}"
 }
 `, policyName)
+}
+
+func testAccAWSIotPolicyAttachmentConfigUpdate1(policyName, policyName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_policy" "policy" {
+  name = "%s"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iot:*"],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iot_policy" "policy2" {
+  name = "%s"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iot:*"],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iot_policy_attachment" "att" {
+  policy = "${aws_iot_policy.policy.name}"
+  target = "${aws_iot_certificate.cert.arn}"
+}
+
+resource "aws_iot_policy_attachment" "att2" {
+  policy = "${aws_iot_policy.policy2.name}"
+  target = "${aws_iot_certificate.cert.arn}"
+}
+`, policyName, policyName2)
+}
+
+func testAccAWSIotPolicyAttachmentConfigUpdate2(policyName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_policy" "policy2" {
+  name = "%s"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iot:*"],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iot_policy_attachment" "att2" {
+  policy = "${aws_iot_policy.policy2.name}"
+  target = "${aws_iot_certificate.cert.arn}"
+}
+`, policyName2)
+}
+
+func testAccAWSIotPolicyAttachmentConfigUpdate3(policyName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_certificate" "cert2" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_policy" "policy2" {
+  name = "%s"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iot:*"],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iot_policy_attachment" "att2" {
+  policy = "${aws_iot_policy.policy2.name}"
+  target = "${aws_iot_certificate.cert.arn}"
+}
+
+resource "aws_iot_policy_attachment" "att3" {
+  policy = "${aws_iot_policy.policy2.name}"
+  target = "${aws_iot_certificate.cert2.arn}"
+}
+`, policyName2)
 }

--- a/aws/resource_aws_iot_policy_attachment_test.go
+++ b/aws/resource_aws_iot_policy_attachment_test.go
@@ -1,0 +1,100 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSIoTPolicyAttachment_basic(t *testing.T) {
+	policyName := acctest.RandomWithPrefix("PolicyName-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIoTPolicyAttchmentDestroy_basic,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIoTPolicyAttachmentConfig(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIoTPolicyAttachmentExists("aws_iot_policy_attachment.att"),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccCheckAWSIoTPolicyAttchmentDestroy_basic(s *terraform.State) error {
+	return nil
+}
+
+func testAccCheckAWSIoTPolicyAttachmentExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No policy name is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+		target := rs.Primary.Attributes["target"]
+		policyName := rs.Primary.Attributes["policy"]
+
+		out, err := conn.ListAttachedPolicies(&iot.ListAttachedPoliciesInput{
+			Target:   aws.String(target),
+			PageSize: aws.Int64(250),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error: Failed to get attached policies for target %s (%s)", target, n)
+		}
+		if len(out.Policies) != 1 {
+			return fmt.Errorf("Error: Target (%s) has wrong number of policies attached on initial creation", target)
+		}
+
+		attPolicyName := aws.StringValue(out.Policies[0].PolicyName)
+
+		if policyName != attPolicyName {
+			return fmt.Errorf("Error: Target (%s) has wrong policy attached, expected %s, got %s", target, policyName, attPolicyName)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSIoTPolicyAttachmentConfig(policyName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_policy" "policy" {
+  name = "%s"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["iot:*"],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
+resource "aws_iot_policy_attachment" "att" {
+  policy = "${aws_iot_policy.policy.name}"
+  target = "${aws_iot_certificate.cert.arn}"
+}
+`, policyName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1402,6 +1402,11 @@
                     <li<%= sidebar_current("docs-aws-resource-iot-policy") %>>
                       <a href="/docs/providers/aws/r/iot_policy.html">aws_iot_policy</a>
                     </li>
+
+                    <li<%= sidebar_current("docs-aws-resource-iot-policy-attachment") %>>
+                      <a href="/docs/providers/aws/r/iot_policy_attachment.html">aws_iot_policy_attachment</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-aws-resource-iot-topic-rule") %>>
                         <a href="/docs/providers/aws/r/iot_topic_rule.html">aws_iot_topic_rule</a>
                     </li>

--- a/website/docs/r/iot_policy_attachment.html.markdown
+++ b/website/docs/r/iot_policy_attachment.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iot_policy_attachment"
+sidebar_current: "docs-aws-resource-iot-policy-attachment"
+description: |-
+  Provides an IoT policy attachment.
+---
+
+# aws_iot_policy_attachment
+
+Provides an IoT policy attachment.
+
+## Example Usage
+
+```hcl
+resource "aws_iot_policy" "pubsub" {
+  name        = "PubSubToAnyTopic"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "iot:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_policy_attachment" "att" {
+  policy = "${aws_iot_policy.pubsub.name}"
+  target = "${aws_iot_certificate.cert.arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy` - (Required) The name of the policy to attach.
+* `target` - (Required) The identity to which the policy is attached.


### PR DESCRIPTION
Added aws_iot_policy_attachment resource.

Test results:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIoTPolicyAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIoTPolicyAttachment_basic -timeout 120m
=== RUN   TestAccAWSIoTPolicyAttachment_basic
--- PASS: TestAccAWSIoTPolicyAttachment_basic (23.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	23.650s
```
