### PR TITLE
Support for policy in secrets manager datasource

### DIFF
--- a/aws/data_source_aws_secretsmanager_secret.go
+++ b/aws/data_source_aws_secretsmanager_secret.go
@@ -37,7 +37,6 @@ func dataSourceAwsSecretsManagerSecret() *schema.Resource {
 			},
 			"policy": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"rotation_enabled": {
@@ -109,6 +108,7 @@ func dataSourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interfac
 	d.Set("name", output.Name)
 	d.Set("rotation_enabled", output.RotationEnabled)
 	d.Set("rotation_lambda_arn", output.RotationLambdaARN)
+	d.Set("policy", "")
 
 	pIn := &secretsmanager.GetResourcePolicyInput{
 		SecretId: aws.String(d.Id()),
@@ -119,7 +119,7 @@ func dataSourceAwsSecretsManagerSecretRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("error reading Secrets Manager Secret policy: %s", err)
 	}
 
-	if pOut.ResourcePolicy != nil {
+	if pOut != nil && pOut.ResourcePolicy != nil {
 		policy, err := structure.NormalizeJsonString(aws.StringValue(pOut.ResourcePolicy))
 		if err != nil {
 			return fmt.Errorf("policy contains an invalid JSON: %s", err)

--- a/aws/data_source_aws_secretsmanager_secret_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_test.go
@@ -69,6 +69,25 @@ func TestAccDataSourceAwsSecretsManagerSecret_Name(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsSecretsManagerSecret_Policy(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_secretsmanager_secret.test"
+	datasourceName := "data.aws_secretsmanager_secret.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsSecretsManagerSecretConfig_Policy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsSecretsManagerSecretCheck(datasourceName, resourceName),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsSecretsManagerSecretCheck(datasourceName, resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resource, ok := s.RootModule().Resources[datasourceName]
@@ -86,6 +105,7 @@ func testAccDataSourceAwsSecretsManagerSecretCheck(datasourceName, resourceName 
 			"description",
 			"kms_key_id",
 			"name",
+			"policy",
 			"rotation_enabled",
 			"rotation_lambda_arn",
 			"rotation_rules.#",
@@ -144,6 +164,36 @@ resource "aws_secretsmanager_secret" "test" {
 
 data "aws_secretsmanager_secret" "test" {
   name = "${aws_secretsmanager_secret.test.name}"
+}
+`, rName)
+}
+
+func testAccDataSourceAwsSecretsManagerSecretConfig_Policy(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_secretsmanager_secret" "test" {
+  name = "%[1]s"
+
+	policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+	{
+	  "Sid": "EnableAllPermissions",
+	  "Effect": "Allow",
+	  "Principal": {
+		"AWS": "*"
+	  },
+	  "Action": "secretsmanager:GetSecretValue",
+	  "Resource": "*"
+	}
+  ]
+}
+POLICY
+}
+
+data "aws_secretsmanager_secret" "test" {
+  name = "${aws_secretsmanager_secret.test.name}"
+	policy = "${aws_secretsmanager_secret.test.policy}"
 }
 `, rName)
 }

--- a/aws/data_source_aws_secretsmanager_secret_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_test.go
@@ -171,7 +171,7 @@ data "aws_secretsmanager_secret" "test" {
 func testAccDataSourceAwsSecretsManagerSecretConfig_Policy(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_secretsmanager_secret" "test" {
-  name = "%[1]s"
+  name   = "%[1]s"
 
 	policy = <<POLICY
 {
@@ -192,8 +192,7 @@ POLICY
 }
 
 data "aws_secretsmanager_secret" "test" {
-  name = "${aws_secretsmanager_secret.test.name}"
-	policy = "${aws_secretsmanager_secret.test.policy}"
+  name   = "${aws_secretsmanager_secret.test.name}"
 }
 `, rName)
 }

--- a/website/docs/d/secretsmanager_secret.html.markdown
+++ b/website/docs/d/secretsmanager_secret.html.markdown
@@ -43,3 +43,4 @@ data "aws_secretsmanager_secret" "by-name" {
 * `rotation_lambda_arn` - Rotation Lambda function Amazon Resource Name (ARN) if rotation is enabled.
 * `rotation_rules` - Rotation rules if rotation is enabled.
 * `tags` - Tags of the secret.
+* `policy` - The resource-based policy document that's attached to the secret.


### PR DESCRIPTION
Fixes #5329

Changes proposed in this pull request:
* Add support for the policy in secrets manager's data source.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsSecretsManagerSecret'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccDataSourceAwsSecretsManagerSecret -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceAwsSecretsManagerSecret_Basic
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_Basic (12.48s)
=== RUN   TestAccDataSourceAwsSecretsManagerSecret_ARN
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_ARN (34.63s)
=== RUN   TestAccDataSourceAwsSecretsManagerSecret_Name
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_Name (34.90s)
=== RUN   TestAccDataSourceAwsSecretsManagerSecret_Policy
--- PASS: TestAccDataSourceAwsSecretsManagerSecret_Policy (39.18s)
=== RUN   TestAccDataSourceAwsSecretsManagerSecretVersion_Basic
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_Basic (41.26s)
=== RUN   TestAccDataSourceAwsSecretsManagerSecretVersion_VersionID
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_VersionID (38.00s)
=== RUN   TestAccDataSourceAwsSecretsManagerSecretVersion_VersionStage
--- PASS: TestAccDataSourceAwsSecretsManagerSecretVersion_VersionStage (39.45s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	239.940s
...
```
