### PR TITLE
resource/aws_network_acl_rule: Properly handle ICMP code and type with IPv6 ICMP (protocol 58)

### DIFF
--- a/aws/resource_aws_network_acl_rule.go
+++ b/aws/resource_aws_network_acl_rule.go
@@ -139,7 +139,7 @@ func resourceAwsNetworkAclRuleCreate(d *schema.ResourceData, meta interface{}) e
 
 	// Specify additional required fields for ICMP. For the list
 	// of ICMP codes and types, see: https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml
-	if p == 1 {
+	if p == 1 || p == 58 {
 		params.IcmpTypeCode = &ec2.IcmpTypeCode{}
 		if v, ok := d.GetOk("icmp_type"); ok {
 			icmpType, err := strconv.Atoi(v.(string))


### PR DESCRIPTION
Fixes #4737 

Changes proposed in this pull request:

* Allow `protocol` 58 to propagate ICMP code and type configuration

Previously:

```
--- FAIL: TestAccAWSNetworkAclRule_ipv6ICMP (12.47s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_network_acl_rule.test: 1 error occurred:
        	* aws_network_acl_rule.test: Error Creating Network Acl Rule: MissingParameter: The request must contain the parameter icmpTypeCode.type
        	status code: 400, request id: a0e8e287-af99-4da9-9b5f-e641e41d3fe7
```

Output from acceptance testing:

```
--- PASS: TestAccAWSNetworkAclRule_ipv6ICMP (24.21s)
```
