### PR TITLE
aws_egress_only_internet_gateway: Adjust eventualy consistent logic

### DIFF
--- a/aws/resource_aws_egress_only_internet_gateway.go
+++ b/aws/resource_aws_egress_only_internet_gateway.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -40,18 +39,6 @@ func resourceAwsEgressOnlyInternetGatewayCreate(d *schema.ResourceData, meta int
 
 	d.SetId(*resp.EgressOnlyInternetGateway.EgressOnlyInternetGatewayId)
 
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		igRaw, _, err := EIGWStateRefreshFunc(conn, d.Id())()
-		if igRaw != nil {
-			return nil
-		}
-		if err == nil {
-			return resource.RetryableError(err)
-		} else {
-			return resource.NonRetryableError(err)
-		}
-	})
-
 	if err != nil {
 		return fmt.Errorf("%s", err)
 	}
@@ -59,50 +46,35 @@ func resourceAwsEgressOnlyInternetGatewayCreate(d *schema.ResourceData, meta int
 	return resourceAwsEgressOnlyInternetGatewayRead(d, meta)
 }
 
-func EIGWStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeEgressOnlyInternetGateways(&ec2.DescribeEgressOnlyInternetGatewaysInput{
-			EgressOnlyInternetGatewayIds: []*string{aws.String(id)},
-		})
-		if err != nil {
-			ec2err, ok := err.(awserr.Error)
-			if ok && ec2err.Code() == "InvalidEgressInternetGatewayID.NotFound" {
-				resp = nil
-			} else {
-				log.Printf("[ERROR] Error on EIGWStateRefreshFunc: %s", err)
-				return nil, "", err
-			}
-		}
-		if len(resp.EgressOnlyInternetGateways) < 1 {
-			resp = nil
-		}
-
-		if resp == nil {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
-		}
-
-		ig := resp.EgressOnlyInternetGateways[0]
-		return ig, "available", nil
-	}
-}
-
 func resourceAwsEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	resp, err := conn.DescribeEgressOnlyInternetGateways(&ec2.DescribeEgressOnlyInternetGatewaysInput{
+	var found bool
+	var req = &ec2.DescribeEgressOnlyInternetGatewaysInput{
 		EgressOnlyInternetGatewayIds: []*string{aws.String(d.Id())},
-	})
-	if err != nil {
-		return fmt.Errorf("Error describing egress internet gateway: %s", err)
 	}
 
-	found := false
-	for _, igw := range resp.EgressOnlyInternetGateways {
-		if *igw.EgressOnlyInternetGatewayId == d.Id() {
-			found = true
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		resp, err := conn.DescribeEgressOnlyInternetGateways(req)
+		if err != nil {
+			return resource.NonRetryableError(err)
 		}
+		if resp != nil && len(resp.EgressOnlyInternetGateways) > 0 {
+			for _, igw := range resp.EgressOnlyInternetGateways {
+				if *igw.EgressOnlyInternetGatewayId == d.Id() {
+					found = true
+					break
+				}
+			}
+		}
+		if d.IsNewResource() && !found {
+			return resource.RetryableError(nil)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error describing egress internet gateway: %s", err)
 	}
 
 	if !found {

--- a/aws/resource_aws_egress_only_internet_gateway.go
+++ b/aws/resource_aws_egress_only_internet_gateway.go
@@ -61,14 +61,14 @@ func resourceAwsEgressOnlyInternetGatewayRead(d *schema.ResourceData, meta inter
 		}
 		if resp != nil && len(resp.EgressOnlyInternetGateways) > 0 {
 			for _, igw := range resp.EgressOnlyInternetGateways {
-				if *igw.EgressOnlyInternetGatewayId == d.Id() {
+				if aws.StringValue(igw.EgressOnlyInternetGatewayId) == d.Id() {
 					found = true
 					break
 				}
 			}
 		}
 		if d.IsNewResource() && !found {
-			return resource.RetryableError(nil)
+			return resource.RetryableError(fmt.Errorf("Egress Only Internet Gateway (%s) not found.", d.Id()))
 		}
 		return nil
 	})


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes eventually consistent creates not being captured by the current logic.

Changes proposed in this pull request:

* Remove state change function that is overly verbose for our situation.
* Move eventually consistent logic in to read function.
  * The current logic does an immediate read after the first success which could still lead to the new object being removed from the state.
* Remove the check for a non existent error.
  * The error ```InvalidEgressInternetGatewayID.NotFound``` is not a real error. Instead the behaviour is an empty array. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#CommonErrors

Other:
I kept the weird logic of checking the array for the id being found but I'm not sure that is really needed either.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEgressOnlyInternetGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEgressOnlyInternetGateway_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEgressOnlyInternetGateway_basic
=== PAUSE TestAccAWSEgressOnlyInternetGateway_basic
=== CONT  TestAccAWSEgressOnlyInternetGateway_basic
--- PASS: TestAccAWSEgressOnlyInternetGateway_basic (32.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.481s

```
This is the first time I've tried to run the tests. If this wasn't done correctly let me know.