### PR TITLE
Update s3_bucket.html.markdown

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -119,13 +119,8 @@ resource "aws_s3_bucket" "bucket" {
     }
 
     transition {
-      days = 15
-      storage_class = "ONEZONE_IA"
-    }
-
-    transition {
       days          = 30
-      storage_class = "STANDARD_IA"
+      storage_class = "STANDARD_IA" # or "ONEZONE_IA"
     }
 
     transition {


### PR DESCRIPTION
`days = 15` isn't valid, AWS requires at least 30. Additionally the example of transitioning from `ONEZONE_IA` to `STANDARD_IA` doesn't make sense.