### PR TITLE
Added more color to fixed_gop so it is clear which property it maps to

### DIFF
--- a/website/docs/r/elastic_transcoder_preset.html.markdown
+++ b/website/docs/r/elastic_transcoder_preset.html.markdown
@@ -124,7 +124,7 @@ The `video` object supports the following:
 * `bit_rate` - The bit rate of the video stream in the output file, in kilobits/second. You can configure variable bit rate or constant bit rate encoding.
 * `codec` - The video codec for the output file. Valid values are `gif`, `H.264`, `mpeg2`, `vp8`, and `vp9`.
 * `display_aspect_ratio` - The value that Elastic Transcoder adds to the metadata in the output file. If you set DisplayAspectRatio to auto, Elastic Transcoder chooses an aspect ratio that ensures square pixels. If you specify another option, Elastic Transcoder sets that value in the output file.
-* `fixed_gop` - Whether to use a fixed value for Video:FixedGOP. Not applicable for containers of type gif. Valid values are true and false.
+* `fixed_gop` - Whether to use a fixed value for Video:FixedGOP. Not applicable for containers of type gif. Valid values are true and false. Also known as, Fixed Number of Frames Between Keyframes.
 * `frame_rate` - The frames per second for the video stream in the output file. The following values are valid: `auto`, `10`, `15`, `23.97`, `24`, `25`, `29.97`, `30`, `50`, `60`.
 * `keyframes_max_dist` - The maximum number of frames between key frames. Not applicable for containers of type gif.
 * `max_frame_rate` - If you specify auto for FrameRate, Elastic Transcoder uses the frame rate of the input video for the frame rate of the output video, up to the maximum frame rate. If you do not specify a MaxFrameRate, Elastic Transcoder will use a default of 30.


### PR DESCRIPTION
Changes proposed in this pull request:

* Update `fixed_gop` property documentation for `aws_elastictranscoder_preset` so it is clear that it maps to Fixed Number of Frames Between Keyframes
