### PR TITLE
tests/ec2: Enhance sweepers for VPC deletion

### DIFF
--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -33,6 +33,7 @@ func testSweepNatGateways(region string) error {
 				Name: aws.String("tag-value"),
 				Values: []*string{
 					aws.String("terraform-testacc-*"),
+					aws.String("tf-acc-test-*"),
 				},
 			},
 		},

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
@@ -11,6 +12,60 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_route_table", &resource.Sweeper{
+		Name: "aws_route_table",
+		F:    testSweepRouteTables,
+	})
+}
+
+func testSweepRouteTables(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag-value"),
+				Values: []*string{
+					aws.String("terraform-testacc-*"),
+					aws.String("tf-acc-test-*"),
+				},
+			},
+		},
+	}
+	resp, err := conn.DescribeRouteTables(req)
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Route Table sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error describing Route Tables: %s", err)
+	}
+
+	if len(resp.RouteTables) == 0 {
+		log.Print("[DEBUG] No Route Tables to sweep")
+		return nil
+	}
+
+	for _, routeTable := range resp.RouteTables {
+		input := &ec2.DeleteRouteTableInput{
+			RouteTableId: routeTable.RouteTableId,
+		}
+
+		log.Printf("[DEBUG] Deleting Route Table: %s", input)
+		_, err := conn.DeleteRouteTable(input)
+		if err != nil {
+			return fmt.Errorf("error deleting Route Table (%s): %s", aws.StringValue(routeTable.RouteTableId), err)
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSRouteTable_basic(t *testing.T) {
 	var v ec2.RouteTable

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -36,8 +36,11 @@ func testSweepSecurityGroups(region string) error {
 	req := &ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag-value"),
-				Values: []*string{aws.String("tf-acc-revoke*")},
+				Name: aws.String("tag-value"),
+				Values: []*string{
+					aws.String("tf-acc-revoke*"),
+					aws.String("tf-acc-test-*"),
+				},
 			},
 		},
 	}

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -21,6 +21,7 @@ func init() {
 			"aws_internet_gateway",
 			"aws_nat_gateway",
 			"aws_network_acl",
+			"aws_route_table",
 			"aws_security_group",
 			"aws_subnet",
 			"aws_vpn_gateway",
@@ -42,6 +43,7 @@ func testSweepVPCs(region string) error {
 				Name: aws.String("tag-value"),
 				Values: []*string{
 					aws.String("terraform-testacc-*"),
+					aws.String("tf-acc-test-*"),
 				},
 			},
 		},

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -34,6 +34,7 @@ func testSweepVPNGateways(region string) error {
 				Name: aws.String("tag-value"),
 				Values: []*string{
 					aws.String("terraform-testacc-*"),
+					aws.String("tf-acc-test-*"),
 				},
 			},
 		},


### PR DESCRIPTION
While attempting to clean up `tf-acc-test-*` VPC resources, ran into missing functionality with the existing sweepers.

Changes:
* Add `aws_route_table` test sweeper
* Loop through Internet Gateway attachments and complete detachments before attempting deletion
* Add `tf-acc-test-*` to test sweepers for aws_internet_gateway, aws_nat_gateway, aws_security_group, aws_vpc, and aws_vpn_gateway

Previously (before fixing `aws_internet_gateway` sweeper):

```
2018/09/16 13:38:32 [ERR] error running (aws_vpc): Error deleting Internet Gateway (igw-05927556b524fb89a): DependencyViolation: The internetGateway 'igw-05927556b524fb89a' has dependencies and cannot be deleted.
```

Previously (before adding `aws_route_table` sweeper):

```
2018/09/16 14:02:57 [ERR] error running (aws_vpc): Error deleting VPC (vpc-0bf9aa31cc08f54b3): DependencyViolation: The vpc 'vpc-0bf9aa31cc08f54b3' has dependencies and cannot be deleted.
```

Now:

```
$ make sweep SWEEP=us-west-2 SWEEPARGS='-sweep-run=aws_vpc'
...
2018/09/16 14:16:39 [DEBUG] Deleting VPC: {
  VpcId: "vpc-0bf9aa31cc08f54b3"
}
...
2018/09/16 14:16:51 Sweeper Tests ran:
	- aws_elb
	- aws_subnet
	- aws_route_table
	- aws_batch_compute_environment
	- aws_beanstalk_environment
	- aws_elasticsearch_domain
	- aws_elasticache_replication_group
	- aws_security_group
	- aws_batch_job_queue
	- aws_db_instance
	- aws_eks_cluster
	- aws_lb
	- aws_redshift_cluster
	- aws_spot_fleet_request
	- aws_vpn_gateway
	- aws_nat_gateway
	- aws_elasticache_cluster
	- aws_instance
	- aws_lambda_function
	- aws_vpc
	- aws_internet_gateway
	- aws_network_acl
	- aws_autoscaling_group
	- aws_mq_broker
ok  	github.com/terraform-providers/terraform-provider-aws/aws	117.935s
```
