### PR TITLE
resource/aws_wafregional_byte_match_set: Properly read byte_match_tuple into Terraform state

### DIFF
--- a/aws/resource_aws_wafregional_byte_match_set.go
+++ b/aws/resource_aws_wafregional_byte_match_set.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -32,7 +31,7 @@ func resourceAwsWafRegionalByteMatchSet() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"field_to_match": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -69,7 +68,7 @@ func resourceAwsWafRegionalByteMatchSet() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"field_to_match": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -139,20 +138,31 @@ func resourceAwsWafRegionalByteMatchSetRead(d *schema.ResourceData, meta interfa
 	}
 
 	resp, err := conn.GetByteMatchSet(params)
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
-			log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
-			d.SetId("")
-			return nil
-		}
 
-		return err
+	if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
+		log.Printf("[WARN] WAF Regional Byte Set Match (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting WAF Regional Byte Match Set (%s): %s", d.Id(), err)
+	}
+
+	if resp == nil || resp.ByteMatchSet == nil {
+		log.Printf("[WARN] WAF Regional Byte Set Match (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	if _, ok := d.GetOk("byte_match_tuple"); ok {
-		d.Set("byte_match_tuple", flattenWafByteMatchTuplesWR(resp.ByteMatchSet.ByteMatchTuples))
+		if err := d.Set("byte_match_tuple", flattenWafByteMatchTuplesWR(resp.ByteMatchSet.ByteMatchTuples)); err != nil {
+			return fmt.Errorf("error setting byte_match_tuple: %s", err)
+		}
 	} else {
-		d.Set("byte_match_tuples", flattenWafByteMatchTuplesWR(resp.ByteMatchSet.ByteMatchTuples))
+		if err := d.Set("byte_match_tuples", flattenWafByteMatchTuplesWR(resp.ByteMatchSet.ByteMatchTuples)); err != nil {
+			return fmt.Errorf("error setting byte_match_tuples: %s", err)
+		}
 	}
 	d.Set("name", resp.ByteMatchSet.Name)
 
@@ -160,30 +170,21 @@ func resourceAwsWafRegionalByteMatchSetRead(d *schema.ResourceData, meta interfa
 }
 
 func flattenWafByteMatchTuplesWR(in []*waf.ByteMatchTuple) []interface{} {
-	tuples := make([]interface{}, len(in), len(in))
+	tuples := make([]interface{}, len(in))
 
 	for i, tuple := range in {
-		field_to_match := tuple.FieldToMatch
+		fieldToMatchMap := map[string]interface{}{
+			"data": aws.StringValue(tuple.FieldToMatch.Data),
+			"type": aws.StringValue(tuple.FieldToMatch.Type),
+		}
+
 		m := map[string]interface{}{
-			"type": *field_to_match.Type,
+			"field_to_match":        []map[string]interface{}{fieldToMatchMap},
+			"positional_constraint": aws.StringValue(tuple.PositionalConstraint),
+			"target_string":         string(tuple.TargetString),
+			"text_transformation":   aws.StringValue(tuple.TextTransformation),
 		}
-
-		if field_to_match.Data == nil {
-			m["data"] = ""
-		} else {
-			m["data"] = *field_to_match.Data
-		}
-
-		var ms []map[string]interface{}
-		ms = append(ms, m)
-
-		tuple := map[string]interface{}{
-			"field_to_match":        ms,
-			"positional_constraint": *tuple.PositionalConstraint,
-			"target_string":         tuple.TargetString,
-			"text_transformation":   *tuple.TextTransformation,
-		}
-		tuples[i] = tuple
+		tuples[i] = m
 	}
 
 	return tuples
@@ -283,7 +284,7 @@ func diffByteMatchSetTuple(oldT, newT []interface{}) []*waf.ByteMatchSetUpdate {
 		updates = append(updates, &waf.ByteMatchSetUpdate{
 			Action: aws.String(waf.ChangeActionDelete),
 			ByteMatchTuple: &waf.ByteMatchTuple{
-				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
 				PositionalConstraint: aws.String(tuple["positional_constraint"].(string)),
 				TargetString:         []byte(tuple["target_string"].(string)),
 				TextTransformation:   aws.String(tuple["text_transformation"].(string)),
@@ -297,7 +298,7 @@ func diffByteMatchSetTuple(oldT, newT []interface{}) []*waf.ByteMatchSetUpdate {
 		updates = append(updates, &waf.ByteMatchSetUpdate{
 			Action: aws.String(waf.ChangeActionInsert),
 			ByteMatchTuple: &waf.ByteMatchTuple{
-				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
 				PositionalConstraint: aws.String(tuple["positional_constraint"].(string)),
 				TargetString:         []byte(tuple["target_string"].(string)),
 				TextTransformation:   aws.String(tuple["text_transformation"].(string)),

--- a/aws/resource_aws_wafregional_byte_match_set_test.go
+++ b/aws/resource_aws_wafregional_byte_match_set_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/hashicorp/terraform/helper/acctest"
 )
@@ -31,25 +30,29 @@ func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
 			},
 		},
@@ -75,25 +78,29 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -105,25 +112,29 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
 			},
 		},
@@ -148,25 +159,25 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.target_string", "badrefer1"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2174619346.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.data", "referer"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.field_to_match.2991901334.type", "HEADER"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.positional_constraint", "CONTAINS"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.target_string", "badrefer2"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.839525137.text_transformation", "NONE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
 			},
 			{
@@ -178,25 +189,29 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.field_to_match.4253810390.data", "GET"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.field_to_match.4253810390.type", "METHOD"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.positional_constraint", "STARTS_WITH"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.field_to_match.0.type", "METHOD"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.target_string", "badrefer1+"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.positional_constraint", "EXACTLY"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2397850647.text_transformation", "LOWERCASE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.target_string", "GET"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.field_to_match.3756326843.data", ""),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.field_to_match.3756326843.type", "URI"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.positional_constraint", "ENDS_WITH"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.target_string", "badrefer2+"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.field_to_match.0.type", "URI"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.4153613423.text_transformation", "LOWERCASE"),
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.positional_constraint", "ENDS_WITH"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.target_string", "badrefer2+"),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.text_transformation", "LOWERCASE"),
 				),
 			},
 		},
@@ -338,11 +353,8 @@ func testAccCheckAWSWafRegionalByteMatchSetDestroy(s *terraform.State) error {
 			}
 		}
 
-		// Return nil if the ByteMatchSet is already destroyed
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "WAFNonexistentItemException" {
-				return nil
-			}
+		if isAWSErr(err, waf.ErrCodeNonexistentItemException, "") {
+			continue
 		}
 
 		return err
@@ -415,12 +427,11 @@ func testAccAWSWafRegionalByteMatchSetConfigChangeByteMatchTuples(name string) s
 resource "aws_wafregional_byte_match_set" "byte_set" {
   name = "%s"
   byte_match_tuples {
-    text_transformation = "LOWERCASE"
-    target_string = "badrefer1+"
-    positional_constraint = "STARTS_WITH"
+    text_transformation = "NONE"
+    target_string = "GET"
+    positional_constraint = "EXACTLY"
     field_to_match {
       type = "METHOD"
-      data = "GET"
     }
   }
 


### PR DESCRIPTION
Fixes #5372 

This converts the `field_to_match` `schema.TypeSet` with `MaxItems: 1` to `schema.TypeList` for simplification and ensures its properly handled during read.

This also fixes the invalid test configuration being used in `TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples` (`METHOD` `fields_to_match` `type` does not use `data` and the API strips the extraneous `data` value).

Previously (after adding `d.Set()` error check):

```
--- FAIL: TestAccAWSWafRegionalRateBasedRule_changePredicates (21.39s)
    testing.go:527: Step 1 error: Error applying: 1 error occurred:
        	* aws_wafregional_byte_match_set.set: 1 error occurred:
        	* aws_wafregional_byte_match_set.set: error setting byte_match_tuple: Invalid address to set: []string{"byte_match_tuple", "0", "field_to_match"}
```

Now:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegional\(ByteMatchSet\|RateBasedRule\)_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSWafRegional\(ByteMatchSet\|RateBasedRule\)_ -timeout 120m
=== RUN   TestAccAWSWafRegionalByteMatchSet_basic
--- PASS: TestAccAWSWafRegionalByteMatchSet_basic (14.74s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeNameForceNew (25.20s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples (25.18s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
--- PASS: TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples (10.37s)
=== RUN   TestAccAWSWafRegionalByteMatchSet_disappears
--- PASS: TestAccAWSWafRegionalByteMatchSet_disappears (11.83s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_basic
--- PASS: TestAccAWSWafRegionalRateBasedRule_basic (20.16s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (40.48s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_disappears
--- PASS: TestAccAWSWafRegionalRateBasedRule_disappears (21.64s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changePredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_changePredicates (44.00s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_changeRateLimit
--- PASS: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (21.72s)
=== RUN   TestAccAWSWafRegionalRateBasedRule_noPredicates
--- PASS: TestAccAWSWafRegionalRateBasedRule_noPredicates (14.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	250.679s
```