### PR TITLE
Add logging options to AWS MQ

### DIFF
--- a/aws/data_source_aws_mq_broker.go
+++ b/aws/data_source_aws_mq_broker.go
@@ -76,10 +76,38 @@ func dataSourceAwsMqBroker() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"endpoints": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"logs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				// Ignore missing configuration block
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "1" && new == "0" {
+						return true
+					}
+					return false
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"general": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"audit": {
+							Type:     schema.TypeBool,
+							Computed: true,
 						},
 					},
 				},

--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -48,6 +48,9 @@ func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 						"data.aws_mq_broker.by_id", "instances.#",
 						"aws_mq_broker.acctest", "instances.#"),
 					resource.TestCheckResourceAttrPair(
+						"data.aws_mq_broker.by_id", "logs.#",
+						"aws_mq_broker.acctest", "logs.#"),
+					resource.TestCheckResourceAttrPair(
 						"data.aws_mq_broker.by_id", "maintenance_window_start_time.#",
 						"aws_mq_broker.acctest", "maintenance_window_start_time.#"),
 					resource.TestCheckResourceAttrPair(

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -80,6 +80,32 @@ func resourceAwsMqBroker() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"logs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				// Ignore missing configuration block
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "1" && new == "0" {
+						return true
+					}
+					return false
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"general": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"audit": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
 			"maintenance_window_start_time": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -196,6 +222,7 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 		PubliclyAccessible:      aws.Bool(d.Get("publicly_accessible").(bool)),
 		SecurityGroups:          expandStringSet(d.Get("security_groups").(*schema.Set)),
 		Users:                   expandMqUsers(d.Get("user").(*schema.Set).List()),
+		Logs:                    expandMqLogs(d.Get("logs").([]interface{})),
 	}
 
 	if v, ok := d.GetOk("configuration"); ok {
@@ -277,12 +304,18 @@ func resourceAwsMqBrokerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("engine_version", out.EngineVersion)
 	d.Set("host_instance_type", out.HostInstanceType)
 	d.Set("publicly_accessible", out.PubliclyAccessible)
+	d.Set("enable_logging", out.Logs.General)
+	d.Set("enable_auditing", out.Logs.Audit)
 	err = d.Set("maintenance_window_start_time", flattenMqWeeklyStartTime(out.MaintenanceWindowStartTime))
 	if err != nil {
 		return err
 	}
 	d.Set("security_groups", aws.StringValueSlice(out.SecurityGroups))
 	d.Set("subnet_ids", aws.StringValueSlice(out.SubnetIds))
+
+	if err := d.Set("logs", flattenMqLogs(out.Logs)); err != nil {
+		return fmt.Errorf("error setting logs: %s", err)
+	}
 
 	err = d.Set("configuration", flattenMqConfigurationId(out.Configurations.Current))
 	if err != nil {
@@ -322,6 +355,16 @@ func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
 		_, err := conn.UpdateBroker(&mq.UpdateBrokerRequest{
 			BrokerId:      aws.String(d.Id()),
 			Configuration: expandMqConfigurationId(d.Get("configuration").([]interface{})),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("logs") {
+		_, err := conn.UpdateBroker(&mq.UpdateBrokerRequest{
+			BrokerId: aws.String(d.Id()),
+			Logs:     expandMqLogs(d.Get("logs").([]interface{})),
 		})
 		if err != nil {
 			return err

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -262,6 +262,9 @@ func TestAccAWSMqBroker_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.#", "1"),
 					resource.TestCheckResourceAttrSet("aws_mq_broker.test", "maintenance_window_start_time.0.day_of_week"),
 					resource.TestCheckResourceAttrSet("aws_mq_broker.test", "maintenance_window_start_time.0.time_of_day"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.#", "1"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.0.general", "true"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.0.audit", "false"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.0.time_zone", "UTC"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "publicly_accessible", "false"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "security_groups.#", "1"),
@@ -330,6 +333,9 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.0.day_of_week", "TUESDAY"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.0.time_of_day", "02:00"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.0.time_zone", "CET"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.#", "1"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.0.general", "false"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.0.audit", "false"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "publicly_accessible", "true"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "security_groups.#", "2"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "subnet_ids.#", "2"),
@@ -436,6 +442,9 @@ func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.0.day_of_week", "TUESDAY"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.0.time_of_day", "02:00"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "maintenance_window_start_time.0.time_zone", "CET"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.#", "1"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.0.general", "true"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "logs.0.audit", "true"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "publicly_accessible", "true"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "security_groups.#", "2"),
 					resource.TestCheckResourceAttr("aws_mq_broker.test", "subnet_ids.#", "2"),
@@ -604,7 +613,10 @@ resource "aws_mq_broker" "test" {
   engine_version = "5.15.0"
   host_instance_type = "mq.t2.micro"
   security_groups = ["${aws_security_group.test.id}"]
-  user {
+  logs {
+		general = true
+	}
+	user {
     username = "Test"
     password = "TestTest1234"
   }
@@ -733,6 +745,10 @@ resource "aws_mq_broker" "test" {
   engine_type = "ActiveMQ"
   engine_version = "5.15.0"
   host_instance_type = "mq.t2.micro"
+  logs {
+		general = true
+		audit = true
+	}
   maintenance_window_start_time {
     day_of_week = "TUESDAY"
     time_of_day = "02:00"

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3989,6 +3989,34 @@ func flattenMqBrokerInstances(instances []*mq.BrokerInstance) []interface{} {
 	return l
 }
 
+func flattenMqLogs(logs *mq.LogsSummary) []interface{} {
+	if logs == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"general": aws.BoolValue(logs.General),
+		"audit":   aws.BoolValue(logs.Audit),
+	}
+
+	return []interface{}{m}
+}
+
+func expandMqLogs(l []interface{}) *mq.Logs {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	logs := &mq.Logs{
+		Audit:   aws.Bool(m["audit"].(bool)),
+		General: aws.Bool(m["general"].(bool)),
+	}
+
+	return logs
+}
+
 func flattenResourceLifecycleConfig(rlc *elasticbeanstalk.ApplicationResourceLifecycleConfig) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
 

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 * `security_groups` - (Required) The list of security group IDs assigned to the broker.
 * `subnet_ids` - (Optional) The list of subnet IDs in which to launch the broker. A `SINGLE_INSTANCE` deployment requires one subnet. An `ACTIVE_STANDBY_MULTI_AZ` deployment requires two subnets.
 * `maintenance_window_start_time` - (Optional) Maintenance window start time. See below.
+* `logging` - (Optional) Logging configuration of the broker. See below.
 * `user` - (Optional) The list of all ActiveMQ usernames for the specified broker. See below.
 
 ### Nested Fields
@@ -77,9 +78,14 @@ The following arguments are supported:
 * `time_of_day` - (Required) The time, in 24-hour format. e.g. `02:00`
 * `time_zone` - (Required) The time zone, UTC by default, in either the Country/City format, or the UTC offset format. e.g. `CET`
 
+### `logging`
+
+* `general` - (Optional) Enables general logging via CloudWatch. Defaults to `false`.
+* `audit` - (Optional) Enables audit logging. User management action made using JMX or the ActiveMQ Web Console is logged. Defaults to `false`.
+
 #### `user`
 
-* `console_access` - (Optional) Whether to enable access to the the [ActiveMQ Web Console](http://activemq.apache.org/web-console.html) for the user.
+* `console_access` - (Optional) Whether to enable access to the [ActiveMQ Web Console](http://activemq.apache.org/web-console.html) for the user.
 * `groups` - (Optional) The list of groups (20 maximum) to which the ActiveMQ user belongs.
 * `password` - (Required) The password of the user. It must be 12 to 250 characters long, at least 4 unique characters, and must not contain commas.
 * `username` - (Required) The username of the user.


### PR DESCRIPTION
Changes proposed in this pull request:

* Add `enable_logging` flag to `aws_mq_broker` resource.
* Add `enable_auditing` flag to `aws_mq_broker` resource.
* Add missing property in `instances` to the `aws_mq_broker` data resource.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSMq'
=== RUN   TestAccDataSourceAWSMqBroker_basic
--- PASS: TestAccDataSourceAWSMqBroker_basic (1320.48s)
=== RUN   TestResourceAWSMqBrokerPasswordValidation
--- PASS: TestResourceAWSMqBrokerPasswordValidation (0.00s)
=== RUN   TestAccAWSMqBroker_basic
--- PASS: TestAccAWSMqBroker_basic (965.95s)
=== RUN   TestAccAWSMqBroker_allFieldsDefaultVpc
--- PASS: TestAccAWSMqBroker_allFieldsDefaultVpc (1976.66s)
=== RUN   TestAccAWSMqBroker_allFieldsCustomVpc
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (2081.69s)
=== RUN   TestAccAWSMqBroker_updateUsers
--- PASS: TestAccAWSMqBroker_updateUsers (1425.87s)
```
