### PR TITLE
Update cognito_user_pool.markdown

### DIFF
--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -115,7 +115,7 @@ The following arguments are supported:
 
   * `default_email_option` (Optional) - The default email option. Must be either `CONFIRM_WITH_CODE` or `CONFIRM_WITH_LINK`. Defaults to `CONFIRM_WITH_CODE`.
   * `email_message` (Optional) - The email message template. Must contain the `{####}` placeholder. **NOTE:** - If `email_verification_message` and `verification_message_template.email_message` are specified and the values are different, either one is prioritized and updated.
-  * `email_message_by_link` (Optional) - The email message template for sending a confirmation link to the user, it must contain the `{##VERIFY EMAIL##}` placeholder.
+  * `email_message_by_link` (Optional) - The email message template for sending a confirmation link to the user, it must contain the `{##Click Here##}` placeholder.
   * `email_subject` (Optional) - The subject line for the email message template. **NOTE:** - If `email_verification_subject` and `verification_message_template.email_subject` are specified and the values are different, either one is prioritized and updated.
   * `email_subject_by_link` (Optional) - The subject line for the email message template for sending a confirmation link to the user.
   * `sms_message` (Optional) - The SMS message template. Must contain the `{####}` placeholder.


### PR DESCRIPTION
Fix documentation error on the verify by link for Cognito Pool.

With {##VERIFY EMAIL##} we get:
 
```
* module.cognito.aws_cognito_user_pool.pool: 1 error(s) occurred:

* aws_cognito_user_pool.pool: Error updating Cognito User pool: InvalidParameterException: The message is invalid.
        status code: 400, request id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx
```

But with this change ( {##Click Here##} ) we get the proper response:

```
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

