### PR TITLE
elasticache: Fully expand cluster and replication group resource schemas

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -18,238 +18,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 )
 
-func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
-
-	return map[string]*schema.Schema{
-		"availability_zones": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			ForceNew: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			Set:      schema.HashString,
-		},
-		"node_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"engine": {
-			Type:     schema.TypeString,
-			Optional: true,
-			//Computed: true, Set in resourceAwsElasticacheCluster because this Schema is used in resource_aws_elasticache_replication_group with a default value.
-			ForceNew: true,
-		},
-		"engine_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"parameter_group_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"subnet_group_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-			ForceNew: true,
-		},
-		"security_group_names": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Computed: true,
-			ForceNew: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			Set:      schema.HashString,
-		},
-		"security_group_ids": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			Set:      schema.HashString,
-		},
-		// A single-element string list containing an Amazon Resource Name (ARN) that
-		// uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
-		// file will be used to populate the node group.
-		//
-		// See also:
-		// https://github.com/aws/aws-sdk-go/blob/4862a174f7fc92fb523fc39e68f00b87d91d2c3d/service/elasticache/api.go#L2079
-		"snapshot_arns": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			ForceNew: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			Set:      schema.HashString,
-		},
-		"snapshot_window": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validateOnceADayWindowFormat,
-		},
-		"snapshot_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
-		},
-
-		"maintenance_window": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-			StateFunc: func(val interface{}) string {
-				// Elasticache always changes the maintenance
-				// to lowercase
-				return strings.ToLower(val.(string))
-			},
-			ValidateFunc: validateOnceAWeekWindowFormat,
-		},
-		"port": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			ForceNew: true,
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// Suppress default memcached/redis ports when not defined
-				if !d.IsNewResource() && new == "0" && (old == "6379" || old == "11211") {
-					return true
-				}
-				return false
-			},
-		},
-		"notification_topic_arn": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-
-		"snapshot_retention_limit": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			ValidateFunc: validation.IntAtMost(35),
-		},
-
-		"apply_immediately": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-		},
-
-		"tags": tagsSchema(),
-	}
-}
-
 func resourceAwsElasticacheCluster() *schema.Resource {
-	resourceSchema := resourceAwsElastiCacheCommonSchema()
-
-	resourceSchema["engine"].Computed = true
-
-	resourceSchema["cluster_id"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Required: true,
-		ForceNew: true,
-		StateFunc: func(val interface{}) string {
-			// Elasticache normalizes cluster ids to lowercase,
-			// so we have to do this too or else we can end up
-			// with non-converging diffs.
-			return strings.ToLower(val.(string))
-		},
-		ValidateFunc: validateElastiCacheClusterId,
-	}
-
-	resourceSchema["num_cache_nodes"] = &schema.Schema{
-		Type:     schema.TypeInt,
-		Optional: true,
-		Computed: true,
-	}
-
-	resourceSchema["az_mode"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
-		ValidateFunc: validation.StringInSlice([]string{
-			elasticache.AZModeCrossAz,
-			elasticache.AZModeSingleAz,
-		}, false),
-	}
-
-	resourceSchema["availability_zone"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
-		ForceNew: true,
-	}
-
-	resourceSchema["availability_zones"].ConflictsWith = []string{"preferred_availability_zones"}
-	resourceSchema["availability_zones"].Deprecated = "Use `preferred_availability_zones` instead"
-
-	resourceSchema["configuration_endpoint"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	}
-
-	resourceSchema["cluster_address"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	}
-
-	resourceSchema["cache_nodes"] = &schema.Schema{
-		Type:     schema.TypeList,
-		Computed: true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"id": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"address": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"port": {
-					Type:     schema.TypeInt,
-					Computed: true,
-				},
-				"availability_zone": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-			},
-		},
-	}
-
-	resourceSchema["preferred_availability_zones"] = &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		Elem:     &schema.Schema{Type: schema.TypeString},
-	}
-
-	resourceSchema["replication_group_id"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		ForceNew: true,
-		ConflictsWith: []string{
-			"availability_zones",
-			"az_mode",
-			"engine_version",
-			"engine",
-			"maintenance_window",
-			"node_type",
-			"notification_topic_arn",
-			"num_cache_nodes",
-			"parameter_group_name",
-			"port",
-			"security_group_ids",
-			"security_group_names",
-			"snapshot_arns",
-			"snapshot_name",
-			"snapshot_retention_limit",
-			"snapshot_window",
-			"subnet_group_name",
-		},
-		Computed: true,
-	}
-
 	return &schema.Resource{
 		Create: resourceAwsElasticacheClusterCreate,
 		Read:   resourceAwsElasticacheClusterRead,
@@ -259,7 +28,215 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: resourceSchema,
+		Schema: map[string]*schema.Schema{
+			"apply_immediately": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"availability_zones": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ForceNew:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
+				ConflictsWith: []string{"preferred_availability_zones"},
+				Deprecated:    "Use `preferred_availability_zones` instead",
+			},
+			"az_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					elasticache.AZModeCrossAz,
+					elasticache.AZModeSingleAz,
+				}, false),
+			},
+			"cache_nodes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					// Elasticache normalizes cluster ids to lowercase,
+					// so we have to do this too or else we can end up
+					// with non-converging diffs.
+					return strings.ToLower(val.(string))
+				},
+				ValidateFunc: validateElastiCacheClusterId,
+			},
+			"configuration_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"maintenance_window": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				StateFunc: func(val interface{}) string {
+					// Elasticache always changes the maintenance
+					// to lowercase
+					return strings.ToLower(val.(string))
+				},
+				ValidateFunc: validateOnceAWeekWindowFormat,
+			},
+			"node_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"notification_topic_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"num_cache_nodes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"parameter_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Suppress default memcached/redis ports when not defined
+					if !d.IsNewResource() && new == "0" && (old == "6379" || old == "11211") {
+						return true
+					}
+					return false
+				},
+			},
+			"preferred_availability_zones": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"replication_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"availability_zones",
+					"az_mode",
+					"engine_version",
+					"engine",
+					"maintenance_window",
+					"node_type",
+					"notification_topic_arn",
+					"num_cache_nodes",
+					"parameter_group_name",
+					"port",
+					"security_group_ids",
+					"security_group_names",
+					"snapshot_arns",
+					"snapshot_name",
+					"snapshot_retention_limit",
+					"snapshot_window",
+					"subnet_group_name",
+				},
+				Computed: true,
+			},
+			"security_group_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			// A single-element string list containing an Amazon Resource Name (ARN) that
+			// uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
+			// file will be used to populate the node group.
+			//
+			// See also:
+			// https://github.com/aws/aws-sdk-go/blob/4862a174f7fc92fb523fc39e68f00b87d91d2c3d/service/elasticache/api.go#L2079
+			"snapshot_arns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"snapshot_retention_limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtMost(35),
+			},
+			"snapshot_window": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateOnceADayWindowFormat,
+			},
+			"snapshot_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"subnet_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
+		},
 
 		CustomizeDiff: customdiff.Sequence(
 			func(diff *schema.ResourceDiff, v interface{}) error {

--- a/aws/resource_aws_elasticache_replication_group.go
+++ b/aws/resource_aws_elasticache_replication_group.go
@@ -11,113 +11,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsElasticacheReplicationGroup() *schema.Resource {
-
-	resourceSchema := resourceAwsElastiCacheCommonSchema()
-
-	resourceSchema["replication_group_id"] = &schema.Schema{
-		Type:         schema.TypeString,
-		Required:     true,
-		ForceNew:     true,
-		ValidateFunc: validateAwsElastiCacheReplicationGroupId,
-		StateFunc: func(val interface{}) string {
-			return strings.ToLower(val.(string))
-		},
-	}
-
-	resourceSchema["automatic_failover_enabled"] = &schema.Schema{
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
-	}
-
-	resourceSchema["auto_minor_version_upgrade"] = &schema.Schema{
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  true,
-	}
-
-	resourceSchema["replication_group_description"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Required: true,
-	}
-
-	resourceSchema["number_cache_clusters"] = &schema.Schema{
-		Type:     schema.TypeInt,
-		Computed: true,
-		Optional: true,
-	}
-
-	resourceSchema["member_clusters"] = &schema.Schema{
-		Type:     schema.TypeSet,
-		Computed: true,
-		Elem:     &schema.Schema{Type: schema.TypeString},
-		Set:      schema.HashString,
-	}
-
-	resourceSchema["primary_endpoint_address"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	}
-
-	resourceSchema["configuration_endpoint_address"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	}
-
-	resourceSchema["cluster_mode"] = &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		// We allow Computed: true here since using number_cache_clusters
-		// and a cluster mode enabled parameter_group_name will create
-		// a single shard replication group with number_cache_clusters - 1
-		// read replicas. Otherwise, the resource is marked ForceNew.
-		Computed: true,
-		MaxItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"replicas_per_node_group": {
-					Type:     schema.TypeInt,
-					Required: true,
-					ForceNew: true,
-				},
-				"num_node_groups": {
-					Type:     schema.TypeInt,
-					Required: true,
-				},
-			},
-		},
-	}
-
-	resourceSchema["engine"].Required = false
-	resourceSchema["engine"].Optional = true
-	resourceSchema["engine"].Default = "redis"
-	resourceSchema["engine"].ValidateFunc = validateAwsElastiCacheReplicationGroupEngine
-
-	resourceSchema["at_rest_encryption_enabled"] = &schema.Schema{
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
-		ForceNew: true,
-	}
-
-	resourceSchema["transit_encryption_enabled"] = &schema.Schema{
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
-		ForceNew: true,
-	}
-
-	resourceSchema["auth_token"] = &schema.Schema{
-		Type:         schema.TypeString,
-		Optional:     true,
-		Sensitive:    true,
-		ForceNew:     true,
-		ValidateFunc: validateAwsElastiCacheReplicationGroupAuthToken,
-	}
-
 	return &schema.Resource{
 		Create: resourceAwsElasticacheReplicationGroupCreate,
 		Read:   resourceAwsElasticacheReplicationGroupRead,
@@ -127,7 +24,204 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema:        resourceSchema,
+		Schema: map[string]*schema.Schema{
+			"apply_immediately": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"at_rest_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"auth_token": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsElastiCacheReplicationGroupAuthToken,
+			},
+			"auto_minor_version_upgrade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"automatic_failover_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"availability_zones": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"cluster_mode": {
+				Type:     schema.TypeList,
+				Optional: true,
+				// We allow Computed: true here since using number_cache_clusters
+				// and a cluster mode enabled parameter_group_name will create
+				// a single shard replication group with number_cache_clusters - 1
+				// read replicas. Otherwise, the resource is marked ForceNew.
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"replicas_per_node_group": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+						"num_node_groups": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+			"configuration_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "redis",
+				ValidateFunc: validateAwsElastiCacheReplicationGroupEngine,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"maintenance_window": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				StateFunc: func(val interface{}) string {
+					// Elasticache always changes the maintenance
+					// to lowercase
+					return strings.ToLower(val.(string))
+				},
+				ValidateFunc: validateOnceAWeekWindowFormat,
+			},
+			"member_clusters": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"node_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"notification_topic_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"number_cache_clusters": {
+				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+			},
+			"parameter_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Suppress default memcached/redis ports when not defined
+					if !d.IsNewResource() && new == "0" && (old == "6379" || old == "11211") {
+						return true
+					}
+					return false
+				},
+			},
+			"primary_endpoint_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"replication_group_description": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"replication_group_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsElastiCacheReplicationGroupId,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+			},
+			"security_group_names": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			// A single-element string list containing an Amazon Resource Name (ARN) that
+			// uniquely identifies a Redis RDB snapshot file stored in Amazon S3. The snapshot
+			// file will be used to populate the node group.
+			//
+			// See also:
+			// https://github.com/aws/aws-sdk-go/blob/4862a174f7fc92fb523fc39e68f00b87d91d2c3d/service/elasticache/api.go#L2079
+			"snapshot_arns": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"snapshot_retention_limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtMost(35),
+			},
+			"snapshot_window": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateOnceADayWindowFormat,
+			},
+			"snapshot_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"subnet_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
+			"transit_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+		},
 		SchemaVersion: 1,
 
 		Timeouts: &schema.ResourceTimeout{

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -311,13 +311,13 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "number_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "automatic_failover_enabled", "true"),
+						"aws_elasticache_replication_group.bar", "automatic_failover_enabled", "false"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "snapshot_window", "02:00-03:00"),
 					resource.TestCheckResourceAttr(
 						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "7"),
 					resource.TestCheckResourceAttrSet(
-						"aws_elasticache_replication_group.bar", "configuration_endpoint_address"),
+						"aws_elasticache_replication_group.bar", "primary_endpoint_address"),
 				),
 			},
 		},

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1151,7 +1151,7 @@ resource "aws_security_group" "bar" {
 resource "aws_elasticache_replication_group" "bar" {
     replication_group_id = "tf-%s"
     replication_group_description = "test description"
-    node_type = "cache.t2.micro"
+    node_type = "cache.m3.medium"
     number_cache_clusters = "2"
     port = 6379
     subnet_group_name = "${aws_elasticache_subnet_group.bar.name}"


### PR DESCRIPTION
Closes #4828

Changes proposed in this pull request:

* Detailed information and reasoning here: https://github.com/terraform-providers/terraform-provider-aws/issues/4828
* Fixes longstanding failing acceptance test `TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2`

Output from acceptance testing:

```
41 tests passed (all tests)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic (3.07s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (3.25s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic (439.36s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic (509.96s)
--- PASS: TestAccAWSElasticacheCluster_Port_Ec2Classic (520.43s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic (521.33s)
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (525.83s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic (542.09s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (570.71s)
--- PASS: TestAccAWSElasticacheCluster_vpc (716.09s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (735.73s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (825.07s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (838.26s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (859.28s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1056.37s)
--- PASS: TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError (6.33s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic (1085.71s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic (1083.05s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic (1103.90s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1128.02s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1129.33s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1177.38s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1177.83s)
--- PASS: TestAccAWSElasticacheReplicationGroup_Uppercase (731.15s)
--- PASS: TestAccAWSElasticacheReplicationGroup_basic (837.28s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateDescription (836.50s)
--- PASS: TestAccAWSElasticacheReplicationGroup_importBasic (922.42s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (961.21s)
--- PASS: TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2 (755.75s)
--- PASS: TestAccAWSElasticacheReplicationGroup_multiAzInVpc (877.17s)
--- PASS: TestAccAWSElasticacheReplicationGroup_vpc (936.22s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (1150.02s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_Basic (1009.87s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (815.91s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAuthTokenTransitEncryption (796.36s)
--- PASS: TestAccAWSElasticacheReplicationGroup_enableAtRestEncryption (1048.82s)
--- PASS: TestAccAWSElasticacheReplicationGroup_updateNodeSize (1675.04s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1366.64s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (1482.89s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (1596.92s)
--- PASS: TestAccAWSElasticacheReplicationGroup_ClusterMode_NumNodeGroups (3537.44s)
```
