### PR TITLE
resource/aws_ecs_task_definition: Support task scoped docker volume configurations

### DIFF
--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -947,7 +947,7 @@ TASK_DEFINITION
   volume {
     name = "database_scratch"
     docker_volume_configuration {
-			autoprovision = true
+      autoprovision = true
     }
   }
 }
@@ -974,7 +974,7 @@ TASK_DEFINITION
   volume {
     name = "database_scratch"
     docker_volume_configuration {
-			scope = "task"
+      scope = "task"
     }
   }
 }

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -918,7 +918,7 @@ TASK_DEFINITION
   volume {
     name = "database_scratch"
     docker_volume_configuration {
-			scope = "task"
+      scope = "task"
     }
   }
 }

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -118,6 +118,35 @@ func TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig(t *testing.T) {
 				Config: testAccAWSEcsTaskDefinitionWithDockerVolumesMinimalConfig(tdName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.scope", "task"),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "volume.584193650.docker_volume_configuration.0.driver", "local"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume(t *testing.T) {
+	var def ecs.TaskDefinition
+
+	rString := acctest.RandString(8)
+	tdName := fmt.Sprintf("tf_acc_td_with_docker_volume_%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsTaskDefinitionWithTaskScopedDockerVolume(tdName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
 					testAccCheckAWSTaskDefinitionDockerVolumeConfigurationAutoprovisionNil(&def),
 					resource.TestCheckResourceAttr(
 						"aws_ecs_task_definition.sleep", "volume.#", "1"),
@@ -918,7 +947,34 @@ TASK_DEFINITION
   volume {
     name = "database_scratch"
     docker_volume_configuration {
-      scope = "task"
+			autoprovision = true
+    }
+  }
+}
+`, tdName)
+}
+
+func testAccAWSEcsTaskDefinitionWithTaskScopedDockerVolume(tdName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "sleep" {
+  family = "%s"
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+TASK_DEFINITION
+
+  volume {
+    name = "database_scratch"
+    docker_volume_configuration {
+			scope = "task"
     }
   }
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -118,14 +118,14 @@ func expandEcsVolumes(configured []interface{}) ([]*ecs.Volume, error) {
 			config := configList[0].(map[string]interface{})
 			l.DockerVolumeConfiguration = &ecs.DockerVolumeConfiguration{}
 
-			if v, ok := config["autoprovision"]; ok && v != "" {
-				l.DockerVolumeConfiguration.Autoprovision = aws.Bool(v.(bool))
-			}
-
 			if v, ok := config["scope"].(string); ok && v != "" {
 				l.DockerVolumeConfiguration.Scope = aws.String(v)
-				if v == ecs.ScopeTask {
-					l.DockerVolumeConfiguration.Autoprovision = nil
+			}
+
+			if v, ok := config["autoprovision"]; ok && v != "" {
+				scope := l.DockerVolumeConfiguration.Scope
+				if scope == nil || *scope != ecs.ScopeTask || v.(bool) {
+					l.DockerVolumeConfiguration.Autoprovision = aws.Bool(v.(bool))
 				}
 			}
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -118,12 +118,15 @@ func expandEcsVolumes(configured []interface{}) ([]*ecs.Volume, error) {
 			config := configList[0].(map[string]interface{})
 			l.DockerVolumeConfiguration = &ecs.DockerVolumeConfiguration{}
 
-			if v, ok := config["scope"].(string); ok && v != "" {
-				l.DockerVolumeConfiguration.Scope = aws.String(v)
+			if v, ok := config["autoprovision"]; ok && v != "" {
+				l.DockerVolumeConfiguration.Autoprovision = aws.Bool(v.(bool))
 			}
 
-			if v, ok := config["autoprovision"]; ok {
-				l.DockerVolumeConfiguration.Autoprovision = aws.Bool(v.(bool))
+			if v, ok := config["scope"].(string); ok && v != "" {
+				l.DockerVolumeConfiguration.Scope = aws.String(v)
+				if v == ecs.ScopeTask {
+					l.DockerVolumeConfiguration.Autoprovision = nil
+				}
 			}
 
 			if v, ok := config["driver"].(string); ok && v != "" {


### PR DESCRIPTION
Recently support was added for Docker volume configurations for ECS task definitions: #5727 

Unfortunately, if you want a task scoped docker volume configuration this implementation doesn't work resulting in the following error:

```
Error: Error applying plan:

1 error(s) occurred:

* aws_ecs_task_definition.service: 1 error(s) occurred:

* aws_ecs_task_definition.service: ClientException: When 'scope' parameter is 'task', 'autoprovision' must either not be specified or set to 'True'.
	status code: 400, request id: <REQUEST_ID>

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

With the following configuraiton:

```
volume {
    name      = "scratch"
    docker_volume_configuration {
        scope         = "task"
        driver        = "local"
    }
}
```

It seems that not specifying a value results in `autoprovision` being set to `false`. Setting `autoprovison` to `true` results in an error when the ECS agent tries to run the task.

AWS documentation states that `autoprovision` is only used for `shared` scope: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-volumes.html

Changes proposed in this pull request:

* Set `Autoprovision` to `nil` when using a `task` scoped docker volume and `autoprovision` is set to `false`.

Questions:

- I tried removing the `Default` value of false, but `false` was still picked up as the value. Is there a way to check for no value and set it to `nil` instead?