### PR TITLE
[wip] resource/aws_ses_receipt_rule: support import functionality

### DIFF
--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -20,6 +21,9 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 		Update: resourceAwsSesReceiptRuleUpdate,
 		Read:   resourceAwsSesReceiptRuleRead,
 		Delete: resourceAwsSesReceiptRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsSesReceiptRuleImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -354,6 +358,22 @@ func resourceAwsSesReceiptRule() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceAwsSesReceiptRuleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.Split(d.Id(), ":")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <ruleset-name>:<rule-name>", d.Id())
+	}
+
+	ruleSetName := idParts[0]
+	ruleName := idParts[1]
+
+	d.Set("rule_set_name", ruleSetName)
+	d.Set("name", ruleName)
+	d.SetId(ruleName)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAwsSesReceiptRuleCreate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -27,6 +27,11 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 					testAccCheckAwsSESReceiptRuleExists("aws_ses_receipt_rule.basic"),
 				),
 			},
+			{
+				ResourceName:      "aws_ses_receipt_rule.basic",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAwsSesReceiptRuleImportStateIdFunc("aws_ses_receipt_rule.basic"),
+			},
 		},
 	})
 }
@@ -155,6 +160,17 @@ func testAccCheckAwsSESReceiptRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		return nil
+	}
+}
+
+func testAccAwsSesReceiptRuleImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s:%s", rs.Primary.Attributes["rule_set_name"], rs.Primary.Attributes["name"])
 	}
 }
 

--- a/website/docs/r/ses_receipt_rule.html.markdown
+++ b/website/docs/r/ses_receipt_rule.html.markdown
@@ -97,3 +97,11 @@ WorkMail actions support the following:
 * `organization_arn` - (Required) The ARN of the WorkMail organization
 * `topic_arn` - (Optional) The ARN of an SNS topic to notify
 * `position` - (Required) The position of the action in the receipt rule
+
+## Import
+
+SES receipt rules can be imported using the ruleset name and rule name separated by `:`.
+
+```
+$ terraform import aws_ses_receipt_rule.my_rule my_rule_set:my_rule
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Add import functionality for aws_ses_receipt_rule

Output from acceptance testing:

Haven't run it yet, waiting on response to the below comment.
