### PR TITLE
Add "name_with_path" to iam_role data source and resource

### DIFF
--- a/aws/data_source_aws_iam_role.go
+++ b/aws/data_source_aws_iam_role.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -58,6 +59,10 @@ func dataSourceAwsIAMRole() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"name_with_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"create_date": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -105,6 +110,8 @@ func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("max_session_duration", output.Role.MaxSessionDuration)
 	d.Set("name", output.Role.RoleName)
 	d.Set("path", output.Role.Path)
+	d.Set("name_with_path", strings.Replace(aws.StringValue(output.Role.Path), "/", "", 1)+
+		aws.StringValue(output.Role.RoleName))
 	d.Set("permissions_boundary", "")
 	if output.Role.PermissionsBoundary != nil {
 		d.Set("permissions_boundary", output.Role.PermissionsBoundary.PermissionsBoundaryArn)

--- a/aws/data_source_aws_iam_role_test.go
+++ b/aws/data_source_aws_iam_role_test.go
@@ -24,6 +24,7 @@ func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_iam_role.test", "path", "/testpath/"),
 					resource.TestCheckResourceAttr("data.aws_iam_role.test", "permissions_boundary", ""),
 					resource.TestCheckResourceAttr("data.aws_iam_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("data.aws_iam_role.test", "name_with_path", "testpath/"+roleName),
 					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "create_date"),
 					resource.TestMatchResourceAttr("data.aws_iam_role.test", "arn",
 						regexp.MustCompile(`^arn:[\w-]+:([a-zA-Z0-9\-])+:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12})?:(.*)$`)),

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -55,6 +56,11 @@ func resourceAwsIamRole() *schema.Resource {
 					}
 					return
 				},
+			},
+
+			"name_with_path": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"name_prefix": {
@@ -210,6 +216,8 @@ func resourceAwsIamRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", role.Description)
 	d.Set("max_session_duration", role.MaxSessionDuration)
 	d.Set("name", role.RoleName)
+	d.Set("name_with_path", strings.Replace(aws.StringValue(role.Path), "/", "", 1)+
+		aws.StringValue(role.RoleName))
 	d.Set("path", role.Path)
 	if role.PermissionsBoundary != nil {
 		d.Set("permissions_boundary", role.PermissionsBoundary.PermissionsBoundaryArn)

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -51,6 +51,29 @@ func TestAccAWSIAMRole_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
 					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/"),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "name_with_path", "test-role-"+rName),
+					resource.TestCheckResourceAttrSet("aws_iam_role.role", "create_date"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIAMRole_basicWithPath(t *testing.T) {
+	var conf iam.GetRoleOutput
+	rName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMRoleConfigWithPath(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/foo/bar/"),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "name_with_path", "foo/bar/test-role-"+rName),
 					resource.TestCheckResourceAttrSet("aws_iam_role.role", "create_date"),
 				),
 			},
@@ -477,6 +500,16 @@ func testAccAWSIAMRoleConfig(rName string) string {
 resource "aws_iam_role" "role" {
   name   = "test-role-%s"
   path = "/"
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+`, rName)
+}
+
+func testAccAWSIAMRoleConfigWithPath(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name   = "test-role-%s"
+  path = "/foo/bar/"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
 }
 `, rName)

--- a/website/docs/d/iam_role.html.markdown
+++ b/website/docs/d/iam_role.html.markdown
@@ -28,6 +28,7 @@ data "aws_iam_role" "example" {
 
 * `id` - The friendly IAM role name to match.
 * `arn` - The Amazon Resource Name (ARN) specifying the role.
+* `name_with_path` - The [friendly name](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names) of the role including the path without the leading slash.
 * `assume_role_policy` - The policy document associated with the role.
 * `path` - The path to the role.
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the role.

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -59,7 +59,8 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - The Amazon Resource Name (ARN) specifying the role.
 * `create_date` - The creation date of the IAM role.
 * `unique_id` - The stable and unique string identifying the role.
-* `name` - The name of the role.
+* `name` - The name of the role, without the path.
+* `name_with_path` - The [friendly name](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names) of the role including the path without the leading slash.
 * `description` - The description of the role.
 
 ## Example of Using Data Source for Assume Role Policy


### PR DESCRIPTION
Changes proposed in this pull request:

Add "name_with_path" to iam_role data source and resource

- Provides the "friendly name" plus the path without leading slash,
which in some cases must be used instead of "id"/friendly name when the
role has a non-default path (anything but "/").

Output from acceptance testing:

Not run (sorry).
