### PR TITLE
Use current instance types in examples.

### DIFF
--- a/website/docs/r/dax_cluster.html.markdown
+++ b/website/docs/r/dax_cluster.html.markdown
@@ -16,7 +16,7 @@ Provides a DAX Cluster resource.
 resource "aws_dax_cluster" "bar" {
   cluster_name       = "cluster-example"
   iam_role_arn       = "${data.aws_iam_role.example.arn}"
-  node_type          = "dax.r3.large"
+  node_type          = "dax.r4.large"
   replication_factor = 1
 }
 ```

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -27,7 +27,7 @@ See the AWS Docs on [Modifying an ElastiCache Cache Cluster][2] for more informa
 resource "aws_elasticache_cluster" "example" {
   cluster_id           = "cluster-example"
   engine               = "memcached"
-  node_type            = "cache.m3.medium"
+  node_type            = "cache.m4.medium"
   num_cache_nodes      = 2
   parameter_group_name = "default.memcached1.4"
   port                 = 11211
@@ -40,7 +40,7 @@ resource "aws_elasticache_cluster" "example" {
 resource "aws_elasticache_cluster" "example" {
   cluster_id           = "cluster-example"
   engine               = "redis"
-  node_type            = "cache.m3.medium"
+  node_type            = "cache.m4.medium"
   num_cache_nodes      = 1
   parameter_group_name = "default.redis3.2"
   port                 = 6379

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -24,7 +24,7 @@ resource "aws_elasticache_replication_group" "example" {
   availability_zones            = ["us-west-2a", "us-west-2b"]
   replication_group_id          = "tf-rep-group-1"
   replication_group_description = "test description"
-  node_type                     = "cache.m3.medium"
+  node_type                     = "cache.m4.medium"
   number_cache_clusters         = 2
   parameter_group_name          = "default.redis3.2"
   port                          = 6379
@@ -42,7 +42,7 @@ resource "aws_elasticache_replication_group" "example" {
   availability_zones            = ["us-west-2a", "us-west-2b"]
   replication_group_id          = "tf-rep-group-1"
   replication_group_description = "test description"
-  node_type                     = "cache.m3.medium"
+  node_type                     = "cache.m4.medium"
   number_cache_clusters         = 2
   parameter_group_name          = "default.redis3.2"
   port                          = 6379
@@ -68,7 +68,7 @@ To create two shards with a primary and a single read replica each:
 resource "aws_elasticache_replication_group" "baz" {
   replication_group_id          = "tf-redis-cluster"
   replication_group_description = "test description"
-  node_type                     = "cache.m1.small"
+  node_type                     = "cache.t2.small"
   port                          = 6379
   parameter_group_name          = "default.redis3.2.cluster.on"
   automatic_failover_enabled    = true

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -24,7 +24,7 @@ resource "aws_elasticsearch_domain" "es" {
   domain_name           = "${var.domain}"
   elasticsearch_version = "1.5"
   cluster_config {
-    instance_type = "r3.large.elasticsearch"
+    instance_type = "r4.large.elasticsearch"
   }
 
   advanced_options {

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -84,8 +84,8 @@ EOF
 }
   ebs_root_volume_size     = 100
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "m5.xlarge"
+  core_instance_type   = "m5.xlarge"
   core_instance_count  = 1
 
   tags {
@@ -355,8 +355,8 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  master_instance_type = "m3.xlarge"
-  core_instance_type   = "m3.xlarge"
+  master_instance_type = "m5.xlarge"
+  core_instance_type   = "m5.xlarge"
   core_instance_count  = 1
 
   tags {

--- a/website/docs/r/emr_instance_group.html.markdown
+++ b/website/docs/r/emr_instance_group.html.markdown
@@ -21,7 +21,7 @@ Terraform will resize any Instance Group to zero when destroying the resource.
 resource "aws_emr_instance_group" "task" {
   cluster_id     = "${aws_emr_cluster.tf-test-cluster.id}"
   instance_count = 1
-  instance_type  = "m3.xlarge"
+  instance_type  = "m5.xlarge"
   name           = "my little instance group"
 }
 ```

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -28,7 +28,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count              = 2
   identifier         = "aurora-cluster-demo-${count.index}"
   cluster_identifier = "${aws_rds_cluster.default.id}"
-  instance_class     = "db.r3.large"
+  instance_class     = "db.r4.large"
 }
 
 resource "aws_rds_cluster" "default" {

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -70,7 +70,7 @@ resource "aws_spot_fleet_request" "foo" {
   }
 
   launch_specification {
-    instance_type     = "m3.large"
+    instance_type     = "m5.large"
     ami               = "ami-d06a90b0"
     key_name          = "my-key"
     availability_zone = "us-west-2a"


### PR DESCRIPTION
For users who hypothetically copy and paste config from docs, let's reference current instance types so that nobody is using `r3`s instead of `r4`s.
