### PR TITLE
[WIP] resource/aws_db_instance: Properly set backup_retention_period = 0 with snapshot_identifier

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -773,7 +773,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.AvailabilityZone = aws.String(attr.(string))
 		}
 
-		if attr, ok := d.GetOk("backup_retention_period"); ok {
+		if attr, ok := d.GetOkExists("backup_retention_period"); ok {
 			modifyDbInstanceInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
 			requiresModifyDbInstance = true
 		}


### PR DESCRIPTION
_Work in progress_ Currently fixes `backup_retention_period` but only contains failing test (and not the fix yet) for unsetting `tags` on creation with `snapshot_identifier`

Reference: #5959 

Previously:

```
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1601.52s)
    testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'backup_retention_period' expected "0", got "1"
--- FAIL: TestAccAWSDBInstance_SnapshotIdentifier_Tags_Unset (1086.15s)
    testing.go:527: Step 0 error: Check failed: Check 4/4 error: aws_db_instance.test: Attribute 'tags.%' expected "0", got "1"
```

Now:

```
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1807.63s)
```
