### PR TITLE
removing unfound ecs service from state file

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -487,7 +487,9 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 			if d.IsNewResource() {
 				return resource.RetryableError(fmt.Errorf("ECS service not created yet: %q", d.Id()))
 			}
-			return resource.NonRetryableError(fmt.Errorf("No ECS service found: %q", d.Id()))
+			log.Printf("[WARN] ECS Service %s not found, removing from state.", d.Id())
+			d.SetId("")
+			return nil
 		}
 
 		service := out.Services[0]

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -148,13 +148,6 @@ func TestAccAWSEcsService_basicImport(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Test non-existent resource import
-			{
-				ResourceName:      resourceName,
-				ImportStateId:     fmt.Sprintf("%s/nonexistent", clusterName),
-				ImportState:       true,
-				ImportStateVerify: false,
-			},
 		},
 	})
 }

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -154,7 +154,6 @@ func TestAccAWSEcsService_basicImport(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s/nonexistent", clusterName),
 				ImportState:       true,
 				ImportStateVerify: false,
-				ExpectError:       regexp.MustCompile(`No ECS service found`),
 			},
 		},
 	})

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -152,6 +152,31 @@ func TestAccAWSEcsService_basicImport(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsService_disappears(t *testing.T) {
+	var service ecs.Service
+	rString := acctest.RandString(8)
+
+	clusterName := fmt.Sprintf("tf-acc-cluster-svc-w-arn-%s", rString)
+	tdName := fmt.Sprintf("tf-acc-td-svc-w-arn-%s", rString)
+	svcName := fmt.Sprintf("tf-acc-svc-w-arn-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsService(clusterName, tdName, svcName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
+					testAccCheckAWSEcsServiceDisappears(&service),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSEcsService_withUnnormalizedPlacementStrategy(t *testing.T) {
 	var service ecs.Service
 	rString := acctest.RandString(8)
@@ -792,6 +817,22 @@ func testAccCheckAWSEcsServiceExists(name string, service *ecs.Service) resource
 		*service = *output.Services[0]
 
 		return nil
+	}
+}
+
+func testAccCheckAWSEcsServiceDisappears(service *ecs.Service) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ecsconn
+
+		input := &ecs.DeleteServiceInput{
+			Cluster: aws.String(*service.ClusterArn),
+			Service: aws.String(*service.ServiceName),
+			Force:   aws.Bool(true),
+		}
+
+		_, err := conn.DeleteService(input)
+
+		return err
 	}
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Removing unfound ecs service from statefile instead of throwing an error when running `terraform refresh` to resolve drift

note about acceptance tests: my corporate aws account is not allowed to perform some actions required to run acceptance tests. below is the output, account id/profile have been scrubbed out

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService*'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSEcsService* -timeout 120m
=== RUN   TestAccAWSEcsServiceDataSource_basic
--- PASS: TestAccAWSEcsServiceDataSource_basic (52.43s)
=== RUN   TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withARN (77.58s)
=== RUN   TestAccAWSEcsService_basicImport
--- PASS: TestAccAWSEcsService_basicImport (44.08s)
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (48.04s)
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (89.89s)
=== RUN   TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withRenamedCluster (82.52s)
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- FAIL: TestAccAWSEcsService_healthCheckGracePeriodSeconds (21.41s)
        testing.go:527: Step 2 error: Error applying: 2 errors occurred:
                        * aws_iam_role.ecs_service: 1 error occurred:
                        * aws_iam_role.ecs_service: Error creating IAM Role tf-acc-role-svc-w-hcgps-xvft7vse: AccessDenied: User: arn:aws:sts::aws_account_number:assumed-role/aws_profile is not authorized to perform: iam:CreateRole on resource: arn:aws:iam::aws_account_number:role/tf-acc-role-svc-w-hcgps-xvft7vse
                        status code: 403, request id: 8c8d5c95-c5bf-11e8-9d6d-435ec3fa931d


                        * aws_vpc.main: 1 error occurred:
                        * aws_vpc.main: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 0dbb3119-7f40-4343-82a6-2a2595c01050




=== RUN   TestAccAWSEcsService_withIamRole
--- FAIL: TestAccAWSEcsService_withIamRole (16.24s)
        testing.go:527: Step 0 error: Error applying: 2 errors occurred:
                        * aws_iam_role.ecs_service: 1 error occurred:
                        * aws_iam_role.ecs_service: Error creating IAM Role tf-acc-role-svc-w-iam-role-4yc2quyc: AccessDenied: User: arn:aws:sts::aws_account_number:assumed-role/aws_profile is not authorized to perform: iam:CreateRole on resource: arn:aws:iam::aws_account_number:role/tf-acc-role-svc-w-iam-role-4yc2quyc
                        status code: 403, request id: 977b8482-c5bf-11e8-82b7-9513ec8e5604


                        * aws_elb.main: 1 error occurred:
                        * aws_elb.main: AccessDenied: User: arn:aws:sts::aws_account_number:assumed-role/aws_profile is not authorized to perform: ec2:CreateSecurityGroup
                        status code: 403, request id: 97a02447-c5bf-11e8-ad34-a9caa0ed026f




=== RUN   TestAccAWSEcsService_withDeploymentValues
--- PASS: TestAccAWSEcsService_withDeploymentValues (51.68s)
=== RUN   TestAccAWSEcsService_withLbChanges
--- FAIL: TestAccAWSEcsService_withLbChanges (67.02s)
        testing.go:527: Step 0 error: Error applying: 2 errors occurred:
                        * aws_iam_role.ecs_service: 1 error occurred:
                        * aws_iam_role.ecs_service: Error creating IAM Role tf-acc-role-svc-w-lbc-l9ziw4xb: AccessDenied: User: arn:aws:sts::aws_account_number:assumed-role/aws_profile is not authorized to perform: iam:CreateRole on resource: arn:aws:iam::aws_account_number:role/tf-acc-role-svc-w-lbc-l9ziw4xb
                        status code: 403, request id: c1862791-c5bf-11e8-8720-f72ce63c99cf


                        * aws_elb.main: 1 error occurred:
                        * aws_elb.main: AccessDenied: User: arn:aws:sts::aws_account_number:assumed-role/aws_profile is not authorized to perform: ec2:CreateSecurityGroup
                        status code: 403, request id: d5ab9fec-c5bf-11e8-afec-f737cfce2486




=== RUN   TestAccAWSEcsService_withEcsClusterName
--- PASS: TestAccAWSEcsService_withEcsClusterName (40.68s)
=== RUN   TestAccAWSEcsService_withAlb
--- FAIL: TestAccAWSEcsService_withAlb (29.47s)
        testing.go:527: Step 0 error: Error applying: 2 errors occurred:
                        * aws_iam_role.ecs_service: 1 error occurred:
                        * aws_iam_role.ecs_service: Error creating IAM Role tf-acc-role-svc-w-alb-jarde82x: AccessDenied: User: arn:aws:sts::aws_account_number:assumed-role/aws_profile is not authorized to perform: iam:CreateRole on resource: arn:aws:iam::aws_account_number:role/tf-acc-role-svc-w-alb-jarde82x
                        status code: 403, request id: 06df72a2-c5c0-11e8-9d6d-435ec3fa931d


                        * aws_vpc.main: 1 error occurred:
                        * aws_vpc.main: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 186713db-f3c7-4b8b-a738-a3957b61d227




=== RUN   TestAccAWSEcsService_withPlacementStrategy
--- PASS: TestAccAWSEcsService_withPlacementStrategy (134.49s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints
--- PASS: TestAccAWSEcsService_withPlacementConstraints (51.19s)
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (39.85s)
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- FAIL: TestAccAWSEcsService_withLaunchTypeFargate (56.44s)
        testing.go:527: Step 0 error: Error applying: 1 error occurred:
                        * aws_vpc.main: 1 error occurred:
                        * aws_vpc.main: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 845c93fc-0f3e-49fc-8d23-4d2921157e2d




        testing.go:527: Step 0 error: Error applying: 1 error occurred:
                        * aws_vpc.main: 1 error occurred:
                        * aws_vpc.main: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 0b9abc5b-3a8a-45b8-8a68-fc88590c4285




        testing.go:527: Step 0 error: Error applying: 1 error occurred:
                        * aws_vpc.main: 1 error occurred:
                        * aws_vpc.main: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 01bf5345-9953-447f-af31-dd2e7c4b67aa




=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
--- FAIL: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (56.57s)
        testing.go:527: Step 0 error: Error applying: 1 error occurred:
                        * aws_vpc.main: 1 error occurred:
                        * aws_vpc.main: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 98fa3fdd-bcef-4080-8d05-3f3917811d28




=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategy
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (49.64s)
=== RUN   TestAccAWSEcsService_withReplicaSchedulingStrategy
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (52.12s)
=== RUN   TestAccAWSEcsService_withServiceRegistries
--- FAIL: TestAccAWSEcsService_withServiceRegistries (21.18s)
        testing.go:527: Step 0 error: Error applying: 1 error occurred:
                        * aws_vpc.test: 1 error occurred:
                        * aws_vpc.test: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 1799a702-d690-4b34-b2d1-42fe65182355




=== RUN   TestAccAWSEcsService_withServiceRegistries_container
--- FAIL: TestAccAWSEcsService_withServiceRegistries_container (21.69s)
        testing.go:527: Step 0 error: Error applying: 1 error occurred:
                        * aws_vpc.test: 1 error occurred:
                        * aws_vpc.test: Error creating VPC: UnauthorizedOperation: You are not authorized to perform this operation.
                        status code: 403, request id: 4704308a-daa5-4902-b28d-d0ba9b30074a




FAIL
exit status 1
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       1108.355s
make: *** [testacc] Error 1
```
