### PR TITLE
Remove KmsKeyId from MongoDbSettings for aws_dms_endpoint

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -244,7 +244,6 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 			ServerName:   aws.String(d.Get("server_name").(string)),
 			Port:         aws.Int64(int64(d.Get("port").(int))),
 			DatabaseName: aws.String(d.Get("database_name").(string)),
-			KmsKeyId:     aws.String(d.Get("kms_key_arn").(string)),
 
 			AuthType:          aws.String(d.Get("mongodb_settings.0.auth_type").(string)),
 			AuthMechanism:     aws.String(d.Get("mongodb_settings.0.auth_mechanism").(string)),
@@ -430,7 +429,6 @@ func resourceAwsDmsEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 				ServerName:   aws.String(d.Get("server_name").(string)),
 				Port:         aws.Int64(int64(d.Get("port").(int))),
 				DatabaseName: aws.String(d.Get("database_name").(string)),
-				KmsKeyId:     aws.String(d.Get("kms_key_arn").(string)),
 
 				AuthType:          aws.String(d.Get("mongodb_settings.0.auth_type").(string)),
 				AuthMechanism:     aws.String(d.Get("mongodb_settings.0.auth_mechanism").(string)),


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6209

Changes proposed in this pull request:

* Stop passing KmsKeyId as part of MongoDbSettings for aws_dms_endpoint

I have not worked in Go before so I did not run the automated tests, I apologize. But based on what I am seeing from the CLI, it looks like passing KmsKeyId in MongoDbSettings is no longer supported. I've been chatting with AWS Support about this and unfortunately they're being very unhelpful about whether or not this is an API bug or a documentation bug. Since KmsKeyId is passed through other arguments, I can't imagine that this change is bad.