### PR TITLE
Align resource example like terraform fmt would do

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -19,12 +19,12 @@ resource "aws_cloudwatch_event_target" "yada" {
   arn       = "${aws_kinesis_stream.test_stream.arn}"
 
   run_command_targets {
-    key = "tag:Name"
+    key    = "tag:Name"
     values = ["FooBar"]
   }
 
   run_command_targets {
-    key = "InstanceIds"
+    key    = "InstanceIds"
     values = ["i-162058cd308bffec2"]
   }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

* Change terraform example whitespace to what terraform fmt would produce
