### PR TITLE
service/elbv2: Prevent panics with actions deleted outside Terraform

### DIFF
--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -550,9 +551,11 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("certificate_arn", listener.Certificates[0].CertificateArn)
 	}
 
-	sortedActions := sortActionsBasedonTypeinTFFile("default_action", listener.DefaultActions, d)
-	defaultActions := make([]interface{}, len(sortedActions))
-	for i, defaultAction := range sortedActions {
+	sort.Slice(listener.DefaultActions, func(i, j int) bool {
+		return aws.Int64Value(listener.DefaultActions[i].Order) < aws.Int64Value(listener.DefaultActions[j].Order)
+	})
+	defaultActions := make([]interface{}, len(listener.DefaultActions))
+	for i, defaultAction := range listener.DefaultActions {
 		defaultActionMap := make(map[string]interface{})
 		defaultActionMap["type"] = aws.StringValue(defaultAction.Type)
 		defaultActionMap["order"] = aws.Int64Value(defaultAction.Order)

--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -557,9 +557,11 @@ func resourceAwsLbListenerRuleRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	sortedActions := sortActionsBasedonTypeinTFFile("action", rule.Actions, d)
-	actions := make([]interface{}, len(sortedActions))
-	for i, action := range sortedActions {
+	sort.Slice(rule.Actions, func(i, j int) bool {
+		return aws.Int64Value(rule.Actions[i].Order) < aws.Int64Value(rule.Actions[j].Order)
+	})
+	actions := make([]interface{}, len(rule.Actions))
+	for i, action := range rule.Actions {
 		actionMap := make(map[string]interface{})
 		actionMap["type"] = aws.StringValue(action.Type)
 		actionMap["order"] = aws.Int64Value(action.Order)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -29,7 +29,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
 	"github.com/aws/aws-sdk-go/service/elb"
-	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iot"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -1906,20 +1905,6 @@ func sortListBasedonTFFile(in []string, d *schema.ResourceData, listName string)
 		return in, nil
 	}
 	return in, fmt.Errorf("Could not find list: %s", listName)
-}
-
-// This function sorts LB Actions to look like whats found in the tf file
-func sortActionsBasedonTypeinTFFile(actionName string, actions []*elbv2.Action, d *schema.ResourceData) []*elbv2.Action {
-	actionCount := d.Get(actionName + ".#").(int)
-	for i := 0; i < actionCount; i++ {
-		currAction := d.Get(actionName + "." + strconv.Itoa(i)).(map[string]interface{})
-		for j, action := range actions {
-			if currAction["type"].(string) == aws.StringValue(action.Type) {
-				actions[i], actions[j] = actions[j], actions[i]
-			}
-		}
-	}
-	return actions
 }
 
 func flattenApiGatewayThrottleSettings(settings *apigateway.ThrottleSettings) []map[string]interface{} {


### PR DESCRIPTION
We will now always sort the API response by Action.Order for reading into the Terraform state. This could potentially cause a plan difference in configurations which list actions out of order so will need a note in the CHANGELOG, however this behavior seems more desirable than switching to schema.TypeSet and removing the ability to omit order from configurations.

Fixes #6171 
Fixes #6256

Changes proposed in this pull request:

* Remove `sortActionsBasedonTypeinTFFile()` which did not account for actions performed outside Terraform and instead sort `listener.DefaultActions` by `Order` and `rule.Actions` by `Order`
* Add acceptance testing to cover scenario

Previously:

```
=== CONT  TestAccAWSLBListener_DefaultAction_Order_Recreates
panic: runtime error: index out of range

goroutine 2681 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.sortActionsBasedonTypeinTFFile(0x441e604, 0xe, 0xc00000f5f0, 0x1, 0x1, 0xc00078ddc0, 0x0, 0xc000702ac0, 0x39eee80)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/structure.go:1918 +0x313
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsLbListenerRead(0xc00078ddc0, 0x3e81980, 0xc0005f6000, 0xc00078ddc0, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_lb_listener.go:553 +0x3ff
=== CONT  TestAccAWSLBListenerRule_Action_Order_Recreates
panic: runtime error: index out of range

goroutine 2952 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.sortActionsBasedonTypeinTFFile(0x440a5f0, 0x6, 0xc000612aa0, 0x1, 0x1, 0xc000320000, 0x0, 0xc000cb91f0, 0x1015115)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/structure.go:1918 +0x313
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsLbListenerRuleRead(0xc000320000, 0x3e82320, 0xc00078c000, 0xc000320000, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_lb_listener_rule.go:560 +0x3a2
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (1.88s)
--- PASS: TestAccAWSLBListener_basic (197.21s)
--- PASS: TestAccAWSLBListener_cognito (215.75s)
--- PASS: TestAccAWSLBListenerRule_redirect (229.92s)
--- PASS: TestAccAWSLBListenerRule_basic (231.29s)
--- PASS: TestAccAWSLBListenerRule_cognito (232.58s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (238.55s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (239.66s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (246.70s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (250.83s)
--- PASS: TestAccAWSLBListenerRule_oidc (251.18s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (252.49s)
--- PASS: TestAccAWSLBListener_fixedResponse (266.42s)
--- PASS: TestAccAWSLBListener_oidc (284.99s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (303.61s)
--- PASS: TestAccAWSLBListener_redirect (308.81s)
--- PASS: TestAccAWSLBListener_https (335.90s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (346.05s)
--- PASS: TestAccAWSLBListenerRule_priority (416.86s)
```
