### PR TITLE
aws_ssm_parameter data source doesn't allow you to store a parameter

### DIFF
--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -12,8 +12,6 @@ Provides an SSM Parameter data source.
 
 ## Example Usage
 
-To store a basic string parameter:
-
 ```hcl
 data "aws_ssm_parameter" "foo" {
   name  = "foo"


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove statement which claims the aws_ssm_parameter data source example is storing a parameter