### PR TITLE
data-source/aws_ami: Prevent panics with AMIs in failed image state

### DIFF
--- a/aws/data_source_aws_ami.go
+++ b/aws/data_source_aws_ami.go
@@ -341,31 +341,23 @@ func amiBlockDeviceMappings(m []*ec2.BlockDeviceMapping) *schema.Set {
 	}
 	for _, v := range m {
 		mapping := map[string]interface{}{
-			"device_name": *v.DeviceName,
+			"device_name":  aws.StringValue(v.DeviceName),
+			"virtual_name": aws.StringValue(v.VirtualName),
 		}
+
 		if v.Ebs != nil {
 			ebs := map[string]interface{}{
-				"delete_on_termination": fmt.Sprintf("%t", *v.Ebs.DeleteOnTermination),
-				"encrypted":             fmt.Sprintf("%t", *v.Ebs.Encrypted),
-				"volume_size":           fmt.Sprintf("%d", *v.Ebs.VolumeSize),
-				"volume_type":           *v.Ebs.VolumeType,
-			}
-			// Iops is not always set
-			if v.Ebs.Iops != nil {
-				ebs["iops"] = fmt.Sprintf("%d", *v.Ebs.Iops)
-			} else {
-				ebs["iops"] = "0"
-			}
-			// snapshot id may not be set
-			if v.Ebs.SnapshotId != nil {
-				ebs["snapshot_id"] = *v.Ebs.SnapshotId
+				"delete_on_termination": fmt.Sprintf("%t", aws.BoolValue(v.Ebs.DeleteOnTermination)),
+				"encrypted":             fmt.Sprintf("%t", aws.BoolValue(v.Ebs.Encrypted)),
+				"iops":                  fmt.Sprintf("%d", aws.Int64Value(v.Ebs.Iops)),
+				"volume_size":           fmt.Sprintf("%d", aws.Int64Value(v.Ebs.VolumeSize)),
+				"snapshot_id":           aws.StringValue(v.Ebs.SnapshotId),
+				"volume_type":           aws.StringValue(v.Ebs.VolumeType),
 			}
 
 			mapping["ebs"] = ebs
 		}
-		if v.VirtualName != nil {
-			mapping["virtual_name"] = *v.VirtualName
-		}
+
 		log.Printf("[DEBUG] aws_ami - adding block device mapping: %v", mapping)
 		s.Add(mapping)
 	}
@@ -379,8 +371,8 @@ func amiProductCodes(m []*ec2.ProductCode) *schema.Set {
 	}
 	for _, v := range m {
 		code := map[string]interface{}{
-			"product_code_id":   *v.ProductCodeId,
-			"product_code_type": *v.ProductCodeType,
+			"product_code_id":   aws.StringValue(v.ProductCodeId),
+			"product_code_type": aws.StringValue(v.ProductCodeType),
 		}
 		s.Add(code)
 	}
@@ -407,8 +399,8 @@ func amiRootSnapshotId(image *ec2.Image) string {
 func amiStateReason(m *ec2.StateReason) map[string]interface{} {
 	s := make(map[string]interface{})
 	if m != nil {
-		s["code"] = *m.Code
-		s["message"] = *m.Message
+		s["code"] = aws.StringValue(m.Code)
+		s["message"] = aws.StringValue(m.Message)
 	} else {
 		s["code"] = "UNSET"
 		s["message"] = "UNSET"

--- a/aws/data_source_aws_ami_test.go
+++ b/aws/data_source_aws_ami_test.go
@@ -65,7 +65,7 @@ func TestAccAWSAmiDataSource_windowsInstance(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "architecture", "x86_64"),
 					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "block_device_mappings.#", "27"),
 					resource.TestMatchResourceAttr("data.aws_ami.windows_ami", "creation_date", regexp.MustCompile("^20[0-9]{2}-")),
-					resource.TestMatchResourceAttr("data.aws_ami.windows_ami", "description", regexp.MustCompile("^Microsoft Windows Server 2012")),
+					resource.TestMatchResourceAttr("data.aws_ami.windows_ami", "description", regexp.MustCompile("^Microsoft Windows Server")),
 					resource.TestCheckResourceAttr("data.aws_ami.windows_ami", "hypervisor", "xen"),
 					resource.TestMatchResourceAttr("data.aws_ami.windows_ami", "image_id", regexp.MustCompile("^ami-")),
 					resource.TestMatchResourceAttr("data.aws_ami.windows_ami", "image_location", regexp.MustCompile("^amazon/")),


### PR DESCRIPTION
Fixes #5963 

When an EBS BlockDeviceMapping AMI is in a failed image state, the API can omit volumeSize, which causes a panic. This switches the EBS BlockDeviceMapping handling to use the AWS SDK provided functions for dereferencing values instead of raw dereferences. To properly acceptance test this we would purposefully need to create a failed AMI, which seems like more effort than its worth compared to fixing the trivial issue.

This also fixes an odd scenario with `TestAccAWSAmiDataSource_windowsInstance` where Amazon published an AMI with a mismatched 2012 vs 2016 description.

```
            <imageId>ami-0d786d5cc800b2456</imageId>
            <imageLocation>amazon/Windows_Server-2012-R2_RTM-English-64Bit-HyperV-2018.09.15</imageLocation>
            <imageOwnerAlias>amazon</imageOwnerAlias>
            <name>Windows_Server-2012-R2_RTM-English-64Bit-HyperV-2018.09.15</name>
            <description>Microsoft Windows Server 2016 Locale English with Hyper-V AMI provided by Amazon</description>
```

Acceptance testing output:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSAmiDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAmiDataSource_ -timeout 120m
=== RUN   TestAccAWSAmiDataSource_natInstance
--- PASS: TestAccAWSAmiDataSource_natInstance (16.98s)
=== RUN   TestAccAWSAmiDataSource_windowsInstance
--- PASS: TestAccAWSAmiDataSource_windowsInstance (21.23s)
=== RUN   TestAccAWSAmiDataSource_instanceStore
--- PASS: TestAccAWSAmiDataSource_instanceStore (14.81s)
=== RUN   TestAccAWSAmiDataSource_owners
--- PASS: TestAccAWSAmiDataSource_owners (88.64s)
=== RUN   TestAccAWSAmiDataSource_ownersEmpty
--- PASS: TestAccAWSAmiDataSource_ownersEmpty (15.92s)
=== RUN   TestAccAWSAmiDataSource_localNameFilter
--- PASS: TestAccAWSAmiDataSource_localNameFilter (18.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	177.259s
```