### PR TITLE
resource/aws_route53_zone: Support multiple vpc associations, deprecate vpc_id and vpc_region, and enhance acceptance testing

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -1,18 +1,19 @@
 package aws
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsRoute53Zone() *schema.Resource {
@@ -39,18 +40,46 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				Default:  "Managed by Terraform",
 			},
 
+			"vpc": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				// Deprecated: Remove Computed: true in next major version of the provider
+				Computed:      true,
+				MinItems:      1,
+				ConflictsWith: []string{"delegation_set_id", "vpc_id", "vpc_region"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vpc_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.NoZeroValues,
+						},
+						"vpc_region": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+				Set: route53HostedZoneVPCHash,
+			},
+
 			"vpc_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"delegation_set_id"},
+				Computed:      true,
+				ConflictsWith: []string{"delegation_set_id", "vpc"},
+				Deprecated:    "use 'vpc' attribute instead",
 			},
 
 			"vpc_region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ConflictsWith: []string{"delegation_set_id", "vpc"},
+				Deprecated:    "use 'vpc' attribute instead",
 			},
 
 			"zone_id": {
@@ -83,141 +112,171 @@ func resourceAwsRoute53Zone() *schema.Resource {
 }
 
 func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).r53conn
+	conn := meta.(*AWSClient).r53conn
+	region := meta.(*AWSClient).region
 
-	req := &route53.CreateHostedZoneInput{
-		Name:             aws.String(d.Get("name").(string)),
-		HostedZoneConfig: &route53.HostedZoneConfig{Comment: aws.String(d.Get("comment").(string))},
-		CallerReference:  aws.String(resource.UniqueId()),
-	}
-	if v := d.Get("vpc_id"); v != "" {
-		req.VPC = &route53.VPC{
-			VPCId:     aws.String(v.(string)),
-			VPCRegion: aws.String(meta.(*AWSClient).region),
-		}
-		if w := d.Get("vpc_region"); w != "" {
-			req.VPC.VPCRegion = aws.String(w.(string))
-		}
-		d.Set("vpc_region", req.VPC.VPCRegion)
+	input := &route53.CreateHostedZoneInput{
+		CallerReference: aws.String(resource.UniqueId()),
+		Name:            aws.String(d.Get("name").(string)),
+		HostedZoneConfig: &route53.HostedZoneConfig{
+			Comment: aws.String(d.Get("comment").(string)),
+		},
 	}
 
 	if v, ok := d.GetOk("delegation_set_id"); ok {
-		req.DelegationSetId = aws.String(v.(string))
+		input.DelegationSetId = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", *req.Name)
-	var err error
-	resp, err := r53.CreateHostedZone(req)
+	// Private Route53 Hosted Zones can only be created with their first VPC association,
+	// however we need to associate the remaining after creation.
+	var vpcs []*route53.VPC
+	vpcs = expandRoute53VPCs(d.Get("vpc").(*schema.Set).List(), region)
+
+	// Backwards compatibility
+	if vpcID, ok := d.GetOk("vpc_id"); ok {
+		vpc := &route53.VPC{
+			VPCId:     aws.String(vpcID.(string)),
+			VPCRegion: aws.String(region),
+		}
+
+		if vpcRegion, ok := d.GetOk("vpc_region"); ok {
+			vpc.VPCRegion = aws.String(vpcRegion.(string))
+		}
+
+		vpcs = []*route53.VPC{vpc}
+	}
+
+	if len(vpcs) > 0 {
+		input.VPC = vpcs[0]
+	}
+
+	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", input)
+	output, err := conn.CreateHostedZone(input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Route53 Hosted Zone: %s", err)
 	}
 
-	// Store the zone_id
-	zone := cleanZoneID(*resp.HostedZone.Id)
-	d.Set("zone_id", zone)
-	d.SetId(zone)
+	d.SetId(cleanZoneID(aws.StringValue(output.HostedZone.Id)))
 
-	// Wait until we are done initializing
-	wait := resource.StateChangeConf{
-		Delay:      30 * time.Second,
-		Pending:    []string{"PENDING"},
-		Target:     []string{"INSYNC"},
-		Timeout:    15 * time.Minute,
-		MinTimeout: 2 * time.Second,
-		Refresh: func() (result interface{}, state string, err error) {
-			changeRequest := &route53.GetChangeInput{
-				Id: aws.String(cleanChangeID(*resp.ChangeInfo.Id)),
+	if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
+		return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) creation: %s", d.Id(), err)
+	}
+
+	if err := setTagsR53(conn, d, route53.TagResourceTypeHostedzone); err != nil {
+		return fmt.Errorf("error setting tags for Route53 Hosted Zone (%s): %s", d.Id(), err)
+	}
+
+	// Associate additional VPCs beyond the first
+	if len(vpcs) > 1 {
+		for _, vpc := range vpcs[1:] {
+			err := route53HostedZoneVPCAssociate(conn, d.Id(), vpc)
+
+			if err != nil {
+				return err
 			}
-			return resourceAwsGoRoute53Wait(r53, changeRequest)
-		},
+		}
 	}
-	_, err = wait.WaitForState()
-	if err != nil {
-		return err
-	}
-	return resourceAwsRoute53ZoneUpdate(d, meta)
+
+	return resourceAwsRoute53ZoneRead(d, meta)
 }
 
 func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).r53conn
-	zone, err := r53.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(d.Id())})
+	conn := meta.(*AWSClient).r53conn
+
+	input := &route53.GetHostedZoneInput{
+		Id: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Getting Route53 Hosted Zone: %s", input)
+	output, err := conn.GetHostedZone(input)
+
+	if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+		log.Printf("[WARN] Route53 Hosted Zone (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		// Handle a deleted zone
-		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error getting Route53 Hosted Zone (%s): %s", d.Id(), err)
 	}
 
-	// In the import case this will be empty
-	if _, ok := d.GetOk("zone_id"); !ok {
-		d.Set("zone_id", d.Id())
-	}
-	if _, ok := d.GetOk("name"); !ok {
-		d.Set("name", zone.HostedZone.Name)
+	if output == nil || output.HostedZone == nil {
+		log.Printf("[WARN] Route53 Hosted Zone (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	if !*zone.HostedZone.Config.PrivateZone {
-		ns := make([]string, len(zone.DelegationSet.NameServers))
-		for i := range zone.DelegationSet.NameServers {
-			ns[i] = *zone.DelegationSet.NameServers[i]
-		}
-		sort.Strings(ns)
-		if err := d.Set("name_servers", ns); err != nil {
-			return fmt.Errorf("Error setting name servers for: %s, error: %#v", d.Id(), err)
-		}
-	} else {
-		ns, err := getNameServers(d.Id(), d.Get("name").(string), r53)
-		if err != nil {
-			return err
-		}
-		if err := d.Set("name_servers", ns); err != nil {
-			return fmt.Errorf("Error setting name servers for: %s, error: %#v", d.Id(), err)
-		}
+	d.Set("comment", "")
+	d.Set("delegation_set_id", "")
+	d.Set("name", output.HostedZone.Name)
+	d.Set("zone_id", cleanZoneID(aws.StringValue(output.HostedZone.Id)))
 
-		// In the import case we just associate it with the first VPC
-		if _, ok := d.GetOk("vpc_id"); !ok {
-			if len(zone.VPCs) > 1 {
-				return fmt.Errorf(
-					"Can't import a route53_zone with more than one VPC attachment")
-			}
+	var nameServers []string
 
-			if len(zone.VPCs) > 0 {
-				d.Set("vpc_id", zone.VPCs[0].VPCId)
-				d.Set("vpc_region", zone.VPCs[0].VPCRegion)
+	if output.DelegationSet != nil {
+		d.Set("delegation_set_id", cleanDelegationSetId(aws.StringValue(output.DelegationSet.Id)))
+
+		nameServers = aws.StringValueSlice(output.DelegationSet.NameServers)
+	}
+
+	if output.HostedZone.Config != nil {
+		d.Set("comment", output.HostedZone.Config.Comment)
+
+		if aws.BoolValue(output.HostedZone.Config.PrivateZone) {
+			var err error
+			nameServers, err = getNameServers(d.Id(), d.Get("name").(string), conn)
+
+			if err != nil {
+				return fmt.Errorf("error getting Route53 Hosted Zone (%s) name servers: %s", d.Id(), err)
 			}
 		}
+	}
 
-		var associatedVPC *route53.VPC
-		for _, vpc := range zone.VPCs {
-			if *vpc.VPCId == d.Get("vpc_id") {
-				associatedVPC = vpc
-				break
+	sort.Strings(nameServers)
+	if err := d.Set("name_servers", nameServers); err != nil {
+		return fmt.Errorf("error setting name_servers: %s", err)
+	}
+
+	// Backwards compatibility: only set vpc_id/vpc_region if either is true:
+	//  * Previously configured
+	//  * Only one VPC association
+	existingVpcID := d.Get("vpc_id").(string)
+
+	// Detect drift in configuration
+	d.Set("vpc_id", "")
+	d.Set("vpc_region", "")
+
+	if len(output.VPCs) == 1 && output.VPCs[0] != nil {
+		d.Set("vpc_id", output.VPCs[0].VPCId)
+		d.Set("vpc_region", output.VPCs[0].VPCRegion)
+	} else if len(output.VPCs) > 1 {
+		for _, vpc := range output.VPCs {
+			if vpc == nil {
+				continue
+			}
+			if aws.StringValue(vpc.VPCId) == existingVpcID {
+				d.Set("vpc_id", vpc.VPCId)
+				d.Set("vpc_region", vpc.VPCRegion)
 			}
 		}
-		if associatedVPC == nil {
-			return fmt.Errorf("VPC: %v is not associated with Zone: %v", d.Get("vpc_id"), d.Id())
-		}
 	}
 
-	if zone.DelegationSet != nil && zone.DelegationSet.Id != nil {
-		d.Set("delegation_set_id", cleanDelegationSetId(*zone.DelegationSet.Id))
-	}
-
-	if zone.HostedZone != nil && zone.HostedZone.Config != nil && zone.HostedZone.Config.Comment != nil {
-		d.Set("comment", zone.HostedZone.Config.Comment)
+	if err := d.Set("vpc", flattenRoute53VPCs(output.VPCs)); err != nil {
+		return fmt.Errorf("error setting vpc: %s", err)
 	}
 
 	// get tags
 	req := &route53.ListTagsForResourceInput{
 		ResourceId:   aws.String(d.Id()),
-		ResourceType: aws.String("hostedzone"),
+		ResourceType: aws.String(route53.TagResourceTypeHostedzone),
 	}
 
-	resp, err := r53.ListTagsForResource(req)
+	log.Printf("[DEBUG] Listing tags for Route53 Hosted Zone: %s", req)
+	resp, err := conn.ListTagsForResource(req)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error listing tags for Route53 Hosted Zone (%s): %s", d.Id(), err)
 	}
 
 	var tags []*route53.Tag
@@ -234,27 +293,66 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceAwsRoute53ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
+	region := meta.(*AWSClient).region
 
 	d.Partial(true)
 
 	if d.HasChange("comment") {
-		zoneInput := route53.UpdateHostedZoneCommentInput{
+		input := route53.UpdateHostedZoneCommentInput{
 			Id:      aws.String(d.Id()),
 			Comment: aws.String(d.Get("comment").(string)),
 		}
 
-		_, err := conn.UpdateHostedZoneComment(&zoneInput)
+		_, err := conn.UpdateHostedZoneComment(&input)
+
 		if err != nil {
-			return err
-		} else {
-			d.SetPartial("comment")
+			return fmt.Errorf("error updating Route53 Hosted Zone (%s) comment: %s", d.Id(), err)
 		}
+
+		d.SetPartial("comment")
 	}
 
-	if err := setTagsR53(conn, d, "hostedzone"); err != nil {
-		return err
-	} else {
+	if d.HasChange("tags") {
+		if err := setTagsR53(conn, d, route53.TagResourceTypeHostedzone); err != nil {
+			return err
+		}
+
 		d.SetPartial("tags")
+	}
+
+	if d.HasChange("vpc") {
+		o, n := d.GetChange("vpc")
+		oldVPCs := o.(*schema.Set)
+		newVPCs := n.(*schema.Set)
+
+		// VPCs cannot be empty, so add first and then remove
+		for _, vpcRaw := range newVPCs.Difference(oldVPCs).List() {
+			if vpcRaw == nil {
+				continue
+			}
+
+			vpc := expandRoute53VPC(vpcRaw.(map[string]interface{}), region)
+			err := route53HostedZoneVPCAssociate(conn, d.Id(), vpc)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, vpcRaw := range oldVPCs.Difference(newVPCs).List() {
+			if vpcRaw == nil {
+				continue
+			}
+
+			vpc := expandRoute53VPC(vpcRaw.(map[string]interface{}), region)
+			err := route53HostedZoneVPCDisassociate(conn, d.Id(), vpc)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		d.SetPartial("vpc")
 	}
 
 	d.Partial(false)
@@ -263,22 +361,27 @@ func resourceAwsRoute53ZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).r53conn
+	conn := meta.(*AWSClient).r53conn
 
 	if d.Get("force_destroy").(bool) {
-		if err := deleteAllRecordsInHostedZoneId(d.Id(), d.Get("name").(string), r53); err != nil {
-			return fmt.Errorf("%s", err)
+		if err := deleteAllRecordsInHostedZoneId(d.Id(), d.Get("name").(string), conn); err != nil {
+			return fmt.Errorf("error deleting records in Route53 Hosted Zone (%s): %s", d.Id(), err)
 		}
 	}
 
-	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",
-		d.Get("name").(string), d.Id())
-	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{Id: aws.String(d.Id())})
+	input := &route53.DeleteHostedZoneInput{
+		Id: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Route53 Hosted Zone: %s", input)
+	_, err := conn.DeleteHostedZone(input)
+
+	if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+		return nil
+	}
+
 	if err != nil {
-		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
-			return nil
-		}
-		return err
+		return fmt.Errorf("error deleting Route53 Hosted Zone (%s): %s", d.Id(), err)
 	}
 
 	return nil
@@ -386,4 +489,130 @@ func getNameServers(zoneId string, zoneName string, r53 *route53.Route53) ([]str
 	}
 	sort.Strings(ns)
 	return ns, nil
+}
+
+func expandRoute53VPCs(l []interface{}, currentRegion string) []*route53.VPC {
+	vpcs := []*route53.VPC{}
+
+	for _, mRaw := range l {
+		if mRaw == nil {
+			continue
+		}
+
+		vpcs = append(vpcs, expandRoute53VPC(mRaw.(map[string]interface{}), currentRegion))
+	}
+
+	return vpcs
+}
+
+func expandRoute53VPC(m map[string]interface{}, currentRegion string) *route53.VPC {
+	vpc := &route53.VPC{
+		VPCId:     aws.String(m["vpc_id"].(string)),
+		VPCRegion: aws.String(currentRegion),
+	}
+
+	if v, ok := m["vpc_region"]; ok && v.(string) != "" {
+		vpc.VPCRegion = aws.String(v.(string))
+	}
+
+	return vpc
+}
+
+func flattenRoute53VPCs(vpcs []*route53.VPC) []interface{} {
+	l := []interface{}{}
+
+	for _, vpc := range vpcs {
+		if vpc == nil {
+			continue
+		}
+
+		m := map[string]interface{}{
+			"vpc_id":     aws.StringValue(vpc.VPCId),
+			"vpc_region": aws.StringValue(vpc.VPCRegion),
+		}
+
+		l = append(l, m)
+	}
+
+	return l
+}
+
+func route53HostedZoneVPCAssociate(conn *route53.Route53, zoneID string, vpc *route53.VPC) error {
+	input := &route53.AssociateVPCWithHostedZoneInput{
+		HostedZoneId: aws.String(zoneID),
+		VPC:          vpc,
+	}
+
+	log.Printf("[DEBUG] Associating Route53 Hosted Zone with VPC: %s", input)
+	output, err := conn.AssociateVPCWithHostedZone(input)
+
+	if err != nil {
+		return fmt.Errorf("error associating Route53 Hosted Zone (%s) to VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
+		return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) association to VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	return nil
+}
+
+func route53HostedZoneVPCDisassociate(conn *route53.Route53, zoneID string, vpc *route53.VPC) error {
+	input := &route53.DisassociateVPCFromHostedZoneInput{
+		HostedZoneId: aws.String(zoneID),
+		VPC:          vpc,
+	}
+
+	log.Printf("[DEBUG] Disassociating Route53 Hosted Zone with VPC: %s", input)
+	output, err := conn.DisassociateVPCFromHostedZone(input)
+
+	if err != nil {
+		return fmt.Errorf("error disassociating Route53 Hosted Zone (%s) from VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
+		return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) disassociation from VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	return nil
+}
+
+func route53HostedZoneVPCHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["vpc_id"].(string)))
+
+	return hashcode.String(buf.String())
+}
+
+func route53WaitForChangeSynchronization(conn *route53.Route53, changeID string) error {
+	conf := resource.StateChangeConf{
+		Delay:      30 * time.Second,
+		Pending:    []string{route53.ChangeStatusPending},
+		Target:     []string{route53.ChangeStatusInsync},
+		Timeout:    15 * time.Minute,
+		MinTimeout: 2 * time.Second,
+		Refresh: func() (result interface{}, state string, err error) {
+			input := &route53.GetChangeInput{
+				Id: aws.String(changeID),
+			}
+
+			log.Printf("[DEBUG] Getting Route53 Change status: %s", input)
+			output, err := conn.GetChange(input)
+
+			if err != nil {
+				return nil, "UNKNOWN", err
+			}
+
+			if output == nil || output.ChangeInfo == nil {
+				return nil, "UNKNOWN", fmt.Errorf("Route53 GetChange response empty for ID: %s", changeID)
+			}
+
+			return true, aws.StringValue(output.ChangeInfo.Status), nil
+		},
+	}
+
+	_, err := conf.WaitForState()
+
+	return err
 }

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -65,10 +65,11 @@ func TestCleanChangeID(t *testing.T) {
 	}
 }
 
-func TestAccAWSRoute53Zone_importBasic(t *testing.T) {
-	resourceName := "aws_route53_zone.main"
+func TestAccAWSRoute53Zone_basic(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
 
 	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
 	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -78,8 +79,14 @@ func TestAccAWSRoute53Zone_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53ZoneConfig(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s.", zoneName)),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "0"),
+				),
 			},
-
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -90,39 +97,26 @@ func TestAccAWSRoute53Zone_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53Zone_basic(t *testing.T) {
-	var zone, zone0, zone1, zone2, zone3, zone4 route53.GetHostedZoneOutput
-	var td route53.ResourceTagSet
-
-	rString := acctest.RandString(8)
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+func TestAccAWSRoute53Zone_multiple(t *testing.T) {
+	var zone0, zone1, zone2, zone3, zone4 route53.GetHostedZoneOutput
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_zone.main",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53ZoneDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ZoneConfig(zoneName),
+				Config: testAccRoute53ZoneConfigMultiple(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
-					testAccLoadTagsR53(&zone, &td),
-					testAccCheckTagsR53(&td.Tags, "foo", "bar"),
-				),
-			},
-			{
-				Config: testAccRoute53ZoneCountConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.0", &zone0),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.0", &zone0),
 					testAccCheckDomainName(&zone0, "subdomain0.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.1", &zone1),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.1", &zone1),
 					testAccCheckDomainName(&zone1, "subdomain1.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.2", &zone2),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.2", &zone2),
 					testAccCheckDomainName(&zone2, "subdomain2.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.3", &zone3),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.3", &zone3),
 					testAccCheckDomainName(&zone3, "subdomain3.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.4", &zone4),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.4", &zone4),
 					testAccCheckDomainName(&zone4, "subdomain4.terraformtest.com."),
 				),
 			},
@@ -130,111 +124,322 @@ func TestAccAWSRoute53Zone_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53Zone_forceDestroy(t *testing.T) {
-	var zone, zoneWithDot route53.GetHostedZoneOutput
+func TestAccAWSRoute53Zone_Comment(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
 
 	rString := acctest.RandString(8)
-	zoneName1 := fmt.Sprintf("%s-one.terraformtest.com", rString)
-	zoneName2 := fmt.Sprintf("%s-two.terraformtest.com", rString)
-
-	// record the initialized providers so that we can use them to
-	// check for the instances in each region
-	var providers []*schema.Provider
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     "aws_route53_zone.destroyable",
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckRoute53ZoneDestroyWithProvider, &providers),
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ZoneConfig_forceDestroy(zoneName1, zoneName2),
+				Config: testAccRoute53ZoneConfigComment(zoneName, "comment1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExistsWithProvider("aws_route53_zone.destroyable", &zone,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					// Add >100 records to verify pagination works ok
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zone, 100),
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zone, 5),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "comment", "comment1"),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigComment(zoneName, "comment2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "comment", "comment2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
 
-					testAccCheckRoute53ZoneExistsWithProvider("aws_route53_zone.with_trailing_dot", &zoneWithDot,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
+func TestAccAWSRoute53Zone_DelegationSetID(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	delegationSetResourceName := "aws_route53_delegation_set.test"
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigDelegationSetID(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttrPair(resourceName, "delegation_set_id", delegationSetResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_ForceDestroy(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigForceDestroy(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
 					// Add >100 records to verify pagination works ok
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zoneWithDot, 100),
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zoneWithDot, 5),
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 100),
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 5),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSRoute53Zone_updateComment(t *testing.T) {
+func TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigForceDestroyTrailingPeriod(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					// Add >100 records to verify pagination works ok
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 100),
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 5),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_Tags(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 	var td route53.ResourceTagSet
 
-	rString := acctest.RandString(8)
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_zone.main",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53ZoneDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ZoneConfig(zoneName),
+				Config: testAccRoute53ZoneConfigTagsSingle(zoneName, "tag1key", "tag1value"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag1key", "tag1value"),
 					testAccLoadTagsR53(&zone, &td),
-					testAccCheckTagsR53(&td.Tags, "foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"aws_route53_zone.main", "comment", "Custom comment"),
+					testAccCheckTagsR53(&td.Tags, "tag1key", "tag1value"),
 				),
 			},
-
 			{
-				Config: testAccRoute53ZoneConfigUpdateComment(zoneName),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccRoute53ZoneConfigTagsMultiple(zoneName, "tag1key", "tag1valueupdated", "tag2key", "tag2value"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag1key", "tag1valueupdated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag2key", "tag2value"),
 					testAccLoadTagsR53(&zone, &td),
-					resource.TestCheckResourceAttr(
-						"aws_route53_zone.main", "comment", "Change Custom Comment"),
+					testAccCheckTagsR53(&td.Tags, "tag1key", "tag1valueupdated"),
+					testAccCheckTagsR53(&td.Tags, "tag2key", "tag2value"),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigTagsSingle(zoneName, "tag2key", "tag2value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag2key", "tag2value"),
+					testAccLoadTagsR53(&zone, &td),
+					testAccCheckTagsR53(&td.Tags, "tag2key", "tag2value"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSRoute53Zone_private_basic(t *testing.T) {
+func TestAccAWSRoute53Zone_VPC_Single(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
-	rString := acctest.RandString(8)
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName := "aws_vpc.test1"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_zone.main",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53ZoneDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53PrivateZoneConfig(zoneName),
+				Config: testAccRoute53ZoneConfigVPCSingle(rName, zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
-					testAccCheckRoute53ZoneAssociatesWithVpc("aws_vpc.main", &zone),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName, &zone),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_VPC_Multiple(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName1 := "aws_vpc.test1"
+	vpcResourceName2 := "aws_vpc.test2"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigVPCMultiple(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "2"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName2, &zone),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_VPC_Updates(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName1 := "aws_vpc.test1"
+	vpcResourceName2 := "aws_vpc.test2"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigVPCSingle(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigVPCMultiple(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "2"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName2, &zone),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigVPCSingle(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSRoute53Zone_private_region(t *testing.T) {
+func TestAccAWSRoute53Zone_VPCID(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
 	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName := "aws_vpc.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigVPCID(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName, &zone),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_VPCRegion(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName := "aws_vpc.test"
 	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
 
 	// record the initialized providers so that we can use them to
@@ -243,17 +448,26 @@ func TestAccAWSRoute53Zone_private_region(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     "aws_route53_zone.main",
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckWithProviders(testAccCheckRoute53ZoneDestroyWithProvider, &providers),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53PrivateZoneRegionConfig(zoneName),
+				Config: testAccRoute53ZoneConfigVPCRegion(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExistsWithProvider("aws_route53_zone.main", &zone,
+					testAccCheckRoute53ZoneExistsWithProvider(resourceName, &zone,
 						testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					testAccCheckRoute53ZoneAssociatesWithVpc("aws_vpc.main", &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName, &zone),
 				),
+			},
+			{
+				// Config must be provided for aliased provider
+				Config:                  testAccRoute53ZoneConfigVPCRegion(zoneName),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -276,6 +490,10 @@ func testAccCheckRoute53ZoneDestroyWithProvider(s *terraform.State, provider *sc
 		}
 	}
 	return nil
+}
+
+func testAccCreateRandomRoute53RecordsInZoneId(zone *route53.GetHostedZoneOutput, recordsCount int) resource.TestCheckFunc {
+	return testAccCreateRandomRoute53RecordsInZoneIdWithProvider(func() *schema.Provider { return testAccProvider }, zone, recordsCount)
 }
 
 func testAccCreateRandomRoute53RecordsInZoneIdWithProvider(providerF func() *schema.Provider, zone *route53.GetHostedZoneOutput, recordsCount int) resource.TestCheckFunc {
@@ -378,16 +596,13 @@ func testAccCheckRoute53ZoneAssociatesWithVpc(n string, zone *route53.GetHostedZ
 			return fmt.Errorf("No VPC ID is set")
 		}
 
-		var associatedVPC *route53.VPC
 		for _, vpc := range zone.VPCs {
-			if *vpc.VPCId == rs.Primary.ID {
-				associatedVPC = vpc
+			if aws.StringValue(vpc.VPCId) == rs.Primary.ID {
+				return nil
 			}
 		}
-		if associatedVPC == nil {
-			return fmt.Errorf("VPC: %v is not associated to Zone: %v", n, cleanZoneID(*zone.HostedZone.Id))
-		}
-		return nil
+
+		return fmt.Errorf("VPC: %s is not associated to Zone: %v", n, cleanZoneID(aws.StringValue(zone.HostedZone.Id)))
 	}
 }
 
@@ -428,103 +643,182 @@ func testAccCheckDomainName(zone *route53.GetHostedZoneOutput, domain string) re
 }
 func testAccRoute53ZoneConfig(zoneName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
-	name = "%s."
-	comment = "Custom comment"
-
-	tags {
-		foo = "bar"
-		Name = "tf-route53-tag-test"
-	}
+resource "aws_route53_zone" "test" {
+  name = "%s."
 }
 `, zoneName)
 }
 
-func testAccRoute53ZoneCountConfig() string {
+func testAccRoute53ZoneConfigMultiple() string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
-	name = "subdomain${count.index}.terraformtest.com"
+resource "aws_route53_zone" "test" {
+  count = 5
 
-	count = 5
+  name = "subdomain${count.index}.terraformtest.com"
 }
 `)
 }
 
-func testAccRoute53ZoneConfig_forceDestroy(zoneName1, zoneName2 string) string {
+func testAccRoute53ZoneConfigComment(zoneName, comment string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "destroyable" {
-	name = "%s"
-	force_destroy = true
+resource "aws_route53_zone" "test" {
+  comment = %q
+  name    = "%s."
+}
+`, comment, zoneName)
 }
 
-resource "aws_route53_zone" "with_trailing_dot" {
-	name = "%s."
-	force_destroy = true
-}
-`, zoneName1, zoneName2)
-}
-
-func testAccRoute53ZoneConfigUpdateComment(zoneName string) string {
+func testAccRoute53ZoneConfigDelegationSetID(zoneName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
-	name = "%s."
-	comment = "Change Custom Comment"
+resource "aws_route53_delegation_set" "test" {}
 
-	tags {
-		foo = "bar"
-		Name = "tf-route53-tag-test"
-	}
+resource "aws_route53_zone" "test" {
+  delegation_set_id = "${aws_route53_delegation_set.test.id}"
+  name              = "%s."
 }
 `, zoneName)
 }
 
-func testAccRoute53PrivateZoneConfig(zoneName string) string {
+func testAccRoute53ZoneConfigForceDestroy(zoneName string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "main" {
-	cidr_block = "172.29.0.0/24"
-	instance_tenancy = "default"
-	enable_dns_support = true
-	enable_dns_hostnames = true
-	tags {
-		Name = "terraform-testacc-route53-zone-private"
-	}
-}
-
-resource "aws_route53_zone" "main" {
-	name = "%s."
-	vpc_id = "${aws_vpc.main.id}"
+resource "aws_route53_zone" "test" {
+  force_destroy = true
+  name          = "%s"
 }
 `, zoneName)
 }
 
-func testAccRoute53PrivateZoneRegionConfig(zoneName string) string {
+func testAccRoute53ZoneConfigForceDestroyTrailingPeriod(zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  force_destroy = true
+  name          = "%s."
+}
+`, zoneName)
+}
+
+func testAccRoute53ZoneConfigTagsSingle(zoneName, tag1Key, tag1Value string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  tags {
+    %q = %q
+  }
+}
+`, zoneName, tag1Key, tag1Value)
+}
+
+func testAccRoute53ZoneConfigTagsMultiple(zoneName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  tags {
+    %q = %q
+    %q = %q
+  }
+}
+`, zoneName, tag1Key, tag1Value, tag2Key, tag2Value)
+}
+
+func testAccRoute53ZoneConfigVPCID(zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.29.0.0/24"
+
+  tags {
+    Name = "terraform-testacc-route53-zone-private"
+  }
+}
+
+resource "aws_route53_zone" "test" {
+  name   = "%s."
+  vpc_id = "${aws_vpc.test.id}"
+}
+`, zoneName)
+}
+
+func testAccRoute53ZoneConfigVPCRegion(zoneName string) string {
 	return fmt.Sprintf(`
 provider "aws" {
-	alias = "west"
-	region = "us-west-2"
+  alias  = "west"
+  region = "us-west-2"
 }
 
 provider "aws" {
-	alias = "east"
-	region = "us-east-1"
+  alias  = "east"
+  region = "us-east-1"
 }
 
-resource "aws_vpc" "main" {
-	provider = "aws.east"
-	cidr_block = "172.29.0.0/24"
-	instance_tenancy = "default"
-	enable_dns_support = true
-	enable_dns_hostnames = true
-	tags {
-		Name = "terraform-testacc-route53-zone-private-region"
-	}
+resource "aws_vpc" "test" {
+  provider = "aws.east"
+
+  cidr_block = "172.29.0.0/24"
+
+  tags {
+    Name = "terraform-testacc-route53-zone-private-region"
+  }
 }
 
-resource "aws_route53_zone" "main" {
-	provider = "aws.west"
-	name = "%s."
-	vpc_id = "${aws_vpc.main.id}"
-	vpc_region = "us-east-1"
+resource "aws_route53_zone" "test" {
+  provider = "aws.west"
+
+  name       = "%s."
+  vpc_id     = "${aws_vpc.test.id}"
+  vpc_region = "us-east-1"
 }
 `, zoneName)
+}
+
+func testAccRoute53ZoneConfigVPCSingle(rName, zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  vpc {
+    vpc_id = "${aws_vpc.test1.id}"
+  }
+}
+`, rName, zoneName)
+}
+
+func testAccRoute53ZoneConfigVPCMultiple(rName, zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.2.0.0/16"
+
+  tags {
+    Name = %q
+  }
+}
+
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  vpc {
+    vpc_id = "${aws_vpc.test1.id}"
+  }
+
+  vpc {
+    vpc_id = "${aws_vpc.test2.id}"
+  }
+}
+`, rName, rName, zoneName)
 }

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -42,6 +42,7 @@ Upgrade topics:
 - [Resource: aws_network_acl](#resource-aws_network_acl)
 - [Resource: aws_redshift_cluster](#resource-aws_redshift_cluster)
 - [Resource: aws_route_table](#resource-aws_route_table)
+- [Resource: aws_route53_zone](#resource-aws_route53_zone)
 - [Resource: aws_wafregional_byte_match_set](#resource-aws_wafregional_byte_match_set)
 
 <!-- /TOC -->
@@ -618,6 +619,34 @@ resource "aws_redshift_cluster" "example" {
 Previously, importing this resource resulted in an `aws_route` resource for each route, in
 addition to the `aws_route_table`, in the Terraform state. Support for importing `aws_route` resources has been added and importing this resource only adds the `aws_route_table` 
 resource, with in-line routes, to the state.
+
+## Resource: aws_route53_zone
+
+### vpc_id and vpc_region Argument Removal
+
+Switch your Terraform configuration to `vpc` configuration block(s) instead.
+
+For example, given this previous configuration:
+
+```hcl
+resource "aws_route53_zone" "example" {
+  # ... other configuration ...
+
+  vpc_id = "..."
+}
+```
+
+An updated configuration:
+
+```hcl
+resource "aws_route53_zone" "example" {
+  # ... other configuration ...
+
+  vpc {
+    vpc_id = "..."
+  }
+}
+```
 
 ## Resource: aws_wafregional_byte_match_set
 

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -3,20 +3,24 @@ layout: "aws"
 page_title: "AWS: aws_route53_zone"
 sidebar_current: "docs-aws-resource-route53-zone"
 description: |-
-  Provides a Route53 Hosted Zone resource.
+  Manages a Route53 Hosted Zone
 ---
 
 # aws_route53_zone
 
-Provides a Route53 Hosted Zone resource.
+Manages a Route53 Hosted Zone.
 
 ## Example Usage
+
+### Public Zone
 
 ```hcl
 resource "aws_route53_zone" "primary" {
   name = "example.com"
 }
 ```
+
+### Public Subdomain Zone
 
 For use in subdomains, note that you need to create a
 `aws_route53_record` of type `NS` as well as the subdomain
@@ -50,20 +54,39 @@ resource "aws_route53_record" "dev-ns" {
 }
 ```
 
+### Private Zone
+
+~> **NOTE:** Terraform provides both exclusive VPC associations defined in-line in this resource via `vpc` configuration blocks and a separate [Zone VPC Association](/docs/providers/aws/r/route53_zone_association.html) resource. At this time, you cannot use in-line VPC associations in conjunction with any `aws_route53_zone_association` resources with the same zone ID otherwise it will cause a perpetual difference in plan output. You can optionally use the generic Terraform resource [lifecycle configuration block](/docs/configuration/resources.html#lifecycle) with `ignore_changes` to manage additional associations via the `aws_route53_zone_association` resource.
+
+~> **NOTE:** Private zones require at least one VPC association at all times.
+
+```hcl
+resource "aws_route53_zone" "private" {
+  name = "example.com"
+
+  vpc {
+    vpc_id = "${aws_vpc.example.id}"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) This is the name of the hosted zone.
 * `comment` - (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.
+* `delegation_set_id` - (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with `vpc` and `vpc_id` as delegation sets can only be used for public zones.
+* `force_destroy` - (Optional) Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone.
 * `tags` - (Optional) A mapping of tags to assign to the zone.
-* `vpc_id` - (Optional) The VPC to associate with a private hosted zone. Specifying `vpc_id` will create a private hosted zone.
-  Conflicts w/ `delegation_set_id` as delegation sets can only be used for public zones.
-* `vpc_region` - (Optional) The VPC's region. Defaults to the region of the AWS provider.
-* `delegation_set_id` - (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone.
-  Conflicts w/ `vpc_id` as delegation sets can only be used for public zones.
-* `force_destroy` - (Optional) Whether to destroy all records (possibly managed outside of Terraform)
-  in the zone when destroying the zone.
+* `vpc` - (Optional) Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with `delegation_set_id`, `vpc_id`, and `vpc_region` in this resource and any [`aws_route53_zone_association` resource](/docs/providers/aws/r/route53_zone_association.html) specifying the same zone ID. Detailed below.
+* `vpc_id` - (Optional, **DEPRECATED**) Use `vpc` instead. The VPC to associate with a private hosted zone. Specifying `vpc_id` will create a private hosted zone. Conflicts with `delegation_set_id` as delegation sets can only be used for public zones and `vpc`.
+* `vpc_region` - (Optional, **DEPRECATED**) Use `vpc` instead. The VPC's region. Defaults to the region of the AWS provider.
+
+### vpc Argument Reference
+
+* `vpc_id` - (Required) ID of the VPC to associate.
+* `vpc_region` - (Optional) Region of the VPC to associate. Defaults to AWS provider region.
 
 ## Attributes Reference
 

--- a/website/docs/r/route53_zone_association.html.markdown
+++ b/website/docs/r/route53_zone_association.html.markdown
@@ -3,12 +3,16 @@ layout: "aws"
 page_title: "AWS: aws_route53_zone_association"
 sidebar_current: "docs-aws-resource-route53-zone-association"
 description: |-
-  Provides a Route53 private Hosted Zone to VPC association resource.
+  Manages a Route53 Hosted Zone VPC association
 ---
 
 # aws_route53_zone_association
 
-Provides a Route53 private Hosted Zone to VPC association resource.
+Manages a Route53 Hosted Zone VPC association. VPC associations can only be made on private zones.
+
+~> **NOTE:** Unless explicit association ordering is required (e.g. a separate cross-account association authorization), usage of this resource is not recommended. Use the `vpc` configuration blocks available within the [`aws_route53_zone` resource](/docs/providers/aws/r/route53_zone.html) instead.
+
+~> **NOTE:** Terraform provides both this standalone Zone VPC Association resource and exclusive VPC associations defined in-line in the [`aws_route53_zone` resource](/docs/providers/aws/r/route53_zone.html) via `vpc` configuration blocks. At this time, you cannot use those in-line VPC associations in conjunction with this resource and the same zone ID otherwise it will cause a perpetual difference in plan output. You can optionally use the generic Terraform resource [lifecycle configuration block](/docs/configuration/resources.html#lifecycle) with `ignore_changes` in the `aws_route53_zone` resource to manage additional associations via this resource.
 
 ## Example Usage
 
@@ -27,7 +31,19 @@ resource "aws_vpc" "secondary" {
 
 resource "aws_route53_zone" "example" {
   name   = "example.com"
-  vpc_id = "${aws_vpc.primary.id}"
+
+  # NOTE: The aws_route53_zone vpc argument accepts multiple configuration
+  #       blocks. The below usage of the single vpc configuration, the
+  #       lifecycle configuration, and the aws_route53_zone_association
+  #       resource is for illustrative purposes (e.g. for a separate
+  #       cross-account authorization process, which is not shown here).
+  vpc {
+    vpc_id = "${aws_vpc.primary.id}"
+  }
+
+  lifecycle {
+    ignore_changes = ["vpc"]
+  }
 }
 
 resource "aws_route53_zone_association" "secondary" {


### PR DESCRIPTION
Route53 Hosted Zones can have multiple VPC associations. Previously, the resource would error when attempting to import a zone with multiple associations. I wasn't planning on this large refactoring but trying to get the other changes in highlighted the need to bring this resource up to more current practices.

Closes #892
Closes #5317
Closes #5736

Changes:
* Add `vpc` TypeSet attribute to support exclusive management and import of multiple VPC associations
* Deprecate `vpc_id` and `vpc_region` attributes in favor of `vpc`, adding note to Version 2 Upgrade Guide
* Call Read instead of Update after Create
* Refactor Create/Read/Update/Delete to return error message context, use AWS Go SDK helpers to prevent panics, use AWS Go SDK constants, always call d.Set(), and use isAWSErr()
* Add acceptance testing for delegation_set_id attribute
* Enhance acceptance testing for tags to test updates
* Migrate _importBasic acceptance test to Import TestStep in all acceptance tests

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53Zone_basic (73.02s)
--- PASS: TestAccAWSRoute53Zone_VPCRegion (73.44s)
--- PASS: TestAccAWSRoute53Zone_DelegationSetID (76.95s)
--- PASS: TestAccAWSRoute53Zone_Comment (81.43s)
--- PASS: TestAccAWSRoute53Zone_VPCID (82.88s)
--- PASS: TestAccAWSRoute53Zone_multiple (84.98s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (88.03s)
--- PASS: TestAccAWSRoute53Zone_Tags (91.95s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (140.49s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (226.21s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy (249.03s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (249.05s)
```
