### PR TITLE
Update elasticache_replication_group documentation

### DIFF
--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -82,8 +82,7 @@ resource "aws_elasticache_replication_group" "baz" {
 ~> **Note:** We currently do not support passing a `primary_cluster_id` in order to create the Replication Group.
 
 ~> **Note:** Automatic Failover is unavailable for Redis versions earlier than 2.8.6,
-and unavailable on T1 and T2 node types. See the [Amazon Replication with
-Redis](http://docs.aws.amazon.com/en_en/AmazonElastiCache/latest/UserGuide/Replication.html) guide
+and unavailable on T1 node types. For T2 node types, it is only available on Redis version 3.2.4 or later with cluster mode enabled. See the [High Availability Using Replication Groups](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.html) guide
 for full details on using Replication Groups.
 
 ## Argument Reference


### PR DESCRIPTION
- T2 node types are supported for Redis 3.2.4+ with cluster mode enabled.
- Fix broken link

ref: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html#AutoFailover.Notes
