### PR TITLE
Support for setting of certificate in `aws_codebuild_project`

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -992,7 +992,7 @@ func flattenAwsCodeBuildProjectEnvironment(environment *codebuild.ProjectEnviron
 	envConfig["type"] = *environment.Type
 	envConfig["compute_type"] = *environment.ComputeType
 	envConfig["image"] = *environment.Image
-	envConfig["certificate"] = *environment.Certificate
+	envConfig["certificate"] = aws.StringValue(environment.Certificate)
 	envConfig["privileged_mode"] = *environment.PrivilegedMode
 
 	if environment.EnvironmentVariables != nil {
@@ -1074,13 +1074,11 @@ func resourceAwsCodeBuildProjectEnvironmentHash(v interface{}) int {
 	environmentType := m["type"].(string)
 	computeType := m["compute_type"].(string)
 	image := m["image"].(string)
-	certificate := m["certificate"].(string)
 	privilegedMode := m["privileged_mode"].(bool)
 	environmentVariables := m["environment_variable"].([]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", environmentType))
 	buf.WriteString(fmt.Sprintf("%s-", computeType))
 	buf.WriteString(fmt.Sprintf("%s-", image))
-	buf.WriteString(fmt.Sprintf("%s-", certificate))
 	buf.WriteString(fmt.Sprintf("%t-", privilegedMode))
 	for _, e := range environmentVariables {
 		if e != nil { // Old statefiles might have nil values in them

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -177,6 +177,10 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"certificate": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 				Set: resourceAwsCodeBuildProjectEnvironmentHash,
@@ -619,6 +623,10 @@ func expandProjectEnvironment(d *schema.ResourceData) *codebuild.ProjectEnvironm
 		projectEnv.Type = aws.String(v.(string))
 	}
 
+	if v := envConfig["certificate"]; v != nil {
+		projectEnv.Certificate = aws.String(v.(string))
+	}
+
 	if v := envConfig["environment_variable"]; v != nil {
 		envVariables := v.([]interface{})
 		if len(envVariables) > 0 {
@@ -984,6 +992,7 @@ func flattenAwsCodeBuildProjectEnvironment(environment *codebuild.ProjectEnviron
 	envConfig["type"] = *environment.Type
 	envConfig["compute_type"] = *environment.ComputeType
 	envConfig["image"] = *environment.Image
+	envConfig["certificate"] = *environment.Certificate
 	envConfig["privileged_mode"] = *environment.PrivilegedMode
 
 	if environment.EnvironmentVariables != nil {
@@ -1065,11 +1074,13 @@ func resourceAwsCodeBuildProjectEnvironmentHash(v interface{}) int {
 	environmentType := m["type"].(string)
 	computeType := m["compute_type"].(string)
 	image := m["image"].(string)
+	certificate := m["certificate"].(string)
 	privilegedMode := m["privileged_mode"].(bool)
 	environmentVariables := m["environment_variable"].([]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", environmentType))
 	buf.WriteString(fmt.Sprintf("%s-", computeType))
 	buf.WriteString(fmt.Sprintf("%s-", image))
+	buf.WriteString(fmt.Sprintf("%s-", certificate))
 	buf.WriteString(fmt.Sprintf("%t-", privilegedMode))
 	for _, e := range environmentVariables {
 		if e != nil { // Old statefiles might have nil values in them

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -286,6 +286,27 @@ func TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type(t *testing.
 	})
 }
 
+func TestAccAWSCodeBuildProject_Environment_Certificate(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_Environment_Certificate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "environment.3925601246.certificate", "arn:aws:s3:::secret_bucket/cert.pem"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCodeBuildProject_Source_Auth(t *testing.T) {
 	var project codebuild.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1015,6 +1036,35 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, rName, environmentVariableType)
+}
+
+func testAccAWSCodeBuildProjectConfig_Environment_Certificate(rName string) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = %q
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+		certificate  = "arn:aws:s3:::secret_bucket/cert.pem"
+  }
+
+  source {
+    location = "https://example.com/organization/repository.git"
+    type     = "GITHUB_ENTERPRISE"
+		auth {
+      resource = "FAKESOURCE"
+      type     = "OAUTH"
+    }
+  }
+}
+`, rName)
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Auth(rName, authResource, authType string) string {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -158,7 +158,7 @@ The following arguments are supported:
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `vpc_config` - (Optional) Configuration for the builds to run inside a VPC. VPC config blocks are documented below.
 * `secondary_artifacts` - (Optional) A set of secondary artifacts to be used inside the build. Secondary artifacts blocks are documented below.
-* `secondary_sources` - (Optional) A set of secondary sources to be used inside the build. Secondary sources blocks are documented below. 
+* `secondary_sources` - (Optional) A set of secondary sources to be used inside the build. Secondary sources blocks are documented below.
 
 `artifacts` supports the following:
 
@@ -182,6 +182,7 @@ The following arguments are supported:
 * `type` - (Required) The type of build environment to use for related builds. Available values are: `LINUX_CONTAINER` or `WINDOWS_CONTAINER`.
 * `environment_variable` - (Optional) A set of environment variables to make available to builds for this build project.
 * `privileged_mode` - (Optional) If set to true, enables running the Docker daemon inside a Docker container. Defaults to `false`.
+* `certificate` - (Optional) The ARN of the S3 bucket, path prefix and object key that contains the PEM-encoded certificate.
 
 `environment_variable` supports the following:
 
@@ -214,7 +215,7 @@ The following arguments are supported:
 `secondary_artifacts` supports the following:
 
 * `type` - (Required) The build output artifact's type. Valid values for this parameter are: `CODEPIPELINE`, `NO_ARTIFACTS` or `S3`.
-* `artifact_identifier` - (Required) The artifact identifier. Must be the same specified inside AWS CodeBuild buildspec. 
+* `artifact_identifier` - (Required) The artifact identifier. Must be the same specified inside AWS CodeBuild buildspec.
 * `encryption_disabled` - (Optional) If set to true, output artifacts will not be encrypted. If `type` is set to `NO_ARTIFACTS` then this value will be ignored. Defaults to `false`.
 * `location` - (Optional) Information about the build output artifact location. If `type` is set to `CODEPIPELINE` or `NO_ARTIFACTS` then this value will be ignored. If `type` is set to `S3`, this is the name of the output bucket. If `path` is not also specified, then `location` can also specify the path of the output artifact in the output bucket.
 * `name` - (Optional) The name of the project. If `type` is set to `S3`, this is the name of the output artifact object


### PR DESCRIPTION
Fixes #4742 

This change allows the certificate to be set for an `aws_codebuild_project`.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run= TestAccAWSCodeBuildProject_Environment_Certificate'

TF_ACC=1 go test ./... -v -run=TestAccAWSCodeBuildProject_Environment_Certificate -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCodeBuildProject_Environment_Certificate
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (79.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	80.019s
...
```
