### PR TITLE
Issue #6120 Resource 'data.aws_vpc.production' does not have attribute 'main_route_table_id'

### DIFF
--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -212,9 +212,11 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("enable_dns_hostnames", attResp.EnableDnsHostnames.Value)
 
-	if err := resourceAwsVpcSetMainRouteTable(conn, d); err != nil {
+	routeTableId, err := resourceAwsVpcSetMainRouteTable(conn, aws.StringValue(vpc.VpcId))
+	if err != nil {
 		log.Printf("[WARN] Unable to set Main Route Table: %s", err)
 	}
+	d.Set("main_route_table_id", routeTableId)
 
 	return nil
 }

--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -15,6 +15,11 @@ func dataSourceAwsVpc() *schema.Resource {
 		Read: dataSourceAwsVpcRead,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -42,15 +47,25 @@ func dataSourceAwsVpc() *schema.Resource {
 				},
 			},
 
+			"default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
 			"dhcp_options_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"default": {
+			"enable_dns_hostnames": {
 				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
+			},
+
+			"enable_dns_support": {
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 
@@ -77,24 +92,14 @@ func dataSourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"main_route_table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
-			},
-
-			"enable_dns_hostnames": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-
-			"enable_dns_support": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-
-			"arn": {
-				Type:     schema.TypeString,
 				Computed: true,
 			},
 
@@ -160,7 +165,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 	vpc := resp.Vpcs[0]
 
-	d.SetId(*vpc.VpcId)
+	d.SetId(aws.StringValue(vpc.VpcId))
 	d.Set("cidr_block", vpc.CidrBlock)
 	d.Set("dhcp_options_id", vpc.DhcpOptionsId)
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
@@ -195,17 +200,21 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("ipv6_cidr_block", vpc.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock)
 	}
 
-	attResp, err := awsVpcDescribeVpcAttribute("enableDnsSupport", *vpc.VpcId, conn)
+	attResp, err := awsVpcDescribeVpcAttribute("enableDnsSupport", aws.StringValue(vpc.VpcId), conn)
 	if err != nil {
 		return err
 	}
 	d.Set("enable_dns_support", attResp.EnableDnsSupport.Value)
 
-	attResp, err = awsVpcDescribeVpcAttribute("enableDnsHostnames", *vpc.VpcId, conn)
+	attResp, err = awsVpcDescribeVpcAttribute("enableDnsHostnames", aws.StringValue(vpc.VpcId), conn)
 	if err != nil {
 		return err
 	}
 	d.Set("enable_dns_hostnames", attResp.EnableDnsHostnames.Value)
+
+	if err := resourceAwsVpcSetMainRouteTable(conn, d); err != nil {
+		log.Printf("[WARN] Unable to set Main Route Table: %s", err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -32,6 +32,8 @@ func TestAccDataSourceAwsVpc_basic(t *testing.T) {
 						"data.aws_vpc.by_id", "enable_dns_hostnames", "false"),
 					resource.TestCheckResourceAttrSet(
 						"data.aws_vpc.by_id", "arn"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_vpc.by_id", "main_route_table_id"),
 				),
 			},
 		},

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -32,8 +32,8 @@ func TestAccDataSourceAwsVpc_basic(t *testing.T) {
 						"data.aws_vpc.by_id", "enable_dns_hostnames", "false"),
 					resource.TestCheckResourceAttrSet(
 						"data.aws_vpc.by_id", "arn"),
-					resource.TestCheckResourceAttrSet(
-						"data.aws_vpc.by_id", "main_route_table_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.aws_vpc.by_id", "main_route_table_id", "aws_vpc.test", "main_route_table_id"),
 				),
 			},
 		},

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -686,7 +686,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_pinpoint_apns_sandbox_channel":                resourceAwsPinpointAPNSSandboxChannel(),
 			"aws_pinpoint_apns_voip_channel":                   resourceAwsPinpointAPNSVoipChannel(),
 			"aws_pinpoint_apns_voip_sandbox_channel":           resourceAwsPinpointAPNSVoipSandboxChannel(),
-      "aws_pinpoint_baidu_channel":                       resourceAwsPinpointBaiduChannel(),
+			"aws_pinpoint_baidu_channel":                       resourceAwsPinpointBaiduChannel(),
 			"aws_pinpoint_email_channel":                       resourceAwsPinpointEmailChannel(),
 			"aws_pinpoint_event_stream":                        resourceAwsPinpointEventStream(),
 			"aws_pinpoint_gcm_channel":                         resourceAwsPinpointGCMChannel(),

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -273,7 +273,6 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	if err := resourceAwsVpcSetMainRouteTable(conn, d); err != nil {
 		log.Printf("[WARN] Unable to set Main Route Table: %s", err)
 	}
-
 	if err := resourceAwsVpcSetDefaultNetworkAcl(conn, d); err != nil {
 		log.Printf("[WARN] Unable to set Default Network ACL: %s", err)
 	}

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -128,6 +128,8 @@ func TestAccAWSVpc_basic(t *testing.T) {
 						"aws_vpc.foo", "instance_tenancy", "default"),
 					resource.TestCheckResourceAttrSet(
 						"aws_vpc.foo", "default_route_table_id"),
+					resource.TestCheckResourceAttrSet(
+						"aws_vpc.foo", "main_route_table_id"),
 					resource.TestCheckResourceAttr(
 						"aws_vpc.foo", "enable_dns_support", "true"),
 					resource.TestCheckResourceAttrSet(

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -76,12 +76,13 @@ the selected VPC.
 The following attribute is additionally exported:
 
 * `arn` - Amazon Resource Name (ARN) of VPC
+* `enable_dns_support` - Whether or not the VPC has DNS support
+* `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support
 * `instance_tenancy` - The allowed tenancy of instances launched into the
   selected VPC. May be any of `"default"`, `"dedicated"`, or `"host"`.
 * `ipv6_association_id` - The association ID for the IPv6 CIDR block.
 * `ipv6_cidr_block` - The IPv6 CIDR block.
-* `enable_dns_support` - Whether or not the VPC has DNS support
-* `enable_dns_hostnames` - Whether or not the VPC has DNS hostname support
+* `main_route_table_id` - The ID of the main route table associated with this VPC.
 
 `cidr_block_associations` is also exported with the following attributes:
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6120 

Changes proposed in this pull request:

* Change 1
created separate func to set attr `main_route_table_id` in resource `aws_vpc` to avoid code duplication. 
* Change 2
Added attr `main_route_table_id` in datasource `aws_vpc`

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsVpc_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsVpc_basic -timeout 120m
=== RUN   TestAccDataSourceAwsVpc_basic
=== PAUSE TestAccDataSourceAwsVpc_basic
=== CONT  TestAccDataSourceAwsVpc_basic
--- PASS: TestAccDataSourceAwsVpc_basic (91.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	91.629s
...
```
