### PR TITLE
data-source/aws_iot_endpoint: Add endpoint_type argument

### DIFF
--- a/aws/data_source_aws_iot_endpoint.go
+++ b/aws/data_source_aws_iot_endpoint.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iot"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsIotEndpoint() *schema.Resource {
@@ -16,6 +17,16 @@ func dataSourceAwsIotEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"endpoint_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"iot:CredentialProvider",
+					"iot:Data",
+					"iot:Data-ATS",
+					"iot:Jobs",
+				}, false),
+			},
 		},
 	}
 }
@@ -23,6 +34,10 @@ func dataSourceAwsIotEndpoint() *schema.Resource {
 func dataSourceAwsIotEndpointRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).iotconn
 	input := &iot.DescribeEndpointInput{}
+
+	if v, ok := d.GetOk("endpoint_type"); ok {
+		input.EndpointType = aws.String(v.(string))
+	}
 
 	output, err := conn.DescribeEndpoint(input)
 	if err != nil {

--- a/aws/data_source_aws_iot_endpoint_test.go
+++ b/aws/data_source_aws_iot_endpoint_test.go
@@ -1,12 +1,16 @@
 package aws
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAWSIotEndpointDataSource(t *testing.T) {
+func TestAccAWSIotEndpointDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_iot_endpoint.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -14,7 +18,75 @@ func TestAccAWSIotEndpointDataSource(t *testing.T) {
 			{
 				Config: testAccAWSIotEndpointConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_iot_endpoint.example", "endpoint_address"),
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint_address", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]+(-ats)?.iot.%s.amazonaws.com$", testAccGetRegion()))),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIotEndpointDataSource_EndpointType_IOTCredentialProvider(t *testing.T) {
+	dataSourceName := "data.aws_iot_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotEndpointConfigEndpointType("iot:CredentialProvider"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint_address", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]+.credentials.iot.%s.amazonaws.com$", testAccGetRegion()))),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIotEndpointDataSource_EndpointType_IOTData(t *testing.T) {
+	dataSourceName := "data.aws_iot_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotEndpointConfigEndpointType("iot:Data"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint_address", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]+.iot.%s.amazonaws.com$", testAccGetRegion()))),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIotEndpointDataSource_EndpointType_IOTDataATS(t *testing.T) {
+	dataSourceName := "data.aws_iot_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotEndpointConfigEndpointType("iot:Data-ATS"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint_address", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]+-ats.iot.%s.amazonaws.com$", testAccGetRegion()))),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIotEndpointDataSource_EndpointType_IOTJobs(t *testing.T) {
+	dataSourceName := "data.aws_iot_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotEndpointConfigEndpointType("iot:Jobs"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "endpoint_address", regexp.MustCompile(fmt.Sprintf("^[a-z0-9]+.jobs.iot.%s.amazonaws.com$", testAccGetRegion()))),
 				),
 			},
 		},
@@ -22,5 +94,13 @@ func TestAccAWSIotEndpointDataSource(t *testing.T) {
 }
 
 const testAccAWSIotEndpointConfig = `
-data "aws_iot_endpoint" "example" {}
+data "aws_iot_endpoint" "test" {}
 `
+
+func testAccAWSIotEndpointConfigEndpointType(endpointType string) string {
+	return fmt.Sprintf(`
+data "aws_iot_endpoint" "test" {
+  endpoint_type = %q
+}
+`, endpointType)
+}

--- a/website/docs/d/iot_endpoint.html.markdown
+++ b/website/docs/d/iot_endpoint.html.markdown
@@ -37,8 +37,13 @@ resource "kubernetes_pod" "agent" {
 
 ## Argument Reference
 
-N/A
+* `endpoint_type` - (Optional) Endpoint type. Valid values: `iot:CredentialProvider`, `iot:Data`, `iot:Data-ATS`, `iot:Job`.
 
 ## Attributes Reference
 
-* `endpoint_address` - The endpoint. The format of the endpoint is as follows: `IDENTIFIER.iot.REGION.amazonaws.com`.
+* `endpoint_address` - The endpoint based on `endpoint_type`:
+  * No `endpoint_type`: Either `iot:Data` or `iot:Data-ATS` [depending on region](https://aws.amazon.com/blogs/iot/aws-iot-core-ats-endpoints/)
+  * `iot:CredentialsProvider`: `IDENTIFIER.credentials.iot.REGION.amazonaws.com`
+  * `iot:Data`: `IDENTIFIER.iot.REGION.amazonaws.com`
+  * `iot:Data-ATS`: `IDENTIFIER-ats.iot.REGION.amazonaws.com`
+  * `iot:Job`: `IDENTIFIER.jobs.iot.REGION.amazonaws.com`


### PR DESCRIPTION
Closes #6213 

The old VeriSign endpoints can cause issues due to the Symantec distrust process rolling out.

Changes proposed in this pull request:

* Add `endpoint_type` argument to `aws_iot_endpoint` data source

Output from acceptance testing:

```
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTJobs (9.57s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTCredentialProvider (9.64s)
--- PASS: TestAccAWSIotEndpointDataSource_basic (9.73s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTDataATS (9.78s)
--- PASS: TestAccAWSIotEndpointDataSource_EndpointType_IOTData (9.95s)
```