### PR TITLE
Fix AWS lb listener authentication documentation

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -101,7 +101,7 @@ The following arguments are supported:
 
 Action Blocks (for `default_action`) support the following:
 
-* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect` and `fixed-response`.
+* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response` and `authenticate-cognito`.
 * `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Required if `type` is `forward`.
 * `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
 * `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -131,6 +131,43 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
+### Authenticate-oidc Action
+
+```hcl
+resource "aws_lb" "front_end" {
+  # ...
+}
+
+resource "aws_lb_target_group" "front_end" {
+  # ...
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.front_end.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    order = 1
+    type  = "authenticate-oidc"
+    authenticate_oidc {
+      authorization_endpoint = "https://example.com/authorization_endpoint"
+      client_id              = "client_id"
+      client_secret          = "client_secret"
+      issuer                 = "https://example.com"
+      token_endpoint         = "https://example.com/token_endpoint"
+      user_info_endpoint     = "https://example.com/user_info_endpoint"
+    }
+  }
+
+  default_action {
+    order            = 2
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.front_end.arn}"
+  }
+}
+```
+
 
 ## Argument Reference
 

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -85,6 +85,52 @@ resource "aws_lb_listener" "front_end" {
 }
 ```
 
+### Authenticate-cognito Action
+
+```hcl
+resource "aws_lb" "front_end" {
+  # ...
+}
+
+resource "aws_lb_target_group" "front_end" {
+  # ...
+}
+
+resource "aws_cognito_user_pool" "pool" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  # ...
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = "${aws_lb.front_end.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    order = 1
+    type  = "authenticate-cognito"
+    authenticate_cognito {
+      user_pool_arn       = "${aws_cognito_user_pool.pool.arn}"
+      user_pool_client_id = "${aws_cognito_user_pool_client.client.id}"
+      user_pool_domain    = "${aws_cognito_user_pool_domain.domain.domain}"
+    }
+  }
+
+  default_action {
+    order            = 2
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.front_end.arn}"
+  }
+}
+```
+
 
 ## Argument Reference
 

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -214,7 +214,7 @@ Authenticate Cognito Blocks (for `authenticate_cognito`) supports the following:
 * `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
 * `session_time_out` - (Optional) The maximum duration of the authentication session, in seconds.
 * `user_pool_arn` - (Required) The ARN of the Cognito user pool.
-* `user_pool_client` - (Required) The ID of the Cognito user pool client.
+* `user_pool_client_id` - (Required) The ID of the Cognito user pool client.
 * `user_pool_domain` - (Required) The domain prefix or fully-qualified domain name of the Cognito user pool.
 
 Authenticate OIDC Blocks (for `authenticate_oidc`) supports the following:

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -147,7 +147,7 @@ The following arguments are supported:
 
 Action Blocks (for `default_action`) support the following:
 
-* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response` and `authenticate-cognito`.
+* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 * `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Required if `type` is `forward`.
 * `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
 * `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -95,6 +95,39 @@ resource "aws_lb_listener_rule" "health_check" {
   }
 }
 
+# Authenticate-cognito Action
+
+resource "aws_cognito_user_pool" "pool" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_client" "client" {
+  # ...
+}
+
+resource "aws_cognito_user_pool_domain" "domain" {
+  # ...
+}
+
+resource "aws_lb_listener_rule" "admin" {
+  listener_arn = "${aws_lb_listener.front_end.arn}"
+
+  action {
+    order = 1
+    type  = "authenticate-cognito"
+    authenticate_cognito {
+      user_pool_arn       = "${aws_cognito_user_pool.pool.arn}"
+      user_pool_client_id = "${aws_cognito_user_pool_client.client.id}"
+      user_pool_domain    = "${aws_cognito_user_pool_domain.domain.domain}"
+    }
+  }
+
+  action {
+    order            = 2
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.static.arn}"
+  }
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -141,7 +141,7 @@ The following arguments are supported:
 
 Action Blocks (for `action`) support the following:
 
-* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response` and `authenticate-cognito`.
+* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response`, `authenticate-cognito` and `authenticate-oidc`.
 * `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Required if `type` is `forward`.
 * `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
 * `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -128,6 +128,31 @@ resource "aws_lb_listener_rule" "admin" {
     target_group_arn = "${aws_lb_target_group.static.arn}"
   }
 }
+
+# Authenticate-oidc Action
+
+resource "aws_lb_listener" "admin" {
+  listener_arn = "${aws_lb_listener.front_end.arn}"
+
+  action {
+    order = 1
+    type  = "authenticate-oidc"
+    authenticate_oidc {
+      authorization_endpoint = "https://example.com/authorization_endpoint"
+      client_id              = "client_id"
+      client_secret          = "client_secret"
+      issuer                 = "https://example.com"
+      token_endpoint         = "https://example.com/token_endpoint"
+      user_info_endpoint     = "https://example.com/user_info_endpoint"
+    }
+  }
+
+  action {
+    order            = 2
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.static.arn}"
+  }
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 Action Blocks (for `action`) support the following:
 
-* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect` and `fixed-response`.
+* `type` - (Required) The type of routing action. Valid values are `forward`, `redirect`, `fixed-response` and `authenticate-cognito`.
 * `target_group_arn` - (Optional) The ARN of the Target Group to which to route traffic. Required if `type` is `forward`.
 * `redirect` - (Optional) Information for creating a redirect action. Required if `type` is `redirect`.
 * `fixed_response` - (Optional) Information for creating an action that returns a custom HTTP response. Required if `type` is `fixed-response`.

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -198,7 +198,7 @@ Authenticate Cognito Blocks (for `authenticate_cognito`) supports the following:
 * `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
 * `session_time_out` - (Optional) The maximum duration of the authentication session, in seconds.
 * `user_pool_arn` - (Required) The ARN of the Cognito user pool.
-* `user_pool_client` - (Required) The ID of the Cognito user pool client.
+* `user_pool_client_id` - (Required) The ID of the Cognito user pool client.
 * `user_pool_domain` - (Required) The domain prefix or fully-qualified domain name of the Cognito user pool.
 
 Authenticate OIDC Blocks (for `authenticate_oidc`) supports the following:


### PR DESCRIPTION
Followup to #6094 which was merged and [will be released in `1.40.0`](https://github.com/terraform-providers/terraform-provider-aws/issues/4707#issuecomment-428039238).

Changes proposed in this pull request:

* Added `authenticate-cognito` action example
* Added `authenticate-oidc` action example
* Added `authenticate-cognito` and `authenticate-oidc` in valid values for `type`
* Renamed `user_pool_client` to `user_pool_client_id` to match the code

The examples are based on the tests of #6094.