### PR TITLE
adding importing instructions to Cognito User Pool Domains documentation

### DIFF
--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -38,3 +38,11 @@ In addition to all arguments above, the following attributes are exported:
 * `cloudfront_distribution_arn` - The ARN of the CloudFront distribution.
 * `s3_bucket` - The S3 bucket where the static files for this domain are stored.
 * `version` - The app version.
+
+## Import
+
+Cognito User Pool Domains can be imported using the `domain`, e.g.
+
+```
+$ terraform import aws_cognito_user_pool_domain.main <domain>
+```


### PR DESCRIPTION
Reasoning: the importing of Cognito User Pool Domain was added a long time ago (October 2017) but the documentation lacks the instructions on how to do it.

Relevant Terraform version: v1.2.0 and up

No new resources
No code changes