### PR TITLE
Set `apply_method` to state in `aws_rds_cluster_parameter_group`

### DIFF
--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -153,7 +153,7 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 	// Only include user customized parameters as there's hundreds of system/default ones
 	describeParametersOpts := rds.DescribeDBClusterParametersInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
-		Source: aws.String("user"),
+		Source:                      aws.String("user"),
 	}
 
 	describeParametersResp, err := rdsconn.DescribeDBClusterParameters(&describeParametersOpts)

--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -75,14 +75,6 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "immediate",
-							// this parameter is not actually state, but a
-							// meta-parameter describing how the RDS API call
-							// to modify the parameter group should be made.
-							// Future reads of the resource from AWS don't tell
-							// us what we used for apply_method previously, so
-							// by squashing state to an empty string we avoid
-							// needing to do an update for every future run.
-							StateFunc: func(interface{}) string { return "" },
 						},
 					},
 				},
@@ -161,7 +153,7 @@ func resourceAwsRDSClusterParameterGroupRead(d *schema.ResourceData, meta interf
 	// Only include user customized parameters as there's hundreds of system/default ones
 	describeParametersOpts := rds.DescribeDBClusterParametersInput{
 		DBClusterParameterGroupName: aws.String(d.Id()),
-		Source:                      aws.String("user"),
+		Source: aws.String("user"),
 	}
 
 	describeParametersResp, err := rdsconn.DescribeDBClusterParameters(&describeParametersOpts)

--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -115,6 +115,46 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBClusterParameterGroup_withApplyMethod(t *testing.T) {
+	var v rds.DBClusterParameterGroup
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBClusterParameterGroupConfigWithApplyMethod(parameterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-pg:.+`)),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "family", "aurora5.6"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "description", "Test cluster parameter group for terraform"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.name", "character_set_server"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "parameter.2421266705.apply_method", "immediate"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.name", "character_set_client"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.value", "utf8"),
+					resource.TestCheckResourceAttr(
+						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.apply_method", "pending-reboot"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBClusterParameterGroup_namePrefix(t *testing.T) {
 	var v rds.DBClusterParameterGroup
 
@@ -333,6 +373,31 @@ resource "aws_rds_cluster_parameter_group" "bar" {
   parameter {
     name  = "character_set_results"
     value = "utf8"
+  }
+
+  tags {
+    foo = "bar"
+  }
+}
+`, name)
+}
+
+func testAccAWSDBClusterParameterGroupConfigWithApplyMethod(name string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster_parameter_group" "bar" {
+  name        = "%s"
+  family      = "aurora5.6"
+  description = "Test cluster parameter group for terraform"
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8"
+  }
+
+  parameter {
+    name  = "character_set_client"
+    value = "utf8"
+		apply_method = "pending-reboot"
   }
 
   tags {


### PR DESCRIPTION
Following the pattern of https://github.com/hashicorp/terraform/pull/8603
which addressed a similar issue with the db parameter groups.

Fixes #4832

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDBClusterParameterGroup'


==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDBClusterParameterGroup -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBClusterParameterGroup_importBasic
=== PAUSE TestAccAWSDBClusterParameterGroup_importBasic
=== RUN   TestAccAWSDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDBClusterParameterGroup_basic
=== RUN   TestAccAWSDBClusterParameterGroup_withApplyMethod
=== PAUSE TestAccAWSDBClusterParameterGroup_withApplyMethod
=== RUN   TestAccAWSDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDBClusterParameterGroupOnly
=== PAUSE TestAccAWSDBClusterParameterGroupOnly
=== CONT  TestAccAWSDBClusterParameterGroup_importBasic
=== CONT  TestAccAWSDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDBClusterParameterGroupOnly
=== CONT  TestAccAWSDBClusterParameterGroup_withApplyMethod
=== CONT  TestAccAWSDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDBClusterParameterGroup_basic
=== CONT  TestAccAWSDBClusterParameterGroup_disappears
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (8.19s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (10.62s)
--- PASS: TestAccAWSDBClusterParameterGroupOnly (10.81s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (10.87s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (11.13s)
--- PASS: TestAccAWSDBClusterParameterGroup_importBasic (12.26s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (19.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	19.097s
```
