### PR TITLE
aws_s3_bucket: Add MaxItems=1 annotations

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -112,6 +112,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 			"website": {
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"index_document": {
@@ -1315,19 +1316,17 @@ func resourceAwsS3BucketCorsUpdate(s3conn *s3.S3, d *schema.ResourceData) error 
 func resourceAwsS3BucketWebsiteUpdate(s3conn *s3.S3, d *schema.ResourceData) error {
 	ws := d.Get("website").([]interface{})
 
-	if len(ws) == 1 {
-		var w map[string]interface{}
-		if ws[0] != nil {
-			w = ws[0].(map[string]interface{})
-		} else {
-			w = make(map[string]interface{})
-		}
-		return resourceAwsS3BucketWebsitePut(s3conn, d, w)
-	} else if len(ws) == 0 {
+	if len(ws) == 0 {
 		return resourceAwsS3BucketWebsiteDelete(s3conn, d)
-	} else {
-		return fmt.Errorf("Cannot specify more than one website.")
 	}
+
+	var w map[string]interface{}
+	if ws[0] != nil {
+		w = ws[0].(map[string]interface{})
+	} else {
+		w = make(map[string]interface{})
+	}
+	return resourceAwsS3BucketWebsitePut(s3conn, d, w)
 }
 
 func resourceAwsS3BucketWebsitePut(s3conn *s3.S3, d *schema.ResourceData, website map[string]interface{}) error {


### PR DESCRIPTION
## Proposed changes and rationale

In the `aws_s3_bucket` resource, the `website` block for is described as a list with nested schema, however only one element is permitted. This was previously enforced by code in the `resourceAwsS3BucketWebsiteUpdate` function.

This commit makes use of the `MaxItems: 1` facility of `helper/schema` in order to remove custom code and produce better error messages in the face of non-compliance with the reuqirements of the schema.

## Output from acceptance testing:

The failure here is present with or without this pull request and looking at the test workflow is not affected.

```
❯ make testacc TESTARGS='-run=TestAccAWSS3Bucket_Website'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_Website -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3Bucket_Website_Simple
=== PAUSE TestAccAWSS3Bucket_Website_Simple
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
=== PAUSE TestAccAWSS3Bucket_WebsiteRedirect
=== RUN   TestAccAWSS3Bucket_WebsiteRoutingRules
=== PAUSE TestAccAWSS3Bucket_WebsiteRoutingRules
=== CONT  TestAccAWSS3Bucket_Website_Simple
=== CONT  TestAccAWSS3Bucket_WebsiteRoutingRules
=== CONT  TestAccAWSS3Bucket_WebsiteRedirect
--- FAIL: TestAccAWSS3Bucket_WebsiteRoutingRules (29.26s)
    testing.go:538: Step 1 error: Check failed: Check 4/4 error: aws_s3_bucket.bucket: Attribute 'website_endpoint' expected "", got "tf-test-bucket-6022659245226893698.s3-website-us-west-2.amazonaws.com"
--- PASS: TestAccAWSS3Bucket_Website_Simple (45.92s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (54.23s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	54.268s
make: *** [testacc] Error 1
```