### PR TITLE
r/launch_template: ipv4 addresses

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -769,7 +769,7 @@ func getMonitoring(m *ec2.LaunchTemplatesMonitoring) []interface{} {
 func getNetworkInterfaces(n []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecification) []interface{} {
 	s := []interface{}{}
 	for _, v := range n {
-		var ipv4Addresses []string
+		var ipv4Addresses []map[string]interface{}
 
 		networkInterface := map[string]interface{}{
 			"associate_public_ip_address": aws.BoolValue(v.AssociatePublicIpAddress),
@@ -1101,10 +1101,6 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 		networkInterface.AssociatePublicIpAddress = aws.Bool(v.(bool))
 	}
 
-	if v, ok := ni["private_ip_address"].(string); ok && v != "" {
-		networkInterface.PrivateIpAddress = aws.String(v)
-	}
-
 	if v, ok := ni["subnet_id"].(string); ok && v != "" {
 		networkInterface.SubnetId = aws.String(v)
 	}
@@ -1127,7 +1123,9 @@ func readNetworkInterfacesFromConfig(ni map[string]interface{}) *ec2.LaunchTempl
 		networkInterface.Ipv6AddressCount = aws.Int64(int64(v))
 	}
 
-	if v := ni["ipv4_address_count"].(int); v > 0 {
+	if v, ok := ni["private_ip_address"].(string); ok && v != "" {
+		networkInterface.PrivateIpAddress = aws.String(v)
+	} else if v := ni["ipv4_address_count"].(int); v > 0 {
 		networkInterface.SecondaryPrivateIpAddressCount = aws.Int64(int64(v))
 	} else if v, ok := ni["ipv4_addresses"]; ok && len(v.([]interface{})) > 0 {
 		for _, address := range v.([]interface{}) {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -271,6 +271,31 @@ func TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_networkInterface_ipv4Addresses(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resName := "aws_launch_template.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_networkInterfaces_ipv4Addresses,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.#", "1"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_addresses.#", "2"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_addresses.0.primary", "true"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_addresses.0.private_ip_address", "10.1.0.5"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_addresses.1.primary", "false"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_addresses.1.private_ip_address", "10.1.0.6"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLaunchTemplateExists(n string, t *ec2.LaunchTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -561,6 +586,24 @@ resource "aws_launch_template" "test" {
       "0:0:0:0:0:ffff:a01:5",
       "0:0:0:0:0:ffff:a01:6",
     ]
+  }
+}
+`
+
+const testAccAWSLaunchTemplateConfig_networkInterfaces_ipv4Addresses = `
+resource "aws_launch_template" "test" {
+  name = "network-interface-ipv4-addresses-launch-template"
+
+  network_interfaces {
+    ipv4_addresses {
+      primary = true
+      private_ip_address = "10.1.0.5"
+    }
+
+    ipv4_addresses {
+      primary = false
+      private_ip_address = "10.1.0.6"
+    }
   }
 }
 `

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -214,9 +214,9 @@ Each `network_interfaces` block supports the following:
 * `ipv6_addresses` - One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. Conflicts with `ipv6_address_count`
 * `ipv6_address_count` - The number of IPv6 addresses to assign to a network interface. Conflicts with `ipv6_addresses`
 * `network_interface_id` - The ID of the network interface to attach.
-* `private_ip_address` - The primary private IPv4 address.
-* `ipv4_address_count` - The number of secondary private IPv4 addresses to assign to a network interface. Conflicts with `ipv4_address_count`
-* `ipv4_addresses` - One or more private IPv4 addresses to associate. Conflicts with `ipv4_addresses`
+* `private_ip_address` - The primary private IPv4 address. Conflicts with `ipv4_address_count` and `ipv4_addresses`
+* `ipv4_address_count` - The number of secondary private IPv4 addresses to assign to a network interface. Conflicts with `private_ip_address` and `ipv4_addresses`
+* `ipv4_addresses` - One or more private IPv4 addresses to associate. Conflicts with `private_ip_address` and `ipv4_address_count`
 * `security_groups` - A list of security group IDs to associate.
 * `subnet_id` - The VPC Subnet ID to associate.
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5865

Changes proposed in this pull request:

* set ipv4_addresses correctly
* there can only be `private_ip_address`, `ipv4_address_count`, or `ipv4_addresses`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (14.06s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (11.76s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (12.54s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (48.70s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (48.55s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (12.68s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (47.00s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (20.75s)
=== RUN   TestAccAWSLaunchTemplate_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_nonBurstable (11.67s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_networkInterface (29.83s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (10.50s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv4Addresses
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv4Addresses (12.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	280.270s
```
