### PR TITLE
d/aws_cloudwatch_log_group: Reuse existing code to read log group

### DIFF
--- a/aws/data_source_aws_cloudwatch_log_group.go
+++ b/aws/data_source_aws_cloudwatch_log_group.go
@@ -3,8 +3,6 @@ package aws
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -33,27 +31,10 @@ func dataSourceAwsCloudwatchLogGroupRead(d *schema.ResourceData, meta interface{
 	name := d.Get("name").(string)
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 
-	input := &cloudwatchlogs.DescribeLogGroupsInput{
-		LogGroupNamePrefix: aws.String(name),
-	}
-
-	var logGroup *cloudwatchlogs.LogGroup
-	// iterate over the pages of log groups until we find the one we are looking for
-	err := conn.DescribeLogGroupsPages(input,
-		func(resp *cloudwatchlogs.DescribeLogGroupsOutput, _ bool) bool {
-			for _, lg := range resp.LogGroups {
-				if aws.StringValue(lg.LogGroupName) == name {
-					logGroup = lg
-					return false
-				}
-			}
-			return true
-		})
-
+	logGroup, err := lookupCloudWatchLogGroup(conn, name)
 	if err != nil {
 		return err
 	}
-
 	if logGroup == nil {
 		return fmt.Errorf("No log group named %s found\n", name)
 	}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/5888.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCloudwatchLogGroupDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSCloudwatchLogGroupDataSource -timeout 120m
=== RUN   TestAccAWSCloudwatchLogGroupDataSource
--- PASS: TestAccAWSCloudwatchLogGroupDataSource (17.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	17.131s
```