### PR TITLE
docs/resource/aws_lb: Remove non-existent canonical_hosted_zone_id attribute

### DIFF
--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -120,7 +120,6 @@ The following attributes are exported in addition to the arguments listed above:
 * `arn` - The ARN of the load balancer (matches `id`).
 * `arn_suffix` - The ARN suffix for use with CloudWatch Metrics.
 * `dns_name` - The DNS name of the load balancer.
-* `canonical_hosted_zone_id` - The canonical hosted zone ID of the load balancer.
 * `zone_id` - The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
 
 ## Timeouts


### PR DESCRIPTION
Fixes #6126 

Changes proposed in this pull request:

* Remove extraneous `canonical_hosted_zone_id` attribute from `aws_lb` documentation

Output from acceptance testing: N/A
