### PR TITLE
r/aws_s3_bucket: Support S3 Cross-Region Replication filtering based on S3 object tags

### DIFF
--- a/aws/tags.go
+++ b/aws/tags.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -400,4 +402,24 @@ func diffTagsDynamoDb(oldTags, newTags []*dynamodb.Tag) ([]*dynamodb.Tag, []*str
 		}
 	}
 	return tagsFromMapDynamoDb(create), remove
+}
+
+// tagsMapToHash returns a stable hash value for a raw tags map.
+// The returned value map be negative (i.e. not suitable for a 'Set' function).
+func tagsMapToHash(tags map[string]interface{}) int {
+	total := 0
+	for k, v := range tags {
+		total = total ^ hashcode.String(fmt.Sprintf("%s-%s", k, v))
+	}
+	return total
+}
+
+// tagsMapToRaw converts a tags map to its "raw" type.
+func tagsMapToRaw(m map[string]string) map[string]interface{} {
+	raw := make(map[string]interface{})
+	for k, v := range m {
+		raw[k] = v
+	}
+
+	return raw
 }

--- a/aws/tags_test.go
+++ b/aws/tags_test.go
@@ -80,6 +80,50 @@ func TestIgnoringTags(t *testing.T) {
 	}
 }
 
+func TestTagsMapToHash(t *testing.T) {
+	cases := []struct {
+		Left, Right map[string]interface{}
+		MustBeEqual bool
+	}{
+		{
+			Left:        map[string]interface{}{},
+			Right:       map[string]interface{}{},
+			MustBeEqual: true,
+		},
+		{
+			Left: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Right: map[string]interface{}{
+				"bar": "baz",
+				"foo": "bar",
+			},
+			MustBeEqual: true,
+		},
+		{
+			Left: map[string]interface{}{
+				"foo": "bar",
+			},
+			Right: map[string]interface{}{
+				"bar": "baz",
+			},
+			MustBeEqual: false,
+		},
+	}
+
+	for i, tc := range cases {
+		l := tagsMapToHash(tc.Left)
+		r := tagsMapToHash(tc.Right)
+		if tc.MustBeEqual && (l != r) {
+			t.Fatalf("%d: Hashes don't match", i)
+		}
+		if !tc.MustBeEqual && (l == r) {
+			t.Logf("%d: Hashes match", i)
+		}
+	}
+}
+
 // testAccCheckTags can be used to check the tags on a resource.
 func testAccCheckTags(
 	ts *[]*ec2.Tag, key string, value string) resource.TestCheckFunc {

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -404,10 +404,19 @@ The `replication_configuration` object supports the following:
 The `rules` object supports the following:
 
 * `id` - (Optional) Unique identifier for the rule.
+* `priority` - (Optional) The priority associated with the rule.
 * `destination` - (Required) Specifies the destination for the rule (documented below).
 * `source_selection_criteria` - (Optional) Specifies special object selection criteria (documented below).
-* `prefix` - (Required) Object keyname prefix identifying one or more objects to which the rule applies. Set as an empty string to replicate the whole bucket.
+* `prefix` - (Optional) Object keyname prefix identifying one or more objects to which the rule applies.
 * `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+* `filter` - (Optional) Filter that identifies subset of objects to which the replication rule applies (documented below).
+
+~> **NOTE on `prefix` and `filter`:** Amazon S3's latest version of the replication configuration is V2, which includes the `filter` attribute for replication rules.
+With the `filter` attribute, you can specify object filters based on the object key prefix, tags, or both to scope the objects that the rule applies to.
+Replication configuration V1 supports filtering based on only the `prefix` attribute. For backwards compatibility, Amazon S3 continues to support the V1 configuration.
+* For a specific rule, `prefix` conflicts with `filter`
+* If any rule has `filter` specified then they all must
+* `priority` is optional (with a default value of `0`) but must be unique between multiple rules
 
 The `destination` object supports the following:
 
@@ -426,6 +435,12 @@ The `source_selection_criteria` object supports the following:
 The `sse_kms_encrypted_objects` object supports the following:
 
 * `enabled` - (Required) Boolean which indicates if this criteria is enabled.
+
+The `filter` object supports the following:
+
+* `prefix` - (Optional) Object keyname prefix that identifies subset of objects to which the rule applies.
+* `tags` - (Optional)  A mapping of tags that identifies subset of objects to which the rule applies.
+The rule applies only to objects having all the tags in its tagset.
 
 The `server_side_encryption_configuration` object supports the following:
 


### PR DESCRIPTION
Fixes #828 
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/5940.

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3Bucket_Replication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3Bucket_Replication -timeout 120m
=== RUN   TestAccAWSS3Bucket_Replication
=== PAUSE TestAccAWSS3Bucket_Replication
=== RUN   TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== PAUSE TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== PAUSE TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== RUN   TestAccAWSS3Bucket_ReplicationSchemaV2
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (183.92s)
=== CONT  TestAccAWSS3Bucket_Replication
=== CONT  TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== CONT  TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (33.54s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (57.85s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (126.77s)
--- PASS: TestAccAWSS3Bucket_Replication (154.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	338.080s
```