### PR TITLE
 New resource: aws_pinpoint_sms_channel

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -674,6 +674,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_queue":                              resourceAwsBatchJobQueue(),
 			"aws_pinpoint_app":                                 resourceAwsPinpointApp(),
 			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),
+			"aws_pinpoint_sms_channel":                         resourceAwsPinpointSMSChannel(),
 
 			// ALBs are actually LBs because they can be type `network` or `application`
 			// To avoid regressions, we will add a new resource for each and they both point

--- a/aws/resource_aws_pinpoint_sms_channel.go
+++ b/aws/resource_aws_pinpoint_sms_channel.go
@@ -1,0 +1,130 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsPinpointSMSChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsPinpointSMSChannelUpsert,
+		Read:   resourceAwsPinpointSMSChannelRead,
+		Update: resourceAwsPinpointSMSChannelUpsert,
+		Delete: resourceAwsPinpointSMSChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"sender_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"short_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"promotional_messages_per_second": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"transactional_messages_per_second": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsPinpointSMSChannelUpsert(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	applicationId := d.Get("application_id").(string)
+
+	params := &pinpoint.SMSChannelRequest{}
+
+	if d.HasChange("enabled") {
+		params.Enabled = aws.Bool(d.Get("enabled").(bool))
+	}
+
+	if d.HasChange("sender_id") {
+		params.SenderId = aws.String(d.Get("sender_id").(string))
+	}
+
+	if d.HasChange("short_code") {
+		params.ShortCode = aws.String(d.Get("short_code").(string))
+	}
+
+	req := pinpoint.UpdateSmsChannelInput{
+		ApplicationId:     aws.String(applicationId),
+		SMSChannelRequest: params,
+	}
+
+	_, err := conn.UpdateSmsChannel(&req)
+	if err != nil {
+		return fmt.Errorf("error putting Pinpoint SMS Channel for application %s: %s", applicationId, err)
+	}
+
+	d.SetId(applicationId)
+
+	return resourceAwsPinpointSMSChannelRead(d, meta)
+}
+
+func resourceAwsPinpointSMSChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[INFO] Reading Pinpoint SMS Channel  for application %s", d.Id())
+
+	output, err := conn.GetSmsChannel(&pinpoint.GetSmsChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Pinpoint SMS Channel for application %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error getting Pinpoint SMS Channel for application %s: %s", d.Id(), err)
+	}
+
+	d.Set("application_id", output.SMSChannelResponse.ApplicationId)
+	d.Set("enabled", output.SMSChannelResponse.Enabled)
+	d.Set("sender_id", output.SMSChannelResponse.SenderId)
+	d.Set("short_code", output.SMSChannelResponse.ShortCode)
+	d.Set("promotional_messages_per_second", aws.Int64Value(output.SMSChannelResponse.PromotionalMessagesPerSecond))
+	d.Set("transactional_messages_per_second", aws.Int64Value(output.SMSChannelResponse.TransactionalMessagesPerSecond))
+	return nil
+}
+
+func resourceAwsPinpointSMSChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[DEBUG] Deleting Pinpoint SMS Channel for application %s", d.Id())
+	_, err := conn.DeleteSmsChannel(&pinpoint.DeleteSmsChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Pinpoint SMS Channel for application %s: %s", d.Id(), err)
+	}
+	return nil
+}

--- a/aws/resource_aws_pinpoint_sms_channel_test.go
+++ b/aws/resource_aws_pinpoint_sms_channel_test.go
@@ -1,0 +1,158 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSPinpointSMSChannel_basic(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.SMSChannelResponse
+	resourceName := "aws_pinpoint_sms_channel.test_sms_channel"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointSMSChannelConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointSMSChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.SMSChannelResponse
+	resourceName := "aws_pinpoint_sms_channel.test_sms_channel"
+	senderId := "1234"
+	shortCode := "5678"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointSMSChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointSMSChannelConfig_full(senderId, shortCode),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointSMSChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "sender_id", senderId),
+					resource.TestCheckResourceAttr(resourceName, "short_code", shortCode),
+					resource.TestCheckResourceAttrSet(resourceName, "promotional_messages_per_second"),
+					resource.TestCheckResourceAttrSet(resourceName, "transactional_messages_per_second"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPinpointSMSChannelExists(n string, channel *pinpoint.SMSChannelResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Pinpoint SMS Channel with that application ID exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+		// Check if the app exists
+		params := &pinpoint.GetSmsChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetSmsChannel(params)
+
+		if err != nil {
+			return err
+		}
+
+		*channel = *output.SMSChannelResponse
+
+		return nil
+	}
+}
+
+const testAccAWSPinpointSMSChannelConfig_basic = `
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_sms_channel" "test_sms_channel" {
+  application_id = "${aws_pinpoint_app.test_app.application_id}"
+}`
+
+func testAccAWSPinpointSMSChannelConfig_full(senderId, shortCode string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_sms_channel" "test_sms_channel" {
+  application_id = "${aws_pinpoint_app.test_app.application_id}"
+  enabled        = "true"
+  sender_id      = "%s"
+  short_code     = "%s"
+}`, senderId, shortCode)
+}
+
+func testAccCheckAWSPinpointSMSChannelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_pinpoint_sms_channel" {
+			continue
+		}
+
+		// Check if the event stream exists
+		params := &pinpoint.GetSmsChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetSmsChannel(params)
+		if err != nil {
+			if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("SMS Channel exists when it should be destroyed!")
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1682,6 +1682,9 @@
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-event-stream") %>>
                             <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-pinpoint-sms-channel") %>>
+                            <a href="/docs/providers/aws/r/pinpoint_sms_channel.html">aws_pinpoint_sms_channel</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/pinpoint_sms_channel.markdown
+++ b/website/docs/r/pinpoint_sms_channel.markdown
@@ -1,0 +1,46 @@
+---
+layout: "aws"
+page_title: "AWS: aws_pinpoint_sms_channel"
+sidebar_current: "docs-aws-resource-pinpoint-sms-channel"
+description: |-
+  Provides a Pinpoint SMS Channel resource.
+---
+
+# aws_pinpoint_sms_channel
+
+Provides a Pinpoint SMS Channel resource.
+
+## Example Usage
+
+```hcl
+resource "aws_pinpoint_sms_channel" "sms" {
+  application_id = "${aws_pinpoint_app.app.application_id}"
+}
+
+resource "aws_pinpoint_app" "app" {}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The application ID.
+* `enabled` - (Optional) Whether the channel is enabled or disabled. Defaults to `true`.
+* `sender_id` - (Optional) Sender identifier of your messages.
+* `short_code` - (Optional) The Short Code registered with the phone provider.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `promotional_messages_per_second` - Promotional messages per second that can be sent.
+* `transactional_messages_per_second` - Transactional messages per second that can be sent.
+
+## Import
+
+Pinpoint SMS Channel can be imported using the `application-id`, e.g.
+
+```
+$ terraform import aws_pinpoint_sms_channel.sms application-id
+```


### PR DESCRIPTION
Work continues on #4990 

Changes proposed in this pull request:

* New resource `aws_pinpoint_sms_channel` with related docs and acceptance tests

Output from acceptance testing:

```
 $ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointSMSChannel'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointSMS -timeout 120m
=== RUN   TestAccAWSPinpointSMSChannel_basic
--- PASS: TestAccAWSPinpointSMSChannel_basic (19.48s)
=== RUN   TestAccAWSPinpointSMSChannel_full
--- PASS: TestAccAWSPinpointSMSChannel_full (18.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       39.442s
```
