### PR TITLE
Make use of NewSession() because Session() is deprecated

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -115,7 +115,12 @@ func TestFetchRootDevice(t *testing.T) {
 		},
 	}
 
-	conn := ec2.New(session.New(nil))
+	sess, err := session.NewSession(nil)
+	if err != nil {
+		t.Errorf("Error new session: %s", err)
+	}
+
+	conn := ec2.New(sess)
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf(tc.label), func(t *testing.T) {


### PR DESCRIPTION
### Changes proposed in this pull request:

* Make use of NewSession() because Session() is deprecated
* https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#New

### Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestFetchRootDevice'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestFetchRootDevice -timeout 120m
=== RUN   TestFetchRootDevice
=== RUN   TestFetchRootDevice/device_name_in_mappings
2018/09/20 11:48:35 [DEBUG] Describing AMI "ami-123" to get root block device name
=== RUN   TestFetchRootDevice/device_name_not_in_mappings
2018/09/20 11:48:35 [DEBUG] Describing AMI "ami-123" to get root block device name
=== RUN   TestFetchRootDevice/no_images
2018/09/20 11:48:35 [DEBUG] Describing AMI "ami-123" to get root block device name
--- PASS: TestFetchRootDevice (0.00s)
    --- PASS: TestFetchRootDevice/device_name_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/device_name_not_in_mappings (0.00s)
    --- PASS: TestFetchRootDevice/no_images (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.043s
```
