### PR TITLE
Elastic Beanstalk support for PlatformArn

### DIFF
--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -126,6 +126,7 @@ func resourceAwsElasticBeanstalkEnvironment() *schema.Resource {
 			"platform_arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"solution_stack_name", "template_name"},
 			},
 			"template_name": {

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -625,6 +625,10 @@ func resourceAwsElasticBeanstalkEnvironmentRead(d *schema.ResourceData, meta int
 		return err
 	}
 
+	if err := d.Set("platform_arn", env.PlatformArn); err != nil {
+		return err
+	}
+
 	if err := d.Set("autoscaling_groups", flattenBeanstalkAsg(resources.EnvironmentResources.AutoScalingGroups)); err != nil {
 		return err
 	}

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -555,9 +555,7 @@ func TestAccAWSBeanstalkEnv_platformArn(t *testing.T) {
 				Config: testAccBeanstalkEnvConfig_platform_arn(appName, envName, platformArn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
-					resource.TestMatchResourceAttr(
-						"aws_elastic_beanstalk_environment.tfenvtest", "platform_arn",
-						regexp.MustCompile(fmt.Sprintf("^%s$", platformArn))),
+					resource.TestCheckResourceAttr("aws_elastic_beanstalk_environment.tfenvtest", "platform_arn", platformArn),
 				),
 			},
 		},
@@ -849,8 +847,7 @@ resource "aws_elastic_beanstalk_application" "tftest" {
 resource "aws_elastic_beanstalk_environment" "tfenvtest" {
   name = "%s"
   application = "${aws_elastic_beanstalk_application.tftest.name}"
-    platform_arn = "%s"
-    depends_on = ["aws_elastic_beanstalk_application.tftest"]
+  platform_arn = "%s"
 }
 `, appName, envName, platformArn)
 }

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -173,7 +173,6 @@ func TestAccAWSBeanstalkEnv_basic(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func TestAccAWSBeanstalkEnv_tier(t *testing.T) {
@@ -539,6 +538,32 @@ func TestAccAWSBeanstalkEnv_settingWithJsonValue(t *testing.T) {
 	})
 }
 
+func TestAccAWSBeanstalkEnv_platformArn(t *testing.T) {
+	var app elasticbeanstalk.EnvironmentDescription
+
+	rString := acctest.RandString(8)
+	appName := fmt.Sprintf("tf_acc_app_env_platform_arn_%s", rString)
+	envName := fmt.Sprintf("tf-acc-env-platform-arn-%s", rString)
+	platformArn := "arn:aws:elasticbeanstalk:us-east-1::platform/Go 1 running on 64bit Amazon Linux/2.9.0"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBeanstalkEnvDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBeanstalkEnvConfig_platform_arn(appName, envName, platformArn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBeanstalkEnvExists("aws_elastic_beanstalk_environment.tfenvtest", &app),
+					resource.TestMatchResourceAttr(
+						"aws_elastic_beanstalk_environment.tfenvtest", "platform_arn",
+						regexp.MustCompile(fmt.Sprintf("^%s$", platformArn))),
+				),
+			},
+		},
+	})
+}
+
 func testAccVerifyBeanstalkConfig(env *elasticbeanstalk.EnvironmentDescription, expected []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if env == nil {
@@ -808,6 +833,26 @@ func testAccBeanstalkEnvConfig(appName, envName string) string {
 	 depends_on = ["aws_elastic_beanstalk_application.tftest"]
  }
  `, appName, envName)
+}
+
+func testAccBeanstalkEnvConfig_platform_arn(appName, envName, platformArn string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_elastic_beanstalk_application" "tftest" {
+  name = "%s"
+  description = "tf-test-desc"
+}
+
+resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+  name = "%s"
+  application = "${aws_elastic_beanstalk_application.tftest.name}"
+    platform_arn = "%s"
+    depends_on = ["aws_elastic_beanstalk_application.tftest"]
+}
+`, appName, envName, platformArn)
 }
 
 func testAccBeanstalkEnvConfig_empty_settings(appName, envName string) string {

--- a/website/docs/r/elastic_beanstalk_environment.html.markdown
+++ b/website/docs/r/elastic_beanstalk_environment.html.markdown
@@ -50,6 +50,8 @@ The following arguments are supported:
 off of. Example stacks can be found in the [Amazon API documentation][1]
 * `template_name` – (Optional) The name of the Elastic Beanstalk Configuration
   template to use in deployment
+* `platform_arn` – (Optional) The [ARN][2] of the Elastic Beanstalk [Platform][3]
+  to use in deployment
 * `wait_for_ready_timeout` - (Default: `20m`) The maximum
   [duration](https://golang.org/pkg/time/#ParseDuration) that Terraform should
   wait for an Elastic Beanstalk Environment to be in a ready state before timing
@@ -126,7 +128,8 @@ In addition to all arguments above, the following attributes are exported:
 
 
 [1]: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html
-
+[2]: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+[3]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk-environment.html#cfn-beanstalk-environment-platformarn
 
 ## Import
 


### PR DESCRIPTION
If you are using AWS's ready to use [solutions stacks](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html), then you are fine. But if for some reason you would like to use [AWS Custom Platform](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/custom-platforms.html), then Terraform will not support it.
This PR adds support for CloudFormation's parameter `PlatformArn`, therefore adding support for Custom Platforms to Terraform.

Changes proposed in this pull request:

* Add support for `platform_arn` parameter to Elastic Beanstalk Environment resource. More about PlatformArn can be found in [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-beanstalk-environment.html#cfn-beanstalk-environment-platformarn)

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSBeanstalkEnv_platformArn'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSBeanstalkEnv_platformArn -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSBeanstalkEnv_platformArn
--- PASS: TestAccAWSBeanstalkEnv_platformArn (494.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	494.914s
``` 
