### PR TITLE
docs/resource/aws_ecr_lifecycle_policy: Add note that only one resource can be used with the same ECR repository

### DIFF
--- a/website/docs/r/ecr_lifecycle_policy.html.markdown
+++ b/website/docs/r/ecr_lifecycle_policy.html.markdown
@@ -3,12 +3,16 @@ layout: "aws"
 page_title: "AWS: aws_ecr_lifecycle_policy"
 sidebar_current: "docs-aws-resource-ecr-lifecycle-policy"
 description: |-
-  Provides an ECR Lifecycle Policy.
+  Manages an ECR repository lifecycle policy.
 ---
 
 # aws_ecr_lifecycle_policy
 
-Provides an ECR lifecycle policy.
+Manages an ECR repository lifecycle policy.
+
+~> **NOTE:** Only one `aws_ecr_lifecycle_policy` resource can be used with the same ECR repository. To apply multiple rules, they must be combined in the `policy` JSON.
+
+~> **NOTE:** The AWS ECR API seems to reorder rules based on `rulePriority`. If you define multiple rules that are not sorted in ascending `rulePriority` order in the Terraform code, the resource will be flagged for recreation every `terraform plan`.
 
 ## Example Usage
 
@@ -82,8 +86,6 @@ The following arguments are supported:
 
 * `repository` - (Required) Name of the repository to apply the policy.
 * `policy` - (Required) The policy document. This is a JSON formatted string. See more details about [Policy Parameters](http://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html#lifecycle_policy_parameters) in the official AWS docs. For more information about building IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](/docs/providers/aws/guides/iam-policy-documents.html).
-
-~> **NOTE:** The AWS ECR API seems to reorder rules based on `rulePriority`. If you define multiple rules that are not sorted ascending in the TF code will be flagged for recreation every `terraform plan`. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
Reference: #6212 

At some point in the future we can introduce a data source, similar to `aws_iam_policy_document`, that can support better handling of the policy JSON (e.g. combining rules, validation, etc.).

Changes proposed in this pull request:

* Add note about multiple `aws_ecr_lifecycle_policy` against the same repository
* Move note about `rulePriority` to the top as well.

Output from acceptance testing: N/A
