### PR TITLE
Add import instructions to Cognito User Pool Client resource documentation

### DIFF
--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -67,3 +67,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The id of the user pool client.
 * `client_secret` - The client secret of the user pool client.
+
+## Import
+
+Cognito User Pool Clients can be imported using the `id` of the Cognito User Pool, and the `id` of the Cognito User Pool Client, e.g.
+
+```
+$ terraform import aws_cognito_user_pool_client.client <user_pool_id>/<user_pool_client_id>
+```


### PR DESCRIPTION
Reasoning: the importing of Cognito User Pool Client was added a long time ago (January 2018) but the documentation lacks the instructions on how to do it.

Relevant Terraform version: v1.7.0 and up

No new resources
No code changes

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
