### PR TITLE
Issue #4655 Add ability to set default version of aws_launch_template

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -57,6 +57,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 
 			"default_version": {
 				Type:     schema.TypeInt,
+				Optional: true,
 				Computed: true,
 			},
 
@@ -676,6 +677,25 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Partial(false)
+
+	if v, ok := d.GetOk("default_version"); ok {
+		d.Partial(true)
+
+		modifyLaunchTemplateOpts := &ec2.ModifyLaunchTemplateInput{
+			ClientToken:      aws.String(resource.UniqueId()),
+			LaunchTemplateId: aws.String(d.Id()),
+			DefaultVersion:   aws.String(v.(string)),
+		}
+
+		_, modifyErr := conn.ModifyLaunchTemplate(modifyLaunchTemplateOpts)
+		if modifyErr != nil {
+			return modifyErr
+		} else {
+			d.SetPartial("default_version")
+		}
+
+		d.Partial(false)
+	}
 
 	return resourceAwsLaunchTemplateRead(d, meta)
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -430,6 +430,74 @@ func TestAccAWSLaunchTemplate_creditSpecification_t3(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_defaultVersion(t *testing.T) {
+	resName := "aws_launch_template.foo"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_defaultVersion(rInt, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "2"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchTemplate_updateDefaultVersion(t *testing.T) {
+	resName := "aws_launch_template.foo"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_updateDefaultVersion(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "2"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "1"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_updateDefaultVersion(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resName, "default_version", "4"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resName := "aws_launch_template.test"
@@ -857,6 +925,24 @@ resource "aws_launch_template" "foo" {
   }
 }
 `, instanceType, rName, cpuCredits)
+}
+
+func testAccAWSLaunchTemplateConfig_defaultVersion(rInt, defaultVersion int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "foo" {
+	name            = "foo_%d"
+	default_version = %d
+}
+`, rInt, defaultVersion)
+}
+
+func testAccAWSLaunchTemplateConfig_updateDefaultVersion(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "foo" {
+	name                   = "foo_%d"
+	update_default_version = true
+}
+`, rInt)
 }
 
 const testAccAWSLaunchTemplateConfig_networkInterface = `

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -96,6 +96,7 @@ The following arguments are supported:
 * `capacity_reservation_specification` - Targeting for EC2 capacity reservations. See [Capacity Reservation Specification](#capacity-reservation-specification) below for more details.
 * `credit_specification` - Customize the credit specification of the instance. See [Credit
   Specification](#credit-specification) below for more details.
+* `default_version` - The default version of the launch template.
 * `disable_api_termination` - If `true`, enables [EC2 Instance
   Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination)
 * `ebs_optimized` - If `true`, the launched EC2 instance will be EBS-optimized.
@@ -121,6 +122,7 @@ The following arguments are supported:
 * `vpc_security_group_ids` - A list of security group IDs to associate with.
 * `tag_specifications` - The tags to apply to the resources during launch. See [Tags](#tags) below for more details.
 * `tags` - (Optional) A mapping of tags to assign to the launch template.
+* `update_default_version` - (Optional) If `true`, sets the default version of launch template to the latest version.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
 
 ### Block devices
@@ -265,7 +267,6 @@ The following attributes are exported along with all argument references:
 
 * `arn` - Amazon Resource Name (ARN) of the launch template.
 * `id` - The ID of the launch template.
-* `default_version` - The default version of the launch template.
 * `latest_version` - The latest version of the launch template.
 
 ## Import


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4655

Admittedly I didn't realize there was already an open PR (https://github.com/terraform-providers/terraform-provider-aws/pull/5225) to implement this issue. I hope this PR doesn't step on any toes but it doesn't look like there's any recent activity in https://github.com/terraform-providers/terraform-provider-aws/pull/5225 so I figure it can't hurt to give it a shot myself. Plus I'm really eager to have this feature since the project I'm working on could really benefit from it. This is my first time attempting to contribute to an open source project so feedback is greatly appreciated.

Changes proposed in this pull request:

* Change `default_version` to an optional parameter to update the default version
* Add `update_default_version` optional parameter (conflicts with `default_version`) to update the default version to the latest version

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_ -timeout 120m
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (8.17s)
--- PASS: TestAccAWSLaunchTemplate_disappears (13.18s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (15.31s)
--- PASS: TestAccAWSLaunchTemplate_data (15.53s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (15.70s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (15.71s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (15.82s)
--- PASS: TestAccAWSLaunchTemplate_basic (16.20s)
--- PASS: TestAccAWSLaunchTemplate_importData (16.77s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (17.43s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (10.28s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (20.75s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (21.23s)
--- PASS: TestAccAWSLaunchTemplate_tags (26.12s)
--- PASS: TestAccAWSLaunchTemplate_defaultVersion (34.00s)
--- PASS: TestAccAWSLaunchTemplate_updateDefaultVersion (42.99s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (50.28s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (50.67s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (51.22s)
--- PASS: TestAccAWSLaunchTemplate_update (57.45s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (57.85s)
PASS
ok	github.com/terraform-providers/terraform-provider-aws/aws	57.893s
```