### PR TITLE
r/launch_template: fix market options

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -727,17 +727,31 @@ func getInstanceMarketOptions(m *ec2.LaunchTemplateInstanceMarketOptions) []inte
 		mo := map[string]interface{}{
 			"market_type": aws.StringValue(m.MarketType),
 		}
-		spot := []interface{}{}
 		so := m.SpotOptions
 		if so != nil {
-			spot = append(spot, map[string]interface{}{
-				"block_duration_minutes":         aws.Int64Value(so.BlockDurationMinutes),
-				"instance_interruption_behavior": aws.StringValue(so.InstanceInterruptionBehavior),
-				"max_price":                      aws.StringValue(so.MaxPrice),
-				"spot_instance_type":             aws.StringValue(so.SpotInstanceType),
-				"valid_until":                    aws.TimeValue(so.ValidUntil).Format(time.RFC3339),
-			})
-			mo["spot_options"] = spot
+			spotOptions := map[string]interface{}{}
+
+			if so.BlockDurationMinutes != nil {
+				spotOptions["block_duration_minutes"] = aws.Int64Value(so.BlockDurationMinutes)
+			}
+
+			if so.InstanceInterruptionBehavior != nil {
+				spotOptions["instance_interruption_behavior"] = aws.StringValue(so.InstanceInterruptionBehavior)
+			}
+
+			if so.MaxPrice != nil {
+				spotOptions["max_price"] = aws.StringValue(so.MaxPrice)
+			}
+
+			if so.SpotInstanceType != nil {
+				spotOptions["spot_instance_type"] = aws.StringValue(so.SpotInstanceType)
+			}
+
+			if so.ValidUntil != nil {
+				spotOptions["valid_until"] = aws.TimeValue(so.ValidUntil).Format(time.RFC3339)
+			}
+
+			mo["spot_options"] = []interface{}{spotOptions}
 		}
 		s = append(s, mo)
 	}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5455

Changes proposed in this pull request:

* only set market option attributes when present

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
--- PASS: TestAccAWSLaunchTemplate_importBasic (13.66s)
=== RUN   TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_importData (11.91s)
=== RUN   TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (13.62s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (48.81s)
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (49.03s)
=== RUN   TestAccAWSLaunchTemplate_data
--- PASS: TestAccAWSLaunchTemplate_data (11.93s)
=== RUN   TestAccAWSLaunchTemplate_update
--- PASS: TestAccAWSLaunchTemplate_update (45.77s)
=== RUN   TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_tags (21.27s)
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (11.76s)
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (10.47s)
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (12.16s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_networkInterface (29.96s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (11.00s)
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (11.95s)
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (47.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	350.492s
```
