### PR TITLE
Ignore SSM parameter overwrite change

### DIFF
--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -58,8 +58,9 @@ func resourceAwsSsmParameter() *schema.Resource {
 				Computed: true,
 			},
 			"overwrite": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:             schema.TypeBool,
+				Optional:         true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool { return true },
 			},
 			"allowed_pattern": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Fixes #3181

Changes proposed in this pull request:

* Allows to go from overwrite "true" to overwrite "false"

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSSMParameter -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMParameter_importBasic
--- PASS: TestAccAWSSSMParameter_importBasic (24.35s)
=== RUN   TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_basic (21.79s)
=== RUN   TestAccAWSSSMParameter_disappears
--- PASS: TestAccAWSSSMParameter_disappears (13.74s)
=== RUN   TestAccAWSSSMParameter_update
--- PASS: TestAccAWSSSMParameter_update (52.23s)
=== RUN   TestAccAWSSSMParameter_updateDescription
--- PASS: TestAccAWSSSMParameter_updateDescription (41.41s)
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (37.97s)
=== RUN   TestAccAWSSSMParameter_fullPath
--- PASS: TestAccAWSSSMParameter_fullPath (21.57s)
=== RUN   TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_secure (20.18s)
=== RUN   TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_secure_with_key (55.68s)
=== RUN   TestAccAWSSSMParameter_secure_keyUpdate
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (95.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       384.312s
```
