### PR TITLE
tests/resource/aws_iam_user_login_profile: Remove usage of acctest.RandIntRange()

### DIFF
--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -136,7 +135,6 @@ func TestAccAWSUserLoginProfile_notAKey(t *testing.T) {
 func TestAccAWSUserLoginProfile_PasswordLength(t *testing.T) {
 	var conf iam.GetLoginProfileOutput
 
-	passwordLength := acctest.RandIntRange(4, 128)
 	username := fmt.Sprintf("test-user-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
@@ -145,10 +143,10 @@ func TestAccAWSUserLoginProfile_PasswordLength(t *testing.T) {
 		CheckDestroy: testAccCheckAWSUserLoginProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSUserLoginProfileConfig_PasswordLength(username, "/", testPubKey1, passwordLength),
+				Config: testAccAWSUserLoginProfileConfig_PasswordLength(username, "/", testPubKey1, 128),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
-					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", strconv.Itoa(passwordLength)),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", "128"),
 				),
 			},
 		},


### PR DESCRIPTION
Not sure why `acctest.RandIntRange()` would generate an integer outside its defined range 🤔 , but we also do not need a random integer for this test.

Changes proposed in this pull request:

* Hardcode expected password length in `TestAccAWSUserLoginProfile_PasswordLength`

Previously:

```
--- FAIL: TestAccAWSUserLoginProfile_PasswordLength (0.50s)
    testing.go:527: Step 0 error: config is invalid: aws_iam_user_login_profile.user: expected password_length to be in the range (5 - 128), got 1
```

Output from acceptance testing:

```
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (13.13s)
```
