### PR TITLE
resource/aws_security_group_rule: Add import functionality for security group rules

### DIFF
--- a/aws/resource_aws_security_group_rule.go
+++ b/aws/resource_aws_security_group_rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +24,25 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 		Read:   resourceAwsSecurityGroupRuleRead,
 		Update: resourceAwsSecurityGroupRuleUpdate,
 		Delete: resourceAwsSecurityGroupRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				importParts, err := validateSecurityGroupRuleImportString(d.Id())
+				if err != nil {
+					return nil, err
+				}
+				if err := populateSecurityGroupRuleFromImport(d, importParts); err != nil {
+					return nil, err
+				}
+				err = resourceAwsSecurityGroupRuleRead(d, meta)
+				if err != nil {
+					return nil, err
+				}
+
+				results := make([]*schema.ResourceData, 1)
+				results[0] = d
+				return results, nil
+			},
+		},
 
 		SchemaVersion: 2,
 		MigrateState:  resourceAwsSecurityGroupRuleMigrateState,
@@ -256,6 +276,7 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 	default:
 		rules = sg.IpPermissionsEgress
 	}
+	log.Printf("[DEBUG] Rules %v", rules)
 
 	p, err := expandIPPerm(d, sg)
 	if err != nil {
@@ -286,6 +307,12 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("description", descriptionFromIPPerm(d, rule))
+
+	if strings.Contains(d.Id(), "_") {
+		// import so fix the id
+		id := ipPermissionIDHash(sg_id, ruleType, p)
+		d.SetId(id)
+	}
 
 	return nil
 }
@@ -842,6 +869,107 @@ func resourceSecurityGroupRuleDescriptionUpdate(conn *ec2.EC2, d *schema.Resourc
 				sg_id, err)
 		}
 	}
+
+	return nil
+}
+
+// validateSecurityGroupRuleImportString does minimal validation of import string without going to AWS
+func validateSecurityGroupRuleImportString(importStr string) ([]string, error) {
+	// example: sg-09a093729ef9382a6_ingress_tcp_8000_8000_10.0.3.0/24
+	// example: sg-09a093729ef9382a6_ingress_92_0_65536_10.0.3.0/24_10.0.4.0/24
+	// example: sg-09a093729ef9382a6_egress_tcp_8000_8000_10.0.3.0/24
+	// example: sg-09a093729ef9382a6_egress_tcp_8000_8000_pl-34800000
+	// example: sg-09a093729ef9382a6_ingress_all_0_65536_sg-08123412342323
+	// example: sg-09a093729ef9382a6_ingress_tcp_100_121_10.1.0.0/16_2001:db8::/48_10.2.0.0/16_2002:db8::/48
+
+	log.Printf("[DEBUG] Validating import string %s", importStr)
+
+	importParts := strings.Split(strings.ToLower(importStr), "_")
+	errStr := "unexpected format of import string (%q), expected SECURITYGROUPID_TYPE_PROTOCOL_FROMPORT_TOPORT_SOURCE[_SOURCE]*: %s"
+	if len(importParts) < 6 {
+		return nil, fmt.Errorf(errStr, importStr, "too few parts")
+	}
+
+	sgID := importParts[0]
+	ruleType := importParts[1]
+	protocol := importParts[2]
+	fromPort := importParts[3]
+	toPort := importParts[4]
+	sources := importParts[5:]
+
+	if !strings.HasPrefix(sgID, "sg-") {
+		return nil, fmt.Errorf(errStr, importStr, "invalid security group ID")
+	}
+
+	if ruleType != "ingress" && ruleType != "egress" {
+		return nil, fmt.Errorf(errStr, importStr, "expecting 'ingress' or 'egress'")
+	}
+
+	if _, ok := sgProtocolIntegers()[protocol]; !ok {
+		if _, err := strconv.Atoi(protocol); err != nil {
+			return nil, fmt.Errorf(errStr, importStr, "protocol must be tcp/udp/icmp/all or a number")
+		}
+	}
+
+	if p1, err := strconv.Atoi(fromPort); err != nil {
+		return nil, fmt.Errorf(errStr, importStr, "invalid port")
+	} else if p2, err := strconv.Atoi(toPort); err != nil || p2 < p1 {
+		return nil, fmt.Errorf(errStr, importStr, "invalid port")
+	}
+
+	for _, source := range sources {
+		// will be properly validated later
+		if source != "self" && !strings.Contains(source, "sg-") && !strings.Contains(source, "pl-") && !strings.Contains(source, ":") && !strings.Contains(source, ".") {
+			return nil, fmt.Errorf(errStr, importStr, "source must be cidr, ipv6cidr, prefix list, 'self', or a sg ID")
+		}
+	}
+
+	log.Printf("[DEBUG] Validated import string %s", importStr)
+	return importParts, nil
+}
+
+func populateSecurityGroupRuleFromImport(d *schema.ResourceData, importParts []string) error {
+	log.Printf("[DEBUG] Populating resource data on import: %v", importParts)
+
+	sgID := importParts[0]
+	ruleType := importParts[1]
+	protocol := importParts[2]
+	fromPort, _ := strconv.Atoi(importParts[3])
+	toPort, _ := strconv.Atoi(importParts[4])
+	sources := importParts[5:]
+
+	d.Set("security_group_id", sgID)
+
+	if ruleType == "ingress" {
+		d.Set("type", ruleType)
+	} else {
+		d.Set("type", "egress")
+	}
+
+	d.Set("protocol", protocolForValue(protocol))
+	d.Set("from_port", fromPort)
+	d.Set("to_port", toPort)
+
+	d.Set("self", false)
+	var cidrs []string
+	var prefixList []string
+	var ipv6cidrs []string
+	for _, source := range sources {
+		if source == "self" {
+			d.Set("self", true)
+		} else if strings.Contains(source, "sg-") {
+			d.Set("source_security_group_id", source)
+		} else if strings.Contains(source, "pl-") {
+			prefixList = append(prefixList, source)
+		} else if strings.Contains(source, ":") {
+			ipv6cidrs = append(ipv6cidrs, source)
+		} else {
+			cidrs = append(cidrs, source)
+		}
+	}
+	d.Set("ipv6_cidr_blocks", ipv6cidrs)
+	d.Set("cidr_blocks", cidrs)
+	d.Set("prefix_list_ids", prefixList)
 
 	return nil
 }

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -1199,24 +1199,25 @@ func testAccAWSSecurityGroupRuleImportGetAttrs(attrs map[string]string, key stri
 
 func testAccAWSSecurityGroupRuleIngressConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_security_group" "web" {
-		name = "terraform_test_%d"
-		description = "Used in the terraform acceptance tests"
+resource "aws_security_group" "web" {
+    name = "terraform_test_%d"
+    description = "Used in the terraform acceptance tests"
 
-					tags {
-									Name = "tf-acc-test"
-					}
-	}
+    tags {
+      Name = "tf-acc-test"
+    }
+}
 
-	resource "aws_security_group_rule" "ingress_1" {
-		type = "ingress"
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
+resource "aws_security_group_rule" "ingress_1" {
+    type = "ingress"
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
 
-		security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+    security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 const testAccAWSSecurityGroupRuleIngress_ipv6Config = `
@@ -1277,10 +1278,6 @@ resource "aws_security_group_rule" "ingress_1" {
 `
 
 const testAccAWSSecurityGroupRuleIssue5310 = `
-provider "aws" {
-        region = "us-east-1"
-}
-
 resource "aws_security_group" "issue_5310" {
     name = "terraform-test-issue_5310"
     description = "SG for test of issue 5310"
@@ -1298,50 +1295,48 @@ resource "aws_security_group_rule" "issue_5310" {
 
 func testAccAWSSecurityGroupRuleIngressClassicConfig(rInt int) string {
 	return fmt.Sprintf(`
-	provider "aws" {
-					region = "us-east-1"
-	}
+resource "aws_security_group" "web" {
+    name = "terraform_test_%d"
+    description = "Used in the terraform acceptance tests"
 
-	resource "aws_security_group" "web" {
-		name = "terraform_test_%d"
-		description = "Used in the terraform acceptance tests"
+    tags {
+        Name = "tf-acc-test"
+    }
+}
 
-					tags {
-									Name = "tf-acc-test"
-					}
-	}
+resource "aws_security_group_rule" "ingress_1" {
+    type = "ingress"
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
 
-	resource "aws_security_group_rule" "ingress_1" {
-		type = "ingress"
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-
-		security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+    security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 func testAccAWSSecurityGroupRuleEgressConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_security_group" "web" {
-		name = "terraform_test_%d"
-		description = "Used in the terraform acceptance tests"
+resource "aws_security_group" "web" {
+    name = "terraform_test_%d"
+    description = "Used in the terraform acceptance tests"
 
-					tags {
-									Name = "tf-acc-test"
-					}
-	}
+                tags {
+                                Name = "tf-acc-test"
+                }
+}
 
-	resource "aws_security_group_rule" "egress_1" {
-		type = "egress"
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
+resource "aws_security_group_rule" "egress_1" {
+    type = "egress"
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
 
-		security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+    security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 const testAccAWSSecurityGroupRuleConfigMultiIngress = `
@@ -1380,75 +1375,75 @@ resource "aws_security_group_rule" "ingress_2" {
 func testAccAWSSecurityGroupRuleMultiDescription(rInt int, rType string) string {
 	var b bytes.Buffer
 	b.WriteString(fmt.Sprintf(`
-	resource "aws_vpc" "tf_sgrule_description_test" {
-		cidr_block = "10.0.0.0/16"
-		tags {
-			Name = "terraform-testacc-security-group-rule-multi-desc"
-		}
-	}
+resource "aws_vpc" "tf_sgrule_description_test" {
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-security-group-rule-multi-desc"
+    }
+}
 
-	resource "aws_vpc_endpoint" "s3-us-west-2" {
-		vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
-		service_name = "com.amazonaws.us-west-2.s3"
-  	}
+resource "aws_vpc_endpoint" "s3-us-west-2" {
+    vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
+    service_name = "com.amazonaws.us-west-2.s3"
+    }
 
-	resource "aws_security_group" "worker" {
-		name = "terraform_test_%[1]d"
-		vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
-		description = "Used in the terraform acceptance tests"
-		tags { Name = "tf-sg-rule-description" }
-	}
+resource "aws_security_group" "worker" {
+    name = "terraform_test_%[1]d"
+    vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
+    description = "Used in the terraform acceptance tests"
+    tags { Name = "tf-sg-rule-description" }
+}
 
-	resource "aws_security_group" "nat" {
-		name = "terraform_test_%[1]d_nat"
-		vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
-		description = "Used in the terraform acceptance tests"
-		tags { Name = "tf-sg-rule-description" }
-	}
+resource "aws_security_group" "nat" {
+    name = "terraform_test_%[1]d_nat"
+    vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
+    description = "Used in the terraform acceptance tests"
+    tags { Name = "tf-sg-rule-description" }
+}
 
-	resource "aws_security_group_rule" "%[2]s_rule_1" {
-		security_group_id = "${aws_security_group.worker.id}"
-		description = "CIDR Description"
-		type = "%[2]s"
-		protocol = "tcp"
-		from_port = 22
-		to_port = 22
-		cidr_blocks = ["0.0.0.0/0"]
-	}
+resource "aws_security_group_rule" "%[2]s_rule_1" {
+    security_group_id = "${aws_security_group.worker.id}"
+    description = "CIDR Description"
+    type = "%[2]s"
+    protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    cidr_blocks = ["0.0.0.0/0"]
+}
 
-	resource "aws_security_group_rule" "%[2]s_rule_2" {
-		security_group_id = "${aws_security_group.worker.id}"
-		description = "IPv6 CIDR Description"
-		type = "%[2]s"
-		protocol = "tcp"
-		from_port = 22
-		to_port = 22
-		ipv6_cidr_blocks = ["::/0"]
-	}
+resource "aws_security_group_rule" "%[2]s_rule_2" {
+    security_group_id = "${aws_security_group.worker.id}"
+    description = "IPv6 CIDR Description"
+    type = "%[2]s"
+    protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    ipv6_cidr_blocks = ["::/0"]
+}
 
-	resource "aws_security_group_rule" "%[2]s_rule_3" {
-		security_group_id = "${aws_security_group.worker.id}"
-		description = "NAT SG Description"
-		type = "%[2]s"
-		protocol = "tcp"
-		from_port = 22
-		to_port = 22
-		source_security_group_id = "${aws_security_group.nat.id}"
-	}
-	`, rInt, rType))
+resource "aws_security_group_rule" "%[2]s_rule_3" {
+    security_group_id = "${aws_security_group.worker.id}"
+    description = "NAT SG Description"
+    type = "%[2]s"
+    protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    source_security_group_id = "${aws_security_group.nat.id}"
+}
+    `, rInt, rType))
 
 	if rType == "egress" {
 		b.WriteString(fmt.Sprintf(`
-	resource "aws_security_group_rule" "egress_rule_4" {
-		security_group_id = "${aws_security_group.worker.id}"
-		description = "Prefix List Description"
-		type = "egress"
-		protocol = "tcp"
-		from_port = 22
-		to_port = 22
-		prefix_list_ids = ["${aws_vpc_endpoint.s3-us-west-2.prefix_list_id}"]
-	}
-		`))
+resource "aws_security_group_rule" "egress_rule_4" {
+    security_group_id = "${aws_security_group.worker.id}"
+    description = "Prefix List Description"
+    type = "egress"
+    protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    prefix_list_ids = ["${aws_vpc_endpoint.s3-us-west-2.prefix_list_id}"]
+}
+        `))
 	}
 
 	return b.String()
@@ -1456,10 +1451,6 @@ func testAccAWSSecurityGroupRuleMultiDescription(rInt int, rType string) string 
 
 // check for GH-1985 regression
 const testAccAWSSecurityGroupRuleConfigSelfReference = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
   tags {
@@ -1487,105 +1478,107 @@ resource "aws_security_group_rule" "self" {
 
 func testAccAWSSecurityGroupRulePartialMatchingConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "default" {
-		cidr_block = "10.0.0.0/16"
-		tags {
-			Name = "terraform-testacc-security-group-rule-partial-match"
-		}
-	}
+resource "aws_vpc" "default" {
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-security-group-rule-partial-match"
+    }
+}
 
-	resource "aws_security_group" "web" {
-			name = "tf-other-%d"
-			vpc_id = "${aws_vpc.default.id}"
-			tags {
-					Name        = "tf-other-sg"
-			}
-	}
+resource "aws_security_group" "web" {
+        name = "tf-other-%d"
+        vpc_id = "${aws_vpc.default.id}"
+        tags {
+                Name        = "tf-other-sg"
+        }
+}
 
-	resource "aws_security_group" "nat" {
-			name = "tf-nat-%d"
-			vpc_id = "${aws_vpc.default.id}"
-			tags {
-					Name        = "tf-nat-sg"
-			}
-	}
+resource "aws_security_group" "nat" {
+        name = "tf-nat-%d"
+        vpc_id = "${aws_vpc.default.id}"
+        tags {
+                Name        = "tf-nat-sg"
+        }
+}
 
-	resource "aws_security_group_rule" "ingress" {
-			type        = "ingress"
-			from_port   = 80
-			to_port     = 80
-			protocol    = "tcp"
-			cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+resource "aws_security_group_rule" "ingress" {
+        type        = "ingress"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
 
-		 security_group_id = "${aws_security_group.web.id}"
-	}
+        security_group_id = "${aws_security_group.web.id}"
+}
 
-	resource "aws_security_group_rule" "other" {
-			type        = "ingress"
-			from_port   = 80
-			to_port     = 80
-			protocol    = "tcp"
-			cidr_blocks = ["10.0.5.0/24"]
+resource "aws_security_group_rule" "other" {
+        type        = "ingress"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_blocks = ["10.0.5.0/24"]
 
-		 security_group_id = "${aws_security_group.web.id}"
-	}
+        security_group_id = "${aws_security_group.web.id}"
+}
 
-	// same a above, but different group, to guard against bad hashing
-	resource "aws_security_group_rule" "nat_ingress" {
-			type        = "ingress"
-			from_port   = 80
-			to_port     = 80
-			protocol    = "tcp"
-			cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+// same a above, but different group, to guard against bad hashing
+resource "aws_security_group_rule" "nat_ingress" {
+        type        = "ingress"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
 
-		 security_group_id = "${aws_security_group.nat.id}"
-	}`, rInt, rInt)
+        security_group_id = "${aws_security_group.nat.id}"
+}
+    `, rInt, rInt)
 }
 
 func testAccAWSSecurityGroupRulePartialMatching_SourceConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "default" {
-		cidr_block = "10.0.0.0/16"
-		tags {
-			Name = "terraform-testacc-security-group-rule-partial-match"
-		}
-	}
+resource "aws_vpc" "default" {
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-security-group-rule-partial-match"
+    }
+}
 
-	resource "aws_security_group" "web" {
-			name = "tf-other-%d"
-			vpc_id = "${aws_vpc.default.id}"
-			tags {
-					Name        = "tf-other-sg"
-			}
-	}
+resource "aws_security_group" "web" {
+        name = "tf-other-%d"
+        vpc_id = "${aws_vpc.default.id}"
+        tags {
+                Name        = "tf-other-sg"
+        }
+}
 
-	resource "aws_security_group" "nat" {
-			name = "tf-nat-%d"
-			vpc_id = "${aws_vpc.default.id}"
-			tags {
-					Name        = "tf-nat-sg"
-			}
-	}
+resource "aws_security_group" "nat" {
+        name = "tf-nat-%d"
+        vpc_id = "${aws_vpc.default.id}"
+        tags {
+                Name        = "tf-nat-sg"
+        }
+}
 
-	resource "aws_security_group_rule" "source_ingress" {
-			type        = "ingress"
-			from_port   = 80
-			to_port     = 80
-			protocol    = "tcp"
+resource "aws_security_group_rule" "source_ingress" {
+        type        = "ingress"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
 
-									source_security_group_id = "${aws_security_group.nat.id}"
-		 security_group_id = "${aws_security_group.web.id}"
-	}
+                                source_security_group_id = "${aws_security_group.nat.id}"
+        security_group_id = "${aws_security_group.web.id}"
+}
 
-	resource "aws_security_group_rule" "other_ingress" {
-			type        = "ingress"
-			from_port   = 80
-			to_port     = 80
-			protocol    = "tcp"
-			cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+resource "aws_security_group_rule" "other_ingress" {
+        type        = "ingress"
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
 
-		 security_group_id = "${aws_security_group.web.id}"
-	}`, rInt, rInt)
+        security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt, rInt)
 }
 
 const testAccAWSSecurityGroupRulePrefixListEgressConfig = `
@@ -1602,21 +1595,21 @@ resource "aws_route_table" "default" {
 }
 
 resource "aws_vpc_endpoint" "s3-us-west-2" {
-  	vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
-  	service_name = "com.amazonaws.us-west-2.s3"
-  	route_table_ids = ["${aws_route_table.default.id}"]
-  	policy = <<POLICY
+      vpc_id = "${aws_vpc.tf_sg_prefix_list_egress_test.id}"
+      service_name = "com.amazonaws.us-west-2.s3"
+      route_table_ids = ["${aws_route_table.default.id}"]
+      policy = <<POLICY
 {
-	"Version": "2012-10-17",
-	"Statement": [
-		{
-			"Sid":"AllowAll",
-			"Effect":"Allow",
-			"Principal":"*",
-			"Action":"*",
-			"Resource":"*"
-		}
-	]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid":"AllowAll",
+            "Effect":"Allow",
+            "Principal":"*",
+            "Action":"*",
+            "Resource":"*"
+        }
+    ]
 }
 POLICY
 }
@@ -1633,192 +1626,198 @@ resource "aws_security_group_rule" "egress_1" {
   from_port = 0
   to_port = 0
   prefix_list_ids = ["${aws_vpc_endpoint.s3-us-west-2.prefix_list_id}"]
-	security_group_id = "${aws_security_group.egress.id}"
+    security_group_id = "${aws_security_group.egress.id}"
 }
 `
 
 func testAccAWSSecurityGroupRuleIngressDescriptionConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_security_group" "web" {
-		name = "terraform_test_%d"
-		description = "Used in the terraform acceptance tests"
+resource "aws_security_group" "web" {
+    name = "terraform_test_%d"
+    description = "Used in the terraform acceptance tests"
 
-					tags {
-									Name = "tf-acc-test"
-					}
-	}
+                tags {
+                                Name = "tf-acc-test"
+                }
+}
 
-	resource "aws_security_group_rule" "ingress_1" {
-		type = "ingress"
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-		description = "TF acceptance test ingress rule"
+resource "aws_security_group_rule" "ingress_1" {
+    type = "ingress"
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+    description = "TF acceptance test ingress rule"
 
-		security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+    security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 func testAccAWSSecurityGroupRuleIngress_updateDescriptionConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_security_group" "web" {
-		name = "terraform_test_%d"
-		description = "Used in the terraform acceptance tests"
+resource "aws_security_group" "web" {
+    name = "terraform_test_%d"
+    description = "Used in the terraform acceptance tests"
 
-					tags {
-									Name = "tf-acc-test"
-					}
-	}
+                tags {
+                                Name = "tf-acc-test"
+                }
+}
 
-	resource "aws_security_group_rule" "ingress_1" {
-		type = "ingress"
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-		description = "TF acceptance test ingress rule updated"
+resource "aws_security_group_rule" "ingress_1" {
+    type = "ingress"
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+    description = "TF acceptance test ingress rule updated"
 
-		security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+    security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 func testAccAWSSecurityGroupRuleEgressDescriptionConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_security_group" "web" {
-		name = "terraform_test_%d"
-		description = "Used in the terraform acceptance tests"
+resource "aws_security_group" "web" {
+    name = "terraform_test_%d"
+    description = "Used in the terraform acceptance tests"
 
-					tags {
-									Name = "tf-acc-test"
-					}
-	}
+                tags {
+                                Name = "tf-acc-test"
+                }
+}
 
-	resource "aws_security_group_rule" "egress_1" {
-		type = "egress"
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-		description = "TF acceptance test egress rule"
+resource "aws_security_group_rule" "egress_1" {
+    type = "egress"
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+    description = "TF acceptance test egress rule"
 
-		security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+    security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 func testAccAWSSecurityGroupRuleEgress_updateDescriptionConfig(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_security_group" "web" {
-		name = "terraform_test_%d"
-		description = "Used in the terraform acceptance tests"
+resource "aws_security_group" "web" {
+    name = "terraform_test_%d"
+    description = "Used in the terraform acceptance tests"
 
-					tags {
-									Name = "tf-acc-test"
-					}
-	}
+                tags {
+                                Name = "tf-acc-test"
+                }
+}
 
-	resource "aws_security_group_rule" "egress_1" {
-		type = "egress"
-		protocol = "tcp"
-		from_port = 80
-		to_port = 8000
-		cidr_blocks = ["10.0.0.0/8"]
-		description = "TF acceptance test egress rule updated"
+resource "aws_security_group_rule" "egress_1" {
+    type = "egress"
+    protocol = "tcp"
+    from_port = 80
+    to_port = 8000
+    cidr_blocks = ["10.0.0.0/8"]
+    description = "TF acceptance test egress rule updated"
 
-		security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+    security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 var testAccAWSSecurityGroupRuleRace = func() string {
 	var b bytes.Buffer
 	iterations := 50
 	b.WriteString(fmt.Sprintf(`
-		resource "aws_vpc" "default" {
-			cidr_block = "10.0.0.0/16"
-			tags {
-				Name = "terraform-testacc-security-group-rule-race"
-			}
-		}
+resource "aws_vpc" "default" {
+    cidr_block = "10.0.0.0/16"
+    tags {
+        Name = "terraform-testacc-security-group-rule-race"
+    }
+}
 
-		resource "aws_security_group" "race" {
-			name   = "tf-sg-rule-race-group-%d"
-			vpc_id = "${aws_vpc.default.id}"
-		}
-	`, acctest.RandInt()))
+resource "aws_security_group" "race" {
+    name   = "tf-sg-rule-race-group-%d"
+    vpc_id = "${aws_vpc.default.id}"
+}
+    `, acctest.RandInt()))
 	for i := 1; i < iterations; i++ {
 		b.WriteString(fmt.Sprintf(`
-			resource "aws_security_group_rule" "ingress%d" {
-				security_group_id = "${aws_security_group.race.id}"
-				type              = "ingress"
-				from_port         = %d
-				to_port           = %d
-				protocol          = "tcp"
-				cidr_blocks       = ["10.0.0.%d/32"]
-			}
+resource "aws_security_group_rule" "ingress%d" {
+    security_group_id = "${aws_security_group.race.id}"
+    type              = "ingress"
+    from_port         = %d
+    to_port           = %d
+    protocol          = "tcp"
+    cidr_blocks       = ["10.0.0.%d/32"]
+}
 
-			resource "aws_security_group_rule" "egress%d" {
-				security_group_id = "${aws_security_group.race.id}"
-				type              = "egress"
-				from_port         = %d
-				to_port           = %d
-				protocol          = "tcp"
-				cidr_blocks       = ["10.0.0.%d/32"]
-			}
-		`, i, i, i, i, i, i, i, i))
+resource "aws_security_group_rule" "egress%d" {
+    security_group_id = "${aws_security_group.race.id}"
+    type              = "egress"
+    from_port         = %d
+    to_port           = %d
+    protocol          = "tcp"
+    cidr_blocks       = ["10.0.0.%d/32"]
+}
+        `, i, i, i, i, i, i, i, i))
 	}
 	return b.String()
 }()
 
 func testAccAWSSecurityGroupRuleSelfInSource(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "foo" {
-		cidr_block = "10.1.0.0/16"
+resource "aws_vpc" "foo" {
+    cidr_block = "10.1.0.0/16"
 
-		tags {
-			Name = "terraform-testacc-security-group-rule-self-ingress"
-		}
-	}
+    tags {
+        Name = "terraform-testacc-security-group-rule-self-ingress"
+    }
+}
 
-	resource "aws_security_group" "web" {
-		name        = "allow_all-%d"
-		description = "Allow all inbound traffic"
-		vpc_id      = "${aws_vpc.foo.id}"
-	}
+resource "aws_security_group" "web" {
+    name        = "allow_all-%d"
+    description = "Allow all inbound traffic"
+    vpc_id      = "${aws_vpc.foo.id}"
+}
 
-	resource "aws_security_group_rule" "allow_self" {
-		type                     = "ingress"
-		from_port                = 0
-		to_port                  = 0
-		protocol                 = "-1"
-		security_group_id        = "${aws_security_group.web.id}"
-		source_security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+resource "aws_security_group_rule" "allow_self" {
+    type                     = "ingress"
+    from_port                = 0
+    to_port                  = 0
+    protocol                 = "-1"
+    security_group_id        = "${aws_security_group.web.id}"
+    source_security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 func testAccAWSSecurityGroupRuleExpectInvalidType(rInt int) string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "foo" {
-		cidr_block = "10.1.0.0/16"
+resource "aws_vpc" "foo" {
+    cidr_block = "10.1.0.0/16"
 
-		tags {
-			Name = "terraform-testacc-security-group-rule-invalid-type"
-		}
-	}
+    tags {
+        Name = "terraform-testacc-security-group-rule-invalid-type"
+    }
+}
 
-	resource "aws_security_group" "web" {
-		name        = "allow_all-%d"
-		description = "Allow all inbound traffic"
-		vpc_id      = "${aws_vpc.foo.id}"
-	}
+resource "aws_security_group" "web" {
+    name        = "allow_all-%d"
+    description = "Allow all inbound traffic"
+    vpc_id      = "${aws_vpc.foo.id}"
+}
 
-	resource "aws_security_group_rule" "allow_self" {
-		type                     = "foobar"
-		from_port                = 0
-		to_port                  = 0
-		protocol                 = "-1"
-		security_group_id        = "${aws_security_group.web.id}"
-		source_security_group_id = "${aws_security_group.web.id}"
-	}`, rInt)
+resource "aws_security_group_rule" "allow_self" {
+    type                     = "foobar"
+    from_port                = 0
+    to_port                  = 0
+    protocol                 = "-1"
+    security_group_id        = "${aws_security_group.web.id}"
+    source_security_group_id = "${aws_security_group.web.id}"
+}
+    `, rInt)
 }
 
 func testAccAWSSecurityGroupRuleInvalidIPv4CIDR(rInt int) string {
@@ -1834,7 +1833,8 @@ resource "aws_security_group_rule" "ing" {
   protocol = "-1"
   cidr_blocks = ["1.2.3.4/33"]
   security_group_id = "${aws_security_group.foo.id}"
-}`, rInt)
+}
+    `, rInt)
 }
 
 func testAccAWSSecurityGroupRuleInvalidIPv6CIDR(rInt int) string {
@@ -1850,5 +1850,6 @@ resource "aws_security_group_rule" "ing" {
   protocol = "-1"
   ipv6_cidr_blocks = ["::/244"]
   security_group_id = "${aws_security_group.foo.id}"
-}`, rInt)
+}
+    `, rInt)
 }

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -142,6 +144,12 @@ func TestAccAWSSecurityGroupRule_Ingress_VPC(t *testing.T) {
 					testRuleCount,
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_1"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -178,6 +186,12 @@ func TestAccAWSSecurityGroupRule_Ingress_Protocol(t *testing.T) {
 						"aws_security_group_rule.ingress_1", "from_port", "80"),
 					testRuleCount,
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_1"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -219,6 +233,12 @@ func TestAccAWSSecurityGroupRule_Ingress_Ipv6(t *testing.T) {
 					testRuleCount,
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_1"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -256,6 +276,12 @@ func TestAccAWSSecurityGroupRule_Ingress_Classic(t *testing.T) {
 						"aws_security_group_rule.ingress_1", "from_port", "80"),
 					testRuleCount,
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_1"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -297,6 +323,12 @@ func TestAccAWSSecurityGroupRule_MultiIngress(t *testing.T) {
 					testMultiRuleCount,
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_2",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_2"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -317,6 +349,12 @@ func TestAccAWSSecurityGroupRule_Egress(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_1"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -334,6 +372,12 @@ func TestAccAWSSecurityGroupRule_SelfReference(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.self",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.self"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -412,6 +456,24 @@ func TestAccAWSSecurityGroupRule_PartialMatching_basic(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.nat_ingress", &group, &o, "ingress"),
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_security_group_rule.other",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.other"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_security_group_rule.nat_ingress",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.nat_ingress"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -456,6 +518,12 @@ func TestAccAWSSecurityGroupRule_PartialMatching_Source(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.source_ingress", &group, &p, "ingress"),
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.source_ingress",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.source_ingress"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -473,6 +541,12 @@ func TestAccAWSSecurityGroupRule_Issue5310(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.issue_5310", &group),
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.issue_5310",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.issue_5310"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -510,6 +584,12 @@ func TestAccAWSSecurityGroupRule_SelfSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.allow_self",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.allow_self"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -570,6 +650,12 @@ func TestAccAWSSecurityGroupRule_PrefixListEgress(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, &p, "egress"),
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_1"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -591,6 +677,12 @@ func TestAccAWSSecurityGroupRule_IngressDescription(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_1", "description", "TF acceptance test ingress rule"),
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_1"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -611,6 +703,12 @@ func TestAccAWSSecurityGroupRule_EgressDescription(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
 					resource.TestCheckResourceAttr("aws_security_group_rule.egress_1", "description", "TF acceptance test egress rule"),
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_1"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -642,6 +740,12 @@ func TestAccAWSSecurityGroupRule_IngressDescription_updates(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_security_group_rule.ingress_1", "description", "TF acceptance test ingress rule updated"),
 				),
 			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_1"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -671,6 +775,12 @@ func TestAccAWSSecurityGroupRule_EgressDescription_updates(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
 					resource.TestCheckResourceAttr("aws_security_group_rule.egress_1", "description", "TF acceptance test egress rule updated"),
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_1"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -784,6 +894,24 @@ func TestAccAWSSecurityGroupRule_MultiDescription(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_security_group_rule.ingress_rule_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_rule_1"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_rule_2",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_rule_2"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_security_group_rule.ingress_rule_3",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.ingress_rule_3"),
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSSecurityGroupRuleMultiDescription(rInt, "egress"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.worker", &group),
@@ -804,6 +932,30 @@ func TestAccAWSSecurityGroupRule_MultiDescription(t *testing.T) {
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_rule_4", &group, &rule4, "egress"),
 					resource.TestCheckResourceAttr("aws_security_group_rule.egress_rule_4", "description", "Prefix List Description"),
 				),
+			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_rule_1",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_rule_1"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_rule_2",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_rule_2"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_rule_3",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_rule_3"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_security_group_rule.egress_rule_4",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSecurityGroupRuleImportStateIdFunc("aws_security_group_rule.egress_rule_4"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -979,6 +1131,70 @@ func testAccCheckAWSSecurityGroupRuleAttributes(n string, group *ec2.SecurityGro
 
 		return fmt.Errorf("Error here\n\tlooking for %s, wasn't found in %s", p, rules)
 	}
+}
+
+func testAccAWSSecurityGroupRuleImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		sgID := rs.Primary.Attributes["security_group_id"]
+		ruleType := rs.Primary.Attributes["type"]
+		protocol := rs.Primary.Attributes["protocol"]
+		fromPort := rs.Primary.Attributes["from_port"]
+		toPort := rs.Primary.Attributes["to_port"]
+
+		cidrs, err := testAccAWSSecurityGroupRuleImportGetAttrs(rs.Primary.Attributes, "cidr_blocks")
+		if err != nil {
+			return "", err
+		}
+
+		ipv6CIDRs, err := testAccAWSSecurityGroupRuleImportGetAttrs(rs.Primary.Attributes, "ipv6_cidr_blocks")
+		if err != nil {
+			return "", err
+		}
+
+		prefixes, err := testAccAWSSecurityGroupRuleImportGetAttrs(rs.Primary.Attributes, "prefix_list_ids")
+		if err != nil {
+			return "", err
+		}
+
+		var parts []string
+		parts = append(parts, sgID)
+		parts = append(parts, ruleType)
+		parts = append(parts, protocol)
+		parts = append(parts, fromPort)
+		parts = append(parts, toPort)
+		parts = append(parts, *cidrs...)
+		parts = append(parts, *ipv6CIDRs...)
+		parts = append(parts, *prefixes...)
+
+		if sgSource, ok := rs.Primary.Attributes["source_security_group_id"]; ok {
+			parts = append(parts, sgSource)
+		}
+
+		if rs.Primary.Attributes["self"] == "true" {
+			parts = append(parts, "self")
+		}
+
+		return strings.Join(parts, "_"), nil
+	}
+}
+
+func testAccAWSSecurityGroupRuleImportGetAttrs(attrs map[string]string, key string) (*[]string, error) {
+	var values []string
+	if countStr, ok := attrs[fmt.Sprintf("%s.#", key)]; ok && countStr != "0" {
+		count, err := strconv.Atoi(countStr)
+		if err != nil {
+			return nil, err
+		}
+		for i := 0; i < count; i++ {
+			values = append(values, attrs[fmt.Sprintf("%s.%d", key, i)])
+		}
+	}
+	return &values, nil
 }
 
 func testAccAWSSecurityGroupRuleIngressConfig(rInt int) string {

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -87,3 +87,47 @@ In addition to all arguments above, the following attributes are exported:
 * `to_port` - The end port (or ICMP code if protocol is "icmp")
 * `protocol` – The protocol used
 * `description` – Description of the rule
+
+## Import
+
+Security Group Rules can be imported using the `security_group_id`, `type`, `protocol`, `from_port`, `to_port`, and source(s)/destination(s) (e.g. `cidr_block`) separated by underscores (`_`). All parts are required.
+
+Not all rule permissions (e.g., not all of a rule's CIDR blocks) need to be imported for Terraform to manage rule permissions. However, importing some of a rule's permissions but not others, and then making changes to the rule will result in the creation of an additional rule to capture the updated permissions. Rule permissions that were not imported are left intact in the original rule.
+
+### Examples
+
+Import an ingress rule in security group `sg-6e616f6d69` for TCP port 8000 with an IPv4 destination CIDR of `10.0.3.0/24`:
+
+```console
+$ terraform import aws_security_group_rule.ingress sg-6e616f6d69_ingress_tcp_8000_8000_10.0.3.0/24
+```
+
+Import a rule with various IPv4 and IPv6 source CIDR blocks:
+
+```console
+$ terraform import aws_security_group_rule.ingress sg-4973616163_ingress_tcp_100_121_10.1.0.0/16_2001:db8::/48_10.2.0.0/16_2002:db8::/48
+```
+
+Import a rule, applicable to all ports, with a protocol other than TCP/UDP/ICMP/ALL, e.g., Multicast Transport Protocol (MTP), using the IANA protocol number, e.g., 92.
+
+```console
+$ terraform import aws_security_group_rule.ingress sg-6777656e646f6c796e_ingress_92_0_65536_10.0.3.0/24_10.0.4.0/24
+```
+
+Import an egress rule with a prefix list ID destination:
+
+```console
+$ terraform import aws_security_group_rule.egress sg-62726f6479_egress_tcp_8000_8000_pl-6469726b
+```
+
+Import a rule applicable to all protocols and ports with a security group source:
+
+```console
+$ example: sg-7472697374616e_ingress_all_0_65536_sg-6176657279
+```
+
+Import a rule that has itself and an IPv6 CIDR block as sources:
+
+```console
+$ example: sg-656c65616e6f72_ingress_tcp_80_80_self_2001:db8::/48
+```


### PR DESCRIPTION
Fixes #2895

Changes proposed in this pull request:

* Add functionality to the existing resource `aws_security_group_rule` to allow for importing rules
* Add importing and import verification to the acceptance tests
* Add import documentation

## How it works

### Import string/ID

The import string/ID can be complex but manageable. It follows this format:

`SECURITYGROUPID_TYPE_PROTOCOL_FROMPORT_TOPORT_SOURCE[_SOURCE]*`

These are valid examples of import strings:
* `sg-09a093729ef9382a6_ingress_tcp_8000_8000_10.0.3.0/24`
* `sg-09a093729ef9382a6_ingress_92_0_65535_10.0.3.0/24_10.0.4.0/24` (multiple CIDR blocks)
* `sg-09a093729ef9382a6_egress_tcp_100_8000_10.0.3.0/24` (port range)
* `sg-09a093729ef9382a6_egress_tcp_8000_8000_pl-34800000` (prefix list id destination)
* `sg-09a093729ef9382a6_ingress_all_0_65535_sg-08123412342323`
* `sg-09a093729ef9382a6_ingress_tcp_100_121_10.1.0.0/16_2001:db8::/48_10.2.0.0/16_2002:db8::/48` (mixture of IPv4 and IPv6 CIDRs)
* `sg-09a093729ef9382a6_ingress_tcp_0_65535_self_2001:db8::/48` (self + IPv6 CIDR block)
* `sg-09a093729ef9382a6_ingress_92_0_65535_self` (if protocol is not TCP/UDP/ICMP/ALL then it must be a protocol number)

### All tricky functionality 

This captures all security group rule functionality including the tricky bits:
* as many CIDR blocks as someone wants to type
* self
* `all` protocols
* `all` ports
* port ranges
* multiple IPv4/6 CIDR blocks, prefix list IDs
* source/destination security groups

### Flexible: Config / import ID don't have to match

AWS is not particular about needing to modify an entire rule. Thus, you can partially import (i.e., some CIDR blocks but not others) and then update those within Terraform. AWS gracefully adjusts rules accordingly.

## Acceptance tests:

I added imports/state verification to 17 of 20 existing tests. Import didn't make sense for the other 3 -- 2 test error conditions and 1 tests a race condition.

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSSecurityGroupRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSSecurityGroupRule_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSecurityGroupRule_Ingress_VPC
--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (21.20s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Protocol
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (35.63s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Ipv6
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Ipv6 (35.64s)
=== RUN   TestAccAWSSecurityGroupRule_Ingress_Classic
--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (20.46s)
=== RUN   TestAccAWSSecurityGroupRule_MultiIngress
--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (23.22s)
=== RUN   TestAccAWSSecurityGroupRule_Egress
--- PASS: TestAccAWSSecurityGroupRule_Egress (18.58s)
=== RUN   TestAccAWSSecurityGroupRule_SelfReference
--- PASS: TestAccAWSSecurityGroupRule_SelfReference (35.63s)
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (0.85s)
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (0.98s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_basic
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (41.64s)
=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_Source
--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (37.77s)
=== RUN   TestAccAWSSecurityGroupRule_Issue5310
--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (18.91s)
=== RUN   TestAccAWSSecurityGroupRule_Race
--- PASS: TestAccAWSSecurityGroupRule_Race (318.46s)
=== RUN   TestAccAWSSecurityGroupRule_SelfSource
--- PASS: TestAccAWSSecurityGroupRule_SelfSource (35.23s)
=== RUN   TestAccAWSSecurityGroupRule_PrefixListEgress
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (50.37s)
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription (21.09s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription (20.27s)
=== RUN   TestAccAWSSecurityGroupRule_IngressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_IngressDescription_updates (30.31s)
=== RUN   TestAccAWSSecurityGroupRule_EgressDescription_updates
--- PASS: TestAccAWSSecurityGroupRule_EgressDescription_updates (29.49s)
=== RUN   TestAccAWSSecurityGroupRule_MultiDescription
--- PASS: TestAccAWSSecurityGroupRule_MultiDescription (87.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	866.721s
```