### PR TITLE
resource/aws_budgets_budget: Support resource import

### DIFF
--- a/aws/resource_aws_budgets_budget.go
+++ b/aws/resource_aws_budgets_budget.go
@@ -135,6 +135,9 @@ func resourceAwsBudgetsBudget() *schema.Resource {
 		Read:   resourceAwsBudgetsBudgetRead,
 		Update: resourceAwsBudgetsBudgetUpdate,
 		Delete: resourceAwsBudgetsBudgetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 
@@ -221,8 +224,8 @@ func resourceAwsBudgetsBudgetRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", budget.BudgetName)
 
 	if budget.TimePeriod != nil {
-		d.Set("time_period_end", budget.TimePeriod.End)
-		d.Set("time_period_start", budget.TimePeriod.Start)
+		d.Set("time_period_end", aws.TimeValue(budget.TimePeriod.End).Format("2006-01-02_15:04"))
+		d.Set("time_period_start", aws.TimeValue(budget.TimePeriod.Start).Format("2006-01-02_15:04"))
 	}
 
 	d.Set("time_unit", budget.TimeUnit)

--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -59,6 +59,12 @@ func TestAccAWSBudgetsBudget_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_budgets_budget.foo", "time_unit", *configBasicUpdate.TimeUnit),
 				),
 			},
+			{
+				ResourceName:            "aws_budgets_budget.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
 		},
 	})
 }
@@ -100,6 +106,13 @@ func TestAccAWSBudgetsBudget_prefix(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_budgets_budget.foo", "time_period_end", configBasicUpdate.TimePeriod.End.Format("2006-01-02_15:04")),
 					resource.TestCheckResourceAttr("aws_budgets_budget.foo", "time_unit", *configBasicUpdate.TimeUnit),
 				),
+			},
+
+			{
+				ResourceName:            "aws_budgets_budget.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
 			},
 		},
 	})


### PR DESCRIPTION
Closes #6180 

The support was documented, but never implemented.

Changes proposed in this pull request:

* Support resource import
* Properly read `time_period_start` and `time_period_end` into Terraform state

Output from acceptance testing:

```
--- PASS: TestAccAWSBudgetsBudget_prefix (18.37s)
--- PASS: TestAccAWSBudgetsBudget_basic (20.81s)
```
