### PR TITLE
Fix changing engine_version attempts to update resource class

### DIFF
--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -259,7 +259,7 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 
 	if d.HasChange("engine_version") {
 		if v, ok := d.GetOk("engine_version"); ok {
-			request.ReplicationInstanceClass = aws.String(v.(string))
+			request.EngineVersion = aws.String(v.(string))
 			hasChanges = true
 		}
 	}


### PR DESCRIPTION
Currently when changing a DMS instance, any change to the `engine_version` attempts to update the `ReplicationInstanceClass`

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Bugfix to ensure DMS `engine_version` can be updated.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
