### PR TITLE
aws_dynamodb_table: Work around tagging limitation in dynamodb-local

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/hashicorp/terraform/helper/customdiff"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -690,16 +689,8 @@ func readDynamoDbTableTags(arn string, conn *dynamodb.DynamoDB) (map[string]stri
 		ResourceArn: aws.String(arn),
 	})
 
-	// Do not fail when interfacing with dynamodb-local
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Message() == "Tagging is not currently supported in DynamoDB Local." {
-				err = nil
-			}
-		}
-	}
-
-	if err != nil {
+	// Do not fail if interfacing with dynamodb-local
+	if err != nil && !isAWSErr(err, "UnknownOperationException", "Tagging is not currently supported in DynamoDB Local.") {
 		return nil, fmt.Errorf("Error reading tags from dynamodb resource: %s", err)
 	}
 


### PR DESCRIPTION
Changes proposed in this pull request:
* Support tagging limitation in dynamodb-local.

I have yet to try more complicated things with dynamodb-local.

Here's how I use [dynamodb-local](https://hub.docker.com/r/amazon/dynamodb-local/):

```
docker run -p 8000:8000 amazon/dynamodb-local
```

Terraform:

```
provider "aws" {
  endpoints {
    dynamodb = "http://localhost:8000"
  }
}

resource "aws_dynamodb_table" "basic-dynamodb-table" {
  # ...
}
```

This would fail with:

```
* aws_dynamodb_table.basic-dynamodb-table: aws_dynamodb_table.basic-dynamodb-table: Error reading tags from dynamodb resource: UnknownOperationException: Tagging is not currently supported in DynamoDB Local.
	status code: 400, request id: d2dabf86-9643-4cc5-b601-f473573c6506
* data.aws_dynamodb_table.movies: 1 error(s) occurred:
```

I don't think there is a need to work around setting tags at this time. In Terraform 0.12 that can probably be easily done with the new `if` statement.

This problem is referenced in this issue (but also other problems): https://github.com/terraform-providers/terraform-provider-aws/issues/1059

P.S. Can you please take a second look at some of my other PRs?
- https://github.com/terraform-providers/terraform-provider-aws/pull/4488
  - I think this can be merged now.
- https://github.com/terraform-providers/terraform-provider-aws/pull/5728
  - I need help with tests on this one.
- https://github.com/terraform-providers/terraform-provider-aws/pull/5812
  - I know this is a breaking change, but would be nice to know if/how it can be merged.

Thank you!!