### PR TITLE
Add KMS encryption support to the aws_athena_database resource.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -237,6 +237,13 @@ existing resources, but you still get to implement something completely new.
    covering their behavior. See [Writing Acceptance
    Tests](#writing-acceptance-tests) below for a detailed guide on how to
    approach these.
+ - [ ] __Naming__: Resources should be named `aws_<service>_<name>` where 
+   `service` is the AWS short service name and `name` is a short, preferably
+   single word, description of the resource. Use `_` as a separator.
+   resources. We therefore encourage you to only submit **1 resource at a time**.
+ - [ ] __Arguments_and_Attributes__: The HCL for Arguments and attributes should
+   mimic the types and structs presented by the AWS API. API arguments should be
+   converted from `CamelCase` to `camel_case`.
  - [ ] __Documentation__: Each resource gets a page in the Terraform
    documentation. The [Terraform website][website] source is in this
    repo and includes instructions for getting a local copy of the site up and

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -241,7 +241,7 @@ existing resources, but you still get to implement something completely new.
    `service` is the AWS short service name and `name` is a short, preferably
    single word, description of the resource. Use `_` as a separator.
    resources. We therefore encourage you to only submit **1 resource at a time**.
- - [ ] __Arguments_and_Attributes__: The HCL for Arguments and attributes should
+ - [ ] __Arguments_and_Attributes__: The HCL for arguments and attributes should
    mimic the types and structs presented by the AWS API. API arguments should be
    converted from `CamelCase` to `camel_case`.
  - [ ] __Documentation__: Each resource gets a page in the Terraform

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ sweep:
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
 
-testacc:
+testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 fmt:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ sweep:
 test: fmtcheck
 	go test $(TEST) -timeout=30s -parallel=4
 
-testacc: fmtcheck
+testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 fmt:

--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -66,7 +66,7 @@ func getResultConfig(d *schema.ResourceData) (*athena.ResultConfiguration, error
 
 	e := d.Get("encryption_key").([]interface{})
 	if len(e) <= 0 {
-		return &resultConfig
+		return &resultConfig, nil
 	}
 
 	data := e[0].(map[string]interface{})
@@ -74,7 +74,7 @@ func getResultConfig(d *schema.ResourceData) (*athena.ResultConfiguration, error
 	keyID := data["id"].(string)
 
 	if len(keyType) <= 0 {
-		return fmt.Errorf("An encryption key type is required")
+		return nil, fmt.Errorf("An encryption key type is required")
 	}
 
 	if strings.HasSuffix(keyType, "_KMS") && len(keyID) <= 0 {

--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -38,17 +38,17 @@ func resourceAwsAthenaDatabase() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"encryption_key": {
+			"encryption_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
+						"kms_key": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"type": {
+						"encryption_option": {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
@@ -74,8 +74,8 @@ func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList 
 	}
 
 	data := encryptionConfigurationList[0].(map[string]interface{})
-	keyType := data["type"].(string)
-	keyID := data["id"].(string)
+	keyType := data["encryption_option"].(string)
+	keyID := data["kms_key"].(string)
 
 	encryptionConfig := athena.EncryptionConfiguration{
 		EncryptionOption: aws.String(keyType),
@@ -93,7 +93,7 @@ func expandAthenaResultConfiguration(bucket string, encryptionConfigurationList 
 func resourceAwsAthenaDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).athenaconn
 
-	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_key").([]interface{}))
+	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_configuration").([]interface{}))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func resourceAwsAthenaDatabaseCreate(d *schema.ResourceData, meta interface{}) e
 func resourceAwsAthenaDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).athenaconn
 
-	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_key").([]interface{}))
+	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_configuration").([]interface{}))
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func resourceAwsAthenaDatabaseUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceAwsAthenaDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).athenaconn
 
-	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_key").([]interface{}))
+	resultConfig, err := expandAthenaResultConfiguration(d.Get("bucket").(string), d.Get("encryption_configuration").([]interface{}))
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_athena_database_test.go
+++ b/aws/resource_aws_athena_database_test.go
@@ -43,7 +43,7 @@ func TestAccAWSAthenaDatabase_encryption(t *testing.T) {
 				Config: testAccAthenaDatabaseWithKMSConfig(rInt, dbName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAthenaDatabaseExists("aws_athena_database.hoge"),
-					resource.TestCheckResourceAttr("aws_athena_database.hoge", "encryption_key.0.type", "SSE_KMS"),
+					resource.TestCheckResourceAttr("aws_athena_database.hoge", "encryption_configuration.0.encryption_option", "SSE_KMS"),
 				),
 			},
 		},
@@ -378,9 +378,9 @@ resource "aws_athena_database" "hoge" {
   bucket        = "${aws_s3_bucket.hoge.bucket}"
   force_destroy = %[3]t
 
-  encryption_key {
-    type = "SSE_KMS"
-    id   = "${aws_kms_key.hoge.arn}" 
+  encryption_configuration {
+    encryption_option = "SSE_KMS"
+    kms_key           = "${aws_kms_key.hoge.arn}" 
   }
 }
     `, randInt, dbName, forceDestroy)

--- a/aws/resource_aws_athena_database_test.go
+++ b/aws/resource_aws_athena_database_test.go
@@ -31,6 +31,25 @@ func TestAccAWSAthenaDatabase_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAthenaDatabase_encryption(t *testing.T) {
+	rInt := acctest.RandInt()
+	dbName := acctest.RandString(8)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAthenaDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAthenaDatabaseWithKMSConfig(rInt, dbName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAthenaDatabaseExists("aws_athena_database.hoge"),
+					resource.TestCheckResourceAttr("aws_athena_database.hoge", "encryption_key.0.type", "SSE_KMS"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAthenaDatabase_nameStartsWithUnderscore(t *testing.T) {
 	rInt := acctest.RandInt()
 	dbName := "_" + acctest.RandString(8)
@@ -331,5 +350,38 @@ func testAccAthenaDatabaseConfig(randInt int, dbName string, forceDestroy bool) 
 	  bucket = "${aws_s3_bucket.hoge.bucket}"
 	  force_destroy = %[3]t
     }
+    `, randInt, dbName, forceDestroy)
+}
+
+func testAccAthenaDatabaseWithKMSConfig(randInt int, dbName string, forceDestroy bool) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "hoge" {
+  deletion_window_in_days = 10
+}
+
+resource "aws_s3_bucket" "hoge" {
+  bucket        = "tf-athena-db-%[1]d"
+  force_destroy = true
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${aws_kms_key.hoge.arn}"
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}
+
+resource "aws_athena_database" "hoge" {
+  name          = "%[2]s"
+  bucket        = "${aws_s3_bucket.hoge.bucket}"
+  force_destroy = %[3]t
+
+  encryption_key {
+    type = "SSE_KMS"
+    id   = "${aws_kms_key.hoge.arn}" 
+  }
+}
     `, randInt, dbName, forceDestroy)
 }

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -29,10 +29,10 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the database to create.
 * `bucket` - (Required) Name of s3 bucket to save the results of the query execution.
-* `encryption_configuration` - (Optional) The encryption key block AWS Athena uses to decrypt the data in S3, such as an AWS Key Management Service (AWS KMS) key. An `encryption_key` block is documented below.
+* `encryption_configuration` - (Optional) The encryption key block AWS Athena uses to decrypt the data in S3, such as an AWS Key Management Service (AWS KMS) key. An `encryption_configuration` block is documented below.
 * `force_destroy` - (Optional, Default: false) A boolean that indicates all tables should be deleted from the database so that the database can be destroyed without error. The tables are *not* recoverable.
 
-An `encryption_key` block supports the following arguments:
+An `encryption_configuration` block supports the following arguments:
 
 * `encryption_option` - (Required) The type of key; one of `SSE_S3`, `SSE_KMS`, `CSE_KMS`
 * `kms_key` - (Optional) The KMS key ARN or ID; required for key types `SSE_KMS` and `CSE_KMS`.

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -29,7 +29,13 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the database to create.
 * `bucket` - (Required) Name of s3 bucket to save the results of the query execution.
+* `encryption_key` - (Optional) The encryption key block AWS Athena uses to decrypt the data in S3, such as an AWS Key Management Service (AWS KMS) key. An `encryption_key` block is documented below.
 * `force_destroy` - (Optional, Default: false) A boolean that indicates all tables should be deleted from the database so that the database can be destroyed without error. The tables are *not* recoverable.
+
+An `encryption_key` block supports the following arguments:
+
+* `type` - (Required) The type of key; one of `SSE_S3`, `SSE_KMS`, `CSE_KMS`
+* `id` - (Optional) The KMS key ARN or ID; required for key types `SSE_KMS` and `CSE_KMS`.
 
 ~> **NOTE:** When Athena queries are executed, result files may be created in the specified bucket. Consider using `force_destroy` on the bucket too in order to avoid any problems when destroying the bucket.  
 

--- a/website/docs/r/athena_database.html.markdown
+++ b/website/docs/r/athena_database.html.markdown
@@ -29,13 +29,13 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the database to create.
 * `bucket` - (Required) Name of s3 bucket to save the results of the query execution.
-* `encryption_key` - (Optional) The encryption key block AWS Athena uses to decrypt the data in S3, such as an AWS Key Management Service (AWS KMS) key. An `encryption_key` block is documented below.
+* `encryption_configuration` - (Optional) The encryption key block AWS Athena uses to decrypt the data in S3, such as an AWS Key Management Service (AWS KMS) key. An `encryption_key` block is documented below.
 * `force_destroy` - (Optional, Default: false) A boolean that indicates all tables should be deleted from the database so that the database can be destroyed without error. The tables are *not* recoverable.
 
 An `encryption_key` block supports the following arguments:
 
-* `type` - (Required) The type of key; one of `SSE_S3`, `SSE_KMS`, `CSE_KMS`
-* `id` - (Optional) The KMS key ARN or ID; required for key types `SSE_KMS` and `CSE_KMS`.
+* `encryption_option` - (Required) The type of key; one of `SSE_S3`, `SSE_KMS`, `CSE_KMS`
+* `kms_key` - (Optional) The KMS key ARN or ID; required for key types `SSE_KMS` and `CSE_KMS`.
 
 ~> **NOTE:** When Athena queries are executed, result files may be created in the specified bucket. Consider using `force_destroy` on the bucket too in order to avoid any problems when destroying the bucket.  
 

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -142,7 +142,7 @@ An `artifact_store` block supports the following arguments:
 * `type` - (Required) The type of the artifact store, such as Amazon S3
 * `encryption_key` - (Optional) The encryption key block AWS CodePipeline uses to encrypt the data in the artifact store, such as an AWS Key Management Service (AWS KMS) key. If you don't specify a key, AWS CodePipeline uses the default key for Amazon Simple Storage Service (Amazon S3). An `encryption_key` block is documented below.
 
-A `encryption_key` block supports the following arguments:
+An `encryption_key` block supports the following arguments:
 
 * `id` - (Required) The KMS key ARN or ID
 * `type` - (Required) The type of key; currently only `KMS` is supported


### PR DESCRIPTION
## What does this add?

Adds an `encryption_key` attribute to the `aws_athena_database` resource. This allows TF to create databases that read from encrypted S3 buckets.

## Example HCL

```hcl
resource "aws_kms_key" "test" {
  name = "athenta-test"
}

resource "aws_athena_database" "test" {
  name          = "athena-test"
  bucket        = "${aws_s3_bucket.test.bucket}"
  force_destroy = true

  encryption_key {
    type = "SSE_KMS"
    id   = "${aws_kms_key.test.arn}" 
  }
}
```

## Test output

```
make testacc TESTARGS='-run=TestAccAWSAthenaDatabase'
TF_ACC=1 go test ./... -v -run=TestAccAWSAthenaDatabase -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAthenaDatabase_basic
--- PASS: TestAccAWSAthenaDatabase_basic (49.53s)
=== RUN   TestAccAWSAthenaDatabase_encryption
--- PASS: TestAccAWSAthenaDatabase_encryption (79.31s)
=== RUN   TestAccAWSAthenaDatabase_nameStartsWithUnderscore
--- PASS: TestAccAWSAthenaDatabase_nameStartsWithUnderscore (49.75s)
=== RUN   TestAccAWSAthenaDatabase_nameCantHaveUppercase
--- PASS: TestAccAWSAthenaDatabase_nameCantHaveUppercase (0.92s)
=== RUN   TestAccAWSAthenaDatabase_destroyFailsIfTablesExist
--- PASS: TestAccAWSAthenaDatabase_destroyFailsIfTablesExist (61.16s)
=== RUN   TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds
--- PASS: TestAccAWSAthenaDatabase_forceDestroyAlwaysSucceeds (72.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	314.027s
```