### PR TITLE
Fix non-alphanumeric VPC name in aws_cloudformation_stack example usage

### DIFF
--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -30,7 +30,7 @@ resource "aws_cloudformation_stack" "network" {
     }
   },
   "Resources" : {
-    "my-vpc": {
+    "myVpc": {
       "Type" : "AWS::EC2::VPC",
       "Properties" : {
         "CidrBlock" : { "Ref" : "VPCCidr" },


### PR DESCRIPTION
Current code in the example usage cannot be executed because "-" is not allowed in a VPC name.
