### PR TITLE
resource/aws_cloudwatch_metric_alarm: Allow EC2 Automate ARNs with alarm_actions

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -73,8 +73,11 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validateArn,
+					Type: schema.TypeString,
+					ValidateFunc: validateAny(
+						validateArn,
+						validateEC2AutomateARN,
+					),
 				},
 				Set: schema.HashString,
 			},


### PR DESCRIPTION
Fixes #6203

The `validateAny()` function will be submitted upstream to the provider SDK to be available as `validation.Any()` for all providers.

Changes proposed in this pull request:

* Allow `aws:PARTITION:automate:REGION:ec2:ACTION` ARNs in `alarm_actions` validation
* Consolidate `_importBasic` acceptance test into `basic` acceptance test

Output from acceptance testing:

Previously:

```
--- FAIL: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (5.65s)
    testing.go:538: Step 0 error: Error planning: 1 error occurred:
        	* aws_cloudwatch_metric_alarm.test: "alarm_actions.0" doesn't look like a valid ARN ("^arn:[\\w-]+:([a-zA-Z0-9\\-])+:([a-z]{2}-(gov-)?[a-z]+-\\d{1})?:(\\d{12})?:(.*)$"): "arn:aws:automate:us-west-2:ec2:recover"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (3.93s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (10.93s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (10.98s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (12.42s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (14.00s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (14.27s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (17.89s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (17.93s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (137.37s)
```
