### PR TITLE
New resource: aws_pinpoint_baidu_channel

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -677,6 +677,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_batch_job_queue":                              resourceAwsBatchJobQueue(),
 			"aws_pinpoint_app":                                 resourceAwsPinpointApp(),
 			"aws_pinpoint_adm_channel":                         resourceAwsPinpointADMChannel(),
+			"aws_pinpoint_baidu_channel":                       resourceAwsPinpointBaiduChannel(),
 			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),
 			"aws_pinpoint_gcm_channel":                         resourceAwsPinpointGCMChannel(),
 			"aws_pinpoint_sms_channel":                         resourceAwsPinpointSMSChannel(),

--- a/aws/resource_aws_pinpoint_baidu_channel.go
+++ b/aws/resource_aws_pinpoint_baidu_channel.go
@@ -1,0 +1,122 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsPinpointBaiduChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsPinpointBaiduChannelUpsert,
+		Read:   resourceAwsPinpointBaiduChannelRead,
+		Update: resourceAwsPinpointBaiduChannelUpsert,
+		Delete: resourceAwsPinpointBaiduChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"api_key": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"secret_key": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceAwsPinpointBaiduChannelUpsert(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	applicationId := d.Get("application_id").(string)
+
+	params := &pinpoint.BaiduChannelRequest{}
+
+	if d.HasChange("enabled") {
+		params.Enabled = aws.Bool(d.Get("enabled").(bool))
+	}
+
+	if d.HasChange("api_key") {
+		params.ApiKey = aws.String(d.Get("api_key").(string))
+	}
+
+	if d.HasChange("secret_key") {
+		params.SecretKey = aws.String(d.Get("secret_key").(string))
+	}
+
+	req := pinpoint.UpdateBaiduChannelInput{
+		ApplicationId:       aws.String(applicationId),
+		BaiduChannelRequest: params,
+	}
+
+	_, err := conn.UpdateBaiduChannel(&req)
+	if err != nil {
+		return fmt.Errorf("error updating Pinpoint Baidu Channel for application %s: %s", applicationId, err)
+	}
+
+	d.SetId(applicationId)
+
+	return resourceAwsPinpointBaiduChannelRead(d, meta)
+}
+
+func resourceAwsPinpointBaiduChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[INFO] Reading Pinpoint Baidu Channel for application %s", d.Id())
+
+	output, err := conn.GetBaiduChannel(&pinpoint.GetBaiduChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Pinpoint Baidu Channel for application %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error getting Pinpoint Baidu Channel for application %s: %s", d.Id(), err)
+	}
+
+	d.Set("application_id", output.BaiduChannelResponse.ApplicationId)
+	d.Set("enabled", output.BaiduChannelResponse.Enabled)
+	// ApiKey and SecretKey are never returned
+
+	return nil
+}
+
+func resourceAwsPinpointBaiduChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[DEBUG] Deleting Pinpoint Baidu Channel for application %s", d.Id())
+	_, err := conn.DeleteBaiduChannel(&pinpoint.DeleteBaiduChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Pinpoint Baidu Channel for application %s: %s", d.Id(), err)
+	}
+	return nil
+}

--- a/aws/resource_aws_pinpoint_baidu_channel.go
+++ b/aws/resource_aws_pinpoint_baidu_channel.go
@@ -51,17 +51,9 @@ func resourceAwsPinpointBaiduChannelUpsert(d *schema.ResourceData, meta interfac
 
 	params := &pinpoint.BaiduChannelRequest{}
 
-	if d.HasChange("enabled") {
-		params.Enabled = aws.Bool(d.Get("enabled").(bool))
-	}
-
-	if d.HasChange("api_key") {
-		params.ApiKey = aws.String(d.Get("api_key").(string))
-	}
-
-	if d.HasChange("secret_key") {
-		params.SecretKey = aws.String(d.Get("secret_key").(string))
-	}
+	params.Enabled = aws.Bool(d.Get("enabled").(bool))
+	params.ApiKey = aws.String(d.Get("api_key").(string))
+	params.SecretKey = aws.String(d.Get("secret_key").(string))
 
 	req := pinpoint.UpdateBaiduChannelInput{
 		ApplicationId:       aws.String(applicationId),

--- a/aws/resource_aws_pinpoint_baidu_channel_test.go
+++ b/aws/resource_aws_pinpoint_baidu_channel_test.go
@@ -21,6 +21,7 @@ func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
 	resourceName := "aws_pinpoint_baidu_channel.channel"
 
 	apiKey := "123"
+	apikeyUpdated := "234"
 	secretKey := "456"
 
 	resource.Test(t, resource.TestCase{
@@ -33,7 +34,7 @@ func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
 				Config: testAccAWSPinpointBaiduChannelConfig_basic(apiKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointBaiduChannelExists(resourceName, &channel),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "api_key", apiKey),
 					resource.TestCheckResourceAttr(resourceName, "secret_key", secretKey),
 				),
@@ -43,6 +44,15 @@ func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"api_key", "secret_key"},
+			},
+			{
+				Config: testAccAWSPinpointBaiduChannelConfig_update(apikeyUpdated, secretKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointBaiduChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "api_key", apikeyUpdated),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", secretKey),
+				),
 			},
 		},
 	})
@@ -87,7 +97,26 @@ resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_baidu_channel" "channel" {
     application_id = "${aws_pinpoint_app.test_app.application_id}"
+    
+    enabled    = "false"
+    api_key    = "%s"
+    secret_key = "%s"
+}
+`, apiKey, secretKey)
+}
 
+func testAccAWSPinpointBaiduChannelConfig_update(apiKey, secretKey string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_baidu_channel" "channel" {
+    application_id = "${aws_pinpoint_app.test_app.application_id}"
+    
+    enabled    = "false"
     api_key    = "%s"
     secret_key = "%s"
 }

--- a/aws/resource_aws_pinpoint_baidu_channel_test.go
+++ b/aws/resource_aws_pinpoint_baidu_channel_test.go
@@ -1,0 +1,120 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSPinpointBaiduChannel_basic(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.BaiduChannelResponse
+	resourceName := "aws_pinpoint_baidu_channel.channel"
+
+	apiKey := "123"
+	secretKey := "456"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointBaiduChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointBaiduChannelConfig_basic(apiKey, secretKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointBaiduChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "api_key", apiKey),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", secretKey),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"api_key", "secret_key"},
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPinpointBaiduChannelExists(n string, channel *pinpoint.BaiduChannelResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Pinpoint Baidu channel with that Application ID exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+		// Check if the Baidu Channel exists
+		params := &pinpoint.GetBaiduChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetBaiduChannel(params)
+
+		if err != nil {
+			return err
+		}
+
+		*channel = *output.BaiduChannelResponse
+
+		return nil
+	}
+}
+
+func testAccAWSPinpointBaiduChannelConfig_basic(apiKey, secretKey string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_baidu_channel" "channel" {
+    application_id = "${aws_pinpoint_app.test_app.application_id}"
+
+    api_key    = "%s"
+    secret_key = "%s"
+}
+`, apiKey, secretKey)
+}
+
+func testAccCheckAWSPinpointBaiduChannelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_pinpoint_baidu_channel" {
+			continue
+		}
+
+		// Check if the Baidu channel exists by fetching its attributes
+		params := &pinpoint.GetBaiduChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetBaiduChannel(params)
+		if err != nil {
+			if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("Baidu Channel exists when it should be destroyed!")
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1689,6 +1689,9 @@
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-adm-channel") %>>
                             <a href="/docs/providers/aws/r/pinpoint_adm_channel.html">aws_pinpoint_adm_channel</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-pinpoint-baidu-channel") %>>
+                            <a href="/docs/providers/aws/r/pinpoint_baidu_channel.html">aws_pinpoint_baidu_channel</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-event-stream") %>>
                             <a href="/docs/providers/aws/r/pinpoint_event_stream.html">aws_pinpoint_event_stream</a>
                         </li>

--- a/website/docs/r/pinpoint_baidu_channel.markdown
+++ b/website/docs/r/pinpoint_baidu_channel.markdown
@@ -1,0 +1,46 @@
+---
+layout: "aws"
+page_title: "AWS: aws_pinpoint_baidu_channel"
+sidebar_current: "docs-aws-resource-pinpoint-baidu-channel"
+description: |-
+  Provides a Pinpoint Baidu Channel resource.
+---
+
+# aws_pinpoint_baidu_channel
+
+Provides a Pinpoint Baidu Channel resource.
+
+~> **Note:** All arguments including the Api Key and Secret Key will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+
+## Example Usage
+
+```hcl
+resource "aws_pinpoint_app" "app" {}
+
+resource "aws_pinpoint_baidu_channel" "channel" {
+    application_id = "${aws_pinpoint_app.app.application_id}"
+    api_key        = ""
+    secret_key     = ""
+    
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The application ID.
+* `enabled` - (Optional) Specifies whether to enable the channel. Defaults to `true`.
+* `api_key` - (Required) Platform credential API key from Baidu.
+* `secret_key` - (Required) Platform credential Secret key from Baidu.
+
+## Import
+
+Pinpoint Baidu Channel can be imported using the `application-id`, e.g.
+
+```
+$ terraform import aws_pinpoint_baidu_channel.channel application-id
+```


### PR DESCRIPTION
Work continues on #4990

Changes proposed in this pull request:

* New resource aws_pinpoint_baidu_channel with related docs and acceptance tests

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointBaiduChannel'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointBaiduChannel -timeout 120m
=== RUN   TestAccAWSPinpointBaiduChannel_basic
--- PASS: TestAccAWSPinpointBaiduChannel_basic (18.46s)
PASS
ok                                               github.com/terraform-providers/terraform-provider-aws/aws     19.578s
```
NOTES:
* Baidu channel does not validate api_key nor secret_key, therefore I used mock values.