### PR TITLE
tests/resource/aws_cloudfront_distribution: Switch from resource.Test() to resource.ParallelTest()

### DIFF
--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -83,7 +83,7 @@ func TestAccAWSCloudFrontDistribution_importBasic(t *testing.T) {
 
 	resourceName := "aws_cloudfront_distribution.s3_distribution"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -108,7 +108,7 @@ func TestAccAWSCloudFrontDistribution_importBasic(t *testing.T) {
 func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 	ri := acctest.RandInt()
 	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3Config, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -135,7 +135,7 @@ func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTags, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 	postConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTagsUpdated, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -176,7 +176,7 @@ func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -200,7 +200,7 @@ func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 	resourceName := "aws_cloudfront_distribution.multi_origin_distribution"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -226,7 +226,7 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 	resourceName := "aws_cloudfront_distribution.main"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -252,7 +252,7 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 }
 
 func TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -266,7 +266,7 @@ func TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName(t *testing.T) {
 }
 
 func TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -286,7 +286,7 @@ func TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID(t *testing.T) {
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 	resourceName := "aws_cloudfront_distribution.no_optional_items"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -370,7 +370,7 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 // If you are testing manually and can't wait for deletion, set the
 // TF_TEST_CLOUDFRONT_RETAIN environment variable.
 func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -388,7 +388,7 @@ func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
 }
 
 func TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
@@ -408,7 +408,7 @@ func TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig(t *testing.T) {
 }
 
 func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,


### PR DESCRIPTION
Reference: #5874 

Canary deployment of `resource.ParallelTest()`. We'll default to `-parallel=20` in the Make target during actual deployment.

Changes proposed in this pull request:

* tests/resource/aws_cloudfront_distribution: Switch `resource.Test()` to `resource.ParallelTest()`

Output from acceptance testing (locally):

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudFrontDistribution_ -parallel=20'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -run=TestAccAWSCloudFrontDistribution_ -parallel=20 -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
=== PAUSE TestAccAWSCloudFrontDistribution_importBasic
=== RUN   TestAccAWSCloudFrontDistribution_S3Origin
=== PAUSE TestAccAWSCloudFrontDistribution_S3Origin
=== RUN   TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== PAUSE TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== RUN   TestAccAWSCloudFrontDistribution_customOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_customOrigin
=== RUN   TestAccAWSCloudFrontDistribution_multiOrigin
=== PAUSE TestAccAWSCloudFrontDistribution_multiOrigin
=== RUN   TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== RUN   TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== PAUSE TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== RUN   TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== RUN   TestAccAWSCloudFrontDistribution_HTTP11Config
=== PAUSE TestAccAWSCloudFrontDistribution_HTTP11Config
=== RUN   TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== PAUSE TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== RUN   TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== PAUSE TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== CONT  TestAccAWSCloudFrontDistribution_importBasic
=== CONT  TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig
=== CONT  TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID
=== CONT  TestAccAWSCloudFrontDistribution_multiOrigin
=== CONT  TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName
=== CONT  TestAccAWSCloudFrontDistribution_HTTP11Config
=== CONT  TestAccAWSCloudFrontDistribution_orderedCacheBehavior
=== CONT  TestAccAWSCloudFrontDistribution_noOptionalItemsConfig
=== CONT  TestAccAWSCloudFrontDistribution_S3OriginWithTags
=== CONT  TestAccAWSCloudFrontDistribution_customOrigin
=== CONT  TestAccAWSCloudFrontDistribution_S3Origin
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.50s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.51s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (984.84s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (984.94s)
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (985.47s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (987.17s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (987.19s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (992.72s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (992.97s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (995.10s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1358.05s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1358.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1360.145s
```

Output from acceptance testing (TeamCity):

```
12 tests passed (all tests)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (0.94s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.39s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (904.35s)
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (907.59s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (908.16s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (909.00s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (909.30s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (910.23s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (911.42s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (911.87s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (913.44s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (913.72s)
```