### PR TITLE
resource/aws_rds_cluster_instance: Properly handle publicly_accessible updates

### DIFF
--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -467,6 +467,12 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 		requestUpdate = true
 	}
 
+	if d.HasChange("publicly_accessible") {
+		d.SetPartial("publicly_accessible")
+		req.PubliclyAccessible = aws.Bool(d.Get("publicly_accessible").(bool))
+		requestUpdate = true
+	}
+
 	log.Printf("[DEBUG] Send DB Instance Modification request: %#v", requestUpdate)
 	if requestUpdate {
 		log.Printf("[DEBUG] DB Instance Modification request: %#v", req)


### PR DESCRIPTION
Fixes #5691 
Fixes #2381

Changes proposed in this pull request:

* Properly pass `PubliclyAccessible` during resource update

Previously:

```
--- FAIL: TestAccAWSRDSClusterInstance_PubliclyAccessible (623.05s)
    testing.go:527: Step 2 error: Check failed: Check 2/2 error: aws_rds_cluster_instance.test: Attribute 'publicly_accessible' expected "false", got "true"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (2268.66s)
```
