### PR TITLE
resource/aws_lb_listener(_rule): Set action order to Computed

### DIFF
--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -92,6 +92,7 @@ func resourceAwsLbListener() *schema.Resource {
 						"order": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 50000),
 						},
 

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -63,6 +63,7 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 						"order": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 50000),
 						},
 


### PR DESCRIPTION
Fixes #6116 

While the acceptance testing is not finding this scenario, the order value may return as `1`. This may be caused by web console updates. We should not default this to `1` as that could cause `0` to `1` plan differences and shying away from a stopgap `DiffSuppressFunc` here because we may make this configuration based on the `TypeList` index in the future if its undefined.

Changes proposed in this pull request:

* resource/aws_lb_listener: Set `default_action` `order` to `Computed`
* resource/aws_lb_listener_rule: Set `action` `order` to `Computed`

Output from acceptance testing:

```
15 tests passed (all tests)
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (1.63s)
--- PASS: TestAccAWSLBListener_oidc (191.06s)
--- PASS: TestAccAWSLBListener_basic (198.17s)
--- PASS: TestAccAWSLBListener_redirect (199.97s)
--- PASS: TestAccAWSLBListenerRule_basic (202.39s)
--- PASS: TestAccAWSLBListenerRule_cognito (202.91s)
--- PASS: TestAccAWSLBListener_https (207.19s)
--- PASS: TestAccAWSLBListener_cognito (208.68s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (219.09s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (240.27s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (246.74s)
--- PASS: TestAccAWSLBListener_fixedResponse (255.55s)
--- PASS: TestAccAWSLBListenerRule_priority (281.37s)
--- PASS: TestAccAWSLBListenerRule_redirect (281.80s)
--- PASS: TestAccAWSLBListenerRule_oidc (318.27s)
```
