### PR TITLE
add import docs for ses_receipt_rule_set and ses_domain_identity

### DIFF
--- a/website/docs/r/ses_domain_identity.html.markdown
+++ b/website/docs/r/ses_domain_identity.html.markdown
@@ -46,3 +46,10 @@ resource "aws_route53_record" "example_amazonses_verification_record" {
 }
 ```
 
+## Import
+
+SES domain identities can be imported using the domain name.
+
+```
+$ terraform import aws_ses_domain_identity.example example.com
+```

--- a/website/docs/r/ses_receipt_rule_set.html.markdown
+++ b/website/docs/r/ses_receipt_rule_set.html.markdown
@@ -23,3 +23,11 @@ resource "aws_ses_receipt_rule_set" "main" {
 The following arguments are supported:
 
 * `rule_set_name` - (Required) The name of the rule set
+
+## Import
+
+SES receipt rule sets can be imported using the rule set name.
+
+```
+$ terraform import aws_ses_receipt_rule_set.my_rule_set my_rule_set_name
+```


### PR DESCRIPTION
Noticed these resources support importing, but it was undocumented

Changes proposed in this pull request:

* Add import docs for `ses_receipt_rule_set` and `ses_domain_identity`

Output from acceptance testing: n/a
