### PR TITLE
New Resource: aws_glue_security_configuration

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -448,6 +448,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_glue_connection":                              resourceAwsGlueConnection(),
 			"aws_glue_crawler":                                 resourceAwsGlueCrawler(),
 			"aws_glue_job":                                     resourceAwsGlueJob(),
+			"aws_glue_security_configuration":                  resourceAwsGlueSecurityConfiguration(),
 			"aws_glue_trigger":                                 resourceAwsGlueTrigger(),
 			"aws_guardduty_detector":                           resourceAwsGuardDutyDetector(),
 			"aws_guardduty_ipset":                              resourceAwsGuardDutyIpset(),

--- a/aws/resource_aws_glue_security_configuration.go
+++ b/aws/resource_aws_glue_security_configuration.go
@@ -255,13 +255,13 @@ func expandGlueJobBookmarksEncryption(l []interface{}) *glue.JobBookmarksEncrypt
 }
 
 func expandGlueS3Encryptions(l []interface{}) []*glue.S3Encryption {
-	s3Encryptions := make([]*glue.S3Encryption, len(l))
+	s3Encryptions := make([]*glue.S3Encryption, 0)
 
-	for i, s3Encryption := range l {
+	for _, s3Encryption := range l {
 		if s3Encryption == nil {
 			continue
 		}
-		s3Encryptions[i] = expandGlueS3Encryption(s3Encryption.(map[string]interface{}))
+		s3Encryptions = append(s3Encryptions, expandGlueS3Encryption(s3Encryption.(map[string]interface{})))
 	}
 
 	return s3Encryptions
@@ -320,13 +320,13 @@ func flattenGlueJobBookmarksEncryption(jobBookmarksEncryption *glue.JobBookmarks
 }
 
 func flattenGlueS3Encryptions(s3Encryptions []*glue.S3Encryption) []interface{} {
-	l := make([]interface{}, len(s3Encryptions))
+	l := make([]interface{}, 0)
 
-	for i, s3Encryption := range s3Encryptions {
+	for _, s3Encryption := range s3Encryptions {
 		if s3Encryption == nil {
 			continue
 		}
-		l[i] = flattenGlueS3Encryption(s3Encryption)
+		l = append(l, flattenGlueS3Encryption(s3Encryption))
 	}
 
 	return l

--- a/aws/resource_aws_glue_security_configuration.go
+++ b/aws/resource_aws_glue_security_configuration.go
@@ -1,0 +1,342 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsGlueSecurityConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsGlueSecurityConfigurationCreate,
+		Read:   resourceAwsGlueSecurityConfigurationRead,
+		Delete: resourceAwsGlueSecurityConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"encryption_configuration": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cloudwatch_encryption": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cloudwatch_encryption_mode": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Default:  glue.CloudWatchEncryptionModeDisabled,
+										ValidateFunc: validation.StringInSlice([]string{
+											glue.CloudWatchEncryptionModeDisabled,
+											glue.CloudWatchEncryptionModeSseKms,
+										}, false),
+									},
+									"kms_key_arn": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"job_bookmarks_encryption": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"job_bookmarks_encryption_mode": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Default:  glue.JobBookmarksEncryptionModeDisabled,
+										ValidateFunc: validation.StringInSlice([]string{
+											glue.JobBookmarksEncryptionModeCseKms,
+											glue.JobBookmarksEncryptionModeDisabled,
+										}, false),
+									},
+									"kms_key_arn": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"s3_encryption": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kms_key_arn": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"s3_encryption_mode": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Default:  glue.S3EncryptionModeDisabled,
+										ValidateFunc: validation.StringInSlice([]string{
+											glue.S3EncryptionModeDisabled,
+											glue.S3EncryptionModeSseKms,
+											glue.S3EncryptionModeSseS3,
+										}, false),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func resourceAwsGlueSecurityConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+	name := d.Get("name").(string)
+
+	input := &glue.CreateSecurityConfigurationInput{
+		EncryptionConfiguration: expandGlueEncryptionConfiguration(d.Get("encryption_configuration").([]interface{})),
+		Name:                    aws.String(name),
+	}
+
+	log.Printf("[DEBUG] Creating Glue Security Configuration: %s", input)
+	_, err := conn.CreateSecurityConfiguration(input)
+	if err != nil {
+		return fmt.Errorf("error creating Glue Security Configuration (%s): %s", name, err)
+	}
+
+	d.SetId(name)
+
+	return resourceAwsGlueSecurityConfigurationRead(d, meta)
+}
+
+func resourceAwsGlueSecurityConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	input := &glue.GetSecurityConfigurationInput{
+		Name: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading Glue Security Configuration: %s", input)
+	output, err := conn.GetSecurityConfiguration(input)
+
+	if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+		log.Printf("[WARN] Glue Security Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Glue Security Configuration (%s): %s", d.Id(), err)
+	}
+
+	securityConfiguration := output.SecurityConfiguration
+	if securityConfiguration == nil {
+		log.Printf("[WARN] Glue Security Configuration (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("encryption_configuration", flattenGlueEncryptionConfiguration(securityConfiguration.EncryptionConfiguration)); err != nil {
+		return fmt.Errorf("error setting encryption_configuration: %s", err)
+	}
+
+	d.Set("name", securityConfiguration.Name)
+
+	return nil
+}
+
+func resourceAwsGlueSecurityConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).glueconn
+
+	log.Printf("[DEBUG] Deleting Glue Security Configuration: %s", d.Id())
+	err := deleteGlueSecurityConfiguration(conn, d.Id())
+	if err != nil {
+		return fmt.Errorf("error deleting Glue Security Configuration (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func deleteGlueSecurityConfiguration(conn *glue.Glue, name string) error {
+	input := &glue.DeleteSecurityConfigurationInput{
+		Name: aws.String(name),
+	}
+
+	_, err := conn.DeleteSecurityConfiguration(input)
+
+	if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandGlueCloudWatchEncryption(l []interface{}) *glue.CloudWatchEncryption {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	cloudwatchEncryption := &glue.CloudWatchEncryption{
+		CloudWatchEncryptionMode: aws.String(m["cloudwatch_encryption_mode"].(string)),
+	}
+
+	if v, ok := m["kms_key_arn"]; ok {
+		cloudwatchEncryption.KmsKeyArn = aws.String(v.(string))
+	}
+
+	return cloudwatchEncryption
+}
+
+func expandGlueEncryptionConfiguration(l []interface{}) *glue.EncryptionConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	encryptionConfiguration := &glue.EncryptionConfiguration{
+		CloudWatchEncryption:   expandGlueCloudWatchEncryption(m["cloudwatch_encryption"].([]interface{})),
+		JobBookmarksEncryption: expandGlueJobBookmarksEncryption(m["job_bookmarks_encryption"].([]interface{})),
+		S3Encryption:           expandGlueS3Encryptions(m["s3_encryption"].([]interface{})),
+	}
+
+	return encryptionConfiguration
+}
+
+func expandGlueJobBookmarksEncryption(l []interface{}) *glue.JobBookmarksEncryption {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	jobBookmarksEncryption := &glue.JobBookmarksEncryption{
+		JobBookmarksEncryptionMode: aws.String(m["job_bookmarks_encryption_mode"].(string)),
+	}
+
+	if v, ok := m["kms_key_arn"]; ok {
+		jobBookmarksEncryption.KmsKeyArn = aws.String(v.(string))
+	}
+
+	return jobBookmarksEncryption
+}
+
+func expandGlueS3Encryptions(l []interface{}) []*glue.S3Encryption {
+	s3Encryptions := make([]*glue.S3Encryption, len(l))
+
+	for i, s3Encryption := range l {
+		if s3Encryption == nil {
+			continue
+		}
+		s3Encryptions[i] = expandGlueS3Encryption(s3Encryption.(map[string]interface{}))
+	}
+
+	return s3Encryptions
+}
+
+func expandGlueS3Encryption(m map[string]interface{}) *glue.S3Encryption {
+	s3Encryption := &glue.S3Encryption{
+		S3EncryptionMode: aws.String(m["s3_encryption_mode"].(string)),
+	}
+
+	if v, ok := m["kms_key_arn"]; ok {
+		s3Encryption.KmsKeyArn = aws.String(v.(string))
+	}
+
+	return s3Encryption
+}
+
+func flattenGlueCloudWatchEncryption(cloudwatchEncryption *glue.CloudWatchEncryption) []interface{} {
+	if cloudwatchEncryption == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"cloudwatch_encryption_mode": aws.StringValue(cloudwatchEncryption.CloudWatchEncryptionMode),
+		"kms_key_arn":                aws.StringValue(cloudwatchEncryption.KmsKeyArn),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenGlueEncryptionConfiguration(encryptionConfiguration *glue.EncryptionConfiguration) []interface{} {
+	if encryptionConfiguration == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"cloudwatch_encryption":    flattenGlueCloudWatchEncryption(encryptionConfiguration.CloudWatchEncryption),
+		"job_bookmarks_encryption": flattenGlueJobBookmarksEncryption(encryptionConfiguration.JobBookmarksEncryption),
+		"s3_encryption":            flattenGlueS3Encryptions(encryptionConfiguration.S3Encryption),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenGlueJobBookmarksEncryption(jobBookmarksEncryption *glue.JobBookmarksEncryption) []interface{} {
+	if jobBookmarksEncryption == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"job_bookmarks_encryption_mode": aws.StringValue(jobBookmarksEncryption.JobBookmarksEncryptionMode),
+		"kms_key_arn":                   aws.StringValue(jobBookmarksEncryption.KmsKeyArn),
+	}
+
+	return []interface{}{m}
+}
+
+func flattenGlueS3Encryptions(s3Encryptions []*glue.S3Encryption) []interface{} {
+	l := make([]interface{}, len(s3Encryptions))
+
+	for i, s3Encryption := range s3Encryptions {
+		if s3Encryption == nil {
+			continue
+		}
+		l[i] = flattenGlueS3Encryption(s3Encryption)
+	}
+
+	return l
+}
+
+func flattenGlueS3Encryption(s3Encryption *glue.S3Encryption) map[string]interface{} {
+	m := map[string]interface{}{
+		"kms_key_arn":        aws.StringValue(s3Encryption.KmsKeyArn),
+		"s3_encryption_mode": aws.StringValue(s3Encryption.S3EncryptionMode),
+	}
+
+	return m
+}

--- a/aws/resource_aws_glue_security_configuration_test.go
+++ b/aws/resource_aws_glue_security_configuration_test.go
@@ -1,0 +1,414 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/glue"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_glue_security_configuration", &resource.Sweeper{
+		Name: "aws_glue_security_configuration",
+		F:    testSweepGlueSecurityConfigurations,
+	})
+}
+
+func testSweepGlueSecurityConfigurations(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).glueconn
+
+	input := &glue.GetSecurityConfigurationsInput{}
+
+	for {
+		output, err := conn.GetSecurityConfigurations(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Glue Security Configuration sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving Glue Security Configurations: %s", err)
+		}
+
+		for _, securityConfiguration := range output.SecurityConfigurations {
+			name := aws.StringValue(securityConfiguration.Name)
+
+			if !strings.HasPrefix(name, "tf-acc-test") {
+				log.Printf("[INFO] Skipping Glue Security Configuration: %s", name)
+				continue
+			}
+
+			log.Printf("[INFO] Deleting Glue Security Configuration: %s", name)
+			err := deleteGlueSecurityConfiguration(conn, name)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete Glue Security Configuration %s: %s", name, err)
+			}
+		}
+
+		if output.NextToken == nil {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
+
+func TestAccAWSGlueSecurityConfiguration_Basic(t *testing.T) {
+	var securityConfiguration glue.SecurityConfiguration
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_security_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueSecurityConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueSecurityConfigurationConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueSecurityConfigurationExists(resourceName, &securityConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.cloudwatch_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.cloudwatch_encryption.0.cloudwatch_encryption_mode", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.cloudwatch_encryption.0.kms_key_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.job_bookmarks_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.job_bookmarks_encryption.0.job_bookmarks_encryption_mode", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.job_bookmarks_encryption.0.kms_key_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.kms_key_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.s3_encryption_mode", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueSecurityConfiguration_CloudWatchEncryption_CloudWatchEncryptionMode_SSEKMS(t *testing.T) {
+	var securityConfiguration glue.SecurityConfiguration
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_glue_security_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueSecurityConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueSecurityConfigurationConfig_CloudWatchEncryption_CloudWatchEncryptionMode_SSEKMS(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueSecurityConfigurationExists(resourceName, &securityConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.cloudwatch_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.cloudwatch_encryption.0.cloudwatch_encryption_mode", "SSE-KMS"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.0.cloudwatch_encryption.0.kms_key_arn", kmsKeyResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueSecurityConfiguration_JobBookmarksEncryption_JobBookmarksEncryptionMode_CSEKMS(t *testing.T) {
+	var securityConfiguration glue.SecurityConfiguration
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_glue_security_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueSecurityConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueSecurityConfigurationConfig_JobBookmarksEncryption_JobBookmarksEncryptionMode_CSEKMS(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueSecurityConfigurationExists(resourceName, &securityConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.job_bookmarks_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.job_bookmarks_encryption.0.job_bookmarks_encryption_mode", "CSE-KMS"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.0.job_bookmarks_encryption.0.kms_key_arn", kmsKeyResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueSecurityConfiguration_S3Encryption_S3EncryptionMode_SSEKMS(t *testing.T) {
+	var securityConfiguration glue.SecurityConfiguration
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	kmsKeyResourceName := "aws_kms_key.test"
+	resourceName := "aws_glue_security_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueSecurityConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSEKMS(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueSecurityConfigurationExists(resourceName, &securityConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.s3_encryption_mode", "SSE-KMS"),
+					resource.TestCheckResourceAttrPair(resourceName, "encryption_configuration.0.s3_encryption.0.kms_key_arn", kmsKeyResourceName, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSGlueSecurityConfiguration_S3Encryption_S3EncryptionMode_SSES3(t *testing.T) {
+	var securityConfiguration glue.SecurityConfiguration
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_security_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueSecurityConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSGlueSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSES3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueSecurityConfigurationExists(resourceName, &securityConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.s3_encryption_mode", "SSE-S3"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_configuration.0.s3_encryption.0.kms_key_arn", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSGlueSecurityConfigurationExists(resourceName string, securityConfiguration *glue.SecurityConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Glue Security Configuration ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetSecurityConfiguration(&glue.GetSecurityConfigurationInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if output.SecurityConfiguration == nil {
+			return fmt.Errorf("Glue Security Configuration (%s) not found", rs.Primary.ID)
+		}
+
+		if aws.StringValue(output.SecurityConfiguration.Name) == rs.Primary.ID {
+			*securityConfiguration = *output.SecurityConfiguration
+			return nil
+		}
+
+		return fmt.Errorf("Glue Security Configuration (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSGlueSecurityConfigurationDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_glue_security_configuration" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).glueconn
+
+		output, err := conn.GetSecurityConfiguration(&glue.GetSecurityConfigurationInput{
+			Name: aws.String(rs.Primary.ID),
+		})
+
+		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		securityConfiguration := output.SecurityConfiguration
+		if securityConfiguration != nil && aws.StringValue(securityConfiguration.Name) == rs.Primary.ID {
+			return fmt.Errorf("Glue Security Configuration %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSGlueSecurityConfigurationConfig_Basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_security_configuration" "test" {
+  name = %q
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "DISABLED"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "DISABLED"
+    }
+
+    s3_encryption {
+      s3_encryption_mode = "DISABLED"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSGlueSecurityConfigurationConfig_CloudWatchEncryption_CloudWatchEncryptionMode_SSEKMS(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+resource "aws_glue_security_configuration" "test" {
+  name = %q
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "SSE-KMS"
+      kms_key_arn                = "${aws_kms_key.test.arn}"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "DISABLED"
+    }
+
+    s3_encryption {
+      s3_encryption_mode = "DISABLED"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSGlueSecurityConfigurationConfig_JobBookmarksEncryption_JobBookmarksEncryptionMode_CSEKMS(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+resource "aws_glue_security_configuration" "test" {
+  name = %q
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "DISABLED"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "CSE-KMS"
+      kms_key_arn                   = "${aws_kms_key.test.arn}"
+    }
+
+    s3_encryption {
+      s3_encryption_mode = "DISABLED"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSGlueSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSEKMS(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+resource "aws_glue_security_configuration" "test" {
+  name = %q
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "DISABLED"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "DISABLED"
+    }
+
+    s3_encryption {
+      kms_key_arn        = "${aws_kms_key.test.arn}"
+      s3_encryption_mode = "SSE-KMS"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccAWSGlueSecurityConfigurationConfig_S3Encryption_S3EncryptionMode_SSES3(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_security_configuration" "test" {
+  name = %q
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "DISABLED"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "DISABLED"
+    }
+
+    s3_encryption {
+      s3_encryption_mode = "SSE-S3"
+    }
+  }
+}
+`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1312,6 +1312,9 @@
                         <li<%= sidebar_current("docs-aws-resource-glue-job") %>>
                             <a href="/docs/providers/aws/r/glue_job.html">aws_glue_job</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-glue-security-configuration") %>>
+                            <a href="/docs/providers/aws/r/glue_security_configuration.html">aws_glue_security_configuration</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-resource-glue-trigger") %>>
                             <a href="/docs/providers/aws/r/glue_trigger.html">aws_glue_trigger</a>
                         </li>

--- a/website/docs/r/glue_security_configuration.html.markdown
+++ b/website/docs/r/glue_security_configuration.html.markdown
@@ -1,0 +1,76 @@
+---
+layout: "aws"
+page_title: "AWS: aws_glue_security_configuration"
+sidebar_current: "docs-aws-resource-glue-security-configuration"
+description: |-
+  Manages a Glue Security Configuration
+---
+
+# aws_glue_security_configuration
+
+Manages a Glue Security Configuration.
+
+## Example Usage
+
+```hcl
+resource "aws_glue_security_configuration" "example" {
+  name = "example"
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "DISABLED"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "DISABLED"
+    }
+
+    s3_encryption {
+      kms_key_arn        = "${data.aws_kms_key.example.arn}"
+      s3_encryption_mode = "SSE-KMS"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `encryption_configuration` – (Required) Configuration block containing encryption configuration. Detailed below.
+* `name` – (Required) Name of the security configuration.
+
+### encryption_configuration Argument Reference
+
+* `cloudwatch_encryption` - (Required) Configuration block containing encryption configuration for CloudWatch. Detailed below.
+* `job_bookmarks_encryption` - (Required) Configuration block containing encryption configuration for job bookmarks. Detailed below.
+* `s3_encryption` - (Required) Configuration block containing encryption configuration for S3 data. Detailed below.
+
+#### cloudwatch_encryption Argument Reference
+
+* `cloudwatch_encryption_mode` - (Optional) Encryption mode to use for CloudWatch data. Valid values: `DISABLED`, `SSE-KMS`. Default value: `DISABLED`.
+* `kms_key_arn` - (Optional) Amazon Resource Name (ARN) of the KMS key to be used to encrypt the data.
+
+#### job_bookmarks_encryption Argument Reference
+
+* `job_bookmarks_encryption_mode` - (Optional) Encryption mode to use for job bookmarks data. Valid values: `CSE-KMS`, `DISABLED`. Default value: `DISABLED`.
+* `kms_key_arn` - (Optional) Amazon Resource Name (ARN) of the KMS key to be used to encrypt the data.
+
+#### s3_encryption Argument Reference
+
+* `s3_encryption_mode` - (Optional) Encryption mode to use for S3 data. Valid values: `DISABLED`, `SSE-KMS`, `SSE-S3`. Default value: `DISABLED`.
+* `kms_key_arn` - (Optional) Amazon Resource Name (ARN) of the KMS key to be used to encrypt the data.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Security configuration name
+
+## Import
+
+Glue Security Configurations can be imported using `name`, e.g.
+
+```
+$ terraform import aws_glue_security_configuration.example example
+```

--- a/website/docs/r/glue_security_configuration.html.markdown
+++ b/website/docs/r/glue_security_configuration.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Security configuration name
+* `id` - Glue security configuration name
 
 ## Import
 

--- a/website/docs/r/glue_security_configuration.html.markdown
+++ b/website/docs/r/glue_security_configuration.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `cloudwatch_encryption` - (Required) Configuration block containing encryption configuration for CloudWatch. Detailed below.
 * `job_bookmarks_encryption` - (Required) Configuration block containing encryption configuration for job bookmarks. Detailed below.
-* `s3_encryption` - (Required) Configuration block containing encryption configuration for S3 data. Detailed below.
+* `s3_encryption` - (Required) A `s3_encryption ` block as described below, which contains encryption configuration for S3 data.
 
 #### cloudwatch_encryption Argument Reference
 

--- a/website/docs/r/glue_security_configuration.html.markdown
+++ b/website/docs/r/glue_security_configuration.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 ### encryption_configuration Argument Reference
 
 * `cloudwatch_encryption ` - (Required) A `cloudwatch_encryption ` block as described below, which contains encryption configuration for CloudWatch.
-* `job_bookmarks_encryption` - (Required) Configuration block containing encryption configuration for job bookmarks. Detailed below.
+* `job_bookmarks_encryption ` - (Required) A `job_bookmarks_encryption ` block as described below, which contains encryption configuration for job bookmarks.
 * `s3_encryption` - (Required) A `s3_encryption ` block as described below, which contains encryption configuration for S3 data.
 
 #### cloudwatch_encryption Argument Reference

--- a/website/docs/r/glue_security_configuration.html.markdown
+++ b/website/docs/r/glue_security_configuration.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 ### encryption_configuration Argument Reference
 
-* `cloudwatch_encryption` - (Required) Configuration block containing encryption configuration for CloudWatch. Detailed below.
+* `cloudwatch_encryption ` - (Required) A `cloudwatch_encryption ` block as described below, which contains encryption configuration for CloudWatch.
 * `job_bookmarks_encryption` - (Required) Configuration block containing encryption configuration for job bookmarks. Detailed below.
 * `s3_encryption` - (Required) A `s3_encryption ` block as described below, which contains encryption configuration for S3 data.
 


### PR DESCRIPTION
Closes #6286

Changes proposed in this pull request:

* New Resource: `aws_glue_security_configuration`

Output from acceptance testing:

```
--- PASS: TestAccAWSGlueSecurityConfiguration_S3Encryption_S3EncryptionMode_SSES3 (11.83s)
--- PASS: TestAccAWSGlueSecurityConfiguration_Basic (12.00s)
--- PASS: TestAccAWSGlueSecurityConfiguration_CloudWatchEncryption_CloudWatchEncryptionMode_SSEKMS (39.17s)
--- PASS: TestAccAWSGlueSecurityConfiguration_JobBookmarksEncryption_JobBookmarksEncryptionMode_CSEKMS (39.26s)
--- PASS: TestAccAWSGlueSecurityConfiguration_S3Encryption_S3EncryptionMode_SSEKMS (39.38s)
```
