### PR TITLE
resource/aws_ami: Support resource import

### DIFF
--- a/aws/resource_aws_ami.go
+++ b/aws/resource_aws_ami.go
@@ -27,6 +27,16 @@ const (
 func resourceAwsAmi() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsAmiCreate,
+		// The Read, Update and Delete operations are shared with aws_ami_copy
+		// and aws_ami_from_instance, since they differ only in how the image
+		// is created.
+		Read:   resourceAwsAmiRead,
+		Update: resourceAwsAmiUpdate,
+		Delete: resourceAwsAmiDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(AWSAMIRetryTimeout),
@@ -195,13 +205,6 @@ func resourceAwsAmi() *schema.Resource {
 				Default:  "paravirtual",
 			},
 		},
-
-		// The Read, Update and Delete operations are shared with aws_ami_copy
-		// and aws_ami_from_instance, since they differ only in how the image
-		// is created.
-		Read:   resourceAwsAmiRead,
-		Update: resourceAwsAmiUpdate,
-		Delete: resourceAwsAmiDelete,
 	}
 }
 

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -17,7 +17,8 @@ import (
 
 func TestAccAWSAMI_basic(t *testing.T) {
 	var ami ec2.Image
-	rInt := acctest.RandInt()
+	resourceName := "aws_ami.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,16 +26,18 @@ func TestAccAWSAMI_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAmiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAmiConfig_basic(rInt),
+				Config: testAccAmiConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAmiExists("aws_ami.foo", &ami),
-					resource.TestCheckResourceAttr(
-						"aws_ami.foo", "name", fmt.Sprintf("tf-testing-%d", rInt)),
-					resource.TestMatchResourceAttr(
-						"aws_ami.foo", "root_snapshot_id", regexp.MustCompile("^snap-")),
-					resource.TestCheckResourceAttr(
-						"aws_ami.foo", "ena_support", "true"),
+					testAccCheckAmiExists(resourceName, &ami),
+					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestMatchResourceAttr(resourceName, "root_snapshot_id", regexp.MustCompile("^snap-")),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -43,7 +46,8 @@ func TestAccAWSAMI_basic(t *testing.T) {
 func TestAccAWSAMI_snapshotSize(t *testing.T) {
 	var ami ec2.Image
 	var bd ec2.BlockDeviceMapping
-	rInt := acctest.RandInt()
+	resourceName := "aws_ami.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	expectedDevice := &ec2.EbsBlockDevice{
 		DeleteOnTermination: aws.Bool(true),
@@ -59,16 +63,19 @@ func TestAccAWSAMI_snapshotSize(t *testing.T) {
 		CheckDestroy: testAccCheckAmiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAmiConfig_snapshotSize(rInt),
+				Config: testAccAmiConfig_snapshotSize(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAmiExists("aws_ami.foo", &ami),
+					testAccCheckAmiExists(resourceName, &ami),
 					testAccCheckAmiBlockDevice(&ami, &bd, "/dev/sda1"),
 					testAccCheckAmiEbsBlockDevice(&bd, expectedDevice),
-					resource.TestCheckResourceAttr(
-						"aws_ami.foo", "name", fmt.Sprintf("tf-testing-%d", rInt)),
-					resource.TestCheckResourceAttr(
-						"aws_ami.foo", "architecture", "x86_64"),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "x86_64"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -205,7 +212,7 @@ func testAccCheckAmiEbsBlockDevice(bd *ec2.BlockDeviceMapping, ed *ec2.EbsBlockD
 	}
 }
 
-func testAccAmiConfig_basic(rInt int) string {
+func testAccAmiConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
@@ -225,20 +232,21 @@ resource "aws_ebs_snapshot" "foo" {
   }
 }
 
-resource "aws_ami" "foo" {
-  name = "tf-testing-%d"
+resource "aws_ami" "test" {
+  ena_support         = true
+  name                = %q
+  root_device_name    = "/dev/sda1"
   virtualization_type = "hvm"
-  root_device_name = "/dev/sda1"
+
   ebs_block_device {
     device_name = "/dev/sda1"
     snapshot_id = "${aws_ebs_snapshot.foo.id}"
   }
-  ena_support = true
 }
-	`, rInt)
+`, rName)
 }
 
-func testAccAmiConfig_snapshotSize(rInt int) string {
+func testAccAmiConfig_snapshotSize(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
@@ -258,14 +266,15 @@ resource "aws_ebs_snapshot" "foo" {
   }
 }
 
-resource "aws_ami" "foo" {
-  name = "tf-testing-%d"
+resource "aws_ami" "test" {
+  name                = %q
+  root_device_name    = "/dev/sda1"
   virtualization_type = "hvm"
-  root_device_name = "/dev/sda1"
+
   ebs_block_device {
     device_name = "/dev/sda1"
     snapshot_id = "${aws_ebs_snapshot.foo.id}"
   }
 }
-	`, rInt)
+`, rName)
 }

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -109,3 +109,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the created AMI.
 * `root_snapshot_id` - The Snapshot ID for the root volume (for EBS-backed AMIs)
+
+## Import
+
+`aws_ami` can be imported using the ID of the AMI, e.g.
+
+```
+$ terraform import aws_ami.example ami-12345678
+```


### PR DESCRIPTION
Closes #4907 

Changes proposed in this pull request:

* Support `aws_ami` resource import

Output from acceptance testing:

```
--- PASS: TestAccAWSAMI_snapshotSize (71.88s)
--- PASS: TestAccAWSAMI_basic (71.99s)
```
