### PR TITLE
readme: Add link to docs page of AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ make build
 
 Using the provider
 ----------------------
-If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it.
+If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it. You can find out about the provider specific configuration options [here](https://www.terraform.io/docs/providers/aws/index.html).
 
 Developing the Provider
 ---------------------------


### PR DESCRIPTION
Changes proposed in this pull request:

* Add link in `README` to directly take users to the page on the documentation website where the usage and configuration information for this provider is documented. This makes it easier for newcomers to find out how to use this plugin as the current link on using the provider points only to the generic page on how to install plugins.


