### PR TITLE
resource/aws_appsync_graphql_api: Various enhancements and properly handle updates

### DIFF
--- a/aws/resource_aws_appsync_graphql_api.go
+++ b/aws/resource_aws_appsync_graphql_api.go
@@ -30,6 +30,7 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 					appsync.AuthenticationTypeApiKey,
 					appsync.AuthenticationTypeAwsIam,
 					appsync.AuthenticationTypeAmazonCognitoUserPools,
+					appsync.AuthenticationTypeOpenidConnect,
 				}, false),
 			},
 			"name": {
@@ -41,6 +42,53 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 						errors = append(errors, fmt.Errorf("%q must match [_A-Za-z][_0-9A-Za-z]*", k))
 					}
 					return
+				},
+			},
+			"log_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloudwatch_logs_role_arn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"field_log_level": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								appsync.FieldLogLevelAll,
+								appsync.FieldLogLevelError,
+								appsync.FieldLogLevelNone,
+							}, false),
+						},
+					},
+				},
+			},
+			"openid_connect_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_ttl": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"client_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"iat_ttl": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"issuer": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
 				},
 			},
 			"user_pool_config": {
@@ -55,7 +103,8 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 						},
 						"aws_region": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Computed: true,
 						},
 						"default_action": {
 							Type:     schema.TypeString,
@@ -76,6 +125,11 @@ func resourceAwsAppsyncGraphqlApi() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"uris": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -88,8 +142,16 @@ func resourceAwsAppsyncGraphqlApiCreate(d *schema.ResourceData, meta interface{}
 		Name:               aws.String(d.Get("name").(string)),
 	}
 
+	if v, ok := d.GetOk("log_config"); ok {
+		input.LogConfig = expandAppsyncGraphqlApiLogConfig(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("openid_connect_config"); ok {
+		input.OpenIDConnectConfig = expandAppsyncGraphqlApiOpenIDConnectConfig(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("user_pool_config"); ok {
-		input.UserPoolConfig = expandAppsyncGraphqlApiUserPoolConfig(v.([]interface{}))
+		input.UserPoolConfig = expandAppsyncGraphqlApiUserPoolConfig(v.([]interface{}), meta.(*AWSClient).region)
 	}
 
 	resp, err := conn.CreateGraphqlApi(input)
@@ -98,8 +160,8 @@ func resourceAwsAppsyncGraphqlApiCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	d.SetId(*resp.GraphqlApi.ApiId)
-	d.Set("arn", resp.GraphqlApi.Arn)
-	return nil
+
+	return resourceAwsAppsyncGraphqlApiRead(d, meta)
 }
 
 func resourceAwsAppsyncGraphqlApiRead(d *schema.ResourceData, meta interface{}) error {
@@ -119,10 +181,26 @@ func resourceAwsAppsyncGraphqlApiRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	d.Set("arn", resp.GraphqlApi.Arn)
 	d.Set("authentication_type", resp.GraphqlApi.AuthenticationType)
 	d.Set("name", resp.GraphqlApi.Name)
-	d.Set("user_pool_config", flattenAppsyncGraphqlApiUserPoolConfig(resp.GraphqlApi.UserPoolConfig))
-	d.Set("arn", resp.GraphqlApi.Arn)
+
+	if err := d.Set("log_config", flattenAppsyncGraphqlApiLogConfig(resp.GraphqlApi.LogConfig)); err != nil {
+		return fmt.Errorf("error setting log_config: %s", err)
+	}
+
+	if err := d.Set("openid_connect_config", flattenAppsyncGraphqlApiOpenIDConnectConfig(resp.GraphqlApi.OpenIDConnectConfig)); err != nil {
+		return fmt.Errorf("error setting openid_connect_config: %s", err)
+	}
+
+	if err := d.Set("user_pool_config", flattenAppsyncGraphqlApiUserPoolConfig(resp.GraphqlApi.UserPoolConfig)); err != nil {
+		return fmt.Errorf("error setting user_pool_config: %s", err)
+	}
+
+	if err := d.Set("uris", aws.StringValueMap(resp.GraphqlApi.Uris)); err != nil {
+		return fmt.Errorf("error setting uris")
+	}
+
 	return nil
 }
 
@@ -130,15 +208,21 @@ func resourceAwsAppsyncGraphqlApiUpdate(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).appsyncconn
 
 	input := &appsync.UpdateGraphqlApiInput{
-		ApiId: aws.String(d.Id()),
-		Name:  aws.String(d.Get("name").(string)),
+		ApiId:              aws.String(d.Id()),
+		AuthenticationType: aws.String(d.Get("authentication_type").(string)),
+		Name:               aws.String(d.Get("name").(string)),
 	}
 
-	if d.HasChange("authentication_type") {
-		input.AuthenticationType = aws.String(d.Get("authentication_type").(string))
+	if v, ok := d.GetOk("log_config"); ok {
+		input.LogConfig = expandAppsyncGraphqlApiLogConfig(v.([]interface{}))
 	}
-	if d.HasChange("user_pool_config") {
-		input.UserPoolConfig = expandAppsyncGraphqlApiUserPoolConfig(d.Get("user_pool_config").([]interface{}))
+
+	if v, ok := d.GetOk("openid_connect_config"); ok {
+		input.OpenIDConnectConfig = expandAppsyncGraphqlApiOpenIDConnectConfig(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("user_pool_config"); ok {
+		input.UserPoolConfig = expandAppsyncGraphqlApiUserPoolConfig(v.([]interface{}), meta.(*AWSClient).region)
 	}
 
 	_, err := conn.UpdateGraphqlApi(input)
@@ -166,33 +250,112 @@ func resourceAwsAppsyncGraphqlApiDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func expandAppsyncGraphqlApiUserPoolConfig(config []interface{}) *appsync.UserPoolConfig {
-	if len(config) < 1 {
+func expandAppsyncGraphqlApiLogConfig(l []interface{}) *appsync.LogConfig {
+	if len(l) < 1 || l[0] == nil {
 		return nil
 	}
-	cg := config[0].(map[string]interface{})
-	upc := &appsync.UserPoolConfig{
-		AwsRegion:     aws.String(cg["aws_region"].(string)),
-		DefaultAction: aws.String(cg["default_action"].(string)),
-		UserPoolId:    aws.String(cg["user_pool_id"].(string)),
+
+	m := l[0].(map[string]interface{})
+
+	logConfig := &appsync.LogConfig{
+		CloudWatchLogsRoleArn: aws.String(m["cloudwatch_logs_role_arn"].(string)),
+		FieldLogLevel:         aws.String(m["field_log_level"].(string)),
 	}
-	if v, ok := cg["app_id_client_regex"].(string); ok && v != "" {
-		upc.AppIdClientRegex = aws.String(v)
-	}
-	return upc
+
+	return logConfig
 }
 
-func flattenAppsyncGraphqlApiUserPoolConfig(upc *appsync.UserPoolConfig) []interface{} {
-	if upc == nil {
+func expandAppsyncGraphqlApiOpenIDConnectConfig(l []interface{}) *appsync.OpenIDConnectConfig {
+	if len(l) < 1 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	openIDConnectConfig := &appsync.OpenIDConnectConfig{
+		Issuer: aws.String(m["issuer"].(string)),
+	}
+
+	if v, ok := m["auth_ttl"].(int); ok && v != 0 {
+		openIDConnectConfig.AuthTTL = aws.Int64(int64(v))
+	}
+
+	if v, ok := m["client_id"].(string); ok && v != "" {
+		openIDConnectConfig.ClientId = aws.String(v)
+	}
+
+	if v, ok := m["iat_ttl"].(int); ok && v != 0 {
+		openIDConnectConfig.IatTTL = aws.Int64(int64(v))
+	}
+
+	return openIDConnectConfig
+}
+
+func expandAppsyncGraphqlApiUserPoolConfig(l []interface{}, currentRegion string) *appsync.UserPoolConfig {
+	if len(l) < 1 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	userPoolConfig := &appsync.UserPoolConfig{
+		AwsRegion:     aws.String(currentRegion),
+		DefaultAction: aws.String(m["default_action"].(string)),
+		UserPoolId:    aws.String(m["user_pool_id"].(string)),
+	}
+
+	if v, ok := m["app_id_client_regex"].(string); ok && v != "" {
+		userPoolConfig.AppIdClientRegex = aws.String(v)
+	}
+
+	if v, ok := m["aws_region"].(string); ok && v != "" {
+		userPoolConfig.AwsRegion = aws.String(v)
+	}
+
+	return userPoolConfig
+}
+
+func flattenAppsyncGraphqlApiLogConfig(logConfig *appsync.LogConfig) []interface{} {
+	if logConfig == nil {
 		return []interface{}{}
 	}
-	m := make(map[string]interface{}, 1)
 
-	m["aws_region"] = *upc.AwsRegion
-	m["default_action"] = *upc.DefaultAction
-	m["user_pool_id"] = *upc.UserPoolId
-	if upc.AppIdClientRegex != nil {
-		m["app_id_client_regex"] = *upc.AppIdClientRegex
+	m := map[string]interface{}{
+		"cloudwatch_logs_role_arn": aws.StringValue(logConfig.CloudWatchLogsRoleArn),
+		"field_log_level":          aws.StringValue(logConfig.FieldLogLevel),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenAppsyncGraphqlApiOpenIDConnectConfig(openIDConnectConfig *appsync.OpenIDConnectConfig) []interface{} {
+	if openIDConnectConfig == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"auth_ttl":  aws.Int64Value(openIDConnectConfig.AuthTTL),
+		"client_id": aws.StringValue(openIDConnectConfig.ClientId),
+		"iat_ttl":   aws.Int64Value(openIDConnectConfig.IatTTL),
+		"issuer":    aws.StringValue(openIDConnectConfig.Issuer),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenAppsyncGraphqlApiUserPoolConfig(userPoolConfig *appsync.UserPoolConfig) []interface{} {
+	if userPoolConfig == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"aws_region":     aws.StringValue(userPoolConfig.AwsRegion),
+		"default_action": aws.StringValue(userPoolConfig.DefaultAction),
+		"user_pool_id":   aws.StringValue(userPoolConfig.UserPoolId),
+	}
+
+	if userPoolConfig.AppIdClientRegex != nil {
+		m["app_id_client_regex"] = aws.StringValue(userPoolConfig.AppIdClientRegex)
 	}
 
 	return []interface{}{m}

--- a/aws/resource_aws_appsync_graphql_api_test.go
+++ b/aws/resource_aws_appsync_graphql_api_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,66 +13,504 @@ import (
 )
 
 func TestAccAWSAppsyncGraphqlApi_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncGraphqlApiConfig_apikey(acctest.RandString(5)),
+				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName, "API_KEY"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncGraphqlApiExists("aws_appsync_graphql_api.test_apikey"),
-					resource.TestCheckResourceAttrSet("aws_appsync_graphql_api.test_apikey", "arn"),
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "appsync", regexp.MustCompile(`apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "API_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "log_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "uris.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "uris.GRAPHQL"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_AuthenticationType(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName, "API_KEY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "API_KEY"),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName, "AWS_IAM"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "AWS_IAM"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName, "API_KEY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "appsync", regexp.MustCompile(`apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "API_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName, "AWS_IAM"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "appsync", regexp.MustCompile(`apis/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "AWS_IAM"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cognitoUserPoolResourceName := "aws_cognito_user_pool.test"
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_UserPoolConfig_DefaultAction(rName, "ALLOW"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "AMAZON_COGNITO_USER_POOLS"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.aws_region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.default_action", "ALLOW"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_pool_config.0.user_pool_id", cognitoUserPoolResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_Issuer(rName, "https://example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_LogConfig(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_LogConfig_FieldLogLevel(rName, "ALL"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "log_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_config.0.cloudwatch_logs_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_config.0.field_log_level", "ALL"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_LogConfig_FieldLogLevel(rName, "ALL"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "log_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_config.0.cloudwatch_logs_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_config.0.field_log_level", "ALL"),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_LogConfig_FieldLogLevel(rName, "ERROR"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "log_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_config.0.cloudwatch_logs_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_config.0.field_log_level", "ERROR"),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_LogConfig_FieldLogLevel(rName, "NONE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "log_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "log_config.0.cloudwatch_logs_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "log_config.0.field_log_level", "NONE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_AuthTTL(rName, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.auth_ttl", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_AuthTTL(rName, 2000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.auth_ttl", "2000"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_ClientID(rName, "ClientID1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.client_id", "ClientID1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_ClientID(rName, "ClientID2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.client_id", "ClientID2"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_IatTTL(rName, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.iat_ttl", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_IatTTL(rName, 2000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.iat_ttl", "2000"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_Issuer(rName, "https://example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.com"),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_Issuer(rName, "https://example.org"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "OPENID_CONNECT"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.issuer", "https://example.org"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAppsyncGraphqlApi_Name(t *testing.T) {
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName1, "API_KEY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_AuthenticationType(rName2, "API_KEY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSAppsyncGraphqlApi_iam(t *testing.T) {
+func TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cognitoUserPoolResourceName := "aws_cognito_user_pool.test"
+	resourceName := "aws_appsync_graphql_api.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncGraphqlApiConfig_iam(acctest.RandString(5)),
+				Config: testAccAppsyncGraphqlApiConfig_UserPoolConfig_AwsRegion(rName, testAccGetRegion()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncGraphqlApiExists("aws_appsync_graphql_api.test_iam"),
-					resource.TestCheckResourceAttrSet("aws_appsync_graphql_api.test_iam", "arn"),
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "AMAZON_COGNITO_USER_POOLS"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.aws_region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.default_action", "ALLOW"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_pool_config.0.user_pool_id", cognitoUserPoolResourceName, "id"),
 				),
+			},
+			{
+				Config: testAccAppsyncGraphqlApiConfig_UserPoolConfig_DefaultAction(rName, "ALLOW"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "AMAZON_COGNITO_USER_POOLS"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.aws_region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.default_action", "ALLOW"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_pool_config.0.user_pool_id", cognitoUserPoolResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSAppsyncGraphqlApi_cognito(t *testing.T) {
+func TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cognitoUserPoolResourceName := "aws_cognito_user_pool.test"
+	resourceName := "aws_appsync_graphql_api.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncGraphqlApiConfig_cognito(acctest.RandString(5)),
+				Config: testAccAppsyncGraphqlApiConfig_UserPoolConfig_DefaultAction(rName, "ALLOW"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncGraphqlApiExists("aws_appsync_graphql_api.test_cognito"),
-					resource.TestCheckResourceAttrSet("aws_appsync_graphql_api.test_cognito", "arn"),
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "AMAZON_COGNITO_USER_POOLS"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.aws_region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.default_action", "ALLOW"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_pool_config.0.user_pool_id", cognitoUserPoolResourceName, "id"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSAppsyncGraphqlApi_import(t *testing.T) {
-	resourceName := "aws_appsync_graphql_api.test_apikey"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncGraphqlApiConfig_apikey(acctest.RandString(5)),
+				Config: testAccAppsyncGraphqlApiConfig_UserPoolConfig_DefaultAction(rName, "DENY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncGraphqlApiExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_type", "AMAZON_COGNITO_USER_POOLS"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.aws_region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceName, "user_pool_config.0.default_action", "DENY"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_pool_config.0.user_pool_id", cognitoUserPoolResourceName, "id"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -126,42 +565,143 @@ func testAccCheckAwsAppsyncGraphqlApiExists(name string) resource.TestCheckFunc 
 	}
 }
 
-func testAccAppsyncGraphqlApiConfig_apikey(rName string) string {
+func testAccAppsyncGraphqlApiConfig_AuthenticationType(rName, authenticationType string) string {
 	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test_apikey" {
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = %q
+  name                = %q
+}
+`, authenticationType, rName)
+}
+
+func testAccAppsyncGraphqlApiConfig_LogConfig_FieldLogLevel(rName, fieldLogLevel string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "appsync.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
+  role       = "${aws_iam_role.test.name}"
+}
+
+resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
-  name = "tf_appsync_%s"
-}
-`, rName)
-}
+  name                = %q
 
-func testAccAppsyncGraphqlApiConfig_iam(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test_iam" {
-  authentication_type = "AWS_IAM"
-  name = "tf_appsync_%s"
-}
-`, rName)
-}
-
-func testAccAppsyncGraphqlApiConfig_cognito(rName string) string {
-	return fmt.Sprintf(`
-data "aws_region" "test" {
-  current = true
-}
-
-resource "aws_cognito_user_pool" "test" {
-  name = "tf-%s"
-}
-
-resource "aws_appsync_graphql_api" "test_cognito" {
-  authentication_type = "AMAZON_COGNITO_USER_POOLS"
-  name = "tf_appsync_%s"
-  user_pool_config {
-    aws_region = "${data.aws_region.test.name}"
-    default_action = "ALLOW"
-    user_pool_id = "${aws_cognito_user_pool.test.id}"
+  log_config {
+    cloudwatch_logs_role_arn = "${aws_iam_role.test.arn}"
+    field_log_level          = %q
   }
 }
-`, rName, rName)
+`, rName, rName, fieldLogLevel)
+}
+
+func testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_AuthTTL(rName string, authTTL int) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "OPENID_CONNECT"
+  name                = %q
+
+  openid_connect_config {
+    auth_ttl = %d
+    issuer   = "https://example.com"
+  }
+}
+`, rName, authTTL)
+}
+
+func testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_ClientID(rName, clientID string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "OPENID_CONNECT"
+  name                = %q
+
+  openid_connect_config {
+    client_id = %q
+    issuer    = "https://example.com"
+  }
+}
+`, rName, clientID)
+}
+
+func testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_IatTTL(rName string, iatTTL int) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "OPENID_CONNECT"
+  name                = %q
+
+  openid_connect_config {
+    iat_ttl = %d
+    issuer  = "https://example.com"
+  }
+}
+`, rName, iatTTL)
+}
+
+func testAccAppsyncGraphqlApiConfig_OpenIDConnectConfig_Issuer(rName, issuer string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "OPENID_CONNECT"
+  name                = %q
+
+  openid_connect_config {
+    issuer = %q
+  }
+}
+`, rName, issuer)
+}
+
+func testAccAppsyncGraphqlApiConfig_UserPoolConfig_AwsRegion(rName, awsRegion string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %q
+}
+
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "AMAZON_COGNITO_USER_POOLS"
+  name                = %q
+
+  user_pool_config {
+    aws_region     = %q
+    default_action = "ALLOW"
+    user_pool_id   = "${aws_cognito_user_pool.test.id}"
+  }
+}
+`, rName, rName, awsRegion)
+}
+
+func testAccAppsyncGraphqlApiConfig_UserPoolConfig_DefaultAction(rName, defaultAction string) string {
+	return fmt.Sprintf(`
+resource "aws_cognito_user_pool" "test" {
+  name = %q
+}
+
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "AMAZON_COGNITO_USER_POOLS"
+  name                = %q
+
+  user_pool_config {
+    default_action = %q
+    user_pool_id   = "${aws_cognito_user_pool.test.id}"
+  }
+}
+`, rName, rName, defaultAction)
 }

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -12,10 +12,86 @@ Provides an AppSync GraphQL API.
 
 ## Example Usage
 
+### API Key Authentication
+
 ```hcl
 resource "aws_appsync_graphql_api" "example" {
   authentication_type = "API_KEY"
+  name                = "example"
+}
+```
+
+### AWS Cognito User Pool Authentication
+
+```hcl
+resource "aws_appsync_graphql_api" "example" {
+  authentication_type = "AMAZON_COGNITO_USER_POOLS"
+  name                = "example"
+
+  user_pool_config {
+    aws_region     = "${data.aws_region.current.name}"
+    default_action = "DENY"
+    user_pool_id   = "${aws_cognito_user_pool.example.id}"
+  }
+}
+```
+
+### AWS IAM Authentication
+
+```hcl
+resource "aws_appsync_graphql_api" "example" {
+  authentication_type = "AWS_IAM"
+  name                = "example"
+}
+```
+
+### OpenID Connect Authentication
+
+```hcl
+resource "aws_appsync_graphql_api" "example" {
+  authentication_type = "OPENID_CONNECT"
+  name                = "example"
+
+  openid_connect_config {
+    issuer = "https://example.com"
+  }
+}
+```
+
+### Enabling Logging
+
+```hcl
+resource "aws_iam_role" "example" {
   name = "example"
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "appsync.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "example" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
+  role       = "${aws_iam_role.example.name}"
+}
+
+resource "aws_appsync_graphql_api" "example" {
+  # ... other configuration ...
+
+  log_config {
+    cloudwatch_logs_role_arn = "${aws_iam_role.example.arn}"
+    field_log_level          = "ERROR"
+  }
 }
 ```
 
@@ -23,18 +99,36 @@ resource "aws_appsync_graphql_api" "example" {
 
 The following arguments are supported:
 
+* `authentication_type` - (Required) The authentication type. Valid values: `API_KEY`, `AWS_IAM`, `AMAZON_COGNITO_USER_POOLS`, `OPENID_CONNECT`
 * `name` - (Required) A user-supplied name for the GraphqlApi.
-* `authentication_type` - (Required) The authentication type. Valid values: `API_KEY`, `AWS_IAM` and `AMAZON_COGNITO_USER_POOLS`
-* `user_pool_config` - (Optional) The Amazon Cognito User Pool configuration. See [below](#user_pool_config)
+* `log_config` - (Optional) Nested argument containing logging configuration. Defined below.
+* `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. Defined below.
+* `user_pool_config` - (Optional) The Amazon Cognito User Pool configuration. Defined below.
+
+### log_config
+
+The following arguments are supported:
+
+* `cloudwatch_logs_role_arn` - (Required) Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account.
+* `field_log_level` - (Required) Field logging level. Valid values: `ALL`, `ERROR`, `NONE`.
+
+### openid_connect_config
+
+The following arguments are supported:
+
+* `issuer` - (Required) Issuer for the OpenID Connect configuration. The issuer returned by discovery MUST exactly match the value of iss in the ID Token.
+* `auth_ttl` - (Optional) Number of milliseconds a token is valid after being authenticated.
+* `client_id` - (Optional) Client identifier of the Relying party at the OpenID identity provider. This identifier is typically obtained when the Relying party is registered with the OpenID identity provider. You can specify a regular expression so the AWS AppSync can validate against multiple client identifiers at a time.
+* `iat_ttl` - (Optional) Number of milliseconds a token is valid after being issued to a user.
 
 ### user_pool_config
 
 The following arguments are supported:
 
-* `aws_region` - (Required) The AWS region in which the user pool was created.
 * `default_action` - (Required) The action that you want your GraphQL API to take when a request that uses Amazon Cognito User Pool authentication doesn't match the Amazon Cognito User Pool configuration. Valid: `ALLOW` and `DENY`
 * `user_pool_id` - (Required) The user pool ID.
 * `app_id_client_regex` - (Optional) A regular expression for validating the incoming Amazon Cognito User Pool app client ID.
+* `aws_region` - (Optional) The AWS region in which the user pool was created.
 
 ## Attributes Reference
 
@@ -42,6 +136,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - API ID
 * `arn` - The ARN
+* `uris` - Map of URIs associated with the API. e.g. `uris["GRAPHQL"] = https://ID.appsync-api.REGION.amazonaws.com/graphql`
 
 ## Import
 


### PR DESCRIPTION
Closes #3974
Closes #4879
Closes #5937
Closes #6134

Changes proposed in this pull request:

* Support logging configuration
* Support `OPENID_CONNECT` authentication
* Make Cognito User Pool AWS Region configuration optional
* Add `uris` attribute
* Properly handle updates by passing all parameters

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppsyncGraphqlApi_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSAppsyncGraphqlApi_ -timeout 120m
=== RUN   TestAccAWSAppsyncGraphqlApi_basic
--- PASS: TestAccAWSAppsyncGraphqlApi_basic (10.12s)
=== RUN   TestAccAWSAppsyncGraphqlApi_AuthenticationType
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType (14.83s)
=== RUN   TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (11.27s)
=== RUN   TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (8.65s)
=== RUN   TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (13.12s)
=== RUN   TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (9.29s)
=== RUN   TestAccAWSAppsyncGraphqlApi_LogConfig
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig (11.77s)
=== RUN   TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (23.29s)
=== RUN   TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (21.16s)
=== RUN   TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (16.24s)
=== RUN   TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (16.75s)
=== RUN   TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (15.49s)
=== RUN   TestAccAWSAppsyncGraphqlApi_Name
--- PASS: TestAccAWSAppsyncGraphqlApi_Name (15.78s)
=== RUN   TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (22.30s)
=== RUN   TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (18.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	231.295s
```