### PR TITLE
resource/aws_launch_template: Properly recreate existing resource when deleted

### DIFF
--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -78,6 +78,28 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_disappears(t *testing.T) {
+	var launchTemplate ec2.LaunchTemplate
+	resourceName := "aws_launch_template.foo"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &launchTemplate),
+					testAccCheckAWSLaunchTemplateDisappears(&launchTemplate),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS(t *testing.T) {
 	var template ec2.LaunchTemplate
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -435,6 +457,20 @@ func testAccCheckAWSLaunchTemplateDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckAWSLaunchTemplateDisappears(launchTemplate *ec2.LaunchTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		input := &ec2.DeleteLaunchTemplateInput{
+			LaunchTemplateId: launchTemplate.LaunchTemplateId,
+		}
+
+		_, err := conn.DeleteLaunchTemplate(input)
+
+		return err
+	}
 }
 
 func testAccAWSLaunchTemplateConfig_basic(rInt int) string {


### PR DESCRIPTION
Fixes #5965 

Previously:

```
--- FAIL: TestAccAWSLaunchTemplate_disappears (10.27s)
    testing.go:527: Step 0 error: Error on follow-up refresh: 1 error occurred:
        	* aws_launch_template.foo: 1 error occurred:
        	* aws_launch_template.foo: aws_launch_template.foo: Error getting launch template: InvalidLaunchTemplateId.NotFound: Atleast one of the launch templates specified in the request does not exist.
```

Now:

```
--- PASS: TestAccAWSLaunchTemplate_disappears (10.60s)
```
