### PR TITLE
Support all DX connection speeds

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1717,7 +1717,15 @@ func validateCognitoUserPoolDomain(v interface{}, k string) (ws []string, errors
 }
 
 func validateDxConnectionBandWidth() schema.SchemaValidateFunc {
-	return validation.StringInSlice([]string{"1Gbps", "10Gbps"}, false)
+	return validation.StringInSlice([]string{
+		"1Gbps",
+		"10Gbps",
+		"50Mbps",
+		"100Mbps",
+		"200Mbps",
+		"300Mbps",
+		"400Mbps",
+		"500Mbps"}, false)
 }
 
 func validateKmsKey(v interface{}, k string) (ws []string, errors []error) {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2979,3 +2979,38 @@ func TestValidateCloudFrontPublicKeyNamePrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateDxConnectionBandWidth(t *testing.T) {
+	validBandwidths := []string{
+		"1Gbps",
+		"10Gbps",
+		"50Mbps",
+		"100Mbps",
+		"200Mbps",
+		"300Mbps",
+		"400Mbps",
+		"500Mbps",
+	}
+	for _, v := range validBandwidths {
+		_, errors := validateDxConnectionBandWidth()(v, "bandwidth")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid bandwidth: %q", v, errors)
+		}
+	}
+
+	invalidBandwidths := []string{
+		"1Tbps",
+		"100Gbps",
+		"10GBpS",
+		"42Mbps",
+		"0",
+		"???",
+		"a lot",
+	}
+	for _, v := range invalidBandwidths {
+		_, errors := validateDxConnectionBandWidth()(v, "bandwidth")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid bandwidth", v)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6043.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDxConnection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDxConnection_basic -timeout 120m
=== RUN   TestAccAWSDxConnection_basic
--- PASS: TestAccAWSDxConnection_basic (41.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.373s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDxLag_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -run=TestAccAWSDxLag_basic -timeout 120m
=== RUN   TestAccAWSDxLag_basic
--- PASS: TestAccAWSDxLag_basic (118.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	119.199s
```