### PR TITLE
Issue #6144 Resource 'aws_iam_role_policy.example_policy' does not have attribute 'name'

### DIFF
--- a/aws/resource_aws_iam_role_policy.go
+++ b/aws/resource_aws_iam_role_policy.go
@@ -79,7 +79,7 @@ func resourceAwsIamRolePolicyPut(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", *request.RoleName, *request.PolicyName))
-	return nil
+	return resourceAwsIamRolePolicyRead(d, meta)
 }
 
 func resourceAwsIamRolePolicyRead(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_iam_role_policy_test.go
+++ b/aws/resource_aws_iam_role_policy_test.go
@@ -96,6 +96,7 @@ func TestAccAWSIAMRolePolicy_namePrefix(t *testing.T) {
 						"aws_iam_role_policy.test",
 						&rolePolicy1,
 					),
+					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
 				),
 			},
 			{
@@ -107,6 +108,7 @@ func TestAccAWSIAMRolePolicy_namePrefix(t *testing.T) {
 						&rolePolicy2,
 					),
 					testAccCheckAWSIAMRolePolicyNameMatches(&rolePolicy1, &rolePolicy2),
+					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
 				),
 			},
 		},
@@ -131,6 +133,7 @@ func TestAccAWSIAMRolePolicy_generatedName(t *testing.T) {
 						"aws_iam_role_policy.test",
 						&rolePolicy1,
 					),
+					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
 				),
 			},
 			{
@@ -142,6 +145,7 @@ func TestAccAWSIAMRolePolicy_generatedName(t *testing.T) {
 						&rolePolicy2,
 					),
 					testAccCheckAWSIAMRolePolicyNameMatches(&rolePolicy1, &rolePolicy2),
+					resource.TestCheckResourceAttrSet("aws_iam_role_policy.test", "name"),
 				),
 			},
 		},


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6144 

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSIAMRolePolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSIAMRolePolicy_ -timeout 120m
=== RUN   TestAccAWSIAMRolePolicy_importBasic
=== PAUSE TestAccAWSIAMRolePolicy_importBasic
=== RUN   TestAccAWSIAMRolePolicy_basic
=== PAUSE TestAccAWSIAMRolePolicy_basic
=== RUN   TestAccAWSIAMRolePolicy_namePrefix
=== PAUSE TestAccAWSIAMRolePolicy_namePrefix
=== RUN   TestAccAWSIAMRolePolicy_generatedName
=== PAUSE TestAccAWSIAMRolePolicy_generatedName
=== RUN   TestAccAWSIAMRolePolicy_invalidJSON
=== PAUSE TestAccAWSIAMRolePolicy_invalidJSON
=== CONT  TestAccAWSIAMRolePolicy_importBasic
=== CONT  TestAccAWSIAMRolePolicy_generatedName
=== CONT  TestAccAWSIAMRolePolicy_namePrefix
=== CONT  TestAccAWSIAMRolePolicy_basic
=== CONT  TestAccAWSIAMRolePolicy_invalidJSON
--- PASS: TestAccAWSIAMRolePolicy_invalidJSON (3.39s)
--- PASS: TestAccAWSIAMRolePolicy_importBasic (56.54s)
--- PASS: TestAccAWSIAMRolePolicy_generatedName (74.13s)
--- PASS: TestAccAWSIAMRolePolicy_namePrefix (74.94s)
--- PASS: TestAccAWSIAMRolePolicy_basic (77.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws
...
```
