### PR TITLE
New resource: aws_pinpoint_gcm_channel

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -674,6 +674,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_queue":                              resourceAwsBatchJobQueue(),
 			"aws_pinpoint_app":                                 resourceAwsPinpointApp(),
 			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),
+			"aws_pinpoint_gcm_channel":                         resourceAwsPinpointGCMChannel(),
 			"aws_pinpoint_sms_channel":                         resourceAwsPinpointSMSChannel(),
 
 			// ALBs are actually LBs because they can be type `network` or `application`

--- a/aws/resource_aws_pinpoint_gcm_channel.go
+++ b/aws/resource_aws_pinpoint_gcm_channel.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsPinpointGCMChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsPinpointGCMChannelUpsert,
+		Read:   resourceAwsPinpointGCMChannelRead,
+		Update: resourceAwsPinpointGCMChannelUpsert,
+		Delete: resourceAwsPinpointGCMChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"api_key": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+	}
+}
+
+func resourceAwsPinpointGCMChannelUpsert(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	applicationId := d.Get("application_id").(string)
+
+	params := &pinpoint.GCMChannelRequest{}
+
+	if d.HasChange("api_key") {
+		params.ApiKey = aws.String(d.Get("api_key").(string))
+	}
+
+	if d.HasChange("enabled") {
+		params.Enabled = aws.Bool(d.Get("enabled").(bool))
+	}
+
+	req := pinpoint.UpdateGcmChannelInput{
+		ApplicationId:     aws.String(applicationId),
+		GCMChannelRequest: params,
+	}
+
+	_, err := conn.UpdateGcmChannel(&req)
+	if err != nil {
+		return fmt.Errorf("error putting Pinpoint GCM Channel for application %s: %s", applicationId, err)
+	}
+
+	d.SetId(applicationId)
+
+	return resourceAwsPinpointGCMChannelRead(d, meta)
+}
+
+func resourceAwsPinpointGCMChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[INFO] Reading Pinpoint GCM Channel for application %s", d.Id())
+
+	output, err := conn.GetGcmChannel(&pinpoint.GetGcmChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Pinpoint GCM Channel for application %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error getting Pinpoint GCM Channel for application %s: %s", d.Id(), err)
+	}
+
+	d.Set("application_id", output.GCMChannelResponse.ApplicationId)
+	d.Set("enabled", output.GCMChannelResponse.Enabled)
+	// api_key is never returned
+
+	return nil
+}
+
+func resourceAwsPinpointGCMChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[DEBUG] Deleting Pinpoint GCM Channel for application %s", d.Id())
+	_, err := conn.DeleteGcmChannel(&pinpoint.DeleteGcmChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Pinpoint GCM Channel for application %s: %s", d.Id(), err)
+	}
+	return nil
+}

--- a/aws/resource_aws_pinpoint_gcm_channel_test.go
+++ b/aws/resource_aws_pinpoint_gcm_channel_test.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+/**
+ Before running this test, the following ENV variable must be set:
+
+ GCM_API_KEY - Google Cloud Messaging Api Key
+**/
+
+func TestAccAWSPinpointGCMChannel_basic(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.GCMChannelResponse
+	resourceName := "aws_pinpoint_gcm_channel.test_gcm_channel"
+
+	if os.Getenv("GCM_API_KEY") == "" {
+		t.Skipf("GCM_API_KEY env missing, skip test")
+	}
+
+	apiKey := os.Getenv("GCM_API_KEY")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointGCMChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointGCMChannelConfig_basic(apiKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointGCMChannelExists(resourceName, &channel),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"api_key"},
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPinpointGCMChannelExists(n string, channel *pinpoint.GCMChannelResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Pinpoint GCM Channel with that application ID exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+		// Check if the app exists
+		params := &pinpoint.GetGcmChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetGcmChannel(params)
+
+		if err != nil {
+			return err
+		}
+
+		*channel = *output.GCMChannelResponse
+
+		return nil
+	}
+}
+
+func testAccAWSPinpointGCMChannelConfig_basic(apiKey string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_gcm_channel" "test_gcm_channel" {
+  application_id = "${aws_pinpoint_app.test_app.application_id}"
+  enabled        = "true"
+  api_key        = "%s"
+}`, apiKey)
+}
+
+func testAccCheckAWSPinpointGCMChannelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_pinpoint_gcm_channel" {
+			continue
+		}
+
+		// Check if the event stream exists
+		params := &pinpoint.GetGcmChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetGcmChannel(params)
+		if err != nil {
+			if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("GCM Channel exists when it should be destroyed!")
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1682,6 +1682,9 @@
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-event-stream") %>>
                             <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-pinpoint-gcm-channel") %>>
+                            <a href="/docs/providers/aws/r/pinpoint_gcm_channel.html">aws_pinpoint_gcm_channel</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-sms-channel") %>>
                             <a href="/docs/providers/aws/r/pinpoint_sms_channel.html">aws_pinpoint_sms_channel</a>
                         </li>

--- a/website/docs/r/pinpoint_gcm_channel.markdown
+++ b/website/docs/r/pinpoint_gcm_channel.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: aws_pinpoint_gcm_channel"
+sidebar_current: "docs-aws-resource-pinpoint-gcm-channel"
+description: |-
+  Provides a Pinpoint GCM Channel resource.
+---
+
+# aws_pinpoint_gcm_channel
+
+Provides a Pinpoint GCM Channel resource.
+
+~> **Note:** Api Key argument will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+resource "aws_pinpoint_gcm_channel" "gcm" {
+  application_id = "${aws_pinpoint_app.app.application_id}"
+  api_key        = "api_key"
+}
+
+resource "aws_pinpoint_app" "app" {}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The application ID.
+* `api_key` - (Required) Platform credential API key from Google.
+* `enabled` - (Optional) Whether the channel is enabled or disabled. Defaults to `true`.
+
+## Import
+
+Pinpoint GCM Channel can be imported using the `application-id`, e.g.
+
+```
+$ terraform import aws_pinpoint_gcm_channel.gcm application-id
+```


### PR DESCRIPTION
Work continues on #4990

Changes proposed in this pull request:

* New resource `aws_pinpoint_gcm_channel` with related docs and acceptance tests

Output from acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointGCMChannel'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointGCMChannel -timeout 120m
=== RUN   TestAccAWSPinpointGCMChannel_basic
--- PASS: TestAccAWSPinpointGCMChannel_basic (18.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       20.085s
```

NOTES:

1. I recycled env `GCM_API_KEY` since it was already defined in other tests and name suggested it to be generic. Test is skipped if env is missing
2. `api_key` is ignored during import since the SDK never returns it.