### PR TITLE
resouce/aws_waf_rule: add import ability

### DIFF
--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -17,6 +17,9 @@ func resourceAwsWafRule() *schema.Resource {
 		Read:   resourceAwsWafRuleRead,
 		Update: resourceAwsWafRuleUpdate,
 		Delete: resourceAwsWafRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_waf_rule_test.go
+++ b/aws/resource_aws_waf_rule_test.go
@@ -34,6 +34,11 @@ func TestAccAWSWafRule_basic(t *testing.T) {
 						"aws_waf_rule.wafrule", "metric_name", wafRuleName),
 				),
 			},
+			{
+				ResourceName:      "aws_waf_rule.wafrule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -58,10 +58,16 @@ See the [WAF Documentation](https://docs.aws.amazon.com/waf/latest/APIReference/
 * `data_id` - (Required) A unique identifier for a predicate in the rule, such as Byte Match Set ID or IPSet ID.
 * `type` - (Required) The type of predicate in a rule. Valid values: `ByteMatch`, `GeoMatch`, `IPMatch`, `RegexMatch`, `SizeConstraint`, `SqlInjectionMatch`, or `XssMatch`.
 
-## Remarks
-
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF rule.
+
+## Import
+
+WAF rules can be imported using the id, e.g.
+
+```
+$ terraform import aws_waf_rule.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Add import ability to waf rule (following similar approach as https://github.com/terraform-providers/terraform-provider-aws/commit/742357c2701fd4d63e4a6d7e030f7c27e6ea98d5)

Output from acceptance testing:

```
=== RUN   TestAccAWSWafRule_basic
=== PAUSE TestAccAWSWafRule_basic
=== CONT  TestAccAWSWafRule_basic
--- PASS: TestAccAWSWafRule_basic (16.65s)
PASS
```
