### PR TITLE
service/codedeploy: Support resource import

### DIFF
--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -1,11 +1,11 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -13,30 +13,44 @@ import (
 )
 
 func TestAccAWSCodeDeployApp_basic(t *testing.T) {
+	var application1 codedeploy.ApplicationInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codedeploy_app.test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodeDeployAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeDeployApp,
+				Config: testAccAWSCodeDeployAppConfigName(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_codedeploy_app.foo", "compute_platform", "Server"),
-					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
+					testAccCheckAWSCodeDeployAppExists(resourceName, &application1),
+					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Server"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
+			// Import by ID
 			{
-				Config: testAccAWSCodeDeployAppModified,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Import by name
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rName,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSCodeDeployApp_computePlatform(t *testing.T) {
-	rName := acctest.RandString(5)
+	var application1, application2 codedeploy.ApplicationInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codedeploy_app.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,20 +58,59 @@ func TestAccAWSCodeDeployApp_computePlatform(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeDeployAppDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Server"),
+				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Lambda"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_app.foo", "compute_platform", "Server"),
+					testAccCheckAWSCodeDeployAppExists(resourceName, &application1),
+					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Lambda"),
 				),
 			},
 			{
-				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Lambda"),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Server"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployAppExists("aws_codedeploy_app.foo"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_app.foo", "compute_platform", "Lambda"),
+					testAccCheckAWSCodeDeployAppExists(resourceName, &application2),
+					testAccCheckAWSCodeDeployAppRecreated(&application1, &application2),
+					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Server"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployApp_name(t *testing.T) {
+	var application1, application2 codedeploy.ApplicationInfo
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codedeploy_app.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployAppConfigName(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists(resourceName, &application1),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+				),
+			},
+			{
+				Config: testAccAWSCodeDeployAppConfigName(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists(resourceName, &application2),
+					testAccCheckAWSCodeDeployAppRecreated(&application1, &application2),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -75,11 +128,11 @@ func testAccCheckAWSCodeDeployAppDestroy(s *terraform.State) error {
 			ApplicationName: aws.String(rs.Primary.Attributes["name"]),
 		})
 
+		if isAWSErr(err, codedeploy.ErrCodeApplicationDoesNotExistException, "") {
+			continue
+		}
+
 		if err != nil {
-			// Verify the error is what we want
-			if ae, ok := err.(awserr.Error); ok && ae.Code() == "ApplicationDoesNotExistException" {
-				continue
-			}
 			return err
 		}
 
@@ -89,31 +142,58 @@ func testAccCheckAWSCodeDeployAppDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSCodeDeployAppExists(name string) resource.TestCheckFunc {
+func testAccCheckAWSCodeDeployAppExists(name string, application *codedeploy.ApplicationInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).codedeployconn
+
+		input := &codedeploy.GetApplicationInput{
+			ApplicationName: aws.String(rs.Primary.Attributes["name"]),
+		}
+
+		output, err := conn.GetApplication(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Application == nil {
+			return fmt.Errorf("error reading CodeDeploy Application (%s): empty response", rs.Primary.ID)
+		}
+
+		*application = *output.Application
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCodeDeployAppRecreated(i, j *codedeploy.ApplicationInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreateTime) == aws.TimeValue(j.CreateTime) {
+			return errors.New("CodeDeploy Application was not recreated")
 		}
 
 		return nil
 	}
 }
 
-func testAccAWSCodeDeployAppConfigComputePlatform(rName string, value string) string {
+func testAccAWSCodeDeployAppConfigComputePlatform(rName string, computePlatform string) string {
 	return fmt.Sprintf(`
-resource "aws_codedeploy_app" "foo" {
-	name = "test-codedeploy-app-%s"
-	compute_platform = "%s"
-}`, rName, value)
+resource "aws_codedeploy_app" "test" {
+  compute_platform = %q
+  name             = %q
+}
+`, computePlatform, rName)
 }
 
-var testAccAWSCodeDeployApp = `
-resource "aws_codedeploy_app" "foo" {
-	name = "foo"
-}`
-
-var testAccAWSCodeDeployAppModified = `
-resource "aws_codedeploy_app" "foo" {
-	name = "bar"
-}`
+func testAccAWSCodeDeployAppConfigName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codedeploy_app" "test" {
+  name = %q
+}
+`, rName)
+}

--- a/aws/resource_aws_codedeploy_deployment_config.go
+++ b/aws/resource_aws_codedeploy_deployment_config.go
@@ -16,6 +16,9 @@ func resourceAwsCodeDeployDeploymentConfig() *schema.Resource {
 		Create: resourceAwsCodeDeployDeploymentConfigCreate,
 		Read:   resourceAwsCodeDeployDeploymentConfigRead,
 		Delete: resourceAwsCodeDeployDeploymentConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"deployment_config_name": {

--- a/aws/resource_aws_codedeploy_deployment_config_test.go
+++ b/aws/resource_aws_codedeploy_deployment_config_test.go
@@ -6,17 +6,16 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSCodeDeployDeploymentConfig_fleetPercent(t *testing.T) {
-	var config1, config2 codedeploy.DeploymentConfigInfo
-
-	rName := acctest.RandString(5)
+func TestAccAWSCodeDeployDeploymentConfig_basic(t *testing.T) {
+	var config1 codedeploy.DeploymentConfigInfo
+	resourceName := "aws_codedeploy_deployment_config.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -26,23 +25,52 @@ func TestAccAWSCodeDeployDeploymentConfig_fleetPercent(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentConfigFleet(rName, 75),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config1),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.type", "FLEET_PERCENT"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.value", "75"),
+					testAccCheckAWSCodeDeployDeploymentConfigExists(resourceName, &config1),
+					resource.TestCheckResourceAttr(resourceName, "deployment_config_name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentConfig_fleetPercent(t *testing.T) {
+	var config1, config2 codedeploy.DeploymentConfigInfo
+	resourceName := "aws_codedeploy_deployment_config.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployDeploymentConfigFleet(rName, 75),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentConfigExists(resourceName, &config1),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.type", "FLEET_PERCENT"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.value", "75"),
 				),
 			},
 			{
 				Config: testAccAWSCodeDeployDeploymentConfigFleet(rName, 50),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config2),
+					testAccCheckAWSCodeDeployDeploymentConfigExists(resourceName, &config2),
 					testAccCheckAWSCodeDeployDeploymentConfigRecreated(&config1, &config2),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.type", "FLEET_PERCENT"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.value", "50"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.type", "FLEET_PERCENT"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.value", "50"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -50,8 +78,8 @@ func TestAccAWSCodeDeployDeploymentConfig_fleetPercent(t *testing.T) {
 
 func TestAccAWSCodeDeployDeploymentConfig_hostCount(t *testing.T) {
 	var config1, config2 codedeploy.DeploymentConfigInfo
-
-	rName := acctest.RandString(5)
+	resourceName := "aws_codedeploy_deployment_config.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,23 +89,26 @@ func TestAccAWSCodeDeployDeploymentConfig_hostCount(t *testing.T) {
 			{
 				Config: testAccAWSCodeDeployDeploymentConfigHostCount(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config1),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.type", "HOST_COUNT"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.value", "1"),
+					testAccCheckAWSCodeDeployDeploymentConfigExists(resourceName, &config1),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.type", "HOST_COUNT"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.value", "1"),
 				),
 			},
 			{
 				Config: testAccAWSCodeDeployDeploymentConfigHostCount(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config2),
+					testAccCheckAWSCodeDeployDeploymentConfigExists(resourceName, &config2),
 					testAccCheckAWSCodeDeployDeploymentConfigRecreated(&config1, &config2),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.type", "HOST_COUNT"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.value", "2"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.type", "HOST_COUNT"),
+					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_hosts.0.value", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -95,7 +126,7 @@ func testAccCheckAWSCodeDeployDeploymentConfigDestroy(s *terraform.State) error 
 			DeploymentConfigName: aws.String(rs.Primary.ID),
 		})
 
-		if ae, ok := err.(awserr.Error); ok && ae.Code() == "DeploymentConfigDoesNotExistException" {
+		if isAWSErr(err, codedeploy.ErrCodeDeploymentConfigDoesNotExistException, "") {
 			continue
 		}
 
@@ -146,22 +177,26 @@ func testAccCheckAWSCodeDeployDeploymentConfigRecreated(i, j *codedeploy.Deploym
 
 func testAccAWSCodeDeployDeploymentConfigFleet(rName string, value int) string {
 	return fmt.Sprintf(`
-resource "aws_codedeploy_deployment_config" "foo" {
-	deployment_config_name = "test-deployment-config-%s"
-	minimum_healthy_hosts {
-		type = "FLEET_PERCENT"
-		value = %d
-	}
-}`, rName, value)
+resource "aws_codedeploy_deployment_config" "test" {
+  deployment_config_name = %q
+
+  minimum_healthy_hosts {
+    type  = "FLEET_PERCENT"
+    value = %d
+  }
+}
+`, rName, value)
 }
 
 func testAccAWSCodeDeployDeploymentConfigHostCount(rName string, value int) string {
 	return fmt.Sprintf(`
-resource "aws_codedeploy_deployment_config" "foo" {
-	deployment_config_name = "test-deployment-config-%s"
-	minimum_healthy_hosts {
-		type = "HOST_COUNT"
-		value = %d
-	}
-}`, rName, value)
+resource "aws_codedeploy_deployment_config" "test" {
+  deployment_config_name = %q
+
+  minimum_healthy_hosts {
+    type  = "HOST_COUNT"
+    value = %d
+  }
+}
+`, rName, value)
 }

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -94,6 +94,12 @@ func TestAccAWSCodeDeployDeploymentGroup_basic(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -178,6 +184,12 @@ func TestAccAWSCodeDeployDeploymentGroup_basic_tagSet(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo", "trigger_configuration.#", "0"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -212,6 +224,12 @@ func TestAccAWSCodeDeployDeploymentGroup_onPremiseTag(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo", "on_premises_instance_tag_filter.2916377465.value", "filtervalue"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -275,6 +293,12 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic(t *testing.T
 					}),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -328,6 +352,12 @@ func TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple(t *testin
 						regexp.MustCompile("^arn:aws:sns:[^:]+:[0-9]{12}:baz-topic-"+rName+"$")),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -363,6 +393,12 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create(t *tes
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -408,6 +444,12 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update(t *tes
 						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -443,6 +485,12 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete(t *tes
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.#", "0"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -486,6 +534,12 @@ func TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable(t *te
 						"aws_codedeploy_deployment_group.foo_group", "auto_rollback_configuration.0.events.135881253", "DEPLOYMENT_FAILURE"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -523,6 +577,12 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create(t *testing.T)
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -572,6 +632,12 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update(t *testing.T)
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "true"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -609,6 +675,12 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete(t *testing.T)
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.#", "0"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -656,6 +728,12 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T
 						"aws_codedeploy_deployment_group.foo_group", "alarm_configuration.0.ignore_poll_alarm_failure", "false"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -682,6 +760,12 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -728,6 +812,12 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -765,6 +855,12 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -806,6 +902,12 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -839,6 +941,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -878,6 +986,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.4206303396.name", "bar-elb"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -914,6 +1028,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -948,6 +1068,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.4178177480.name", "foo-tg"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -987,6 +1113,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.target_group_info.2940009368.name", "bar-tg"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1020,6 +1152,12 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1067,6 +1205,12 @@ func TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_contro
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1135,6 +1279,12 @@ func TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_contro
 						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1183,6 +1333,12 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1365,6 +1521,12 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
 						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
 				),
 			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1460,6 +1622,12 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete(t *testing
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "0"),
 				),
+			},
+			{
+				ResourceName:      "aws_codedeploy_deployment_group.foo_group",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc("aws_codedeploy_deployment_group.foo_group"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -2090,6 +2258,17 @@ func TestAWSCodeDeployDeploymentGroup_handleCodeDeployApiError(t *testing.T) {
 			t.Fatalf(`handleCodeDeployApiError output is not correct. Expected: %v, Actual: %v.`,
 				tc.Expected, actual)
 		}
+	}
+}
+
+func testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s:%s", rs.Primary.Attributes["app_name"], rs.Primary.Attributes["deployment_group_name"]), nil
 	}
 }
 

--- a/website/docs/r/codedeploy_app.html.markdown
+++ b/website/docs/r/codedeploy_app.html.markdown
@@ -31,3 +31,11 @@ The following arguments are exported:
 
 * `id` - Amazon's assigned ID for the application.
 * `name` - The application's name.
+
+## Import
+
+CodeDeploy Applications can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_codedeploy_app.example my-application
+```

--- a/website/docs/r/codedeploy_deployment_config.html.markdown
+++ b/website/docs/r/codedeploy_deployment_config.html.markdown
@@ -73,3 +73,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The deployment group's config name.
 * `deployment_config_id` - The AWS Assigned deployment config id
+
+## Import
+
+CodeDeploy Deployment Configurations can be imported using the `deployment_config_name`, e.g.
+
+```
+$ terraform import aws_codedeploy_app.example my-deployment-config
+```

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -257,4 +257,12 @@ In addition to all arguments above, the following attributes are exported:
 * `autoscaling_groups` - The autoscaling groups associated with the deployment group.
 * `deployment_config_name` - The name of the group's deployment config.
 
+## Import
+
+CodeDeploy Deployment Groups can be imported by their `app_name`, a colon, and `deployment_group_name`, e.g.
+
+```
+$ terraform import aws_codedeploy_deployment_group.example my-application:my-deployment-group
+```
+
 [1]: http://docs.aws.amazon.com/codedeploy/latest/userguide/monitoring-sns-event-notifications-create-trigger.html


### PR DESCRIPTION
Closes #314
Closes #1473

Changes proposed in this pull request:

* resource/aws_codedeploy_app: Support resource import
* tests/resource/aws_codedeploy_app: Enhance acceptance testing
* resource/aws_codedeploy_deployment_config: Support resource import
* resource/aws_codedeploy_deployment_group: Support resource import
* resource/aws_codedeploy_deployment_group: Properly read `autoscaling_groups` into Terraform state

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeDeployApp_basic (13.20s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform (18.91s)
--- PASS: TestAccAWSCodeDeployApp_name (16.95s)

--- PASS: TestAccAWSCodeDeployDeploymentConfig_basic (12.22s)
--- PASS: TestAccAWSCodeDeployDeploymentConfig_fleetPercent (19.44s)
--- PASS: TestAccAWSCodeDeployDeploymentConfig_hostCount (17.21s)

--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (33.39s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (38.15s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (30.64s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (34.09s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (32.85s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (31.12s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (34.25s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (34.28s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (42.35s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (49.20s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (27.32s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (179.42s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (48.55s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (35.89s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (42.16s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (24.59s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (31.31s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (34.56s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (19.01s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create (50.42s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (27.53s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (28.65s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (32.94s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (34.29s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (40.39s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (41.76s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (23.76s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (32.13s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (34.72s)
```
