### PR TITLE
resource/aws_launch_template: Support credit_specification configuration of T3 instance types

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -563,7 +563,7 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	if strings.HasPrefix(aws.StringValue(ltData.InstanceType), "t2") {
+	if strings.HasPrefix(aws.StringValue(ltData.InstanceType), "t2") || strings.HasPrefix(aws.StringValue(ltData.InstanceType), "t3") {
 		if err := d.Set("credit_specification", getCreditSpecification(ltData.CreditSpecification)); err != nil {
 			return err
 		}
@@ -903,7 +903,7 @@ func buildLaunchTemplateData(d *schema.ResourceData, meta interface{}) (*ec2.Req
 		opts.BlockDeviceMappings = blockDeviceMappings
 	}
 
-	if v, ok := d.GetOk("credit_specification"); ok && strings.HasPrefix(instanceType, "t2") {
+	if v, ok := d.GetOk("credit_specification"); ok && (strings.HasPrefix(instanceType, "t2") || strings.HasPrefix(instanceType, "t3")) {
 		cs := v.([]interface{})
 
 		if len(cs) > 0 {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -121,7 +121,6 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resName, &template),
 					resource.TestCheckResourceAttr(resName, "block_device_mappings.#", "1"),
-					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
 					resource.TestCheckResourceAttrSet(resName, "disable_api_termination"),
 					resource.TestCheckResourceAttr(resName, "ebs_optimized", "false"),
 					resource.TestCheckResourceAttr(resName, "elastic_gpu_specifications.#", "1"),
@@ -208,8 +207,9 @@ func TestAccAWSLaunchTemplate_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSLaunchTemplate_nonBurstable(t *testing.T) {
+func TestAccAWSLaunchTemplate_creditSpecification_nonBurstable(t *testing.T) {
 	var template ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resName := "aws_launch_template.foo"
 
 	resource.Test(t, resource.TestCase{
@@ -218,9 +218,53 @@ func TestAccAWSLaunchTemplate_nonBurstable(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_nonBurstable,
+				Config: testAccAWSLaunchTemplateConfig_creditSpecification(rName, "m1.small", "standard"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resName, &template),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchTemplate_creditSpecification_t2(t *testing.T) {
+	var template ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resName := "aws_launch_template.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_creditSpecification(rName, "t2.micro", "unlimited"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchTemplate_creditSpecification_t3(t *testing.T) {
+	var template ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resName := "aws_launch_template.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_creditSpecification(rName, "t3.micro", "unlimited"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					resource.TestCheckResourceAttr(resName, "credit_specification.#", "1"),
+					resource.TestCheckResourceAttr(resName, "credit_specification.0.cpu_credits", "unlimited"),
 				),
 			},
 		},
@@ -449,10 +493,6 @@ resource "aws_launch_template" "foo" {
     device_name = "test"
   }
 
-  credit_specification {
-    cpu_credits = "standard"
-  }
-
   disable_api_termination = true
 
   ebs_optimized = false
@@ -518,15 +558,18 @@ resource "aws_launch_template" "foo" {
 `, rInt)
 }
 
-const testAccAWSLaunchTemplateConfig_nonBurstable = `
+func testAccAWSLaunchTemplateConfig_creditSpecification(rName, instanceType, cpuCredits string) string {
+	return fmt.Sprintf(`
 resource "aws_launch_template" "foo" {
-  name = "non-burstable-launch-template"
-  instance_type = "m1.small"
+  instance_type = %q
+  name          = %q
+
   credit_specification {
-    cpu_credits = "standard"
+    cpu_credits = %q
   }
 }
-`
+`, instanceType, rName, cpuCredits)
+}
 
 const testAccAWSLaunchTemplateConfig_networkInterface = `
 resource "aws_vpc" "test" {


### PR DESCRIPTION
Fixes #5761 

Changes proposed in this pull request:

* Allow T3 instance types to configure and read `credit_specification`

Output from acceptance testing:


```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (14.07s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (11.44s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (12.69s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (49.13s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (49.96s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (12.07s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (46.23s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (21.18s)
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (11.90s)
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (10.68s)
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (11.85s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_networkInterface (32.63s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (10.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	295.142s
```
