### PR TITLE
tests/resource/aws_dax_subnet_group: Refactor import acceptance test into basic acceptance test

### DIFF
--- a/aws/resource_aws_dax_subnet_group_test.go
+++ b/aws/resource_aws_dax_subnet_group_test.go
@@ -13,6 +13,8 @@ import (
 
 func TestAccAwsDaxSubnetGroup_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_dax_subnet_group.test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -35,22 +37,6 @@ func TestAccAwsDaxSubnetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_dax_subnet_group.test", "vpc_id"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAwsDaxSubnetGroup_import(t *testing.T) {
-	resourceName := "aws_dax_subnet_group.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDaxSubnetGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDaxSubnetGroupConfig(acctest.RandString(5)),
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,


### PR DESCRIPTION
The random name generation previously had issues, likely because it was failing the "must begin with a letter" condition. We don't need a separate testing for checking import anyways.

Changes proposed in this pull request:

* Combine import acceptance test into basic acceptance test

Previously:

```
--- FAIL: TestAccAwsDaxSubnetGroup_import (5.43s)
    testing.go:527: Step 0 error: Error applying: 1 error occurred:
        	* aws_dax_subnet_group.test: 1 error occurred:
        	* aws_dax_subnet_group.test: InvalidParameterValueException: The parameter CacheSubnetGroupName is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
```

Output from acceptance testing:

```
--- PASS: TestAccAwsDaxSubnetGroup_basic (56.58s)
```
