### PR TITLE
resource/aws_glue_crawler: Suppress role difference when using ARN

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -38,6 +38,11 @@ func resourceAwsGlueCrawler() *schema.Resource {
 			"role": {
 				Type:     schema.TypeString,
 				Required: true,
+				// Glue API always returns name
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					newName, err := getIAMRoleNameFromIAMRoleARN(new)
+					return err == nil && newName == old
+				},
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -5,9 +5,11 @@ import (
 	"log"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -399,4 +401,16 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 		return nil
 	})
+}
+
+func getIAMRoleNameFromIAMRoleARN(inputARN string) (string, error) {
+	parsedARN, err := arn.Parse(inputARN)
+
+	if err != nil {
+		return "", fmt.Errorf("error parsing ARN (%s): %s", inputARN, err)
+	}
+
+	name := strings.TrimPrefix(parsedARN.Resource, "role/")
+
+	return name, nil
 }

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -15,6 +15,42 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestGetIAMRoleNameFromIAMRoleARN(t *testing.T) {
+	var testCases = []struct {
+		ARN      string
+		Name     string
+		ErrCount int
+	}{
+		{
+			ARN:      "not-an-arn",
+			ErrCount: 1,
+		},
+		{
+			ARN:      "arn:aws:iam::123456789012:role/test",
+			Name:     "test",
+			ErrCount: 0,
+		},
+		{
+			ARN:      "arn:aws:iam::123456789012:role/path/to/test",
+			Name:     "path/to/test",
+			ErrCount: 0,
+		},
+	}
+
+	for i, tc := range testCases {
+		actualName, err := getIAMRoleNameFromIAMRoleARN(tc.ARN)
+		if tc.ErrCount == 0 && err != nil {
+			t.Fatalf("Test case %d: expected %q not to trigger an error, received: %s", i, tc.ARN, err)
+		}
+		if tc.ErrCount > 0 && err == nil {
+			t.Fatalf("Test case %d: expected %q to trigger an error", i, tc.ARN)
+		}
+		if actualName != tc.Name {
+			t.Fatalf("Test case %d: expected name %q to be %q", i, actualName, tc.Name)
+		}
+	}
+}
+
 func TestAccAWSIAMRole_importBasic(t *testing.T) {
 	resourceName := "aws_iam_role.role"
 	rName := acctest.RandString(10)


### PR DESCRIPTION
Fixes #6292 

Changes proposed in this pull request:

* Add `DiffSuppressFunc` to `aws_glue_crawler` `role` attribute to prevent difference of ARN in configuration and API response of name with path.

Previously:

```
--- FAIL: TestAccAWSGlueCrawler_Role_ARN_NoPath (22.42s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_glue_crawler.test
          role: "tf-acc-test-8172536439889733682" => "arn:aws:iam::123456789012:role/tf-acc-test-8172536439889733682"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSGlueCrawler_Role_ARN_NoPath (33.69s)
--- PASS: TestAccAWSGlueCrawler_TablePrefix (62.37s)
--- PASS: TestAccAWSGlueCrawler_Role_Name_Path (62.40s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (65.18s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (67.71s)
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (68.43s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (80.19s)
--- PASS: TestAccAWSGlueCrawler_Schedule (85.71s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (85.83s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_Path (86.12s)
--- PASS: TestAccAWSGlueCrawler_Classifiers (87.78s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (88.38s)
--- PASS: TestAccAWSGlueCrawler_S3Target (90.89s)
--- PASS: TestAccAWSGlueCrawler_Description (91.87s)
--- PASS: TestAccAWSGlueCrawler_recreates (93.85s)
--- PASS: TestAccAWSGlueCrawler_Configuration (101.18s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (105.39s)
```
