### PR TITLE
resource/aws_s3_bucket_inventory: Allow SSE-S3 encryption

### DIFF
--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -329,14 +328,6 @@ func resourceAwsS3BucketInventoryRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if output.InventoryConfiguration.Destination != nil {
-		// Flag the existence of SSE-S3 encryption because it cannot be marshaled when updating a resource.
-		// Allowing import would risk disabling encryption inadvertently when applying updates.
-		if output.InventoryConfiguration.Destination.S3BucketDestination.Encryption != nil {
-			if output.InventoryConfiguration.Destination.S3BucketDestination.Encryption.SSES3 != nil {
-				return errors.New("sse_s3 encryption is unsupported")
-			}
-		}
-
 		destination := map[string]interface{}{
 			"bucket": flattenS3InventoryS3BucketDestination(output.InventoryConfiguration.Destination.S3BucketDestination),
 		}

--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -60,8 +60,6 @@ func TestAccAWSS3BucketInventory_basic(t *testing.T) {
 }
 
 func TestAccAWSS3BucketInventory_encryptWithSSES3(t *testing.T) {
-	t.Skip("SSE-S3 is not supported by the SDK.")
-
 	var conf s3.InventoryConfiguration
 	rString := acctest.RandString(8)
 	resourceName := "aws_s3_bucket_inventory.test"

--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -111,8 +111,6 @@ The `bucket` configuration supports the following:
 
 The `encryption` configuration supports the following:
 
-~> **NOTE:** `sse_s3` is currently unsupported.
-
 * `sse_kms` - (Optional) Specifies to use server-side encryption with AWS KMS-managed keys to encrypt the inventory file (documented below).
 * `sse_s3` - (Optional) Specifies to use server-side encryption with Amazon S3-managed keys (SSE-S3) to encrypt the inventory file.
 


### PR DESCRIPTION
The upstream AWS Go SDK issue was fixed. 🎉 

Closes #5046

Changes proposed in this pull request:

* Remove apply-time restrictions for SSE-S3 encryption support for `aws_s3_bucket_inventory` resousrce

Output from acceptance testing:

```
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (6.59s)
--- PASS: TestAccAWSS3BucketInventory_basic (7.09s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (27.21s)
```
