### PR TITLE
Allow ecs task dynamic host port mapping.

### DIFF
--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -143,8 +143,8 @@ resource "aws_security_group" "instance_sg" {
 
   ingress {
     protocol  = "tcp"
-    from_port = 8080
-    to_port   = 8080
+    from_port = 32768
+    to_port   = 61000
 
     security_groups = [
       "${aws_security_group.lb_sg.id}",
@@ -185,7 +185,7 @@ resource "aws_ecs_service" "test" {
   name            = "tf-example-ecs-ghost"
   cluster         = "${aws_ecs_cluster.main.id}"
   task_definition = "${aws_ecs_task_definition.ghost.arn}"
-  desired_count   = 1
+  desired_count   = "${var.service_desired}"
   iam_role        = "${aws_iam_role.ecs_service.name}"
 
   load_balancer {

--- a/examples/ecs-alb/task-definition.json
+++ b/examples/ecs-alb/task-definition.json
@@ -8,7 +8,7 @@
     "portMappings": [
       {
         "containerPort": 2368,
-        "hostPort": 8080
+        "hostPort": 0
       }
     ],
     "logConfiguration": {

--- a/examples/ecs-alb/variables.tf
+++ b/examples/ecs-alb/variables.tf
@@ -32,6 +32,11 @@ variable "asg_desired" {
   default     = "1"
 }
 
+variable "service_desired" {
+  description = "Desired numbers of instances in the ecs service"
+  default     = "1"
+}
+
 variable "admin_cidr_ingress" {
   description = "CIDR to allow tcp/22 ingress to EC2 instance"
 }


### PR DESCRIPTION
* Allows > 1 container instance to be deployed per ec2 instance. You can scale up the number of ecs service instances per ec2 instance, especially when using the default 1 ec2 instance.
* Make the ecs service definition use a variable for number of instances so this can easily be adjusted.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
