### PR TITLE
resource/aws_ses_configuration_set: Acceptance test and document resource import

### DIFF
--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -24,6 +24,11 @@ func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 					testAccCheckAwsSESConfigurationSetExists("aws_ses_configuration_set.test"),
 				),
 			},
+			{
+				ResourceName:      "aws_ses_configuration_set.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/ses_configuration_set.markdown
+++ b/website/docs/r/ses_configuration_set.markdown
@@ -23,3 +23,11 @@ resource "aws_ses_configuration_set" "test" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the configuration set
+
+## Import
+
+SES Configuration Sets can be imported using their `name`, e.g.
+
+```
+$ terraform import aws_ses_configuration_set.test some-configuration-set-test
+```


### PR DESCRIPTION
Reference #6265 

Changes proposed in this pull request:

* Acceptance test `aws_ses_configuration_set` import
* Document `aws_ses_configuration_set` import

Output from acceptance testing:

```
--- PASS: TestAccAWSSESConfigurationSet_basic (12.05s)
```
