### PR TITLE
tests/resource/aws_ses_receipt_filter: Refactor and enhance testing

### DIFF
--- a/aws/resource_aws_ses_receipt_filter_test.go
+++ b/aws/resource_aws_ses_receipt_filter_test.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSSESReceiptFilter_importBasic(t *testing.T) {
+func TestAccAWSSESReceiptFilter_basic(t *testing.T) {
 	resourceName := "aws_ses_receipt_filter.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,31 +21,18 @@ func TestAccAWSSESReceiptFilter_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckSESReceiptFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSESReceiptFilterConfig,
+				Config: testAccAWSSESReceiptFilterConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESReceiptFilterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "10.10.10.10"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "policy", "Block"),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSSESReceiptFilter_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSESReceiptFilterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSESReceiptFilterConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESReceiptFilterExists("aws_ses_receipt_filter.test"),
-				),
 			},
 		},
 	})
@@ -61,17 +51,11 @@ func testAccCheckSESReceiptFilterDestroy(s *terraform.State) error {
 			return err
 		}
 
-		found := false
 		for _, element := range response.Filters {
-			if *element.Name == "block-some-ip" {
-				found = true
+			if aws.StringValue(element.Name) == rs.Primary.ID {
+				return fmt.Errorf("SES Receipt Filter (%s) still exists", rs.Primary.ID)
 			}
 		}
-
-		if found {
-			return fmt.Errorf("The receipt filter still exists")
-		}
-
 	}
 
 	return nil
@@ -96,25 +80,22 @@ func testAccCheckAwsSESReceiptFilterExists(n string) resource.TestCheckFunc {
 			return err
 		}
 
-		found := false
 		for _, element := range response.Filters {
-			if *element.Name == "block-some-ip" {
-				found = true
+			if aws.StringValue(element.Name) == rs.Primary.ID {
+				return nil
 			}
 		}
 
-		if !found {
-			return fmt.Errorf("The receipt filter was not created")
-		}
-
-		return nil
+		return fmt.Errorf("The receipt filter was not created")
 	}
 }
 
-const testAccAWSSESReceiptFilterConfig = `
+func testAccAWSSESReceiptFilterConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_ses_receipt_filter" "test" {
-    name = "block-some-ip"
-    cidr = "10.10.10.10"
-    policy = "Block"
+  cidr   = "10.10.10.10"
+  name   = %q
+  policy = "Block"
 }
-`
+`, rName)
+}


### PR DESCRIPTION
Changes proposed in this pull request:

* Consolidate importBasic acceptance test into basic acceptance test
* Randomize naming
* Additionally check Terraform state for cidr, name, and policy attribute

Previously:

```
--- FAIL: TestAccAWSSESReceiptFilter_basic (1.33s)
    testing.go:527: Step 0 error: Error applying: 1 error occurred:
        	* aws_ses_receipt_filter.test: 1 error occurred:
        	* aws_ses_receipt_filter.test: Error creating SES receipt filter: AlreadyExists: Filter already exists: block-some-ip
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSESReceiptFilter_basic (13.29s)
```
