### PR TITLE
Fix "random" ECS task placement strategy

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -648,11 +648,14 @@ func flattenPlacementStrategyDeprecated(pss []*ecs.PlacementStrategy) []map[stri
 	for _, ps := range pss {
 		c := make(map[string]interface{})
 		c["type"] = *ps.Type
-		c["field"] = *ps.Field
 
-		// for some fields the API requires lowercase for creation but will return uppercase on query
-		if *ps.Field == "MEMORY" || *ps.Field == "CPU" {
-			c["field"] = strings.ToLower(*ps.Field)
+		if ps.Field != nil {
+			c["field"] = *ps.Field
+
+			// for some fields the API requires lowercase for creation but will return uppercase on query
+			if *ps.Field == "MEMORY" || *ps.Field == "CPU" {
+				c["field"] = strings.ToLower(*ps.Field)
+			}
 		}
 
 		results = append(results, c)
@@ -664,7 +667,7 @@ func expandPlacementStrategy(s []interface{}) ([]*ecs.PlacementStrategy, error) 
 	if len(s) == 0 {
 		return nil, nil
 	}
-	ps := make([]*ecs.PlacementStrategy, 0)
+	pss := make([]*ecs.PlacementStrategy, 0)
 	for _, raw := range s {
 		p := raw.(map[string]interface{})
 		t := p["type"].(string)
@@ -672,19 +675,23 @@ func expandPlacementStrategy(s []interface{}) ([]*ecs.PlacementStrategy, error) 
 		if err := validateAwsEcsPlacementStrategy(t, f); err != nil {
 			return nil, err
 		}
-		ps = append(ps, &ecs.PlacementStrategy{
-			Type:  aws.String(t),
-			Field: aws.String(f),
-		})
+		ps := &ecs.PlacementStrategy{
+			Type: aws.String(t),
+		}
+		if f != "" {
+			// Field must be omitted (i.e. not empty string) for random strategy
+			ps.Field = aws.String(f)
+		}
+		pss = append(pss, ps)
 	}
-	return ps, nil
+	return pss, nil
 }
 
 func expandPlacementStrategyDeprecated(s *schema.Set) ([]*ecs.PlacementStrategy, error) {
 	if len(s.List()) == 0 {
 		return nil, nil
 	}
-	ps := make([]*ecs.PlacementStrategy, 0)
+	pss := make([]*ecs.PlacementStrategy, 0)
 	for _, raw := range s.List() {
 		p := raw.(map[string]interface{})
 		t := p["type"].(string)
@@ -692,12 +699,16 @@ func expandPlacementStrategyDeprecated(s *schema.Set) ([]*ecs.PlacementStrategy,
 		if err := validateAwsEcsPlacementStrategy(t, f); err != nil {
 			return nil, err
 		}
-		ps = append(ps, &ecs.PlacementStrategy{
-			Type:  aws.String(t),
-			Field: aws.String(f),
-		})
+		ps := &ecs.PlacementStrategy{
+			Type: aws.String(t),
+		}
+		if f != "" {
+			// Field must be omitted (i.e. not empty string) for random strategy
+			ps.Field = aws.String(f)
+		}
+		pss = append(pss, ps)
 	}
-	return ps, nil
+	return pss, nil
 }
 
 func flattenPlacementStrategy(pss []*ecs.PlacementStrategy) []interface{} {
@@ -708,11 +719,14 @@ func flattenPlacementStrategy(pss []*ecs.PlacementStrategy) []interface{} {
 	for _, ps := range pss {
 		c := make(map[string]interface{})
 		c["type"] = *ps.Type
-		c["field"] = *ps.Field
 
-		// for some fields the API requires lowercase for creation but will return uppercase on query
-		if *ps.Field == "MEMORY" || *ps.Field == "CPU" {
-			c["field"] = strings.ToLower(*ps.Field)
+		if ps.Field != nil {
+			c["field"] = *ps.Field
+
+			// for some fields the API requires lowercase for creation but will return uppercase on query
+			if *ps.Field == "MEMORY" || *ps.Field == "CPU" {
+				c["field"] = strings.ToLower(*ps.Field)
+			}
 		}
 
 		results = append(results, c)

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -500,7 +500,7 @@ func TestAccAWSEcsService_withPlacementStrategy(t *testing.T) {
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
 					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.#", "1"),
 					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.type", "random"),
-					resource.TestCheckNoResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.field"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.field", ""),
 				),
 			},
 			{

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -495,6 +495,15 @@ func TestAccAWSEcsService_withPlacementStrategy(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAWSEcsServiceWithRandomPlacementStrategy(clusterName, tdName, svcName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.#", "1"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.type", "random"),
+					resource.TestCheckNoResourceAttr("aws_ecs_service.mongo", "ordered_placement_strategy.0.field"),
+				),
+			},
+			{
 				Config: testAccAWSEcsServiceWithMultiPlacementStrategy(clusterName, tdName, svcName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo", &service),
@@ -992,6 +1001,39 @@ resource "aws_ecs_service" "mongo" {
   ordered_placement_strategy {
     type = "binpack"
     field = "memory"
+  }
+}
+`, clusterName, tdName, svcName)
+}
+
+func testAccAWSEcsServiceWithRandomPlacementStrategy(clusterName, tdName, svcName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "default" {
+  name = "%s"
+}
+
+resource "aws_ecs_task_definition" "mongo" {
+  family = "%s"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "mongo" {
+  name = "%s"
+  cluster = "${aws_ecs_cluster.default.id}"
+  task_definition = "${aws_ecs_task_definition.mongo.arn}"
+  desired_count = 1
+  ordered_placement_strategy {
+    type = "random"
   }
 }
 `, clusterName, tdName, svcName)

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -785,8 +785,11 @@ func validateAwsDynamoDbGlobalTableName(v interface{}, k string) (ws []string, e
 func validateAwsEcsPlacementStrategy(stratType, stratField string) error {
 	switch stratType {
 	case "random":
-		// random does not need the field attribute set, could error, but it isn't read at the API level
-		return nil
+		// random requires the field attribute to be unset.
+		if stratField != "" {
+			return fmt.Errorf("Random type requires the field attribute to be unset. Got: %s",
+				stratField)
+		}
 	case "spread":
 		//  For the spread placement strategy, valid values are instanceId
 		// (or host, which has the same effect), or any platform or custom attribute


### PR DESCRIPTION
This change fixes the "random" ECS task placement strategy. Without this change, it is impossible to use this strategy. The AWS Go SDK requires the `Field` parameter to be `nil` when `Type` is random, but we were sending a pointer to `""`.

Fixes #5387