### PR TITLE
issue #6153 terraform validate does not catch name violation for aws_alb_target_group

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -45,14 +45,14 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc:  validation.StringLenBetween(0, 32),
+				ValidateFunc:  validateLbTargetGroupName,
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
-				ValidateFunc:  validation.StringLenBetween(0, 32-resource.UniqueIDSuffixLength),
+				ValidateFunc:  validateLbTargetGroupNamePrefix,
 			},
 
 			"port": {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2040,3 +2040,42 @@ func validateCloudFrontPublicKeyNamePrefix(v interface{}, k string) (ws []string
 	}
 	return
 }
+
+func validateLbTargetGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 32 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 32 characters", k))
+	}
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if regexp.MustCompile(`^-`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot begin with a hyphen", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	return
+}
+
+func validateLbTargetGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	prefixMaxLength := 32 - resource.UniqueIDSuffixLength
+	if len(value) > prefixMaxLength {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than %d characters", k, prefixMaxLength))
+	}
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if regexp.MustCompile(`^-`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot begin with a hyphen", k))
+	}
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3014,3 +3014,61 @@ func TestValidateDxConnectionBandWidth(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateLbTargetGroupName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tf.test.elb.target.1",
+			ErrCount: 1,
+		},
+		{
+			Value:    "-tf-test-target",
+			ErrCount: 1,
+		},
+		{
+			Value:    "tf-test-target-",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(33),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateLbTargetGroupName(tc.Value, "aws_lb_target_group")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the AWS LB Target Group Name to trigger a validation error for %q", tc.Value)
+		}
+	}
+}
+
+func TestValidateLbTargetGroupNamePrefix(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tf.lb",
+			ErrCount: 1,
+		},
+		{
+			Value:    "-tf-lb",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(32),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateLbTargetGroupNamePrefix(tc.Value, "aws_lb_target_group")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the AWS LB Target Group Name to trigger a validation error for %q", tc.Value)
+		}
+	}
+}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6153 

Changes proposed in this pull request:

* Change 1
Added validation check.