### PR TITLE
resource/aws_ecs_service: Continue supporting replica deployment_minimum_healthy_percent = 0 and deployment_maximum_percent = 100

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -380,6 +380,29 @@ func TestAccAWSEcsService_withDeploymentValues(t *testing.T) {
 	})
 }
 
+// Regression for https://github.com/terraform-providers/terraform-provider-aws/issues/6315
+func TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred(t *testing.T) {
+	var service ecs.Service
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecs_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsServiceConfigDeploymentPercents(rName, 0, 100),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists(resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "deployment_maximum_percent", "100"),
+					resource.TestCheckResourceAttr(resourceName, "deployment_minimum_healthy_percent", "0"),
+				),
+			},
+		},
+	})
+}
+
 // Regression for https://github.com/hashicorp/terraform/issues/3444
 func TestAccAWSEcsService_withLbChanges(t *testing.T) {
 	var service ecs.Service
@@ -692,7 +715,7 @@ func TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum(t *te
 	tdName := fmt.Sprintf("tf-acc-td-svc-w-ss-daemon-%s", rString)
 	svcName := fmt.Sprintf("tf-acc-svc-w-ss-daemon-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
@@ -2189,6 +2212,39 @@ resource "aws_ecs_service" "ghost" {
   deployment_minimum_healthy_percent = "50"
 }
 `, clusterName, tdName, svcName)
+}
+
+func testAccAWSEcsServiceConfigDeploymentPercents(rName string, deploymentMinimumHealthyPercent, deploymentMaximumPercent int) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family = %q
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "test" {
+  cluster                            = "${aws_ecs_cluster.test.id}"
+  deployment_maximum_percent         = %d
+  deployment_minimum_healthy_percent = %d
+  desired_count                      = 1
+  name                               = %q
+  task_definition                    = "${aws_ecs_task_definition.test.arn}"
+}
+`, rName, rName, deploymentMaximumPercent, deploymentMinimumHealthyPercent, rName)
 }
 
 func testAccAWSEcsServiceWithReplicaSchedulingStrategy(clusterName, tdName, svcName string) string {


### PR DESCRIPTION
This PR reverts some unexpected behaviors introduced by #6150 -- the defaults are safe to re-add as they match the API and previous resource schema.

Fixes #6315 

Changes proposed in this pull request:

* Cleanup handling of replica versus daemon in Create/Update
* Add acceptance test for replica strategy with deployment minimum 0 and maximum 100
* Switch `TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum` to `resource.ParallelTest()` to match other tests

Previously:

```
--- FAIL: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (8.16s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_ecs_service.test: 1 error occurred:
        	* aws_ecs_service.test: InvalidParameterException: Both maximumPercent and minimumHealthyPercent cannot be 100 as this will block deployments.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (248.39s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (30.56s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (15.64s)
--- PASS: TestAccAWSEcsService_disappears (20.72s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (14.37s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (30.45s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (30.86s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (30.93s)
--- PASS: TestAccAWSEcsService_basicImport (33.06s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (36.79s)
--- PASS: TestAccAWSEcsService_withARN (38.20s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (40.93s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (41.09s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (41.43s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (50.67s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (52.10s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (63.64s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (77.10s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (105.04s)
--- PASS: TestAccAWSEcsService_withIamRole (130.78s)
--- PASS: TestAccAWSEcsService_withLbChanges (218.96s)
--- PASS: TestAccAWSEcsService_withAlb (243.76s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (264.39s)
```
