### PR TITLE
New resource: aws_pinpoint_adm_channel

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -673,6 +673,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_definition":                         resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                              resourceAwsBatchJobQueue(),
 			"aws_pinpoint_app":                                 resourceAwsPinpointApp(),
+			"aws_pinpoint_adm_channel":                         resourceAwsPinpointADMChannel(),
 			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),
 			"aws_pinpoint_sms_channel":                         resourceAwsPinpointSMSChannel(),
 

--- a/aws/resource_aws_pinpoint_adm_channel.go
+++ b/aws/resource_aws_pinpoint_adm_channel.go
@@ -1,0 +1,120 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsPinpointADMChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsPinpointADMChannelUpsert,
+		Read:   resourceAwsPinpointADMChannelRead,
+		Update: resourceAwsPinpointADMChannelUpsert,
+		Delete: resourceAwsPinpointADMChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"client_id": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"client_secret": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func resourceAwsPinpointADMChannelUpsert(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	applicationId := d.Get("application_id").(string)
+
+	d.SetId(applicationId)
+
+	params := &pinpoint.ADMChannelRequest{}
+
+	if d.HasChange("client_id") {
+		params.ClientId = aws.String(d.Get("client_id").(string))
+	}
+
+	if d.HasChange("client_secret") {
+		params.ClientSecret = aws.String(d.Get("client_secret").(string))
+	}
+
+	if d.HasChange("enabled") {
+		params.Enabled = aws.Bool(d.Get("enabled").(bool))
+	}
+
+	req := pinpoint.UpdateAdmChannelInput{
+		ApplicationId:     aws.String(applicationId),
+		ADMChannelRequest: params,
+	}
+
+	_, err := conn.UpdateAdmChannel(&req)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsPinpointADMChannelRead(d, meta)
+}
+
+func resourceAwsPinpointADMChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[INFO] Reading Pinpoint ADM Channel for application %s", d.Id())
+
+	channel, err := conn.GetAdmChannel(&pinpoint.GetAdmChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Pinpoint ADM Channel for application %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("application_id", channel.ADMChannelResponse.ApplicationId)
+	d.Set("enabled", channel.ADMChannelResponse.Enabled)
+
+	return nil
+}
+
+func resourceAwsPinpointADMChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[DEBUG] Pinpoint Delete ADM Channel: %s", d.Id())
+	_, err := conn.DeleteAdmChannel(&pinpoint.DeleteAdmChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/aws/resource_aws_pinpoint_adm_channel.go
+++ b/aws/resource_aws_pinpoint_adm_channel.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,7 +38,7 @@ func resourceAwsPinpointADMChannel() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 		},
 	}
@@ -47,8 +48,6 @@ func resourceAwsPinpointADMChannelUpsert(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).pinpointconn
 
 	applicationId := d.Get("application_id").(string)
-
-	d.SetId(applicationId)
 
 	params := &pinpoint.ADMChannelRequest{}
 
@@ -74,6 +73,8 @@ func resourceAwsPinpointADMChannelUpsert(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+	d.SetId(applicationId)
+
 	return resourceAwsPinpointADMChannelRead(d, meta)
 }
 
@@ -92,11 +93,12 @@ func resourceAwsPinpointADMChannelRead(d *schema.ResourceData, meta interface{})
 			return nil
 		}
 
-		return err
+		return fmt.Errorf("error getting Pinpoint ADM Channel for application %s: %s", d.Id(), err)
 	}
 
 	d.Set("application_id", channel.ADMChannelResponse.ApplicationId)
 	d.Set("enabled", channel.ADMChannelResponse.Enabled)
+	// client_id and client_secret are never returned
 
 	return nil
 }
@@ -114,7 +116,7 @@ func resourceAwsPinpointADMChannelDelete(d *schema.ResourceData, meta interface{
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting Pinpoint ADM Channel for application %s: %s", d.Id(), err)
 	}
 	return nil
 }

--- a/aws/resource_aws_pinpoint_adm_channel_test.go
+++ b/aws/resource_aws_pinpoint_adm_channel_test.go
@@ -27,11 +27,11 @@ type testAccAwsPinpointADMChannelConfiguration struct {
 func testAccAwsPinpointADMChannelConfigurationFromEnv(t *testing.T) *testAccAwsPinpointADMChannelConfiguration {
 
 	if os.Getenv("ADM_CLIENT_ID") == "" {
-		t.Fatalf("ADM_CLIENT_ID ENV is missing")
+		t.Skipf("ADM_CLIENT_ID ENV is missing")
 	}
 
 	if os.Getenv("ADM_CLIENT_SECRET") == "" {
-		t.Fatalf("ADM_CLIENT_SECRET ENV is missing")
+		t.Skipf("ADM_CLIENT_SECRET ENV is missing")
 	}
 
 	conf := testAccAwsPinpointADMChannelConfiguration{
@@ -63,6 +63,12 @@ func TestAccAWSPinpointADMChannel_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointADMChannelExists(resourceName, &channel),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_id", "client_secret"},
 			},
 		},
 	})

--- a/aws/resource_aws_pinpoint_adm_channel_test.go
+++ b/aws/resource_aws_pinpoint_adm_channel_test.go
@@ -1,0 +1,141 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+/**
+ Before running this test, the following two ENV variables must be set:
+
+ ADM_CLIENT_ID     - Amazon ADM OAuth Credentials Client ID
+ ADM_CLIENT_SECRET - Amazon ADM OAuth Credentials Client Secret
+**/
+
+type testAccAwsPinpointADMChannelConfiguration struct {
+	ClientID     string
+	ClientSecret string
+}
+
+func testAccAwsPinpointADMChannelConfigurationFromEnv(t *testing.T) *testAccAwsPinpointADMChannelConfiguration {
+
+	if os.Getenv("ADM_CLIENT_ID") == "" {
+		t.Fatalf("ADM_CLIENT_ID ENV is missing")
+	}
+
+	if os.Getenv("ADM_CLIENT_SECRET") == "" {
+		t.Fatalf("ADM_CLIENT_SECRET ENV is missing")
+	}
+
+	conf := testAccAwsPinpointADMChannelConfiguration{
+		ClientID:     os.Getenv("ADM_CLIENT_ID"),
+		ClientSecret: os.Getenv("ADM_CLIENT_SECRET"),
+	}
+
+	return &conf
+}
+
+func TestAccAWSPinpointADMChannel_basic(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.ADMChannelResponse
+	resourceName := "aws_pinpoint_adm_channel.channel"
+
+	config := testAccAwsPinpointADMChannelConfigurationFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointADMChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointADMChannelConfig_basic(config),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointADMChannelExists(resourceName, &channel),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPinpointADMChannelExists(n string, channel *pinpoint.ADMChannelResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Pinpoint ADM channel with that Application ID exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+		// Check if the ADM Channel exists
+		params := &pinpoint.GetAdmChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetAdmChannel(params)
+
+		if err != nil {
+			return err
+		}
+
+		*channel = *output.ADMChannelResponse
+
+		return nil
+	}
+}
+
+func testAccAWSPinpointADMChannelConfig_basic(conf *testAccAwsPinpointADMChannelConfiguration) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_adm_channel" "channel" {
+    application_id = "${aws_pinpoint_app.test_app.application_id}"
+
+    client_id     = "%s"
+    client_secret = "%s"
+    enabled       = true
+}
+`, conf.ClientID, conf.ClientSecret)
+}
+
+func testAccCheckAWSPinpointADMChannelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_pinpoint_adm_channel" {
+			continue
+		}
+
+		// Check if the ADM channel exists by fetching its attributes
+		params := &pinpoint.GetAdmChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetAdmChannel(params)
+		if err != nil {
+			if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("ADM Channel exists when it should be destroyed!")
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1679,6 +1679,9 @@
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-app") %>>
                             <a href="/docs/providers/aws/r/pinpoint_app.html">aws_pinpoint_app</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-pinpoint-adm-channel") %>>
+                            <a href="/docs/providers/aws/r/pinpoint_adm_channel.html">aws_pinpoint_adm_channel</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-event-stream") %>>
                             <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
                         </li>

--- a/website/docs/r/pinpoint_adm_channel.markdown
+++ b/website/docs/r/pinpoint_adm_channel.markdown
@@ -1,0 +1,47 @@
+---
+layout: "aws"
+page_title: "AWS: aws_pinpoint_adm_channel"
+sidebar_current: "docs-aws-resource-pinpoint-adm-channel"
+description: |-
+  Provides a Pinpoint ADM Channel resource.
+---
+
+# aws_pinpoint_adm_channel
+
+Provides a Pinpoint ADM (Amazon Device Messaging) Channel resource.
+
+~> **Note:** All arguments including the Client ID and Client Secret will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+
+## Example Usage
+
+```hcl
+resource "aws_pinpoint_app" "app" {}
+
+resource "aws_pinpoint_adm_channel" "channel" {
+    application_id = "${aws_pinpoint_app.app.application_id}"
+    client_id      = ""
+    client_secret  = ""
+    enabled        = true
+    
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The application ID.
+* `client_id` - (Required) Client ID (part of OAuth Credentials) obtained via Amazon Developer Account.
+* `client_secret` - (Required) Client Secret (part of OAuth Credentials) obtained via Amazon Developer Account.
+* `enabled` - (Optional) Specifies whether to enable the channel. Defaults to `false`.
+
+## Import
+
+Pinpoint ADM Channel can be imported using the `application-id`, e.g.
+
+```
+$ terraform import aws_pinpoint_adm_channel.channel application-id
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Work continues on #4990

Changes proposed in this pull request:

* New resource `aws_pinpoint_adm_channel` with related docs and acceptance tests 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointADMChannel'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointADMChannel -timeout 120m
=== RUN   TestAccAWSPinpointADMChannel_basic
--- PASS: TestAccAWSPinpointADMChannel_basic (19.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       21.018s
```

Couple notes/questions:
1. There is no chance to read `client_id` and `client_secret` from the get-response. I hope this is fine with the import phase (test passes).
2. In order to run the acceptance test the OAuth credentials must be valid. I handled the case with two ENV variables. (To obtain credentials one may follow this guide if necessary: https://developer.amazon.com/docs/adm/obtain-credentials.html ) . Is this the right approach?
3. Does it make sense to create a separate PR for each channel? (9 in total)