### PR TITLE
issue #6163 Directly Set RDS Parameter Group During Restore from snapshot

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -858,9 +858,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr, ok := d.GetOk("parameter_group_name"); ok {
-			modifyDbInstanceInput.DBParameterGroupName = aws.String(attr.(string))
-			requiresModifyDbInstance = true
-			requiresRebootDbInstance = true
+			opts.DBParameterGroupName = aws.String(attr.(string))
 		}
 
 		if attr, ok := d.GetOk("password"); ok {

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -466,8 +466,8 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			opts.VpcSecurityGroupIds = expandStringList(attr.List())
 		}
 
-		if _, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
-			clusterUpdate = true
+		if attr, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
+			opts.DBClusterParameterGroupName = aws.String(attr.(string))
 		}
 
 		if _, ok := d.GetOk("backup_retention_period"); ok {
@@ -490,7 +490,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if clusterUpdate {
-			log.Printf("[INFO] RDS Cluster is restoring from snapshot with default db_cluster_parameter_group_name, backup_retention_period and vpc_security_group_ids" +
+			log.Printf("[INFO] RDS Cluster is restoring from snapshot with default backup_retention_period and vpc_security_group_ids" +
 				"but custom values should be set, will now update after snapshot is restored!")
 
 			d.SetId(identifier)


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6163 

Changes proposed in this pull request:

* Change 1
Set DBClusterParameterGroupName directly during RestoreDBClusterFromSnapshot action and set DBParameterGroupName directly during RestoreDBInstanceFromDBSnapshot action.
