### PR TITLE
New resource: aws_pinpoint_event_stream

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -672,6 +672,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_definition":                         resourceAwsBatchJobDefinition(),
 			"aws_batch_job_queue":                              resourceAwsBatchJobQueue(),
 			"aws_pinpoint_app":                                 resourceAwsPinpointApp(),
+			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),
 
 			// ALBs are actually LBs because they can be type `network` or `application`
 			// To avoid regressions, we will add a new resource for each and they both point

--- a/aws/resource_aws_pinpoint_event_stream.go
+++ b/aws/resource_aws_pinpoint_event_stream.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -41,8 +42,6 @@ func resourceAwsPinpointEventStreamUpsert(d *schema.ResourceData, meta interface
 
 	applicationId := d.Get("application_id").(string)
 
-	d.SetId(applicationId)
-
 	params := &pinpoint.WriteEventStream{}
 
 	if d.HasChange("destination_stream_arn") {
@@ -60,8 +59,10 @@ func resourceAwsPinpointEventStreamUpsert(d *schema.ResourceData, meta interface
 
 	_, err := conn.PutEventStream(&req)
 	if err != nil {
-		return err
+		return fmt.Errorf("error putting Pinpoint Event Stream for application %s: %s", applicationId, err)
 	}
+
+	d.SetId(applicationId)
 
 	return resourceAwsPinpointEventStreamRead(d, meta)
 }
@@ -81,7 +82,7 @@ func resourceAwsPinpointEventStreamRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return err
+		return fmt.Errorf("error getting Pinpoint Event Stream for application %s: %s", d.Id(), err)
 	}
 
 	d.Set("application_id", output.EventStream.ApplicationId)
@@ -104,7 +105,7 @@ func resourceAwsPinpointEventStreamDelete(d *schema.ResourceData, meta interface
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting Pinpoint Event Stream for application %s: %s", d.Id(), err)
 	}
 	return nil
 }

--- a/aws/resource_aws_pinpoint_event_stream_test.go
+++ b/aws/resource_aws_pinpoint_event_stream_test.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSPinpointEventStream_basic(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var stream pinpoint.EventStream
+	resourceName := "aws_pinpoint_event_stream.test_event_stream"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointEventStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointEventStreamConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointEventStreamExists(resourceName, &stream),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPinpointEventStreamExists(n string, stream *pinpoint.EventStream) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Pinpoint event stream with that ID exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+		// Check if the app exists
+		params := &pinpoint.GetEventStreamInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetEventStream(params)
+
+		if err != nil {
+			return err
+		}
+
+		*stream = *output.EventStream
+
+		return nil
+	}
+}
+
+const testAccAWSPinpointEventStreamConfig_basic = `
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_event_stream" "test_event_stream" {
+  application_id         = "${aws_pinpoint_app.test_app.application_id}"
+  destination_stream_arn = "${aws_kinesis_stream.test_stream.arn}"
+  role_arn               = "${aws_iam_role.test_role.arn}"
+}
+
+resource "aws_kinesis_stream" "test_stream" {
+  name        = "terraform-kinesis-test"
+  shard_count = 1
+}
+
+resource "aws_iam_role" "test_role" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "pinpoint.us-east-1.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_role_policy" {
+  name   = "test_policy"
+  role   = "${aws_iam_role.test_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Action": [
+      "kinesis:PutRecords",
+      "kinesis:DescribeStream"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "arn:aws:kinesis:us-east-1:*:*/*"
+    ]
+  }
+}
+EOF
+}
+`
+
+func testAccCheckAWSPinpointEventStreamDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_pinpoint_event_stream" {
+			continue
+		}
+
+		// Check if the event stream exists
+		params := &pinpoint.GetEventStreamInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetEventStream(params)
+		if err != nil {
+			if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("Event stream exists when it should be destroyed!")
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1669,6 +1669,9 @@
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-app") %>>
                             <a href="/docs/providers/aws/r/pinpoint_app.html">aws_pinpoint_app</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-pinpoint-event-stream") %>>
+                            <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/pinpoint_event_stream.markdown
+++ b/website/docs/r/pinpoint_event_stream.markdown
@@ -1,0 +1,83 @@
+---
+layout: "aws"
+page_title: "AWS: aws_pinpoint_event_stream"
+sidebar_current: "docs-aws-resource-pinpoint-event-stream"
+description: |-
+  Provides a Pinpoint Event Stream resource.
+---
+
+# aws_pinpoint_event_stream
+
+Provides a Pinpoint Event Stream resource.
+
+## Example Usage
+
+```hcl
+resource "aws_pinpoint_event_stream" "stream" {
+  application_id         = "${aws_pinpoint_app.app.application_id}"
+  destination_stream_arn = "${aws_kinesis_stream.test_stream.arn}"
+  role_arn               = "${aws_iam_role.test_role.arn}"
+}
+
+resource "aws_pinpoint_app" "app" {}
+
+resource "aws_kinesis_stream" "test_stream" {
+  name        = "pinpoint-kinesis-test"
+  shard_count = 1
+}
+
+resource "aws_iam_role" "test_role" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "pinpoint.us-east-1.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_role_policy" {
+  name   = "test_policy"
+  role   = "${aws_iam_role.test_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Action": [
+      "kinesis:PutRecords",
+      "kinesis:DescribeStream"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "arn:aws:kinesis:us-east-1:*:*/*"
+    ]
+  }
+}
+EOF
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The application ID.
+* `destination_stream_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon Kinesis stream or Firehose delivery stream to which you want to publish events.
+* `role_arn` - (Required) The IAM role that authorizes Amazon Pinpoint to publish events to the stream in your account.
+
+## Import
+
+Pinpoint Event Stream can be imported using the `application-id`, e.g.
+
+```
+$ terraform import aws_pinpoint_event_stream.stream application-id
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Work continues on #4990

Changes proposed in this pull request:

* New resource `aws_pinpoint_event_stream` with related docs and acceptance tests 

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointEventStream'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointEventStream -timeout 120m
=== RUN   TestAccAWSPinpointEventStream_basic
--- PASS: TestAccAWSPinpointEventStream_basic (96.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       97.498s
```