### PR TITLE
resource/aws_launch_configuration: Add support for capacity reservations

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -139,6 +139,37 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 				},
 			},
 
+			"capacity_reservation_specification": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"capacity_reservation_preference": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								ec2.CapacityReservationPreferenceOpen,
+								ec2.CapacityReservationPreferenceNone,
+							}, false),
+						},
+						"capacity_reservation_target": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"capacity_reservation_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"credit_specification": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -574,6 +605,10 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
+	if err := d.Set("capacity_reservation_specification", getCapacityReservationSpecification(ltData.CapacityReservationSpecification)); err != nil {
+		return err
+	}
+
 	if strings.HasPrefix(aws.StringValue(ltData.InstanceType), "t2") || strings.HasPrefix(aws.StringValue(ltData.InstanceType), "t3") {
 		if err := d.Set("credit_specification", getCreditSpecification(ltData.CreditSpecification)); err != nil {
 			return err
@@ -702,6 +737,27 @@ func getBlockDeviceMappings(m []*ec2.LaunchTemplateBlockDeviceMapping) []interfa
 			mapping["ebs"] = []interface{}{ebs}
 		}
 		s = append(s, mapping)
+	}
+	return s
+}
+
+func getCapacityReservationSpecification(crs *ec2.LaunchTemplateCapacityReservationSpecificationResponse) []interface{} {
+	s := []interface{}{}
+	if crs != nil {
+		s = append(s, map[string]interface{}{
+			"capacity_reservation_preference": aws.StringValue(crs.CapacityReservationPreference),
+			"capacity_reservation_target":     getCapacityReservationTarget(crs.CapacityReservationTarget),
+		})
+	}
+	return s
+}
+
+func getCapacityReservationTarget(crt *ec2.CapacityReservationTargetResponse) []interface{} {
+	s := []interface{}{}
+	if crt != nil {
+		s = append(s, map[string]interface{}{
+			"capacity_reservation_id": aws.StringValue(crt.CapacityReservationId),
+		})
 	}
 	return s
 }
@@ -931,6 +987,14 @@ func buildLaunchTemplateData(d *schema.ResourceData, meta interface{}) (*ec2.Req
 			blockDeviceMappings = append(blockDeviceMappings, blockDeviceMapping)
 		}
 		opts.BlockDeviceMappings = blockDeviceMappings
+	}
+
+	if v, ok := d.GetOk("capacity_reservation_specification"); ok {
+		crs := v.([]interface{})
+
+		if len(crs) > 0 {
+			opts.CapacityReservationSpecification = readCapacityReservationSpecificationFromConfig(crs[0].(map[string]interface{}))
+		}
 	}
 
 	if v, ok := d.GetOk("credit_specification"); ok && (strings.HasPrefix(instanceType, "t2") || strings.HasPrefix(instanceType, "t3")) {
@@ -1172,6 +1236,34 @@ func readIamInstanceProfileFromConfig(iip map[string]interface{}) *ec2.LaunchTem
 	}
 
 	return iamInstanceProfile
+}
+
+func readCapacityReservationSpecificationFromConfig(crs map[string]interface{}) *ec2.LaunchTemplateCapacityReservationSpecificationRequest {
+	capacityReservationSpecification := &ec2.LaunchTemplateCapacityReservationSpecificationRequest{}
+
+	if v, ok := crs["capacity_reservation_preference"].(string); ok && v != "" {
+		capacityReservationSpecification.CapacityReservationPreference = aws.String(v)
+	}
+
+	if v, ok := crs["capacity_reservation_target"]; ok {
+		crt := v.([]interface{})
+
+		if len(crt) > 0 {
+			capacityReservationSpecification.CapacityReservationTarget = readCapacityReservationTargetFromConfig(crt[0].(map[string]interface{}))
+		}
+	}
+
+	return capacityReservationSpecification
+}
+
+func readCapacityReservationTargetFromConfig(crt map[string]interface{}) *ec2.CapacityReservationTarget {
+	capacityReservationTarget := &ec2.CapacityReservationTarget{}
+
+	if v, ok := crt["capacity_reservation_id"].(string); ok && v != "" {
+		capacityReservationTarget.CapacityReservationId = aws.String(v)
+	}
+
+	return capacityReservationTarget
 }
 
 func readCreditSpecificationFromConfig(cs map[string]interface{}) *ec2.CreditSpecificationRequest {

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -23,6 +23,10 @@ resource "aws_launch_template" "foo" {
     }
   }
 
+  capacity_reservation_specification {
+    capacity_reservation_preference = "open"
+  }
+
   credit_specification {
     cpu_credits = "standard"
   }
@@ -75,7 +79,7 @@ resource "aws_launch_template" "foo" {
       Name = "test"
     }
   }
-  
+
   user_data = "${base64encode(...)}"
 }
 ```
@@ -89,7 +93,8 @@ The following arguments are supported:
 * `description` - Description of the launch template.
 * `block_device_mappings` - Specify volumes to attach to the instance besides the volumes specified by the AMI.
   See [Block Devices](#block-devices) below for details.
-* `credit_specification` - Customize the credit specification of the instance. See [Credit 
+* `capacity_reservation_specification` - Targeting for EC2 capacity reservations. See [Capacity Reservation Specification](#capacity-reservation-specification) below for more details.
+* `credit_specification` - Customize the credit specification of the instance. See [Credit
   Specification](#credit-specification) below for more details.
 * `disable_api_termination` - If `true`, enables [EC2 Instance
   Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination)
@@ -107,7 +112,7 @@ The following arguments are supported:
 * `kernel_id` - The kernel ID.
 * `key_name` - The key name to use for the instance.
 * `monitoring` - The monitoring option for the instance. See [Monitoring](#monitoring) below for more details.
-* `network_interfaces` - Customize network interfaces to be attached at instance boot time. See [Network 
+* `network_interfaces` - Customize network interfaces to be attached at instance boot time. See [Network
   Interfaces](#network-interfaces) below for more details.
 * `placement` - The placement of the instance. See [Placement](#placement) below for more details.
 * `ram_disk_id` - The ID of the RAM disk.
@@ -149,6 +154,17 @@ The `ebs` block supports the following:
 * `volume_size` - The size of the volume in gigabytes.
 * `volume_type` - The type of volume. Can be `"standard"`, `"gp2"`, or `"io1"`. (Default: `"standard"`).
 
+### Capacity Reservation Specification
+
+The `capacity_reservation_specification` block supports the following:
+
+* `capacity_reservation_preference` - Indicates the instance's Capacity Reservation preferences. Can be `open` or `none`. (Default `none`).
+* `capacity_reservation_target` - Used to target a specific Capacity Reservation:
+
+The `capacity_reservation_target` block supports the following:
+
+* `capacity_reservation_id` - The ID of the Capacity Reservation to target.
+
 ### Credit Specification
 
 Credit specification can be applied/modified to the EC2 Instance at any time.
@@ -187,7 +203,7 @@ The `instance_market_options` block supports the following:
 The `spot_options` block supports the following:
 
 * `block_duration_minutes` - The required duration in minutes. This value must be a multiple of 60.
-* `instance_interruption_behavior` - The behavior when a Spot Instance is interrupted. Can be `hibernate`, 
+* `instance_interruption_behavior` - The behavior when a Spot Instance is interrupted. Can be `hibernate`,
   `stop`, or `terminate`. (Default: `terminate`).
 * `max_price` - The maximum hourly price you're willing to pay for the Spot Instances.
 * `spot_instance_type` - The Spot Instance request type. Can be `one-time`, or `persistent`.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6323

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_capacityReservation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_capacityReservation -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (52.77s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (87.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	87.480s
```
