### PR TITLE
Update default_network_acl.html.markdown

### DIFF
--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -165,7 +165,7 @@ As an alternative to the above, you can also specify the following lifecycle con
 ```hcl
 lifecycle {
     ignore_changes = ["subnet_ids"]
-  }
+}
  ```
 
 ### Removing `aws_default_network_acl` from your configuration

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -160,6 +160,14 @@ adopted by the Default Network ACL. In order to avoid a reoccurring plan, they
 will need to be reassigned, destroyed, or added to the `subnet_ids` attribute of
 the `aws_default_network_acl` entry.
 
+As an alternative to the above, you can also specify the following lifecycle configuration in your `aws_default_network_acl` resource::
+
+```hcl
+lifecycle {
+    ignore_changes = ["subnet_ids"]
+  }
+ ```
+
 ### Removing `aws_default_network_acl` from your configuration
 
 Each AWS VPC comes with a Default Network ACL that cannot be deleted. The `aws_default_network_acl`

--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -160,7 +160,7 @@ adopted by the Default Network ACL. In order to avoid a reoccurring plan, they
 will need to be reassigned, destroyed, or added to the `subnet_ids` attribute of
 the `aws_default_network_acl` entry.
 
-As an alternative to the above, you can also specify the following lifecycle configuration in your `aws_default_network_acl` resource::
+As an alternative to the above, you can also specify the following lifecycle configuration in your `aws_default_network_acl` resource:
 
 ```hcl
 lifecycle {


### PR DESCRIPTION
The `aws_default_network_acl` is a resource users tend to struggle with. In environments where one can't control all the subnets, adding them all to the default ACL is not practical or sometimes possible.

Using this lifecycle configuration will prevent a plan to show a change that won't be applied.
