### PR TITLE
resource/aws_dms_replication_instance: Refactor and enhance testing for all attributes

### DIFF
--- a/aws/resource_aws_dms_replication_instance.go
+++ b/aws/resource_aws_dms_replication_instance.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	dms "github.com/aws/aws-sdk-go/service/databasemigrationservice"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -134,6 +133,7 @@ func resourceAwsDmsReplicationInstanceCreate(d *schema.ResourceData, meta interf
 	request := &dms.CreateReplicationInstanceInput{
 		AutoMinorVersionUpgrade:       aws.Bool(d.Get("auto_minor_version_upgrade").(bool)),
 		PubliclyAccessible:            aws.Bool(d.Get("publicly_accessible").(bool)),
+		MultiAZ:                       aws.Bool(d.Get("multi_az").(bool)),
 		ReplicationInstanceClass:      aws.String(d.Get("replication_instance_class").(string)),
 		ReplicationInstanceIdentifier: aws.String(d.Get("replication_instance_id").(string)),
 		Tags:                          dmsTagsFromMap(d.Get("tags").(map[string]interface{})),
@@ -145,6 +145,9 @@ func resourceAwsDmsReplicationInstanceCreate(d *schema.ResourceData, meta interf
 
 	if v, ok := d.GetOk("allocated_storage"); ok {
 		request.AllocatedStorage = aws.Int64(int64(v.(int)))
+	}
+	if v, ok := d.GetOk("availability_zone"); ok {
+		request.AvailabilityZone = aws.String(v.(string))
 	}
 	if v, ok := d.GetOk("engine_version"); ok {
 		request.EngineVersion = aws.String(v.(string))
@@ -162,24 +165,11 @@ func resourceAwsDmsReplicationInstanceCreate(d *schema.ResourceData, meta interf
 		request.VpcSecurityGroupIds = expandStringList(v.(*schema.Set).List())
 	}
 
-	az, azSet := d.GetOk("availability_zone")
-	if azSet {
-		request.AvailabilityZone = aws.String(az.(string))
-	}
-
-	if multiAz, ok := d.GetOk("multi_az"); ok {
-		request.MultiAZ = aws.Bool(multiAz.(bool))
-
-		if multiAz.(bool) && azSet {
-			return fmt.Errorf("Cannot set availability_zone if multi_az is set to true")
-		}
-	}
-
 	log.Println("[DEBUG] DMS create replication instance:", request)
 
 	_, err := conn.CreateReplicationInstance(request)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating DMS Replication Instance: %s", err)
 	}
 
 	d.SetId(d.Get("replication_instance_id").(string))
@@ -187,7 +177,7 @@ func resourceAwsDmsReplicationInstanceCreate(d *schema.ResourceData, meta interf
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "modifying"},
 		Target:     []string{"available"},
-		Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(d, meta),
+		Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(conn, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
@@ -196,7 +186,7 @@ func resourceAwsDmsReplicationInstanceCreate(d *schema.ResourceData, meta interf
 	// Wait, catching any errors
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return err
+		return fmt.Errorf("error waiting for DMS Replication Instance (%s) creation: %s", d.Id(), err)
 	}
 
 	return resourceAwsDmsReplicationInstanceRead(d, meta)
@@ -213,32 +203,73 @@ func resourceAwsDmsReplicationInstanceRead(d *schema.ResourceData, meta interfac
 			},
 		},
 	})
-	if err != nil {
-		if dmserr, ok := err.(awserr.Error); ok && dmserr.Code() == "ResourceNotFoundFault" {
-			log.Printf("[DEBUG] DMS Replication Instance %q Not Found", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+
+	if isAWSErr(err, dms.ErrCodeResourceNotFoundFault, "") {
+		log.Printf("[WARN] DMS Replication Instance (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	err = resourceAwsDmsReplicationInstanceSetState(d, response.ReplicationInstances[0])
 	if err != nil {
-		return err
+		return fmt.Errorf("error describing DMS Replication Instance (%s): %s", d.Id(), err)
+	}
+
+	if response == nil || len(response.ReplicationInstances) == 0 || response.ReplicationInstances[0] == nil {
+		log.Printf("[WARN] DMS Replication Instance (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	instance := response.ReplicationInstances[0]
+
+	d.Set("allocated_storage", instance.AllocatedStorage)
+	d.Set("auto_minor_version_upgrade", instance.AutoMinorVersionUpgrade)
+	d.Set("availability_zone", instance.AvailabilityZone)
+	d.Set("engine_version", instance.EngineVersion)
+	d.Set("kms_key_arn", instance.KmsKeyId)
+	d.Set("multi_az", instance.MultiAZ)
+	d.Set("preferred_maintenance_window", instance.PreferredMaintenanceWindow)
+	d.Set("publicly_accessible", instance.PubliclyAccessible)
+	d.Set("replication_instance_arn", instance.ReplicationInstanceArn)
+	d.Set("replication_instance_class", instance.ReplicationInstanceClass)
+	d.Set("replication_instance_id", instance.ReplicationInstanceIdentifier)
+
+	if err := d.Set("replication_instance_private_ips", aws.StringValueSlice(instance.ReplicationInstancePrivateIpAddresses)); err != nil {
+		return fmt.Errorf("error setting replication_instance_private_ips: %s", err)
+	}
+
+	if err := d.Set("replication_instance_public_ips", aws.StringValueSlice(instance.ReplicationInstancePublicIpAddresses)); err != nil {
+		return fmt.Errorf("error setting replication_instance_private_ips: %s", err)
+	}
+
+	d.Set("replication_subnet_group_id", instance.ReplicationSubnetGroup.ReplicationSubnetGroupIdentifier)
+
+	vpc_security_group_ids := []string{}
+	for _, sg := range instance.VpcSecurityGroups {
+		vpc_security_group_ids = append(vpc_security_group_ids, aws.StringValue(sg.VpcSecurityGroupId))
+	}
+
+	if err := d.Set("vpc_security_group_ids", vpc_security_group_ids); err != nil {
+		return fmt.Errorf("error setting vpc_security_group_ids: %s", err)
 	}
 
 	tagsResp, err := conn.ListTagsForResource(&dms.ListTagsForResourceInput{
 		ResourceArn: aws.String(d.Get("replication_instance_arn").(string)),
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error listing tags for DMS Replication Instance (%s): %s", d.Id(), err)
 	}
-	d.Set("tags", dmsTagsToMap(tagsResp.TagList))
+
+	if err := d.Set("tags", dmsTagsToMap(tagsResp.TagList)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 
 	return nil
 }
 
 func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dmsconn
+
 	request := &dms.ModifyReplicationInstanceInput{
 		ApplyImmediately:       aws.Bool(d.Get("apply_immediately").(bool)),
 		ReplicationInstanceArn: aws.String(d.Get("replication_instance_arn").(string)),
@@ -265,10 +296,8 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 	}
 
 	if d.HasChange("multi_az") {
-		if v, ok := d.GetOk("multi_az"); ok {
-			request.MultiAZ = aws.Bool(v.(bool))
-			hasChanges = true
-		}
+		request.MultiAZ = aws.Bool(d.Get("multi_az").(bool))
+		hasChanges = true
 	}
 
 	if d.HasChange("preferred_maintenance_window") {
@@ -279,10 +308,8 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 	}
 
 	if d.HasChange("replication_instance_class") {
-		if v, ok := d.GetOk("replication_instance_class"); ok {
-			request.ReplicationInstanceClass = aws.String(v.(string))
-			hasChanges = true
-		}
+		request.ReplicationInstanceClass = aws.String(d.Get("replication_instance_class").(string))
+		hasChanges = true
 	}
 
 	if d.HasChange("vpc_security_group_ids") {
@@ -300,17 +327,15 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 	}
 
 	if hasChanges {
-		conn := meta.(*AWSClient).dmsconn
-
 		_, err := conn.ModifyReplicationInstance(request)
 		if err != nil {
-			return err
+			return fmt.Errorf("error modifying DMS Replication Instance (%s): %s", d.Id(), err)
 		}
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"modifying", "upgrading"},
 			Target:     []string{"available"},
-			Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(d, meta),
+			Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(conn, d.Id()),
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // Wait 30 secs before starting
@@ -319,13 +344,11 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 		// Wait, catching any errors
 		_, err = stateConf.WaitForState()
 		if err != nil {
-			return err
+			return fmt.Errorf("error waiting for DMS Replication Instance (%s) modification: %s", d.Id(), err)
 		}
-
-		return resourceAwsDmsReplicationInstanceRead(d, meta)
 	}
 
-	return nil
+	return resourceAwsDmsReplicationInstanceRead(d, meta)
 }
 
 func resourceAwsDmsReplicationInstanceDelete(d *schema.ResourceData, meta interface{}) error {
@@ -338,14 +361,19 @@ func resourceAwsDmsReplicationInstanceDelete(d *schema.ResourceData, meta interf
 	log.Printf("[DEBUG] DMS delete replication instance: %#v", request)
 
 	_, err := conn.DeleteReplicationInstance(request)
+
+	if isAWSErr(err, dms.ErrCodeResourceNotFoundFault, "") {
+		return nil
+	}
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting DMS Replication Instance (%s): %s", d.Id(), err)
 	}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"deleting"},
 		Target:     []string{},
-		Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(d, meta),
+		Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(conn, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
@@ -354,81 +382,35 @@ func resourceAwsDmsReplicationInstanceDelete(d *schema.ResourceData, meta interf
 	// Wait, catching any errors
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return err
+		return fmt.Errorf("error waiting for DMS Replication Instance (%s) deletion: %s", d.Id(), err)
 	}
 
 	return nil
 }
 
-func resourceAwsDmsReplicationInstanceSetState(d *schema.ResourceData, instance *dms.ReplicationInstance) error {
-	d.SetId(*instance.ReplicationInstanceIdentifier)
-
-	d.Set("replication_instance_id", instance.ReplicationInstanceIdentifier)
-	d.Set("allocated_storage", instance.AllocatedStorage)
-	d.Set("auto_minor_version_upgrade", instance.AutoMinorVersionUpgrade)
-	d.Set("availability_zone", instance.AvailabilityZone)
-	d.Set("engine_version", instance.EngineVersion)
-	d.Set("kms_key_arn", instance.KmsKeyId)
-	d.Set("multi_az", instance.MultiAZ)
-	d.Set("preferred_maintenance_window", instance.PreferredMaintenanceWindow)
-	d.Set("publicly_accessible", instance.PubliclyAccessible)
-	d.Set("replication_instance_arn", instance.ReplicationInstanceArn)
-	d.Set("replication_instance_class", instance.ReplicationInstanceClass)
-	d.Set("replication_subnet_group_id", instance.ReplicationSubnetGroup.ReplicationSubnetGroupIdentifier)
-
-	vpc_security_group_ids := []string{}
-	for _, sg := range instance.VpcSecurityGroups {
-		vpc_security_group_ids = append(vpc_security_group_ids, aws.StringValue(sg.VpcSecurityGroupId))
-	}
-
-	d.Set("vpc_security_group_ids", vpc_security_group_ids)
-
-	private_ip_addresses := []string{}
-	for _, ip := range instance.ReplicationInstancePrivateIpAddresses {
-		private_ip_addresses = append(private_ip_addresses, aws.StringValue(ip))
-	}
-
-	d.Set("replication_instance_private_ips", private_ip_addresses)
-
-	public_ip_addresses := []string{}
-	for _, ip := range instance.ReplicationInstancePublicIpAddresses {
-		public_ip_addresses = append(public_ip_addresses, aws.StringValue(ip))
-	}
-
-	d.Set("replication_instance_public_ips", public_ip_addresses)
-
-	return nil
-}
-
-func resourceAwsDmsReplicationInstanceStateRefreshFunc(
-	d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+func resourceAwsDmsReplicationInstanceStateRefreshFunc(conn *dms.DatabaseMigrationService, replicationInstanceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		conn := meta.(*AWSClient).dmsconn
-
 		v, err := conn.DescribeReplicationInstances(&dms.DescribeReplicationInstancesInput{
 			Filters: []*dms.Filter{
 				{
 					Name:   aws.String("replication-instance-id"),
-					Values: []*string{aws.String(d.Id())}, // Must use d.Id() to work with import.
+					Values: []*string{aws.String(replicationInstanceID)},
 				},
 			},
 		})
-		if err != nil {
-			if dmserr, ok := err.(awserr.Error); ok && dmserr.Code() == "ResourceNotFoundFault" {
-				return nil, "", nil
-			}
-			log.Printf("Error on retrieving DMS Replication Instance when waiting: %s", err)
-			return nil, "", err
-		}
 
-		if v == nil {
+		if isAWSErr(err, dms.ErrCodeResourceNotFoundFault, "") {
 			return nil, "", nil
 		}
 
-		if v.ReplicationInstances == nil {
-			return nil, "", fmt.Errorf("Error on retrieving DMS Replication Instance when waiting for State")
+		if err != nil {
+			return nil, "", err
 		}
 
-		return v, *v.ReplicationInstances[0].ReplicationInstanceStatus, nil
+		if v == nil || len(v.ReplicationInstances) == 0 || v.ReplicationInstances[0] == nil {
+			return nil, "", nil
+		}
+
+		return v, aws.StringValue(v.ReplicationInstances[0].ReplicationInstanceStatus), nil
 	}
 }

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -12,34 +12,138 @@ import (
 )
 
 func TestAccAWSDmsReplicationInstance_Basic(t *testing.T) {
-	resourceName := "aws_dms_replication_instance.dms_replication_instance"
-	randId := acctest.RandString(8)
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: dmsReplicationInstanceDestroy,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: dmsReplicationInstanceConfig(randId),
+				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, "dms.t2.micro"),
 				Check: resource.ComposeTestCheckFunc(
-					checkDmsReplicationInstanceExists(resourceName),
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "50"),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
+					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_key_arn"),
+					resource.TestCheckResourceAttr(resourceName, "multi_az", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "preferred_maintenance_window"),
+					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "false"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_private_ips.#", "1"),
+					// ARN resource is its own unique identifier
 					resource.TestCheckResourceAttrSet(resourceName, "replication_instance_arn"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", "dms.t2.micro"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_id", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_AllocatedStorage(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
 			{
-				Config: dmsReplicationInstanceConfigUpdate(randId),
+				Config: testAccAWSDmsReplicationInstanceConfig_AllocatedStorage(rName, 5),
 				Check: resource.ComposeTestCheckFunc(
-					checkDmsReplicationInstanceExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "apply_immediately"),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttr(resourceName, "preferred_maintenance_window", "mon:00:30-mon:02:30"),
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "5"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_AllocatedStorage(rName, 6),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_AutoMinorVersionUpgrade(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_AutoMinorVersionUpgrade(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_AutoMinorVersionUpgrade(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+				),
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_AutoMinorVersionUpgrade(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_AvailabilityZone(t *testing.T) {
+	dataSourceName := "data.aws_availability_zones.available"
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_AvailabilityZone(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", dataSourceName, "names.0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 		},
 	})
@@ -52,12 +156,12 @@ func TestAccAWSDmsReplicationInstance_EngineVersion(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: dmsReplicationInstanceDestroy,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDmsReplicationInstanceConfig_EngineVersion(rName, "2.4.2"),
 				Check: resource.ComposeTestCheckFunc(
-					checkDmsReplicationInstanceExists(resourceName),
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "2.4.2"),
 				),
 			},
@@ -70,7 +174,7 @@ func TestAccAWSDmsReplicationInstance_EngineVersion(t *testing.T) {
 			{
 				Config: testAccAWSDmsReplicationInstanceConfig_EngineVersion(rName, "2.4.3"),
 				Check: resource.ComposeTestCheckFunc(
-					checkDmsReplicationInstanceExists(resourceName),
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "engine_version", "2.4.3"),
 				),
 			},
@@ -78,7 +182,264 @@ func TestAccAWSDmsReplicationInstance_EngineVersion(t *testing.T) {
 	})
 }
 
-func checkDmsReplicationInstanceExists(n string) resource.TestCheckFunc {
+func TestAccAWSDmsReplicationInstance_KmsKeyArn(t *testing.T) {
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_KmsKeyArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", kmsKeyResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_MultiAz(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_MultiAz(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "multi_az", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_MultiAz(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "multi_az", "false"),
+				),
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_MultiAz(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "multi_az", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_PreferredMaintenanceWindow(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_PreferredMaintenanceWindow(rName, "sun:00:30-sun:02:30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "preferred_maintenance_window", "sun:00:30-sun:02:30"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_PreferredMaintenanceWindow(rName, "mon:00:30-mon:02:30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "preferred_maintenance_window", "mon:00:30-mon:02:30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_PubliclyAccessible(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_PubliclyAccessible(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "publicly_accessible", "true"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_public_ips.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_ReplicationInstanceClass(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, "dms.t2.micro"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", "dms.t2.micro"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, "dms.t2.small"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", "dms.t2.small"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId(t *testing.T) {
+	dmsReplicationSubnetGroupResourceName := "aws_dms_replication_subnet_group.test"
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationSubnetGroupId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "replication_subnet_group_id", dmsReplicationSubnetGroupResourceName, "replication_subnet_group_id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_Tags(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_Tags_One(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_Tags_Two(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_Tags_One(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDmsReplicationInstance_VpcSecurityGroupIds(t *testing.T) {
+	resourceName := "aws_dms_replication_instance.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDmsReplicationInstanceConfig_VpcSecurityGroupIds(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "vpc_security_group_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately"},
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDmsReplicationInstanceExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -101,7 +462,7 @@ func checkDmsReplicationInstanceExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("DMS replication instance error: %v", err)
 		}
-		if resp.ReplicationInstances == nil {
+		if resp == nil || len(resp.ReplicationInstances) == 0 {
 			return fmt.Errorf("DMS replication instance not found")
 		}
 
@@ -109,128 +470,76 @@ func checkDmsReplicationInstanceExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func dmsReplicationInstanceDestroy(s *terraform.State) error {
+func testAccCheckAWSDmsReplicationInstanceDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_dms_replication_instance" {
 			continue
 		}
 
-		err := checkDmsReplicationInstanceExists(rs.Primary.ID)
-		if err == nil {
-			return fmt.Errorf("Found replication instance that was not destroyed: %s", rs.Primary.ID)
+		conn := testAccProvider.Meta().(*AWSClient).dmsconn
+
+		resp, err := conn.DescribeReplicationInstances(&dms.DescribeReplicationInstancesInput{
+			Filters: []*dms.Filter{
+				{
+					Name:   aws.String("replication-instance-id"),
+					Values: []*string{aws.String(rs.Primary.ID)},
+				},
+			},
+		})
+
+		if isAWSErr(err, dms.ErrCodeResourceNotFoundFault, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if resp != nil {
+			for _, replicationInstance := range resp.ReplicationInstances {
+				if aws.StringValue(replicationInstance.ReplicationInstanceIdentifier) == rs.Primary.ID {
+					return fmt.Errorf("DMS Replication Instance (%s) still exists", rs.Primary.ID)
+				}
+			}
 		}
 	}
 
 	return nil
 }
 
-func dmsReplicationInstanceConfig(randId string) string {
+func testAccAWSDmsReplicationInstanceConfig_AllocatedStorage(rName string, allocatedStorage int) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "dms_vpc" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-dms-replication-instance"
-	}
+resource "aws_dms_replication_instance" "test" {
+  allocated_storage          = %d
+  apply_immediately          = true
+  replication_instance_class = "dms.t2.micro"
+  replication_instance_id    = %q
+}
+`, allocatedStorage, rName)
 }
 
-resource "aws_subnet" "dms_subnet_1" {
-	cidr_block = "10.1.1.0/24"
-	availability_zone = "us-west-2a"
-	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
-		Name = "tf-acc-dms-replication-instance-1"
-	}
-	depends_on = ["aws_vpc.dms_vpc"]
-}
-
-resource "aws_subnet" "dms_subnet_2" {
-	cidr_block = "10.1.2.0/24"
-	availability_zone = "us-west-2b"
-	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
-		Name = "tf-acc-dms-replication-instance-2"
-	}
-	depends_on = ["aws_vpc.dms_vpc"]
-}
-
-resource "aws_dms_replication_subnet_group" "dms_replication_subnet_group" {
-	replication_subnet_group_id = "tf-test-dms-replication-subnet-group-%[1]s"
-	replication_subnet_group_description = "terraform test for replication subnet group"
-	subnet_ids = ["${aws_subnet.dms_subnet_1.id}", "${aws_subnet.dms_subnet_2.id}"]
-}
-
-resource "aws_dms_replication_instance" "dms_replication_instance" {
-	allocated_storage = 5
-	auto_minor_version_upgrade = true
-	replication_instance_class = "dms.t2.micro"
-	replication_instance_id = "tf-test-dms-replication-instance-%[1]s"
-	preferred_maintenance_window = "sun:00:30-sun:02:30"
-	publicly_accessible = false
-	replication_subnet_group_id = "${aws_dms_replication_subnet_group.dms_replication_subnet_group.replication_subnet_group_id}"
-	tags {
-		Name = "tf-test-dms-replication-instance-%[1]s"
-		Update = "to-update"
-		Remove = "to-remove"
-	}
-
-	timeouts {
-		create = "40m"
-	}
-}
-`, randId)
-}
-
-func dmsReplicationInstanceConfigUpdate(randId string) string {
+func testAccAWSDmsReplicationInstanceConfig_AutoMinorVersionUpgrade(rName string, autoMinorVersionUpgrade bool) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "dms_vpc" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-dms-replication-instance"
-	}
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately          = true
+  auto_minor_version_upgrade = %t
+  replication_instance_class = "dms.t2.micro"
+  replication_instance_id    = %q
+}
+`, autoMinorVersionUpgrade, rName)
 }
 
-resource "aws_subnet" "dms_subnet_1" {
-	cidr_block = "10.1.1.0/24"
-	availability_zone = "us-west-2a"
-	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
-		Name = "tf-acc-dms-replication-instance-1"
-	}
-	depends_on = ["aws_vpc.dms_vpc"]
-}
+func testAccAWSDmsReplicationInstanceConfig_AvailabilityZone(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
 
-resource "aws_subnet" "dms_subnet_2" {
-	cidr_block = "10.1.2.0/24"
-	availability_zone = "us-west-2b"
-	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
-		Name = "tf-acc-dms-replication-instance-2"
-	}
-	depends_on = ["aws_vpc.dms_vpc"]
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately          = true
+  availability_zone          = "${data.aws_availability_zones.available.names[0]}"
+  replication_instance_class = "dms.t2.micro"
+  replication_instance_id    = %q
 }
-
-resource "aws_dms_replication_subnet_group" "dms_replication_subnet_group" {
-	replication_subnet_group_id = "tf-test-dms-replication-subnet-group-%[1]s"
-	replication_subnet_group_description = "terraform test for replication subnet group"
-	subnet_ids = ["${aws_subnet.dms_subnet_1.id}", "${aws_subnet.dms_subnet_2.id}"]
-}
-
-resource "aws_dms_replication_instance" "dms_replication_instance" {
-	allocated_storage = 5
-	apply_immediately = true
-	auto_minor_version_upgrade = false
-	replication_instance_class = "dms.t2.micro"
-	replication_instance_id = "tf-test-dms-replication-instance-%[1]s"
-	preferred_maintenance_window = "mon:00:30-mon:02:30"
-	publicly_accessible = false
-	replication_subnet_group_id = "${aws_dms_replication_subnet_group.dms_replication_subnet_group.replication_subnet_group_id}"
-	tags {
-		Name = "tf-test-dms-replication-instance-%[1]s"
-		Update = "updated"
-		Add = "added"
-	}
-}
-`, randId)
+`, rName)
 }
 
 func testAccAWSDmsReplicationInstanceConfig_EngineVersion(rName, engineVersion string) string {
@@ -242,4 +551,175 @@ resource "aws_dms_replication_instance" "test" {
   replication_instance_id    = %q
 }
 `, engineVersion, rName)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_KmsKeyArn(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately          = true
+  kms_key_arn                = "${aws_kms_key.test.arn}"
+  replication_instance_class = "dms.t2.micro"
+  replication_instance_id    = %q
+}
+`, rName)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_MultiAz(rName string, multiAz bool) string {
+	return fmt.Sprintf(`
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately          = true
+  multi_az                   = %t
+  replication_instance_class = "dms.t2.micro"
+  replication_instance_id    = %q
+}
+`, multiAz, rName)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_PreferredMaintenanceWindow(rName, preferredMaintenanceWindow string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately            = true
+  preferred_maintenance_window = %q
+  replication_instance_class   = "dms.t2.micro"
+  replication_instance_id      = %q
+}
+`, preferredMaintenanceWindow, rName)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_PubliclyAccessible(rName string, publiclyAccessible bool) string {
+	return fmt.Sprintf(`
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately          = true
+  publicly_accessible        = %t
+  replication_instance_class = "dms.t2.micro"
+  replication_instance_id    = %q
+}
+`, publiclyAccessible, rName)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, replicationInstanceClass string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately            = true
+  replication_instance_class   = %q
+  replication_instance_id      = %q
+}
+`, replicationInstanceClass, rName)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_ReplicationSubnetGroupId(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "10.1.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "${aws_vpc.test.tags["Name"]}"
+  }
+}
+
+resource "aws_dms_replication_subnet_group" "test" {
+  replication_subnet_group_description = %q
+  replication_subnet_group_id          = %q
+  subnet_ids                           = ["${aws_subnet.test.*.id}"]
+}
+
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately           = true
+  replication_instance_class  = "dms.t2.micro"
+  replication_instance_id     = %q
+  replication_subnet_group_id = "${aws_dms_replication_subnet_group.test.replication_subnet_group_id}"
+}
+`, rName, rName, rName, rName)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_Tags_One(rName, key1, value1 string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately            = true
+  replication_instance_class   = "dms.t2.micro"
+  replication_instance_id      = %q
+
+  tags {
+    %q = %q
+  }
+}
+`, rName, key1, value1)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_Tags_Two(rName, key1, value1, key2, value2 string) string {
+	return fmt.Sprintf(`
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately            = true
+  replication_instance_class   = "dms.t2.micro"
+  replication_instance_id      = %q
+
+  tags {
+    %q = %q
+    %q = %q
+  }
+}
+`, rName, key1, value1, key2, value2)
+}
+
+func testAccAWSDmsReplicationInstanceConfig_VpcSecurityGroupIds(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = "${aws_vpc.test.tags["Name"]}"
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "10.1.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "${aws_vpc.test.tags["Name"]}"
+  }
+}
+
+resource "aws_dms_replication_subnet_group" "test" {
+  replication_subnet_group_description = %q
+  replication_subnet_group_id          = %q
+  subnet_ids                           = ["${aws_subnet.test.*.id}"]
+}
+
+resource "aws_dms_replication_instance" "test" {
+  apply_immediately           = true
+  replication_instance_class  = "dms.t2.micro"
+  replication_instance_id     = %q
+  replication_subnet_group_id = "${aws_dms_replication_subnet_group.test.replication_subnet_group_id}"
+  vpc_security_group_ids      = ["${aws_security_group.test.id}"]
+}
+`, rName, rName, rName, rName)
 }


### PR DESCRIPTION
Changes:
* Prevent `ResourceNotFound` error during deletion
* Enhance error messaging to provide context of action that failed
* Prevent panics during read with empty response
* Add acceptance tests for all attributes

Output from acceptance testing:

```
13 tests passed (all tests)
--- PASS: TestAccAWSDmsReplicationInstance_VpcSecurityGroupIds (322.38s)
--- PASS: TestAccAWSDmsReplicationInstance_Tags (423.76s)
--- PASS: TestAccAWSDmsReplicationInstance_Basic (438.89s)
--- PASS: TestAccAWSDmsReplicationInstance_AvailabilityZone (438.89s)
--- PASS: TestAccAWSDmsReplicationInstance_PubliclyAccessible (458.94s)
--- PASS: TestAccAWSDmsReplicationInstance_PreferredMaintenanceWindow (461.37s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId (523.15s)
--- PASS: TestAccAWSDmsReplicationInstance_KmsKeyArn (539.77s)
--- PASS: TestAccAWSDmsReplicationInstance_EngineVersion (541.86s)
--- PASS: TestAccAWSDmsReplicationInstance_AutoMinorVersionUpgrade (564.97s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationInstanceClass (883.47s)
--- PASS: TestAccAWSDmsReplicationInstance_AllocatedStorage (1024.63s)
--- PASS: TestAccAWSDmsReplicationInstance_MultiAz (1955.33s)
```
