### PR TITLE
[WIP] Add `instance_pools_to_use` parameter to `aws_spot_fleet_request`

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -285,6 +285,12 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Default:  "lowestPrice",
 				ForceNew: true,
 			},
+			"instance_pools_to_use": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+				ForceNew: true,
+			},
 			"excess_capacity_termination_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -623,6 +629,13 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotFleetConfig.AllocationStrategy = aws.String("lowestPrice")
 	}
 
+	if v, ok := d.GetOk("instance_pools_to_use"); ok {
+		if *(spotFleetConfig.AllocationStrategy) != "lowestPrice" {
+			return fmt.Errorf("Specifying instance_pools_to_use requires allocation_strategy=lowestPrice")
+		}
+		spotFleetConfig.InstancePoolsToUseCount = aws.Int64(int64(v.(int)))
+	}
+
 	if v, ok := d.GetOk("spot_price"); ok && v.(string) != "" {
 		spotFleetConfig.SpotPrice = aws.String(v.(string))
 	}
@@ -877,6 +890,10 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 
 	if config.AllocationStrategy != nil {
 		d.Set("allocation_strategy", aws.StringValue(config.AllocationStrategy))
+	}
+
+	if config.InstancePoolsToUseCount != nil {
+		d.Set("instance_pools_to_use", aws.Int64Value(config.InstancePoolsToUseCount))
 	}
 
 	if config.ClientToken != nil {

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -106,10 +106,15 @@ across different markets and instance types.
   timeout of 10m is reached.
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
-important to your application workload, such as vCPUs, memory, or I/O.
+  important to your application workload, such as vCPUs, memory, or I/O.
 * `allocation_strategy` - Indicates how to allocate the target capacity across
   the Spot pools specified by the Spot fleet request. The default is
-lowestPrice.
+  `lowestPrice`.
+* `instance_pools_to_use` - (Optional; Default: 1)
+  The number of Spot pools across which to allocate your target Spot capacity. 
+  Valid only when `allocation_strategy` is set to `lowestPrice`. Spot Fleet selects 
+  the cheapest Spot pools and evenly allocates your target Spot capacity across 
+  the number of Spot pools that you specify.
 * `excess_capacity_termination_policy` - Indicates whether running Spot
   instances should be terminated if the target capacity of the Spot fleet
   request is decreased below the current size of the Spot fleet.


### PR DESCRIPTION
Fixes #5928

Changes proposed in this pull request:

* add `instance_pools_to_use` parameter to `aws_spot_fleet_request` resource

Output from acceptance testing:

* not run, please assist 

Please comment and review, this is my attempt at working with `terraform` code. 