### PR TITLE
resource/aws_ami_launch_permission: Prevent panic reading public permissions

### DIFF
--- a/aws/resource_aws_ami_launch_permission.go
+++ b/aws/resource_aws_ami_launch_permission.go
@@ -106,7 +106,7 @@ func hasLaunchPermission(conn *ec2.EC2, image_id string, account_id string) (boo
 	}
 
 	for _, lp := range attrs.LaunchPermissions {
-		if *lp.UserId == account_id {
+		if aws.StringValue(lp.UserId) == account_id {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Fixes #6222 

Changes proposed in this pull request:

* Dereference via AWS Go SDK helper instead of using `*` since the field might not exist
* Also parallelizes other cases of removing launch permissions and AMI.

Previously:

```
=== CONT  TestAccAWSAMILaunchPermission_Disappears_LaunchPermission_Public
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2abb7a7]

goroutine 1240 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.hasLaunchPermission(0xc00000e1e0, 0xc0009a2240, 0x15, 0xc0007aa480, 0xc, 0xc0005c8000, 0xc00099b700, 0x1870888)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_ami_launch_permission.go:109 +0x137
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsAmiLaunchPermissionExists(0xc0005c8000, 0x3e0b7e0, 0xc000c26300, 0xc0005c8000, 0x0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_ami_launch_permission.go:41 +0x101
```

Now:

```
--- PASS: TestAccAWSAMILaunchPermission_Disappears_LaunchPermission (335.48s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_LaunchPermission_Public (345.99s)
--- PASS: TestAccAWSAMILaunchPermission_Basic (346.17s)
--- PASS: TestAccAWSAMILaunchPermission_Disappears_AMI (353.34s)
```