### PR TITLE
New resource: aws_pinpoint_apns_voip_sandbox_channel

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -683,6 +683,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_pinpoint_app":                                 resourceAwsPinpointApp(),
 			"aws_pinpoint_adm_channel":                         resourceAwsPinpointADMChannel(),
 			"aws_pinpoint_apns_channel":                        resourceAwsPinpointAPNSChannel(),
+			"aws_pinpoint_apns_voip_sandbox_channel":           resourceAwsPinpointAPNSVoipSandboxChannel(),
 			"aws_pinpoint_baidu_channel":                       resourceAwsPinpointBaiduChannel(),
 			"aws_pinpoint_email_channel":                       resourceAwsPinpointEmailChannel(),
 			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),

--- a/aws/resource_aws_pinpoint_apns_voip_sandbox_channel.go
+++ b/aws/resource_aws_pinpoint_apns_voip_sandbox_channel.go
@@ -1,0 +1,159 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsPinpointAPNSVoipSandboxChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsPinpointAPNSVoipSandboxChannelUpsert,
+		Read:   resourceAwsPinpointAPNSVoipSandboxChannelRead,
+		Update: resourceAwsPinpointAPNSVoipSandboxChannelUpsert,
+		Delete: resourceAwsPinpointAPNSVoipSandboxChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"bundle_id": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"certificate": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"default_authentication_method": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"private_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"team_id": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"token_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"token_key_id": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceAwsPinpointAPNSVoipSandboxChannelUpsert(d *schema.ResourceData, meta interface{}) error {
+	certificate, certificateOk := d.GetOk("certificate")
+	privateKey, privateKeyOk := d.GetOk("private_key")
+
+	bundleId, bundleIdOk := d.GetOk("bundle_id")
+	teamId, teamIdOk := d.GetOk("team_id")
+	tokenKey, tokenKeyOk := d.GetOk("token_key")
+	tokenKeyId, tokenKeyIdOk := d.GetOk("token_key_id")
+
+	if !(certificateOk && privateKeyOk) && !(bundleIdOk && teamIdOk && tokenKeyOk && tokenKeyIdOk) {
+		return errors.New("At least one set of credentials is required; either [certificate, private_key] or [bundle_id, team_id, token_key, token_key_id]")
+	}
+
+	conn := meta.(*AWSClient).pinpointconn
+
+	applicationId := d.Get("application_id").(string)
+
+	params := &pinpoint.APNSVoipSandboxChannelRequest{}
+
+	params.DefaultAuthenticationMethod = aws.String(d.Get("default_authentication_method").(string))
+	params.Enabled = aws.Bool(d.Get("enabled").(bool))
+
+	params.Certificate = aws.String(certificate.(string))
+	params.PrivateKey = aws.String(privateKey.(string))
+
+	params.BundleId = aws.String(bundleId.(string))
+	params.TeamId = aws.String(teamId.(string))
+	params.TokenKey = aws.String(tokenKey.(string))
+	params.TokenKeyId = aws.String(tokenKeyId.(string))
+
+	req := pinpoint.UpdateApnsVoipSandboxChannelInput{
+		ApplicationId:                 aws.String(applicationId),
+		APNSVoipSandboxChannelRequest: params,
+	}
+
+	_, err := conn.UpdateApnsVoipSandboxChannel(&req)
+	if err != nil {
+		return fmt.Errorf("error updating Pinpoint APNs Voip Sandbox Channel for Application %s: %s", applicationId, err)
+	}
+
+	d.SetId(applicationId)
+
+	return resourceAwsPinpointAPNSVoipSandboxChannelRead(d, meta)
+}
+
+func resourceAwsPinpointAPNSVoipSandboxChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[INFO] Reading Pinpoint APNs Voip Sandbox Channel for Application %s", d.Id())
+
+	output, err := conn.GetApnsVoipSandboxChannel(&pinpoint.GetApnsVoipSandboxChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] Pinpoint APNs Voip Sandbox Channel for application %s not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("error getting Pinpoint APNs Voip Sandbox Channel for application %s: %s", d.Id(), err)
+	}
+
+	d.Set("application_id", output.APNSVoipSandboxChannelResponse.ApplicationId)
+	d.Set("default_authentication_method", output.APNSVoipSandboxChannelResponse.DefaultAuthenticationMethod)
+	d.Set("enabled", output.APNSVoipSandboxChannelResponse.Enabled)
+	// Sensitive params are not returned
+
+	return nil
+}
+
+func resourceAwsPinpointAPNSVoipSandboxChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).pinpointconn
+
+	log.Printf("[DEBUG] Deleting Pinpoint APNs Voip Sandbox Channel: %s", d.Id())
+	_, err := conn.DeleteApnsVoipSandboxChannel(&pinpoint.DeleteApnsVoipSandboxChannelInput{
+		ApplicationId: aws.String(d.Id()),
+	})
+
+	if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Pinpoint APNs Voip Sandbox Channel for Application %s: %s", d.Id(), err)
+	}
+	return nil
+}

--- a/aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go
+++ b/aws/resource_aws_pinpoint_apns_voip_sandbox_channel_test.go
@@ -1,0 +1,257 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pinpoint"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+/**
+ Before running this test, one of the following two ENV variables set must be defined. See here for details:
+ https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-mobile-manage.html
+
+ * Key Configuration (ref. https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns )
+ APNS_VOIP_BUNDLE_ID    - APNs Bundle ID
+ APNS_VOIP_TEAM_ID      - APNs Team ID
+ APNS_VOIP_TOKEN_KEY    - Token key file content (.p8 file)
+ APNS_VOIP_TOKEN_KEY_ID - APNs Token Key ID
+
+ * Certificate Configuration (ref. https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_certificate-based_connection_to_apns - Select "VoIP Services Certificate" )
+ APNS_VOIP_CERTIFICATE             - APNs Certificate content (.pem file content)
+ APNS_VOIP_CERTIFICATE_PRIVATE_KEY - APNs Certificate Private Key File content
+**/
+
+type testAccAwsPinpointAPNSVoipSandboxChannelCertConfiguration struct {
+	Certificate string
+	PrivateKey  string
+}
+
+type testAccAwsPinpointAPNSVoipSandboxChannelTokenConfiguration struct {
+	BundleId   string
+	TeamId     string
+	TokenKey   string
+	TokenKeyId string
+}
+
+func testAccAwsPinpointAPNSVoipSandboxChannelCertConfigurationFromEnv(t *testing.T) *testAccAwsPinpointAPNSVoipSandboxChannelCertConfiguration {
+	var conf *testAccAwsPinpointAPNSVoipSandboxChannelCertConfiguration
+	if os.Getenv("APNS_VOIP_CERTIFICATE") != "" {
+		if os.Getenv("APNS_VOIP_CERTIFICATE_PRIVATE_KEY") == "" {
+			t.Fatalf("APNS_VOIP_CERTIFICATE set but missing APNS_VOIP_CERTIFICATE_PRIVATE_KEY")
+		}
+
+		conf = &testAccAwsPinpointAPNSVoipSandboxChannelCertConfiguration{
+			Certificate: fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_CERTIFICATE"))),
+			PrivateKey:  fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_CERTIFICATE_PRIVATE_KEY"))),
+		}
+	}
+
+	if conf == nil {
+		t.Skipf("Pinpoint certificate credentials envs are missing, skipping test")
+	}
+
+	return conf
+}
+
+func testAccAwsPinpointAPNSVoipSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testAccAwsPinpointAPNSVoipSandboxChannelTokenConfiguration {
+	if os.Getenv("APNS_VOIP_BUNDLE_ID") == "" {
+		t.Skipf("APNS_VOIP_BUNDLE_ID env is missing, skipping test")
+	}
+
+	if os.Getenv("APNS_VOIP_TEAM_ID") == "" {
+		t.Skipf("APNS_VOIP_TEAM_ID env is missing, skipping test")
+	}
+
+	if os.Getenv("APNS_VOIP_TOKEN_KEY") == "" {
+		t.Skipf("APNS_VOIP_TOKEN_KEY env is missing, skipping test")
+	}
+
+	if os.Getenv("APNS_VOIP_TOKEN_KEY_ID") == "" {
+		t.Skipf("APNS_VOIP_TOKEN_KEY_ID env is missing, skipping test")
+	}
+
+	conf := testAccAwsPinpointAPNSVoipSandboxChannelTokenConfiguration{
+		BundleId:   strconv.Quote(strings.TrimSpace(os.Getenv("APNS_VOIP_BUNDLE_ID"))),
+		TeamId:     strconv.Quote(strings.TrimSpace(os.Getenv("APNS_VOIP_TEAM_ID"))),
+		TokenKey:   fmt.Sprintf("<<EOF\n%s\nEOF\n", strings.TrimSpace(os.Getenv("APNS_VOIP_TOKEN_KEY"))),
+		TokenKeyId: strconv.Quote(strings.TrimSpace(os.Getenv("APNS_VOIP_TOKEN_KEY_ID"))),
+	}
+
+	return &conf
+}
+
+func TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.APNSVoipSandboxChannelResponse
+	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"
+
+	configuration := testAccAwsPinpointAPNSVoipSandboxChannelCertConfigurationFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicCertificate(configuration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointAPNSVoipSandboxChannelExists(resourceName, &channel),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate", "private_key"},
+			},
+			{
+				Config: testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicCertificate(configuration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointAPNSVoipSandboxChannelExists(resourceName, &channel),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSPinpointAPNSVoipSandboxChannel_basicToken(t *testing.T) {
+	oldDefaultRegion := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldDefaultRegion)
+
+	var channel pinpoint.APNSVoipSandboxChannelResponse
+	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"
+
+	configuration := testAccAwsPinpointAPNSVoipSandboxChannelTokenConfigurationFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceName,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicToken(configuration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointAPNSVoipSandboxChannelExists(resourceName, &channel),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"team_id", "bundle_id", "token_key", "token_key_id"},
+			},
+			{
+				Config: testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicToken(configuration),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPinpointAPNSVoipSandboxChannelExists(resourceName, &channel),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPinpointAPNSVoipSandboxChannelExists(n string, channel *pinpoint.APNSVoipSandboxChannelResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Pinpoint APNs Voip Sandbox Channel with that Application ID exists")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+		// Check if the app exists
+		params := &pinpoint.GetApnsVoipSandboxChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		output, err := conn.GetApnsVoipSandboxChannel(params)
+
+		if err != nil {
+			return err
+		}
+
+		*channel = *output.APNSVoipSandboxChannelResponse
+
+		return nil
+	}
+}
+
+func testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicCertificate(conf *testAccAwsPinpointAPNSVoipSandboxChannelCertConfiguration) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_apns_voip_sandbox_channel" "test_channel" {
+  application_id                = "${aws_pinpoint_app.test_app.application_id}"
+  enabled                       = false
+  default_authentication_method = "CERTIFICATE"
+  certificate                   = %s
+  private_key                   = %s
+}`, conf.Certificate, conf.PrivateKey)
+}
+
+func testAccAWSPinpointAPNSVoipSandboxChannelConfig_basicToken(conf *testAccAwsPinpointAPNSVoipSandboxChannelTokenConfiguration) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_pinpoint_app" "test_app" {}
+
+resource "aws_pinpoint_apns_voip_sandbox_channel" "test_channel" {
+  application_id = "${aws_pinpoint_app.test_app.application_id}"
+  enabled        = false
+  
+  default_authentication_method = "TOKEN"
+
+  bundle_id      = %s
+  team_id        = %s
+  token_key      = %s
+  token_key_id   = %s
+}`, conf.BundleId, conf.TeamId, conf.TokenKey, conf.TokenKeyId)
+}
+
+func testAccCheckAWSPinpointAPNSVoipSandboxChannelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).pinpointconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_pinpoint_apns_voip_sandbox_channel" {
+			continue
+		}
+
+		// Check if the channel exists
+		params := &pinpoint.GetApnsVoipSandboxChannelInput{
+			ApplicationId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.GetApnsVoipSandboxChannel(params)
+		if err != nil {
+			if isAWSErr(err, pinpoint.ErrCodeNotFoundException, "") {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("APNs Voip Sandbox Channel exists when it should be destroyed!")
+	}
+
+	return nil
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1712,6 +1712,9 @@
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-apns-channel") %>>
                             <a href="/docs/providers/aws/r/pinpoint_apns_channel.html">aws_pinpoint_apns_channel</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-pinpoint-apns-voip-sandbox-channel") %>>
+                            <a href="/docs/providers/aws/r/pinpoint_apns_voip_sandbox_channel.html">aws_pinpoint_apns_voip_sandbox_channel</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-pinpoint-baidu-channel") %>>
                             <a href="/docs/providers/aws/r/pinpoint_baidu_channel.html">aws_pinpoint_baidu_channel</a>
                         </li>

--- a/website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown
+++ b/website/docs/r/pinpoint_apns_voip_sandbox_channel.markdown
@@ -1,0 +1,59 @@
+---
+layout: "aws"
+page_title: "AWS: aws_pinpoint_apns_voip_sandbox_channel"
+sidebar_current: "docs-aws-resource-pinpoint-apns-voip-sandbox-channel"
+description: |-
+  Provides a Pinpoint APNs VoIP Sandbox Channel resource.
+---
+
+# aws_pinpoint_apns_voip_sandbox_channel
+
+Provides a Pinpoint APNs VoIP Sandbox Channel resource.
+
+~> **Note:** All arguments, including certificates and tokens, will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+resource "aws_pinpoint_apns_voip_sandbox_channel" "apns_voip_sandbox" {
+  application_id = "${aws_pinpoint_app.app.application_id}"
+  
+  certificate = "${file("./certificate.pem")}"
+  private_key = "${file("./private_key.key")}"
+}
+
+resource "aws_pinpoint_app" "app" {}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The application ID.
+* `enabled` - (Optional) Whether the channel is enabled or disabled. Defaults to `true`.
+* `default_authentication_method` - (Optional) The default authentication method used for APNs. 
+  __NOTE__: Amazon Pinpoint uses this default for every APNs push notification that you send using the console.
+  You can override the default when you send a message programmatically using the Amazon Pinpoint API, the AWS CLI, or an AWS SDK.
+  If your default authentication type fails, Amazon Pinpoint doesn't attempt to use the other authentication type.
+
+One of the following sets of credentials is also required.
+
+If you choose to use __Certificate credentials__ you will have to provide:
+* `certificate` - (Required) The pem encoded TLS Certificate from Apple.
+* `private_key` - (Required) The Certificate Private Key file (ie. `.key` file).
+
+If you choose to use __Key credentials__ you will have to provide:
+* `bundle_id` - (Required) The ID assigned to your iOS app. To find this value, choose Certificates, IDs & Profiles, choose App IDs in the Identifiers section, and choose your app.
+* `team_id` - (Required) The ID assigned to your Apple developer account team. This value is provided on the Membership page.
+* `token_key` - (Required) The `.p8` file that you download from your Apple developer account when you create an authentication key. 
+* `token_key_id` - (Required) The ID assigned to your signing key. To find this value, choose Certificates, IDs & Profiles, and choose your key in the Keys section.
+
+## Import
+
+Pinpoint APNs VoIP Sandbox Channel can be imported using the `application-id`, e.g.
+
+```
+$ terraform import aws_pinpoint_apns_voip_sandbox_channel.apns_voip_sandbox application-id
+```


### PR DESCRIPTION
Work continues on #4990

Changes proposed in this pull request:

* New resource `aws_pinpoint_apns_voip_sandbox_channel` with related docs and acceptance tests
Output from acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPinpointAPNSVoipSandboxChannel'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSPinpointAPNSVoipSandboxChannel -timeout 120m
=== RUN   TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate
--- PASS: TestAccAWSPinpointAPNSVoipSandboxChannel_basicCertificate (31.35s)
=== RUN   TestAccAWSPinpointAPNSVoipSandboxChannel_basicToken
--- PASS: TestAccAWSPinpointAPNSVoipSandboxChannel_basicToken (30.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       61.419s
```
NOTES:
* The tests require two set of credentials, one for TLS certificate credentials and the other for key credentials. The two tests are independent from each other, and inside the test file I referenced Apple docs about retrieving the credentials. It is possible to use the same credentials for VoIP produciton and VoIP sandbox tests.