### PR TITLE
Fix typo on replication_subnet_group_id

### DIFF
--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -26,7 +26,7 @@ resource "aws_dms_replication_instance" "test" {
   publicly_accessible          = true
   replication_instance_class   = "dms.t2.micro"
   replication_instance_id      = "test-dms-replication-instance-tf"
-  replication_subnet_group_id  = "${aws_dms_replication_subnet_group.test-dms-replication-subnet-group-tf}"
+  replication_subnet_group_id  = "${aws_dms_replication_subnet_group.test-dms-replication-subnet-group-tf.id}"
 
   tags {
     Name = "test"


### PR DESCRIPTION
I'm setting up AWS DMS via Terraform, and I noticed a little typo in the docs, I hope that PRs as welcome :)