### PR TITLE
resource/aws_glue_job: Support security_configuration property

### DIFF
--- a/aws/resource_aws_glue_job.go
+++ b/aws/resource_aws_glue_job.go
@@ -95,6 +95,10 @@ func resourceAwsGlueJob() *schema.Resource {
 				Optional: true,
 				Default:  2880,
 			},
+			"security_configuration": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -138,6 +142,10 @@ func resourceAwsGlueJobCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("max_retries"); ok {
 		input.MaxRetries = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("security_configuration"); ok {
+		input.SecurityConfiguration = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Creating Glue Job: %s", input)
@@ -194,6 +202,9 @@ func resourceAwsGlueJobRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", job.Name)
 	d.Set("role_arn", job.Role)
 	d.Set("timeout", int(aws.Int64Value(job.Timeout)))
+	if err := d.Set("security_configuration", job.SecurityConfiguration); err != nil {
+		return fmt.Errorf("error setting security_configuration: %s", err)
+	}
 
 	return nil
 }
@@ -235,6 +246,10 @@ func resourceAwsGlueJobUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("max_retries"); ok {
 		jobUpdate.MaxRetries = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("security_configuration"); ok {
+		jobUpdate.SecurityConfiguration = aws.String(v.(string))
 	}
 
 	input := &glue.UpdateJobInput{

--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `name` – (Required) The name you assign to this job. It must be unique in your account.
 * `role_arn` – (Required) The ARN of the IAM role associated with this job.
 * `timeout` – (Optional) The job timeout in minutes. The default is 2880 minutes (48 hours).
+* `security_configuration` - (Optional) The name of the Security Configuration to be associated with the job. 
 
 ### command Argument Reference
 


### PR DESCRIPTION
Fixes #6099

Changes proposed in this pull request:

* Add support for the security_configuration property on Glue jobs.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSGlueJob'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGlueJob -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSGlueJob_Basic
=== PAUSE TestAccAWSGlueJob_Basic
=== RUN   TestAccAWSGlueJob_AllocatedCapacity
=== PAUSE TestAccAWSGlueJob_AllocatedCapacity
=== RUN   TestAccAWSGlueJob_Command
=== PAUSE TestAccAWSGlueJob_Command
=== RUN   TestAccAWSGlueJob_DefaultArguments
=== PAUSE TestAccAWSGlueJob_DefaultArguments
=== RUN   TestAccAWSGlueJob_Description
=== PAUSE TestAccAWSGlueJob_Description
=== RUN   TestAccAWSGlueJob_ExecutionProperty
=== PAUSE TestAccAWSGlueJob_ExecutionProperty
=== RUN   TestAccAWSGlueJob_MaxRetries
=== PAUSE TestAccAWSGlueJob_MaxRetries
=== RUN   TestAccAWSGlueJob_Timeout
=== PAUSE TestAccAWSGlueJob_Timeout
=== RUN   TestAccAWSGlueJob_SecurityConfiguration
=== PAUSE TestAccAWSGlueJob_SecurityConfiguration
=== CONT  TestAccAWSGlueJob_Basic
=== CONT  TestAccAWSGlueJob_ExecutionProperty
=== CONT  TestAccAWSGlueJob_DefaultArguments
=== CONT  TestAccAWSGlueJob_SecurityConfiguration
=== CONT  TestAccAWSGlueJob_Command
=== CONT  TestAccAWSGlueJob_Timeout
=== CONT  TestAccAWSGlueJob_MaxRetries
=== CONT  TestAccAWSGlueJob_AllocatedCapacity
=== CONT  TestAccAWSGlueJob_Description
--- PASS: TestAccAWSGlueJob_Timeout (36.72s)
--- PASS: TestAccAWSGlueJob_DefaultArguments (41.07s)
--- PASS: TestAccAWSGlueJob_AllocatedCapacity (43.13s)
--- PASS: TestAccAWSGlueJob_SecurityConfiguration (46.15s)
--- PASS: TestAccAWSGlueJob_ExecutionProperty (46.42s)
--- PASS: TestAccAWSGlueJob_Command (47.31s)
--- PASS: TestAccAWSGlueJob_MaxRetries (48.87s)
--- PASS: TestAccAWSGlueJob_Description (54.62s)
--- PASS: TestAccAWSGlueJob_Basic (67.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	67.295s
...
```
