### PR TITLE
WIP: fix #6071

### DIFF
--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -91,7 +91,8 @@ func resourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	if jq == nil {
-		return fmt.Errorf("Error reading JobQueue: \"%s\"", err)
+		d.SetId("")
+		return nil
 	}
 	d.Set("arn", jq.JobQueueArn)
 	d.Set("compute_environments", jq.ComputeEnvironmentOrder)


### PR DESCRIPTION
Fixes #6071 

Changes proposed in this pull request:

* return nil if the job queue cannot be found on read instead of erroring (which prevents a proper destroy workflow in some scenarios).

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
(WIP - currently don't have access to an AWS account with billing enabled to run/fix/create acceptance tests.).