### PR TITLE
resource/aws_codepipeline_webhook: Support resource import

### DIFF
--- a/aws/resource_aws_codepipeline_webhook.go
+++ b/aws/resource_aws_codepipeline_webhook.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform/helper/resource"
-
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsCodePipelineWebhook() *schema.Resource {
@@ -19,6 +17,9 @@ func resourceAwsCodePipelineWebhook() *schema.Resource {
 		Read:   resourceAwsCodePipelineWebhookRead,
 		Update: nil,
 		Delete: resourceAwsCodePipelineWebhookDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"authentication": {

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -15,6 +15,7 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}
 
+	resourceName := "aws_codepipeline_webhook.bar"
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -26,11 +27,17 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 				Config: testAccAWSCodePipelineWebhookConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
-					testAccCheckAWSCodePipelineWebhookExists("aws_codepipeline_webhook.bar"),
-					resource.TestCheckResourceAttrSet("aws_codepipeline_webhook.bar", "id"),
-					resource.TestCheckResourceAttrSet("aws_codepipeline_webhook.bar", "url"),
-					resource.TestCheckResourceAttr("aws_codepipeline_webhook.bar", "authentication_configuration.0.secret_token", "super-secret"),
+					testAccCheckAWSCodePipelineWebhookExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_configuration.0.secret_token", "super-secret"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -41,6 +48,7 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}
 
+	resourceName := "aws_codepipeline_webhook.bar"
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -52,11 +60,17 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 				Config: testAccAWSCodePipelineWebhookConfig_ipAuth(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
-					testAccCheckAWSCodePipelineWebhookExists("aws_codepipeline_webhook.bar"),
-					resource.TestCheckResourceAttrSet("aws_codepipeline_webhook.bar", "id"),
-					resource.TestCheckResourceAttrSet("aws_codepipeline_webhook.bar", "url"),
-					resource.TestCheckResourceAttr("aws_codepipeline_webhook.bar", "authentication_configuration.0.allowed_ip_range", "0.0.0.0/0"),
+					testAccCheckAWSCodePipelineWebhookExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_configuration.0.allowed_ip_range", "0.0.0.0/0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -67,6 +81,7 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 		t.Skip("Environment variable GITHUB_TOKEN is not set")
 	}
 
+	resourceName := "aws_codepipeline_webhook.bar"
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -78,10 +93,15 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 				Config: testAccAWSCodePipelineWebhookConfig_unauthenticated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
-					testAccCheckAWSCodePipelineWebhookExists("aws_codepipeline_webhook.bar"),
-					resource.TestCheckResourceAttrSet("aws_codepipeline_webhook.bar", "id"),
-					resource.TestCheckResourceAttrSet("aws_codepipeline_webhook.bar", "url"),
+					testAccCheckAWSCodePipelineWebhookExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/codepipeline_webhook.markdown
+++ b/website/docs/r/codepipeline_webhook.markdown
@@ -130,3 +130,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The CodePipeline webhook's ARN.
 * `url` - The CodePipeline webhook's URL. POST events to this endpoint to trigger the target.
+
+## Import
+
+CodePipeline Webhooks can be imported by their ARN, e.g.
+
+```
+$ terraform import aws_codepipeline_webhook.example arn:aws:codepipeline:us-west-2:123456789012:webhook:example
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* On the tin 😄 

Output from acceptance testing:

```
--- PASS: TestAccAWSCodePipelineWebhook_unauthenticated (24.86s)
--- PASS: TestAccAWSCodePipelineWebhook_ipAuth (27.24s)
--- PASS: TestAccAWSCodePipelineWebhook_basic (38.04s)
```
