### PR TITLE
resource/aws_codebuild_project: Support secondary artifacts and secondary sources

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -183,6 +183,123 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateAwsCodeBuildProjectName,
 			},
+			"secondary_artifacts": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      resourceAwsCodeBuildProjectArtifactsHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"encryption_disabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"namespace_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								codebuild.ArtifactNamespaceNone,
+								codebuild.ArtifactNamespaceBuildId,
+							}, false),
+						},
+						"packaging": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"artifact_identifier": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								codebuild.ArtifactsTypeCodepipeline,
+								codebuild.ArtifactsTypeS3,
+								codebuild.ArtifactsTypeNoArtifacts,
+							}, false),
+						},
+					},
+				},
+			},
+			"secondary_sources": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth": {
+							Type: schema.TypeSet,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"resource": {
+										Type:      schema.TypeString,
+										Sensitive: true,
+										Optional:  true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											codebuild.SourceAuthTypeOauth,
+										}, false),
+									},
+								},
+							},
+							Optional: true,
+							Set:      resourceAwsCodeBuildProjectSourceAuthHash,
+						},
+						"buildspec": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								codebuild.SourceTypeCodecommit,
+								codebuild.SourceTypeCodepipeline,
+								codebuild.SourceTypeGithub,
+								codebuild.SourceTypeS3,
+								codebuild.SourceTypeBitbucket,
+								codebuild.SourceTypeGithubEnterprise,
+							}, false),
+						},
+						"git_clone_depth": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+						"insecure_ssl": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"report_build_status": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"source_identifier": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			"service_role": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -324,12 +441,16 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 	projectEnv := expandProjectEnvironment(d)
 	projectSource := expandProjectSource(d)
 	projectArtifacts := expandProjectArtifacts(d)
+	projectSecondaryArtifacts := expandProjectSecondaryArtifacts(d)
+	projectSecondarySources := expandProjectSecondarySources(d)
 
 	params := &codebuild.CreateProjectInput{
-		Environment: projectEnv,
-		Name:        aws.String(d.Get("name").(string)),
-		Source:      &projectSource,
-		Artifacts:   &projectArtifacts,
+		Environment:        projectEnv,
+		Name:               aws.String(d.Get("name").(string)),
+		Source:             &projectSource,
+		Artifacts:          &projectArtifacts,
+		SecondaryArtifacts: projectSecondaryArtifacts,
+		SecondarySources:   projectSecondarySources,
 	}
 
 	if v, ok := d.GetOk("cache"); ok {
@@ -393,10 +514,31 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 	return resourceAwsCodeBuildProjectRead(d, meta)
 }
 
+func expandProjectSecondaryArtifacts(d *schema.ResourceData) []*codebuild.ProjectArtifacts {
+	artifacts := make([]*codebuild.ProjectArtifacts, 0)
+
+	configsList := d.Get("secondary_artifacts").(*schema.Set).List()
+
+	if len(configsList) == 0 {
+		return nil
+	}
+
+	for _, config := range configsList {
+		art := expandProjectArtifactData(config.(map[string]interface{}))
+		artifacts = append(artifacts, &art)
+	}
+
+	return artifacts
+}
+
 func expandProjectArtifacts(d *schema.ResourceData) codebuild.ProjectArtifacts {
 	configs := d.Get("artifacts").(*schema.Set).List()
 	data := configs[0].(map[string]interface{})
 
+	return expandProjectArtifactData(data)
+}
+
+func expandProjectArtifactData(data map[string]interface{}) codebuild.ProjectArtifacts {
 	artifactType := data["type"].(string)
 
 	projectArtifacts := codebuild.ProjectArtifacts{
@@ -407,6 +549,10 @@ func expandProjectArtifacts(d *schema.ResourceData) codebuild.ProjectArtifacts {
 	// InvalidInputException: Invalid artifacts: artifact type NO_ARTIFACTS should have null encryptionDisabled
 	if artifactType == codebuild.ArtifactsTypeS3 || artifactType == codebuild.ArtifactsTypeCodepipeline {
 		projectArtifacts.EncryptionDisabled = aws.Bool(data["encryption_disabled"].(bool))
+	}
+
+	if data["artifact_identifier"] != nil && data["artifact_identifier"].(string) != "" {
+		projectArtifacts.ArtifactIdentifier = aws.String(data["artifact_identifier"].(string))
 	}
 
 	if data["location"].(string) != "" {
@@ -515,37 +661,58 @@ func expandCodeBuildVpcConfig(rawVpcConfig []interface{}) *codebuild.VpcConfig {
 	return &vpcConfig
 }
 
+func expandProjectSecondarySources(d *schema.ResourceData) []*codebuild.ProjectSource {
+	configs := d.Get("secondary_sources").(*schema.Set).List()
+
+	if len(configs) == 0 {
+		return nil
+	}
+
+	sources := make([]*codebuild.ProjectSource, 0)
+
+	for _, config := range configs {
+		source := expandProjectSourceData(config.(map[string]interface{}))
+		sources = append(sources, &source)
+	}
+
+	return sources
+}
+
 func expandProjectSource(d *schema.ResourceData) codebuild.ProjectSource {
 	configs := d.Get("source").(*schema.Set).List()
-	projectSource := codebuild.ProjectSource{}
 
-	for _, configRaw := range configs {
-		data := configRaw.(map[string]interface{})
+	data := configs[0].(map[string]interface{})
+	return expandProjectSourceData(data)
+}
 
-		sourceType := data["type"].(string)
+func expandProjectSourceData(data map[string]interface{}) codebuild.ProjectSource {
+	sourceType := data["type"].(string)
 
-		projectSource = codebuild.ProjectSource{
-			Buildspec:     aws.String(data["buildspec"].(string)),
-			GitCloneDepth: aws.Int64(int64(data["git_clone_depth"].(int))),
-			InsecureSsl:   aws.Bool(data["insecure_ssl"].(bool)),
-			Location:      aws.String(data["location"].(string)),
-			Type:          aws.String(sourceType),
-		}
+	projectSource := codebuild.ProjectSource{
+		Buildspec:     aws.String(data["buildspec"].(string)),
+		GitCloneDepth: aws.Int64(int64(data["git_clone_depth"].(int))),
+		InsecureSsl:   aws.Bool(data["insecure_ssl"].(bool)),
+		Location:      aws.String(data["location"].(string)),
+		Type:          aws.String(sourceType),
+	}
 
-		// Only valid for GITHUB source type, e.g.
-		// InvalidInputException: Source type GITHUB_ENTERPRISE does not support ReportBuildStatus
-		if sourceType == codebuild.SourceTypeGithub {
-			projectSource.ReportBuildStatus = aws.Bool(data["report_build_status"].(bool))
-		}
+	if data["source_identifier"] != nil {
+		projectSource.SourceIdentifier = aws.String(data["source_identifier"].(string))
+	}
 
-		if v, ok := data["auth"]; ok {
-			if len(v.(*schema.Set).List()) > 0 {
-				auth := v.(*schema.Set).List()[0].(map[string]interface{})
+	// Only valid for GITHUB source type, e.g.
+	// InvalidInputException: Source type GITHUB_ENTERPRISE does not support ReportBuildStatus
+	if sourceType == codebuild.SourceTypeGithub {
+		projectSource.ReportBuildStatus = aws.Bool(data["report_build_status"].(bool))
+	}
 
-				projectSource.Auth = &codebuild.SourceAuth{
-					Type:     aws.String(auth["type"].(string)),
-					Resource: aws.String(auth["resource"].(string)),
-				}
+	if v, ok := data["auth"]; ok {
+		if len(v.(*schema.Set).List()) > 0 {
+			auth := v.(*schema.Set).List()[0].(map[string]interface{})
+
+			projectSource.Auth = &codebuild.SourceAuth{
+				Type:     aws.String(auth["type"].(string)),
+				Resource: aws.String(auth["resource"].(string)),
 			}
 		}
 	}
@@ -584,6 +751,14 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if err := d.Set("cache", flattenAwsCodebuildProjectCache(project.Cache)); err != nil {
+		return err
+	}
+
+	if err := d.Set("secondary_artifacts", flattenAwsCodeBuildProjectSecondaryArtifacts(project.SecondaryArtifacts)); err != nil {
+		return err
+	}
+
+	if err := d.Set("secondary_sources", flattenAwsCodeBuildProjectSecondarySources(project.SecondarySources)); err != nil {
 		return err
 	}
 
@@ -635,6 +810,16 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("artifacts") {
 		projectArtifacts := expandProjectArtifacts(d)
 		params.Artifacts = &projectArtifacts
+	}
+
+	if d.HasChange("secondary_sources") {
+		projectSecondarySources := expandProjectSecondarySources(d)
+		params.SecondarySources = projectSecondarySources
+	}
+
+	if d.HasChange("secondary_artifacts") {
+		projectSecondaryArtifacts := expandProjectSecondaryArtifacts(d)
+		params.SecondaryArtifacts = projectSecondaryArtifacts
 	}
 
 	if d.HasChange("vpc_config") {
@@ -717,15 +902,38 @@ func resourceAwsCodeBuildProjectDelete(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
+func flattenAwsCodeBuildProjectSecondaryArtifacts(artifactsList []*codebuild.ProjectArtifacts) *schema.Set {
+	artifactSet := schema.Set{
+		F: resourceAwsCodeBuildProjectArtifactsHash,
+	}
+
+	for _, artifacts := range artifactsList {
+		artifactSet.Add(flattenAwsCodeBuildProjectArtifactsData(*artifacts))
+	}
+	return &artifactSet
+}
+
 func flattenAwsCodeBuildProjectArtifacts(artifacts *codebuild.ProjectArtifacts) *schema.Set {
 
 	artifactSet := schema.Set{
 		F: resourceAwsCodeBuildProjectArtifactsHash,
 	}
 
+	values := flattenAwsCodeBuildProjectArtifactsData(*artifacts)
+
+	artifactSet.Add(values)
+
+	return &artifactSet
+}
+
+func flattenAwsCodeBuildProjectArtifactsData(artifacts codebuild.ProjectArtifacts) map[string]interface{} {
 	values := map[string]interface{}{}
 
 	values["type"] = *artifacts.Type
+
+	if artifacts.ArtifactIdentifier != nil {
+		values["artifact_identifier"] = *artifacts.ArtifactIdentifier
+	}
 
 	if artifacts.EncryptionDisabled != nil {
 		values["encryption_disabled"] = *artifacts.EncryptionDisabled
@@ -749,10 +957,7 @@ func flattenAwsCodeBuildProjectArtifacts(artifacts *codebuild.ProjectArtifacts) 
 	if artifacts.Path != nil {
 		values["path"] = *artifacts.Path
 	}
-
-	artifactSet.Add(values)
-
-	return &artifactSet
+	return values
 }
 
 func flattenAwsCodebuildProjectCache(cache *codebuild.ProjectCache) []interface{} {
@@ -784,8 +989,25 @@ func flattenAwsCodeBuildProjectEnvironment(environment *codebuild.ProjectEnviron
 
 }
 
+func flattenAwsCodeBuildProjectSecondarySources(sourceList []*codebuild.ProjectSource) []interface{} {
+	l := make([]interface{}, 0)
+
+	for _, source := range sourceList {
+		l = append(l, flattenAwsCodeBuildProjectSourceData(source))
+	}
+
+	return l
+}
+
 func flattenAwsCodeBuildProjectSource(source *codebuild.ProjectSource) []interface{} {
 	l := make([]interface{}, 1)
+
+	l[0] = flattenAwsCodeBuildProjectSourceData(source)
+
+	return l
+}
+
+func flattenAwsCodeBuildProjectSourceData(source *codebuild.ProjectSource) interface{} {
 	m := map[string]interface{}{
 		"buildspec":           aws.StringValue(source.Buildspec),
 		"location":            aws.StringValue(source.Location),
@@ -799,9 +1021,11 @@ func flattenAwsCodeBuildProjectSource(source *codebuild.ProjectSource) []interfa
 		m["auth"] = schema.NewSet(resourceAwsCodeBuildProjectSourceAuthHash, []interface{}{sourceAuthToMap(source.Auth)})
 	}
 
-	l[0] = m
+	if source.SourceIdentifier != nil {
+		m["source_identifier"] = aws.StringValue(source.SourceIdentifier)
+	}
 
-	return l
+	return m
 }
 
 func flattenAwsCodeBuildVpcConfig(vpcConfig *codebuild.VpcConfig) []interface{} {
@@ -823,6 +1047,9 @@ func resourceAwsCodeBuildProjectArtifactsHash(v interface{}) int {
 
 	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
 
+	if v, ok := m["artifact_identifier"]; ok {
+		buf.WriteString(fmt.Sprintf("%s:", v.(string)))
+	}
 	return hashcode.String(buf.String())
 }
 
@@ -859,6 +1086,9 @@ func resourceAwsCodeBuildProjectSourceHash(v interface{}) int {
 	m := v.(map[string]interface{})
 
 	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
+	if v, ok := m["source_identifier"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", strconv.Itoa(v.(int))))
+	}
 	if v, ok := m["buildspec"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -623,6 +623,53 @@ func TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodeBuildProject_SecondaryArtifacts(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	bName := acctest.RandomWithPrefix("tf-acc-test-bucket")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodebuildProjectConfig_SecondaryArtifacts(rName, bName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.2341549664.artifact_identifier", "secondaryArtifact1"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_artifacts.2696701347.artifact_identifier", "secondaryArtifact2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildProject_SecondarySources_CodeCommit(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_SecondarySources_CodeCommit(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "source.3715340088.type", "CODECOMMIT"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_sources.3525046785.source_identifier", "secondarySource1"),
+					resource.TestCheckResourceAttr(resourceName, "secondary_sources.2644986630.source_identifier", "secondarySource2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAWSCodeBuildProject_nameValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -1318,4 +1365,77 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, rName, encryptionDisabled)
+}
+
+func testAccAWSCodebuildProjectConfig_SecondaryArtifacts(rName string, bName string) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name          = "%s"
+  service_role  = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    location            = "${aws_s3_bucket.test.bucket}"
+    type                = "S3"
+  }
+
+  secondary_artifacts {
+    artifact_identifier = "secondaryArtifact1"
+    location            = "${aws_s3_bucket.test.bucket}"
+    type                = "S3"
+  }
+
+  secondary_artifacts {
+    artifact_identifier = "secondaryArtifact2"
+    location            = "${aws_s3_bucket.test.bucket}"
+    type                = "S3"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/hashicorp/packer.git"
+  }
+}
+`, rName)
+}
+
+func testAccAWSCodeBuildProjectConfig_SecondarySources_CodeCommit(rName string) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = %q
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    location = "https://git-codecommit.region-id.amazonaws.com/v1/repos/repo-name"
+    type     = "CODECOMMIT"
+  }
+
+  secondary_sources {
+    location = "https://git-codecommit.region-id.amazonaws.com/v1/repos/second-repo-name"
+    type     = "CODECOMMIT"
+	source_identifier = "secondarySource1"
+  }
+
+  secondary_sources {
+    location = "https://git-codecommit.region-id.amazonaws.com/v1/repos/third-repo-name"
+    type     = "CODECOMMIT"
+	source_identifier = "secondarySource2"
+  }
+}
+`, rName)
 }

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -157,6 +157,8 @@ The following arguments are supported:
 * `service_role` - (Required) The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `vpc_config` - (Optional) Configuration for the builds to run inside a VPC. VPC config blocks are documented below.
+* `secondary_artifacts` - (Optional) A set of secondary artifacts to be used inside the build. Secondary artifacts blocks are documented below.
+* `secondary_sources` - (Optional) A set of secondary sources to be used inside the build. Secondary sources blocks are documented below. 
 
 `artifacts` supports the following:
 
@@ -207,6 +209,30 @@ The following arguments are supported:
 * `security_group_ids` - (Required) The security group IDs to assign to running builds.
 * `subnets` - (Required) The subnet IDs within which to run builds.
 * `vpc_id` - (Required) The ID of the VPC within which to run builds.
+
+
+`secondary_artifacts` supports the following:
+
+* `type` - (Required) The build output artifact's type. Valid values for this parameter are: `CODEPIPELINE`, `NO_ARTIFACTS` or `S3`.
+* `artifact_identifier` - (Required) The artifact identifier. Must be the same specified inside AWS CodeBuild buildspec. 
+* `encryption_disabled` - (Optional) If set to true, output artifacts will not be encrypted. If `type` is set to `NO_ARTIFACTS` then this value will be ignored. Defaults to `false`.
+* `location` - (Optional) Information about the build output artifact location. If `type` is set to `CODEPIPELINE` or `NO_ARTIFACTS` then this value will be ignored. If `type` is set to `S3`, this is the name of the output bucket. If `path` is not also specified, then `location` can also specify the path of the output artifact in the output bucket.
+* `name` - (Optional) The name of the project. If `type` is set to `S3`, this is the name of the output artifact object
+* `namespace_type` - (Optional) The namespace to use in storing build artifacts. If `type` is set to `S3`, then valid values for this parameter are: `BUILD_ID` or `NONE`.
+* `packaging` - (Optional) The type of build output artifact to create. If `type` is set to `S3`, valid values for this parameter are: `NONE` or `ZIP`
+* `path` - (Optional) If `type` is set to `S3`, this is the path to the output artifact
+
+`secondary_sources` supports the following:
+
+* `type` - (Required) The type of repository that contains the source code to be built. Valid values for this parameter are: `CODECOMMIT`, `CODEPIPELINE`, `GITHUB`, `GITHUB_ENTERPRISE`, `BITBUCKET` or `S3`.
+* `source_identifier` - (Required) The source identifier. Source data will be put inside a folder named as this parameter inside AWS CodeBuild source directory
+* `auth` - (Optional) Information about the authorization settings for AWS CodeBuild to access the source code to be built. Auth blocks are documented below.
+* `buildspec` - (Optional) The build spec declaration to use for this build project's related builds.
+* `git_clone_depth` - (Optional) Truncate git history to this many commits.
+* `insecure_ssl` - (Optional) Ignore SSL warnings when connecting to source control.
+* `location` - (Optional) The location of the source code from git or s3.
+* `report_build_status` - (Optional) Set to `true` to report the status of a build's start and finish to your source provider. This option is only valid when your source provider is GitHub.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Related issue: #5826 
This PR adds necessary attributes to AWS CodeBuild. Since it's my first contribution, be kind :D

Changes proposed in this pull request:

* resource/aws_codebuild_project: new secondary_artifacts and secondary_sources attributes
* resource/aws_codebuild_project: added acceptance tests
* resource/aws_codebuild_project: updated documentation

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCodeBuildProject_ -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_importBasic
--- PASS: TestAccAWSCodeBuildProject_importBasic (54.28s)
=== RUN   TestAccAWSCodeBuildProject_basic
--- PASS: TestAccAWSCodeBuildProject_basic (44.38s)
=== RUN   TestAccAWSCodeBuildProject_BadgeEnabled
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (39.50s)
=== RUN   TestAccAWSCodeBuildProject_BuildTimeout
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (59.28s)
=== RUN   TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_Cache (253.37s)
=== RUN   TestAccAWSCodeBuildProject_Description
--- PASS: TestAccAWSCodeBuildProject_Description (63.74s)
=== RUN   TestAccAWSCodeBuildProject_EncryptionKey
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (189.51s)
=== RUN   TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (65.16s)
=== RUN   TestAccAWSCodeBuildProject_Source_Auth
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (39.55s)
=== RUN   TestAccAWSCodeBuildProject_Source_GitCloneDepth
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (69.81s)
=== RUN   TestAccAWSCodeBuildProject_Source_InsecureSSL
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (163.56s)
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus (65.51s)
=== RUN   TestAccAWSCodeBuildProject_Source_Type_Bitbucket
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (43.69s)
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodeCommit
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (43.35s)
=== RUN   TestAccAWSCodeBuildProject_Source_Type_CodePipeline
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (39.25s)
=== RUN   TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (161.17s)
=== RUN   TestAccAWSCodeBuildProject_Source_Type_S3
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (45.44s)
=== RUN   TestAccAWSCodeBuildProject_Tags
--- PASS: TestAccAWSCodeBuildProject_Tags (62.75s)
=== RUN   TestAccAWSCodeBuildProject_VpcConfig
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (254.48s)
=== RUN   TestAccAWSCodeBuildProject_WindowsContainer
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (40.56s)
=== RUN   TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (69.56s)
=== RUN   TestAccAWSCodeBuildProject_SecondaryArtifacts
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (175.00s)
=== RUN   TestAccAWSCodeBuildProject_SecondarySources_CodeCommit
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (80.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2125.347s

```
