### PR TITLE
Add import for aws_iam_role_policy_attachment

### DIFF
--- a/aws/resource_aws_iam_role_policy_attachment.go
+++ b/aws/resource_aws_iam_role_policy_attachment.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -16,6 +17,9 @@ func resourceAwsIamRolePolicyAttachment() *schema.Resource {
 		Create: resourceAwsIamRolePolicyAttachmentCreate,
 		Read:   resourceAwsIamRolePolicyAttachmentRead,
 		Delete: resourceAwsIamRolePolicyAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIamRolePolicyAttachmentImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"role": {
@@ -101,6 +105,22 @@ func resourceAwsIamRolePolicyAttachmentDelete(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error removing policy %s from IAM Role %s: %v", arn, role, err)
 	}
 	return nil
+}
+
+func resourceAwsIamRolePolicyAttachmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <role-name>/<policy_arn>", d.Id())
+	}
+
+	roleName := idParts[0]
+	policyARN := idParts[1]
+
+	d.Set("role", roleName)
+	d.Set("policy_arn", policyARN)
+	d.SetId(fmt.Sprintf("%s-%s", roleName, policyARN))
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func attachPolicyToRole(conn *iam.IAM, role string, arn string) error {

--- a/aws/resource_aws_iam_role_policy_attachment_test.go
+++ b/aws/resource_aws_iam_role_policy_attachment_test.go
@@ -32,6 +32,11 @@ func TestAccAWSRolePolicyAttachment_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_iam_role_policy_attachment.test-attach",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSIAMRolePolicyAttachmentImportStateIdFunc,
+			},
+			{
 				Config: testAccAWSRolePolicyAttachConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRolePolicyAttachmentExists("aws_iam_role_policy_attachment.test-attach", 2, &out),
@@ -91,6 +96,21 @@ func testAccCheckAWSRolePolicyAttachmentAttributes(policies []string, out *iam.L
 		}
 		return nil
 	}
+}
+
+func testAccAWSIAMRolePolicyAttachmentImportStateIdFunc(s *terraform.State) (string, error) {
+	resources := s.RootModule().Resources
+
+	roleResource, ok := resources["aws_iam_role.role"]
+	if !ok {
+		return "", fmt.Errorf("role not found: aws_iam_role.role")
+	}
+	policyResource, ok := resources["aws_iam_policy.policy"]
+	if !ok {
+		return "", fmt.Errorf("policy not found: aws_iam_policy.policy")
+	}
+
+	return fmt.Sprintf("%s/%s", roleResource.Primary.Attributes["name"], policyResource.Primary.Attributes["arn"]), nil
 }
 
 func testAccAWSRolePolicyAttachConfig(rInt int) string {

--- a/website/docs/r/iam_role_policy_attachment.markdown
+++ b/website/docs/r/iam_role_policy_attachment.markdown
@@ -63,3 +63,11 @@ The following arguments are supported:
 
 * `role`		(Required) - The role the policy should be applied to
 * `policy_arn`	(Required) - The ARN of the policy you want to apply
+
+## Import
+
+IAM role policy attachments can be imported using the role name and policy arn separated by `/`.
+
+```
+$ terraform import aws_iam_role_policy_attachment.test-attach test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #544

Changes proposed in this pull request:

* Add import for aws_iam_role_policy_attachment without changing create behavior. See previous discussion on PR https://github.com/terraform-providers/terraform-provider-aws/pull/4527

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSRolePolicyAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSRolePolicyAttachment_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRolePolicyAttachment_basic
--- PASS: TestAccAWSRolePolicyAttachment_basic (25.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.256s
```
