### PR TITLE
r/resource_aws_rds_cluster: Honor kms_key_id when restoring from snapshot

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -430,6 +430,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			opts.AvailabilityZones = expandStringList(attr.List())
 		}
 
+		if attr, ok := d.GetOk("kms_key_id"); ok {
+			opts.KmsKeyId = aws.String(attr.(string))
+		}
+
 		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
 			opts.DBSubnetGroupName = aws.String(attr.(string))
 		}


### PR DESCRIPTION
Currently, `kms_key_id` is ignored when restoring a cluster by setting `snapshot_identifier`. AWS then creates the new cluster using the encryption setting from the snapshot (if the snapshot was encrypted, the same key is used for the cluster, otherwise the cluster is unencrypted).

On subsequent `plan`, `kms_key_id` would be honored, forcing a plan that would re-create the cluster (to change the encryption settings)

This PR adds the `kms_key_id` to the `RestoreDBClusterFromSnapshotInput` so that the cluster is created with the key specified in terraform instead of defaulting to the snapshots encryption settings. 

This is a slight change in behavior that in theory could impact existing users. However, the behavior that is changed isn't particularly useful right now so I wouldn't think too many people depend on it. 
Let me know if you see a problem there. We could, for example, add a flag `inherit_encryption_settings_from_snapshot` that's true by default to keep the old behavior. This would probably make it more unintuitive for most users and harder to maintain for developers though.


Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSCluster_SnapshotIdentifier'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSRDSCluster_SnapshotIdentifier -timeout 120m
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (387.07s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (399.09s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (367.47s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
	resource_aws_rds_cluster_test.go:733: serverless does not support snapshot restore on an empty volume
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_Tags
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (449.96s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (482.00s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (422.29s)
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (375.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2883.521s
```
