### PR TITLE
New resource: aws_pinpoint_email_channel

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -677,6 +677,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_queue":                              resourceAwsBatchJobQueue(),
 			"aws_pinpoint_app":                                 resourceAwsPinpointApp(),
 			"aws_pinpoint_adm_channel":                         resourceAwsPinpointADMChannel(),
+			"aws_pinpoint_email_channel":                       resourceAwsPinpointEmailChannel(),
 			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),
 			"aws_pinpoint_gcm_channel":                         resourceAwsPinpointGCMChannel(),
 			"aws_pinpoint_sms_channel":                         resourceAwsPinpointSMSChannel(),

--- a/aws/resource_aws_pinpoint_email_channel.go
+++ b/aws/resource_aws_pinpoint_email_channel.go
@@ -57,21 +57,10 @@ func resourceAwsPinpointEmailChannelUpsert(d *schema.ResourceData, meta interfac
 
 	params := &pinpoint.EmailChannelRequest{}
 
-	if d.HasChange("enabled") {
-		params.Enabled = aws.Bool(d.Get("enabled").(bool))
-	}
-
-	if d.HasChange("from_address") {
-		params.FromAddress = aws.String(d.Get("from_address").(string))
-	}
-
-	if d.HasChange("identity") {
-		params.Identity = aws.String(d.Get("identity").(string))
-	}
-
-	if d.HasChange("role_arn") {
-		params.RoleArn = aws.String(d.Get("role_arn").(string))
-	}
+	params.Enabled = aws.Bool(d.Get("enabled").(bool))
+	params.FromAddress = aws.String(d.Get("from_address").(string))
+	params.Identity = aws.String(d.Get("identity").(string))
+	params.RoleArn = aws.String(d.Get("role_arn").(string))
 
 	req := pinpoint.UpdateEmailChannelInput{
 		ApplicationId:       aws.String(applicationId),

--- a/aws/resource_aws_pinpoint_email_channel.go
+++ b/aws/resource_aws_pinpoint_email_channel.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsPinpointEmailChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsPinpointEmailChannelUpsert,
+		Read:   resourceAwsPinpointEmailChannelRead,
+		Update: resourceAwsPinpointEmailChannelUpsert,
+		Delete: resourceAwsPinpointEmailChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"from_address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"identity": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"messages_per_second": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsPinpointEmailChannelUpsert(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	applicationId := d.Get("application_id").(string)
+
+	params := &pinpoint.EmailChannelRequest{}
+
+	if d.HasChange("enabled") {
+		params.Enabled = aws.Bool(d.Get("enabled").(bool))
+	}
+
+	if d.HasChange("from_address") {
+		params.FromAddress = aws.String(d.Get("from_address").(string))
+	}
+
+	if d.HasChange("identity") {
+		params.Identity = aws.String(d.Get("identity").(string))
+	}
+
+	if d.HasChange("role_arn") {
+		params.RoleArn = aws.String(d.Get("role_arn").(string))
+	}
+
+	req := pinpoint.UpdateEmailChannelInput{
+		ApplicationId:       aws.String(applicationId),
+		EmailChannelRequest: params,
+	}
+
+	_, err := conn.UpdateEmailChannel(&req)
+	if err != nil {
+		return fmt.Errorf("error updating Pinpoint Email Channel for application %s: %s", applicationId, err)
+	}
+
+	d.SetId(applicationId)
+
+	return resourceAwsPinpointEmailChannelRead(d, meta)
+}
+
+func resourceAwsPinpointEmailChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[INFO] Reading Pinpoint Email Channel for application %s", d.Id())
+
+	output, err := conn.GetEmailChannel(&pinpoint.GetEmailChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Pinpoint Email Channel for application %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error getting Pinpoint Email Channel for application %s: %s", d.Id(), err)
+	}
+
+	d.Set("application_id", output.EmailChannelResponse.ApplicationId)
+	d.Set("enabled", output.EmailChannelResponse.Enabled)
+	d.Set("from_address", output.EmailChannelResponse.FromAddress)
+	d.Set("identity", output.EmailChannelResponse.Identity)
+	d.Set("role_arn", output.EmailChannelResponse.RoleArn)
+	d.Set("messages_per_second", aws.Int64Value(output.EmailChannelResponse.MessagesPerSecond))
+	return nil
+}
+
+func resourceAwsPinpointEmailChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[DEBUG] Deleting Pinpoint Email Channel for application %s", d.Id())
+	_, err := conn.DeleteEmailChannel(&pinpoint.DeleteEmailChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Pinpoint Email Channel for application %s: %s", d.Id(), err)
+	}
+	return nil
+}

--- a/aws/resource_aws_pinpoint_email_channel_test.go
+++ b/aws/resource_aws_pinpoint_email_channel_test.go
@@ -1,0 +1,155 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSPinpointEmailChannel_basic(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.EmailChannelResponse
+	resourceName := "aws_pinpoint_email_channel.test_email_channel"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointEmailChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointEmailChannelConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointEmailChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "messages_per_second"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPinpointEmailChannelExists(n string, channel *pinpoint.EmailChannelResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Pinpoint Email Channel with that application ID exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+		// Check if the app exists
+		params := &pinpoint.GetEmailChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetEmailChannel(params)
+
+		if err != nil {
+			return err
+		}
+
+		*channel = *output.EmailChannelResponse
+
+		return nil
+	}
+}
+
+const testAccAWSPinpointEmailChannelConfig_basic = `
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_email_channel" "test_email_channel" {
+  application_id = "${aws_pinpoint_app.test_app.application_id}"
+  from_address   = "user@example.com"
+  identity       = "${aws_ses_domain_identity.test_identity.arn}"
+  role_arn       = "${aws_iam_role.test_role.arn}"
+}
+
+resource "aws_ses_domain_identity" "test_identity" {
+  domain = "example.com"
+}
+
+resource "aws_iam_role" "test_role" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "pinpoint.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_role_policy" {
+  name   = "test_policy"
+  role   = "${aws_iam_role.test_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Action": [
+      "mobileanalytics:PutEvents",
+      "mobileanalytics:PutItems"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "*"
+    ]
+  }
+}
+EOF
+}
+`
+
+func testAccCheckAWSPinpointEmailChannelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_pinpoint_email_channel" {
+			continue
+		}
+
+		// Check if the event stream exists
+		params := &pinpoint.GetEmailChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetEmailChannel(params)
+		if err != nil {
+			if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("Email Channel exists when it should be destroyed!")
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1689,6 +1689,9 @@
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-adm-channel") %>>
                             <a href="/docs/providers/aws/r/pinpoint_adm_channel.html">aws_pinpoint_adm_channel</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-pinpoint-email-channel") %>>
+                            <a href="/docs/providers/aws/r/pinpoint_email_channel.html">aws_pinpoint_email_channel</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-event-stream") %>>
                             <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
                         </li>

--- a/website/docs/r/pinpoint_email_channel.markdown
+++ b/website/docs/r/pinpoint_email_channel.markdown
@@ -1,0 +1,92 @@
+---
+layout: "aws"
+page_title: "AWS: aws_pinpoint_email_channel"
+sidebar_current: "docs-aws-resource-pinpoint-email-channel"
+description: |-
+  Provides a Pinpoint SMS Channel resource.
+---
+
+# aws_pinpoint_email_channel
+
+Provides a Pinpoint SMS Channel resource.
+
+## Example Usage
+
+```hcl
+resource "aws_pinpoint_email_channel" "email" {
+  application_id = "${aws_pinpoint_app.app.application_id}"
+  from_address   = "user@example.com"
+  identity       = "${aws_ses_domain_identity.identity.arn}"
+  role_arn       = "${aws_iam_role.role.arn}"
+}
+
+resource "aws_pinpoint_app" "app" {}
+
+resource "aws_ses_domain_identity" "identity" {
+  domain = "example.com"
+}
+
+resource "aws_iam_role" "role" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "pinpoint.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "role_policy" {
+  name   = "role_policy"
+  role   = "${aws_iam_role.role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Action": [
+      "mobileanalytics:PutEvents",
+      "mobileanalytics:PutItems"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "*"
+    ]
+  }
+}
+EOF
+}
+
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The application ID.
+* `enabled` - (Optional) Whether the channel is enabled or disabled. Defaults to `true`.
+* `from_address` - (Required) The email address used to send emails from.
+* `identity` - (Required) The ARN of an identity verified with SES.
+* `role_arn` - (Required) The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `messages_per_second` - Messages per second that can be sent.
+
+## Import
+
+Pinpoint Email Channel can be imported using the `application-id`, e.g.
+
+```
+$ terraform import aws_pinpoint_email_channel.email application-id
+```


### PR DESCRIPTION
Work continues on #4990

Changes proposed in this pull request:

* New resource aws_pinpoint_email_channel with related docs and acceptance tests

Output from acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointEmailChannel'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointEmailChannel -timeout 120m
=== RUN   TestAccAWSPinpointEmailChannel_basic
--- PASS: TestAccAWSPinpointEmailChannel_basic (20.49s)
PASS
ok                                               github.com/terraform-providers/terraform-provider-aws/aws     21.679s
```