### PR TITLE
tests/provider: Add missing testSweepSkipSweepError() handling

### DIFF
--- a/aws/resource_aws_acmpca_certificate_authority_test.go
+++ b/aws/resource_aws_acmpca_certificate_authority_test.go
@@ -29,6 +29,10 @@ func testSweepAcmpcaCertificateAuthorities(region string) error {
 
 	certificateAuthorities, err := listAcmpcaCertificateAuthorities(conn)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping ACMPCA Certificate Authorities sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving ACMPCA Certificate Authorities: %s", err)
 	}
 	if len(certificateAuthorities) == 0 {

--- a/aws/resource_aws_config_aggregate_authorization_test.go
+++ b/aws/resource_aws_config_aggregate_authorization_test.go
@@ -29,6 +29,10 @@ func testSweepConfigAggregateAuthorizations(region string) error {
 
 	aggregateAuthorizations, err := describeConfigAggregateAuthorizations(conn)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Config Aggregate Authorizations sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving config aggregate authorizations: %s", err)
 	}
 

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -30,6 +30,10 @@ func testSweepConfigConfigurationAggregators(region string) error {
 
 	resp, err := conn.DescribeConfigurationAggregators(&configservice.DescribeConfigurationAggregatorsInput{})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Config Configuration Aggregators sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error retrieving config configuration aggregators: %s", err)
 	}
 

--- a/aws/resource_aws_config_configuration_recorder_test.go
+++ b/aws/resource_aws_config_configuration_recorder_test.go
@@ -30,6 +30,10 @@ func testSweepConfigConfigurationRecorder(region string) error {
 	req := &configservice.DescribeConfigurationRecordersInput{}
 	resp, err := conn.DescribeConfigurationRecorders(req)
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Config Configuration Recorders sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing Configuration Recorders: %s", err)
 	}
 

--- a/aws/resource_aws_config_delivery_channel_test.go
+++ b/aws/resource_aws_config_delivery_channel_test.go
@@ -46,6 +46,10 @@ func testSweepConfigDeliveryChannels(region string) error {
 		return nil
 	})
 	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Config Delivery Channels sweep for %s: %s", region, err)
+			return nil
+		}
 		return fmt.Errorf("Error describing Delivery Channels: %s", err)
 	}
 

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -33,6 +33,10 @@ func testSweepEksClusters(region string) error {
 	for {
 		out, err := conn.ListClusters(input)
 		if err != nil {
+			if testSweepSkipSweepError(err) {
+				log.Printf("[WARN] Skipping EKS Clusters sweep for %s: %s", region, err)
+				return nil
+			}
 			return fmt.Errorf("Error retrieving EKS Clusters: %s", err)
 		}
 


### PR DESCRIPTION
To prevent sweeper errors when running in unsupported regions/partitions, e.g.

```
[16:53:32][Step 2/4] 2018/09/18 16:53:32 [DEBUG] [aws-sdk-go] DEBUG: Send Request eks/ListClusters failed, not retrying, error RequestError: send request failed
[16:53:32][Step 2/4] caused by: Get https://eks.us-east-2.amazonaws.com/clusters: dial tcp: lookup eks.us-east-2.amazonaws.com on 192.168.22.2:53: no such host
[16:53:32][Step 2/4] 2018/09/18 16:53:32 [ERR] error running (aws_subnet): Error retrieving EKS Clusters: RequestError: send request failed
[16:53:32][Step 2/4] caused by: Get https://eks.us-east-2.amazonaws.com/clusters: dial tcp: lookup eks.us-east-2.amazonaws.com on 192.168.22.2:53: no such host
[16:53:32][Step 2/4] FAIL github.com/terraform-providers/terraform-provider-aws/aws 14.195s
```