### PR TITLE
[docs] Clarify mfa_delete cannot toggle state

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -359,7 +359,7 @@ The `CORS` object supports the following:
 The `versioning` object supports the following:
 
 * `enabled` - (Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket.
-* `mfa_delete` - (Optional) Enable MFA delete for either `Change the versioning state of your bucket` or `Permanently delete an object version`. Default is `false`.
+* `mfa_delete` - (Optional) Enable MFA delete for either `Change the versioning state of your bucket` or `Permanently delete an object version`. Default is `false`. This cannot be used to toggle this setting but is available to allow managed buckets to reflect the state in AWS
 
 The `logging` object supports the following:
 


### PR DESCRIPTION
Reasoning for docs update: 

Due to #629, you cant manage this attribute using terraform. It can still be useful for modelling the state of a bucket with this turned on - this should be clarified in the docs to stop people trying to manage this attribute with terraform and the root account

 Relevant Terraform version: It applies to the current release