### PR TITLE
d/aws_nat_gateway: Fix filtering and reading of tags

### DIFF
--- a/aws/data_source_aws_nat_gateway.go
+++ b/aws/data_source_aws_nat_gateway.go
@@ -89,6 +89,12 @@ func dataSourceAwsNatGatewayRead(d *schema.ResourceData, meta interface{}) error
 		)...)
 	}
 
+	if tags, ok := d.GetOk("tags"); ok {
+		req.Filter = append(req.Filter, buildEC2TagFilterList(
+			tagsFromMap(tags.(map[string]interface{})),
+		)...)
+	}
+
 	req.Filter = append(req.Filter, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),
 	)...)
@@ -116,6 +122,7 @@ func dataSourceAwsNatGatewayRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("state", ngw.State)
 	d.Set("subnet_id", ngw.SubnetId)
 	d.Set("vpc_id", ngw.VpcId)
+	d.Set("tags", tagsToMap(ngw.Tags))
 
 	for _, address := range ngw.NatGatewayAddresses {
 		if *address.AllocationId != "" {

--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -25,12 +25,16 @@ func TestAccDataSourceAwsNatGateway(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"data.aws_nat_gateway.test_by_subnet_id", "subnet_id",
 						"aws_nat_gateway.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.aws_nat_gateway.test_by_tags", "tags.Name",
+						"aws_nat_gateway.test", "tags.Name"),
 					resource.TestCheckResourceAttrSet("data.aws_nat_gateway.test_by_id", "state"),
 					resource.TestCheckResourceAttrSet("data.aws_nat_gateway.test_by_id", "allocation_id"),
 					resource.TestCheckResourceAttrSet("data.aws_nat_gateway.test_by_id", "network_interface_id"),
 					resource.TestCheckResourceAttrSet("data.aws_nat_gateway.test_by_id", "public_ip"),
 					resource.TestCheckResourceAttrSet("data.aws_nat_gateway.test_by_id", "private_ip"),
 					resource.TestCheckNoResourceAttr("data.aws_nat_gateway.test_by_id", "attached_vpc_id"),
+					resource.TestCheckResourceAttrSet("data.aws_nat_gateway.test_by_id", "tags.OtherTag"),
 				),
 			},
 		},
@@ -73,13 +77,13 @@ resource "aws_internet_gateway" "test" {
   }
 }
 
-# NGWs are not taggable, either
 resource "aws_nat_gateway" "test" {
   subnet_id     = "${aws_subnet.test.id}"
   allocation_id = "${aws_eip.test.id}"
 
   tags {
-    Name = "terraform-testacc-nat-gw-data-source"
+    Name = "terraform-testacc-nat-gw-data-source-%d"
+    OtherTag = "some-value"
   }
 
   depends_on = ["aws_internet_gateway.test"]
@@ -93,5 +97,11 @@ data "aws_nat_gateway" "test_by_subnet_id" {
   subnet_id = "${aws_nat_gateway.test.subnet_id}"
 }
 
-`, rInt, rInt, rInt)
+data "aws_nat_gateway" "test_by_tags" {
+  tags {
+    Name = "${aws_nat_gateway.test.tags["Name"]}"
+  }
+}
+
+`, rInt, rInt, rInt, rInt)
 }

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -42,6 +42,8 @@ Nat Gateway whose data will be exported as attributes.
 * `subnet_id` - (Optional) The id of subnet that the Nat Gateway resides in.
 * `vpc_id` - (Optional) The id of the VPC that the Nat Gateway resides in.
 * `state` - (Optional) The state of the NAT gateway (pending | failed | available | deleting | deleted ).
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired Nat Gateway.
 * `filter` - (Optional) Custom filter block as described below.
 More complex filters can be expressed using one or more `filter` sub-blocks,
 which take the following arguments:


### PR DESCRIPTION
Currently, `tags` can be defined as an argument for the `aws_nat_gateway` data source and are [documented](https://www.terraform.io/docs/providers/aws/d/nat_gateway.html) this way but are silently ignored when searching for the NAT Gateway. When reading NAT Gateway details, tag-values aren't populated in terraform. This PR attempts to fix this.

Changes proposed in this pull request:

* filter for given tags when provided as attribute
* read tags-value from API response

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsNatGateway'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAwsNatGateway -timeout 120m
=== RUN   TestAccDataSourceAwsNatGateway
=== PAUSE TestAccDataSourceAwsNatGateway
=== CONT  TestAccDataSourceAwsNatGateway
--- PASS: TestAccDataSourceAwsNatGateway (244.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	244.155s
```