### PR TITLE
resource/aws_nat_gateway: Remove network_interface_id, private_ip, and public_ip as configurable

### DIFF
--- a/aws/resource_aws_nat_gateway.go
+++ b/aws/resource_aws_nat_gateway.go
@@ -38,19 +38,16 @@ func resourceAwsNatGateway() *schema.Resource {
 
 			"network_interface_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"private_ip": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 
 			"public_ip": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -66,29 +66,9 @@ func testSweepNatGateways(region string) error {
 	return nil
 }
 
-func TestAccAWSNatGateway_importBasic(t *testing.T) {
-	resourceName := "aws_nat_gateway.gateway"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNatGatewayDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccNatGatewayConfig,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSNatGateway_basic(t *testing.T) {
 	var natGateway ec2.NatGateway
+	resourceName := "aws_nat_gateway.gateway"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -99,8 +79,13 @@ func TestAccAWSNatGateway_basic(t *testing.T) {
 			{
 				Config: testAccNatGatewayConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNatGatewayExists("aws_nat_gateway.gateway", &natGateway),
+					testAccCheckNatGatewayExists(resourceName, &natGateway),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -108,6 +93,7 @@ func TestAccAWSNatGateway_basic(t *testing.T) {
 
 func TestAccAWSNatGateway_tags(t *testing.T) {
 	var natGateway ec2.NatGateway
+	resourceName := "aws_nat_gateway.gateway"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -117,7 +103,7 @@ func TestAccAWSNatGateway_tags(t *testing.T) {
 			{
 				Config: testAccNatGatewayConfigTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNatGatewayExists("aws_nat_gateway.gateway", &natGateway),
+					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					testAccCheckTags(&natGateway.Tags, "Name", "terraform-testacc-nat-gw-tags"),
 					testAccCheckTags(&natGateway.Tags, "foo", "bar"),
 				),
@@ -126,11 +112,16 @@ func TestAccAWSNatGateway_tags(t *testing.T) {
 			{
 				Config: testAccNatGatewayConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNatGatewayExists("aws_nat_gateway.gateway", &natGateway),
+					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					testAccCheckTags(&natGateway.Tags, "Name", "terraform-testacc-nat-gw-tags"),
 					testAccCheckTags(&natGateway.Tags, "foo", ""),
 					testAccCheckTags(&natGateway.Tags, "bar", "baz"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #6223 

The API nor the resource actually support configuring these attributes.

Changes proposed in this pull request:

* Remove `Optional` from `network_interface_id`, `private_ip`, and `public_ip` attributes
* tests/resource/aws_nat_gateway: Perform import testing in all acceptance tests and remove bespoke importBasic test

Output from acceptance testing:

```
--- PASS: TestAccAWSNatGateway_basic (221.42s)
--- PASS: TestAccAWSNatGateway_tags (259.84s)
```
