### PR TITLE
resource/aws_rds_cluster: fix the scaling_configuration example value

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -165,7 +165,7 @@ resource "aws_rds_cluster" "example" {
     auto_pause               = true
     max_capacity             = 256
     min_capacity             = 2
-    seconds_until_auto_pause = 60
+    seconds_until_auto_pause = 300
   }
 }
 ```


### PR DESCRIPTION
The `seconds_until_auto_pause` value is documented to be valid with values between 300 and 86400
but the sample hcl shows a value with 60.
This patch simply fixes the sample hcl to use the default value (300).

Fixes #5975

Changes proposed in this pull request:

* Fixing the HCL code sample to use the default value of `seconds_until_auto_pause` instead of the invalid value `60` currently used.
