### PR TITLE
resource/aws_appsync_datasource: Various enhancements

### DIFF
--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,107 +12,373 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsAppsyncDatasource_ddb(t *testing.T) {
+func TestAccAwsAppsyncDatasource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncDatasourceConfig_ddb(acctest.RandString(5)),
+				Config: testAccAppsyncDatasourceConfig_Type_None(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncDatasourceExists("aws_appsync_datasource.test"),
-					resource.TestCheckResourceAttrSet("aws_appsync_datasource.test", "arn"),
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "appsync", regexp.MustCompile(fmt.Sprintf("apis/.+/datasources/%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "NONE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncDatasource_Description(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_Description(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				Config: testAccAppsyncDatasourceConfig_Description(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncDatasource_DynamoDBConfig_Region(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(rName, testAccGetRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.0.region", testAccGetRegion()),
+				),
+			},
+			{
+				Config: testAccAppsyncDatasourceConfig_Type_DynamoDB(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.0.region", testAccGetRegion()),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_DynamoDBConfig_UseCallerCredentials(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.0.use_caller_credentials", "true"),
+				),
+			},
+			{
+				Config: testAccAppsyncDatasourceConfig_DynamoDBConfig_UseCallerCredentials(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.0.use_caller_credentials", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_ElasticsearchConfig_Region(rName, testAccGetRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.0.region", testAccGetRegion()),
+				),
+			},
+			{
+				Config: testAccAppsyncDatasourceConfig_Type_Elasticsearch(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.0.region", testAccGetRegion()),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_HTTPConfig_Endpoint(rName, "http://example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "http_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.endpoint", "http://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "type", "HTTP"),
+				),
+			},
+			{
+				Config: testAccAppsyncDatasourceConfig_HTTPConfig_Endpoint(rName, "http://example.org"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "http_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.endpoint", "http://example.org"),
+					resource.TestCheckResourceAttr(resourceName, "type", "HTTP"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncDatasource_Type(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_Type_None(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", "NONE"),
+				),
+			},
+			{
+				Config: testAccAppsyncDatasourceConfig_Type_HTTP(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", "HTTP"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAwsAppsyncDatasource_es(t *testing.T) {
+func TestAccAwsAppsyncDatasource_Type_DynamoDB(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	dynamodbTableResourceName := "aws_dynamodb_table.test"
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_appsync_datasource.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncDatasourceConfig_es(acctest.RandString(5)),
+				Config: testAccAppsyncDatasourceConfig_Type_DynamoDB(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncDatasourceExists("aws_appsync_datasource.test"),
-					resource.TestCheckResourceAttrSet("aws_appsync_datasource.test", "arn"),
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "dynamodb_config.0.table_name", dynamodbTableResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "dynamodb_config.0.region", testAccGetRegion()),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "type", "AMAZON_DYNAMODB"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAwsAppsyncDatasource_lambda(t *testing.T) {
-	Desc := "appsync datasource"
+func TestAccAwsAppsyncDatasource_Type_Elasticsearch(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_appsync_datasource.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncDatasourceConfig_lambda(acctest.RandString(5), Desc),
+				Config: testAccAppsyncDatasourceConfig_Type_Elasticsearch(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncDatasourceExists("aws_appsync_datasource.test"),
-					resource.TestCheckResourceAttrSet("aws_appsync_datasource.test", "arn"),
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "elasticsearch_config.0.endpoint"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch_config.0.region", testAccGetRegion()),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "type", "AMAZON_ELASTICSEARCH"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAwsAppsyncDatasource_update(t *testing.T) {
-	rName := acctest.RandString(5)
+func TestAccAwsAppsyncDatasource_Type_HTTP(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncDatasourceConfig_ddb(rName),
+				Config: testAccAppsyncDatasourceConfig_Type_HTTP(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncDatasourceExists("aws_appsync_datasource.test"),
-					resource.TestCheckResourceAttrSet("aws_appsync_datasource.test", "arn"),
-					resource.TestCheckResourceAttr("aws_appsync_datasource.test", "type", "AMAZON_DYNAMODB"),
-					resource.TestCheckResourceAttr("aws_appsync_datasource.test", "description", "appsync datasource"),
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "http_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "http_config.0.endpoint", "http://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "type", "HTTP"),
 				),
 			},
 			{
-				Config: testAccAppsyncDatasourceConfig_lambda(rName, "appsync datasource"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncDatasourceExists("aws_appsync_datasource.test"),
-					resource.TestCheckResourceAttrSet("aws_appsync_datasource.test", "arn"),
-					resource.TestCheckResourceAttr("aws_appsync_datasource.test", "type", "AWS_LAMBDA"),
-					resource.TestCheckResourceAttr("aws_appsync_datasource.test", "description", "appsync datasource"),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAwsAppsyncDatasource_updateDescription(t *testing.T) {
-	rName := acctest.RandString(5)
+func TestAccAwsAppsyncDatasource_Type_Lambda(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	iamRoleResourceName := "aws_iam_role.test"
+	lambdaFunctionResourceName := "aws_lambda_function.test"
+	resourceName := "aws_appsync_datasource.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppsyncDatasourceConfig_lambda(rName, "appsync datasource"),
+				Config: testAccAppsyncDatasourceConfig_Type_Lambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncDatasourceExists("aws_appsync_datasource.test"),
-					resource.TestCheckResourceAttr("aws_appsync_datasource.test", "description", "appsync datasource"),
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "lambda_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "lambda_config.0.function_arn", lambdaFunctionResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", iamRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "type", "AWS_LAMBDA"),
 				),
 			},
 			{
-				Config: testAccAppsyncDatasourceConfig_lambda(rName, "appsync datasource v1"),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncDatasource_Type_None(t *testing.T) {
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_datasource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncDatasourceConfig_Type_None(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsAppsyncDatasourceExists("aws_appsync_datasource.test"),
-					resource.TestCheckResourceAttr("aws_appsync_datasource.test", "description", "appsync datasource v1"),
+					testAccCheckAwsAppsyncDatasourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -124,12 +391,18 @@ func testAccCheckAwsAppsyncDatasourceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		input := &appsync.GetDataSourceInput{
-			ApiId: aws.String(rs.Primary.Attributes["api_id"]),
-			Name:  aws.String(rs.Primary.Attributes["name"]),
+		apiID, name, err := decodeAppsyncDataSourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
 		}
 
-		_, err := conn.GetDataSource(input)
+		input := &appsync.GetDataSourceInput{
+			ApiId: aws.String(apiID),
+			Name:  aws.String(name),
+		}
+
+		_, err = conn.GetDataSource(input)
 		if err != nil {
 			if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
 				return nil
@@ -142,29 +415,41 @@ func testAccCheckAwsAppsyncDatasourceDestroy(s *terraform.State) error {
 
 func testAccCheckAwsAppsyncDatasourceExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Not found: %s", name)
 		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Resource has no ID: %s", name)
+		}
 
-		return nil
+		apiID, name, err := decodeAppsyncDataSourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).appsyncconn
+
+		input := &appsync.GetDataSourceInput{
+			ApiId: aws.String(apiID),
+			Name:  aws.String(name),
+		}
+
+		_, err = conn.GetDataSource(input)
+
+		return err
 	}
 }
 
-func testAccAppsyncDatasourceConfig_ddb(rName string) string {
+func testAccAppsyncDatasourceConfig_base_DynamoDB(rName string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {}
-
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name = "tf_appsync_%s"
-}
-
 resource "aws_dynamodb_table" "test" {
-  name = "tf-ddb-%s"
+  hash_key       = "UserId"
+  name           = %q
   read_capacity  = 1
   write_capacity = 1
-  hash_key = "UserId"
+
   attribute {
     name = "UserId"
     type = "S"
@@ -172,7 +457,7 @@ resource "aws_dynamodb_table" "test" {
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-role-%s"
+  name = %q
 
   assume_role_policy = <<EOF
 {
@@ -191,7 +476,6 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-rolepolicy-%s"
   role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
@@ -211,32 +495,14 @@ resource "aws_iam_role_policy" "test" {
 }
 EOF
 }
-
-resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
-  name = "tf_appsync_%s"
-  type = "AMAZON_DYNAMODB"
-  description = "appsync datasource"
-  dynamodb_config {
-    region = "${data.aws_region.current.name}"
-    table_name = "${aws_dynamodb_table.test.name}"
-  }
-  service_role_arn = "${aws_iam_role.test.arn}"
-}
-`, rName, rName, rName, rName, rName)
+`, rName, rName)
 }
 
-func testAccAppsyncDatasourceConfig_es(rName string) string {
+func testAccAppsyncDatasourceConfig_base_Elasticsearch(rName string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {}
-
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name = "tf_appsync_%s"
-}
-
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = "tf-es-%s"
+  domain_name = %q
+
   ebs_options {
     ebs_enabled = true
     volume_size = 10
@@ -244,7 +510,7 @@ resource "aws_elasticsearch_domain" "test" {
 }
 
 resource "aws_iam_role" "test" {
-  name = "tf-role-%s"
+  name = %q
 
   assume_role_policy = <<EOF
 {
@@ -263,7 +529,6 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test" {
-  name = "tf-rolepolicy-%s"
   role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
@@ -283,29 +548,13 @@ resource "aws_iam_role_policy" "test" {
 }
 EOF
 }
-
-resource "aws_appsync_datasource" "test" {
-  api_id = "${aws_appsync_graphql_api.test.id}"
-  name = "tf_appsync_%s"
-  type = "AMAZON_ELASTICSEARCH"
-  elasticsearch_config {
-    region = "${data.aws_region.current.name}"
-    endpoint = "https://${aws_elasticsearch_domain.test.endpoint}"
-  }
-  service_role_arn = "${aws_iam_role.test.arn}"
-}
-`, rName, rName, rName, rName, rName)
+`, rName, rName)
 }
 
-func testAccAppsyncDatasourceConfig_lambda(rName, Desc string) string {
+func testAccAppsyncDatasourceConfig_base_Lambda(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name = "tf_appsync_%s"
-}
-
-resource "aws_iam_role" "test_lambda" {
-  name = "tf-lambdarole-%s"
+resource "aws_iam_role" "lambda" {
+  name = "%slambda"
 
   assume_role_policy = <<EOF
 {
@@ -324,15 +573,15 @@ EOF
 }
 
 resource "aws_lambda_function" "test" {
-  function_name = "tf-lambda-%s"
-  filename = "test-fixtures/lambdatest.zip"
-  role = "${aws_iam_role.test_lambda.arn}"
-  handler = "exports.test"
-  runtime = "nodejs6.10"
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %q
+  handler       = "exports.test"
+  role          = "${aws_iam_role.lambda.arn}"
+  runtime       = "nodejs6.10"
 }
 
-resource "aws_iam_role" "test_applambda" {
-  name = "tf-approle-%s"
+resource "aws_iam_role" "test" {
+  name = %q
 
   assume_role_policy = <<EOF
 {
@@ -350,9 +599,8 @@ resource "aws_iam_role" "test_applambda" {
 EOF
 }
 
-resource "aws_iam_role_policy" "test_applambda" {
-  name = "tf-approlepolicy-%s"
-  role = "${aws_iam_role.test_applambda.id}"
+resource "aws_iam_role_policy" "test" {
+  role = "${aws_iam_role.test.id}"
 
   policy = <<EOF
 {
@@ -371,16 +619,201 @@ resource "aws_iam_role_policy" "test_applambda" {
 }
 EOF
 }
+`, rName, rName, rName)
+}
+
+func testAccAppsyncDatasourceConfig_Description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id      = "${aws_appsync_graphql_api.test.id}"
+  description = %q
+  name        = %q
+  type        = "HTTP"
+
+  http_config {
+    endpoint = "http://example.com"
+  }
+}
+`, rName, description, rName)
+}
+
+func testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(rName, region string) string {
+	return testAccAppsyncDatasourceConfig_base_DynamoDB(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = "${aws_appsync_graphql_api.test.id}"
+  name             = %q
+  service_role_arn = "${aws_iam_role.test.arn}"
+  type             = "AMAZON_DYNAMODB"
+
+  dynamodb_config {
+    region     = %q
+    table_name = "${aws_dynamodb_table.test.name}"
+  }
+}
+`, rName, rName, region)
+}
+
+func testAccAppsyncDatasourceConfig_DynamoDBConfig_UseCallerCredentials(rName string, useCallerCredentials bool) string {
+	return testAccAppsyncDatasourceConfig_base_DynamoDB(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "AWS_IAM"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = "${aws_appsync_graphql_api.test.id}"
+  name             = %q
+  service_role_arn = "${aws_iam_role.test.arn}"
+  type             = "AMAZON_DYNAMODB"
+
+  dynamodb_config {
+    table_name             = "${aws_dynamodb_table.test.name}"
+    use_caller_credentials = %t
+  }
+}
+`, rName, rName, useCallerCredentials)
+}
+
+func testAccAppsyncDatasourceConfig_ElasticsearchConfig_Region(rName, region string) string {
+	return testAccAppsyncDatasourceConfig_base_Elasticsearch(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = "${aws_appsync_graphql_api.test.id}"
+  name             = %q
+  service_role_arn = "${aws_iam_role.test.arn}"
+  type             = "AMAZON_ELASTICSEARCH"
+
+  elasticsearch_config {
+    endpoint = "https://${aws_elasticsearch_domain.test.endpoint}"
+    region   = %q
+  }
+}
+`, rName, rName, region)
+}
+
+func testAccAppsyncDatasourceConfig_HTTPConfig_Endpoint(rName, endpoint string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
 
 resource "aws_appsync_datasource" "test" {
   api_id = "${aws_appsync_graphql_api.test.id}"
-  name = "tf_appsync_%s"
-  type = "AWS_LAMBDA"
-  description = "%s"
+  name   = %q
+  type   = "HTTP"
+
+  http_config {
+    endpoint = %q
+  }
+}
+`, rName, rName, endpoint)
+}
+
+func testAccAppsyncDatasourceConfig_Type_DynamoDB(rName string) string {
+	return testAccAppsyncDatasourceConfig_base_DynamoDB(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = "${aws_appsync_graphql_api.test.id}"
+  name             = %q
+  service_role_arn = "${aws_iam_role.test.arn}"
+  type             = "AMAZON_DYNAMODB"
+
+  dynamodb_config {
+    table_name = "${aws_dynamodb_table.test.name}"
+  }
+}
+`, rName, rName)
+}
+
+func testAccAppsyncDatasourceConfig_Type_Elasticsearch(rName string) string {
+	return testAccAppsyncDatasourceConfig_base_Elasticsearch(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = "${aws_appsync_graphql_api.test.id}"
+  name             = %q
+  service_role_arn = "${aws_iam_role.test.arn}"
+  type             = "AMAZON_ELASTICSEARCH"
+
+  elasticsearch_config {
+    endpoint = "https://${aws_elasticsearch_domain.test.endpoint}"
+  }
+}
+`, rName, rName)
+}
+
+func testAccAppsyncDatasourceConfig_Type_HTTP(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id = "${aws_appsync_graphql_api.test.id}"
+  name   = %q
+  type   = "HTTP"
+
+  http_config {
+    endpoint = "http://example.com"
+  }
+}
+`, rName, rName)
+}
+
+func testAccAppsyncDatasourceConfig_Type_Lambda(rName string) string {
+	return testAccAppsyncDatasourceConfig_base_Lambda(rName) + fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id           = "${aws_appsync_graphql_api.test.id}"
+  name             = %q
+  service_role_arn = "${aws_iam_role.test.arn}"
+  type             = "AWS_LAMBDA"
+
   lambda_config {
     function_arn = "${aws_lambda_function.test.arn}"
   }
-  service_role_arn = "${aws_iam_role.test_applambda.arn}"
 }
-`, rName, rName, rName, rName, rName, rName, Desc)
+`, rName, rName)
+}
+
+func testAccAppsyncDatasourceConfig_Type_None(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %q
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id = "${aws_appsync_graphql_api.test.id}"
+  name   = %q
+  type   = "NONE"
+}
+`, rName, rName)
 }

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -71,14 +71,14 @@ resource "aws_appsync_graphql_api" "example" {
 }
 
 resource "aws_appsync_datasource" "example" {
-  api_id = "${aws_appsync_graphql_api.example.id}"
-  name = "tf_appsync_example"
-  type = "AMAZON_DYNAMODB"
+  api_id           = "${aws_appsync_graphql_api.example.id}"
+  name             = "tf_appsync_example"
+  service_role_arn = "${aws_iam_role.example.arn}"
+  type             = "AMAZON_DYNAMODB"
+
   dynamodb_config {
-    region = "us-west-2"
     table_name = "${aws_dynamodb_table.example.name}"
   }
-  service_role_arn = "${aws_iam_role.example.arn}"
 }
 ```
 
@@ -88,27 +88,34 @@ The following arguments are supported:
 
 * `api_id` - (Required) The API ID for the GraphQL API for the DataSource.
 * `name` - (Required) A user-supplied name for the DataSource.
-* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB` and `AMAZON_ELASTICSEARCH`, `NONE`.
+* `type` - (Required) The type of the DataSource. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`.
 * `description` - (Optional) A description of the DataSource.
 * `service_role_arn` - (Optional) The IAM service role ARN for the data source.
 * `dynamodb_config` - (Optional) DynamoDB settings. See [below](#dynamodb_config)
 * `elasticsearch_config` - (Optional) Amazon Elasticsearch settings. See [below](#elasticsearch_config)
+* `http_config` - (Optional) HTTP settings. See [below](#http_config)
 * `lambda_config` - (Optional) AWS Lambda settings. See [below](#lambda_config)
 
 ### dynamodb_config
 
 The following arguments are supported:
 
-* `region` - (Required) The AWS region.
-* `table_name` - (Required) The table name.
-* `use_caller_credentials` - (Optional) Set to TRUE to use Amazon Cognito credentials with this data source.
+* `table_name` - (Required) Name of the DynamoDB table.
+* `region` - (Optional) AWS region of the DynamoDB table. Defaults to current region.
+* `use_caller_credentials` - (Optional) Set to `true` to use Amazon Cognito credentials with this data source.
 
 ### elasticsearch_config
 
 The following arguments are supported:
 
-* `region` - (Required) The AWS region.
-* `endpoint` - (Required) The endpoint.
+* `endpoint` - (Required) HTTP endpoint of the Elasticsearch domain.
+* `region` - (Optional) AWS region of Elasticsearch domain. Defaults to current region.
+
+### http_config
+
+The following arguments are supported:
+
+* `endpoint` - (Required) HTTP URL.
 
 ### lambda_config
 
@@ -121,3 +128,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN
+
+## Import
+
+`aws_appsync_datasource` can be imported with their `api_id`, a hyphen, and `name`, e.g.
+
+```
+$ terraform import aws_appsync_datasource.example abcdef123456-example
+```


### PR DESCRIPTION
Closes #5674

Changes proposed in this pull request:

* Support resource import
* Support HTTP type
* Make `region` optional for `dynamodb_config` and `elasticsearch_config`

Output from acceptance testing:

```
--- PASS: TestAccAwsAppsyncDatasource_basic (11.88s)
--- PASS: TestAccAwsAppsyncDatasource_Description (48.21s)
--- PASS: TestAccAwsAppsyncDatasource_DynamoDBConfig_Region (121.27s)
--- PASS: TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials (121.21s)
--- PASS: TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region (720.27s)
--- PASS: TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint (18.03s)
--- PASS: TestAccAwsAppsyncDatasource_Type (17.29s)
--- PASS: TestAccAwsAppsyncDatasource_Type_DynamoDB (110.94s)
--- PASS: TestAccAwsAppsyncDatasource_Type_Elasticsearch (773.89s)
--- PASS: TestAccAwsAppsyncDatasource_Type_HTTP (11.83s)
--- PASS: TestAccAwsAppsyncDatasource_Type_Lambda (30.19s)
--- PASS: TestAccAwsAppsyncDatasource_Type_None (11.14s)
```
