### PR TITLE
tests/provider: Fix unparam Linting Issues and Enable in TravisCI Testing

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -9,6 +9,7 @@
         "misspell",
         "structcheck",
         "unconvert",
+        "unparam",
         "unused",
         "varcheck",
         "vet"

--- a/aws/autoscaling_tags.go
+++ b/aws/autoscaling_tags.go
@@ -58,8 +58,8 @@ func setAutoscalingTags(conn *autoscaling.AutoScaling, d *schema.ResourceData) e
 
 	if d.HasChange("tag") || d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tag")
-		o := setToMapByKey(oraw.(*schema.Set), "key")
-		n := setToMapByKey(nraw.(*schema.Set), "key")
+		o := setToMapByKey(oraw.(*schema.Set))
+		n := setToMapByKey(nraw.(*schema.Set))
 
 		old, err := autoscalingTagsFromMap(o, resourceID)
 		if err != nil {
@@ -262,11 +262,11 @@ func autoscalingTagDescriptionsToSlice(ts []*autoscaling.TagDescription) []map[s
 	return tags
 }
 
-func setToMapByKey(s *schema.Set, key string) map[string]interface{} {
+func setToMapByKey(s *schema.Set) map[string]interface{} {
 	result := make(map[string]interface{})
 	for _, rawData := range s.List() {
 		data := rawData.(map[string]interface{})
-		result[data[key].(string)] = data
+		result[data["key"].(string)] = data
 	}
 
 	return result

--- a/aws/awserr.go
+++ b/aws/awserr.go
@@ -19,12 +19,13 @@ func isAWSErr(err error, code string, message string) bool {
 	return false
 }
 
-// Returns true if the error matches all these conditions:
+// IsAWSErrExtended returns true if the error matches all conditions
 //  * err is of type awserr.Error
 //  * Error.Code() matches code
 //  * Error.Message() contains message
 //  * Error.OrigErr() contains origErrMessage
-func isAWSErrExtended(err error, code string, message string, origErrMessage string) bool {
+// Note: This function will be moved out of the aws package in the future.
+func IsAWSErrExtended(err error, code string, message string, origErrMessage string) bool {
 	if !isAWSErr(err, code, message) {
 		return false
 	}
@@ -48,7 +49,9 @@ func retryOnAwsCode(code string, f func() (interface{}, error)) (interface{}, er
 	return resp, err
 }
 
-func retryOnAwsCodes(codes []string, f func() (interface{}, error)) (interface{}, error) {
+// RetryOnAwsCodes retries AWS error codes for one minute
+// Note: This function will be moved out of the aws package in the future.
+func RetryOnAwsCodes(codes []string, f func() (interface{}, error)) (interface{}, error) {
 	var resp interface{}
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		var err error

--- a/aws/config.go
+++ b/aws/config.go
@@ -380,13 +380,13 @@ func (c *Config) Client() (interface{}, error) {
 		}
 		// RequestError: send request failed
 		// caused by: Post https://FQDN/: dial tcp: lookup FQDN: no such host
-		if isAWSErrExtended(r.Error, "RequestError", "send request failed", "no such host") {
+		if IsAWSErrExtended(r.Error, "RequestError", "send request failed", "no such host") {
 			log.Printf("[WARN] Disabling retries after next request due to networking issue")
 			r.Retryable = aws.Bool(false)
 		}
 		// RequestError: send request failed
 		// caused by: Post https://FQDN/: dial tcp IPADDRESS:443: connect: connection refused
-		if isAWSErrExtended(r.Error, "RequestError", "send request failed", "connection refused") {
+		if IsAWSErrExtended(r.Error, "RequestError", "send request failed", "connection refused") {
 			log.Printf("[WARN] Disabling retries after next request due to networking issue")
 			r.Retryable = aws.Bool(false)
 		}

--- a/aws/ecs_task_definition_equivalency.go
+++ b/aws/ecs_task_definition_equivalency.go
@@ -13,7 +13,9 @@ import (
 	"github.com/mitchellh/copystructure"
 )
 
-func ecsContainerDefinitionsAreEquivalent(def1, def2 string, isAWSVPC bool) (bool, error) {
+// EcsContainerDefinitionsAreEquivalent determines equality between two ECS container definition JSON strings
+// Note: This function will be moved out of the aws package in the future.
+func EcsContainerDefinitionsAreEquivalent(def1, def2 string, isAWSVPC bool) (bool, error) {
 	var obj1 containerDefinitions
 	err := json.Unmarshal([]byte(def1), &obj1)
 	if err != nil {

--- a/aws/ecs_task_definition_equivalency_test.go
+++ b/aws/ecs_task_definition_equivalency_test.go
@@ -78,7 +78,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_basic(t *testing.T) {
     }
 ]`
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	equal, err := EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_portMappings(t *testing.T) {
     }
 ]`
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	equal, err := EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_portMappingsIgnoreHostPort(t *t
 		err   error
 	)
 
-	equal, err = ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	equal, err = EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_portMappingsIgnoreHostPort(t *t
 		t.Fatal("Expected definitions to differ.")
 	}
 
-	equal, err = ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, true)
+	equal, err = EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -428,7 +428,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_arrays(t *testing.T) {
 ]
 `
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	equal, err := EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +466,7 @@ func TestAwsEcsContainerDefinitionsAreEquivalent_negative(t *testing.T) {
     }
 ]`
 
-	equal, err := ecsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
+	equal, err := EcsContainerDefinitionsAreEquivalent(cfgRepresention, apiRepresentation, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/aws/resource_aws_api_gateway_stage.go
+++ b/aws/resource_aws_api_gateway_stage.go
@@ -339,7 +339,7 @@ func resourceAwsApiGatewayStageUpdate(d *schema.ResourceData, meta interface{}) 
 		o, n := d.GetChange("variables")
 		oldV := o.(map[string]interface{})
 		newV := n.(map[string]interface{})
-		operations = append(operations, diffVariablesOps("/variables/", oldV, newV)...)
+		operations = append(operations, diffVariablesOps(oldV, newV)...)
 	}
 	if d.HasChange("access_log_settings") {
 		accessLogSettings := d.Get("access_log_settings").([]interface{})
@@ -411,8 +411,9 @@ func resourceAwsApiGatewayStageUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceAwsApiGatewayStageRead(d, meta)
 }
 
-func diffVariablesOps(prefix string, oldVars, newVars map[string]interface{}) []*apigateway.PatchOperation {
+func diffVariablesOps(oldVars, newVars map[string]interface{}) []*apigateway.PatchOperation {
 	ops := make([]*apigateway.PatchOperation, 0)
+	prefix := "/variables/"
 
 	for k := range oldVars {
 		if _, ok := newVars[k]; !ok {

--- a/aws/resource_aws_athena_database.go
+++ b/aws/resource_aws_athena_database.go
@@ -108,7 +108,7 @@ func resourceAwsAthenaDatabaseCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	if err := executeAndExpectNoRowsWhenCreate(*resp.QueryExecutionId, d, conn); err != nil {
+	if err := executeAndExpectNoRowsWhenCreate(*resp.QueryExecutionId, conn); err != nil {
 		return err
 	}
 	d.SetId(d.Get("name").(string))
@@ -169,13 +169,13 @@ func resourceAwsAthenaDatabaseDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	if err := executeAndExpectNoRowsWhenDrop(*resp.QueryExecutionId, d, conn); err != nil {
+	if err := executeAndExpectNoRowsWhenDrop(*resp.QueryExecutionId, conn); err != nil {
 		return err
 	}
 	return nil
 }
 
-func executeAndExpectNoRowsWhenCreate(qeid string, d *schema.ResourceData, conn *athena.Athena) error {
+func executeAndExpectNoRowsWhenCreate(qeid string, conn *athena.Athena) error {
 	rs, err := queryExecutionResult(qeid, conn)
 	if err != nil {
 		return err
@@ -201,7 +201,7 @@ func executeAndExpectMatchingRow(qeid string, dbName string, conn *athena.Athena
 	return fmt.Errorf("Athena not found database: %s, query result: %s", dbName, flattenAthenaResultSet(rs))
 }
 
-func executeAndExpectNoRowsWhenDrop(qeid string, d *schema.ResourceData, conn *athena.Athena) error {
+func executeAndExpectNoRowsWhenDrop(qeid string, conn *athena.Athena) error {
 	rs, err := queryExecutionResult(qeid, conn)
 	if err != nil {
 		return err

--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -410,7 +410,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("tag"); ok {
 		var err error
 		createOpts.Tags, err = autoscalingTagsFromMap(
-			setToMapByKey(v.(*schema.Set), "key"), resourceID)
+			setToMapByKey(v.(*schema.Set)), resourceID)
 		if err != nil {
 			return err
 		}
@@ -566,7 +566,7 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	var v interface{}
 
 	if v, tagOk = d.GetOk("tag"); tagOk {
-		tags := setToMapByKey(v.(*schema.Set), "key")
+		tags := setToMapByKey(v.(*schema.Set))
 		for _, t := range g.Tags {
 			if _, ok := tags[*t.Key]; ok {
 				tagList = append(tagList, t)

--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -138,13 +138,13 @@ func resourceAwsBatchJobQueueDelete(d *schema.ResourceData, meta interface{}) er
 	name := d.Get("name").(string)
 
 	log.Printf("[DEBUG] Disabling Batch Job Queue %s", name)
-	err := disableBatchJobQueue(name, 10*time.Minute, conn)
+	err := disableBatchJobQueue(name, conn)
 	if err != nil {
 		return fmt.Errorf("error disabling Batch Job Queue (%s): %s", name, err)
 	}
 
 	log.Printf("[DEBUG] Deleting Batch Job Queue %s", name)
-	err = deleteBatchJobQueue(name, 10*time.Minute, conn)
+	err = deleteBatchJobQueue(name, conn)
 	if err != nil {
 		return fmt.Errorf("error deleting Batch Job Queue (%s): %s", name, err)
 	}
@@ -162,7 +162,7 @@ func createComputeEnvironmentOrder(order []interface{}) (envs []*batch.ComputeEn
 	return
 }
 
-func deleteBatchJobQueue(jobQueue string, timeout time.Duration, conn *batch.Batch) error {
+func deleteBatchJobQueue(jobQueue string, conn *batch.Batch) error {
 	_, err := conn.DeleteJobQueue(&batch.DeleteJobQueueInput{
 		JobQueue: aws.String(jobQueue),
 	})
@@ -174,7 +174,7 @@ func deleteBatchJobQueue(jobQueue string, timeout time.Duration, conn *batch.Bat
 		Pending:    []string{batch.JQStateDisabled, batch.JQStatusDeleting},
 		Target:     []string{batch.JQStatusDeleted},
 		Refresh:    batchJobQueueRefreshStatusFunc(conn, jobQueue),
-		Timeout:    timeout,
+		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
@@ -183,7 +183,7 @@ func deleteBatchJobQueue(jobQueue string, timeout time.Duration, conn *batch.Bat
 	return err
 }
 
-func disableBatchJobQueue(jobQueue string, timeout time.Duration, conn *batch.Batch) error {
+func disableBatchJobQueue(jobQueue string, conn *batch.Batch) error {
 	_, err := conn.UpdateJobQueue(&batch.UpdateJobQueueInput{
 		JobQueue: aws.String(jobQueue),
 		State:    aws.String(batch.JQStateDisabled),
@@ -196,7 +196,7 @@ func disableBatchJobQueue(jobQueue string, timeout time.Duration, conn *batch.Ba
 		Pending:    []string{batch.JQStatusUpdating},
 		Target:     []string{batch.JQStatusValid},
 		Refresh:    batchJobQueueRefreshStatusFunc(conn, jobQueue),
-		Timeout:    timeout,
+		Timeout:    10 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/batch"
@@ -56,14 +55,14 @@ func testSweepBatchJobQueues(region string) error {
 		}
 
 		log.Printf("[INFO] Disabling Batch Job Queue: %s", *name)
-		err := disableBatchJobQueue(*name, 10*time.Minute, conn)
+		err := disableBatchJobQueue(*name, conn)
 		if err != nil {
 			log.Printf("[ERROR] Failed to disable Batch Job Queue %s: %s", *name, err)
 			continue
 		}
 
 		log.Printf("[INFO] Deleting Batch Job Queue: %s", *name)
-		err = deleteBatchJobQueue(*name, 10*time.Minute, conn)
+		err = deleteBatchJobQueue(*name, conn)
 		if err != nil {
 			log.Printf("[ERROR] Failed to delete Batch Job Queue %s: %s", *name, err)
 		}
@@ -218,12 +217,12 @@ func testAccCheckBatchJobQueueDisappears(jobQueue *batch.JobQueueDetail) resourc
 		conn := testAccProvider.Meta().(*AWSClient).batchconn
 		name := aws.StringValue(jobQueue.JobQueueName)
 
-		err := disableBatchJobQueue(name, 10*time.Minute, conn)
+		err := disableBatchJobQueue(name, conn)
 		if err != nil {
 			return fmt.Errorf("error disabling Batch Job Queue (%s): %s", name, err)
 		}
 
-		return deleteBatchJobQueue(name, 10*time.Minute, conn)
+		return deleteBatchJobQueue(name, conn)
 	}
 }
 

--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -48,7 +48,7 @@ func resourceAwsCloudWatchEventRule() *schema.Resource {
 			"event_pattern": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateEventPatternValue(2048),
+				ValidateFunc: validateEventPatternValue(),
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v.(string))
 					return json
@@ -281,7 +281,7 @@ func getStringStateFromBoolean(isEnabled bool) string {
 	return "DISABLED"
 }
 
-func validateEventPatternValue(length int) schema.SchemaValidateFunc {
+func validateEventPatternValue() schema.SchemaValidateFunc {
 	return func(v interface{}, k string) (ws []string, errors []error) {
 		json, err := structure.NormalizeJsonString(v)
 		if err != nil {
@@ -294,9 +294,9 @@ func validateEventPatternValue(length int) schema.SchemaValidateFunc {
 		}
 
 		// Check whether the normalized JSON is within the given length.
-		if len(json) > length {
+		if len(json) > 2048 {
 			errors = append(errors, fmt.Errorf(
-				"%q cannot be longer than %d characters: %q", k, length, json))
+				"%q cannot be longer than %d characters: %q", k, 2048, json))
 		}
 		return
 	}

--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -269,31 +269,27 @@ func testAccCheckAWSCloudWatchEventRuleDestroy(s *terraform.State) error {
 
 func TestResourceAWSCloudWatchEventRule_validateEventPatternValue(t *testing.T) {
 	type testCases struct {
-		Length   int
 		Value    string
 		ErrCount int
 	}
 
 	invalidCases := []testCases{
 		{
-			Length:   8,
-			Value:    acctest.RandString(16),
+			Value:    acctest.RandString(2049),
 			ErrCount: 1,
 		},
 		{
-			Length:   123,
-			Value:    `{"abc":}`,
+			Value:    `not-json`,
 			ErrCount: 1,
 		},
 		{
-			Length:   1,
-			Value:    `{"abc":["1","2"]}`,
+			Value:    fmt.Sprintf("{%q:[1, 2]}", acctest.RandString(2049)),
 			ErrCount: 1,
 		},
 	}
 
 	for _, tc := range invalidCases {
-		_, errors := validateEventPatternValue(tc.Length)(tc.Value, "event_pattern")
+		_, errors := validateEventPatternValue()(tc.Value, "event_pattern")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
 		}
@@ -301,24 +297,21 @@ func TestResourceAWSCloudWatchEventRule_validateEventPatternValue(t *testing.T) 
 
 	validCases := []testCases{
 		{
-			Length:   0,
 			Value:    ``,
 			ErrCount: 0,
 		},
 		{
-			Length:   2,
 			Value:    `{}`,
 			ErrCount: 0,
 		},
 		{
-			Length:   18,
 			Value:    `{"abc":["1","2"]}`,
 			ErrCount: 0,
 		},
 	}
 
 	for _, tc := range validCases {
-		_, errors := validateEventPatternValue(tc.Length)(tc.Value, "event_pattern")
+		_, errors := validateEventPatternValue()(tc.Value, "event_pattern")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
 		}

--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -109,7 +109,7 @@ func resourceAwsCodeDeployAppCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsCodeDeployAppRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codedeployconn
 
-	_, application := resourceAwsCodeDeployAppParseId(d.Id())
+	application := resourceAwsCodeDeployAppParseId(d.Id())
 	log.Printf("[DEBUG] Reading CodeDeploy application %s", application)
 	resp, err := conn.GetApplication(&codedeploy.GetApplicationInput{
 		ApplicationName: aws.String(application),
@@ -167,7 +167,8 @@ func resourceAwsCodeDeployAppDelete(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-func resourceAwsCodeDeployAppParseId(id string) (string, string) {
+func resourceAwsCodeDeployAppParseId(id string) string {
 	parts := strings.SplitN(id, ":", 2)
-	return parts[0], parts[1]
+	// We currently omit the application ID as it is not currently used anywhere
+	return parts[1]
 }

--- a/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -118,7 +118,7 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentCreate(d *schema.ResourceData,
 
 	// Validates role keys to be either authenticated or unauthenticated,
 	// since ValidateFunc validates only the value not the key.
-	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles"); len(errors) > 0 {
+	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{})); len(errors) > 0 {
 		return fmt.Errorf("Error validating Roles: %v", errors)
 	}
 
@@ -180,7 +180,7 @@ func resourceAwsCognitoIdentityPoolRolesAttachmentUpdate(d *schema.ResourceData,
 
 	// Validates role keys to be either authenticated or unauthenticated,
 	// since ValidateFunc validates only the value not the key.
-	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles"); len(errors) > 0 {
+	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{})); len(errors) > 0 {
 		return fmt.Errorf("Error validating Roles: %v", errors)
 	}
 

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -482,7 +482,7 @@ func resourceAwsDirectoryServiceDirectoryDelete(d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Waiting for Directory Service Directory (%q) to be deleted", d.Id())
-	err = waitForDirectoryServiceDirectoryDeletion(dsconn, d.Id(), 60*time.Minute)
+	err = waitForDirectoryServiceDirectoryDeletion(dsconn, d.Id())
 	if err != nil {
 		return fmt.Errorf("error waiting for Directory Service (%s) to be deleted: %s", d.Id(), err)
 	}
@@ -490,7 +490,7 @@ func resourceAwsDirectoryServiceDirectoryDelete(d *schema.ResourceData, meta int
 	return nil
 }
 
-func waitForDirectoryServiceDirectoryDeletion(conn *directoryservice.DirectoryService, directoryID string, timeout time.Duration) error {
+func waitForDirectoryServiceDirectoryDeletion(conn *directoryservice.DirectoryService, directoryID string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{
 			directoryservice.DirectoryStageActive,
@@ -516,7 +516,7 @@ func waitForDirectoryServiceDirectoryDeletion(conn *directoryservice.DirectorySe
 			log.Printf("[DEBUG] Deletion of Directory Service Directory %q is in following stage: %q.", directoryID, aws.StringValue(ds.Stage))
 			return ds, aws.StringValue(ds.Stage), nil
 		},
-		Timeout: timeout,
+		Timeout: 60 * time.Minute,
 	}
 	_, err := stateConf.WaitForState()
 

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -63,7 +62,7 @@ func testSweepDirectoryServiceDirectories(region string) error {
 			}
 
 			log.Printf("[INFO] Waiting for Directory Service Directory (%q) to be deleted", id)
-			err = waitForDirectoryServiceDirectoryDeletion(conn, id, 60*time.Minute)
+			err = waitForDirectoryServiceDirectoryDeletion(conn, id)
 			if err != nil {
 				return fmt.Errorf("error waiting for Directory Service (%s) to be deleted: %s", id, err)
 			}

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -56,7 +56,7 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					networkMode, ok := d.GetOk("network_mode")
 					isAWSVPC := ok && networkMode.(string) == ecs.NetworkModeAwsvpc
-					equal, _ := ecsContainerDefinitionsAreEquivalent(old, new, isAWSVPC)
+					equal, _ := EcsContainerDefinitionsAreEquivalent(old, new, isAWSVPC)
 					return equal
 				},
 				ValidateFunc: validateAwsEcsTaskDefinitionContainerDefinitions,

--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -323,11 +323,18 @@ func expandETPermList(permissions *schema.Set) []*elastictranscoder.Permission {
 	var perms []*elastictranscoder.Permission
 
 	for _, p := range permissions.List() {
+		if p == nil {
+			continue
+		}
+
+		m := p.(map[string]interface{})
+
 		perm := &elastictranscoder.Permission{
-			Access:      getStringPtrList(p.(map[string]interface{}), "access"),
+			Access:      expandStringList(m["access"].([]interface{})),
 			Grantee:     getStringPtr(p, "grantee"),
 			GranteeType: getStringPtr(p, "grantee_type"),
 		}
+
 		perms = append(perms, perm)
 	}
 	return perms

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -576,7 +576,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 		n := nraw.(int)
 		if n < o {
 			log.Printf("[INFO] Cluster %s is marked for Decreasing cache nodes from %d to %d", d.Id(), o, n)
-			nodesToRemove := getCacheNodesToRemove(d, o, o-n)
+			nodesToRemove := getCacheNodesToRemove(o, o-n)
 			req.CacheNodeIdsToRemove = nodesToRemove
 		} else {
 			log.Printf("[INFO] Cluster %s is marked for increasing cache nodes from %d to %d", d.Id(), o, n)
@@ -628,7 +628,7 @@ func resourceAwsElasticacheClusterUpdate(d *schema.ResourceData, meta interface{
 	return resourceAwsElasticacheClusterRead(d, meta)
 }
 
-func getCacheNodesToRemove(d *schema.ResourceData, oldNumberOfNodes int, cacheNodesToRemove int) []*string {
+func getCacheNodesToRemove(oldNumberOfNodes int, cacheNodesToRemove int) []*string {
 	nodesIdsToRemove := []*string{}
 	for i := oldNumberOfNodes; i > oldNumberOfNodes-cacheNodesToRemove && i > 0; i-- {
 		s := fmt.Sprintf("%04d", i)

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -57,7 +57,7 @@ func testSweepElasticacheReplicationGroups(region string) error {
 				continue
 			}
 			log.Printf("[INFO] Deleting Elasticache Replication Group: %s", id)
-			err := deleteElasticacheReplicationGroup(id, 40*time.Minute, conn)
+			err := deleteElasticacheReplicationGroup(id, conn)
 			if err != nil {
 				log.Printf("[ERROR] Failed to delete Elasticache Replication Group (%s): %s", id, err)
 			}

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1303,7 +1303,7 @@ func expandInstanceGroupConfigs(instanceGroupConfigs []interface{}) ([]*emr.Inst
 		applyBidPrice(config, configAttributes)
 		applyEbsConfig(configAttributes, config)
 
-		if v, ok := configAttributes["autoscaling_policy"]; ok {
+		if v, ok := configAttributes["autoscaling_policy"]; ok && v.(string) != "" {
 			var autoScalingPolicy *emr.AutoScalingPolicy
 
 			err := json.Unmarshal([]byte(v.(string)), &autoScalingPolicy)

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -488,7 +488,13 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	if v, ok := d.GetOk("instance_group"); ok {
 		instanceGroupConfigs := v.(*schema.Set).List()
-		instanceConfig.InstanceGroups = expandInstanceGroupConfigs(instanceGroupConfigs)
+		instanceGroups, err := expandInstanceGroupConfigs(instanceGroupConfigs)
+
+		if err != nil {
+			return fmt.Errorf("error parsing EMR instance groups configuration: %s", err)
+		}
+
+		instanceConfig.InstanceGroups = instanceGroups
 	}
 
 	emrApps := expandApplications(applications)
@@ -655,7 +661,7 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	instanceGroups, err := fetchAllEMRInstanceGroups(emrconn, d.Id())
 	if err == nil {
-		coreGroup := findGroup(instanceGroups, "CORE")
+		coreGroup := emrCoreInstanceGroup(instanceGroups)
 		if coreGroup != nil {
 			d.Set("core_instance_type", coreGroup.InstanceType)
 		}
@@ -765,7 +771,7 @@ func resourceAwsEMRClusterUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		coreInstanceCount := d.Get("core_instance_count").(int)
-		coreGroup := findGroup(groups, "CORE")
+		coreGroup := emrCoreInstanceGroup(groups)
 		if coreGroup == nil {
 			return fmt.Errorf("Error finding core group")
 		}
@@ -1093,12 +1099,10 @@ func flattenBootstrapArguments(actions []*emr.Command) []map[string]interface{} 
 	return result
 }
 
-func findGroup(grps []*emr.InstanceGroup, typ string) *emr.InstanceGroup {
+func emrCoreInstanceGroup(grps []*emr.InstanceGroup) *emr.InstanceGroup {
 	for _, grp := range grps {
-		if grp.InstanceGroupType != nil {
-			if *grp.InstanceGroupType == typ {
-				return grp
-			}
+		if aws.StringValue(grp.InstanceGroupType) == emr.InstanceGroupTypeCore {
+			return grp
 		}
 	}
 	return nil
@@ -1280,7 +1284,7 @@ func expandEmrStepConfigs(l []interface{}) []*emr.StepConfig {
 	return stepConfigs
 }
 
-func expandInstanceGroupConfigs(instanceGroupConfigs []interface{}) []*emr.InstanceGroupConfig {
+func expandInstanceGroupConfigs(instanceGroupConfigs []interface{}) ([]*emr.InstanceGroupConfig, error) {
 	instanceGroupConfig := []*emr.InstanceGroupConfig{}
 
 	for _, raw := range instanceGroupConfigs {
@@ -1298,12 +1302,23 @@ func expandInstanceGroupConfigs(instanceGroupConfigs []interface{}) []*emr.Insta
 
 		applyBidPrice(config, configAttributes)
 		applyEbsConfig(configAttributes, config)
-		applyAutoScalingPolicy(configAttributes, config)
+
+		if v, ok := configAttributes["autoscaling_policy"]; ok {
+			var autoScalingPolicy *emr.AutoScalingPolicy
+
+			err := json.Unmarshal([]byte(v.(string)), &autoScalingPolicy)
+
+			if err != nil {
+				return []*emr.InstanceGroupConfig{}, fmt.Errorf("error parsing EMR Auto Scaling Policy JSON: %s", err)
+			}
+
+			config.AutoScalingPolicy = autoScalingPolicy
+		}
 
 		instanceGroupConfig = append(instanceGroupConfig, config)
 	}
 
-	return instanceGroupConfig
+	return instanceGroupConfig, nil
 }
 
 func applyBidPrice(config *emr.InstanceGroupConfig, configAttributes map[string]interface{}) {
@@ -1340,24 +1355,6 @@ func applyEbsConfig(configAttributes map[string]interface{}, config *emr.Instanc
 
 		config.EbsConfiguration = ebsConfig
 	}
-}
-
-func applyAutoScalingPolicy(configAttributes map[string]interface{}, config *emr.InstanceGroupConfig) {
-	if rawAutoScalingPolicy, ok := configAttributes["autoscaling_policy"]; ok {
-		autoScalingConfig, _ := expandAutoScalingPolicy(rawAutoScalingPolicy.(string))
-		config.AutoScalingPolicy = autoScalingConfig
-	}
-}
-
-func expandAutoScalingPolicy(rawDefinitions string) (*emr.AutoScalingPolicy, error) {
-	var policy *emr.AutoScalingPolicy
-
-	err := json.Unmarshal([]byte(rawDefinitions), &policy)
-	if err != nil {
-		return nil, fmt.Errorf("Error decoding JSON: %s", err)
-	}
-
-	return policy, nil
 }
 
 func expandConfigurationJson(input string) ([]*emr.Configuration, error) {

--- a/aws/resource_aws_iam_policy_attachment.go
+++ b/aws/resource_aws_iam_policy_attachment.go
@@ -146,13 +146,13 @@ func resourceAwsIamPolicyAttachmentUpdate(d *schema.ResourceData, meta interface
 	var userErr, roleErr, groupErr error
 
 	if d.HasChange("users") {
-		userErr = updateUsers(conn, d, meta)
+		userErr = updateUsers(conn, d)
 	}
 	if d.HasChange("roles") {
-		roleErr = updateRoles(conn, d, meta)
+		roleErr = updateRoles(conn, d)
 	}
 	if d.HasChange("groups") {
-		groupErr = updateGroups(conn, d, meta)
+		groupErr = updateGroups(conn, d)
 	}
 	if userErr != nil || roleErr != nil || groupErr != nil {
 		return composeErrors(fmt.Sprint("[WARN] Error updating user, role, or group list from IAM Policy Attachment ", name, ":"), userErr, roleErr, groupErr)
@@ -264,7 +264,7 @@ func attachPolicyToGroups(conn *iam.IAM, groups []*string, arn string) error {
 	}
 	return nil
 }
-func updateUsers(conn *iam.IAM, d *schema.ResourceData, meta interface{}) error {
+func updateUsers(conn *iam.IAM, d *schema.ResourceData) error {
 	arn := d.Get("policy_arn").(string)
 	o, n := d.GetChange("users")
 	if o == nil {
@@ -286,7 +286,7 @@ func updateUsers(conn *iam.IAM, d *schema.ResourceData, meta interface{}) error 
 	}
 	return nil
 }
-func updateRoles(conn *iam.IAM, d *schema.ResourceData, meta interface{}) error {
+func updateRoles(conn *iam.IAM, d *schema.ResourceData) error {
 	arn := d.Get("policy_arn").(string)
 	o, n := d.GetChange("roles")
 	if o == nil {
@@ -308,7 +308,7 @@ func updateRoles(conn *iam.IAM, d *schema.ResourceData, meta interface{}) error 
 	}
 	return nil
 }
-func updateGroups(conn *iam.IAM, d *schema.ResourceData, meta interface{}) error {
+func updateGroups(conn *iam.IAM, d *schema.ResourceData) error {
 	arn := d.Get("policy_arn").(string)
 	o, n := d.GetChange("groups")
 	if o == nil {

--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -468,13 +468,13 @@ func sortStringMapKeys(m map[string]*string) []string {
 // NB: For the constraint hash to be deterministic the order in which
 // print the keys and values of the encryption context maps needs to be
 // determistic, so sort them.
-func sortedConcatStringMap(m map[string]*string, sep string) string {
+func sortedConcatStringMap(m map[string]*string) string {
 	var strList []string
 	mapKeys := sortStringMapKeys(m)
 	for _, key := range mapKeys {
 		strList = append(strList, key, *m[key])
 	}
-	return strings.Join(strList, sep)
+	return strings.Join(strList, "-")
 }
 
 // The hash needs to encapsulate what type of constraint it is
@@ -488,12 +488,12 @@ func resourceKmsGrantConstraintsHash(v interface{}) int {
 
 	if v, ok := m["encryption_context_equals"]; ok {
 		if len(v.(map[string]interface{})) > 0 {
-			buf.WriteString(fmt.Sprintf("encryption_context_equals-%s-", sortedConcatStringMap(stringMapToPointers(v.(map[string]interface{})), "-")))
+			buf.WriteString(fmt.Sprintf("encryption_context_equals-%s-", sortedConcatStringMap(stringMapToPointers(v.(map[string]interface{})))))
 		}
 	}
 	if v, ok := m["encryption_context_subset"]; ok {
 		if len(v.(map[string]interface{})) > 0 {
-			buf.WriteString(fmt.Sprintf("encryption_context_subset-%s-", sortedConcatStringMap(stringMapToPointers(v.(map[string]interface{})), "-")))
+			buf.WriteString(fmt.Sprintf("encryption_context_subset-%s-", sortedConcatStringMap(stringMapToPointers(v.(map[string]interface{})))))
 		}
 	}
 

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -494,7 +494,7 @@ func resourceAwsLaunchTemplateCreate(d *schema.ResourceData, meta interface{}) e
 		ltName = resource.UniqueId()
 	}
 
-	launchTemplateData, err := buildLaunchTemplateData(d, meta)
+	launchTemplateData, err := buildLaunchTemplateData(d)
 	if err != nil {
 		return err
 	}
@@ -650,7 +650,7 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*AWSClient).ec2conn
 
 	if !d.IsNewResource() {
-		launchTemplateData, err := buildLaunchTemplateData(d, meta)
+		launchTemplateData, err := buildLaunchTemplateData(d)
 		if err != nil {
 			return err
 		}
@@ -925,7 +925,7 @@ func getTagSpecifications(t []*ec2.LaunchTemplateTagSpecification) []interface{}
 	return s
 }
 
-func buildLaunchTemplateData(d *schema.ResourceData, meta interface{}) (*ec2.RequestLaunchTemplateData, error) {
+func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplateData, error) {
 	opts := &ec2.RequestLaunchTemplateData{
 		UserData: aws.String(d.Get("user_data").(string)),
 	}

--- a/aws/resource_aws_opsworks_instance.go
+++ b/aws/resource_aws_opsworks_instance.go
@@ -531,7 +531,7 @@ func resourceAwsOpsworksInstanceRead(d *schema.ResourceData, meta interface{}) e
 	for _, v := range instance.LayerIds {
 		layerIds = append(layerIds, *v)
 	}
-	layerIds, err = sortListBasedonTFFile(layerIds, d, "layer_ids")
+	layerIds, err = sortListBasedonTFFile(layerIds, d)
 	if err != nil {
 		return fmt.Errorf("Error sorting layer_ids attribute: %#v", err)
 	}
@@ -561,7 +561,7 @@ func resourceAwsOpsworksInstanceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("virtualization_type", instance.VirtualizationType)
 
 	// Read BlockDeviceMapping
-	ibds, err := readOpsworksBlockDevices(d, instance, meta)
+	ibds, err := readOpsworksBlockDevices(instance)
 	if err != nil {
 		return err
 	}
@@ -825,7 +825,7 @@ func resourceAwsOpsworksInstanceUpdate(d *schema.ResourceData, meta interface{})
 			}
 		} else {
 			if status != "stopped" && status != "stopping" && status != "shutting_down" {
-				err := stopOpsworksInstance(d, meta, true, d.Timeout(schema.TimeoutUpdate))
+				err := stopOpsworksInstance(d, meta, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return err
 				}
@@ -840,7 +840,7 @@ func resourceAwsOpsworksInstanceDelete(d *schema.ResourceData, meta interface{})
 	client := meta.(*AWSClient).opsworksconn
 
 	if v, ok := d.GetOk("status"); ok && v.(string) != "stopped" {
-		err := stopOpsworksInstance(d, meta, true, d.Timeout(schema.TimeoutDelete))
+		err := stopOpsworksInstance(d, meta, d.Timeout(schema.TimeoutDelete))
 		if err != nil {
 			return err
 		}
@@ -910,7 +910,7 @@ func startOpsworksInstance(d *schema.ResourceData, meta interface{}, wait bool, 
 	return nil
 }
 
-func stopOpsworksInstance(d *schema.ResourceData, meta interface{}, wait bool, timeout time.Duration) error {
+func stopOpsworksInstance(d *schema.ResourceData, meta interface{}, timeout time.Duration) error {
 	client := meta.(*AWSClient).opsworksconn
 
 	instanceId := d.Id()
@@ -927,29 +927,26 @@ func stopOpsworksInstance(d *schema.ResourceData, meta interface{}, wait bool, t
 		return err
 	}
 
-	if wait {
-		log.Printf("[DEBUG] Waiting for instance (%s) to become stopped", instanceId)
+	log.Printf("[DEBUG] Waiting for instance (%s) to become stopped", instanceId)
 
-		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"stopping", "terminating", "shutting_down", "terminated"},
-			Target:     []string{"stopped"},
-			Refresh:    OpsworksInstanceStateRefreshFunc(client, instanceId),
-			Timeout:    timeout,
-			Delay:      10 * time.Second,
-			MinTimeout: 3 * time.Second,
-		}
-		_, err = stateConf.WaitForState()
-		if err != nil {
-			return fmt.Errorf("Error waiting for instance (%s) to become stopped: %s",
-				instanceId, err)
-		}
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"stopping", "terminating", "shutting_down", "terminated"},
+		Target:     []string{"stopped"},
+		Refresh:    OpsworksInstanceStateRefreshFunc(client, instanceId),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for instance (%s) to become stopped: %s",
+			instanceId, err)
 	}
 
 	return nil
 }
 
-func readOpsworksBlockDevices(d *schema.ResourceData, instance *opsworks.Instance, meta interface{}) (
-	map[string]interface{}, error) {
+func readOpsworksBlockDevices(instance *opsworks.Instance) (map[string]interface{}, error) {
 
 	blockDevices := make(map[string]interface{})
 	blockDevices["ebs"] = make([]map[string]interface{}, 0)

--- a/aws/resource_aws_proxy_protocol_policy.go
+++ b/aws/resource_aws_proxy_protocol_policy.go
@@ -117,7 +117,7 @@ func resourceAwsProxyProtocolPolicyUpdate(d *schema.ResourceData, meta interface
 	}
 
 	backends := flattenBackendPolicies(resp.LoadBalancerDescriptions[0].BackendServerDescriptions)
-	_, policyName := resourceAwsProxyProtocolPolicyParseId(d.Id())
+	policyName := resourceAwsProxyProtocolPolicyParseId(d.Id())
 
 	d.Partial(true)
 	if d.HasChange("instance_ports") {
@@ -173,7 +173,7 @@ func resourceAwsProxyProtocolPolicyDelete(d *schema.ResourceData, meta interface
 
 	backends := flattenBackendPolicies(resp.LoadBalancerDescriptions[0].BackendServerDescriptions)
 	ports := d.Get("instance_ports").(*schema.Set).List()
-	_, policyName := resourceAwsProxyProtocolPolicyParseId(d.Id())
+	policyName := resourceAwsProxyProtocolPolicyParseId(d.Id())
 
 	inputs, err := resourceAwsProxyProtocolPolicyRemove(policyName, ports, backends)
 	if err != nil {
@@ -259,7 +259,8 @@ func resourceAwsProxyProtocolPolicyAdd(policyName string, ports []interface{}, b
 // resourceAwsProxyProtocolPolicyParseId takes an ID and parses it into
 // it's constituent parts. You need two axes (LB name, policy name)
 // to create or identify a proxy protocol policy in AWS's API.
-func resourceAwsProxyProtocolPolicyParseId(id string) (string, string) {
+func resourceAwsProxyProtocolPolicyParseId(id string) string {
 	parts := strings.SplitN(id, ":", 2)
-	return parts[0], parts[1]
+	// We currently omit the ELB name as it is not currently used anywhere
+	return parts[1]
 }

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -902,7 +902,7 @@ func resourceAwsRedshiftClusterDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	log.Printf("[DEBUG] Deleting Redshift Cluster: %s", deleteOpts)
-	_, err := deleteAwsRedshiftCluster(&deleteOpts, conn)
+	err := deleteAwsRedshiftCluster(&deleteOpts, conn)
 	if err != nil {
 		return err
 	}
@@ -912,7 +912,7 @@ func resourceAwsRedshiftClusterDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func deleteAwsRedshiftCluster(opts *redshift.DeleteClusterInput, conn *redshift.Redshift) (interface{}, error) {
+func deleteAwsRedshiftCluster(opts *redshift.DeleteClusterInput, conn *redshift.Redshift) error {
 	id := *opts.ClusterIdentifier
 	log.Printf("[INFO] Deleting Redshift Cluster %q", id)
 	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
@@ -924,8 +924,7 @@ func deleteAwsRedshiftCluster(opts *redshift.DeleteClusterInput, conn *redshift.
 		return resource.NonRetryableError(err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Error deleting Redshift Cluster (%s): %s",
-			id, err)
+		return fmt.Errorf("Error deleting Redshift Cluster (%s): %s", id, err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -936,7 +935,9 @@ func deleteAwsRedshiftCluster(opts *redshift.DeleteClusterInput, conn *redshift.
 		MinTimeout: 5 * time.Second,
 	}
 
-	return stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
+
+	return err
 }
 
 func resourceAwsRedshiftClusterStateRefreshFunc(id string, conn *redshift.Redshift) resource.StateRefreshFunc {

--- a/aws/resource_aws_ses_receipt_rule.go
+++ b/aws/resource_aws_ses_receipt_rule.go
@@ -360,7 +360,7 @@ func resourceAwsSesReceiptRuleCreate(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*AWSClient).sesConn
 
 	createOpts := &ses.CreateReceiptRuleInput{
-		Rule:        buildReceiptRule(d, meta),
+		Rule:        buildReceiptRule(d),
 		RuleSetName: aws.String(d.Get("rule_set_name").(string)),
 	}
 
@@ -382,7 +382,7 @@ func resourceAwsSesReceiptRuleUpdate(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*AWSClient).sesConn
 
 	updateOpts := &ses.UpdateReceiptRuleInput{
-		Rule:        buildReceiptRule(d, meta),
+		Rule:        buildReceiptRule(d),
 		RuleSetName: aws.String(d.Get("rule_set_name").(string)),
 	}
 
@@ -598,7 +598,7 @@ func resourceAwsSesReceiptRuleDelete(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func buildReceiptRule(d *schema.ResourceData, meta interface{}) *ses.ReceiptRule {
+func buildReceiptRule(d *schema.ResourceData) *ses.ReceiptRule {
 	receiptRule := &ses.ReceiptRule{
 		Name: aws.String(d.Get("name").(string)),
 	}

--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -151,11 +151,11 @@ func resourceAwsSqsQueueCreate(d *schema.ResourceData, meta interface{}) error {
 	cbd := d.Get("content_based_deduplication").(bool)
 
 	if fq {
-		if errors := validateSQSFifoQueueName(name, "name"); len(errors) > 0 {
+		if errors := validateSQSFifoQueueName(name); len(errors) > 0 {
 			return fmt.Errorf("Error validating the FIFO queue name: %v", errors)
 		}
 	} else {
-		if errors := validateSQSNonFifoQueueName(name, "name"); len(errors) > 0 {
+		if errors := validateSQSNonFifoQueueName(name); len(errors) > 0 {
 			return fmt.Errorf("Error validating SQS queue name: %v", errors)
 		}
 	}

--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -218,7 +218,7 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"detached", "attaching"},
 		Target:  []string{"attached"},
-		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "available"),
+		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id()),
 		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -279,7 +279,7 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"attached", "detaching", "available"},
 		Target:  []string{"detached"},
-		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "detached"),
+		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id()),
 		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -293,7 +293,7 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 
 // vpnGatewayAttachStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
 // the state of a VPN gateway's attachment
-func vpnGatewayAttachStateRefreshFunc(conn *ec2.EC2, id string, expected string) resource.StateRefreshFunc {
+func vpnGatewayAttachStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 	var start time.Time
 	return func() (interface{}, string, error) {
 		if start.IsZero() {

--- a/aws/resource_aws_waf_byte_match_set.go
+++ b/aws/resource_aws_waf_byte_match_set.go
@@ -69,7 +69,7 @@ func resourceAwsWafByteMatchSetCreate(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[INFO] Creating ByteMatchSet: %s", d.Get("name").(string))
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateByteMatchSetInput{
 			ChangeToken: token,
@@ -140,7 +140,7 @@ func resourceAwsWafByteMatchSetDelete(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteByteMatchSetInput{
 			ChangeToken:    token,
@@ -157,7 +157,7 @@ func resourceAwsWafByteMatchSetDelete(d *schema.ResourceData, meta interface{}) 
 }
 
 func updateByteMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateByteMatchSetInput{
 			ChangeToken:    token,

--- a/aws/resource_aws_waf_byte_match_set_test.go
+++ b/aws/resource_aws_waf_byte_match_set_test.go
@@ -181,7 +181,7 @@ func testAccCheckAWSWafByteMatchSetDisappears(v *waf.ByteMatchSet) resource.Test
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateByteMatchSetInput{
 				ChangeToken:    token,

--- a/aws/resource_aws_waf_geo_match_set.go
+++ b/aws/resource_aws_waf_geo_match_set.go
@@ -47,7 +47,7 @@ func resourceAwsWafGeoMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Creating GeoMatchSet: %s", d.Get("name").(string))
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateGeoMatchSetInput{
 			ChangeToken: token,
@@ -120,7 +120,7 @@ func resourceAwsWafGeoMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteGeoMatchSetInput{
 			ChangeToken:   token,
@@ -137,7 +137,7 @@ func resourceAwsWafGeoMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func updateGeoMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateGeoMatchSetInput{
 			ChangeToken:   token,

--- a/aws/resource_aws_waf_geo_match_set_test.go
+++ b/aws/resource_aws_waf_geo_match_set_test.go
@@ -174,7 +174,7 @@ func testAccCheckAWSWafGeoMatchSetDisappears(v *waf.GeoMatchSet) resource.TestCh
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateGeoMatchSetInput{
 				ChangeToken:   token,

--- a/aws/resource_aws_waf_ipset.go
+++ b/aws/resource_aws_waf_ipset.go
@@ -57,7 +57,7 @@ func resourceAwsWafIPSet() *schema.Resource {
 func resourceAwsWafIPSetCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateIPSetInput{
 			ChangeToken: token,
@@ -145,7 +145,7 @@ func resourceAwsWafIPSetDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteIPSetInput{
 			ChangeToken: token,
@@ -163,7 +163,7 @@ func resourceAwsWafIPSetDelete(d *schema.ResourceData, meta interface{}) error {
 
 func updateWafIpSetDescriptors(id string, oldD, newD []interface{}, conn *waf.WAF) error {
 	for _, ipSetUpdates := range diffWafIpSetDescriptors(oldD, newD) {
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateIPSetInput{
 				ChangeToken: token,

--- a/aws/resource_aws_waf_ipset_test.go
+++ b/aws/resource_aws_waf_ipset_test.go
@@ -320,7 +320,7 @@ func testAccCheckAWSWafIPSetDisappears(v *waf.IPSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateIPSetInput{
 				ChangeToken: token,

--- a/aws/resource_aws_waf_rate_based_rule.go
+++ b/aws/resource_aws_waf_rate_based_rule.go
@@ -68,7 +68,7 @@ func resourceAwsWafRateBasedRule() *schema.Resource {
 func resourceAwsWafRateBasedRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateRateBasedRuleInput{
 			ChangeToken: token,
@@ -157,7 +157,7 @@ func resourceAwsWafRateBasedRuleDelete(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteRateBasedRuleInput{
 			ChangeToken: token,
@@ -174,7 +174,7 @@ func resourceAwsWafRateBasedRuleDelete(d *schema.ResourceData, meta interface{})
 }
 
 func updateWafRateBasedRuleResource(id string, oldP, newP []interface{}, rateLimit interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateRateBasedRuleInput{
 			ChangeToken: token,

--- a/aws/resource_aws_waf_rate_based_rule_test.go
+++ b/aws/resource_aws_waf_rate_based_rule_test.go
@@ -202,7 +202,7 @@ func testAccCheckAWSWafRateBasedRuleDisappears(v *waf.RateBasedRule) resource.Te
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateRateBasedRuleInput{
 				ChangeToken: token,

--- a/aws/resource_aws_waf_regex_match_set.go
+++ b/aws/resource_aws_waf_regex_match_set.go
@@ -69,7 +69,7 @@ func resourceAwsWafRegexMatchSetCreate(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[INFO] Creating WAF Regex Match Set: %s", d.Get("name").(string))
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateRegexMatchSetInput{
 			ChangeToken: token,
@@ -140,7 +140,7 @@ func resourceAwsWafRegexMatchSetDelete(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteRegexMatchSetInput{
 			ChangeToken:     token,
@@ -157,7 +157,7 @@ func resourceAwsWafRegexMatchSetDelete(d *schema.ResourceData, meta interface{})
 }
 
 func updateRegexMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateRegexMatchSetInput{
 			ChangeToken:     token,

--- a/aws/resource_aws_waf_regex_match_set_test.go
+++ b/aws/resource_aws_waf_regex_match_set_test.go
@@ -62,7 +62,7 @@ func testSweepWafRegexMatchSet(region string) error {
 			return fmt.Errorf("Error updating WAF Regex Match Set: %s", err)
 		}
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.DeleteRegexMatchSetInput{
 				ChangeToken:     token,
@@ -239,7 +239,7 @@ func testAccCheckAWSWafRegexMatchSetDisappears(set *waf.RegexMatchSet) resource.
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateRegexMatchSetInput{
 				ChangeToken:     token,

--- a/aws/resource_aws_waf_regex_pattern_set.go
+++ b/aws/resource_aws_waf_regex_pattern_set.go
@@ -36,7 +36,7 @@ func resourceAwsWafRegexPatternSetCreate(d *schema.ResourceData, meta interface{
 
 	log.Printf("[INFO] Creating WAF Regex Pattern Set: %s", d.Get("name").(string))
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateRegexPatternSetInput{
 			ChangeToken: token,
@@ -109,7 +109,7 @@ func resourceAwsWafRegexPatternSetDelete(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteRegexPatternSetInput{
 			ChangeToken:       token,
@@ -126,7 +126,7 @@ func resourceAwsWafRegexPatternSetDelete(d *schema.ResourceData, meta interface{
 }
 
 func updateWafRegexPatternSetPatternStrings(id string, oldPatterns, newPatterns []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateRegexPatternSetInput{
 			ChangeToken:       token,

--- a/aws/resource_aws_waf_regex_pattern_set_test.go
+++ b/aws/resource_aws_waf_regex_pattern_set_test.go
@@ -132,7 +132,7 @@ func testAccCheckAWSWafRegexPatternSetDisappears(set *waf.RegexPatternSet) resou
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateRegexPatternSetInput{
 				ChangeToken:       token,

--- a/aws/resource_aws_waf_rule.go
+++ b/aws/resource_aws_waf_rule.go
@@ -62,7 +62,7 @@ func resourceAwsWafRule() *schema.Resource {
 func resourceAwsWafRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateRuleInput{
 			ChangeToken: token,
@@ -144,7 +144,7 @@ func resourceAwsWafRuleDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteRuleInput{
 			ChangeToken: token,
@@ -161,7 +161,7 @@ func resourceAwsWafRuleDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateWafRuleResource(id string, oldP, newP []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateRuleInput{
 			ChangeToken: token,

--- a/aws/resource_aws_waf_rule_group.go
+++ b/aws/resource_aws_waf_rule_group.go
@@ -69,7 +69,7 @@ func resourceAwsWafRuleGroup() *schema.Resource {
 func resourceAwsWafRuleGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateRuleGroupInput{
 			ChangeToken: token,
@@ -156,7 +156,7 @@ func deleteWafRuleGroup(id string, oldRules []interface{}, conn *waf.WAF) error 
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteRuleGroupInput{
 			ChangeToken: token,
@@ -172,7 +172,7 @@ func deleteWafRuleGroup(id string, oldRules []interface{}, conn *waf.WAF) error 
 }
 
 func updateWafRuleGroupResource(id string, oldRules, newRules []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateRuleGroupInput{
 			ChangeToken: token,

--- a/aws/resource_aws_waf_rule_group_test.go
+++ b/aws/resource_aws_waf_rule_group_test.go
@@ -267,7 +267,7 @@ func testAccCheckAWSWafRuleGroupDisappears(group *waf.RuleGroup) resource.TestCh
 			return fmt.Errorf("error listing activated rules in WAF Rule Group (%s): %s", aws.StringValue(group.RuleGroupId), err)
 		}
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateRuleGroupInput{
 				ChangeToken: token,

--- a/aws/resource_aws_waf_rule_test.go
+++ b/aws/resource_aws_waf_rule_test.go
@@ -260,7 +260,7 @@ func testAccCheckAWSWafRuleDisappears(v *waf.Rule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateRuleInput{
 				ChangeToken: token,

--- a/aws/resource_aws_waf_size_constraint_set.go
+++ b/aws/resource_aws_waf_size_constraint_set.go
@@ -26,7 +26,7 @@ func resourceAwsWafSizeConstraintSetCreate(d *schema.ResourceData, meta interfac
 
 	log.Printf("[INFO] Creating SizeConstraintSet: %s", d.Get("name").(string))
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateSizeConstraintSetInput{
 			ChangeToken: token,
@@ -98,7 +98,7 @@ func resourceAwsWafSizeConstraintSetDelete(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteSizeConstraintSetInput{
 			ChangeToken:         token,
@@ -114,7 +114,7 @@ func resourceAwsWafSizeConstraintSetDelete(d *schema.ResourceData, meta interfac
 }
 
 func updateSizeConstraintSetResource(id string, oldS, newS []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateSizeConstraintSetInput{
 			ChangeToken:         token,

--- a/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/aws/resource_aws_waf_size_constraint_set_test.go
@@ -187,7 +187,7 @@ func testAccCheckAWSWafSizeConstraintSetDisappears(v *waf.SizeConstraintSet) res
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateSizeConstraintSetInput{
 				ChangeToken:         token,

--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -61,7 +61,7 @@ func resourceAwsWafSqlInjectionMatchSetCreate(d *schema.ResourceData, meta inter
 
 	log.Printf("[INFO] Creating SqlInjectionMatchSet: %s", d.Get("name").(string))
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateSqlInjectionMatchSetInput{
 			ChangeToken: token,
@@ -132,7 +132,7 @@ func resourceAwsWafSqlInjectionMatchSetDelete(d *schema.ResourceData, meta inter
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteSqlInjectionMatchSetInput{
 			ChangeToken:            token,
@@ -149,7 +149,7 @@ func resourceAwsWafSqlInjectionMatchSetDelete(d *schema.ResourceData, meta inter
 }
 
 func updateSqlInjectionMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateSqlInjectionMatchSetInput{
 			ChangeToken:            token,

--- a/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -175,7 +175,7 @@ func testAccCheckAWSWafSqlInjectionMatchSetDisappears(v *waf.SqlInjectionMatchSe
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateSqlInjectionMatchSetInput{
 				ChangeToken:            token,

--- a/aws/resource_aws_waf_web_acl.go
+++ b/aws/resource_aws_waf_web_acl.go
@@ -104,7 +104,7 @@ func resourceAwsWafWebAcl() *schema.Resource {
 func resourceAwsWafWebAclCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateWebACLInput{
 			ChangeToken:   token,
@@ -165,7 +165,7 @@ func resourceAwsWafWebAclUpdate(d *schema.ResourceData, meta interface{}) error 
 		o, n := d.GetChange("rules")
 		oldR, newR := o.(*schema.Set).List(), n.(*schema.Set).List()
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateWebACLInput{
 				ChangeToken:   token,
@@ -189,7 +189,7 @@ func resourceAwsWafWebAclDelete(d *schema.ResourceData, meta interface{}) error 
 	// First, need to delete all rules
 	rules := d.Get("rules").(*schema.Set).List()
 	if len(rules) > 0 {
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateWebACLInput{
 				ChangeToken:   token,
@@ -204,7 +204,7 @@ func resourceAwsWafWebAclDelete(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteWebACLInput{
 			ChangeToken: token,

--- a/aws/resource_aws_waf_web_acl_test.go
+++ b/aws/resource_aws_waf_web_acl_test.go
@@ -188,7 +188,7 @@ func testAccCheckAWSWafWebAclDisappears(v *waf.WebACL) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			opts := &waf.DeleteWebACLInput{

--- a/aws/resource_aws_waf_xss_match_set.go
+++ b/aws/resource_aws_waf_xss_match_set.go
@@ -61,7 +61,7 @@ func resourceAwsWafXssMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Creating XssMatchSet: %s", d.Get("name").(string))
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		params := &waf.CreateXssMatchSetInput{
 			ChangeToken: token,
@@ -132,7 +132,7 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.DeleteXssMatchSetInput{
 			ChangeToken:   token,
@@ -149,7 +149,7 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func updateXssMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WAF) error {
-	wr := newWafRetryer(conn, "global")
+	wr := newWafRetryer(conn)
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateXssMatchSetInput{
 			ChangeToken:   token,

--- a/aws/resource_aws_waf_xss_match_set_test.go
+++ b/aws/resource_aws_waf_xss_match_set_test.go
@@ -199,7 +199,7 @@ func testAccCheckAWSWafXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCh
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		wr := newWafRetryer(conn, "global")
+		wr := newWafRetryer(conn)
 		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 			req := &waf.UpdateXssMatchSetInput{
 				ChangeToken:   token,

--- a/aws/s3_tags.go
+++ b/aws/s3_tags.go
@@ -22,7 +22,7 @@ func setTagsS3(conn *s3.S3, d *schema.ResourceData) error {
 		// Set tags
 		if len(remove) > 0 {
 			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			_, err := retryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"}, func() (interface{}, error) {
+			_, err := RetryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"}, func() (interface{}, error) {
 				return conn.DeleteBucketTagging(&s3.DeleteBucketTaggingInput{
 					Bucket: aws.String(d.Get("bucket").(string)),
 				})
@@ -40,7 +40,7 @@ func setTagsS3(conn *s3.S3, d *schema.ResourceData) error {
 				},
 			}
 
-			_, err := retryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"}, func() (interface{}, error) {
+			_, err := RetryOnAwsCodes([]string{"NoSuchBucket", "OperationAborted"}, func() (interface{}, error) {
 				return conn.PutBucketTagging(req)
 			})
 			if err != nil {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1892,7 +1892,8 @@ func sortInterfaceSlice(in []interface{}) []interface{} {
 }
 
 // This function sorts List A to look like a list found in the tf file.
-func sortListBasedonTFFile(in []string, d *schema.ResourceData, listName string) ([]string, error) {
+func sortListBasedonTFFile(in []string, d *schema.ResourceData) ([]string, error) {
+	listName := "layer_ids"
 	if attributeCount, ok := d.Get(listName + ".#").(int); ok {
 		for i := 0; i < attributeCount; i++ {
 			currAttributeId := d.Get(listName + "." + strconv.Itoa(i))
@@ -1958,22 +1959,6 @@ func getStringPtr(m interface{}, key string) *string {
 
 	default:
 		panic("unknown type in getStringPtr")
-	}
-
-	return nil
-}
-
-// getStringPtrList returns a []*string version of the map value. If the key
-// isn't present, getNilStringList returns nil.
-func getStringPtrList(m map[string]interface{}, key string) []*string {
-	if v, ok := m[key]; ok {
-		var stringList []*string
-		for _, i := range v.([]interface{}) {
-			s := i.(string)
-			stringList = append(stringList, &s)
-		}
-
-		return stringList
 	}
 
 	return nil

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -694,7 +694,8 @@ func validateSQSQueueName(v interface{}, k string) (ws []string, errors []error)
 	return
 }
 
-func validateSQSNonFifoQueueName(v interface{}, k string) (errors []error) {
+func validateSQSNonFifoQueueName(v interface{}) (errors []error) {
+	k := "name"
 	value := v.(string)
 	if len(value) > 80 {
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
@@ -706,7 +707,8 @@ func validateSQSNonFifoQueueName(v interface{}, k string) (errors []error) {
 	return
 }
 
-func validateSQSFifoQueueName(v interface{}, k string) (errors []error) {
+func validateSQSFifoQueueName(v interface{}) (errors []error) {
+	k := "name"
 	value := v.(string)
 
 	if len(value) > 80 {
@@ -1677,7 +1679,8 @@ func validateCognitoRoleMappingsRulesClaim(v interface{}, k string) (ws []string
 }
 
 // Validates that either authenticated or unauthenticated is defined
-func validateCognitoRoles(v map[string]interface{}, k string) (errors []error) {
+func validateCognitoRoles(v map[string]interface{}) (errors []error) {
+	k := "roles"
 	_, hasAuthenticated := v["authenticated"].(string)
 	_, hasUnauthenticated := v["unauthenticated"].(string)
 

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -850,11 +850,11 @@ func TestValidateSQSQueueName(t *testing.T) {
 		strings.Repeat("W", 80),
 	}
 	for _, v := range validNames {
-		if _, errors := validateSQSQueueName(v, "name"); len(errors) > 0 {
+		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) > 0 {
 			t.Fatalf("%q should be a valid SQS queue Name", v)
 		}
 
-		if errors := validateSQSNonFifoQueueName(v, "name"); len(errors) > 0 {
+		if errors := validateSQSNonFifoQueueName(v); len(errors) > 0 {
 			t.Fatalf("%q should be a valid SQS non-fifo queue Name", v)
 		}
 	}
@@ -871,11 +871,11 @@ func TestValidateSQSQueueName(t *testing.T) {
 		strings.Repeat("W", 81), // length > 80
 	}
 	for _, v := range invalidNames {
-		if _, errors := validateSQSQueueName(v, "name"); len(errors) == 0 {
+		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) == 0 {
 			t.Fatalf("%q should be an invalid SQS queue Name", v)
 		}
 
-		if errors := validateSQSNonFifoQueueName(v, "name"); len(errors) == 0 {
+		if errors := validateSQSNonFifoQueueName(v); len(errors) == 0 {
 			t.Fatalf("%q should be an invalid SQS non-fifo queue Name", v)
 		}
 	}
@@ -894,11 +894,11 @@ func TestValidateSQSFifoQueueName(t *testing.T) {
 		fmt.Sprintf("%s.fifo", strings.Repeat("W", 75)),
 	}
 	for _, v := range validNames {
-		if _, errors := validateSQSQueueName(v, "name"); len(errors) > 0 {
+		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) > 0 {
 			t.Fatalf("%q should be a valid SQS queue Name", v)
 		}
 
-		if errors := validateSQSFifoQueueName(v, "name"); len(errors) > 0 {
+		if errors := validateSQSFifoQueueName(v); len(errors) > 0 {
 			t.Fatalf("%q should be a valid SQS FIFO queue Name: %v", v, errors)
 		}
 	}
@@ -916,11 +916,11 @@ func TestValidateSQSFifoQueueName(t *testing.T) {
 		strings.Repeat("W", 81), // length > 80
 	}
 	for _, v := range invalidNames {
-		if _, errors := validateSQSQueueName(v, "name"); len(errors) == 0 {
+		if _, errors := validateSQSQueueName(v, "test_attribute"); len(errors) == 0 {
 			t.Fatalf("%q should be an invalid SQS queue Name", v)
 		}
 
-		if errors := validateSQSFifoQueueName(v, "name"); len(errors) == 0 {
+		if errors := validateSQSFifoQueueName(v); len(errors) == 0 {
 			t.Fatalf("%q should be an invalid SQS FIFO queue Name: %v", v, errors)
 		}
 	}
@@ -2434,7 +2434,7 @@ func TestValidateCognitoRoles(t *testing.T) {
 	}
 
 	for _, s := range validValues {
-		errors := validateCognitoRoles(s, "roles")
+		errors := validateCognitoRoles(s)
 		if len(errors) > 0 {
 			t.Fatalf("%q should be a valid Cognito Roles: %v", s, errors)
 		}
@@ -2446,7 +2446,7 @@ func TestValidateCognitoRoles(t *testing.T) {
 	}
 
 	for _, s := range invalidValues {
-		errors := validateCognitoRoles(s, "roles")
+		errors := validateCognitoRoles(s)
 		if len(errors) == 0 {
 			t.Fatalf("%q should not be a valid Cognito Roles: %v", s, errors)
 		}

--- a/aws/waf_token_handlers.go
+++ b/aws/waf_token_handlers.go
@@ -11,14 +11,13 @@ import (
 
 type WafRetryer struct {
 	Connection *waf.WAF
-	Region     string
 }
 
 type withTokenFunc func(token *string) (interface{}, error)
 
 func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
-	awsMutexKV.Lock(t.Region)
-	defer awsMutexKV.Unlock(t.Region)
+	awsMutexKV.Lock("WafRetryer")
+	defer awsMutexKV.Unlock("WafRetryer")
 
 	var out interface{}
 	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
@@ -44,6 +43,6 @@ func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
 	return out, err
 }
 
-func newWafRetryer(conn *waf.WAF, region string) *WafRetryer {
-	return &WafRetryer{Connection: conn, Region: region}
+func newWafRetryer(conn *waf.WAF) *WafRetryer {
+	return &WafRetryer{Connection: conn}
 }


### PR DESCRIPTION
Closes #6336 
Reference #5983 

Changes proposed in this pull request:

* Fixing straightforward `unparam` linting issues such as unused parameters
* Exporting functions flagged by `unparam` that will eventually be migrated into their own packages (ones that should keep their same function signature)
* Removing `getStringPtrList()` which is part of #5983 👍 

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (45.41s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (47.51s)
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (7.63s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (63.25s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (12.13s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (77.29s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (80.07s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (25.72s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (81.66s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (6.60s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (12.30s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (87.92s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (87.87s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (58.59s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (105.01s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (138.59s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (167.31s)
--- PASS: TestAccAWSAutoScalingGroup_importBasic (168.45s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (198.27s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (198.89s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (233.74s)
--- PASS: TestAccAWSAutoScalingGroup_basic (262.05s)
--- PASS: TestAccAWSAutoScalingGroup_tags (265.68s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (287.56s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (290.00s)
--- PASS: TestAccAWSEMRCluster_additionalInfo (342.91s)
--- PASS: TestAccAWSEMRCluster_basic (372.71s)
--- PASS: TestAccAWSEMRCluster_security_config (385.79s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (414.18s)
--- PASS: TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 (419.35s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (428.42s)
--- PASS: TestAccAWSEMRCluster_instance_group (453.19s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (541.96s)
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (421.97s)
--- PASS: TestAccAWSEMRCluster_keepJob (393.11s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (487.94s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (467.78s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (530.79s)
--- PASS: TestAccAWSEMRCluster_s3Logging (597.50s)
--- PASS: TestAccAWSEMRCluster_tags (612.83s)
--- PASS: TestAccAWSEMRCluster_custom_ami_id (586.37s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (746.05s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (705.99s)
```
