### PR TITLE
resource/aws_alb_target_group: Stricter name validation

### DIFF
--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -83,6 +83,22 @@ func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.TestName", "TestAccAWSALBTargetGroup_basic"),
 				),
 			},
+			{
+				Config:      testAccAWSALBTargetGroupConfig_basic(acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`cannot be longer than 32 characters`),
+			},
+			{
+				Config:      testAccAWSALBTargetGroupConfig_basic("test_target_group"),
+				ExpectError: regexp.MustCompile(`only alphanumeric characters and hyphens allowed`),
+			},
+			{
+				Config:      testAccAWSALBTargetGroupConfig_basic("-test-target-group"),
+				ExpectError: regexp.MustCompile(`cannot begin with a hyphen`),
+			},
+			{
+				Config:      testAccAWSALBTargetGroupConfig_basic("test-target-group-"),
+				ExpectError: regexp.MustCompile(`cannot end with a hyphen`),
+			},
 		},
 	})
 }

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -45,7 +45,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.StringLenBetween(0, 32),
+				ValidateFunc:  validateElbName,
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,


### PR DESCRIPTION
Fixes #6153 

Changes proposed in this pull request:

* Add a stricter validation for ALB target group's name, which *can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen.*

ref: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSALBTargetGroup_basic'

TF_ACC=1 go test ./... -v -run=TestAccAWSALBTargetGroup_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSALBTargetGroup_basic
--- PASS: TestAccAWSALBTargetGroup_basic (46.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.732s
...
```
