### PR TITLE
Bump timeout for subnet delete from 10 to 20 mins

### DIFF
--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -24,7 +24,7 @@ func resourceAwsSubnet() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		SchemaVersion: 1,
@@ -129,7 +129,7 @@ func resourceAwsSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 		Pending: []string{"pending"},
 		Target:  []string{"available"},
 		Refresh: SubnetStateRefreshFunc(conn, *subnet.SubnetId),
-		Timeout: 10 * time.Minute,
+		Timeout: d.Timeout(schema.TimeoutCreate),
 	}
 
 	_, err = stateConf.WaitForState()
@@ -330,7 +330,7 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 	wait := resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     []string{"destroyed"},
-		Timeout:    10 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			_, err := conn.DeleteSubnet(req)


### PR DESCRIPTION
We've seen subnet deletion failures that we think we can trace to ENIs left behind by NLB. We don't have permission to detach or delete those ENIs, so our only recourse is to wait longer.

Both the state change timeout and the overall resource timeout is increased.

```
$ make testacc TESTARGS='-run=TestAccAWSSubnet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSubnet -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSubnet_importBasic
=== PAUSE TestAccAWSSubnet_importBasic
=== RUN   TestAccAWSSubnet_basic
=== PAUSE TestAccAWSSubnet_basic
=== RUN   TestAccAWSSubnet_ipv6
=== PAUSE TestAccAWSSubnet_ipv6
=== RUN   TestAccAWSSubnet_enableIpv6
=== PAUSE TestAccAWSSubnet_enableIpv6
=== CONT  TestAccAWSSubnet_importBasic
=== CONT  TestAccAWSSubnet_enableIpv6
=== CONT  TestAccAWSSubnet_ipv6
=== CONT  TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (23.14s)
--- PASS: TestAccAWSSubnet_importBasic (23.44s)
--- PASS: TestAccAWSSubnet_enableIpv6 (37.74s)
--- PASS: TestAccAWSSubnet_ipv6 (60.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	60.779s
```