### PR TITLE
resource/aws_dx_connection: Export bool value of new MTU parameter

### DIFF
--- a/aws/resource_aws_dx_connection.go
+++ b/aws/resource_aws_dx_connection.go
@@ -43,6 +43,10 @@ func resourceAwsDxConnection() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"jumbo_frame_capable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -111,6 +115,7 @@ func resourceAwsDxConnectionRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("name", connection.ConnectionName)
 	d.Set("bandwidth", connection.Bandwidth)
 	d.Set("location", connection.Location)
+	d.Set("jumbo_frame_capable", connection.JumboFrameCapable)
 
 	if err := getTagsDX(conn, d, arn); err != nil {
 		return err

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -35,6 +35,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the connection.
 * `arn` - The ARN of the connection.
+* `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
 
 ## Import
 


### PR DESCRIPTION
Fixes #6136 

Changes proposed in this pull request:

* Exporting the value of whether or not jumbo frames have been enabled for a given connection

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDxConnection_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSDxConnection_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDxConnection_importBasic
--- PASS: TestAccAWSDxConnection_importBasic (24.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.383s
```
