### PR TITLE
Adding secret_binary to aws_secretsmanager_secret_version

### DIFF
--- a/aws/data_source_aws_secretsmanager_secret_version.go
+++ b/aws/data_source_aws_secretsmanager_secret_version.go
@@ -28,6 +28,11 @@ func dataSourceAwsSecretsManagerSecretVersion() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"secret_binary": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 			"version_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -82,6 +87,7 @@ func dataSourceAwsSecretsManagerSecretVersionRead(d *schema.ResourceData, meta i
 	d.Set("secret_id", secretID)
 	d.Set("secret_string", output.SecretString)
 	d.Set("version_id", output.VersionId)
+	d.Set("secret_binary", fmt.Sprintf("%s", output.SecretBinary))
 	d.Set("arn", output.ARN)
 
 	if err := d.Set("version_stages", flattenStringList(output.VersionStages)); err != nil {

--- a/aws/resource_aws_secretsmanager_secret_version.go
+++ b/aws/resource_aws_secretsmanager_secret_version.go
@@ -76,7 +76,7 @@ func resourceAwsSecretsManagerSecretVersionCreate(d *schema.ResourceData, meta i
 		vs := []byte(v.(string))
 
 		if !isBase64Encoded(vs) {
-			fmt.Errorf("expected base64 in secret_binary")
+			return fmt.Errorf("expected base64 in secret_binary")
 		}
 
 		var err error

--- a/aws/resource_aws_secretsmanager_secret_version_test.go
+++ b/aws/resource_aws_secretsmanager_secret_version_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsSecretsManagerSecretVersion_Basic(t *testing.T) {
+func TestAccAwsSecretsManagerSecretVersion_BasicString(t *testing.T) {
 	var version secretsmanager.GetSecretValueOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret_version.test"
@@ -27,6 +27,37 @@ func TestAccAwsSecretsManagerSecretVersion_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSecretsManagerSecretVersionExists(resourceName, &version),
 					resource.TestCheckResourceAttr(resourceName, "secret_string", "test-string"),
+					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
+					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "version_stages.3070137", "AWSCURRENT"),
+					resource.TestMatchResourceAttr(resourceName, "arn",
+						regexp.MustCompile(`^arn:[\w-]+:secretsmanager:[^:]+:\d{12}:secret:.+$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsSecretsManagerSecretVersion_BasicBinary(t *testing.T) {
+	var version secretsmanager.GetSecretValueOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_secretsmanager_secret_version.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSecretsManagerSecretVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSecretsManagerSecretVersionConfig_SecretBinary(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSecretsManagerSecretVersionExists(resourceName, &version),
+					resource.TestCheckResourceAttr(resourceName, "secret_binary", "test-binary"),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.3070137", "AWSCURRENT"),
@@ -186,6 +217,19 @@ resource "aws_secretsmanager_secret" "test" {
 resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = "${aws_secretsmanager_secret.test.id}"
   secret_string = "test-string"
+}
+`, rName)
+}
+
+func testAccAwsSecretsManagerSecretVersionConfig_SecretBinary(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = "%s"
+}
+
+resource "aws_secretsmanager_secret_version" "test" {
+  secret_id     = "${aws_secretsmanager_secret.test.id}"
+  secret_binary = "test-binary"
 }
 `, rName)
 }

--- a/aws/resource_aws_secretsmanager_secret_version_test.go
+++ b/aws/resource_aws_secretsmanager_secret_version_test.go
@@ -43,7 +43,7 @@ func TestAccAwsSecretsManagerSecretVersion_BasicString(t *testing.T) {
 	})
 }
 
-func TestAccAwsSecretsManagerSecretVersion_BasicBinary(t *testing.T) {
+func TestAccAwsSecretsManagerSecretVersion_Base64Binary(t *testing.T) {
 	var version secretsmanager.GetSecretValueOutput
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_secretsmanager_secret_version.test"
@@ -57,7 +57,7 @@ func TestAccAwsSecretsManagerSecretVersion_BasicBinary(t *testing.T) {
 				Config: testAccAwsSecretsManagerSecretVersionConfig_SecretBinary(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSecretsManagerSecretVersionExists(resourceName, &version),
-					resource.TestCheckResourceAttr(resourceName, "secret_binary", "test-binary"),
+					resource.TestCheckResourceAttr(resourceName, "secret_binary", base64Encode([]byte("test-binary"))),
 					resource.TestCheckResourceAttrSet(resourceName, "version_id"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "version_stages.3070137", "AWSCURRENT"),
@@ -229,7 +229,7 @@ resource "aws_secretsmanager_secret" "test" {
 
 resource "aws_secretsmanager_secret_version" "test" {
   secret_id     = "${aws_secretsmanager_secret.test.id}"
-  secret_binary = "test-binary"
+  secret_binary = "${base64encode("test-binary")}"
 }
 `, rName)
 }

--- a/website/docs/d/secretsmanager_secret_version.html.markdown
+++ b/website/docs/d/secretsmanager_secret_version.html.markdown
@@ -42,4 +42,5 @@ data "aws_secretsmanager_secret_version" "by-version-stage" {
 * `arn` - The ARN of the secret.
 * `id` - The unique identifier of this version of the secret.
 * `secret_string` - The decrypted part of the protected secret information that was originally provided as a string.
+* `secret_binary` - The decrypted part of the protected secret information that was originally provided as a binary.
 * `version_id` - The unique identifier of this version of the secret.

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `secret_id` - (Required) Specifies the secret to which you want to add a new version. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret. The secret must already exist.
 * `secret_string` - (Optional) Specifies text data that you want to encrypt and store in this version of the secret. This is required if secret_binary is not set.
-* `secret_binary` - (Optional) Specifies binary data that you want to encrypt and store in this version of the secret. This is required if secret_string is not set.
+* `secret_binary` - (Optional) Specifies binary data that you want to encrypt and store in this version of the secret. This is required if secret_string is not set. Needs to be encoded to base64.
 * `version_stages` - (Optional) Specifies a list of staging labels that are attached to this version of the secret. A staging label must be unique to a single version of the secret. If you specify a staging label that's already associated with a different version of the same secret then that staging label is automatically removed from the other version and attached to this version. If you do not specify a value, then AWS Secrets Manager automatically moves the staging label `AWSCURRENT` to this new version on creation.
 
 ~> **NOTE:** If `version_stages` is configured, you must include the `AWSCURRENT` staging label if this secret version is the only version or if the label is currently present on this secret version, otherwise Terraform will show a perpetual difference.

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -50,7 +50,8 @@ resource "aws_secretsmanager_secret_version" "example" {
 The following arguments are supported:
 
 * `secret_id` - (Required) Specifies the secret to which you want to add a new version. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret. The secret must already exist.
-* `secret_string` - (Required) Specifies text data that you want to encrypt and store in this version of the secret.
+* `secret_string` - (Optional) Specifies text data that you want to encrypt and store in this version of the secret. This is required if secret_binary is not set.
+* `secret_binary` - (Optional) Specifies binary data that you want to encrypt and store in this version of the secret. This is required if secret_string is not set.
 * `version_stages` - (Optional) Specifies a list of staging labels that are attached to this version of the secret. A staging label must be unique to a single version of the secret. If you specify a staging label that's already associated with a different version of the same secret then that staging label is automatically removed from the other version and attached to this version. If you do not specify a value, then AWS Secrets Manager automatically moves the staging label `AWSCURRENT` to this new version on creation.
 
 ~> **NOTE:** If `version_stages` is configured, you must include the `AWSCURRENT` staging label if this secret version is the only version or if the label is currently present on this secret version, otherwise Terraform will show a perpetual difference.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4571

Changes proposed in this pull request:

* Adding data `secret_binary` for data "aws_secretsmanager_secret_version"
* Adding input `secret_binary` for resource "aws_secretsmanager_secret_version"

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsSecretsManagerSecretVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAwsSecretsManagerSecretVersion -timeout 120m
=== RUN   TestAccAwsSecretsManagerSecretVersion_BasicString
--- PASS: TestAccAwsSecretsManagerSecretVersion_BasicString (12.46s)
=== RUN   TestAccAwsSecretsManagerSecretVersion_BasicBinary
--- PASS: TestAccAwsSecretsManagerSecretVersion_BasicBinary (10.40s)
=== RUN   TestAccAwsSecretsManagerSecretVersion_VersionStages
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (26.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.086s
...
```

First time i contribute to a terraform provider, i hope to do well. 

I have just few doubt about the code for the resource (for the cast []byte <-> string). For the test i only copy/paste the test for `secret_string`