### PR TITLE
d/nat_gateway: Fix formatting when describing filter arguments

### DIFF
--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -43,8 +43,10 @@ Nat Gateway whose data will be exported as attributes.
 * `vpc_id` - (Optional) The id of the VPC that the Nat Gateway resides in.
 * `state` - (Optional) The state of the NAT gateway (pending | failed | available | deleting | deleted ).
 * `filter` - (Optional) Custom filter block as described below.
+
 More complex filters can be expressed using one or more `filter` sub-blocks,
 which take the following arguments:
+
 * `name` - (Required) The name of the field to filter by, as defined by
   [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNatGateways.html).
 * `values` - (Required) Set of values that are accepted for the given field.


### PR DESCRIPTION
The documentation of `aws_nat_gateway` data source currently looks like the `name` and `values` arguments of the `filter` argument are arguments of the data source itself. 

This PR fixes this by using the same formatting style used for `aws_network_acls` and other data sources.

Since this just clarifies the documentation this can be released immediately in my opinion. 
