### PR TITLE
aws_pinpoint_* : fix updates

### DIFF
--- a/aws/resource_aws_pinpoint_adm_channel.go
+++ b/aws/resource_aws_pinpoint_adm_channel.go
@@ -51,17 +51,9 @@ func resourceAwsPinpointADMChannelUpsert(d *schema.ResourceData, meta interface{
 
 	params := &pinpoint.ADMChannelRequest{}
 
-	if d.HasChange("client_id") {
-		params.ClientId = aws.String(d.Get("client_id").(string))
-	}
-
-	if d.HasChange("client_secret") {
-		params.ClientSecret = aws.String(d.Get("client_secret").(string))
-	}
-
-	if d.HasChange("enabled") {
-		params.Enabled = aws.Bool(d.Get("enabled").(bool))
-	}
+	params.ClientId = aws.String(d.Get("client_id").(string))
+	params.ClientSecret = aws.String(d.Get("client_secret").(string))
+	params.Enabled = aws.Bool(d.Get("enabled").(bool))
 
 	req := pinpoint.UpdateAdmChannelInput{
 		ApplicationId:     aws.String(applicationId),

--- a/aws/resource_aws_pinpoint_adm_channel_test.go
+++ b/aws/resource_aws_pinpoint_adm_channel_test.go
@@ -62,6 +62,7 @@ func TestAccAWSPinpointADMChannel_basic(t *testing.T) {
 				Config: testAccAWSPinpointADMChannelConfig_basic(config),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointADMChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 			{
@@ -69,6 +70,13 @@ func TestAccAWSPinpointADMChannel_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"client_id", "client_secret"},
+			},
+			{
+				Config: testAccAWSPinpointADMChannelConfig_basic(config),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointADMChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
 			},
 		},
 	})
@@ -116,7 +124,7 @@ resource "aws_pinpoint_adm_channel" "channel" {
 
     client_id     = "%s"
     client_secret = "%s"
-    enabled       = true
+    enabled       = false
 }
 `, conf.ClientID, conf.ClientSecret)
 }

--- a/aws/resource_aws_pinpoint_event_stream.go
+++ b/aws/resource_aws_pinpoint_event_stream.go
@@ -44,13 +44,8 @@ func resourceAwsPinpointEventStreamUpsert(d *schema.ResourceData, meta interface
 
 	params := &pinpoint.WriteEventStream{}
 
-	if d.HasChange("destination_stream_arn") {
-		params.DestinationStreamArn = aws.String(d.Get("destination_stream_arn").(string))
-	}
-
-	if d.HasChange("role_arn") {
-		params.RoleArn = aws.String(d.Get("role_arn").(string))
-	}
+	params.DestinationStreamArn = aws.String(d.Get("destination_stream_arn").(string))
+	params.RoleArn = aws.String(d.Get("role_arn").(string))
 
 	req := pinpoint.PutEventStreamInput{
 		ApplicationId:    aws.String(applicationId),

--- a/aws/resource_aws_pinpoint_event_stream_test.go
+++ b/aws/resource_aws_pinpoint_event_stream_test.go
@@ -37,6 +37,12 @@ func TestAccAWSPinpointEventStream_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAWSPinpointEventStreamConfig_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointEventStreamExists(resourceName, &stream),
+				),
+			},
 		},
 	})
 }
@@ -85,6 +91,63 @@ resource "aws_pinpoint_event_stream" "test_event_stream" {
 
 resource "aws_kinesis_stream" "test_stream" {
   name        = "terraform-kinesis-test"
+  shard_count = 1
+}
+
+resource "aws_iam_role" "test_role" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "pinpoint.us-east-1.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_role_policy" {
+  name   = "test_policy"
+  role   = "${aws_iam_role.test_role.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Action": [
+      "kinesis:PutRecords",
+      "kinesis:DescribeStream"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "arn:aws:kinesis:us-east-1:*:*/*"
+    ]
+  }
+}
+EOF
+}
+`
+
+const testAccAWSPinpointEventStreamConfig_update = `
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_event_stream" "test_event_stream" {
+  application_id         = "${aws_pinpoint_app.test_app.application_id}"
+  destination_stream_arn = "${aws_kinesis_stream.test_stream_updated.arn}"
+  role_arn               = "${aws_iam_role.test_role.arn}"
+}
+
+resource "aws_kinesis_stream" "test_stream_updated" {
+  name        = "terraform-kinesis-test-updated"
   shard_count = 1
 }
 

--- a/aws/resource_aws_pinpoint_gcm_channel.go
+++ b/aws/resource_aws_pinpoint_gcm_channel.go
@@ -46,13 +46,8 @@ func resourceAwsPinpointGCMChannelUpsert(d *schema.ResourceData, meta interface{
 
 	params := &pinpoint.GCMChannelRequest{}
 
-	if d.HasChange("api_key") {
-		params.ApiKey = aws.String(d.Get("api_key").(string))
-	}
-
-	if d.HasChange("enabled") {
-		params.Enabled = aws.Bool(d.Get("enabled").(bool))
-	}
+	params.ApiKey = aws.String(d.Get("api_key").(string))
+	params.Enabled = aws.Bool(d.Get("enabled").(bool))
 
 	req := pinpoint.UpdateGcmChannelInput{
 		ApplicationId:     aws.String(applicationId),

--- a/aws/resource_aws_pinpoint_gcm_channel_test.go
+++ b/aws/resource_aws_pinpoint_gcm_channel_test.go
@@ -42,6 +42,7 @@ func TestAccAWSPinpointGCMChannel_basic(t *testing.T) {
 				Config: testAccAWSPinpointGCMChannelConfig_basic(apiKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSPinpointGCMChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 			{
@@ -49,6 +50,13 @@ func TestAccAWSPinpointGCMChannel_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"api_key"},
+			},
+			{
+				Config: testAccAWSPinpointGCMChannelConfig_basic(apiKey),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointGCMChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
 			},
 		},
 	})
@@ -93,7 +101,7 @@ resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_gcm_channel" "test_gcm_channel" {
   application_id = "${aws_pinpoint_app.test_app.application_id}"
-  enabled        = "true"
+  enabled        = "false"
   api_key        = "%s"
 }`, apiKey)
 }

--- a/aws/resource_aws_pinpoint_sms_channel.go
+++ b/aws/resource_aws_pinpoint_sms_channel.go
@@ -57,9 +57,7 @@ func resourceAwsPinpointSMSChannelUpsert(d *schema.ResourceData, meta interface{
 
 	params := &pinpoint.SMSChannelRequest{}
 
-	if d.HasChange("enabled") {
-		params.Enabled = aws.Bool(d.Get("enabled").(bool))
-	}
+	params.Enabled = aws.Bool(d.Get("enabled").(bool))
 
 	if d.HasChange("sender_id") {
 		params.SenderId = aws.String(d.Get("sender_id").(string))

--- a/aws/resource_aws_pinpoint_sms_channel_test.go
+++ b/aws/resource_aws_pinpoint_sms_channel_test.go
@@ -38,6 +38,13 @@ func TestAccAWSPinpointSMSChannel_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAWSPinpointSMSChannelConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointSMSChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
 		},
 	})
 }
@@ -50,6 +57,7 @@ func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
 	resourceName := "aws_pinpoint_sms_channel.test_sms_channel"
 	senderId := "1234"
 	shortCode := "5678"
+	newShortCode := "7890"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -63,6 +71,7 @@ func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
 					testAccCheckAWSPinpointSMSChannelExists(resourceName, &channel),
 					resource.TestCheckResourceAttr(resourceName, "sender_id", senderId),
 					resource.TestCheckResourceAttr(resourceName, "short_code", shortCode),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "promotional_messages_per_second"),
 					resource.TestCheckResourceAttrSet(resourceName, "transactional_messages_per_second"),
 				),
@@ -71,6 +80,17 @@ func TestAccAWSPinpointSMSChannel_full(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSPinpointSMSChannelConfig_full(senderId, newShortCode),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointSMSChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "sender_id", senderId),
+					resource.TestCheckResourceAttr(resourceName, "short_code", newShortCode),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "promotional_messages_per_second"),
+					resource.TestCheckResourceAttrSet(resourceName, "transactional_messages_per_second"),
+				),
 			},
 		},
 	})
@@ -126,7 +146,7 @@ resource "aws_pinpoint_app" "test_app" {}
 
 resource "aws_pinpoint_sms_channel" "test_sms_channel" {
   application_id = "${aws_pinpoint_app.test_app.application_id}"
-  enabled        = "true"
+  enabled        = "false"
   sender_id      = "%s"
   short_code     = "%s"
 }`, senderId, shortCode)

--- a/website/docs/r/pinpoint_adm_channel.markdown
+++ b/website/docs/r/pinpoint_adm_channel.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `application_id` - (Required) The application ID.
 * `client_id` - (Required) Client ID (part of OAuth Credentials) obtained via Amazon Developer Account.
 * `client_secret` - (Required) Client Secret (part of OAuth Credentials) obtained via Amazon Developer Account.
-* `enabled` - (Optional) Specifies whether to enable the channel. Defaults to `false`.
+* `enabled` - (Optional) Specifies whether to enable the channel. Defaults to `true`.
 
 ## Import
 


### PR DESCRIPTION
This PR mainly fixes an issue with Pinpoint resources that have an upsert endpoint. It seems that some parameters are not preserved or requires to be provided in sets.
For example:

* "enabled" param is not preserved during updates and defaults to true.
* Credentials params cannot be provided separately (e.g. update "api_key" but not "secret_key")
* event_stream requires all params.

This PR also adds a test scenario for each resource and forces params that caused troubles to be sent each time.

Changes proposed in this pull request:

* resource/aws_pinpoint_adm_channel : update requires all params
* resource/aws_pinpoint_adm_channel : fix in docs
* resource/aws_pinpoint_event_stream : update requires all params
* resource/aws_pinpoint_gcm_channel : update requires all params
* resource/aws_pinpoint_sms_channel : update doesn't preserve "enabled" param


Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointADMChannel'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointADMChannel -timeout 120m
=== RUN   TestAccAWSPinpointADMChannel_basic
--- PASS: TestAccAWSPinpointADMChannel_basic (28.62s)
PASS
ok                                               github.com/terraform-providers/terraform-provider-aws/aws     30.104s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointEventStream'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointEventStream -timeout 120m
=== RUN   TestAccAWSPinpointEventStream_basic
--- PASS: TestAccAWSPinpointEventStream_basic (165.70s)
PASS
ok                                               github.com/terraform-providers/terraform-provider-aws/aws     166.976s


$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointGCMChannel'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointGCMChannel -timeout 120m
=== RUN   TestAccAWSPinpointGCMChannel_basic
--- PASS: TestAccAWSPinpointGCMChannel_basic (29.47s)
PASS
ok                                               github.com/terraform-providers/terraform-provider-aws/aws     30.837s

 
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointSMSChannel'
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./aws -v -run=TestAccAWSPinpointSMSChannel -timeout 120m
=== RUN   TestAccAWSPinpointSMSChannel_basic
--- PASS: TestAccAWSPinpointSMSChannel_basic (28.88s)
=== RUN   TestAccAWSPinpointSMSChannel_full
--- PASS: TestAccAWSPinpointSMSChannel_full (31.39s)
PASS
ok                                               github.com/terraform-providers/terraform-provider-aws/aws     61.566s
```
