### PR TITLE
guides/eks-getting-started: Clarify 602401143452 owners value in aws_ami data source

### DIFF
--- a/examples/eks-getting-started/eks-worker-nodes.tf
+++ b/examples/eks-getting-started/eks-worker-nodes.tf
@@ -93,7 +93,7 @@ data "aws_ami" "eks-worker" {
   }
 
   most_recent = true
-  owners      = ["602401143452"] # Amazon
+  owners      = ["602401143452"] # Amazon EKS AMI Account ID
 }
 
 # EKS currently documents this required userdata for EKS worker nodes to

--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -477,7 +477,7 @@ data "aws_ami" "eks-worker" {
   }
 
   most_recent = true
-  owners      = ["602401143452"] # Amazon Account ID
+  owners      = ["602401143452"] # Amazon EKS AMI Account ID
 }
 ```
 


### PR DESCRIPTION
Reference: #5996 

Changes proposed in this pull request:

* Update comment about `602401143452` account ID in EKS Getting Started Guide
* Update comment about `602401143452` account ID in EKS Getting Started example code

Output from acceptance testing: N/A
