### PR TITLE
Add the custom domain name feature in aws_cognito_user_pool_domain resource

### DIFF
--- a/aws/resource_aws_cognito_user_pool_domain.go
+++ b/aws/resource_aws_cognito_user_pool_domain.go
@@ -136,7 +136,10 @@ func resourceAwsCognitoUserPoolDomainRead(d *schema.ResourceData, meta interface
 	desc := domain.DomainDescription
 
 	d.Set("domain", d.Id())
-	d.Set("certificate_arn", desc.CustomDomainConfig.CertificateArn)
+	d.Set("certificate_arn", "")
+	if desc.CustomDomainConfig != nil {
+		d.Set("certificate_arn", desc.CustomDomainConfig.CertificateArn)
+	}
 	d.Set("aws_account_id", desc.AWSAccountId)
 	d.Set("cloudfront_distribution_arn", desc.CloudFrontDistribution)
 	d.Set("s3_bucket", desc.S3Bucket)

--- a/aws/resource_aws_cognito_user_pool_domain_test.go
+++ b/aws/resource_aws_cognito_user_pool_domain_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -26,6 +27,54 @@ func TestAccAWSCognitoUserPoolDomain_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolDomainExists("aws_cognito_user_pool_domain.main"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_domain.main", "domain", domainName),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "name", poolName),
+					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "aws_account_id"),
+					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "cloudfront_distribution_arn"),
+					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "s3_bucket"),
+					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "version"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoUserPoolDomain_custom(t *testing.T) {
+	poolName := fmt.Sprintf("tf-acc-test-pool-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	// This test must always run in us-east-1
+	// BadRequestException: Invalid certificate ARN: arn:aws:acm:us-west-2:123456789012:certificate/xxxxx. Certificate must be in 'us-east-1'.
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	customDomainName := os.Getenv("AWS_COGNITO_USER_POOL_DOMAIN_ROOT_DOMAIN")
+	if customDomainName == "" {
+		t.Skip(
+			"Environment variable AWS_COGNITO_USER_POOL_DOMAIN_ROOT_DOMAIN is not set. " +
+				"This environment variable must be set to the fqdn of " +
+				"an ISSUED ACM certificate in us-east-1 to enable this test.")
+	}
+
+	customSubDomainName := fmt.Sprintf("%s.%s", fmt.Sprintf("tf-acc-test-domain-%d", acctest.RandInt()), customDomainName)
+	// For now, use an environment variable to limit running this test
+	certificateArn := os.Getenv("AWS_COGNITO_USER_POOL_DOMAIN_CERTIFICATE_ARN")
+	if certificateArn == "" {
+		t.Skip(
+			"Environment variable AWS_COGNITO_USER_POOL_DOMAIN_CERTIFICATE_ARN is not set. " +
+				"This environment variable must be set to the ARN of " +
+				"an ISSUED ACM certificate in us-east-1 to enable this test.")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoUserPoolDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoUserPoolDomainConfig_custom(customDomainName, poolName, certificateArn, customSubDomainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoUserPoolDomainExists("aws_cognito_user_pool_domain.main"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_domain.main", "domain", customSubDomainName),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool_domain.main", "certificate_arn", certificateArn),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.main", "name", poolName),
 					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "aws_account_id"),
 					resource.TestCheckResourceAttrSet("aws_cognito_user_pool_domain.main", "cloudfront_distribution_arn"),
@@ -117,4 +166,23 @@ resource "aws_cognito_user_pool" "main" {
   name = "%s"
 }
 `, domainName, poolName)
+}
+
+func testAccAWSCognitoUserPoolDomainConfig_custom(customDomainName, poolName, certificateArn, customSubDomainName string) string {
+	return fmt.Sprintf(`
+
+data "aws_route53_zone" "tf-zone" {
+  name = "%s"
+}
+
+resource "aws_cognito_user_pool_domain" "main" {
+  domain = "%s"
+  user_pool_id = "${aws_cognito_user_pool.main.id}"
+  certificate_arn = "%s"
+}
+
+resource "aws_cognito_user_pool" "main" {
+  name = "%s"
+}
+`, customDomainName, customSubDomainName, certificateArn, poolName)
 }

--- a/aws/resource_aws_cognito_user_pool_domain_test.go
+++ b/aws/resource_aws_cognito_user_pool_domain_test.go
@@ -70,7 +70,7 @@ func TestAccAWSCognitoUserPoolDomain_custom(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDomainDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolDomainConfig_custom(customDomainName, poolName, certificateArn, customSubDomainName),
+				Config: testAccAWSCognitoUserPoolDomainConfig_custom(customSubDomainName, poolName, certificateArn),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSCognitoUserPoolDomainExists("aws_cognito_user_pool_domain.main"),
 					resource.TestCheckResourceAttr("aws_cognito_user_pool_domain.main", "domain", customSubDomainName),
@@ -168,13 +168,8 @@ resource "aws_cognito_user_pool" "main" {
 `, domainName, poolName)
 }
 
-func testAccAWSCognitoUserPoolDomainConfig_custom(customDomainName, poolName, certificateArn, customSubDomainName string) string {
+func testAccAWSCognitoUserPoolDomainConfig_custom(customSubDomainName, poolName, certificateArn string) string {
 	return fmt.Sprintf(`
-
-data "aws_route53_zone" "tf-zone" {
-  name = "%s"
-}
-
 resource "aws_cognito_user_pool_domain" "main" {
   domain = "%s"
   user_pool_id = "${aws_cognito_user_pool.main.id}"
@@ -184,5 +179,5 @@ resource "aws_cognito_user_pool_domain" "main" {
 resource "aws_cognito_user_pool" "main" {
   name = "%s"
 }
-`, customDomainName, customSubDomainName, certificateArn, poolName)
+`, customSubDomainName, certificateArn, poolName)
 }

--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -12,6 +12,7 @@ Provides a Cognito User Pool Domain resource.
 
 ## Example Usage
 
+### Amazon Cognito domain
 ```hcl
 resource "aws_cognito_user_pool_domain" "main" {
   domain = "example-domain"
@@ -22,6 +23,20 @@ resource "aws_cognito_user_pool" "example" {
   name = "example-pool"
 }
 ```
+### Custom Cognito domain
+```hcl
+resource "aws_cognito_user_pool_domain" "main" {
+  domain = "example-domain.exemple.com"
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  user_pool_id = "${aws_cognito_user_pool.example.id}"
+}
+
+resource "aws_cognito_user_pool" "example" {
+  name = "example-pool"
+}
+```
+
+
 
 ## Argument Reference
 
@@ -29,6 +44,7 @@ The following arguments are supported:
 
 * `domain` - (Required) The domain string.
 * `user_pool_id` - (Required) The user pool ID.
+* `certificate_arn` - (Optional) The ARN of an ISSUED ACM certificate in us-east-1 for a custom domain.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Fixes #5026

Changes proposed in this pull request:

* Add the `certificate_arn` parameter to let use a custom domain 

Output from acceptance testing:

You need to set environment variable for this test : 
 * **AWS_COGNITO_USER_POOL_DOMAIN_ROOT_DOMAIN**  
  This environment variable must be set to the fqdn of an ISSUED ACM certificate in us-east-1 to enable this test. The fqdn must have a A record in the zone.
 * **AWS_COGNITO_USER_POOL_DOMAIN_CERTIFICATE_ARN**
  This environment variable must be set to the ARN of an ISSUED ACM certificate in us-east-1 to enable this test.

```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPoolDomain_custom'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -run=TestAccAWSCognitoUserPoolDomain_custom -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCognitoUserPoolDomain_custom
--- PASS: TestAccAWSCognitoUserPoolDomain_custom (2013.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2013.299s
```
