### PR TITLE
Fix typo in AWS Glue Catalog documentation

### DIFF
--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -60,8 +60,8 @@ The following arguments are supported:
 ##### ser_de_info
 
 * `name` - (Optional) Name of the SerDe.
-* `parameters` - (Optional) Usually the class that implements the SerDe. An example is: org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe.
-* `serialization_library` - (Optional) A list of initialization parameters for the SerDe, in key-value form.
+* `parameters` - (Optional) A map of initialization parameters for the SerDe, in key-value form.
+* `serialization_library` - (Optional) Usually the class that implements the SerDe. An example is: org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe.
 
 ##### sort_column
 


### PR DESCRIPTION
Descriptions are mixed between `parameters` and `serialization_library` in `ser_de_info` section.



<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
