### PR TITLE
docs: fix example code elastic_transcoder_preset

### DIFF
--- a/website/docs/r/elastic_transcoder_preset.html.markdown
+++ b/website/docs/r/elastic_transcoder_preset.html.markdown
@@ -18,7 +18,7 @@ resource "aws_elastictranscoder_preset" "bar" {
   description = "Sample Preset"
   name        = "sample_preset"
 
-  audio = {
+  audio {
     audio_packing_mode = "SingleTrack"
     bit_rate           = 96
     channels           = 2
@@ -26,11 +26,11 @@ resource "aws_elastictranscoder_preset" "bar" {
     sample_rate        = 44100
   }
 
-  audio_codec_options = {
+  audio_codec_options {
     profile = "AAC-LC"
   }
 
-  video = {
+  video {
     bit_rate             = "1600"
     codec                = "H.264"
     display_aspect_ratio = "16:9"
@@ -44,7 +44,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     sizing_policy        = "Fit"
   }
 
-  video_codec_options = {
+  video_codec_options {
     Profile                  = "main"
     Level                    = "2.2"
     MaxReferenceFrames       = 3
@@ -52,7 +52,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     ColorSpaceConversionMode = "None"
   }
 
-  video_watermarks = {
+  video_watermarks {
     id                = "Terraform Test"
     max_width         = "20%"
     max_height        = "20%"
@@ -65,7 +65,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     target            = "Content"
   }
 
-  thumbnails = {
+  thumbnails {
     format         = "png"
     interval       = 120
     max_width      = "auto"

--- a/website/docs/r/elastic_transcoder_preset.html.markdown
+++ b/website/docs/r/elastic_transcoder_preset.html.markdown
@@ -44,7 +44,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     sizing_policy        = "Fit"
   }
 
-  video_codec_options {
+  video_codec_options = {
     Profile                  = "main"
     Level                    = "2.2"
     MaxReferenceFrames       = 3


### PR DESCRIPTION
The example elastic transcoder preset code is not consistent with a valid config. This change fixes the example code.
