### PR TITLE
Fix bad advice on using ".name" property of Role while ignoring path

### DIFF
--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -18,7 +18,7 @@ Manages a Glue Crawler. More information can be found in the [AWS Glue Developer
 resource "aws_glue_crawler" "example" {
   database_name = "${aws_glue_catalog_database.example.name}"
   name          = "example"
-  role          = "${aws_iam_role.example.name}"
+  role          = "${aws_iam_role.example.arn}"
 
   dynamodb_target {
     path = "table-name"
@@ -32,7 +32,7 @@ resource "aws_glue_crawler" "example" {
 resource "aws_glue_crawler" "example" {
   database_name = "${aws_glue_catalog_database.example.name}"
   name          = "example"
-  role          = "${aws_iam_role.example.name}"
+  role          = "${aws_iam_role.example.arn}"
 
   jdbc_target {
     connection_name = "${aws_glue_connection.example.name}"
@@ -47,7 +47,7 @@ resource "aws_glue_crawler" "example" {
 resource "aws_glue_crawler" "example" {
   database_name = "${aws_glue_catalog_database.example.name}"
   name          = "example"
-  role          = "${aws_iam_role.example.name}"
+  role          = "${aws_iam_role.example.arn}"
 
   s3_target {
     path = "s3://${aws_s3_bucket.example.bucket}"
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `database_name` (Required) Glue database where results are written.
 * `name` (Required) Name of the crawler.
-* `role` (Required) The IAM role (or ARN of an IAM role) used by the crawler to access other resources.
+* `role` (Required) The IAM role friendly name (including path without leading slash), or ARN of an IAM role, used by the crawler to access other resources.
 * `classifiers` (Optional) List of custom classifiers. By default, all AWS classifiers are included in a crawl, but these custom classifiers always override the default classifiers for a given classification.
 * `configuration` (Optional) JSON string of configuration information.
 * `description` (Optional) Description of the crawler.


### PR DESCRIPTION
Changes proposed in this pull request:

- When creating an IAM Role with a non-default path (anything other than
"/"), it is not sufficient to use only the "name" property of the Role
when referring to it from the Glue Crawler resource (and probably
others as well). Therefore, in the examples I have replaced usage of
"name" with usage of "arn", and I updated the documentation on the
"role" argument of the aws_glue_crawler resource to clarify the meaning
of "The IAM role" which was not well-defined.
- Relevant Terraform version: This update can be deployed to the site
immediately, it is not specific to an upcoming version of Terraform.

Output from acceptance testing:

Not performed.
