### PR TITLE
provider: Remove errwrap.Wrapf() usage and [LEVEL] in error messaging

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -96,7 +96,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/terraform"
@@ -347,7 +346,7 @@ func (c *Config) Client() (interface{}, error) {
   Please see https://terraform.io/docs/providers/aws/index.html for more information on
   providing credentials for the AWS Provider`)
 		}
-		return nil, errwrap.Wrapf("Error creating AWS session: {{err}}", err)
+		return nil, fmt.Errorf("Error creating AWS session: %s", err)
 	}
 
 	sess.Handlers.Build.PushBackNamed(addTerraformVersionToUserAgent)

--- a/aws/data_source_aws_autoscaling_groups.go
+++ b/aws/data_source_aws_autoscaling_groups.go
@@ -78,7 +78,7 @@ func dataSourceAwsAutoscalingGroupsRead(d *schema.ResourceData, meta interface{}
 	sort.Strings(raw)
 
 	if err := d.Set("names", raw); err != nil {
-		return fmt.Errorf("[WARN] Error setting Autoscaling Group Names: %s", err)
+		return fmt.Errorf("Error setting Autoscaling Group Names: %s", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_availability_zones.go
+++ b/aws/data_source_aws_availability_zones.go
@@ -67,7 +67,7 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 	sort.Strings(raw)
 
 	if err := d.Set("names", raw); err != nil {
-		return fmt.Errorf("[WARN] Error setting Availability Zones: %s", err)
+		return fmt.Errorf("Error setting Availability Zones: %s", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_cloudformation_stack.go
+++ b/aws/data_source_aws_cloudformation_stack.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -116,7 +115,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 
 	template, err := normalizeCloudFormationTemplate(*tOut.TemplateBody)
 	if err != nil {
-		return errwrap.Wrapf("template body contains an invalid JSON or YAML: {{err}}", err)
+		return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 	}
 	d.Set("template_body", template)
 

--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -247,7 +247,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		parameterGroups = append(parameterGroups, *v.DBParameterGroupName)
 	}
 	if err := d.Set("db_parameter_groups", parameterGroups); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting db_parameter_groups attribute: %#v, error: %#v", parameterGroups, err)
+		return fmt.Errorf("Error setting db_parameter_groups attribute: %#v, error: %#v", parameterGroups, err)
 	}
 
 	var dbSecurityGroups []string
@@ -255,7 +255,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		dbSecurityGroups = append(dbSecurityGroups, *v.DBSecurityGroupName)
 	}
 	if err := d.Set("db_security_groups", dbSecurityGroups); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting db_security_groups attribute: %#v, error: %#v", dbSecurityGroups, err)
+		return fmt.Errorf("Error setting db_security_groups attribute: %#v, error: %#v", dbSecurityGroups, err)
 	}
 
 	if dbInstance.DBSubnetGroup != nil {
@@ -287,7 +287,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		optionGroups = append(optionGroups, *v.OptionGroupName)
 	}
 	if err := d.Set("option_group_memberships", optionGroups); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting option_group_memberships attribute: %#v, error: %#v", optionGroups, err)
+		return fmt.Errorf("Error setting option_group_memberships attribute: %#v, error: %#v", optionGroups, err)
 	}
 
 	d.Set("preferred_backup_window", dbInstance.PreferredBackupWindow)
@@ -304,7 +304,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 		vpcSecurityGroups = append(vpcSecurityGroups, *v.VpcSecurityGroupId)
 	}
 	if err := d.Set("vpc_security_groups", vpcSecurityGroups); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting vpc_security_groups attribute: %#v, error: %#v", vpcSecurityGroups, err)
+		return fmt.Errorf("Error setting vpc_security_groups attribute: %#v, error: %#v", vpcSecurityGroups, err)
 	}
 
 	return nil

--- a/aws/data_source_aws_efs_file_system.go
+++ b/aws/data_source_aws_efs_file_system.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/efs"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -66,7 +65,7 @@ func dataSourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Reading EFS File System: %s", describeEfsOpts)
 	describeResp, err := efsconn.DescribeFileSystems(describeEfsOpts)
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving EFS: {{err}}", err)
+		return fmt.Errorf("Error retrieving EFS: %s", err)
 	}
 	if len(describeResp.FileSystems) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(describeResp.FileSystems))

--- a/aws/data_source_aws_efs_file_system_test.go
+++ b/aws/data_source_aws_efs_file_system_test.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestAccDataSourceAwsEfsFileSystem(t *testing.T) {

--- a/aws/data_source_aws_efs_mount_target.go
+++ b/aws/data_source_aws_efs_mount_target.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/efs"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -61,7 +60,7 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Reading EFS Mount Target: %s", describeEfsOpts)
 	resp, err := efsconn.DescribeMountTargets(describeEfsOpts)
 	if err != nil {
-		return errwrap.Wrapf("Error retrieving EFS Mount Target: {{err}}", err)
+		return fmt.Errorf("Error retrieving EFS Mount Target: %s", err)
 	}
 	if len(resp.MountTargets) != 1 {
 		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(resp.MountTargets))
@@ -89,7 +88,7 @@ func dataSourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if err := d.Set("dns_name", resourceAwsEfsMountTargetDnsName(*mt.FileSystemId, meta.(*AWSClient).region)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting dns_name error: %#v", err)
+		return fmt.Errorf("Error setting dns_name error: %#v", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -47,7 +46,7 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading IAM Group: %s", req)
 	resp, err := iamconn.GetGroup(req)
 	if err != nil {
-		return errwrap.Wrapf("Error getting group: {{err}}", err)
+		return fmt.Errorf("Error getting group: %s", err)
 	}
 	if resp == nil {
 		return fmt.Errorf("no IAM group found")

--- a/aws/data_source_aws_iam_instance_profile.go
+++ b/aws/data_source_aws_iam_instance_profile.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -59,7 +58,7 @@ func dataSourceAwsIAMInstanceProfileRead(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Reading IAM Instance Profile: %s", req)
 	resp, err := iamconn.GetInstanceProfile(req)
 	if err != nil {
-		return errwrap.Wrapf("Error getting instance profiles: {{err}}", err)
+		return fmt.Errorf("Error getting instance profiles: %s", err)
 	}
 	if resp == nil {
 		return fmt.Errorf("no IAM instance profile found")

--- a/aws/data_source_aws_iam_server_certificate.go
+++ b/aws/data_source_aws_iam_server_certificate.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -124,7 +123,7 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 		return true
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error describing certificates: {{err}}", err)
+		return fmt.Errorf("Error describing certificates: %s", err)
 	}
 
 	if len(metadatas) == 0 {

--- a/aws/data_source_aws_kms_alias.go
+++ b/aws/data_source_aws_kms_alias.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -54,7 +53,7 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 		return true
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error fetch KMS alias list: {{err}}", err)
+		return fmt.Errorf("Error fetch KMS alias list: %s", err)
 	}
 
 	if alias == nil {
@@ -80,7 +79,7 @@ func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	resp, err := conn.DescribeKey(req)
 	if err != nil {
-		return errwrap.Wrapf("Error calling KMS DescribeKey: {{err}}", err)
+		return fmt.Errorf("Error calling KMS DescribeKey: %s", err)
 	}
 
 	d.Set("target_key_arn", resp.KeyMetadata.Arn)

--- a/aws/data_source_aws_kms_key.go
+++ b/aws/data_source_aws_kms_key.go
@@ -2,10 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/terraform/helper/schema"
-	"time"
 )
 
 func dataSourceAwsKmsKey() *schema.Resource {

--- a/aws/data_source_aws_kms_key_test.go
+++ b/aws/data_source_aws_kms_key_test.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestAccDataSourceAwsKmsKey_basic(t *testing.T) {

--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -89,7 +89,7 @@ func dataSourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 	if len(resp.Listeners) == 0 {
-		return fmt.Errorf("[DEBUG] no listener exists for load balancer: %s", lbArn)
+		return fmt.Errorf("no listener exists for load balancer: %s", lbArn)
 	}
 	for _, listener := range resp.Listeners {
 		if *listener.Port == int64(port.(int)) {

--- a/aws/data_source_aws_redshift_cluster.go
+++ b/aws/data_source_aws_redshift_cluster.go
@@ -207,7 +207,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 		csg = append(csg, *g.ClusterSecurityGroupName)
 	}
 	if err := d.Set("cluster_security_groups", csg); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving Cluster Security Group Names to state for Redshift Cluster (%s): %s", cluster, err)
+		return fmt.Errorf("Error saving Cluster Security Group Names to state for Redshift Cluster (%s): %s", cluster, err)
 	}
 
 	d.Set("cluster_subnet_group_name", rsc.ClusterSubnetGroupName)
@@ -238,7 +238,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 		iamRoles = append(iamRoles, *i.IamRoleArn)
 	}
 	if err := d.Set("iam_roles", iamRoles); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving IAM Roles to state for Redshift Cluster (%s): %s", cluster, err)
+		return fmt.Errorf("Error saving IAM Roles to state for Redshift Cluster (%s): %s", cluster, err)
 	}
 
 	d.Set("kms_key_id", rsc.KmsKeyId)
@@ -256,7 +256,7 @@ func dataSourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) 
 		vpcg = append(vpcg, *g.VpcSecurityGroupId)
 	}
 	if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving VPC Security Group IDs to state for Redshift Cluster (%s): %s", cluster, err)
+		return fmt.Errorf("Error saving VPC Security Group IDs to state for Redshift Cluster (%s): %s", cluster, err)
 	}
 
 	log.Printf("[INFO] Reading Redshift Cluster Logging Status: %s", cluster)

--- a/aws/data_source_aws_security_groups_test.go
+++ b/aws/data_source_aws_security_groups_test.go
@@ -2,9 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"testing"
 )
 
 func TestAccDataSourceAwsSecurityGroups_tag(t *testing.T) {

--- a/aws/data_source_aws_sns.go
+++ b/aws/data_source_aws_sns.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -56,7 +55,7 @@ func dataSourceAwsSnsTopicsRead(d *schema.ResourceData, meta interface{}) error 
 		return true
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error describing topics: {{err}}", err)
+		return fmt.Errorf("Error describing topics: %s", err)
 	}
 
 	if len(arns) == 0 {

--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -56,7 +55,7 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := ssmconn.GetParameter(paramInput)
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error describing SSM parameter: {{err}}", err)
+		return fmt.Errorf("Error describing SSM parameter: %s", err)
 	}
 
 	param := resp.Parameter

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -2,12 +2,12 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestAccDataSourceAwsSubnet_basic(t *testing.T) {

--- a/aws/import_aws_s3_bucket.go
+++ b/aws/import_aws_s3_bucket.go
@@ -1,10 +1,11 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -24,7 +25,7 @@ func resourceAwsS3BucketImportState(
 			// Bucket without policy
 			return results, nil
 		}
-		return nil, errwrap.Wrapf("Error importing AWS S3 bucket policy: {{err}}", err)
+		return nil, fmt.Errorf("Error importing AWS S3 bucket policy: %s", err)
 	}
 
 	policy := resourceAwsS3BucketPolicy()

--- a/aws/import_aws_security_group.go
+++ b/aws/import_aws_security_group.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -179,7 +178,7 @@ func resourceAwsSecurityGroupImportStatePermPair(sg *ec2.SecurityGroup, ruleType
 	}
 
 	if err := setFromIPPerm(d, sg, perm); err != nil {
-		return nil, errwrap.Wrapf("Error importing AWS Security Group: {{err}}", err)
+		return nil, fmt.Errorf("Error importing AWS Security Group: %s", err)
 	}
 
 	return d, nil

--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -1,12 +1,12 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
 	"time"
 
-	"errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
@@ -251,19 +251,19 @@ func resourceAwsApiGatewayUsagePlanRead(d *schema.ResourceData, meta interface{}
 
 	if up.ApiStages != nil {
 		if err := d.Set("api_stages", flattenApiGatewayUsageApiStages(up.ApiStages)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting api_stages error: %#v", err)
+			return fmt.Errorf("Error setting api_stages error: %#v", err)
 		}
 	}
 
 	if up.Throttle != nil {
 		if err := d.Set("throttle_settings", flattenApiGatewayUsagePlanThrottling(up.Throttle)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting throttle_settings error: %#v", err)
+			return fmt.Errorf("Error setting throttle_settings error: %#v", err)
 		}
 	}
 
 	if up.Quota != nil {
 		if err := d.Set("quota_settings", flattenApiGatewayUsagePlanQuota(up.Quota)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting quota_settings error: %#v", err)
+			return fmt.Errorf("Error setting quota_settings error: %#v", err)
 		}
 	}
 

--- a/aws/resource_aws_api_gateway_vpc_link.go
+++ b/aws/resource_aws_api_gateway_vpc_link.go
@@ -70,7 +70,7 @@ func resourceAwsApiGatewayVpcLinkCreate(d *schema.ResourceData, meta interface{}
 	_, err = stateConf.WaitForState()
 	if err != nil {
 		d.SetId("")
-		return fmt.Errorf("[WARN] Error waiting for APIGateway Vpc Link status to be \"%s\": %s", apigateway.VpcLinkStatusAvailable, err)
+		return fmt.Errorf("Error waiting for APIGateway Vpc Link status to be \"%s\": %s", apigateway.VpcLinkStatusAvailable, err)
 	}
 
 	return nil
@@ -145,7 +145,7 @@ func resourceAwsApiGatewayVpcLinkUpdate(d *schema.ResourceData, meta interface{}
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for APIGateway Vpc Link status to be \"%s\": %s", apigateway.VpcLinkStatusAvailable, err)
+		return fmt.Errorf("Error waiting for APIGateway Vpc Link status to be \"%s\": %s", apigateway.VpcLinkStatusAvailable, err)
 	}
 
 	return nil

--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -126,7 +126,7 @@ func executeAndExpectNoRowsWhenCreate(qeid string, d *schema.ResourceData, conn 
 		return err
 	}
 	if len(rs.Rows) != 0 {
-		return fmt.Errorf("[ERROR] Athena create database, unexpected query result: %s", flattenAthenaResultSet(rs))
+		return fmt.Errorf("Athena create database, unexpected query result: %s", flattenAthenaResultSet(rs))
 	}
 	return nil
 }
@@ -143,7 +143,7 @@ func executeAndExpectMatchingRow(qeid string, dbName string, conn *athena.Athena
 			}
 		}
 	}
-	return fmt.Errorf("[ERROR] Athena not found database: %s, query result: %s", dbName, flattenAthenaResultSet(rs))
+	return fmt.Errorf("Athena not found database: %s, query result: %s", dbName, flattenAthenaResultSet(rs))
 }
 
 func executeAndExpectNoRowsWhenDrop(qeid string, d *schema.ResourceData, conn *athena.Athena) error {
@@ -152,7 +152,7 @@ func executeAndExpectNoRowsWhenDrop(qeid string, d *schema.ResourceData, conn *a
 		return err
 	}
 	if len(rs.Rows) != 0 {
-		return fmt.Errorf("[ERROR] Athena drop database, unexpected query result: %s", flattenAthenaResultSet(rs))
+		return fmt.Errorf("Athena drop database, unexpected query result: %s", flattenAthenaResultSet(rs))
 	}
 	return nil
 }

--- a/aws/resource_aws_autoscaling_attachment.go
+++ b/aws/resource_aws_autoscaling_attachment.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -52,7 +51,7 @@ func resourceAwsAutoscalingAttachmentCreate(d *schema.ResourceData, meta interfa
 		log.Printf("[INFO] registering asg %s with ELBs %s", asgName, v.(string))
 
 		if _, err := asgconn.AttachLoadBalancers(attachOpts); err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("Failure attaching AutoScaling Group %s with Elastic Load Balancer: %s: {{err}}", asgName, v.(string)), err)
+			return fmt.Errorf("Failure attaching AutoScaling Group %s with Elastic Load Balancer: %s: %s", asgName, v.(string), err)
 		}
 	}
 
@@ -65,7 +64,7 @@ func resourceAwsAutoscalingAttachmentCreate(d *schema.ResourceData, meta interfa
 		log.Printf("[INFO] registering asg %s with ALB Target Group %s", asgName, v.(string))
 
 		if _, err := asgconn.AttachLoadBalancerTargetGroups(attachOpts); err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("Failure attaching AutoScaling Group %s with ALB Target Group: %s: {{err}}", asgName, v.(string)), err)
+			return fmt.Errorf("Failure attaching AutoScaling Group %s with ALB Target Group: %s: %s", asgName, v.(string), err)
 		}
 	}
 
@@ -137,7 +136,7 @@ func resourceAwsAutoscalingAttachmentDelete(d *schema.ResourceData, meta interfa
 
 		log.Printf("[INFO] Deleting ELB %s association from: %s", v.(string), asgName)
 		if _, err := asgconn.DetachLoadBalancers(detachOpts); err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("Failure detaching AutoScaling Group %s with Elastic Load Balancer: %s: {{err}}", asgName, v.(string)), err)
+			return fmt.Errorf("Failure detaching AutoScaling Group %s with Elastic Load Balancer: %s: %s", asgName, v.(string), err)
 		}
 	}
 
@@ -149,7 +148,7 @@ func resourceAwsAutoscalingAttachmentDelete(d *schema.ResourceData, meta interfa
 
 		log.Printf("[INFO] Deleting ALB Target Group %s association from: %s", v.(string), asgName)
 		if _, err := asgconn.DetachLoadBalancerTargetGroups(detachOpts); err != nil {
-			return errwrap.Wrapf(fmt.Sprintf("Failure detaching AutoScaling Group %s with ALB Target Group: %s: {{err}}", asgName, v.(string)), err)
+			return fmt.Errorf("Failure detaching AutoScaling Group %s with ALB Target Group: %s: %s", asgName, v.(string), err)
 		}
 	}
 

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/customdiff"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -752,7 +751,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 				LoadBalancerNames:    remove,
 			})
 			if err != nil {
-				return fmt.Errorf("[WARN] Error updating Load Balancers for AutoScaling Group (%s), error: %s", d.Id(), err)
+				return fmt.Errorf("Error updating Load Balancers for AutoScaling Group (%s), error: %s", d.Id(), err)
 			}
 		}
 
@@ -762,7 +761,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 				LoadBalancerNames:    add,
 			})
 			if err != nil {
-				return fmt.Errorf("[WARN] Error updating Load Balancers for AutoScaling Group (%s), error: %s", d.Id(), err)
+				return fmt.Errorf("Error updating Load Balancers for AutoScaling Group (%s), error: %s", d.Id(), err)
 			}
 		}
 	}
@@ -788,7 +787,7 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 				TargetGroupARNs:      remove,
 			})
 			if err != nil {
-				return fmt.Errorf("[WARN] Error updating Load Balancers Target Groups for AutoScaling Group (%s), error: %s", d.Id(), err)
+				return fmt.Errorf("Error updating Load Balancers Target Groups for AutoScaling Group (%s), error: %s", d.Id(), err)
 			}
 		}
 
@@ -798,26 +797,26 @@ func resourceAwsAutoscalingGroupUpdate(d *schema.ResourceData, meta interface{})
 				TargetGroupARNs:      add,
 			})
 			if err != nil {
-				return fmt.Errorf("[WARN] Error updating Load Balancers Target Groups for AutoScaling Group (%s), error: %s", d.Id(), err)
+				return fmt.Errorf("Error updating Load Balancers Target Groups for AutoScaling Group (%s), error: %s", d.Id(), err)
 			}
 		}
 	}
 
 	if shouldWaitForCapacity {
 		if err := waitForASGCapacity(d, meta, capacitySatisfiedUpdate); err != nil {
-			return errwrap.Wrapf("Error waiting for AutoScaling Group Capacity: {{err}}", err)
+			return fmt.Errorf("Error waiting for AutoScaling Group Capacity: %s", err)
 		}
 	}
 
 	if d.HasChange("enabled_metrics") {
 		if err := updateASGMetricsCollection(d, conn); err != nil {
-			return errwrap.Wrapf("Error updating AutoScaling Group Metrics collection: {{err}}", err)
+			return fmt.Errorf("Error updating AutoScaling Group Metrics collection: %s", err)
 		}
 	}
 
 	if d.HasChange("suspended_processes") {
 		if err := updateASGSuspendedProcesses(d, conn); err != nil {
-			return errwrap.Wrapf("Error updating AutoScaling Group Suspended Processes: {{err}}", err)
+			return fmt.Errorf("Error updating AutoScaling Group Suspended Processes: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_autoscaling_group_waiting.go
+++ b/aws/resource_aws_autoscaling_group_waiting.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -124,8 +123,7 @@ func waitForASGCapacity(
 		recentStatus = fmt.Sprintf("(Failed to describe scaling activities: %s)", aErr)
 	}
 
-	msg := fmt.Sprintf("{{err}}. Most recent activity: %s", recentStatus)
-	return errwrap.Wrapf(msg, err)
+	return fmt.Errorf("%s. Most recent activity: %s", err, recentStatus)
 }
 
 type capacitySatisfiedFunc func(*schema.ResourceData, int, int) (bool, string)

--- a/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -8,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -67,10 +67,10 @@ func resourceAwsAutoscalingLifecycleHookPutOp(conn *autoscaling.AutoScaling, par
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if strings.Contains(awsErr.Message(), "Unable to publish test message to notification target") {
-					return resource.RetryableError(errwrap.Wrapf("[DEBUG] Retrying AWS AutoScaling Lifecycle Hook: {{err}}", awsErr))
+					return resource.RetryableError(fmt.Errorf("Retrying AWS AutoScaling Lifecycle Hook: %s", awsErr))
 				}
 			}
-			return resource.NonRetryableError(errwrap.Wrapf("Error putting lifecycle hook: {{err}}", err))
+			return resource.NonRetryableError(fmt.Errorf("Error putting lifecycle hook: %s", err))
 		}
 		return nil
 	})
@@ -128,7 +128,7 @@ func resourceAwsAutoscalingLifecycleHookDelete(d *schema.ResourceData, meta inte
 		LifecycleHookName:    aws.String(d.Get("name").(string)),
 	}
 	if _, err := autoscalingconn.DeleteLifecycleHook(&params); err != nil {
-		return errwrap.Wrapf("Autoscaling Lifecycle Hook: {{err}}", err)
+		return fmt.Errorf("Autoscaling Lifecycle Hook: %s", err)
 	}
 
 	return nil
@@ -178,7 +178,7 @@ func getAwsAutoscalingLifecycleHook(d *schema.ResourceData, meta interface{}) (*
 	log.Printf("[DEBUG] AutoScaling Lifecycle Hook Describe Params: %#v", params)
 	resp, err := autoscalingconn.DescribeLifecycleHooks(&params)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error retrieving lifecycle hooks: {{err}}", err)
+		return nil, fmt.Errorf("Error retrieving lifecycle hooks: %s", err)
 	}
 
 	// find lifecycle hooks

--- a/aws/resource_aws_autoscaling_notification.go
+++ b/aws/resource_aws_autoscaling_notification.go
@@ -166,7 +166,7 @@ func addNotificationConfigToGroupsWithTopic(conn *autoscaling.AutoScaling, group
 		_, err := conn.PutNotificationConfiguration(opts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
-				return fmt.Errorf("[WARN] Error creating Autoscaling Group Notification for Group %s, error: \"%s\", code: \"%s\"", *a, awsErr.Message(), awsErr.Code())
+				return fmt.Errorf("Error creating Autoscaling Group Notification for Group %s, error: \"%s\", code: \"%s\"", *a, awsErr.Message(), awsErr.Code())
 			}
 			return err
 		}
@@ -183,7 +183,7 @@ func removeNotificationConfigToGroupsWithTopic(conn *autoscaling.AutoScaling, gr
 
 		_, err := conn.DeleteNotificationConfiguration(opts)
 		if err != nil {
-			return fmt.Errorf("[WARN] Error deleting notification configuration for ASG \"%s\", Topic ARN \"%s\"", *r, topic)
+			return fmt.Errorf("Error deleting notification configuration for ASG \"%s\", Topic ARN \"%s\"", *r, topic)
 		}
 	}
 	return nil

--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -73,7 +73,7 @@ func resourceAwsBatchJobQueueCreate(d *schema.ResourceData, meta interface{}) er
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for JobQueue state to be \"VALID\": %s", err)
+		return fmt.Errorf("Error waiting for JobQueue state to be \"VALID\": %s", err)
 	}
 
 	arn := *out.JobQueueArn
@@ -91,7 +91,7 @@ func resourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	if jq == nil {
-		return fmt.Errorf("[WARN] Error reading JobQueue: \"%s\"", err)
+		return fmt.Errorf("Error reading JobQueue: \"%s\"", err)
 	}
 	d.Set("arn", jq.JobQueueArn)
 	d.Set("compute_environments", jq.ComputeEnvironmentOrder)

--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -123,7 +122,7 @@ func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("template_body"); ok {
 		template, err := normalizeCloudFormationTemplate(v)
 		if err != nil {
-			return errwrap.Wrapf("template body contains an invalid JSON or YAML: {{err}}", err)
+			return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 		}
 		input.TemplateBody = aws.String(template)
 	}
@@ -148,7 +147,7 @@ func resourceAwsCloudFormationStackCreate(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("policy_body"); ok {
 		policy, err := structure.NormalizeJsonString(v)
 		if err != nil {
-			return errwrap.Wrapf("policy body contains an invalid JSON: {{err}}", err)
+			return fmt.Errorf("policy body contains an invalid JSON: %s", err)
 		}
 		input.StackPolicyBody = aws.String(policy)
 	}
@@ -300,7 +299,7 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 
 	template, err := normalizeCloudFormationTemplate(*out.TemplateBody)
 	if err != nil {
-		return errwrap.Wrapf("template body contains an invalid JSON or YAML: {{err}}", err)
+		return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 	}
 	d.Set("template_body", template)
 
@@ -366,7 +365,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("template_body"); ok && input.TemplateURL == nil {
 		template, err := normalizeCloudFormationTemplate(v)
 		if err != nil {
-			return errwrap.Wrapf("template body contains an invalid JSON or YAML: {{err}}", err)
+			return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 		}
 		input.TemplateBody = aws.String(template)
 	}
@@ -392,7 +391,7 @@ func resourceAwsCloudFormationStackUpdate(d *schema.ResourceData, meta interface
 	if d.HasChange("policy_body") {
 		policy, err := structure.NormalizeJsonString(d.Get("policy_body"))
 		if err != nil {
-			return errwrap.Wrapf("policy body contains an invalid JSON: {{err}}", err)
+			return fmt.Errorf("policy body contains an invalid JSON: %s", err)
 		}
 		input.StackPolicyBody = aws.String(policy)
 	}

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -779,9 +778,9 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 	})
 
 	if err != nil {
-		return errwrap.Wrapf(fmt.Sprintf(
-			"Error retrieving EC2 tags for CloudFront Distribution %q (ARN: %q): {{err}}",
-			d.Id(), d.Get("arn").(string)), err)
+		return fmt.Errorf(
+			"Error retrieving EC2 tags for CloudFront Distribution %q (ARN: %q): %s",
+			d.Id(), d.Get("arn").(string), err)
 	}
 
 	if err := d.Set("tags", tagsToMapCloudFront(tagResp.Tags)); err != nil {

--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -92,7 +91,7 @@ func resourceAwsCloudWatchEventRuleCreate(d *schema.ResourceData, meta interface
 
 	input, err := buildPutRuleInputStruct(d, name)
 	if err != nil {
-		return errwrap.Wrapf("Creating CloudWatch Event Rule failed: {{err}}", err)
+		return fmt.Errorf("Creating CloudWatch Event Rule failed: %s", err)
 	}
 	log.Printf("[DEBUG] Creating CloudWatch Event Rule: %s", input)
 
@@ -114,7 +113,7 @@ func resourceAwsCloudWatchEventRuleCreate(d *schema.ResourceData, meta interface
 		return nil
 	})
 	if err != nil {
-		return errwrap.Wrapf("Creating CloudWatch Event Rule failed: {{err}}", err)
+		return fmt.Errorf("Creating CloudWatch Event Rule failed: %s", err)
 	}
 
 	d.Set("arn", out.RuleArn)
@@ -150,7 +149,7 @@ func resourceAwsCloudWatchEventRuleRead(d *schema.ResourceData, meta interface{}
 	if out.EventPattern != nil {
 		pattern, err := structure.NormalizeJsonString(*out.EventPattern)
 		if err != nil {
-			return errwrap.Wrapf("event pattern contains an invalid JSON: {{err}}", err)
+			return fmt.Errorf("event pattern contains an invalid JSON: %s", err)
 		}
 		d.Set("event_pattern", pattern)
 	}
@@ -184,7 +183,7 @@ func resourceAwsCloudWatchEventRuleUpdate(d *schema.ResourceData, meta interface
 
 	input, err := buildPutRuleInputStruct(d, d.Id())
 	if err != nil {
-		return errwrap.Wrapf("Updating CloudWatch Event Rule failed: {{err}}", err)
+		return fmt.Errorf("Updating CloudWatch Event Rule failed: %s", err)
 	}
 	log.Printf("[DEBUG] Updating CloudWatch Event Rule: %s", input)
 
@@ -204,7 +203,7 @@ func resourceAwsCloudWatchEventRuleUpdate(d *schema.ResourceData, meta interface
 		return nil
 	})
 	if err != nil {
-		return errwrap.Wrapf("Updating CloudWatch Event Rule failed: {{err}}", err)
+		return fmt.Errorf("Updating CloudWatch Event Rule failed: %s", err)
 	}
 
 	if d.HasChange("is_enabled") && !d.Get("is_enabled").(bool) {
@@ -246,7 +245,7 @@ func buildPutRuleInputStruct(d *schema.ResourceData, name string) (*events.PutRu
 	if v, ok := d.GetOk("event_pattern"); ok {
 		pattern, err := structure.NormalizeJsonString(v)
 		if err != nil {
-			return nil, errwrap.Wrapf("event pattern contains an invalid JSON: {{err}}", err)
+			return nil, fmt.Errorf("event pattern contains an invalid JSON: %s", err)
 		}
 		input.EventPattern = aws.String(pattern)
 	}

--- a/aws/resource_aws_cloudwatch_event_target.go
+++ b/aws/resource_aws_cloudwatch_event_target.go
@@ -256,37 +256,37 @@ func resourceAwsCloudWatchEventTargetRead(d *schema.ResourceData, meta interface
 
 	if t.RunCommandParameters != nil {
 		if err := d.Set("run_command_targets", flattenAwsCloudWatchEventTargetRunParameters(t.RunCommandParameters)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting run_command_targets error: %#v", err)
+			return fmt.Errorf("Error setting run_command_targets error: %#v", err)
 		}
 	}
 
 	if t.EcsParameters != nil {
 		if err := d.Set("ecs_target", flattenAwsCloudWatchEventTargetEcsParameters(t.EcsParameters)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting ecs_target error: %#v", err)
+			return fmt.Errorf("Error setting ecs_target error: %#v", err)
 		}
 	}
 
 	if t.BatchParameters != nil {
 		if err := d.Set("batch_target", flattenAwsCloudWatchEventTargetBatchParameters(t.BatchParameters)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting batch_target error: %#v", err)
+			return fmt.Errorf("Error setting batch_target error: %#v", err)
 		}
 	}
 
 	if t.KinesisParameters != nil {
 		if err := d.Set("kinesis_target", flattenAwsCloudWatchEventTargetKinesisParameters(t.KinesisParameters)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting kinesis_target error: %#v", err)
+			return fmt.Errorf("Error setting kinesis_target error: %#v", err)
 		}
 	}
 
 	if t.SqsParameters != nil {
 		if err := d.Set("sqs_target", flattenAwsCloudWatchEventTargetSqsParameters(t.SqsParameters)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting sqs_target error: %#v", err)
+			return fmt.Errorf("Error setting sqs_target error: %#v", err)
 		}
 	}
 
 	if t.InputTransformer != nil {
 		if err := d.Set("input_transformer", flattenAwsCloudWatchInputTransformer(t.InputTransformer)); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting input_transformer error: %#v", err)
+			return fmt.Errorf("Error setting input_transformer error: %#v", err)
 		}
 	}
 

--- a/aws/resource_aws_cloudwatch_log_stream.go
+++ b/aws/resource_aws_cloudwatch_log_stream.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -48,7 +47,7 @@ func resourceAwsCloudWatchLogStreamCreate(d *schema.ResourceData, meta interface
 		LogStreamName: aws.String(d.Get("name").(string)),
 	})
 	if err != nil {
-		return errwrap.Wrapf("Creating CloudWatch Log Stream failed: {{err}}", err)
+		return fmt.Errorf("Creating CloudWatch Log Stream failed: %s", err)
 	}
 
 	d.SetId(d.Get("name").(string))
@@ -86,7 +85,7 @@ func resourceAwsCloudWatchLogStreamDelete(d *schema.ResourceData, meta interface
 	}
 	_, err := conn.DeleteLogStream(params)
 	if err != nil {
-		return errwrap.Wrapf("Error deleting CloudWatch Log Stream: {{err}}", err)
+		return fmt.Errorf("Error deleting CloudWatch Log Stream: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -98,7 +98,7 @@ func resourceAwsCloudwatchLogSubscriptionFilterUpdate(d *schema.ResourceData, me
 	_, err := conn.PutSubscriptionFilter(&params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			return fmt.Errorf("[WARN] Error updating SubscriptionFilter (%s) for LogGroup (%s), message: \"%s\", code: \"%s\"",
+			return fmt.Errorf("Error updating SubscriptionFilter (%s) for LogGroup (%s), message: \"%s\", code: \"%s\"",
 				d.Get("name").(string), d.Get("log_group_name").(string), awsErr.Message(), awsErr.Code())
 		}
 		return err

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -385,7 +385,7 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 	})
 
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error creating CodeBuild project: %s", err)
+		return fmt.Errorf("Error creating CodeBuild project: %s", err)
 	}
 
 	d.SetId(*resp.Project.Arn)
@@ -563,7 +563,7 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error retreiving Projects: %q", err)
+		return fmt.Errorf("Error retreiving Projects: %q", err)
 	}
 
 	// if nothing was found, then return no state

--- a/aws/resource_aws_codedeploy_deployment_config.go
+++ b/aws/resource_aws_codedeploy_deployment_config.go
@@ -95,7 +95,7 @@ func resourceAwsCodeDeployDeploymentConfigRead(d *schema.ResourceData, meta inte
 	}
 
 	if resp.DeploymentConfigInfo == nil {
-		return fmt.Errorf("[ERROR] Cannot find DeploymentConfig %q", d.Id())
+		return fmt.Errorf("Cannot find DeploymentConfig %q", d.Id())
 	}
 
 	if err := d.Set("minimum_healthy_hosts", flattenAwsCodeDeployConfigMinimumHealthHosts(resp.DeploymentConfigInfo.MinimumHealthyHosts)); err != nil {

--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -193,10 +193,10 @@ func resourceAwsCodePipelineCreate(d *schema.ResourceData, meta interface{}) err
 		return resource.NonRetryableError(err)
 	})
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error creating CodePipeline: %s", err)
+		return fmt.Errorf("Error creating CodePipeline: %s", err)
 	}
 	if resp.Pipeline == nil {
-		return fmt.Errorf("[ERROR] Error creating CodePipeline: invalid response from AWS")
+		return fmt.Errorf("Error creating CodePipeline: invalid response from AWS")
 	}
 
 	d.SetId(*resp.Pipeline.Name)
@@ -440,7 +440,7 @@ func resourceAwsCodePipelineRead(d *schema.ResourceData, meta interface{}) error
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error retreiving Pipeline: %q", err)
+		return fmt.Errorf("Error retreiving Pipeline: %q", err)
 	}
 	metadata := resp.Metadata
 	pipeline := resp.Pipeline

--- a/aws/resource_aws_cognito_identity_pool.go
+++ b/aws/resource_aws_cognito_identity_pool.go
@@ -170,19 +170,19 @@ func resourceAwsCognitoIdentityPoolRead(d *schema.ResourceData, meta interface{}
 	d.Set("developer_provider_name", ip.DeveloperProviderName)
 
 	if err := d.Set("cognito_identity_providers", flattenCognitoIdentityProviders(ip.CognitoIdentityProviders)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting cognito_identity_providers error: %#v", err)
+		return fmt.Errorf("Error setting cognito_identity_providers error: %#v", err)
 	}
 
 	if err := d.Set("openid_connect_provider_arns", flattenStringList(ip.OpenIdConnectProviderARNs)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting openid_connect_provider_arns error: %#v", err)
+		return fmt.Errorf("Error setting openid_connect_provider_arns error: %#v", err)
 	}
 
 	if err := d.Set("saml_provider_arns", flattenStringList(ip.SamlProviderARNs)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting saml_provider_arns error: %#v", err)
+		return fmt.Errorf("Error setting saml_provider_arns error: %#v", err)
 	}
 
 	if err := d.Set("supported_login_providers", flattenCognitoSupportedLoginProviders(ip.SupportedLoginProviders)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting supported_login_providers error: %#v", err)
+		return fmt.Errorf("Error setting supported_login_providers error: %#v", err)
 	}
 
 	return nil

--- a/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -168,11 +168,11 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentRead(d *schema.ResourceData, m
 	}
 
 	if err := d.Set("roles", flattenCognitoIdentityPoolRoles(ip.Roles)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting roles error: %#v", err)
+		return fmt.Errorf("Error setting roles error: %#v", err)
 	}
 
 	if err := d.Set("role_mapping", flattenCognitoIdentityPoolRoleMappingsAttachment(ip.RoleMappings)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting role mappings error: %#v", err)
+		return fmt.Errorf("Error setting role mappings error: %#v", err)
 	}
 
 	return nil

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -617,7 +616,7 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 		return resource.NonRetryableError(err)
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error creating Cognito User Pool: {{err}}", err)
+		return fmt.Errorf("Error creating Cognito User Pool: %s", err)
 	}
 
 	d.SetId(*resp.UserPool.Id)
@@ -862,7 +861,7 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 		return resource.NonRetryableError(err)
 	})
 	if err != nil {
-		return errwrap.Wrapf("Error updating Cognito User pool: {{err}}", err)
+		return fmt.Errorf("Error updating Cognito User pool: %s", err)
 	}
 
 	return resourceAwsCognitoUserPoolRead(d, meta)
@@ -880,7 +879,7 @@ func resourceAwsCognitoUserPoolDelete(d *schema.ResourceData, meta interface{}) 
 	_, err := conn.DeleteUserPool(params)
 
 	if err != nil {
-		return errwrap.Wrapf("Error deleting user pool: {{err}}", err)
+		return fmt.Errorf("Error deleting user pool: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_cognito_user_pool_client.go
+++ b/aws/resource_aws_cognito_user_pool_client.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -214,7 +213,7 @@ func resourceAwsCognitoUserPoolClientCreate(d *schema.ResourceData, meta interfa
 	resp, err := conn.CreateUserPoolClient(params)
 
 	if err != nil {
-		return errwrap.Wrapf("Error creating Cognito User Pool Client: {{err}}", err)
+		return fmt.Errorf("Error creating Cognito User Pool Client: %s", err)
 	}
 
 	d.SetId(*resp.UserPoolClient.ClientId)
@@ -318,7 +317,7 @@ func resourceAwsCognitoUserPoolClientUpdate(d *schema.ResourceData, meta interfa
 
 	_, err := conn.UpdateUserPoolClient(params)
 	if err != nil {
-		return errwrap.Wrapf("Error updating Cognito User Pool Client: {{err}}", err)
+		return fmt.Errorf("Error updating Cognito User Pool Client: %s", err)
 	}
 
 	return resourceAwsCognitoUserPoolClientRead(d, meta)
@@ -337,7 +336,7 @@ func resourceAwsCognitoUserPoolClientDelete(d *schema.ResourceData, meta interfa
 	_, err := conn.DeleteUserPoolClient(params)
 
 	if err != nil {
-		return errwrap.Wrapf("Error deleting Cognito User Pool Client: {{err}}", err)
+		return fmt.Errorf("Error deleting Cognito User Pool Client: %s", err)
 	}
 
 	return nil
@@ -345,7 +344,7 @@ func resourceAwsCognitoUserPoolClientDelete(d *schema.ResourceData, meta interfa
 
 func resourceAwsCognitoUserPoolClientImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	if len(strings.Split(d.Id(), "/")) != 2 || len(d.Id()) < 3 {
-		return []*schema.ResourceData{}, fmt.Errorf("[ERR] Wrong format of resource: %s. Please follow 'user-pool-id/client-id'", d.Id())
+		return []*schema.ResourceData{}, fmt.Errorf("Wrong format of resource: %s. Please follow 'user-pool-id/client-id'", d.Id())
 	}
 	userPoolId := strings.Split(d.Id(), "/")[0]
 	clientId := strings.Split(d.Id(), "/")[1]

--- a/aws/resource_aws_customer_gateway.go
+++ b/aws/resource_aws_customer_gateway.go
@@ -189,7 +189,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if len(resp.CustomerGateways) != 1 {
-		return fmt.Errorf("[ERROR] Error finding CustomerGateway: %s", d.Id())
+		return fmt.Errorf("Error finding CustomerGateway: %s", d.Id())
 	}
 
 	if *resp.CustomerGateways[0].State == "deleted" {
@@ -261,16 +261,16 @@ func resourceAwsCustomerGatewayDelete(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if len(resp.CustomerGateways) != 1 {
-			return resource.RetryableError(fmt.Errorf("[ERROR] Error finding CustomerGateway for delete: %s", d.Id()))
+			return resource.RetryableError(fmt.Errorf("Error finding CustomerGateway for delete: %s", d.Id()))
 		}
 
 		switch *resp.CustomerGateways[0].State {
 		case "pending", "available", "deleting":
-			return resource.RetryableError(fmt.Errorf("[DEBUG] Gateway (%s) in state (%s), retrying", d.Id(), *resp.CustomerGateways[0].State))
+			return resource.RetryableError(fmt.Errorf("Gateway (%s) in state (%s), retrying", d.Id(), *resp.CustomerGateways[0].State))
 		case "deleted":
 			return nil
 		default:
-			return resource.RetryableError(fmt.Errorf("[DEBUG] Unrecognized state (%s) for Customer Gateway delete on (%s)", *resp.CustomerGateways[0].State, d.Id()))
+			return resource.RetryableError(fmt.Errorf("Unrecognized state (%s) for Customer Gateway delete on (%s)", *resp.CustomerGateways[0].State, d.Id()))
 		}
 	})
 

--- a/aws/resource_aws_dax_cluster.go
+++ b/aws/resource_aws_dax_cluster.go
@@ -385,7 +385,7 @@ func resourceAwsDaxClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		log.Printf("[DEBUG] Modifying DAX Cluster (%s), opts:\n%s", d.Id(), req)
 		_, err := conn.UpdateCluster(req)
 		if err != nil {
-			return fmt.Errorf("[WARN] Error updating DAX cluster (%s), error: %s", d.Id(), err)
+			return fmt.Errorf("Error updating DAX cluster (%s), error: %s", d.Id(), err)
 		}
 		awaitUpdate = true
 	}
@@ -401,7 +401,7 @@ func resourceAwsDaxClusterUpdate(d *schema.ResourceData, meta interface{}) error
 				NewReplicationFactor: aws.Int64(int64(nraw.(int))),
 			})
 			if err != nil {
-				return fmt.Errorf("[WARN] Error increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
+				return fmt.Errorf("Error increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
 			}
 			awaitUpdate = true
 		}
@@ -412,7 +412,7 @@ func resourceAwsDaxClusterUpdate(d *schema.ResourceData, meta interface{}) error
 				NewReplicationFactor: aws.Int64(int64(nraw.(int))),
 			})
 			if err != nil {
-				return fmt.Errorf("[WARN] Error increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
+				return fmt.Errorf("Error increasing nodes in DAX cluster %s, error: %s", d.Id(), err)
 			}
 			awaitUpdate = true
 		}
@@ -524,7 +524,7 @@ func daxClusterStateRefreshFunc(conn *dax.DAX, clusterID, givenState string, pen
 		}
 
 		if len(resp.Clusters) == 0 {
-			return nil, "", fmt.Errorf("[WARN] Error: no DAX clusters found for id (%s)", clusterID)
+			return nil, "", fmt.Errorf("Error: no DAX clusters found for id (%s)", clusterID)
 		}
 
 		var c *dax.Cluster
@@ -536,7 +536,7 @@ func daxClusterStateRefreshFunc(conn *dax.DAX, clusterID, givenState string, pen
 		}
 
 		if c == nil {
-			return nil, "", fmt.Errorf("[WARN] Error: no matching DAX cluster for id (%s)", clusterID)
+			return nil, "", fmt.Errorf("Error: no matching DAX cluster for id (%s)", clusterID)
 		}
 
 		// DescribeCluster returns a response without status late on in the

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1230,7 +1230,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		replicas = append(replicas, *v)
 	}
 	if err := d.Set("replicas", replicas); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting replicas attribute: %#v, error: %#v", replicas, err)
+		return fmt.Errorf("Error setting replicas attribute: %#v, error: %#v", replicas, err)
 	}
 
 	d.Set("replicate_source_db", v.ReadReplicaSourceDBInstanceIdentifier)

--- a/aws/resource_aws_default_network_acl.go
+++ b/aws/resource_aws_default_network_acl.go
@@ -261,7 +261,7 @@ func revokeAllNetworkACLEntries(netaclId string, meta interface{}) error {
 	}
 
 	if resp == nil {
-		return fmt.Errorf("[ERR] Error looking up Default Network ACL Entries: No results")
+		return fmt.Errorf("Error looking up Default Network ACL Entries: No results")
 	}
 
 	networkAcl := resp.NetworkAcls[0]

--- a/aws/resource_aws_default_security_group.go
+++ b/aws/resource_aws_default_security_group.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -67,7 +66,7 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 		// returned, as default is a protected name for each VPC, and for each
 		// Region on EC2 Classic
 		if len(resp.SecurityGroups) != 1 {
-			return fmt.Errorf("[ERR] Error finding default security group; found (%d) groups: %s", len(resp.SecurityGroups), resp)
+			return fmt.Errorf("Error finding default security group; found (%d) groups: %s", len(resp.SecurityGroups), resp)
 		}
 		g = resp.SecurityGroups[0]
 	} else {
@@ -81,7 +80,7 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 	}
 
 	if g == nil {
-		return fmt.Errorf("[ERR] Error finding default security group: no matching group found")
+		return fmt.Errorf("Error finding default security group: no matching group found")
 	}
 
 	d.SetId(*g.GroupId)
@@ -93,7 +92,7 @@ func resourceAwsDefaultSecurityGroupCreate(d *schema.ResourceData, meta interfac
 	}
 
 	if err := revokeDefaultSecurityGroupRules(meta, g); err != nil {
-		return errwrap.Wrapf("{{err}}", err)
+		return fmt.Errorf("%s", err)
 	}
 
 	return resourceAwsSecurityGroupUpdate(d, meta)

--- a/aws/resource_aws_dms_replication_task.go
+++ b/aws/resource_aws_dms_replication_task.go
@@ -104,7 +104,7 @@ func resourceAwsDmsReplicationTaskCreate(d *schema.ResourceData, meta interface{
 	if v, ok := d.GetOk("cdc_start_time"); ok {
 		seconds, err := strconv.ParseInt(v.(string), 10, 64)
 		if err != nil {
-			return fmt.Errorf("[ERROR] DMS create replication task. Invalid CDC Unix timestamp: %s", err)
+			return fmt.Errorf("DMS create replication task. Invalid CDC Unix timestamp: %s", err)
 		}
 		request.CdcStartTime = aws.Time(time.Unix(seconds, 0))
 	}
@@ -188,7 +188,7 @@ func resourceAwsDmsReplicationTaskUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("cdc_start_time") {
 		seconds, err := strconv.ParseInt(d.Get("cdc_start_time").(string), 10, 64)
 		if err != nil {
-			return fmt.Errorf("[ERROR] DMS update replication task. Invalid CRC Unix timestamp: %s", err)
+			return fmt.Errorf("DMS update replication task. Invalid CRC Unix timestamp: %s", err)
 		}
 		request.CdcStartTime = aws.Time(time.Unix(seconds, 0))
 		hasChanges = true

--- a/aws/resource_aws_dx_connection.go
+++ b/aws/resource_aws_dx_connection.go
@@ -88,11 +88,11 @@ func resourceAwsDxConnectionRead(d *schema.ResourceData, meta interface{}) error
 		return nil
 	}
 	if len(resp.Connections) != 1 {
-		return fmt.Errorf("[ERROR] Number of Direct Connect connections (%s) isn't one, got %d", d.Id(), len(resp.Connections))
+		return fmt.Errorf("Number of Direct Connect connections (%s) isn't one, got %d", d.Id(), len(resp.Connections))
 	}
 	connection := resp.Connections[0]
 	if d.Id() != aws.StringValue(connection.ConnectionId) {
-		return fmt.Errorf("[ERROR] Direct Connect connection (%s) not found", d.Id())
+		return fmt.Errorf("Direct Connect connection (%s) not found", d.Id())
 	}
 	if aws.StringValue(connection.ConnectionState) == directconnect.ConnectionStateDeleted {
 		log.Printf("[WARN] Direct Connect connection (%s) not found, removing from state", d.Id())

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -111,11 +111,11 @@ func resourceAwsDxLagRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 	if len(resp.Lags) != 1 {
-		return fmt.Errorf("[ERROR] Number of Direct Connect LAGs (%s) isn't one, got %d", d.Id(), len(resp.Lags))
+		return fmt.Errorf("Number of Direct Connect LAGs (%s) isn't one, got %d", d.Id(), len(resp.Lags))
 	}
 	lag := resp.Lags[0]
 	if d.Id() != aws.StringValue(lag.LagId) {
-		return fmt.Errorf("[ERROR] Direct Connect LAG (%s) not found", d.Id())
+		return fmt.Errorf("Direct Connect LAG (%s) not found", d.Id())
 	}
 
 	if aws.StringValue(lag.LagState) == directconnect.LagStateDeleted {

--- a/aws/resource_aws_dynamodb_table_item_test.go
+++ b/aws/resource_aws_dynamodb_table_item_test.go
@@ -290,7 +290,7 @@ func testAccCheckAWSDynamoDbTableItemExists(n string, item *dynamodb.GetItemOutp
 			ExpressionAttributeNames: buildDynamoDbExpressionAttributeNames(attributes),
 		})
 		if err != nil {
-			return fmt.Errorf("[ERROR] Problem getting table item '%s': %s", rs.Primary.ID, err)
+			return fmt.Errorf("Problem getting table item '%s': %s", rs.Primary.ID, err)
 		}
 
 		*item = *result

--- a/aws/resource_aws_dynamodb_table_migrate.go
+++ b/aws/resource_aws_dynamodb_table_migrate.go
@@ -3,10 +3,10 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"strings"
 )
 
 func resourceAwsDynamoDbTableMigrateState(

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -769,7 +769,7 @@ func testAccCheckDynamoDbTableTimeToLiveWasUpdated(n string) resource.TestCheckF
 		resp, err := conn.DescribeTimeToLive(params)
 
 		if err != nil {
-			return fmt.Errorf("[ERROR] Problem describing time to live for table '%s': %s", rs.Primary.ID, err)
+			return fmt.Errorf("Problem describing time to live for table '%s': %s", rs.Primary.ID, err)
 		}
 
 		ttlDescription := resp.TimeToLiveDescription
@@ -813,7 +813,7 @@ func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "server_side_encryption.#", "0"),
 					func(s *terraform.State) error {
 						if confEncDisabled.Table.CreationDateTime.Equal(*confEncEnabled.Table.CreationDateTime) {
-							return fmt.Errorf("[ERROR] DynamoDB table not recreated when changing SSE")
+							return fmt.Errorf("DynamoDB table not recreated when changing SSE")
 						}
 						return nil
 					},
@@ -826,7 +826,7 @@ func TestAccAWSDynamoDbTable_encryption(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "server_side_encryption.#", "0"),
 					func(s *terraform.State) error {
 						if !confBasic.Table.CreationDateTime.Equal(*confEncDisabled.Table.CreationDateTime) {
-							return fmt.Errorf("[ERROR] DynamoDB table was recreated unexpectedly")
+							return fmt.Errorf("DynamoDB table was recreated unexpectedly")
 						}
 						return nil
 					},
@@ -887,7 +887,7 @@ func testAccCheckInitialAWSDynamoDbTableExists(n string, table *dynamodb.Describ
 		resp, err := conn.DescribeTable(params)
 
 		if err != nil {
-			return fmt.Errorf("[ERROR] Problem describing table '%s': %s", rs.Primary.ID, err)
+			return fmt.Errorf("Problem describing table '%s': %s", rs.Primary.ID, err)
 		}
 
 		*table = *resp
@@ -917,7 +917,7 @@ func testAccCheckInitialAWSDynamoDbTableConf(n string) resource.TestCheckFunc {
 		resp, err := conn.DescribeTable(params)
 
 		if err != nil {
-			return fmt.Errorf("[ERROR] Problem describing table '%s': %s", rs.Primary.ID, err)
+			return fmt.Errorf("Problem describing table '%s': %s", rs.Primary.ID, err)
 		}
 
 		table := resp.Table

--- a/aws/resource_aws_ebs_volume.go
+++ b/aws/resource_aws_ebs_volume.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -141,7 +140,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if _, ok := d.GetOk("tags"); ok {
 		if err := setTags(conn, d); err != nil {
-			return errwrap.Wrapf("Error setting tags for EBS Volume: {{err}}", err)
+			return fmt.Errorf("Error setting tags for EBS Volume: %s", err)
 		}
 	}
 
@@ -152,7 +151,7 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 	conn := meta.(*AWSClient).ec2conn
 	if _, ok := d.GetOk("tags"); ok {
 		if err := setTags(conn, d); err != nil {
-			return errwrap.Wrapf("Error updating tags for EBS Volume: {{err}}", err)
+			return fmt.Errorf("Error updating tags for EBS Volume: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -306,7 +306,7 @@ func resourceAwsEcsService() *schema.Resource {
 
 func resourceAwsEcsServiceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	if len(strings.Split(d.Id(), "/")) != 2 {
-		return []*schema.ResourceData{}, fmt.Errorf("[ERR] Wrong format of resource: %s. Please follow 'cluster-name/service-name'", d.Id())
+		return []*schema.ResourceData{}, fmt.Errorf("Wrong format of resource: %s. Please follow 'cluster-name/service-name'", d.Id())
 	}
 	cluster := strings.Split(d.Id(), "/")[0]
 	name := strings.Split(d.Id(), "/")[1]
@@ -575,11 +575,11 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := d.Set("network_configuration", flattenEcsNetworkConfiguration(service.NetworkConfiguration)); err != nil {
-		return fmt.Errorf("[ERR] Error setting network_configuration for (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error setting network_configuration for (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("service_registries", flattenServiceRegistries(service.ServiceRegistries)); err != nil {
-		return fmt.Errorf("[ERR] Error setting service_registries for (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error setting service_registries for (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_egress_only_internet_gateway.go
+++ b/aws/resource_aws_egress_only_internet_gateway.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -54,7 +53,7 @@ func resourceAwsEgressOnlyInternetGatewayCreate(d *schema.ResourceData, meta int
 	})
 
 	if err != nil {
-		return errwrap.Wrapf("{{err}}", err)
+		return fmt.Errorf("%s", err)
 	}
 
 	return resourceAwsEgressOnlyInternetGatewayRead(d, meta)

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -803,7 +803,7 @@ func environmentStateRefreshFunc(conn *elasticbeanstalk.ElasticBeanstalk, enviro
 		})
 		if err != nil {
 			log.Printf("[Err] Error waiting for Elastic Beanstalk Environment state: %s", err)
-			return -1, "failed", fmt.Errorf("[Err] Error waiting for Elastic Beanstalk Environment state: %s", err)
+			return -1, "failed", fmt.Errorf("Error waiting for Elastic Beanstalk Environment state: %s", err)
 		}
 
 		if resp == nil || len(resp.Environments) == 0 {
@@ -820,7 +820,7 @@ func environmentStateRefreshFunc(conn *elasticbeanstalk.ElasticBeanstalk, enviro
 		}
 
 		if env == nil {
-			return -1, "failed", fmt.Errorf("[Err] Error finding Elastic Beanstalk Environment, environment not found")
+			return -1, "failed", fmt.Errorf("Error finding Elastic Beanstalk Environment, environment not found")
 		}
 
 		envErrors, err := getBeanstalkEnvironmentErrors(conn, environmentId, t)
@@ -968,7 +968,7 @@ func getBeanstalkEnvironmentErrors(conn *elasticbeanstalk.ElasticBeanstalk, envi
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("[Err] Unable to get Elastic Beanstalk Evironment events: %s", err)
+		return nil, fmt.Errorf("Unable to get Elastic Beanstalk Evironment events: %s", err)
 	}
 
 	var events beanstalkEnvironmentErrors

--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -210,7 +210,7 @@ func resourceAwsElasticTranscoderPipelineCreate(d *schema.ResourceData, meta int
 
 	if (req.OutputBucket == nil && (req.ContentConfig == nil || req.ContentConfig.Bucket == nil)) ||
 		(req.OutputBucket != nil && req.ContentConfig != nil && req.ContentConfig.Bucket != nil) {
-		return fmt.Errorf("[ERROR] you must specify only one of output_bucket or content_config.bucket")
+		return fmt.Errorf("you must specify only one of output_bucket or content_config.bucket")
 	}
 
 	log.Printf("[DEBUG] Elastic Transcoder Pipeline create opts: %s", req)

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -628,7 +628,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		log.Printf("[DEBUG] Modifying ElastiCache Cluster (%s), opts:\n%s", d.Id(), req)
 		_, err := conn.ModifyCacheCluster(req)
 		if err != nil {
-			return fmt.Errorf("[WARN] Error updating ElastiCache cluster (%s), error: %s", d.Id(), err)
+			return fmt.Errorf("Error updating ElastiCache cluster (%s), error: %s", d.Id(), err)
 		}
 
 		log.Printf("[DEBUG] Waiting for update: %s", d.Id())
@@ -727,7 +727,7 @@ func cacheClusterStateRefreshFunc(conn *elasticache.ElastiCache, clusterID, give
 		}
 
 		if len(resp.CacheClusters) == 0 {
-			return nil, "", fmt.Errorf("[WARN] Error: no Cache Clusters found for id (%s)", clusterID)
+			return nil, "", fmt.Errorf("Error: no Cache Clusters found for id (%s)", clusterID)
 		}
 
 		var c *elasticache.CacheCluster
@@ -739,7 +739,7 @@ func cacheClusterStateRefreshFunc(conn *elasticache.ElastiCache, clusterID, give
 		}
 
 		if c == nil {
-			return nil, "", fmt.Errorf("[WARN] Error: no matching Elastic Cache cluster for id (%s)", clusterID)
+			return nil, "", fmt.Errorf("Error: no matching Elastic Cache cluster for id (%s)", clusterID)
 		}
 
 		log.Printf("[DEBUG] ElastiCache Cluster (%s) status: %v", clusterID, *c.CacheClusterStatus)

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -697,7 +697,7 @@ func cacheReplicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replic
 		}
 
 		if len(resp.ReplicationGroups) == 0 {
-			return nil, "", fmt.Errorf("[WARN] Error: no Cache Replication Groups found for id (%s)", replicationGroupId)
+			return nil, "", fmt.Errorf("Error: no Cache Replication Groups found for id (%s)", replicationGroupId)
 		}
 
 		var rg *elasticache.ReplicationGroup
@@ -709,7 +709,7 @@ func cacheReplicationGroupStateRefreshFunc(conn *elasticache.ElastiCache, replic
 		}
 
 		if rg == nil {
-			return nil, "", fmt.Errorf("[WARN] Error: no matching ElastiCache Replication Group for id (%s)", replicationGroupId)
+			return nil, "", fmt.Errorf("Error: no matching ElastiCache Replication Group for id (%s)", replicationGroupId)
 		}
 
 		log.Printf("[DEBUG] ElastiCache Replication Group (%s) status: %v", replicationGroupId, *rg.Status)

--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -526,7 +525,7 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	if ds.AccessPolicies != nil && aws.StringValue(ds.AccessPolicies) != "" {
 		policies, err := structure.NormalizeJsonString(aws.StringValue(ds.AccessPolicies))
 		if err != nil {
-			return errwrap.Wrapf("access policies contain an invalid JSON: {{err}}", err)
+			return fmt.Errorf("access policies contain an invalid JSON: %s", err)
 		}
 		d.Set("access_policies", policies)
 	}

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -304,7 +304,7 @@ func resourceAwsElbCreate(d *schema.ResourceData, meta interface{}) error {
 				// Check for IAM SSL Cert error, eventual consistancy issue
 				if awsErr.Code() == "CertificateNotFound" {
 					return resource.RetryableError(
-						fmt.Errorf("[WARN] Error creating ELB Listener with SSL Cert, retrying: %s", err))
+						fmt.Errorf("Error creating ELB Listener with SSL Cert, retrying: %s", err))
 				}
 			}
 			return resource.NonRetryableError(err)
@@ -407,7 +407,7 @@ func flattenAwsELbResource(d *schema.ResourceData, ec2conn *ec2.EC2, elbconn *el
 			elbVpc = *lb.VPCId
 			sgId, err := sourceSGIdByName(ec2conn, *lb.SourceSecurityGroup.GroupName, elbVpc)
 			if err != nil {
-				return fmt.Errorf("[WARN] Error looking up ELB Security Group ID: %s", err)
+				return fmt.Errorf("Error looking up ELB Security Group ID: %s", err)
 			} else {
 				d.Set("source_security_group_id", sgId)
 			}

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -615,7 +615,7 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for EMR Cluster state to be \"WAITING\" or \"RUNNING\": %s", err)
+		return fmt.Errorf("Error waiting for EMR Cluster state to be \"WAITING\" or \"RUNNING\": %s", err)
 	}
 
 	return resourceAwsEMRClusterRead(d, meta)
@@ -767,7 +767,7 @@ func resourceAwsEMRClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		coreInstanceCount := d.Get("core_instance_count").(int)
 		coreGroup := findGroup(groups, "CORE")
 		if coreGroup == nil {
-			return fmt.Errorf("[ERR] Error finding core group")
+			return fmt.Errorf("Error finding core group")
 		}
 
 		params := &emr.ModifyInstanceGroupsInput{
@@ -805,7 +805,7 @@ func resourceAwsEMRClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 		_, err = stateConf.WaitForState()
 		if err != nil {
-			return fmt.Errorf("[WARN] Error waiting for EMR Cluster state to be \"WAITING\" or \"RUNNING\" after modification: %s", err)
+			return fmt.Errorf("Error waiting for EMR Cluster state to be \"WAITING\" or \"RUNNING\" after modification: %s", err)
 		}
 	}
 
@@ -891,7 +891,7 @@ func resourceAwsEMRClusterDelete(d *schema.ResourceData, meta interface{}) error
 			log.Printf("[DEBUG] All (%d) EMR Cluster (%s) Instances terminated", instanceCount, d.Id())
 			return nil
 		}
-		return resource.RetryableError(fmt.Errorf("[DEBUG] EMR Cluster (%s) has (%d) Instances remaining, retrying", d.Id(), len(resp.Instances)))
+		return resource.RetryableError(fmt.Errorf("EMR Cluster (%s) has (%d) Instances remaining, retrying", d.Id(), len(resp.Instances)))
 	})
 
 	if err != nil {

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -449,7 +449,7 @@ func testAccCheck_bootstrap_order(cluster *emr.Cluster, argsInts, argsStrings []
 
 		resp, err := emrconn.ListBootstrapActions(&req)
 		if err != nil {
-			return fmt.Errorf("[ERR] Error listing boostrap actions in test: %s", err)
+			return fmt.Errorf("Error listing boostrap actions in test: %s", err)
 		}
 
 		// make sure we actually checked something

--- a/aws/resource_aws_emr_instance_group.go
+++ b/aws/resource_aws_emr_instance_group.go
@@ -198,10 +198,10 @@ func fetchAllEMRInstanceGroups(conn *emr.EMR, clusterId string) ([]*emr.Instance
 		log.Printf("[DEBUG] EMR Cluster Instance Marker: %s", *marker)
 		respGrps, errGrps := conn.ListInstanceGroups(req)
 		if errGrps != nil {
-			return nil, fmt.Errorf("[ERR] Error reading EMR cluster (%s): %s", clusterId, errGrps)
+			return nil, fmt.Errorf("Error reading EMR cluster (%s): %s", clusterId, errGrps)
 		}
 		if respGrps == nil {
-			return nil, fmt.Errorf("[ERR] Error reading EMR Instance Group for cluster (%s)", clusterId)
+			return nil, fmt.Errorf("Error reading EMR Instance Group for cluster (%s)", clusterId)
 		}
 
 		if respGrps.InstanceGroups != nil {
@@ -215,7 +215,7 @@ func fetchAllEMRInstanceGroups(conn *emr.EMR, clusterId string) ([]*emr.Instance
 	}
 
 	if len(groups) == 0 {
-		return nil, fmt.Errorf("[WARN] No instance groups found for EMR Cluster (%s)", clusterId)
+		return nil, fmt.Errorf("No instance groups found for EMR Cluster (%s)", clusterId)
 	}
 
 	return groups, nil

--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -162,7 +162,7 @@ func resourceAwsLogFlowDelete(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("[WARN] Error deleting Flow Log with ID (%s), error: %s", d.Id(), err)
+		return fmt.Errorf("Error deleting Flow Log with ID (%s), error: %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_glacier_vault.go
+++ b/aws/resource_aws_glacier_vault.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -167,7 +166,7 @@ func resourceAwsGlacierVaultRead(d *schema.ResourceData, meta interface{}) error
 	} else if pol != nil {
 		policy, err := structure.NormalizeJsonString(*pol.Policy.Policy)
 		if err != nil {
-			return errwrap.Wrapf("access policy contains an invalid JSON: {{err}}", err)
+			return fmt.Errorf("access policy contains an invalid JSON: %s", err)
 		}
 		d.Set("access_policy", policy)
 	} else {

--- a/aws/resource_aws_guardduty_ipset.go
+++ b/aws/resource_aws_guardduty_ipset.go
@@ -86,7 +86,7 @@ func resourceAwsGuardDutyIpsetCreate(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for GuardDuty IpSet status to be \"%s\" or \"%s\": %s", guardduty.IpSetStatusActive, guardduty.IpSetStatusInactive, err)
+		return fmt.Errorf("Error waiting for GuardDuty IpSet status to be \"%s\" or \"%s\": %s", guardduty.IpSetStatusActive, guardduty.IpSetStatusInactive, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", detectorID, *resp.IpSetId))
@@ -186,7 +186,7 @@ func resourceAwsGuardDutyIpsetDelete(d *schema.ResourceData, meta interface{}) e
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for GuardDuty IpSet status to be \"%s\": %s", guardduty.IpSetStatusDeleted, err)
+		return fmt.Errorf("Error waiting for GuardDuty IpSet status to be \"%s\": %s", guardduty.IpSetStatusDeleted, err)
 	}
 
 	return nil

--- a/aws/resource_aws_guardduty_threatintelset.go
+++ b/aws/resource_aws_guardduty_threatintelset.go
@@ -86,7 +86,7 @@ func resourceAwsGuardDutyThreatintelsetCreate(d *schema.ResourceData, meta inter
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for GuardDuty ThreatIntelSet status to be \"%s\" or \"%s\": %s",
+		return fmt.Errorf("Error waiting for GuardDuty ThreatIntelSet status to be \"%s\" or \"%s\": %s",
 			guardduty.ThreatIntelSetStatusActive, guardduty.ThreatIntelSetStatusInactive, err)
 	}
 
@@ -187,7 +187,7 @@ func resourceAwsGuardDutyThreatintelsetDelete(d *schema.ResourceData, meta inter
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for GuardDuty ThreatIntelSet status to be \"%s\": %s", guardduty.ThreatIntelSetStatusDeleted, err)
+		return fmt.Errorf("Error waiting for GuardDuty ThreatIntelSet status to be \"%s\": %s", guardduty.ThreatIntelSetStatusDeleted, err)
 	}
 
 	return nil

--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -75,7 +75,7 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(*createResp.AccessKey.AccessKeyId)
 
 	if createResp.AccessKey == nil || createResp.AccessKey.SecretAccessKey == nil {
-		return fmt.Errorf("[ERR] CreateAccessKey response did not contain a Secret Access Key as expected")
+		return fmt.Errorf("CreateAccessKey response did not contain a Secret Access Key as expected")
 	}
 
 	if v, ok := d.GetOk("pgp_key"); ok {

--- a/aws/resource_aws_iam_group_membership.go
+++ b/aws/resource_aws_iam_group_membership.go
@@ -88,7 +88,7 @@ func resourceAwsIamGroupMembershipRead(d *schema.ResourceData, meta interface{})
 	}
 
 	if err := d.Set("users", ul); err != nil {
-		return fmt.Errorf("[WARN] Error setting user list from IAM Group Membership (%s), error: %s", group, err)
+		return fmt.Errorf("Error setting user list from IAM Group Membership (%s), error: %s", group, err)
 	}
 
 	return nil

--- a/aws/resource_aws_iam_group_policy_attachment.go
+++ b/aws/resource_aws_iam_group_policy_attachment.go
@@ -40,7 +40,7 @@ func resourceAwsIamGroupPolicyAttachmentCreate(d *schema.ResourceData, meta inte
 
 	err := attachPolicyToGroup(conn, group, arn)
 	if err != nil {
-		return fmt.Errorf("[WARN] Error attaching policy %s to IAM group %s: %v", arn, group, err)
+		return fmt.Errorf("Error attaching policy %s to IAM group %s: %v", arn, group, err)
 	}
 
 	d.SetId(resource.PrefixedUniqueId(fmt.Sprintf("%s-", group)))
@@ -96,7 +96,7 @@ func resourceAwsIamGroupPolicyAttachmentDelete(d *schema.ResourceData, meta inte
 
 	err := detachPolicyFromGroup(conn, group, arn)
 	if err != nil {
-		return fmt.Errorf("[WARN] Error removing policy %s from IAM Group %s: %v", arn, group, err)
+		return fmt.Errorf("Error removing policy %s from IAM Group %s: %v", arn, group, err)
 	}
 	return nil
 }

--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -65,7 +65,7 @@ func resourceAwsIamPolicyAttachmentCreate(d *schema.ResourceData, meta interface
 	groups := expandStringList(d.Get("groups").(*schema.Set).List())
 
 	if len(users) == 0 && len(roles) == 0 && len(groups) == 0 {
-		return fmt.Errorf("[WARN] No Users, Roles, or Groups specified for IAM Policy Attachment %s", name)
+		return fmt.Errorf("No Users, Roles, or Groups specified for IAM Policy Attachment %s", name)
 	} else {
 		var userErr, roleErr, groupErr error
 		if users != nil {

--- a/aws/resource_aws_iam_role_policy_attachment.go
+++ b/aws/resource_aws_iam_role_policy_attachment.go
@@ -40,7 +40,7 @@ func resourceAwsIamRolePolicyAttachmentCreate(d *schema.ResourceData, meta inter
 
 	err := attachPolicyToRole(conn, role, arn)
 	if err != nil {
-		return fmt.Errorf("[WARN] Error attaching policy %s to IAM Role %s: %v", arn, role, err)
+		return fmt.Errorf("Error attaching policy %s to IAM Role %s: %v", arn, role, err)
 	}
 
 	d.SetId(resource.PrefixedUniqueId(fmt.Sprintf("%s-", role)))
@@ -98,7 +98,7 @@ func resourceAwsIamRolePolicyAttachmentDelete(d *schema.ResourceData, meta inter
 
 	err := detachPolicyFromRole(conn, role, arn)
 	if err != nil {
-		return fmt.Errorf("[WARN] Error removing policy %s from IAM Role %s: %v", arn, role, err)
+		return fmt.Errorf("Error removing policy %s from IAM Role %s: %v", arn, role, err)
 	}
 	return nil
 }

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -113,9 +113,9 @@ func resourceAwsIAMServerCertificateCreate(d *schema.ResourceData, meta interfac
 	resp, err := conn.UploadServerCertificate(createOpts)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			return fmt.Errorf("[WARN] Error uploading server certificate, error: %s: %s", awsErr.Code(), awsErr.Message())
+			return fmt.Errorf("Error uploading server certificate, error: %s: %s", awsErr.Code(), awsErr.Message())
 		}
-		return fmt.Errorf("[WARN] Error uploading server certificate, error: %s", err)
+		return fmt.Errorf("Error uploading server certificate, error: %s", err)
 	}
 
 	d.SetId(*resp.ServerCertificateMetadata.ServerCertificateId)
@@ -137,9 +137,9 @@ func resourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interface{
 				d.SetId("")
 				return nil
 			}
-			return fmt.Errorf("[WARN] Error reading IAM Server Certificate: %s: %s", awsErr.Code(), awsErr.Message())
+			return fmt.Errorf("Error reading IAM Server Certificate: %s: %s", awsErr.Code(), awsErr.Message())
 		}
-		return fmt.Errorf("[WARN] Error reading IAM Server Certificate: %s", err)
+		return fmt.Errorf("Error reading IAM Server Certificate: %s", err)
 	}
 
 	d.SetId(*resp.ServerCertificate.ServerCertificateMetadata.ServerCertificateId)

--- a/aws/resource_aws_iam_user_group_membership.go
+++ b/aws/resource_aws_iam_user_group_membership.go
@@ -86,7 +86,7 @@ func resourceAwsIamUserGroupMembershipRead(d *schema.ResourceData, meta interfac
 	}
 
 	if err := d.Set("groups", gl); err != nil {
-		return fmt.Errorf("[WARN] Error setting group list from IAM (%s), error: %s", user, err)
+		return fmt.Errorf("Error setting group list from IAM (%s), error: %s", user, err)
 	}
 
 	return nil

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/encryption"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -166,7 +165,7 @@ func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface
 			d.Set("encrypted_password", "")
 			return nil
 		}
-		return errwrap.Wrapf(fmt.Sprintf("Error creating IAM User Login Profile for %q: {{err}}", username), err)
+		return fmt.Errorf("Error creating IAM User Login Profile for %q: %s", username, err)
 	}
 
 	d.SetId(*createResp.LoginProfile.UserName)

--- a/aws/resource_aws_iam_user_policy_attachment.go
+++ b/aws/resource_aws_iam_user_policy_attachment.go
@@ -40,7 +40,7 @@ func resourceAwsIamUserPolicyAttachmentCreate(d *schema.ResourceData, meta inter
 
 	err := attachPolicyToUser(conn, user, arn)
 	if err != nil {
-		return fmt.Errorf("[WARN] Error attaching policy %s to IAM User %s: %v", arn, user, err)
+		return fmt.Errorf("Error attaching policy %s to IAM User %s: %v", arn, user, err)
 	}
 
 	d.SetId(resource.PrefixedUniqueId(fmt.Sprintf("%s-", user)))
@@ -95,7 +95,7 @@ func resourceAwsIamUserPolicyAttachmentDelete(d *schema.ResourceData, meta inter
 
 	err := detachPolicyFromUser(conn, user, arn)
 	if err != nil {
-		return fmt.Errorf("[WARN] Error removing policy %s from IAM User %s: %v", arn, user, err)
+		return fmt.Errorf("Error removing policy %s from IAM User %s: %v", arn, user, err)
 	}
 	return nil
 }

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1159,7 +1159,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			})
 		}
 		if mErr != nil {
-			return fmt.Errorf("[WARN] Error updating Instance monitoring: %s", mErr)
+			return fmt.Errorf("Error updating Instance monitoring: %s", mErr)
 		}
 	}
 
@@ -1176,7 +1176,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("[WARN] Error updating Instance credit specification: %s", err)
+				return fmt.Errorf("Error updating Instance credit specification: %s", err)
 			}
 		}
 	}
@@ -1398,7 +1398,7 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 	}
 
 	if rootDeviceName == nil {
-		return nil, fmt.Errorf("[WARN] Error finding Root Device Name for AMI (%s)", ami)
+		return nil, fmt.Errorf("Error finding Root Device Name for AMI (%s)", ami)
 	}
 
 	return rootDeviceName, nil

--- a/aws/resource_aws_internet_gateway.go
+++ b/aws/resource_aws_internet_gateway.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -62,7 +61,7 @@ func resourceAwsInternetGatewayCreate(d *schema.ResourceData, meta interface{}) 
 	})
 
 	if err != nil {
-		return errwrap.Wrapf("{{err}}", err)
+		return fmt.Errorf("%s", err)
 	}
 
 	err = setTags(conn, d)

--- a/aws/resource_aws_iot_policy_test.go
+++ b/aws/resource_aws_iot_policy_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestAccAWSIoTPolicy_basic(t *testing.T) {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1754,7 +1754,7 @@ func extractPrefixConfiguration(s3 map[string]interface{}) *string {
 func createRedshiftConfig(d *schema.ResourceData, s3Config *firehose.S3DestinationConfiguration) (*firehose.RedshiftDestinationConfiguration, error) {
 	redshiftRaw, ok := d.GetOk("redshift_configuration")
 	if !ok {
-		return nil, fmt.Errorf("[ERR] Error loading Redshift Configuration for Kinesis Firehose: redshift_configuration not found")
+		return nil, fmt.Errorf("Error loading Redshift Configuration for Kinesis Firehose: redshift_configuration not found")
 	}
 	rl := redshiftRaw.([]interface{})
 
@@ -1787,7 +1787,7 @@ func createRedshiftConfig(d *schema.ResourceData, s3Config *firehose.S3Destinati
 func updateRedshiftConfig(d *schema.ResourceData, s3Update *firehose.S3DestinationUpdate) (*firehose.RedshiftDestinationUpdate, error) {
 	redshiftRaw, ok := d.GetOk("redshift_configuration")
 	if !ok {
-		return nil, fmt.Errorf("[ERR] Error loading Redshift Configuration for Kinesis Firehose: redshift_configuration not found")
+		return nil, fmt.Errorf("Error loading Redshift Configuration for Kinesis Firehose: redshift_configuration not found")
 	}
 	rl := redshiftRaw.([]interface{})
 
@@ -1820,7 +1820,7 @@ func updateRedshiftConfig(d *schema.ResourceData, s3Update *firehose.S3Destinati
 func createElasticsearchConfig(d *schema.ResourceData, s3Config *firehose.S3DestinationConfiguration) (*firehose.ElasticsearchDestinationConfiguration, error) {
 	esConfig, ok := d.GetOk("elasticsearch_configuration")
 	if !ok {
-		return nil, fmt.Errorf("[ERR] Error loading Elasticsearch Configuration for Kinesis Firehose: elasticsearch_configuration not found")
+		return nil, fmt.Errorf("Error loading Elasticsearch Configuration for Kinesis Firehose: elasticsearch_configuration not found")
 	}
 	esList := esConfig.([]interface{})
 
@@ -1857,7 +1857,7 @@ func createElasticsearchConfig(d *schema.ResourceData, s3Config *firehose.S3Dest
 func updateElasticsearchConfig(d *schema.ResourceData, s3Update *firehose.S3DestinationUpdate) (*firehose.ElasticsearchDestinationUpdate, error) {
 	esConfig, ok := d.GetOk("elasticsearch_configuration")
 	if !ok {
-		return nil, fmt.Errorf("[ERR] Error loading Elasticsearch Configuration for Kinesis Firehose: elasticsearch_configuration not found")
+		return nil, fmt.Errorf("Error loading Elasticsearch Configuration for Kinesis Firehose: elasticsearch_configuration not found")
 	}
 	esList := esConfig.([]interface{})
 
@@ -1891,7 +1891,7 @@ func updateElasticsearchConfig(d *schema.ResourceData, s3Update *firehose.S3Dest
 func createSplunkConfig(d *schema.ResourceData, s3Config *firehose.S3DestinationConfiguration) (*firehose.SplunkDestinationConfiguration, error) {
 	splunkRaw, ok := d.GetOk("splunk_configuration")
 	if !ok {
-		return nil, fmt.Errorf("[ERR] Error loading Splunk Configuration for Kinesis Firehose: splunk_configuration not found")
+		return nil, fmt.Errorf("Error loading Splunk Configuration for Kinesis Firehose: splunk_configuration not found")
 	}
 	sl := splunkRaw.([]interface{})
 
@@ -1923,7 +1923,7 @@ func createSplunkConfig(d *schema.ResourceData, s3Config *firehose.S3Destination
 func updateSplunkConfig(d *schema.ResourceData, s3Update *firehose.S3DestinationUpdate) (*firehose.SplunkDestinationUpdate, error) {
 	splunkRaw, ok := d.GetOk("splunk_configuration")
 	if !ok {
-		return nil, fmt.Errorf("[ERR] Error loading Splunk Configuration for Kinesis Firehose: splunk_configuration not found")
+		return nil, fmt.Errorf("Error loading Splunk Configuration for Kinesis Firehose: splunk_configuration not found")
 	}
 	sl := splunkRaw.([]interface{})
 

--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -171,7 +171,7 @@ func resourceAwsKinesisStreamRead(d *schema.ResourceData, meta interface{}) erro
 				d.SetId("")
 				return nil
 			}
-			return fmt.Errorf("[WARN] Error reading Kinesis Stream: \"%s\", code: \"%s\"", awsErr.Message(), awsErr.Code())
+			return fmt.Errorf("Error reading Kinesis Stream: \"%s\", code: \"%s\"", awsErr.Message(), awsErr.Code())
 		}
 		return err
 

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -132,7 +132,7 @@ func resourceAwsKmsGrantCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := d.GetOk("constraints"); ok {
 		if !kmsGrantConstraintsIsValid(v.(*schema.Set)) {
-			return fmt.Errorf("[ERROR] A grant constraint can't have both encryption_context_equals and encryption_context_subset set")
+			return fmt.Errorf("A grant constraint can't have both encryption_context_equals and encryption_context_subset set")
 		}
 		input.Constraints = expandKmsGrantConstraints(v.(*schema.Set))
 	}
@@ -160,7 +160,7 @@ func resourceAwsKmsGrantCreate(d *schema.ResourceData, meta interface{}) error {
 				isAWSErr(err, kms.ErrCodeInternalException, "") ||
 				isAWSErr(err, kms.ErrCodeInvalidArnException, "") {
 				return resource.RetryableError(
-					fmt.Errorf("[WARN] Error adding new KMS Grant for key: %s, retrying %s",
+					fmt.Errorf("Error adding new KMS Grant for key: %s, retrying %s",
 						*input.KeyId, err))
 			}
 			log.Printf("[ERROR] An error occurred creating new AWS KMS Grant: %s", err)
@@ -355,7 +355,7 @@ func waitForKmsGrantToBeRevoked(conn *kms.KMS, keyId string, grantId string) err
 		if grant != nil {
 			// Force a retry if the grant still exists
 			return resource.RetryableError(
-				fmt.Errorf("[DEBUG] Grant still exists while expected to be revoked, retyring revocation check: %s", *grant.GrantId))
+				fmt.Errorf("Grant still exists while expected to be revoked, retyring revocation check: %s", *grant.GrantId))
 		}
 
 		return resource.NonRetryableError(err)

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -169,7 +168,7 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	p := pOut.(*kms.GetKeyPolicyOutput)
 	policy, err := structure.NormalizeJsonString(*p.Policy)
 	if err != nil {
-		return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
+		return fmt.Errorf("policy contains an invalid JSON: %s", err)
 	}
 	d.Set("policy", policy)
 
@@ -260,7 +259,7 @@ func resourceAwsKmsKeyDescriptionUpdate(conn *kms.KMS, d *schema.ResourceData) e
 func resourceAwsKmsKeyPolicyUpdate(conn *kms.KMS, d *schema.ResourceData) error {
 	policy, err := structure.NormalizeJsonString(d.Get("policy").(string))
 	if err != nil {
-		return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
+		return fmt.Errorf("policy contains an invalid JSON: %s", err)
 	}
 	keyId := d.Get("key_id").(string)
 

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -505,7 +505,7 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 	config := flattenLambdaVpcConfigResponse(function.VpcConfig)
 	log.Printf("[INFO] Setting Lambda %s VPC config %#v from API", d.Id(), config)
 	if err := d.Set("vpc_config", config); err != nil {
-		return fmt.Errorf("[ERR] Error setting vpc_config for Lambda Function (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error setting vpc_config for Lambda Function (%s): %s", d.Id(), err)
 	}
 
 	environment := flattenLambdaEnvironment(function.Environment)

--- a/aws/resource_aws_lambda_permission.go
+++ b/aws/resource_aws_lambda_permission.go
@@ -135,7 +135,7 @@ func resourceAwsLambdaPermissionCreate(d *schema.ResourceData, meta interface{})
 				// IAM is eventually consistent :/
 				if awsErr.Code() == "ResourceConflictException" {
 					return resource.RetryableError(
-						fmt.Errorf("[WARN] Error adding new Lambda Permission for %s, retrying: %s",
+						fmt.Errorf("Error adding new Lambda Permission for %s, retrying: %s",
 							*input.FunctionName, err))
 				}
 			}
@@ -162,12 +162,12 @@ func resourceAwsLambdaPermissionCreate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "Error reading Lambda policy: ResourceNotFoundException") {
 				return resource.RetryableError(
-					fmt.Errorf("[WARN] Error reading newly created Lambda Permission for %s, retrying: %s",
+					fmt.Errorf("Error reading newly created Lambda Permission for %s, retrying: %s",
 						*input.FunctionName, err))
 			}
 			if strings.HasPrefix(err.Error(), "Failed to find statement \""+d.Id()) {
 				return resource.RetryableError(
-					fmt.Errorf("[WARN] Error reading newly created Lambda Permission statement for %s, retrying: %s",
+					fmt.Errorf("Error reading newly created Lambda Permission statement for %s, retrying: %s",
 						*input.FunctionName, err))
 			}
 

--- a/aws/resource_aws_lightsail_instance.go
+++ b/aws/resource_aws_lightsail_instance.go
@@ -132,7 +132,7 @@ func resourceAwsLightsailInstanceCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if len(resp.Operations) == 0 {
-		return fmt.Errorf("[ERR] No operations found for CreateInstance request")
+		return fmt.Errorf("No operations found for CreateInstance request")
 	}
 
 	op := resp.Operations[0]
@@ -254,7 +254,7 @@ func resourceAwsLightsailOperationRefreshFunc(
 		}
 
 		if o.Operation == nil {
-			return nil, "Failed", fmt.Errorf("[ERR] Error retrieving Operation info for operation (%s)", *oid)
+			return nil, "Failed", fmt.Errorf("Error retrieving Operation info for operation (%s)", *oid)
 		}
 
 		log.Printf("[DEBUG] Lightsail Operation (%s) is currently %q", *oid, *o.Operation.Status)

--- a/aws/resource_aws_lightsail_key_pair.go
+++ b/aws/resource_aws_lightsail_key_pair.go
@@ -103,10 +103,10 @@ func resourceAwsLightsailKeyPairCreate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 		if resp.Operation == nil {
-			return fmt.Errorf("[ERR] No operation found for CreateKeyPair response")
+			return fmt.Errorf("No operation found for CreateKeyPair response")
 		}
 		if resp.KeyPair == nil {
-			return fmt.Errorf("[ERR] No KeyPair information found for CreateKeyPair response")
+			return fmt.Errorf("No KeyPair information found for CreateKeyPair response")
 		}
 		d.SetId(kName)
 

--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -652,7 +652,7 @@ func resourceAwsNeptuneClusterDelete(d *schema.ResourceData, meta interface{}) e
 	// Wait, catching any errors
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error deleting Neptune Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error deleting Neptune Cluster (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -538,7 +538,7 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 	})
 
 	if retryErr != nil {
-		return fmt.Errorf("[ERR] Error destroying Network ACL (%s): %s", d.Id(), retryErr)
+		return fmt.Errorf("Error destroying Network ACL (%s): %s", d.Id(), retryErr)
 	}
 	return nil
 }

--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -533,10 +533,10 @@ func resourceAwsOpsworksInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 	layerIds, err = sortListBasedonTFFile(layerIds, d, "layer_ids")
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Error sorting layer_ids attribute: %#v", err)
+		return fmt.Errorf("Error sorting layer_ids attribute: %#v", err)
 	}
 	if err := d.Set("layer_ids", layerIds); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting layer_ids attribute: %#v, error: %#v", layerIds, err)
+		return fmt.Errorf("Error setting layer_ids attribute: %#v, error: %#v", layerIds, err)
 	}
 	d.Set("os", instance.Os)
 	d.Set("platform", instance.Platform)

--- a/aws/resource_aws_opsworks_stack.go
+++ b/aws/resource_aws_opsworks_stack.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -385,7 +384,7 @@ func opsworksConnForRegion(region string, meta interface{}) (*opsworks.OpsWorks,
 	// Set up base session
 	sess, err := session.NewSession(&originalConn.Config)
 	if err != nil {
-		return nil, errwrap.Wrapf("Error creating AWS session: {{err}}", err)
+		return nil, fmt.Errorf("Error creating AWS session: %s", err)
 	}
 
 	sess.Handlers.Build.PushBackNamed(addTerraformVersionToUserAgent)

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -830,7 +830,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 	// Wait, catching any errors
 	_, err := stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for RDS Cluster state to be \"available\": %s", err)
+		return fmt.Errorf("Error waiting for RDS Cluster state to be \"available\": %s", err)
 	}
 
 	if v, ok := d.GetOk("iam_roles"); ok {
@@ -1153,7 +1153,7 @@ func resourceAwsRDSClusterDelete(d *schema.ResourceData, meta interface{}) error
 	// Wait, catching any errors
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error deleting RDS Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error deleting RDS Cluster (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -313,7 +313,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	db, err := resourceAwsDbInstanceRetrieve(d.Id(), meta.(*AWSClient).rdsconn)
 	// Errors from this helper are always reportable
 	if err != nil {
-		return fmt.Errorf("[WARN] Error on retrieving RDS Cluster Instance (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error on retrieving RDS Cluster Instance (%s): %s", d.Id(), err)
 	}
 	// A nil response means "not found"
 	if db == nil {
@@ -340,7 +340,7 @@ func resourceAwsRDSClusterInstanceRead(d *schema.ResourceData, meta interface{})
 	}
 
 	if dbc == nil {
-		return fmt.Errorf("[WARN] Error finding RDS Cluster (%s) for Cluster Instance (%s): %s",
+		return fmt.Errorf("Error finding RDS Cluster (%s) for Cluster Instance (%s): %s",
 			*db.DBClusterIdentifier, *db.DBInstanceIdentifier, err)
 	}
 

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -491,7 +491,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 
 	_, err := stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("[WARN] Error waiting for Redshift Cluster state to be \"available\": %s", err)
+		return fmt.Errorf("Error waiting for Redshift Cluster state to be \"available\": %s", err)
 	}
 
 	if v, ok := d.GetOk("snapshot_copy"); ok {
@@ -591,7 +591,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 		vpcg = append(vpcg, *g.VpcSecurityGroupId)
 	}
 	if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving VPC Security Group IDs to state for Redshift Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving VPC Security Group IDs to state for Redshift Cluster (%s): %s", d.Id(), err)
 	}
 
 	var csg []string
@@ -599,7 +599,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 		csg = append(csg, *g.ClusterSecurityGroupName)
 	}
 	if err := d.Set("cluster_security_groups", csg); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving Cluster Security Group Names to state for Redshift Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving Cluster Security Group Names to state for Redshift Cluster (%s): %s", d.Id(), err)
 	}
 
 	var iamRoles []string
@@ -607,7 +607,7 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 		iamRoles = append(iamRoles, *i.IamRoleArn)
 	}
 	if err := d.Set("iam_roles", iamRoles); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving IAM Roles to state for Redshift Cluster (%s): %s", d.Id(), err)
+		return fmt.Errorf("Error saving IAM Roles to state for Redshift Cluster (%s): %s", d.Id(), err)
 	}
 
 	d.Set("cluster_public_key", rsc.ClusterPublicKey)
@@ -718,7 +718,7 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		log.Printf("[DEBUG] Redshift Cluster Modify options: %s", req)
 		_, err := conn.ModifyCluster(req)
 		if err != nil {
-			return fmt.Errorf("[WARN] Error modifying Redshift Cluster (%s): %s", d.Id(), err)
+			return fmt.Errorf("Error modifying Redshift Cluster (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -748,7 +748,7 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		log.Printf("[DEBUG] Redshift Cluster Modify IAM Role options: %s", req)
 		_, err := conn.ModifyClusterIamRoles(req)
 		if err != nil {
-			return fmt.Errorf("[WARN] Error modifying Redshift Cluster IAM Roles (%s): %s", d.Id(), err)
+			return fmt.Errorf("Error modifying Redshift Cluster IAM Roles (%s): %s", d.Id(), err)
 		}
 
 		d.SetPartial("iam_roles")
@@ -767,7 +767,7 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 		// Wait, catching any errors
 		_, err := stateConf.WaitForState()
 		if err != nil {
-			return fmt.Errorf("[WARN] Error Modifying Redshift Cluster (%s): %s", d.Id(), err)
+			return fmt.Errorf("Error Modifying Redshift Cluster (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -917,7 +917,7 @@ func deleteAwsRedshiftCluster(opts *redshift.DeleteClusterInput, conn *redshift.
 		return resource.NonRetryableError(err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Error deleting Redshift Cluster (%s): %s",
+		return nil, fmt.Errorf("Error deleting Redshift Cluster (%s): %s",
 			id, err)
 	}
 

--- a/aws/resource_aws_redshift_subnet_group.go
+++ b/aws/resource_aws_redshift_subnet_group.go
@@ -100,7 +100,7 @@ func resourceAwsRedshiftSubnetGroupRead(d *schema.ResourceData, meta interface{}
 	d.Set("description", describeResp.ClusterSubnetGroups[0].Description)
 	d.Set("subnet_ids", subnetIdsToSlice(describeResp.ClusterSubnetGroups[0].Subnets))
 	if err := d.Set("tags", tagsToMapRedshift(describeResp.ClusterSubnetGroups[0].Tags)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting Redshift Subnet Group Tags: %#v", err)
+		return fmt.Errorf("Error setting Redshift Subnet Group Tags: %#v", err)
 	}
 
 	return nil

--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -279,7 +278,7 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 	if zoneRecord.HostedZone == nil {
-		return fmt.Errorf("[WARN] No Route53 Zone found for id (%s)", zone)
+		return fmt.Errorf("No Route53 Zone found for id (%s)", zone)
 	}
 
 	// Build the to be deleted record
@@ -353,7 +352,7 @@ func resourceAwsRoute53RecordUpdate(d *schema.ResourceData, meta interface{}) er
 
 	respRaw, err := changeRoute53RecordSet(conn, req)
 	if err != nil {
-		return errwrap.Wrapf("[ERR]: Error building changeset: {{err}}", err)
+		return fmt.Errorf("[ERR]: Error building changeset: %s", err)
 	}
 
 	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo
@@ -389,7 +388,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 	if zoneRecord.HostedZone == nil {
-		return fmt.Errorf("[WARN] No Route53 Zone found for id (%s)", zone)
+		return fmt.Errorf("No Route53 Zone found for id (%s)", zone)
 	}
 
 	// Build the record
@@ -431,7 +430,7 @@ func resourceAwsRoute53RecordCreate(d *schema.ResourceData, meta interface{}) er
 
 	respRaw, err := changeRoute53RecordSet(conn, req)
 	if err != nil {
-		return errwrap.Wrapf("[ERR]: Error building changeset: {{err}}", err)
+		return fmt.Errorf("[ERR]: Error building changeset: %s", err)
 	}
 
 	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo
@@ -534,7 +533,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	err = d.Set("records", flattenResourceRecords(record.ResourceRecords, *record.Type))
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Error setting records for: %s, error: %#v", d.Id(), err)
+		return fmt.Errorf("Error setting records for: %s, error: %#v", d.Id(), err)
 	}
 
 	if alias := record.AliasTarget; alias != nil {
@@ -555,7 +554,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"type": aws.StringValue(record.Failover),
 		}}
 		if err := d.Set("failover_routing_policy", v); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting failover records for: %s, error: %#v", d.Id(), err)
+			return fmt.Errorf("Error setting failover records for: %s, error: %#v", d.Id(), err)
 		}
 	}
 
@@ -566,7 +565,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"subdivision": aws.StringValue(record.GeoLocation.SubdivisionCode),
 		}}
 		if err := d.Set("geolocation_routing_policy", v); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting gelocation records for: %s, error: %#v", d.Id(), err)
+			return fmt.Errorf("Error setting gelocation records for: %s, error: %#v", d.Id(), err)
 		}
 	}
 
@@ -575,7 +574,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"region": aws.StringValue(record.Region),
 		}}
 		if err := d.Set("latency_routing_policy", v); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting latency records for: %s, error: %#v", d.Id(), err)
+			return fmt.Errorf("Error setting latency records for: %s, error: %#v", d.Id(), err)
 		}
 	}
 
@@ -584,13 +583,13 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 			"weight": aws.Int64Value((record.Weight)),
 		}}
 		if err := d.Set("weighted_routing_policy", v); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting weighted records for: %s, error: %#v", d.Id(), err)
+			return fmt.Errorf("Error setting weighted records for: %s, error: %#v", d.Id(), err)
 		}
 	}
 
 	if record.MultiValueAnswer != nil {
 		if err := d.Set("multivalue_answer_routing_policy", *record.MultiValueAnswer); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting multivalue answer records for: %s, error: %#v", d.Id(), err)
+			return fmt.Errorf("Error setting multivalue answer records for: %s, error: %#v", d.Id(), err)
 		}
 	}
 
@@ -727,7 +726,7 @@ func resourceAwsRoute53RecordDelete(d *schema.ResourceData, meta interface{}) er
 
 	respRaw, err := deleteRoute53RecordSet(conn, req)
 	if err != nil {
-		return errwrap.Wrapf("[ERR]: Error building changeset: {{err}}", err)
+		return fmt.Errorf("[ERR]: Error building changeset: %s", err)
 	}
 
 	changeInfo := respRaw.(*route53.ChangeResourceRecordSetsOutput).ChangeInfo

--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -166,7 +165,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 		}
 		sort.Strings(ns)
 		if err := d.Set("name_servers", ns); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting name servers for: %s, error: %#v", d.Id(), err)
+			return fmt.Errorf("Error setting name servers for: %s, error: %#v", d.Id(), err)
 		}
 	} else {
 		ns, err := getNameServers(d.Id(), d.Get("name").(string), r53)
@@ -174,7 +173,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 		if err := d.Set("name_servers", ns); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting name servers for: %s, error: %#v", d.Id(), err)
+			return fmt.Errorf("Error setting name servers for: %s, error: %#v", d.Id(), err)
 		}
 
 		// In the import case we just associate it with the first VPC
@@ -198,7 +197,7 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 			}
 		}
 		if associatedVPC == nil {
-			return fmt.Errorf("[DEBUG] VPC: %v is not associated with Zone: %v", d.Get("vpc_id"), d.Id())
+			return fmt.Errorf("VPC: %v is not associated with Zone: %v", d.Get("vpc_id"), d.Id())
 		}
 	}
 
@@ -268,7 +267,7 @@ func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) erro
 
 	if d.Get("force_destroy").(bool) {
 		if err := deleteAllRecordsInHostedZoneId(d.Id(), d.Get("name").(string), r53); err != nil {
-			return errwrap.Wrapf("{{err}}", err)
+			return fmt.Errorf("%s", err)
 		}
 	}
 

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -540,7 +539,7 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 			if awsErr.Code() == "OperationAborted" {
 				log.Printf("[WARN] Got an error while trying to create S3 bucket %s: %s", bucket, err)
 				return resource.RetryableError(
-					fmt.Errorf("[WARN] Error creating S3 bucket %s, retrying: %s",
+					fmt.Errorf("Error creating S3 bucket %s, retrying: %s",
 						bucket, err))
 			}
 		}
@@ -681,7 +680,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			} else {
 				policy, err := structure.NormalizeJsonString(*v)
 				if err != nil {
-					return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
+					return fmt.Errorf("policy contains an invalid JSON: %s", err)
 				}
 				d.Set("policy", policy)
 			}

--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -283,7 +282,7 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("type", ruleType)
 	if err := setFromIPPerm(d, sg, p); err != nil {
-		return errwrap.Wrapf("Error setting IP Permission for Security Group Rule: {{err}}", err)
+		return fmt.Errorf("Error setting IP Permission for Security Group Rule: %s", err)
 	}
 
 	d.Set("description", descriptionFromIPPerm(d, rule))

--- a/aws/resource_aws_security_group_rule_migrate.go
+++ b/aws/resource_aws_security_group_rule_migrate.go
@@ -37,7 +37,7 @@ func migrateSGRuleStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceS
 	perm, err := migrateExpandIPPerm(is.Attributes)
 
 	if err != nil {
-		return nil, fmt.Errorf("[WARN] Error making new IP Permission in Security Group migration")
+		return nil, fmt.Errorf("Error making new IP Permission in Security Group migration")
 	}
 
 	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)

--- a/aws/resource_aws_sfn_activity_test.go
+++ b/aws/resource_aws_sfn_activity_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -10,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"time"
 )
 
 func TestAccAWSSfnActivity_basic(t *testing.T) {

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sfn"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -88,7 +87,7 @@ func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) 
 	})
 
 	if err != nil {
-		return errwrap.Wrapf("Error creating Step Function State Machine: {{err}}", err)
+		return fmt.Errorf("Error creating Step Function State Machine: %s", err)
 	}
 
 	d.SetId(*activity.StateMachineArn)

--- a/aws/resource_aws_spot_datafeed_subscription.go
+++ b/aws/resource_aws_spot_datafeed_subscription.go
@@ -1,12 +1,12 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -48,7 +48,7 @@ func resourceAwsSpotDataFeedSubscriptionCreate(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Creating Spot Datafeed Subscription")
 	_, err := conn.CreateSpotDatafeedSubscription(params)
 	if err != nil {
-		return errwrap.Wrapf("Error Creating Spot Datafeed Subscription: {{err}}", err)
+		return fmt.Errorf("Error Creating Spot Datafeed Subscription: %s", err)
 	}
 
 	d.SetId("spot-datafeed-subscription")
@@ -66,7 +66,7 @@ func resourceAwsSpotDataFeedSubscriptionRead(d *schema.ResourceData, meta interf
 			d.SetId("")
 			return nil
 		}
-		return errwrap.Wrapf("Error Describing Spot Datafeed Subscription: {{err}}", err)
+		return fmt.Errorf("Error Describing Spot Datafeed Subscription: %s", err)
 	}
 
 	if resp == nil {
@@ -87,7 +87,7 @@ func resourceAwsSpotDataFeedSubscriptionDelete(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] Deleting Spot Datafeed Subscription")
 	_, err := conn.DeleteSpotDatafeedSubscription(&ec2.DeleteSpotDatafeedSubscriptionInput{})
 	if err != nil {
-		return errwrap.Wrapf("Error deleting Spot Datafeed Subscription: {{err}}", err)
+		return fmt.Errorf("Error deleting Spot Datafeed Subscription: %s", err)
 	}
 	return nil
 }

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -696,7 +696,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 				// IAM is eventually consistent :/
 				if awsErr.Code() == "InvalidSpotFleetRequestConfig" {
 					return resource.RetryableError(
-						fmt.Errorf("[WARN] Error creating Spot fleet request, retrying: %s", err))
+						fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))
 				}
 			}
 			return resource.NonRetryableError(err)

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -267,7 +267,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 		d.Set("spot_instance_id", *request.InstanceId)
 		// Read the instance data, setting up connection information
 		if err := readInstance(d, meta); err != nil {
-			return fmt.Errorf("[ERR] Error reading Spot Instance Data: %s", err)
+			return fmt.Errorf("Error reading Spot Instance Data: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -250,7 +250,7 @@ func resourceAwsSqsQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 			Attributes: attributes,
 		}
 		if _, err := sqsconn.SetQueueAttributes(req); err != nil {
-			return fmt.Errorf("[ERR] Error updating SQS attributes: %s", err)
+			return fmt.Errorf("Error updating SQS attributes: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -106,11 +105,11 @@ func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) er
 	})
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating SSM activation: {{err}}", err)
+		return fmt.Errorf("Error creating SSM activation: %s", err)
 	}
 
 	if resp.ActivationId == nil {
-		return fmt.Errorf("[ERROR] ActivationId was nil")
+		return fmt.Errorf("ActivationId was nil")
 	}
 	d.SetId(*resp.ActivationId)
 	d.Set("activation_code", resp.ActivationCode)
@@ -138,10 +137,10 @@ func resourceAwsSsmActivationRead(d *schema.ResourceData, meta interface{}) erro
 	resp, err := ssmconn.DescribeActivations(params)
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error reading SSM activation: {{err}}", err)
+		return fmt.Errorf("Error reading SSM activation: %s", err)
 	}
 	if resp.ActivationList == nil || len(resp.ActivationList) == 0 {
-		return fmt.Errorf("[ERROR] ActivationList was nil or empty")
+		return fmt.Errorf("ActivationList was nil or empty")
 	}
 
 	activation := resp.ActivationList[0] // Only 1 result as MaxResults is 1 above
@@ -168,7 +167,7 @@ func resourceAwsSsmActivationDelete(d *schema.ResourceData, meta interface{}) er
 	_, err := ssmconn.DeleteActivation(params)
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error deleting SSM activation: {{err}}", err)
+		return fmt.Errorf("Error deleting SSM activation: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -131,11 +131,11 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 
 	resp, err := ssmconn.CreateAssociation(associationInput)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error creating SSM association: %s", err)
+		return fmt.Errorf("Error creating SSM association: %s", err)
 	}
 
 	if resp.AssociationDescription == nil {
-		return fmt.Errorf("[ERROR] AssociationDescription was nil")
+		return fmt.Errorf("AssociationDescription was nil")
 	}
 
 	d.SetId(*resp.AssociationDescription.AssociationId)
@@ -160,10 +160,10 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("[ERROR] Error reading SSM association: %s", err)
+		return fmt.Errorf("Error reading SSM association: %s", err)
 	}
 	if resp.AssociationDescription == nil {
-		return fmt.Errorf("[ERROR] AssociationDescription was nil")
+		return fmt.Errorf("AssociationDescription was nil")
 	}
 
 	association := resp.AssociationDescription
@@ -176,11 +176,11 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("document_version", association.DocumentVersion)
 
 	if err := d.Set("targets", flattenAwsSsmTargets(association.Targets)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting targets error: %#v", err)
+		return fmt.Errorf("Error setting targets error: %#v", err)
 	}
 
 	if err := d.Set("output_location", flattenAwsSsmAssociationOutoutLocation(association.OutputLocation)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting output_location error: %#v", err)
+		return fmt.Errorf("Error setting output_location error: %#v", err)
 	}
 
 	return nil
@@ -222,7 +222,7 @@ func resourceAwsSsmAssociationUpdate(d *schema.ResourceData, meta interface{}) e
 
 	_, err := ssmconn.UpdateAssociation(associationInput)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error updating SSM association: %s", err)
+		return fmt.Errorf("Error updating SSM association: %s", err)
 	}
 
 	return resourceAwsSsmAssociationRead(d, meta)
@@ -240,7 +240,7 @@ func resourceAwsSsmAssociationDelete(d *schema.ResourceData, meta interface{}) e
 	_, err := ssmconn.DeleteAssociation(params)
 
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error deleting SSM association: %s", err)
+		return fmt.Errorf("Error deleting SSM association: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -172,7 +171,7 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 	})
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating SSM document: {{err}}", err)
+		return fmt.Errorf("Error creating SSM document: %s", err)
 	}
 
 	if v, ok := d.GetOk("permissions"); ok && v != nil {
@@ -206,7 +205,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 			d.SetId("")
 			return nil
 		}
-		return errwrap.Wrapf("[ERROR] Error describing SSM document: {{err}}", err)
+		return fmt.Errorf("Error describing SSM document: %s", err)
 	}
 
 	doc := resp.Document
@@ -235,7 +234,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		Resource:  fmt.Sprintf("document/%s", *doc.Name),
 	}.String()
 	if err := d.Set("arn", arn); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting arn error: %#v", err)
+		return fmt.Errorf("Error setting arn error: %#v", err)
 	}
 
 	d.Set("status", doc.Status)
@@ -243,7 +242,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	gp, err := getDocumentPermissions(d, meta)
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error reading SSM document permissions: {{err}}", err)
+		return fmt.Errorf("Error reading SSM document permissions: %s", err)
 	}
 
 	d.Set("permissions", gp)
@@ -447,7 +446,7 @@ func getDocumentPermissions(d *schema.ResourceData, meta interface{}) (map[strin
 	resp, err := ssmconn.DescribeDocumentPermission(permInput)
 
 	if err != nil {
-		return nil, errwrap.Wrapf("[ERROR] Error setting permissions for SSM document: {{err}}", err)
+		return nil, fmt.Errorf("Error setting permissions for SSM document: %s", err)
 	}
 
 	var account_ids = make([]string, len(resp.AccountIds))
@@ -496,7 +495,7 @@ func deleteDocumentPermissions(d *schema.ResourceData, meta interface{}) error {
 	_, err := ssmconn.ModifyDocumentPermission(permInput)
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error removing permissions for SSM document: {{err}}", err)
+		return fmt.Errorf("Error removing permissions for SSM document: %s", err)
 	}
 
 	return nil
@@ -525,7 +524,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 
 		newDefaultVersion = d.Get("latest_version").(string)
 	} else if err != nil {
-		return errwrap.Wrapf("Error updating SSM document: {{err}}", err)
+		return fmt.Errorf("Error updating SSM document: %s", err)
 	} else {
 		log.Printf("[INFO] Updating the default version to the new version %s: %s", newDefaultVersion, d.Id())
 		newDefaultVersion = *updated.DocumentDescription.DocumentVersion
@@ -539,7 +538,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 	_, err = ssmconn.UpdateDocumentDefaultVersion(updateDefaultInput)
 
 	if err != nil {
-		return errwrap.Wrapf("Error updating the default document version to that of the updated document: {{err}}", err)
+		return fmt.Errorf("Error updating the default document version to that of the updated document: %s", err)
 	}
 	return nil
 }

--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -109,7 +109,7 @@ func resourceAwsSsmMaintenanceWindowTargetRead(d *schema.ResourceData, meta inte
 			d.Set("resource_type", t.ResourceType)
 
 			if err := d.Set("targets", flattenAwsSsmTargets(t.Targets)); err != nil {
-				return fmt.Errorf("[DEBUG] Error setting targets error: %#v", err)
+				return fmt.Errorf("Error setting targets error: %#v", err)
 			}
 		}
 	}

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -243,18 +243,18 @@ func resourceAwsSsmMaintenanceWindowTaskRead(d *schema.ResourceData, meta interf
 
 			if t.LoggingInfo != nil {
 				if err := d.Set("logging_info", flattenAwsSsmMaintenanceWindowLoggingInfo(t.LoggingInfo)); err != nil {
-					return fmt.Errorf("[DEBUG] Error setting logging_info error: %#v", err)
+					return fmt.Errorf("Error setting logging_info error: %#v", err)
 				}
 			}
 
 			if t.TaskParameters != nil {
 				if err := d.Set("task_parameters", flattenAwsSsmTaskParameters(t.TaskParameters)); err != nil {
-					return fmt.Errorf("[DEBUG] Error setting task_parameters error: %#v", err)
+					return fmt.Errorf("Error setting task_parameters error: %#v", err)
 				}
 			}
 
 			if err := d.Set("targets", flattenAwsSsmTargets(t.Targets)); err != nil {
-				return fmt.Errorf("[DEBUG] Error setting targets error: %#v", err)
+				return fmt.Errorf("Error setting targets error: %#v", err)
 			}
 		}
 	}

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -253,11 +253,11 @@ func resourceAwsSsmPatchBaselineRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("rejected_patches", flattenStringList(resp.RejectedPatches))
 
 	if err := d.Set("global_filter", flattenAwsSsmPatchFilterGroup(resp.GlobalFilters)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting global filters error: %#v", err)
+		return fmt.Errorf("Error setting global filters error: %#v", err)
 	}
 
 	if err := d.Set("approval_rule", flattenAwsSsmPatchRuleGroup(resp.ApprovalRules)); err != nil {
-		return fmt.Errorf("[DEBUG] Error setting approval rules error: %#v", err)
+		return fmt.Errorf("Error setting approval rules error: %#v", err)
 	}
 
 	return nil

--- a/aws/resource_aws_volume_attachment.go
+++ b/aws/resource_aws_volume_attachment.go
@@ -106,7 +106,7 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 		_, err := conn.AttachVolume(opts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
-				return fmt.Errorf("[WARN] Error attaching volume (%s) to instance (%s), message: \"%s\", code: \"%s\"",
+				return fmt.Errorf("Error attaching volume (%s) to instance (%s), message: \"%s\", code: \"%s\"",
 					vID, iID, awsErr.Message(), awsErr.Code())
 			}
 			return err

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
@@ -149,7 +148,7 @@ func resourceAwsVpcEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	if v, ok := d.GetOk("policy"); ok {
 		policy, err := structure.NormalizeJsonString(v)
 		if err != nil {
-			return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
+			return fmt.Errorf("policy contains an invalid JSON: %s", err)
 		}
 		req.PolicyDocument = aws.String(policy)
 	}
@@ -220,7 +219,7 @@ func resourceAwsVpcEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("policy") {
 		policy, err := structure.NormalizeJsonString(d.Get("policy"))
 		if err != nil {
-			return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
+			return fmt.Errorf("policy contains an invalid JSON: %s", err)
 		}
 
 		if policy == "" {
@@ -375,7 +374,7 @@ func vpcEndpointAttributes(d *schema.ResourceData, vpce *ec2.VpcEndpoint, conn *
 
 	policy, err := structure.NormalizeJsonString(aws.StringValue(vpce.PolicyDocument))
 	if err != nil {
-		return errwrap.Wrapf("policy contains an invalid JSON: {{err}}", err)
+		return fmt.Errorf("policy contains an invalid JSON: %s", err)
 	}
 	d.Set("policy", policy)
 

--- a/aws/resource_aws_vpn_connection.go
+++ b/aws/resource_aws_vpn_connection.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -383,7 +382,7 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if len(resp.VpnConnections) != 1 {
-		return fmt.Errorf("[ERROR] Error finding VPN connection: %s", d.Id())
+		return fmt.Errorf("Error finding VPN connection: %s", d.Id())
 	}
 
 	vpnConnection := resp.VpnConnections[0]
@@ -532,7 +531,7 @@ func telemetryToMapList(telemetry []*ec2.VgwTelemetry) []map[string]interface{} 
 func xmlConfigToTunnelInfo(xmlConfig string) (*TunnelInfo, error) {
 	var vpnConfig XmlVpnConnectionConfig
 	if err := xml.Unmarshal([]byte(xmlConfig), &vpnConfig); err != nil {
-		return nil, errwrap.Wrapf("Error Unmarshalling XML: {{err}}", err)
+		return nil, fmt.Errorf("Error Unmarshalling XML: %s", err)
 	}
 
 	// don't expect consistent ordering from the XML

--- a/aws/resource_aws_waf_byte_match_set.go
+++ b/aws/resource_aws_waf_byte_match_set.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -79,7 +78,7 @@ func resourceAwsWafByteMatchSetCreate(d *schema.ResourceData, meta interface{}) 
 		return conn.CreateByteMatchSet(params)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating ByteMatchSet: {{err}}", err)
+		return fmt.Errorf("Error creating ByteMatchSet: %s", err)
 	}
 	resp := out.(*waf.CreateByteMatchSetOutput)
 
@@ -122,7 +121,7 @@ func resourceAwsWafByteMatchSetUpdate(d *schema.ResourceData, meta interface{}) 
 		oldT, newT := o.(*schema.Set).List(), n.(*schema.Set).List()
 		err := updateByteMatchSetResource(d.Id(), oldT, newT, conn)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating ByteMatchSet: %s", err)
 		}
 	}
 
@@ -151,7 +150,7 @@ func resourceAwsWafByteMatchSetDelete(d *schema.ResourceData, meta interface{}) 
 		return conn.DeleteByteMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+		return fmt.Errorf("Error deleting ByteMatchSet: %s", err)
 	}
 
 	return nil
@@ -169,7 +168,7 @@ func updateByteMatchSetResource(id string, oldT, newT []interface{}, conn *waf.W
 		return conn.UpdateByteMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+		return fmt.Errorf("Error updating ByteMatchSet: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_waf_byte_match_set_test.go
+++ b/aws/resource_aws_waf_byte_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
 
@@ -205,7 +204,7 @@ func testAccCheckAWSWafByteMatchSetDisappears(v *waf.ByteMatchSet) resource.Test
 			return conn.UpdateByteMatchSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating ByteMatchSet: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
@@ -216,7 +215,7 @@ func testAccCheckAWSWafByteMatchSetDisappears(v *waf.ByteMatchSet) resource.Test
 			return conn.DeleteByteMatchSet(opts)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error deleting ByteMatchSet: %s", err)
 		}
 
 		return nil

--- a/aws/resource_aws_waf_geo_match_set.go
+++ b/aws/resource_aws_waf_geo_match_set.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -58,7 +57,7 @@ func resourceAwsWafGeoMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 		return conn.CreateGeoMatchSet(params)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating GeoMatchSet: {{err}}", err)
+		return fmt.Errorf("Error creating GeoMatchSet: %s", err)
 	}
 	resp := out.(*waf.CreateGeoMatchSetOutput)
 
@@ -102,7 +101,7 @@ func resourceAwsWafGeoMatchSetUpdate(d *schema.ResourceData, meta interface{}) e
 
 		err := updateGeoMatchSetResource(d.Id(), oldT, newT, conn)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating GeoMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating GeoMatchSet: %s", err)
 		}
 	}
 
@@ -131,7 +130,7 @@ func resourceAwsWafGeoMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 		return conn.DeleteGeoMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error deleting GeoMatchSet: {{err}}", err)
+		return fmt.Errorf("Error deleting GeoMatchSet: %s", err)
 	}
 
 	return nil
@@ -150,7 +149,7 @@ func updateGeoMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WA
 		return conn.UpdateGeoMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error updating GeoMatchSet: {{err}}", err)
+		return fmt.Errorf("Error updating GeoMatchSet: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_waf_geo_match_set_test.go
+++ b/aws/resource_aws_waf_geo_match_set_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
 
@@ -195,7 +194,7 @@ func testAccCheckAWSWafGeoMatchSetDisappears(v *waf.GeoMatchSet) resource.TestCh
 			return conn.UpdateGeoMatchSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating GeoMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating GeoMatchSet: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
@@ -206,7 +205,7 @@ func testAccCheckAWSWafGeoMatchSetDisappears(v *waf.GeoMatchSet) resource.TestCh
 			return conn.DeleteGeoMatchSet(opts)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting GeoMatchSet: {{err}}", err)
+			return fmt.Errorf("Error deleting GeoMatchSet: %s", err)
 		}
 		return nil
 	}

--- a/aws/resource_aws_waf_size_constraint_set.go
+++ b/aws/resource_aws_waf_size_constraint_set.go
@@ -1,12 +1,12 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -36,7 +36,7 @@ func resourceAwsWafSizeConstraintSetCreate(d *schema.ResourceData, meta interfac
 		return conn.CreateSizeConstraintSet(params)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating SizeConstraintSet: {{err}}", err)
+		return fmt.Errorf("Error creating SizeConstraintSet: %s", err)
 	}
 	resp := out.(*waf.CreateSizeConstraintSetOutput)
 
@@ -78,7 +78,7 @@ func resourceAwsWafSizeConstraintSetUpdate(d *schema.ResourceData, meta interfac
 
 		err := updateSizeConstraintSetResource(d.Id(), oldConstraints, newConstraints, conn)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+			return fmt.Errorf("Error updating SizeConstraintSet: %s", err)
 		}
 	}
 
@@ -94,7 +94,7 @@ func resourceAwsWafSizeConstraintSetDelete(d *schema.ResourceData, meta interfac
 		noConstraints := []interface{}{}
 		err := updateSizeConstraintSetResource(d.Id(), oldConstraints, noConstraints, conn)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting SizeConstraintSet: {{err}}", err)
+			return fmt.Errorf("Error deleting SizeConstraintSet: %s", err)
 		}
 	}
 
@@ -107,7 +107,7 @@ func resourceAwsWafSizeConstraintSetDelete(d *schema.ResourceData, meta interfac
 		return conn.DeleteSizeConstraintSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error deleting SizeConstraintSet: {{err}}", err)
+		return fmt.Errorf("Error deleting SizeConstraintSet: %s", err)
 	}
 
 	return nil
@@ -126,7 +126,7 @@ func updateSizeConstraintSetResource(id string, oldS, newS []interface{}, conn *
 		return conn.UpdateSizeConstraintSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+		return fmt.Errorf("Error updating SizeConstraintSet: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/aws/resource_aws_waf_size_constraint_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
 
@@ -210,7 +209,7 @@ func testAccCheckAWSWafSizeConstraintSetDisappears(v *waf.SizeConstraintSet) res
 			return conn.UpdateSizeConstraintSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+			return fmt.Errorf("Error updating SizeConstraintSet: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {

--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -1,12 +1,12 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -71,7 +71,7 @@ func resourceAwsWafSqlInjectionMatchSetCreate(d *schema.ResourceData, meta inter
 		return conn.CreateSqlInjectionMatchSet(params)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating SqlInjectionMatchSet: {{err}}", err)
+		return fmt.Errorf("Error creating SqlInjectionMatchSet: %s", err)
 	}
 	resp := out.(*waf.CreateSqlInjectionMatchSetOutput)
 	d.SetId(*resp.SqlInjectionMatchSet.SqlInjectionMatchSetId)
@@ -112,7 +112,7 @@ func resourceAwsWafSqlInjectionMatchSetUpdate(d *schema.ResourceData, meta inter
 
 		err := updateSqlInjectionMatchSetResource(d.Id(), oldT, newT, conn)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating SqlInjectionMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating SqlInjectionMatchSet: %s", err)
 		}
 	}
 
@@ -128,7 +128,7 @@ func resourceAwsWafSqlInjectionMatchSetDelete(d *schema.ResourceData, meta inter
 		noTuples := []interface{}{}
 		err := updateSqlInjectionMatchSetResource(d.Id(), oldTuples, noTuples, conn)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting SqlInjectionMatchSet: {{err}}", err)
+			return fmt.Errorf("Error deleting SqlInjectionMatchSet: %s", err)
 		}
 	}
 
@@ -142,7 +142,7 @@ func resourceAwsWafSqlInjectionMatchSetDelete(d *schema.ResourceData, meta inter
 		return conn.DeleteSqlInjectionMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error deleting SqlInjectionMatchSet: {{err}}", err)
+		return fmt.Errorf("Error deleting SqlInjectionMatchSet: %s", err)
 	}
 
 	return nil
@@ -161,7 +161,7 @@ func updateSqlInjectionMatchSetResource(id string, oldT, newT []interface{}, con
 		return conn.UpdateSqlInjectionMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error updating SqlInjectionMatchSet: {{err}}", err)
+		return fmt.Errorf("Error updating SqlInjectionMatchSet: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
 
@@ -196,7 +195,7 @@ func testAccCheckAWSWafSqlInjectionMatchSetDisappears(v *waf.SqlInjectionMatchSe
 			return conn.UpdateSqlInjectionMatchSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating SqlInjectionMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating SqlInjectionMatchSet: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
@@ -207,7 +206,7 @@ func testAccCheckAWSWafSqlInjectionMatchSetDisappears(v *waf.SqlInjectionMatchSe
 			return conn.DeleteSqlInjectionMatchSet(opts)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting SqlInjectionMatchSet: {{err}}", err)
+			return fmt.Errorf("Error deleting SqlInjectionMatchSet: %s", err)
 		}
 		return nil
 	}

--- a/aws/resource_aws_waf_xss_match_set.go
+++ b/aws/resource_aws_waf_xss_match_set.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -72,7 +71,7 @@ func resourceAwsWafXssMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 		return conn.CreateXssMatchSet(params)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating XssMatchSet: {{err}}", err)
+		return fmt.Errorf("Error creating XssMatchSet: %s", err)
 	}
 	resp := out.(*waf.CreateXssMatchSetOutput)
 
@@ -114,7 +113,7 @@ func resourceAwsWafXssMatchSetUpdate(d *schema.ResourceData, meta interface{}) e
 
 		err := updateXssMatchSetResource(d.Id(), oldT, newT, conn)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating XssMatchSet: %s", err)
 		}
 	}
 
@@ -143,7 +142,7 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 		return conn.DeleteXssMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error deleting XssMatchSet: {{err}}", err)
+		return fmt.Errorf("Error deleting XssMatchSet: %s", err)
 	}
 
 	return nil
@@ -162,7 +161,7 @@ func updateXssMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WA
 		return conn.UpdateXssMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
+		return fmt.Errorf("Error updating XssMatchSet: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_waf_xss_match_set_test.go
+++ b/aws/resource_aws_waf_xss_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
 
@@ -220,7 +219,7 @@ func testAccCheckAWSWafXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCh
 			return conn.UpdateXssMatchSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating XssMatchSet: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
@@ -231,7 +230,7 @@ func testAccCheckAWSWafXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCh
 			return conn.DeleteXssMatchSet(opts)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting XssMatchSet: {{err}}", err)
+			return fmt.Errorf("Error deleting XssMatchSet: %s", err)
 		}
 		return nil
 	}

--- a/aws/resource_aws_wafregional_byte_match_set.go
+++ b/aws/resource_aws_wafregional_byte_match_set.go
@@ -1,13 +1,13 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -120,7 +120,7 @@ func resourceAwsWafRegionalByteMatchSetCreate(d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error creating ByteMatchSet: {{err}}", err)
+		return fmt.Errorf("Error creating ByteMatchSet: %s", err)
 	}
 	resp := out.(*waf.CreateByteMatchSetOutput)
 
@@ -200,7 +200,7 @@ func resourceAwsWafRegionalByteMatchSetUpdate(d *schema.ResourceData, meta inter
 
 		err := updateByteMatchSetResourceWR(d, oldT, newT, conn, region)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating ByteMatchSet: %s", err)
 		}
 	} else if d.HasChange("byte_match_tuples") {
 		o, n := d.GetChange("byte_match_tuples")
@@ -208,7 +208,7 @@ func resourceAwsWafRegionalByteMatchSetUpdate(d *schema.ResourceData, meta inter
 
 		err := updateByteMatchSetResourceWR(d, oldT, newT, conn, region)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating ByteMatchSet: %s", err)
 		}
 	}
 	return resourceAwsWafRegionalByteMatchSetRead(d, meta)
@@ -232,7 +232,7 @@ func resourceAwsWafRegionalByteMatchSetDelete(d *schema.ResourceData, meta inter
 
 		err := updateByteMatchSetResourceWR(d, oldT, newT, conn, region)
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error deleting ByteMatchSet: %s", err)
 		}
 	}
 
@@ -245,7 +245,7 @@ func resourceAwsWafRegionalByteMatchSetDelete(d *schema.ResourceData, meta inter
 		return conn.DeleteByteMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+		return fmt.Errorf("Error deleting ByteMatchSet: %s", err)
 	}
 
 	return nil
@@ -263,7 +263,7 @@ func updateByteMatchSetResourceWR(d *schema.ResourceData, oldT, newT []interface
 		return conn.UpdateByteMatchSet(req)
 	})
 	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+		return fmt.Errorf("Error updating ByteMatchSet: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_wafregional_byte_match_set_test.go
+++ b/aws/resource_aws_wafregional_byte_match_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
 
@@ -274,7 +273,7 @@ func testAccCheckAWSWafRegionalByteMatchSetDisappears(v *waf.ByteMatchSet) resou
 			return conn.UpdateByteMatchSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error updating ByteMatchSet: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
@@ -285,7 +284,7 @@ func testAccCheckAWSWafRegionalByteMatchSetDisappears(v *waf.ByteMatchSet) resou
 			return conn.DeleteByteMatchSet(opts)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+			return fmt.Errorf("Error deleting ByteMatchSet: %s", err)
 		}
 
 		return nil

--- a/aws/resource_aws_wafregional_size_constraint_set.go
+++ b/aws/resource_aws_wafregional_size_constraint_set.go
@@ -39,7 +39,7 @@ func resourceAwsWafRegionalSizeConstraintSetCreate(d *schema.ResourceData, meta 
 		return conn.CreateSizeConstraintSet(params)
 	})
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error creating WAF Regional SizeConstraintSet: %s", err)
+		return fmt.Errorf("Error creating WAF Regional SizeConstraintSet: %s", err)
 	}
 	resp := out.(*waf.CreateSizeConstraintSetOutput)
 
@@ -80,7 +80,7 @@ func resourceAwsWafRegionalSizeConstraintSetUpdate(d *schema.ResourceData, meta 
 		oldConstraints, newConstraints := o.(*schema.Set).List(), n.(*schema.Set).List()
 
 		if err := updateRegionalSizeConstraintSetResource(d.Id(), oldConstraints, newConstraints, client.wafregionalconn, client.region); err != nil {
-			return fmt.Errorf("[ERROR] Error updating WAF Regional SizeConstraintSet: %s", err)
+			return fmt.Errorf("Error updating WAF Regional SizeConstraintSet: %s", err)
 		}
 	}
 
@@ -96,7 +96,7 @@ func resourceAwsWafRegionalSizeConstraintSetDelete(d *schema.ResourceData, meta 
 	if len(oldConstraints) > 0 {
 		noConstraints := []interface{}{}
 		if err := updateRegionalSizeConstraintSetResource(d.Id(), oldConstraints, noConstraints, conn, region); err != nil {
-			return fmt.Errorf("[ERROR] Error deleting WAF Regional SizeConstraintSet: %s", err)
+			return fmt.Errorf("Error deleting WAF Regional SizeConstraintSet: %s", err)
 		}
 	}
 
@@ -109,7 +109,7 @@ func resourceAwsWafRegionalSizeConstraintSetDelete(d *schema.ResourceData, meta 
 		return conn.DeleteSizeConstraintSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error deleting WAF Regional SizeConstraintSet: %s", err)
+		return fmt.Errorf("Error deleting WAF Regional SizeConstraintSet: %s", err)
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func updateRegionalSizeConstraintSetResource(id string, oldConstraints, newConst
 		return conn.UpdateSizeConstraintSet(req)
 	})
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error updating WAF Regional SizeConstraintSet: %s", err)
+		return fmt.Errorf("Error updating WAF Regional SizeConstraintSet: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_wafregional_size_constraint_set_test.go
+++ b/aws/resource_aws_wafregional_size_constraint_set_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
 
@@ -211,7 +210,7 @@ func testAccCheckAWSWafRegionalSizeConstraintSetDisappears(constraints *waf.Size
 			return conn.UpdateSizeConstraintSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
+			return fmt.Errorf("Error updating SizeConstraintSet: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {

--- a/aws/resource_aws_wafregional_sql_injection_match_set.go
+++ b/aws/resource_aws_wafregional_sql_injection_match_set.go
@@ -122,7 +122,7 @@ func resourceAwsWafRegionalSqlInjectionMatchSetUpdate(d *schema.ResourceData, me
 
 		err := updateSqlInjectionMatchSetResourceWR(d.Id(), oldT, newT, conn, region)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error updating Regional WAF SQL Injection Match Set: %s", err)
+			return fmt.Errorf("Error updating Regional WAF SQL Injection Match Set: %s", err)
 		}
 	}
 
@@ -139,7 +139,7 @@ func resourceAwsWafRegionalSqlInjectionMatchSetDelete(d *schema.ResourceData, me
 		noTuples := []interface{}{}
 		err := updateSqlInjectionMatchSetResourceWR(d.Id(), oldTuples, noTuples, conn, region)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Error deleting Regional WAF SQL Injection Match Set: %s", err)
+			return fmt.Errorf("Error deleting Regional WAF SQL Injection Match Set: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_wafregional_xss_match_set_test.go
+++ b/aws/resource_aws_wafregional_xss_match_set_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -220,7 +219,7 @@ func testAccCheckAWSWafRegionalXssMatchSetDisappears(v *waf.XssMatchSet) resourc
 			return conn.UpdateXssMatchSet(req)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error updating regional WAF XSS Match Set: {{err}}", err)
+			return fmt.Errorf("Error updating regional WAF XSS Match Set: %s", err)
 		}
 
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
@@ -231,7 +230,7 @@ func testAccCheckAWSWafRegionalXssMatchSetDisappears(v *waf.XssMatchSet) resourc
 			return conn.DeleteXssMatchSet(opts)
 		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error deleting regional WAF XSS Match Set: {{err}}", err)
+			return fmt.Errorf("Error deleting regional WAF XSS Match Set: %s", err)
 		}
 		return nil
 	}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -85,7 +85,7 @@ func expandListeners(configured []interface{}) ([]*elb.Listener, error) {
 		if valid {
 			listeners = append(listeners, l)
 		} else {
-			return nil, fmt.Errorf("[ERR] ELB Listener: ssl_certificate_id may be set only when protocol is 'https' or 'ssl'")
+			return nil, fmt.Errorf("ELB Listener: ssl_certificate_id may be set only when protocol is 'https' or 'ssl'")
 		}
 	}
 

--- a/aws/tagsNeptune.go
+++ b/aws/tagsNeptune.go
@@ -121,7 +121,7 @@ func saveTagsNeptune(conn *neptune.Neptune, d *schema.ResourceData, arn string) 
 	})
 
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Error retreiving tags for ARN: %s", arn)
+		return fmt.Errorf("Error retreiving tags for ARN: %s", arn)
 	}
 
 	var dt []*neptune.Tag

--- a/aws/tagsRDS.go
+++ b/aws/tagsRDS.go
@@ -107,7 +107,7 @@ func saveTagsRDS(conn *rds.RDS, d *schema.ResourceData, arn string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("[DEBUG] Error retreiving tags for ARN: %s", arn)
+		return fmt.Errorf("Error retreiving tags for ARN: %s", arn)
 	}
 
 	var dt []*rds.Tag

--- a/aws/tags_dms_test.go
+++ b/aws/tags_dms_test.go
@@ -1,11 +1,11 @@
 package aws
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
-	"reflect"
 )
 
 func TestDmsTagsToMap(t *testing.T) {

--- a/aws/waf_token_handlers.go
+++ b/aws/waf_token_handlers.go
@@ -1,11 +1,11 @@
 package aws
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -27,7 +27,7 @@ func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
 
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 		if err != nil {
-			return resource.NonRetryableError(errwrap.Wrapf("Failed to acquire change token: {{err}}", err))
+			return resource.NonRetryableError(fmt.Errorf("Failed to acquire change token: %s", err))
 		}
 
 		out, err = f(tokenOut.ChangeToken)

--- a/aws/wafregionl_token_handlers.go
+++ b/aws/wafregionl_token_handlers.go
@@ -1,12 +1,12 @@
 package aws
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -28,7 +28,7 @@ func (t *WafRegionalRetryer) RetryWithToken(f withRegionalTokenFunc) (interface{
 
 		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
 		if err != nil {
-			return resource.NonRetryableError(errwrap.Wrapf("Failed to acquire change token: {{err}}", err))
+			return resource.NonRetryableError(fmt.Errorf("Failed to acquire change token: %s", err))
 		}
 
 		out, err = f(tokenOut.ChangeToken)


### PR DESCRIPTION
Changes:
* Replace `errwrap.Wrapf()` usage with `fmt.Errorf()`
* Fix `fmt.Errorf(fmt.Sprintf())` usage
* Fix other `goimports` issues (since the errwrap removal was causing some new ones)
* Remove `[LEVEL]` from error messaging (e.g. `[ERROR] Actual message`)

```
$ make lint
==> Checking source code against linters...
$ make test TEST=./aws
==> Checking that code complies with gofmt requirements...
go test ./aws -timeout=30s -parallel=4
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2.559s
```

Output from acceptance testing: Handled via daily acceptance testing

