### PR TITLE
resource/aws_lb_listener(_rule): Allow order to be based on Terraform configuration ordering

### DIFF
--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -92,6 +92,7 @@ func resourceAwsLbListener() *schema.Resource {
 						"order": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 50000),
 						},
 
@@ -355,14 +356,12 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 		defaultActionMap := defaultAction.(map[string]interface{})
 
 		action := &elbv2.Action{
-			Type: aws.String(defaultActionMap["type"].(string)),
+			Order: aws.Int64(int64(i + 1)),
+			Type:  aws.String(defaultActionMap["type"].(string)),
 		}
 
-		if order, ok := defaultActionMap["order"]; ok && order != 0 {
+		if order, ok := defaultActionMap["order"]; ok && order.(int) != 0 {
 			action.Order = aws.Int64(int64(order.(int)))
-		}
-		if len(defaultActions) != 1 && action.Order == nil {
-			return errors.New("when using more then one action, you need to specify 'order' for each action")
 		}
 
 		switch defaultActionMap["type"].(string) {
@@ -663,14 +662,12 @@ func resourceAwsLbListenerUpdate(d *schema.ResourceData, meta interface{}) error
 			defaultActionMap := defaultAction.(map[string]interface{})
 
 			action := &elbv2.Action{
-				Type: aws.String(defaultActionMap["type"].(string)),
+				Order: aws.Int64(int64(i + 1)),
+				Type:  aws.String(defaultActionMap["type"].(string)),
 			}
 
-			if order, ok := defaultActionMap["order"]; ok && order != 0 {
+			if order, ok := defaultActionMap["order"]; ok && order.(int) != 0 {
 				action.Order = aws.Int64(int64(order.(int)))
-			}
-			if len(defaultActions) != 1 && action.Order == nil {
-				return errors.New("when using more then one action, you need to specify 'order' for each action")
 			}
 
 			switch defaultActionMap["type"].(string) {

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -63,6 +63,7 @@ func resourceAwsLbbListenerRule() *schema.Resource {
 						"order": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(1, 50000),
 						},
 
@@ -331,14 +332,12 @@ func resourceAwsLbListenerRuleCreate(d *schema.ResourceData, meta interface{}) e
 		actionMap := action.(map[string]interface{})
 
 		action := &elbv2.Action{
-			Type: aws.String(actionMap["type"].(string)),
+			Order: aws.Int64(int64(i + 1)),
+			Type:  aws.String(actionMap["type"].(string)),
 		}
 
-		if order, ok := actionMap["order"]; ok && order != 0 {
+		if order, ok := actionMap["order"]; ok && order.(int) != 0 {
 			action.Order = aws.Int64(int64(order.(int)))
-		}
-		if len(actions) != 1 && action.Order == nil {
-			return errors.New("when using more then one action, you need to specify 'order' for each action")
 		}
 
 		switch actionMap["type"].(string) {
@@ -676,8 +675,12 @@ func resourceAwsLbListenerRuleUpdate(d *schema.ResourceData, meta interface{}) e
 			actionMap := action.(map[string]interface{})
 
 			action := &elbv2.Action{
+				Order: aws.Int64(int64(i + 1)),
 				Type:  aws.String(actionMap["type"].(string)),
-				Order: aws.Int64(int64(actionMap["order"].(int))), // TODO, optional
+			}
+
+			if order, ok := actionMap["order"]; ok && order.(int) != 0 {
+				action.Order = aws.Int64(int64(order.(int)))
 			}
 
 			switch actionMap["type"].(string) {

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -73,6 +73,7 @@ func TestAccAWSLBListenerRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.#", "0"),
@@ -106,6 +107,7 @@ func TestAccAWSLBListenerRuleBackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.redirect.#", "0"),
@@ -138,6 +140,7 @@ func TestAccAWSLBListenerRule_redirect(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.type", "redirect"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.target_group_arn", ""),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.#", "1"),
@@ -176,6 +179,7 @@ func TestAccAWSLBListenerRule_fixedResponse(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.static", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.type", "fixed-response"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.target_group_arn", ""),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.redirect.#", "0"),
@@ -362,16 +366,15 @@ func TestAccAWSLBListenerRule_cognito(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.#", "2"),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.type", "authenticate-cognito"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.type", "authenticate-cognito"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito.0.user_pool_arn"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito.0.user_pool_client_id"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito.0.user_pool_domain"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito.0.authentication_request_extra_params.%", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.authenticate_cognito.0.authentication_request_extra_params.param", "test"),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.0.order", "1"),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.1.type", "forward"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.1.order", "2"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "action.1.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.cognito", "action.1.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "condition.#", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.cognito", "condition.1366281676.field", "path-pattern"),
@@ -403,8 +406,8 @@ func TestAccAWSLBListenerRule_oidc(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.oidc", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.#", "2"),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.type", "authenticate-oidc"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.type", "authenticate-oidc"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc.0.authorization_endpoint", "https://example.com/authorization_endpoint"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc.0.client_id", "s6BhdRkqt3"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc.0.client_secret", "7Fjfp0ZBr1KtDRbnfVdmIw"),
@@ -413,14 +416,36 @@ func TestAccAWSLBListenerRule_oidc(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc.0.user_info_endpoint", "https://example.com/user_info_endpoint"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc.0.authentication_request_extra_params.%", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.authenticate_oidc.0.authentication_request_extra_params.param", "test"),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.0.order", "1"),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.1.type", "forward"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.1.order", "2"),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "action.1.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.oidc", "action.1.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "condition.#", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "condition.1366281676.field", "path-pattern"),
 					resource.TestCheckResourceAttr("aws_lb_listener_rule.oidc", "condition.1366281676.values.#", "1"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener_rule.oidc", "condition.1366281676.values.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBListenerRule_Action_Order(t *testing.T) {
+	var rule elbv2.Rule
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lb_listener_rule.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersWithTLS,
+		CheckDestroy: testAccCheckAWSLBListenerRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerRuleConfig_Action_Order(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "action.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "action.1.order", "2"),
 				),
 			},
 		},
@@ -1520,7 +1545,6 @@ func testAccAWSLBListenerRuleConfig_cognito(lbName string, targetGroupName strin
   priority = 100
 
   action {
-    order = 1
     type = "authenticate-cognito"
     authenticate_cognito {
       user_pool_arn = "${aws_cognito_user_pool.test.arn}"
@@ -1534,7 +1558,6 @@ func testAccAWSLBListenerRuleConfig_cognito(lbName string, targetGroupName strin
   }
 
   action {
-    order = 2
     type = "forward"
     target_group_arn = "${aws_lb_target_group.test.arn}"
   }
@@ -1697,7 +1720,6 @@ func testAccAWSLBListenerRuleConfig_oidc(lbName string, targetGroupName string, 
   priority = 100
 
   action {
-    order = 1
     type = "authenticate-oidc"
     authenticate_oidc {
       authorization_endpoint =  "https://example.com/authorization_endpoint"
@@ -1714,7 +1736,6 @@ func testAccAWSLBListenerRuleConfig_oidc(lbName string, targetGroupName string, 
   }
 
   action {
-    order = 2
     type = "forward"
     target_group_arn = "${aws_lb_target_group.test.arn}"
   }
@@ -1848,4 +1869,155 @@ resource "aws_security_group" "alb_test" {
     Name = "TestAccAWSALB_cognito"
   }
 }`, lbName, targetGroupName, certificateName)
+}
+
+func testAccAWSLBListenerRuleConfig_Action_Order(rName string) string {
+	return fmt.Sprintf(`
+variable "rName" {
+  default = %q
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_lb_listener_rule" "test" {
+  listener_arn = "${aws_lb_listener.test.arn}"
+
+  action {
+    order = 1
+    type = "authenticate-oidc"
+
+    authenticate_oidc {
+      authorization_endpoint = "https://example.com/authorization_endpoint"
+      client_id              = "s6BhdRkqt3"
+      client_secret          = "7Fjfp0ZBr1KtDRbnfVdmIw"
+      issuer                 = "https://example.com"
+      token_endpoint         = "https://example.com/token_endpoint"
+      user_info_endpoint     = "https://example.com/user_info_endpoint"
+
+      authentication_request_extra_params {
+        param  = "test"
+      }
+    }
+  }
+
+  action {
+    order            = 2
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.test.arn}"
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/static/*"]
+  }
+}
+
+resource "aws_iam_server_certificate" "test" {
+  certificate_body = "${tls_self_signed_cert.test.cert_pem}"
+  name             = "${var.rName}"
+  private_key      = "${tls_private_key.test.private_key_pem}"
+}
+
+resource "tls_private_key" "test" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "test" {
+  key_algorithm         = "RSA"
+  private_key_pem       = "${tls_private_key.test.private_key_pem}"
+  validity_period_hours = 12
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = "${aws_lb.test.id}"
+  protocol          = "HTTPS"
+  port              = "443"
+  ssl_policy        = "ELBSecurityPolicy-2015-05"
+  certificate_arn   = "${aws_iam_server_certificate.test.arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.test.id}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb" "test" {
+  internal                   = true
+  name                       = "${var.rName}"
+  security_groups            = ["${aws_security_group.test.id}"]
+  subnets                    = ["${aws_subnet.test.*.id}"]
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = "${var.rName}"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = "${aws_vpc.test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "${var.rName}"
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block              = "10.0.${count.index}.0/24"
+  map_public_ip_on_launch = true
+  vpc_id                  = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "${var.rName}"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name        = "${var.rName}"
+  vpc_id      = "${aws_vpc.test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.rName}"
+  }
+}`, rName)
 }

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -32,6 +32,7 @@ func TestAccAWSLBListener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "protocol", "HTTP"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "port", "80"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "default_action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "0"),
@@ -62,6 +63,7 @@ func TestAccAWSLBListenerBackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "protocol", "HTTP"),
 					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "port", "80"),
 					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_alb_listener.front_end", "default_action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_alb_listener.front_end", "default_action.0.redirect.#", "0"),
@@ -92,6 +94,7 @@ func TestAccAWSLBListener_https(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "protocol", "HTTPS"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "port", "443"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.front_end", "default_action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "0"),
@@ -123,6 +126,7 @@ func TestAccAWSLBListener_redirect(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "protocol", "HTTP"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "port", "80"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "redirect"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.target_group_arn", ""),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "1"),
@@ -158,6 +162,7 @@ func TestAccAWSLBListener_fixedResponse(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "protocol", "HTTP"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "port", "80"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.type", "fixed-response"),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.target_group_arn", ""),
 					resource.TestCheckResourceAttr("aws_lb_listener.front_end", "default_action.0.redirect.#", "0"),
@@ -190,14 +195,13 @@ func TestAccAWSLBListener_cognito(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "protocol", "HTTPS"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "port", "443"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.#", "2"),
-					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.type", "authenticate-cognito"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.type", "authenticate-cognito"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.test", "default_action.0.authenticate_cognito.0.user_pool_arn"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.test", "default_action.0.authenticate_cognito.0.user_pool_client_id"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.test", "default_action.0.authenticate_cognito.0.user_pool_domain"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_cognito.0.authentication_request_extra_params.%", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_cognito.0.authentication_request_extra_params.param", "test"),
-					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.1.type", "forward"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.1.order", "2"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.test", "default_action.1.target_group_arn"),
@@ -226,8 +230,8 @@ func TestAccAWSLBListener_oidc(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "protocol", "HTTPS"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "port", "443"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.#", "2"),
-					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.type", "authenticate-oidc"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.type", "authenticate-oidc"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_oidc.0.authorization_endpoint", "https://example.com/authorization_endpoint"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_oidc.0.client_id", "s6BhdRkqt3"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_oidc.0.client_secret", "7Fjfp0ZBr1KtDRbnfVdmIw"),
@@ -236,10 +240,32 @@ func TestAccAWSLBListener_oidc(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_oidc.0.user_info_endpoint", "https://example.com/user_info_endpoint"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_oidc.0.authentication_request_extra_params.%", "1"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.authenticate_oidc.0.authentication_request_extra_params.param", "test"),
-					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.0.order", "1"),
-					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.1.type", "forward"),
 					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.1.order", "2"),
+					resource.TestCheckResourceAttr("aws_lb_listener.test", "default_action.1.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_lb_listener.test", "default_action.1.target_group_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLBListener_DefaultAction_Order(t *testing.T) {
+	var listener elbv2.Listener
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lb_listener.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersWithTLS,
+		CheckDestroy: testAccCheckAWSLBListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBListenerConfig_DefaultAction_Order(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBListenerExists(resourceName, &listener),
+					resource.TestCheckResourceAttr(resourceName, "default_action.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.1.order", "2"),
 				),
 			},
 		},
@@ -928,7 +954,6 @@ resource "aws_lb_listener" "test" {
   certificate_arn = "${aws_iam_server_certificate.test.arn}"
 
   default_action {
-    order = 1
     type = "authenticate-cognito"
     authenticate_cognito {
       user_pool_arn = "${aws_cognito_user_pool.test.arn}"
@@ -942,7 +967,6 @@ resource "aws_lb_listener" "test" {
   }
 
   default_action {
-    order = 2
     target_group_arn = "${aws_lb_target_group.test.id}"
     type = "forward"
   }
@@ -1057,7 +1081,6 @@ resource "aws_lb_listener" "test" {
   certificate_arn = "${aws_iam_server_certificate.test.arn}"
 
   default_action {
-    order = 1
     type = "authenticate-oidc"
     authenticate_oidc {
       authorization_endpoint =  "https://example.com/authorization_endpoint"
@@ -1074,10 +1097,146 @@ resource "aws_lb_listener" "test" {
   }
 
   default_action {
-    order = 2
     target_group_arn = "${aws_lb_target_group.test.id}"
     type = "forward"
   }
 }
 `, rName, rName, rName, rName)
+}
+
+func testAccAWSLBListenerConfig_DefaultAction_Order(rName string) string {
+	return fmt.Sprintf(`
+variable "rName" {
+  default = %q
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = "${aws_lb.test.id}"
+  protocol          = "HTTPS"
+  port              = "443"
+  ssl_policy        = "ELBSecurityPolicy-2015-05"
+  certificate_arn   = "${aws_iam_server_certificate.test.arn}"
+
+  default_action {
+    order = 1
+    type = "authenticate-oidc"
+
+    authenticate_oidc {
+      authorization_endpoint = "https://example.com/authorization_endpoint"
+      client_id              = "s6BhdRkqt3"
+      client_secret          = "7Fjfp0ZBr1KtDRbnfVdmIw"
+      issuer                 = "https://example.com"
+      token_endpoint         = "https://example.com/token_endpoint"
+      user_info_endpoint     = "https://example.com/user_info_endpoint"
+
+      authentication_request_extra_params {
+        param  = "test"
+      }
+    }
+  }
+
+  default_action {
+    order            = 2
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.test.arn}"
+  }
+}
+
+resource "aws_iam_server_certificate" "test" {
+  certificate_body = "${tls_self_signed_cert.test.cert_pem}"
+  name             = "${var.rName}"
+  private_key      = "${tls_private_key.test.private_key_pem}"
+}
+
+resource "tls_private_key" "test" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "test" {
+  key_algorithm         = "RSA"
+  private_key_pem       = "${tls_private_key.test.private_key_pem}"
+  validity_period_hours = 12
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_lb" "test" {
+  internal                   = true
+  name                       = "${var.rName}"
+  security_groups            = ["${aws_security_group.test.id}"]
+  subnets                    = ["${aws_subnet.test.*.id}"]
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = "${var.rName}"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = "${aws_vpc.test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "${var.rName}"
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block              = "10.0.${count.index}.0/24"
+  map_public_ip_on_launch = true
+  vpc_id                  = "${aws_vpc.test.id}"
+
+  tags {
+    Name = "${var.rName}"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name        = "${var.rName}"
+  vpc_id      = "${aws_vpc.test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.rName}"
+  }
+}`, rName)
 }

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -114,7 +114,6 @@ resource "aws_lb_listener" "front_end" {
   protocol          = "HTTP"
 
   default_action {
-    order = 1
     type  = "authenticate-cognito"
     authenticate_cognito {
       user_pool_arn       = "${aws_cognito_user_pool.pool.arn}"
@@ -124,7 +123,6 @@ resource "aws_lb_listener" "front_end" {
   }
 
   default_action {
-    order            = 2
     type             = "forward"
     target_group_arn = "${aws_lb_target_group.front_end.arn}"
   }
@@ -148,7 +146,6 @@ resource "aws_lb_listener" "front_end" {
   protocol          = "HTTP"
 
   default_action {
-    order = 1
     type  = "authenticate-oidc"
     authenticate_oidc {
       authorization_endpoint = "https://example.com/authorization_endpoint"
@@ -161,7 +158,6 @@ resource "aws_lb_listener" "front_end" {
   }
 
   default_action {
-    order            = 2
     type             = "forward"
     target_group_arn = "${aws_lb_target_group.front_end.arn}"
   }

--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -113,7 +113,6 @@ resource "aws_lb_listener_rule" "admin" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
 
   action {
-    order = 1
     type  = "authenticate-cognito"
     authenticate_cognito {
       user_pool_arn       = "${aws_cognito_user_pool.pool.arn}"
@@ -123,7 +122,6 @@ resource "aws_lb_listener_rule" "admin" {
   }
 
   action {
-    order            = 2
     type             = "forward"
     target_group_arn = "${aws_lb_target_group.static.arn}"
   }
@@ -135,7 +133,6 @@ resource "aws_lb_listener" "admin" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
 
   action {
-    order = 1
     type  = "authenticate-oidc"
     authenticate_oidc {
       authorization_endpoint = "https://example.com/authorization_endpoint"
@@ -148,7 +145,6 @@ resource "aws_lb_listener" "admin" {
   }
 
   action {
-    order            = 2
     type             = "forward"
     target_group_arn = "${aws_lb_target_group.static.arn}"
   }


### PR DESCRIPTION
The `Computed` change was just merged with #6119 😄 

Changes proposed in this pull request:

* resource/aws_lb_listener: Allow `default_action` `order` to be based on Terraform configuration ordering
* resource/aws_lb_listener_rule: Allow `action` `order` to be based on Terraform configuration ordering

Output from acceptance testing:

```
17 tests passed (all tests)
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (2.04s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (169.65s)
--- PASS: TestAccAWSLBListener_oidc (177.07s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (189.36s)
--- PASS: TestAccAWSLBListenerRule_cognito (198.84s)
--- PASS: TestAccAWSLBListener_https (198.96s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (199.11s)
--- PASS: TestAccAWSLBListener_cognito (206.89s)
--- PASS: TestAccAWSLBListenerRule_oidc (208.13s)
--- PASS: TestAccAWSLBListener_basic (209.63s)
--- PASS: TestAccAWSLBListener_redirect (212.40s)
--- PASS: TestAccAWSLBListenerRule_redirect (216.05s)
--- PASS: TestAccAWSLBListener_fixedResponse (218.69s)
--- PASS: TestAccAWSLBListenerRule_basic (227.21s)
--- PASS: TestAccAWSLBListenerRule_priority (254.50s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (258.13s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (275.35s)
```
