### PR TITLE
tests/resource/aws_spot_fleet_request: Adjust spot_price for TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList

### DIFF
--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1286,7 +1286,7 @@ resource "aws_subnet" "bar" {
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.03"
+    spot_price = "0.05"
     target_capacity = 4
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true


### PR DESCRIPTION
At some point, we should try to switch this configuration to the `aws_pricing_product` data source to dynamically update the spot price and to be region agnostic, but for now this just fixes the test as-is.

Changes proposed in this pull request:

* Increase `spot_price` to be above threshold

Previously:

```
--- FAIL: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (65.49s)
    testing.go:527: Step 0 error: Error applying: 1 error occurred:
        	* aws_spot_fleet_request.foo: 1 error occurred:
        	* aws_spot_fleet_request.foo: Last events: [{
          EventInformation: {
            EventDescription: "m3.large, ami-d0f506b0, Linux/UNIX, us-west-2b, Spot bid price is less than Spot market price $0.0307",
            EventSubType: "launchSpecUnusable"
          },
          EventType: "information",
          Timestamp: 2018-09-30 21:22:15.683 +0000 UTC
        }]
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (271.34s)
```

