### PR TITLE
docs: Cross-link aws_lb_target_group_attachment and aws_elb_attachment resources

### DIFF
--- a/website/docs/r/elb_attachment.html.markdown
+++ b/website/docs/r/elb_attachment.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws_elb_attachment
 
-Provides an Elastic Load Balancer Attachment resource.
+Attaches an EC2 instance to an Elastic Load Balancer (ELB). For attaching resources with Application Load Balancer (ALB) or Network Load Balancer (NLB), see the [`aws_lb_target_group_attachment` resource](/docs/providers/aws/r/lb_target_group_attachment.html).
 
 ~> **NOTE on ELB Instances and ELB Attachments:** Terraform currently provides
 both a standalone ELB Attachment resource (describing an instance attached to
@@ -16,6 +16,7 @@ an ELB), and an [Elastic Load Balancer resource](elb.html) with
 `instances` defined in-line. At this time you cannot use an ELB with in-line
 instances in conjunction with an ELB Attachment resource. Doing so will cause a
 conflict and will overwrite attachments.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -9,8 +9,7 @@ description: |-
 
 # aws_lb_target_group_attachment
 
-Provides the ability to register instances and containers with a LB
-target group
+Provides the ability to register instances and containers with an Application Load Balancer (ALB) or Network Load Balancer (NLB) target group. For attaching resources with Elastic Load Balancer (ELB), see the [`aws_elb_attachment` resource](/docs/providers/aws/r/elb_attachment.html).
 
 ~> **Note:** `aws_alb_target_group_attachment` is known as `aws_lb_target_group_attachment`. The functionality is identical.
 


### PR DESCRIPTION
Closes #6056 

Changes proposed in this pull request:

* Describe usage of `aws_elb_attachment` resource better and cross link `aws_lb_target_group_attachment` resource
* Cross link `aws_lb_target_group_attachment` resource to `aws_elb_attachment` resource

Output from acceptance testing: N/A
