### PR TITLE
resource/aws_network_acl: Properly handle ICMP code and type with IPv6 ICMP (protocol 58)

### DIFF
--- a/aws/network_acl_entry.go
+++ b/aws/network_acl_entry.go
@@ -43,7 +43,7 @@ func expandNetworkAclEntries(configured []interface{}, entryType string) ([]*ec2
 		}
 
 		// Specify additional required fields for ICMP
-		if p == 1 {
+		if p == 1 || p == 58 {
 			e.IcmpTypeCode = &ec2.IcmpTypeCode{}
 			if v, ok := data["icmp_code"]; ok {
 				e.IcmpTypeCode.Code = aws.Int64(int64(v.(int)))


### PR DESCRIPTION
Fixes #6262 

Changes proposed in this pull request:

* Allow `protocol` 58 to propagate ICMP code and type configuration

Previously:

```
--- FAIL: TestAccAWSNetworkAcl_ipv6ICMPRules (12.17s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_network_acl.test: 1 error occurred:
        	* aws_network_acl.test: Error creating ingress entry: MissingParameter: The request must contain the parameter icmpTypeCode.type
        	status code: 400, request id: 9551aec6-d3cf-435f-a35d-0d60b8fd2a69
```

Output from acceptance testing:

```
--- PASS: TestAccAWSNetworkAcl_ipv6ICMPRules (17.51s)
```