### PR TITLE
documentation: cloudformation parameter is a map, not a list

### DIFF
--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 * `notification_arns` - (Optional) A list of SNS topic ARNs to publish stack related events.
 * `on_failure` - (Optional) Action to be taken if stack creation fails. This must be
   one of: `DO_NOTHING`, `ROLLBACK`, or `DELETE`. Conflicts with `disable_rollback`.
-* `parameters` - (Optional) A list of Parameter structures that specify input parameters for the stack.
+* `parameters` - (Optional) A map of Parameter structures that specify input parameters for the stack.
 * `policy_body` - (Optional) Structure containing the stack policy body.
   Conflicts w/ `policy_url`.
 * `policy_url` - (Optional) Location of a file containing the stack policy.


### PR DESCRIPTION
Changes proposed in this pull request:

* Documentation bugfix only: `aws_cloudformation_stack` attribute of `parameters` should be a map, not a list. https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_cloudformation_stack.go#L76-L77

Output from acceptance testing:

N/A, documentation only.
