### PR TITLE
Data Source: aws_ami_ids, add sort_ascending flag

### DIFF
--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -277,7 +277,7 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 
 // Returns the most recent AMI out of a slice of images.
 func mostRecentAmi(images []*ec2.Image) *ec2.Image {
-	return sortImages(images)[0]
+	return sortImages(images, false)[0]
 }
 
 // populate the numerous fields that the image description returns.

--- a/aws/data_source_aws_ami_ids.go
+++ b/aws/data_source_aws_ami_ids.go
@@ -41,6 +41,11 @@ func dataSourceAwsAmiIds() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"sort_ascending": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -52,6 +57,7 @@ func dataSourceAwsAmiIdsRead(d *schema.ResourceData, meta interface{}) error {
 	filters, filtersOk := d.GetOk("filter")
 	nameRegex, nameRegexOk := d.GetOk("name_regex")
 	owners, ownersOk := d.GetOk("owners")
+	sortAscending := d.Get("sort_ascending").(bool)
 
 	if executableUsersOk == false && filtersOk == false && nameRegexOk == false && ownersOk == false {
 		return fmt.Errorf("One of executable_users, filters, name_regex, or owners must be assigned")
@@ -123,7 +129,7 @@ func dataSourceAwsAmiIdsRead(d *schema.ResourceData, meta interface{}) error {
 		filteredImages = resp.Images[:]
 	}
 
-	for _, image := range sortImages(filteredImages) {
+	for _, image := range sortImages(filteredImages, sortAscending) {
 		imageIds = append(imageIds, *image.ImageId)
 	}
 

--- a/aws/data_source_aws_ami_ids_test.go
+++ b/aws/data_source_aws_ami_ids_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -24,30 +23,35 @@ func TestAccDataSourceAwsAmiIds_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsAmiIds_sorted(t *testing.T) {
-	rName := acctest.RandomWithPrefix("tf-acc-test")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsAmiIdsConfig_sorted1(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("aws_ami_from_instance.a", "id"),
-					resource.TestCheckResourceAttrSet("aws_ami_from_instance.b", "id"),
-				),
-			},
-			{
-				Config: testAccDataSourceAwsAmiIdsConfig_sorted2(rName),
+				Config: testAccDataSourceAwsAmiIdsConfig_sorted(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEbsSnapshotDataSourceID("data.aws_ami_ids.test"),
 					resource.TestCheckResourceAttr("data.aws_ami_ids.test", "ids.#", "2"),
 					resource.TestCheckResourceAttrPair(
 						"data.aws_ami_ids.test", "ids.0",
-						"aws_ami_from_instance.b", "id"),
+						"data.aws_ami.amzn_linux_2018_03", "id"),
 					resource.TestCheckResourceAttrPair(
 						"data.aws_ami_ids.test", "ids.1",
-						"aws_ami_from_instance.a", "id"),
+						"data.aws_ami.amzn_linux_2016_09_0", "id"),
+				),
+			},
+			// Make sure when sort_ascending is set, they're sorted in the inverse order
+			// it uses the same config / dataset as above so no need to verify the other
+			// bits
+			{
+				Config: testAccDataSourceAwsAmiIdsConfig_sorted(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.aws_ami_ids.test", "ids.0",
+						"data.aws_ami.amzn_linux_2016_09_0", "id"),
+					resource.TestCheckResourceAttrPair(
+						"data.aws_ami_ids.test", "ids.1",
+						"data.aws_ami.amzn_linux_2018_03", "id"),
 				),
 			},
 		},
@@ -81,41 +85,33 @@ data "aws_ami_ids" "ubuntu" {
 }
 `
 
-func testAccDataSourceAwsAmiIdsConfig_sorted1(rName string) string {
+func testAccDataSourceAwsAmiIdsConfig_sorted(sort_ascending bool) string {
 	return fmt.Sprintf(`
-resource "aws_instance" "test" {
-    ami           = "ami-efd0428f"
-    instance_type = "m3.medium"
-
-    count = 2
+data "aws_ami" "amzn_linux_2016_09_0" {
+  owners = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-2016.09.0.20161028-x86_64-gp2"]
+  }
 }
 
-resource "aws_ami_from_instance" "a" {
-    name                    = "%s-a"
-    source_instance_id      = "${aws_instance.test.*.id[0]}"
-    snapshot_without_reboot = true
+data "aws_ami" "amzn_linux_2018_03" {
+  owners = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-2018.03.0.20180811-x86_64-gp2"]
+  }
 }
 
-resource "aws_ami_from_instance" "b" {
-    name                    = "%s-b"
-    source_instance_id      = "${aws_instance.test.*.id[1]}"
-    snapshot_without_reboot = true
-
-    // We want to ensure that 'aws_ami_from_instance.a.creation_date' is less
-    // than 'aws_ami_from_instance.b.creation_date' so that we can ensure that
-    // the images are being sorted correctly.
-    depends_on = ["aws_ami_from_instance.a"]
-}
-`, rName, rName)
-}
-
-func testAccDataSourceAwsAmiIdsConfig_sorted2(rName string) string {
-	return testAccDataSourceAwsAmiIdsConfig_sorted1(rName) + fmt.Sprintf(`
 data "aws_ami_ids" "test" {
-  owners     = ["self"]
-  name_regex = "^%s-"
+  owners     = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-2018.03.0.20180811-x86_64-gp2", "amzn-ami-hvm-2016.09.0.20161028-x86_64-gp2"]
+  }
+  sort_ascending = "%t"
 }
-`, rName)
+`, sort_ascending)
 }
 
 const testAccDataSourceAwsAmiIdsConfig_empty = `

--- a/aws/sort.go
+++ b/aws/sort.go
@@ -25,9 +25,14 @@ func (a imageSort) Less(i, j int) bool {
 }
 
 // Sort images by creation date, in descending order.
-func sortImages(images []*ec2.Image) []*ec2.Image {
+func sortImages(images []*ec2.Image, sortAscending bool) []*ec2.Image {
 	sortedImages := images
-	sort.Sort(sort.Reverse(imageSort(sortedImages)))
+	if sortAscending {
+		sort.Sort(imageSort(sortedImages))
+
+	} else {
+		sort.Sort(sort.Reverse(imageSort(sortedImages)))
+	}
 	return sortedImages
 }
 

--- a/website/docs/d/ami_ids.html.markdown
+++ b/website/docs/d/ami_ids.html.markdown
@@ -46,9 +46,10 @@ options to narrow down the list AWS returns.
 ~> **NOTE:** At least one of `executable_users`, `filter`, `owners` or
 `name_regex` must be specified.
 
+* `sort_ascending`  - (Defaults to `false`) Used to sort AMIs by creation time.
+
 ## Attributes Reference
 
-`ids` is set to the list of AMI IDs, sorted by creation time in descending
-order.
+`ids` is set to the list of AMI IDs, sorted by creation time according to `sort_ascending`.
 
 [1]: http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html


### PR DESCRIPTION
This adds the sort ascending flag by creation time to
aws_ami_ids, to allow for a list which only ever adds
items at the end.

This is useful for example, when you have something like this:

```hcl

data "aws_ami_ids" "agent_amis" {
  owners = ["self"]

  filter {
    name   = "name"
    values = ["foo-*"]
  }
}

data "aws_region" "current" {}

resource "aws_ami_launch_permission" "launch_permissions_1234" {
  count      = "${length(data.aws_ami_ids.agent_amis.ids)}"
  image_id   = "${data.aws_ami_ids.agent_amis.ids[count.index]}"
  account_id = "1234"
}
```

Otherwise, every time a new AMI is added that matches "foo-*",
it must "recreate" the launch permissions. Although this may
be trivial for launch permissions, on something like AMI
copy, it can wreak havoc.

Changes proposed in this pull request:

* Add `sort_ascending` flag to data source `ami_ids` to optionally sort ascending. It will not 

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccDataSourceAwsAmiIds_sorted"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceAwsAmiIds_sorted -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceAwsAmiIds_sorted
--- PASS: TestAccDataSourceAwsAmiIds_sorted (9.65s)
PASS
```
