### PR TITLE
Allow prefix_list_ids on ingress rules in an aws_security_group

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -110,6 +110,12 @@ func resourceAwsSecurityGroup() *schema.Resource {
 							},
 						},
 
+						"prefix_list_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
 						"security_groups": {
 							Type:     schema.TypeSet,
 							Optional: true,

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -1753,9 +1753,30 @@ func TestAccAWSSecurityGroup_egressWithPrefixList(t *testing.T) {
 				Config: testAccAWSSecurityGroupConfigPrefixListEgress,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupExists("aws_security_group.egress", &group),
-					testAccCheckAWSSecurityGroupPrefixListAttributes(&group),
+					testAccCheckAWSSecurityGroupEgressPrefixListAttributes(&group),
 					resource.TestCheckResourceAttr(
 						"aws_security_group.egress", "egress.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroup_ingressWithPrefixList(t *testing.T) {
+	var group ec2.SecurityGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupConfigPrefixListIngress,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityGroupExists("aws_security_group.ingress", &group),
+					testAccCheckAWSSecurityGroupIngressPrefixListAttributes(&group),
+					resource.TestCheckResourceAttr(
+						"aws_security_group.ingress", "ingress.#", "1"),
 				),
 			},
 		},
@@ -1839,7 +1860,7 @@ func testAccCheckAWSSecurityGroupSGandCidrAttributes(group *ec2.SecurityGroup) r
 	}
 }
 
-func testAccCheckAWSSecurityGroupPrefixListAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
+func testAccCheckAWSSecurityGroupEgressPrefixListAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *group.GroupName != "terraform_acceptance_test_prefix_list_egress" {
 			return fmt.Errorf("Bad name: %s", *group.GroupName)
@@ -1855,6 +1876,31 @@ func testAccCheckAWSSecurityGroupPrefixListAttributes(group *ec2.SecurityGroup) 
 		}
 
 		p := group.IpPermissionsEgress[0]
+
+		if len(p.PrefixListIds) != 1 {
+			return fmt.Errorf("Expected 1 prefix list, got %d", len(p.PrefixListIds))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSecurityGroupIngressPrefixListAttributes(group *ec2.SecurityGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *group.GroupName != "terraform_acceptance_test_prefix_list_ingress" {
+			return fmt.Errorf("Bad name: %s", *group.GroupName)
+		}
+		if *group.Description != "Used in the terraform acceptance tests" {
+			return fmt.Errorf("Bad description: %s", *group.Description)
+		}
+		if len(group.IpPermissions) == 0 {
+			return fmt.Errorf("No IPPerms")
+		}
+		if len(group.IpPermissions) != 1 {
+			return fmt.Errorf("Expected 1 rule, got %d", len(group.IpPermissions))
+		}
+
+		p := group.IpPermissions[0]
 
 		if len(p.PrefixListIds) != 1 {
 			return fmt.Errorf("Expected 1 prefix list, got %d", len(p.PrefixListIds))
@@ -3399,6 +3445,54 @@ resource "aws_security_group" "egress" {
     vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
 
     egress {
+      protocol = "-1"
+      from_port = 0
+      to_port = 0
+      prefix_list_ids = ["${aws_vpc_endpoint.test.prefix_list_id}"]
+    }
+}
+`
+
+const testAccAWSSecurityGroupConfigPrefixListIngress = `
+data "aws_region" "current" {}
+
+resource "aws_vpc" "tf_sg_prefix_list_ingress_test" {
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-security-group-prefix-list-ingress"
+    }
+}
+
+resource "aws_route_table" "default" {
+    vpc_id = "${aws_vpc.tf_sg_prefix_list_ingress_test.id}"
+}
+
+resource "aws_vpc_endpoint" "test" {
+    vpc_id = "${aws_vpc.tf_sg_prefix_list_ingress_test.id}"
+    service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+    route_table_ids = ["${aws_route_table.default.id}"]
+    policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid":"AllowAll",
+            "Effect":"Allow",
+            "Principal":"*",
+            "Action":"*",
+            "Resource":"*"
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_security_group" "ingress" {
+    name = "terraform_acceptance_test_prefix_list_ingress"
+    description = "Used in the terraform acceptance tests"
+    vpc_id = "${aws_vpc.tf_sg_prefix_list_ingress_test.id}"
+
+    ingress {
       protocol = "-1"
       from_port = 0
       to_port = 0

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -94,6 +94,7 @@ The `ingress` block supports:
 
 * `cidr_blocks` - (Optional) List of CIDR blocks.
 * `ipv6_cidr_blocks` - (Optional) List of IPv6 CIDR blocks.
+* `prefix_list_ids` - (Optional) List of prefix list IDs.
 * `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp")
 * `protocol` - (Required) The protocol. If you select a protocol of
 "-1" (semantically equivalent to `"all"`, which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or "-1" use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)


### PR DESCRIPTION
prefix_list_ids is already allowed on ingress `aws_security_group_rule`s but not available when using inline ingress rules.

```
➜ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSecurityGroup_ingressWithPrefixList'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSSecurityGroup_ingressWithPrefixList -timeout 120m
=== RUN   TestAccAWSSecurityGroup_ingressWithPrefixList
--- PASS: TestAccAWSSecurityGroup_ingressWithPrefixList (72.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	73.326s
```