### PR TITLE
Fix typo on aws_s3_bucket_inventory

### DIFF
--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -38,6 +38,7 @@ resource "aws_s3_bucket_inventory" "test" {
       format = "ORC"
       bucket_arn = "${aws_s3_bucket.inventory.arn}"
     }
+  }
 }
 ```
 


### PR DESCRIPTION
The example usage is invalid because it's missing a closing curly brace.