### PR TITLE
docs/resource/aws_rds_cluster_instance: Add note that Deletion Protection is only available at the cluster level

### DIFF
--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -21,6 +21,8 @@ Cluster, or you may specify different Cluster Instance resources with various
 
 For more information on Amazon Aurora, see [Aurora on Amazon RDS][2] in the Amazon RDS User Guide.
 
+~> **NOTE:** Deletion Protection from the RDS service can only be enabled at the cluster level, not for individual cluster instances. You can still add the [`prevent_destroy` lifecycle behavior](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy) to your Terraform resource configuration if you desire protection from accidental deletion.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Closes #6008 

When attempting to enable `DeletionProtection` with `DBClusterIdentifier`, the RDS API currently throws an error:

```
--- FAIL: TestAccAWSRDSClusterInstance_DeletionProtection (103.54s)
    testing.go:527: Step 0 error: Error applying: 1 error occurred:
        	* aws_rds_cluster_instance.test: 1 error occurred:
        	* aws_rds_cluster_instance.test: error creating RDS DB Instance: InvalidParameterCombination: Deletion Protection can only be applied on the Cluster level, not for individual instances
```
