### PR TITLE
resource/aws_cloudwatch_event_permission: Add condition argument (support Organizations access)

### DIFF
--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -81,7 +81,7 @@ func TestAccAWSCloudWatchEventPermission_Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		CheckDestroy: testAccCheckCloudWatchEventPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic("", statementID),
@@ -116,6 +116,7 @@ func TestAccAWSCloudWatchEventPermission_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventPermissionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "action", "events:PutEvents"),
+					resource.TestCheckResourceAttr(resourceName, "condition.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "principal", principal1),
 					resource.TestCheckResourceAttr(resourceName, "statement_id", statementID),
 				),
@@ -126,6 +127,11 @@ func TestAccAWSCloudWatchEventPermission_Basic(t *testing.T) {
 					testAccCheckCloudWatchEventPermissionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "principal", principal2),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -139,7 +145,7 @@ func TestAccAWSCloudWatchEventPermission_Action(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		CheckDestroy: testAccCheckCloudWatchEventPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckAwsCloudWatchEventPermissionResourceConfigAction("", principal, statementID),
@@ -164,14 +170,18 @@ func TestAccAWSCloudWatchEventPermission_Action(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action", "events:PutEvents"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
-func TestAccAWSCloudWatchEventPermission_Import(t *testing.T) {
-	principal := "123456789012"
-	statementID := acctest.RandomWithPrefix(t.Name())
-	resourceName := "aws_cloudwatch_event_permission.test1"
+func TestAccAWSCloudWatchEventPermission_Condition(t *testing.T) {
+	statementID := acctest.RandomWithPrefix("TestAcc")
+	resourceName := "aws_cloudwatch_event_permission.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -179,12 +189,25 @@ func TestAccAWSCloudWatchEventPermission_Import(t *testing.T) {
 		CheckDestroy: testAccCheckCloudWatchEventPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal, statementID),
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigConditionOrganization(statementID, "o-1234567890"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventPermissionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.key", "aws:PrincipalOrgID"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.type", "StringEquals"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "o-1234567890"),
 				),
 			},
-
+			{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigConditionOrganization(statementID, "o-0123456789"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "condition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.key", "aws:PrincipalOrgID"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.type", "StringEquals"),
+					resource.TestCheckResourceAttr(resourceName, "condition.0.value", "o-0123456789"),
+				),
+			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -205,7 +228,7 @@ func TestAccAWSCloudWatchEventPermission_Multiple(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		CheckDestroy: testAccCheckCloudWatchEventPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal1, statementID1),
@@ -324,6 +347,21 @@ resource "aws_cloudwatch_event_permission" "test1" {
   statement_id = "%[3]s"
 }
 `, action, principal, statementID)
+}
+
+func testAccCheckAwsCloudWatchEventPermissionResourceConfigConditionOrganization(statementID, value string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_permission" "test" {
+  principal    = "*"
+  statement_id = %q
+
+  condition {
+    key   = "aws:PrincipalOrgID"
+    type  = "StringEquals"
+    value = %q
+  }
+}
+`, statementID, value)
 }
 
 func testAccCheckAwsCloudWatchEventPermissionResourceConfigMultiple(principal1, statementID1, principal2, statementID2 string) string {

--- a/website/docs/r/cloudwatch_event_permission.html.markdown
+++ b/website/docs/r/cloudwatch_event_permission.html.markdown
@@ -12,6 +12,8 @@ Provides a resource to create a CloudWatch Events permission to support cross-ac
 
 ## Example Usage
 
+### Account Access
+
 ```hcl
 resource "aws_cloudwatch_event_permission" "DevAccountAccess" {
   principal    = "123456789012"
@@ -19,13 +21,35 @@ resource "aws_cloudwatch_event_permission" "DevAccountAccess" {
 }
 ```
 
+### Organization Access
+
+```hcl
+resource "aws_cloudwatch_event_permission" "OrganizationAccess" {
+  principal    = "*"
+  statement_id = "OrganizationAccess"
+
+  condition {
+    key   = "aws:PrincipalOrgID"
+    type  = "StringEquals"
+    value = "${aws_organizations_organization.example.id}"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `principal` - (Required) The 12-digit AWS account ID that you are permitting to put events to your default event bus. Specify `*` to permit any account to put events to your default event bus.
+* `principal` - (Required) The 12-digit AWS account ID that you are permitting to put events to your default event bus. Specify `*` to permit any account to put events to your default event bus, optionally limited by `condition`.
 * `statement_id` - (Required) An identifier string for the external account that you are granting permissions to.
 * `action` - (Optional) The action that you are enabling the other account to perform. Defaults to `events:PutEvents`.
+* `condition` - (Optional) Configuration block to limit the event bus permissions you are granting to only accounts that fulfill the condition. Specified below.
+
+### condition
+
+* `key` - (Required) Key for the condition. Valid values: `aws:PrincipalOrgID`.
+* `type` - (Required) Type of condition. Value values: `StringEquals`.
+* `value` - (Required) Value for the key.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Closes #6254

Changes proposed in this pull request:

* Add `condition` argument
* Fix acceptance test `CheckDestroy` calls
* Consolidate `_Import` acceptance test into other acceptance tests

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudWatchEventPermission_Action (11.06s)
--- PASS: TestAccAWSCloudWatchEventPermission_Multiple (15.84s)
--- PASS: TestAccAWSCloudWatchEventPermission_Basic (16.57s)
--- PASS: TestAccAWSCloudWatchEventPermission_Condition (16.61s)
```