### PR TITLE
Bugs in sample terraform code docs

### DIFF
--- a/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
+++ b/website/docs/guides/serverless-with-aws-lambda-and-api-gateway.html.md
@@ -403,12 +403,12 @@ file created in an earlier step:
 resource "aws_lambda_permission" "apigw" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.example.arn}"
+  function_name = "${aws_lambda_function.example.function_name}"
   principal     = "apigateway.amazonaws.com"
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.example.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_rest_api.example.execution_arn}/*/*"
 }
 ```
 


### PR DESCRIPTION
The `function_name` and `source_arn` were set incorrectly which led to a complaint about insufficient permissions. The `function_name` should be the `arn` of the function and the `source_arn` should be from the gateway itself rather than the gateway deployment.

*no code changes, just docs*
(edits made for clarity)