### PR TITLE
docs/resource/aws_ecs_task_definition: Clarify resource as managing a single revision

### DIFF
--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_ecs_task_definition"
 sidebar_current: "docs-aws-resource-ecs-task-definition"
 description: |-
-  Provides an ECS task definition.
+  Manages a revision of an ECS task definition.
 ---
 
 # aws_ecs_task_definition
 
-Provides an ECS task definition to be used in `aws_ecs_service`.
+Manages a revision of an ECS task definition to be used in `aws_ecs_service`.
 
 ## Example Usage
 


### PR DESCRIPTION
Closes #6051 

Changes proposed in this pull request:

* Slight adjustment to `aws_ecs_task_definition` resource header and description to clarify it manages a single revision

Output from acceptance testing: N/A