### PR TITLE
resource/aws_network_interface_sg_attachment: Properly handle InvalidNetworkInterfaceID.NotFound errors

### DIFF
--- a/aws/resource_aws_network_interface_sg_attachment_test.go
+++ b/aws/resource_aws_network_interface_sg_attachment_test.go
@@ -2,227 +2,363 @@ package aws
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSNetworkInterfaceSGAttachment(t *testing.T) {
-	cases := []struct {
-		Name         string
-		ResourceAttr string
-		Config       func(bool) string
-	}{
-		{
-			Name:         "instance primary interface",
-			ResourceAttr: "primary_network_interface_id",
-			Config:       testAccAwsNetworkInterfaceSGAttachmentConfigViaInstance,
-		},
-		{
-			Name:         "externally supplied instance through data source",
-			ResourceAttr: "network_interface_id",
-			Config:       testAccAwsNetworkInterfaceSGAttachmentConfigViaDataSource,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
-			resource.Test(t, resource.TestCase{
-				PreCheck:  func() { testAccPreCheck(t) },
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: tc.Config(true),
-						Check:  checkSecurityGroupAttached(tc.ResourceAttr, true),
-					},
-					{
-						Config: tc.Config(false),
-						Check:  checkSecurityGroupAttached(tc.ResourceAttr, false),
-					},
-				},
-			})
-		})
-	}
-}
+func TestAccAWSNetworkInterfaceSGAttachment_basic(t *testing.T) {
+	var networkInterface ec2.NetworkInterface
+	networkInterfaceResourceName := "aws_network_interface.test"
+	securityGroupResourceName := "aws_security_group.test"
+	resourceName := "aws_network_interface_sg_attachment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-func checkSecurityGroupAttached(attr string, expected bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-
-		interfaceID := s.Modules[0].Resources["aws_instance.instance"].Primary.Attributes[attr]
-		sgID := s.Modules[0].Resources["aws_security_group.sg"].Primary.ID
-
-		iface, err := fetchNetworkInterface(conn, interfaceID)
-		if err != nil {
-			return err
-		}
-		actual := sgExistsInENI(sgID, iface)
-		if expected != actual {
-			return fmt.Errorf("expected existence of security group in ENI to be %t, got %t", expected, actual)
-		}
-		return nil
-	}
-}
-
-func testAccAwsNetworkInterfaceSGAttachmentConfigViaInstance(attachmentEnabled bool) string {
-	return fmt.Sprintf(`
-variable "sg_attachment_enabled" {
-  type    = "string"
-  default = "%t"
-}
-
-data "aws_ami" "ami" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-hvm-*"]
-  }
-
-  owners = ["amazon"]
-}
-
-resource "aws_instance" "instance" {
-  instance_type = "t2.micro"
-  ami           = "${data.aws_ami.ami.id}"
-
-  tags = {
-    "type" = "terraform-test-instance"
-  }
-}
-
-resource "aws_security_group" "sg" {
-  tags = {
-    "type" = "terraform-test-security-group"
-  }
-}
-
-resource "aws_network_interface_sg_attachment" "sg_attachment" {
-  count                = "${var.sg_attachment_enabled == "true" ? 1 : 0}"
-  security_group_id    = "${aws_security_group.sg.id}"
-  network_interface_id = "${aws_instance.instance.primary_network_interface_id}"
-}
-`, attachmentEnabled)
-}
-
-func testAccAwsNetworkInterfaceSGAttachmentConfigViaDataSource(attachmentEnabled bool) string {
-	return fmt.Sprintf(`
-variable "sg_attachment_enabled" {
-  type    = "string"
-  default = "%t"
-}
-
-data "aws_ami" "ami" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-hvm-*"]
-  }
-
-  owners = ["amazon"]
-}
-
-resource "aws_instance" "instance" {
-  instance_type = "t2.micro"
-  ami           = "${data.aws_ami.ami.id}"
-
-  tags = {
-    "type" = "terraform-test-instance"
-  }
-}
-
-data "aws_instance" "external_instance" {
-  instance_id = "${aws_instance.instance.id}"
-}
-
-resource "aws_security_group" "sg" {
-  tags = {
-    "type" = "terraform-test-security-group"
-  }
-}
-
-resource "aws_network_interface_sg_attachment" "sg_attachment" {
-  count                = "${var.sg_attachment_enabled == "true" ? 1 : 0}"
-  security_group_id    = "${aws_security_group.sg.id}"
-  network_interface_id = "${data.aws_instance.external_instance.network_interface_id}"
-}
-`, attachmentEnabled)
-}
-
-func TestAccAWSNetworkInterfaceSGAttachmentRaceCheck(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkInterfaceSGAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsNetworkInterfaceSGAttachmentRaceCheckConfig(),
-				Check:  checkSecurityGroupAttachmentRace(),
+				Config: testAccAwsNetworkInterfaceSGAttachmentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName, &networkInterface),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", networkInterfaceResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", securityGroupResourceName, "id"),
+				),
 			},
 		},
 	})
 }
 
-// sgRaceCheckCount specifies the amount of security groups to create in the
-// race check. This should be the maximum amount of security groups that can be
-// attached to an interface at once, minus the default (we don't remove it in
-// the config).
-const sgRaceCheckCount = 4
+func TestAccAWSNetworkInterfaceSGAttachment_disappears(t *testing.T) {
+	var networkInterface ec2.NetworkInterface
+	resourceName := "aws_network_interface_sg_attachment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-func checkSecurityGroupAttachmentRace() resource.TestCheckFunc {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkInterfaceSGAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsNetworkInterfaceSGAttachmentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName, &networkInterface),
+					testAccCheckAwsNetworkInterfaceSGAttachmentDisappears(resourceName, &networkInterface),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAwsNetworkInterfaceSGAttachmentConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName, &networkInterface),
+					testAccCheckAWSENIDisappears(&networkInterface),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSNetworkInterfaceSGAttachment_Instance(t *testing.T) {
+	var networkInterface ec2.NetworkInterface
+	instanceResourceName := "aws_instance.test"
+	securityGroupResourceName := "aws_security_group.test"
+	resourceName := "aws_network_interface_sg_attachment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkInterfaceSGAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsNetworkInterfaceSGAttachmentConfigViaInstance(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName, &networkInterface),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceResourceName, "primary_network_interface_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", securityGroupResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNetworkInterfaceSGAttachment_DataSource(t *testing.T) {
+	var networkInterface ec2.NetworkInterface
+	instanceDataSourceName := "data.aws_instance.test"
+	securityGroupResourceName := "aws_security_group.test"
+	resourceName := "aws_network_interface_sg_attachment.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkInterfaceSGAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsNetworkInterfaceSGAttachmentConfigViaDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName, &networkInterface),
+					resource.TestCheckResourceAttrPair(resourceName, "network_interface_id", instanceDataSourceName, "network_interface_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", securityGroupResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNetworkInterfaceSGAttachment_Multiple(t *testing.T) {
+	var networkInterface ec2.NetworkInterface
+	networkInterfaceResourceName := "aws_network_interface.test"
+	securityGroupResourceName1 := "aws_security_group.test.0"
+	securityGroupResourceName2 := "aws_security_group.test.1"
+	securityGroupResourceName3 := "aws_security_group.test.2"
+	securityGroupResourceName4 := "aws_security_group.test.3"
+	resourceName1 := "aws_network_interface_sg_attachment.test.0"
+	resourceName2 := "aws_network_interface_sg_attachment.test.1"
+	resourceName3 := "aws_network_interface_sg_attachment.test.2"
+	resourceName4 := "aws_network_interface_sg_attachment.test.3"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkInterfaceSGAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsNetworkInterfaceSGAttachmentConfigMultiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName1, &networkInterface),
+					resource.TestCheckResourceAttrPair(resourceName1, "network_interface_id", networkInterfaceResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName1, "security_group_id", securityGroupResourceName1, "id"),
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName2, &networkInterface),
+					resource.TestCheckResourceAttrPair(resourceName2, "network_interface_id", networkInterfaceResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName2, "security_group_id", securityGroupResourceName2, "id"),
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName3, &networkInterface),
+					resource.TestCheckResourceAttrPair(resourceName3, "network_interface_id", networkInterfaceResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName3, "security_group_id", securityGroupResourceName3, "id"),
+					testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName4, &networkInterface),
+					resource.TestCheckResourceAttrPair(resourceName4, "network_interface_id", networkInterfaceResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName4, "security_group_id", securityGroupResourceName4, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSNetworkInterfaceSGAttachmentExists(resourceName string, networkInterface *ec2.NetworkInterface) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-
-		interfaceID := s.Modules[0].Resources["aws_network_interface.interface"].Primary.ID
-		for i := 0; i < sgRaceCheckCount; i++ {
-			sgID := s.Modules[0].Resources["aws_security_group.sg."+strconv.Itoa(i)].Primary.ID
-			iface, err := fetchNetworkInterface(conn, interfaceID)
-			if err != nil {
-				return err
-			}
-			if !sgExistsInENI(sgID, iface) {
-				return fmt.Errorf("security group ID %s was not attached to ENI ID %s", sgID, interfaceID)
-			}
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No resource ID set: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		networkInterfaceID := rs.Primary.Attributes["network_interface_id"]
+		securityGroupID := rs.Primary.Attributes["security_group_id"]
+
+		iface, err := fetchNetworkInterface(conn, networkInterfaceID)
+		if err != nil {
+			return fmt.Errorf("ENI (%s) not found: %s", networkInterfaceID, err)
+		}
+
+		if !sgExistsInENI(securityGroupID, iface) {
+			return fmt.Errorf("Security Group ID (%s) not attached to ENI (%s)", securityGroupID, networkInterfaceID)
+		}
+
+		*networkInterface = *iface
+
 		return nil
 	}
 }
 
-func testAccAwsNetworkInterfaceSGAttachmentRaceCheckConfig() string {
-	return fmt.Sprintf(`
-variable "security_group_count" {
-  type    = "string"
-  default = "%d"
+func testAccCheckAWSNetworkInterfaceSGAttachmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_network_interface_sg_attachment" {
+			continue
+		}
+
+		networkInterfaceID := rs.Primary.Attributes["network_interface_id"]
+		securityGroupID := rs.Primary.Attributes["security_group_id"]
+
+		networkInterface, err := fetchNetworkInterface(conn, networkInterfaceID)
+
+		if isAWSErr(err, "InvalidNetworkInterfaceID.NotFound", "") {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("ENI (%s) not found: %s", networkInterfaceID, err)
+		}
+
+		if sgExistsInENI(securityGroupID, networkInterface) {
+			return fmt.Errorf("Security Group ID (%s) still attached to ENI (%s)", securityGroupID, networkInterfaceID)
+		}
+	}
+
+	return nil
 }
 
+func testAccCheckAwsNetworkInterfaceSGAttachmentDisappears(resourceName string, networkInterface *ec2.NetworkInterface) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		securityGroupID := rs.Primary.Attributes["security_group_id"]
+
+		return delSGFromENI(conn, securityGroupID, networkInterface)
+	}
+}
+
+func testAccAwsNetworkInterfaceSGAttachmentConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.16.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "172.16.10.0/24"
+  vpc_id     = "${aws_vpc.test.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = %q
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = "${aws_subnet.test.id}"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_network_interface_sg_attachment" "test" {
+  network_interface_id = "${aws_network_interface.test.id}"
+  security_group_id    = "${aws_security_group.test.id}"
+}
+`, rName, rName, rName, rName)
+}
+
+func testAccAwsNetworkInterfaceSGAttachmentConfigViaInstance(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ami" "ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*"]
+  }
+
+  owners = ["amazon"]
+}
+
+resource "aws_instance" "test" {
+  instance_type = "t2.micro"
+  ami           = "${data.aws_ami.ami.id}"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_security_group" "test" {
+  name = %q
+}
+
+resource "aws_network_interface_sg_attachment" "test" {
+  network_interface_id = "${aws_instance.test.primary_network_interface_id}"
+  security_group_id    = "${aws_security_group.test.id}"
+}
+`, rName, rName)
+}
+
+func testAccAwsNetworkInterfaceSGAttachmentConfigViaDataSource(rName string) string {
+	return fmt.Sprintf(`
+data "aws_ami" "ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*"]
+  }
+
+  owners = ["amazon"]
+}
+
+resource "aws_instance" "test" {
+  instance_type = "t2.micro"
+  ami           = "${data.aws_ami.ami.id}"
+
+  tags = {
+    Name = %q
+  }
+}
+
+data "aws_instance" "test" {
+  instance_id = "${aws_instance.test.id}"
+}
+
+resource "aws_security_group" "test" {
+  name = %q
+}
+
+resource "aws_network_interface_sg_attachment" "test" {
+  security_group_id    = "${aws_security_group.test.id}"
+  network_interface_id = "${data.aws_instance.test.network_interface_id}"
+}
+`, rName, rName)
+}
+
+func testAccAwsNetworkInterfaceSGAttachmentConfigMultiple(rName string) string {
+	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
-data "aws_subnet" "subnet" {
+data "aws_subnet" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   default_for_az    = "true"
 }
 
-resource "aws_network_interface" "interface" {
-  subnet_id = "${data.aws_subnet.subnet.id}"
+resource "aws_network_interface" "test" {
+  subnet_id = "${data.aws_subnet.test.id}"
 
   tags = {
-    "type" = "terraform-test-network-interface"
+    Name = %q
   }
 }
 
-resource "aws_security_group" "sg" {
-  count = "${var.security_group_count}"
-
-  tags = {
-    "type" = "terraform-test-security-group"
-  }
+resource "aws_security_group" "test" {
+  count = 4
+  name  = "%s-${count.index}"
 }
 
-resource "aws_network_interface_sg_attachment" "sg_attachment" {
-  count                = "${var.security_group_count}"
-  security_group_id    = "${aws_security_group.sg.*.id[count.index]}"
-  network_interface_id = "${aws_network_interface.interface.id}"
+resource "aws_network_interface_sg_attachment" "test" {
+  count                = 4
+  network_interface_id = "${aws_network_interface.test.id}"
+  security_group_id    = "${aws_security_group.test.*.id[count.index]}"
 }
-`, sgRaceCheckCount)
+`, rName, rName)
 }

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -60,6 +60,27 @@ func TestAccAWSENI_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSENI_disappears(t *testing.T) {
+	var networkInterface ec2.NetworkInterface
+	resourceName := "aws_network_interface.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSENIConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists(resourceName, &networkInterface),
+					testAccCheckAWSENIDisappears(&networkInterface),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSENI_updatedDescription(t *testing.T) {
 	var conf ec2.NetworkInterface
 
@@ -297,6 +318,19 @@ func testAccCheckAWSENIDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckAWSENIDisappears(networkInterface *ec2.NetworkInterface) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		input := &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: networkInterface.NetworkInterfaceId,
+		}
+		_, err := conn.DeleteNetworkInterface(input)
+
+		return err
+	}
 }
 
 func testAccCheckAWSENIMakeExternalAttachment(n string, conf *ec2.NetworkInterface) resource.TestCheckFunc {


### PR DESCRIPTION
Fixes #1796

Changes:
* Refactor `aws_network_interface_sg_attachments` acceptance testing to align with other resources
* Add `testAccCheckAWSENIDisappears`
* Add `TestAccAWSNetworkInterfaceSGAttachment_disappears` acceptance test for verifying error handling
* Ensure `aws_network_interface_sg_attachment` resource removes resource during Read and exits successfully during Delete if it receives `InvalidNetworkInterfaceID.NotFound` error

Previously (before code updates):

```
--- PASS: TestAccAWSENI_disappears (35.81s)
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_Multiple (33.03s)
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_basic (34.00s)
--- FAIL: TestAccAWSNetworkInterfaceSGAttachment_disappears (41.18s)
    testing.go:527: Step 1 error: Error on follow-up refresh: 1 error occurred:
        	* aws_network_interface_sg_attachment.test: 1 error occurred:
        	* aws_network_interface_sg_attachment.test: aws_network_interface_sg_attachment.test: InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'eni-06f5470ea633d8b1c' does not exist
        	status code: 400, request id: 8f424390-cf91-4ef7-9d03-ed6e8711244c
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_DataSource (113.03s)
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_Instance (119.99s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_Multiple (33.00s)
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_basic (35.31s)
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_disappears (50.21s)
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_DataSource (115.76s)
--- PASS: TestAccAWSNetworkInterfaceSGAttachment_Instance (131.26s)
```