### PR TITLE
Added invoke_arn to lambda alias resource (GH-4479)

### DIFF
--- a/aws/resource_aws_lambda_alias.go
+++ b/aws/resource_aws_lambda_alias.go
@@ -40,6 +40,10 @@ func resourceAwsLambdaAlias() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"invoke_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"routing_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -113,6 +117,9 @@ func resourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("function_version", aliasConfiguration.FunctionVersion)
 	d.Set("name", aliasConfiguration.Name)
 	d.Set("arn", aliasConfiguration.AliasArn)
+
+	invokeArn := lambdaFunctionInvokeArn(*aliasConfiguration.AliasArn, meta)
+	d.Set("invoke_arn", invokeArn)
 
 	if err := d.Set("routing_config", flattenLambdaAliasRoutingConfiguration(aliasConfiguration.RoutingConfig)); err != nil {
 		return fmt.Errorf("error setting routing_config: %s", err)

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -563,13 +563,7 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("qualified_arn", lastQualifiedArn)
 	}
 
-	invokeArn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "apigateway",
-		Region:    meta.(*AWSClient).region,
-		AccountID: "lambda",
-		Resource:  fmt.Sprintf("path/2015-03-31/functions/%s/invocations", *function.FunctionArn),
-	}.String()
+	invokeArn := lambdaFunctionInvokeArn(*function.FunctionArn, meta)
 	d.Set("invoke_arn", invokeArn)
 
 	return nil
@@ -880,4 +874,14 @@ func readEnvironmentVariables(ev map[string]interface{}) map[string]string {
 	}
 
 	return variables
+}
+
+func lambdaFunctionInvokeArn(functionArn string, meta interface{}) string {
+	return arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "apigateway",
+		Region:    meta.(*AWSClient).region,
+		AccountID: "lambda",
+		Resource:  fmt.Sprintf("path/2015-03-31/functions/%s/invocations", functionArn),
+	}.String()
 }

--- a/website/docs/r/lambda_alias.html.markdown
+++ b/website/docs/r/lambda_alias.html.markdown
@@ -44,8 +44,8 @@ For **routing_config** the following attributes are supported:
 ## Attributes Reference
 
 * `arn` - The Amazon Resource Name (ARN) identifying your Lambda function alias.
+* `invoke_arn` - The ARN to be used for invoking Lambda Function from API Gateway - to be used in [`aws_api_gateway_integration`](/docs/providers/aws/r/api_gateway_integration.html)'s `uri`
 
 [1]: http://docs.aws.amazon.com/lambda/latest/dg/welcome.html
 [2]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/API_AliasRoutingConfiguration.html
-


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4479

Changes proposed in this pull request:

* Added invoke_arn to the AWS Lambda Alias resource
* Refactored AWS Lambda Function to DRY the interpolation of invoke_arn

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction TestAccAWSLambdaAlias'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaFunction TestAccAWSLambdaAlias -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLambdaFunction_importLocalFile
=== PAUSE TestAccAWSLambdaFunction_importLocalFile
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
=== PAUSE TestAccAWSLambdaFunction_importLocalFile_VPC
=== RUN   TestAccAWSLambdaFunction_importS3
=== PAUSE TestAccAWSLambdaFunction_importS3
=== RUN   TestAccAWSLambdaFunction_basic
=== PAUSE TestAccAWSLambdaFunction_basic
=== RUN   TestAccAWSLambdaFunction_concurrency
=== PAUSE TestAccAWSLambdaFunction_concurrency
=== RUN   TestAccAWSLambdaFunction_concurrencyCycle
=== PAUSE TestAccAWSLambdaFunction_concurrencyCycle
=== RUN   TestAccAWSLambdaFunction_updateRuntime
=== PAUSE TestAccAWSLambdaFunction_updateRuntime
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== PAUSE TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
=== RUN   TestAccAWSLambdaFunction_envVariables
=== PAUSE TestAccAWSLambdaFunction_envVariables
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
=== PAUSE TestAccAWSLambdaFunction_encryptedEnvVariables
=== RUN   TestAccAWSLambdaFunction_versioned
=== PAUSE TestAccAWSLambdaFunction_versioned
=== RUN   TestAccAWSLambdaFunction_versionedUpdate
=== PAUSE TestAccAWSLambdaFunction_versionedUpdate
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== PAUSE TestAccAWSLambdaFunction_DeadLetterConfigUpdated
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
=== PAUSE TestAccAWSLambdaFunction_nilDeadLetterConfig
=== RUN   TestAccAWSLambdaFunction_tracingConfig
=== PAUSE TestAccAWSLambdaFunction_tracingConfig
=== RUN   TestAccAWSLambdaFunction_VPC
=== PAUSE TestAccAWSLambdaFunction_VPC
=== RUN   TestAccAWSLambdaFunction_VPCRemoval
=== PAUSE TestAccAWSLambdaFunction_VPCRemoval
=== RUN   TestAccAWSLambdaFunction_VPCUpdate
=== PAUSE TestAccAWSLambdaFunction_VPCUpdate
=== RUN   TestAccAWSLambdaFunction_VPC_withInvocation
=== PAUSE TestAccAWSLambdaFunction_VPC_withInvocation
=== RUN   TestAccAWSLambdaFunction_EmptyVpcConfig
=== PAUSE TestAccAWSLambdaFunction_EmptyVpcConfig
=== RUN   TestAccAWSLambdaFunction_s3
=== PAUSE TestAccAWSLambdaFunction_s3
=== RUN   TestAccAWSLambdaFunction_localUpdate
=== PAUSE TestAccAWSLambdaFunction_localUpdate
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
=== PAUSE TestAccAWSLambdaFunction_localUpdate_nameOnly
=== RUN   TestAccAWSLambdaFunction_s3Update_basic
=== PAUSE TestAccAWSLambdaFunction_s3Update_basic
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
=== PAUSE TestAccAWSLambdaFunction_s3Update_unversioned
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_noRuntime
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python27
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_java8
=== RUN   TestAccAWSLambdaFunction_tags
=== PAUSE TestAccAWSLambdaFunction_tags
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python36
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_python36
=== CONT  TestAccAWSLambdaFunction_importLocalFile
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python36
=== CONT  TestAccAWSLambdaFunction_tags
=== CONT  TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (56.75s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfigUpdated
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (78.18s)
=== CONT  TestAccAWSLambdaFunction_DeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_importLocalFile (78.67s)
=== CONT  TestAccAWSLambdaFunction_versionedUpdate
--- PASS: TestAccAWSLambdaFunction_tags (163.96s)
=== CONT  TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (125.69s)
=== CONT  TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (122.34s)
=== CONT  TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (128.24s)
=== CONT  TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_versioned (80.90s)
=== CONT  TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (55.16s)
=== CONT  TestAccAWSLambdaFunction_concurrencyCycle
--- FAIL: TestAccAWSLambdaFunction_encryptedEnvVariables (124.89s)
    testing.go:538: Step 1 error: Check failed: Check 5/5 error: aws_lambda_function.lambda_function_test: Attribute 'kms_key_arn' expected "", got "arn:aws:kms:us-west-2:552577692908:key/b9bdefa4-ef66-4a7a-bbbd-b52f0c5335f7"
=== CONT  TestAccAWSLambdaFunction_concurrency
--- PASS: TestAccAWSLambdaFunction_updateRuntime (117.87s)
=== CONT  TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_envVariables (202.86s)
=== CONT  TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (158.28s)
=== CONT  TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_concurrency (116.04s)
=== CONT  TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_basic (76.43s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_java8
--- PASS: TestAccAWSLambdaFunction_importS3 (85.79s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_python27
--- PASS: TestAccAWSLambdaFunction_localUpdate (80.72s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (78.62s)
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (100.33s)
=== CONT  TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (2.74s)
=== CONT  TestAccAWSLambdaFunction_s3Update_basic
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (76.82s)
=== CONT  TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs43 (81.36s)
=== CONT  TestAccAWSLambdaFunction_VPCUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (85.05s)
=== CONT  TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (138.01s)
=== CONT  TestAccAWSLambdaFunction_EmptyVpcConfig
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (138.15s)
=== CONT  TestAccAWSLambdaFunction_VPC_withInvocation
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (141.34s)
=== CONT  TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_s3 (75.95s)
=== CONT  TestAccAWSLambdaFunction_VPCRemoval
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (75.65s)
=== CONT  TestAccAWSLambdaFunction_tracingConfig
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (128.44s)
--- PASS: TestAccAWSLambdaFunction_VPC (366.11s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (531.76s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (525.40s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	1259.271s

```

Note: that TestAccAWSLambdaFunction_encryptedEnvVariables seems unrelated to these changes. I cam across #2959, not sure if it's related to that (although it's marked as closed). I'm not really sure what to do with this one...