### PR TITLE
New resource: aws_iot_thing_principal_attachment

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -474,6 +474,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iot_certificate":                              resourceAwsIotCertificate(),
 			"aws_iot_policy":                                   resourceAwsIotPolicy(),
 			"aws_iot_thing":                                    resourceAwsIotThing(),
+			"aws_iot_thing_principal_attachment":               resourceAwsIotThingPrincipalAttachment(),
 			"aws_iot_thing_type":                               resourceAwsIotThingType(),
 			"aws_iot_topic_rule":                               resourceAwsIotTopicRule(),
 			"aws_key_pair":                                     resourceAwsKeyPair(),

--- a/aws/resource_aws_iot_thing_principal_attachment.go
+++ b/aws/resource_aws_iot_thing_principal_attachment.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsIotThingPrincipalAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIotThingPrincipalAttachmentCreate,
+		Read:   resourceAwsIotThingPrincipalAttachmentRead,
+		Delete: resourceAwsIotThingPrincipalAttachmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"principal": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"thing": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsIotThingPrincipalAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	principal := d.Get("principal").(string)
+	thing := d.Get("thing").(string)
+
+	_, err := conn.AttachThingPrincipal(&iot.AttachThingPrincipalInput{
+		Principal: aws.String(principal),
+		ThingName: aws.String(thing),
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Error attaching principal %s to thing %s: %s", principal, thing, err)
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s|%s", thing, principal))
+	return resourceAwsIotThingPrincipalAttachmentRead(d, meta)
+}
+
+func resourceAwsIotThingPrincipalAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	principal := d.Get("principal").(string)
+	thing := d.Get("thing").(string)
+
+	out, err := conn.ListThingPrincipals(&iot.ListThingPrincipalsInput{
+		ThingName: aws.String(thing),
+	})
+
+	if err != nil {
+		log.Printf("[ERROR] Error listing principals for thing %s: %s", thing, err)
+		return err
+	}
+
+	found := false
+
+	for _, name := range out.Principals {
+		if principal == aws.StringValue(name) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceAwsIotThingPrincipalAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	principal := d.Get("principal").(string)
+	thing := d.Get("thing").(string)
+
+	_, err := conn.DetachThingPrincipal(&iot.DetachThingPrincipalInput{
+		Principal: aws.String(principal),
+		ThingName: aws.String(thing),
+	})
+
+	if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] IoT Principal %s or Thing %s not found - removing from state", principal, thing)
+	} else if err != nil {
+		log.Printf("[ERROR] Error detaching principal %s from thing %s: %s", principal, thing, err)
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_iot_thing_principal_attachment_test.go
+++ b/aws/resource_aws_iot_thing_principal_attachment_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccAWSIotThingPrincipalAttachment_basic(t *testing.T) {
 	thingName := acctest.RandomWithPrefix("tf-acc")
+	thingName2 := acctest.RandomWithPrefix("tf-acc2")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,7 +23,40 @@ func TestAccAWSIotThingPrincipalAttachment_basic(t *testing.T) {
 			{
 				Config: testAccAWSIotThingPrincipalAttachmentConfig(thingName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att"),
+					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att", 1),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName, true, []string{"aws_iot_certificate.cert"}),
+				),
+			},
+			{
+				Config: testAccAWSIotThingPrincipalAttachmentConfigUpdate1(thingName, thingName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att", 1),
+					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att2", 1),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName, true, []string{"aws_iot_certificate.cert"}),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName2, true, []string{"aws_iot_certificate.cert"}),
+				),
+			},
+			{
+				Config: testAccAWSIotThingPrincipalAttachmentConfigUpdate2(thingName, thingName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att", 1),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName, true, []string{"aws_iot_certificate.cert"}),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName2, true, []string{}),
+				),
+			},
+			{
+				Config: testAccAWSIotThingPrincipalAttachmentConfigUpdate3(thingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att", 2),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName, true, []string{"aws_iot_certificate.cert", "aws_iot_certificate.cert2"}),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName2, false, []string{}),
+				),
+			},
+			{
+				Config: testAccAWSIotThingPrincipalAttachmentConfigUpdate4(thingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att2", 1),
+					testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName, true, []string{"aws_iot_certificate.cert2"}),
 				),
 			},
 		},
@@ -33,7 +67,7 @@ func testAccCheckAWSIotThingPrincipalAttachmentDestroy_basic(s *terraform.State)
 	return nil
 }
 
-func testAccCheckAWSIotThingPrincipalAttachmentExists(n string) resource.TestCheckFunc {
+func testAccCheckAWSIotThingPrincipalAttachmentExists(n string, c int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -48,7 +82,7 @@ func testAccCheckAWSIotThingPrincipalAttachmentExists(n string) resource.TestChe
 		thing := rs.Primary.Attributes["thing"]
 		principal := rs.Primary.Attributes["principal"]
 
-		out, err := conn.ListThingPrincipals(&iot.ListThingPrincipalsInput{
+		res, err := conn.ListThingPrincipals(&iot.ListThingPrincipalsInput{
 			ThingName: aws.String(thing),
 		})
 
@@ -56,12 +90,71 @@ func testAccCheckAWSIotThingPrincipalAttachmentExists(n string) resource.TestChe
 			return fmt.Errorf("Error: Failed to get principals for thing %s (%s)", thing, n)
 		}
 
-		if len(out.Principals) != 1 {
+		if len(res.Principals) != c {
 			return fmt.Errorf("Error: Thing (%s) has wrong number of principals attached on initial creation", thing)
 		}
 
-		if principal != aws.StringValue(out.Principals[0]) {
-			return fmt.Errorf("Error: Thing (%s) has wrong principal, expected %s, got %s", thing, principal, aws.StringValue(out.Principals[0]))
+		found := false
+		for _, p := range res.Principals {
+			if principal == aws.StringValue(p) {
+				found = true
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Error: Principal %s is not attached to thing %s", thing, principal)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSIotThingPrincipalAttachmentStatus(thingName string, exists bool, principals []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+
+		principalARNs := make(map[string]string)
+
+		for _, p := range principals {
+			pr, ok := s.RootModule().Resources[p]
+			if !ok {
+				return fmt.Errorf("Not found: %s", p)
+			}
+			principalARNs[pr.Primary.Attributes["arn"]] = p
+		}
+
+		thing, err := conn.DescribeThing(&iot.DescribeThingInput{
+			ThingName: aws.String(thingName),
+		})
+
+		if isAWSErr(err, iot.ErrCodeResourceNotFoundException, "") {
+			if exists {
+				return fmt.Errorf("Error: Thing (%s) exists, but expected to be removed", thingName)
+			} else {
+				return nil
+			}
+		} else if err != nil {
+			return fmt.Errorf("Error: cannot describe thing %s: %s", thingName, err)
+		} else if !exists {
+			return fmt.Errorf("Error: Thing (%s) does not exist, but expected to be", thingName)
+		}
+
+		res, err := conn.ListThingPrincipals(&iot.ListThingPrincipalsInput{
+			ThingName: aws.String(thingName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error: Cannot list thing (%s) principals: %s", thingName, err)
+		}
+
+		if len(res.Principals) != len(principalARNs) {
+			return fmt.Errorf("Error: Thing (%s) has wrong number of principals attached", thing)
+		}
+
+		for _, p := range res.Principals {
+			if principal, ok := principalARNs[aws.StringValue(p)]; !ok {
+				return fmt.Errorf("Error: Principal %s is not attached to thing %s", principal, thingName)
+			}
 		}
 
 		return nil
@@ -82,6 +175,101 @@ resource "aws_iot_thing" "thing" {
 resource "aws_iot_thing_principal_attachment" "att" {
   thing = "${aws_iot_thing.thing.name}"
   principal = "${aws_iot_certificate.cert.arn}"
+}
+`, thingName)
+}
+
+func testAccAWSIotThingPrincipalAttachmentConfigUpdate1(thingName, thingName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_thing" "thing" {
+  name = "%s"
+}
+
+resource "aws_iot_thing" "thing2" {
+  name = "%s"
+}
+
+resource "aws_iot_thing_principal_attachment" "att" {
+  thing = "${aws_iot_thing.thing.name}"
+  principal = "${aws_iot_certificate.cert.arn}"
+}
+
+resource "aws_iot_thing_principal_attachment" "att2" {
+  thing = "${aws_iot_thing.thing2.name}"
+  principal = "${aws_iot_certificate.cert.arn}"
+}
+`, thingName, thingName2)
+}
+
+func testAccAWSIotThingPrincipalAttachmentConfigUpdate2(thingName, thingName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_thing" "thing" {
+  name = "%s"
+}
+
+resource "aws_iot_thing" "thing2" {
+  name = "%s"
+}
+
+resource "aws_iot_thing_principal_attachment" "att" {
+  thing = "${aws_iot_thing.thing.name}"
+  principal = "${aws_iot_certificate.cert.arn}"
+}
+`, thingName, thingName2)
+}
+
+func testAccAWSIotThingPrincipalAttachmentConfigUpdate3(thingName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_certificate" "cert2" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_thing" "thing" {
+  name = "%s"
+}
+
+resource "aws_iot_thing_principal_attachment" "att" {
+  thing = "${aws_iot_thing.thing.name}"
+  principal = "${aws_iot_certificate.cert.arn}"
+}
+
+resource "aws_iot_thing_principal_attachment" "att2" {
+  thing = "${aws_iot_thing.thing.name}"
+  principal = "${aws_iot_certificate.cert2.arn}"
+}
+`, thingName)
+}
+
+func testAccAWSIotThingPrincipalAttachmentConfigUpdate4(thingName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert2" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_thing" "thing" {
+  name = "%s"
+}
+
+resource "aws_iot_thing_principal_attachment" "att2" {
+  thing = "${aws_iot_thing.thing.name}"
+  principal = "${aws_iot_certificate.cert2.arn}"
 }
 `, thingName)
 }

--- a/aws/resource_aws_iot_thing_principal_attachment_test.go
+++ b/aws/resource_aws_iot_thing_principal_attachment_test.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSIotThingPrincipalAttachment_basic(t *testing.T) {
+	thingName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIotThingPrincipalAttachmentDestroy_basic,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotThingPrincipalAttachmentConfig(thingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotThingPrincipalAttachmentExists("aws_iot_thing_principal_attachment.att"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSIotThingPrincipalAttachmentDestroy_basic(s *terraform.State) error {
+	return nil
+}
+
+func testAccCheckAWSIotThingPrincipalAttachmentExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No attachment")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+		thing := rs.Primary.Attributes["thing"]
+		principal := rs.Primary.Attributes["principal"]
+
+		out, err := conn.ListThingPrincipals(&iot.ListThingPrincipalsInput{
+			ThingName: aws.String(thing),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error: Failed to get principals for thing %s (%s)", thing, n)
+		}
+
+		if len(out.Principals) != 1 {
+			return fmt.Errorf("Error: Thing (%s) has wrong number of principals attached on initial creation", thing)
+		}
+
+		if principal != aws.StringValue(out.Principals[0]) {
+			return fmt.Errorf("Error: Thing (%s) has wrong principal, expected %s, got %s", thing, principal, aws.StringValue(out.Principals[0]))
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSIotThingPrincipalAttachmentConfig(thingName string) string {
+	return fmt.Sprintf(`
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("test-fixtures/iot-csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_thing" "thing" {
+  name = "%s"
+}
+
+resource "aws_iot_thing_principal_attachment" "att" {
+  thing = "${aws_iot_thing.thing.name}"
+  principal = "${aws_iot_certificate.cert.arn}"
+}
+`, thingName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1408,6 +1408,11 @@
                     <li<%= sidebar_current("docs-aws-resource-iot-thing") %>>
                         <a href="/docs/providers/aws/r/iot_thing.html">aws_iot_thing</a>
                     </li>
+
+                    <li<%= sidebar_current("docs-aws-resource-iot-thing-principal-attachment") %>>
+                        <a href="/docs/providers/aws/r/iot_thing.html">aws_iot_thing_principal_attachment</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-aws-resource-iot-thing-type") %>>
                         <a href="/docs/providers/aws/r/iot_thing_type.html">aws_iot_thing_type</a>
                     </li>

--- a/website/docs/r/iot_thing_principal_attachment.html.markdown
+++ b/website/docs/r/iot_thing_principal_attachment.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iot_thing_principal_attachment"
+sidebar_current: "docs-aws-resource-iot-thing-principal-attachment"
+description: |-
+    Provides AWS IoT Thing Principal attachment.
+---
+
+# aws_iot_thing_principal_attachment
+
+Attaches Principal to AWS IoT Thing.
+
+## Example Usage
+
+```hcl
+resource "aws_iot_thing" "example" {
+  name = "example"
+}
+
+resource "aws_iot_certificate" "cert" {
+  csr = "${file("csr.pem")}"
+  active = true
+}
+
+resource "aws_iot_thing_attachment" "att" {
+  principal = "${aws_iot_certificate.cert.arn}"
+  thing = "${aws_iot_thing.example.name}"
+}
+```
+
+## Argument Reference
+
+* `principal` - (Required) The AWS IoT Certificate ARN or Amazon Cognito Identity ID.
+* `thing` - (Required) The name of the thing.


### PR DESCRIPTION
Added aws_iot_thing_principal_attachment resource.

Test results:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIotThingPrincipalAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSIotThingPrincipalAttachment_basic -timeout 120m
=== RUN   TestAccAWSIotThingPrincipalAttachment_basic
--- PASS: TestAccAWSIotThingPrincipalAttachment_basic (22.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.549s
```