### PR TITLE
Allow parallel running of DX VIF acceptance tests

### DIFF
--- a/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
@@ -25,6 +25,7 @@ func TestAccAwsDxHostedPrivateVirtualInterface_basic(t *testing.T) {
 	}
 	vifName := fmt.Sprintf("terraform-testacc-dxvif-%s", acctest.RandString(5))
 	bgpAsn := randIntRange(64512, 65534)
+	vlan := randIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -32,7 +33,7 @@ func TestAccAwsDxHostedPrivateVirtualInterface_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxHostedPrivateVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn),
+				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
 					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
@@ -61,14 +62,15 @@ func TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate(t *testing.T) {
 	}
 	vifName := fmt.Sprintf("terraform-testacc-dxvif-%s", acctest.RandString(5))
 	bgpAsn := randIntRange(64512, 65534)
+	vlan := randIntRange(2049, 4094)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDxHostedPrivateVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn),
+				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
 					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
@@ -77,7 +79,7 @@ func TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_JumboFrames(connectionId, ownerAccountId, vifName, bgpAsn),
+				Config: testAccDxHostedPrivateVirtualInterfaceConfig_JumboFrames(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
 					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
@@ -85,7 +87,7 @@ func TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn),
+				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
 					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
@@ -132,31 +134,31 @@ func testAccCheckAwsDxHostedPrivateVirtualInterfaceExists(name string) resource.
 	}
 }
 
-func testAccDxHostedPrivateVirtualInterfaceConfig_basic(cid, ownerAcctId, n string, bgpAsn int) string {
+func testAccDxHostedPrivateVirtualInterfaceConfig_basic(cid, ownerAcctId, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_hosted_private_virtual_interface" "foo" {
   connection_id    = "%s"
   owner_account_id = "%s"
 
   name           = "%s"
-  vlan           = 4094
+  vlan           = %d
   address_family = "ipv4"
   bgp_asn        = %d
 }
-`, cid, ownerAcctId, n, bgpAsn)
+`, cid, ownerAcctId, n, vlan, bgpAsn)
 }
 
-func testAccDxHostedPrivateVirtualInterfaceConfig_JumboFrames(cid, ownerAcctId, n string, bgpAsn int) string {
+func testAccDxHostedPrivateVirtualInterfaceConfig_JumboFrames(cid, ownerAcctId, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_hosted_private_virtual_interface" "foo" {
   connection_id    = "%s"
   owner_account_id = "%s"
 
   name           = "%s"
-  vlan           = 4094
+  vlan           = %d
   address_family = "ipv4"
   bgp_asn        = %d
   mtu			 = 9001
 }
-`, cid, ownerAcctId, n, bgpAsn)
+`, cid, ownerAcctId, n, vlan, bgpAsn)
 }

--- a/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
@@ -25,6 +25,7 @@ func TestAccAwsDxHostedPublicVirtualInterface_basic(t *testing.T) {
 	}
 	vifName := fmt.Sprintf("terraform-testacc-dxvif-%s", acctest.RandString(5))
 	bgpAsn := randIntRange(64512, 65534)
+	vlan := randIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -32,7 +33,7 @@ func TestAccAwsDxHostedPublicVirtualInterface_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxHostedPublicVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxHostedPublicVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn),
+				Config: testAccDxHostedPublicVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxHostedPublicVirtualInterfaceExists("aws_dx_hosted_public_virtual_interface.foo"),
 					resource.TestCheckResourceAttr("aws_dx_hosted_public_virtual_interface.foo", "name", vifName),
@@ -84,14 +85,14 @@ func testAccCheckAwsDxHostedPublicVirtualInterfaceExists(name string) resource.T
 	}
 }
 
-func testAccDxHostedPublicVirtualInterfaceConfig_basic(cid, ownerAcctId, n string, bgpAsn int) string {
+func testAccDxHostedPublicVirtualInterfaceConfig_basic(cid, ownerAcctId, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_hosted_public_virtual_interface" "foo" {
   connection_id    = "%s"
   owner_account_id = "%s"
 
   name           = "%s"
-  vlan           = 4094
+  vlan           = %d
   address_family = "ipv4"
   bgp_asn        = %d
 
@@ -102,5 +103,5 @@ resource "aws_dx_hosted_public_virtual_interface" "foo" {
 	"175.45.176.0/22"
   ]
 }
-`, cid, ownerAcctId, n, bgpAsn)
+`, cid, ownerAcctId, n, vlan, bgpAsn)
 }

--- a/aws/resource_aws_dx_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_public_virtual_interface_test.go
@@ -20,6 +20,7 @@ func TestAccAwsDxPublicVirtualInterface_basic(t *testing.T) {
 	}
 	vifName := fmt.Sprintf("terraform-testacc-dxvif-%s", acctest.RandString(5))
 	bgpAsn := randIntRange(64512, 65534)
+	vlan := randIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,7 +28,7 @@ func TestAccAwsDxPublicVirtualInterface_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxPublicVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxPublicVirtualInterfaceConfig_noTags(connectionId, vifName, bgpAsn),
+				Config: testAccDxPublicVirtualInterfaceConfig_noTags(connectionId, vifName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxPublicVirtualInterfaceExists("aws_dx_public_virtual_interface.foo"),
 					resource.TestCheckResourceAttr("aws_dx_public_virtual_interface.foo", "name", vifName),
@@ -35,7 +36,7 @@ func TestAccAwsDxPublicVirtualInterface_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDxPublicVirtualInterfaceConfig_tags(connectionId, vifName, bgpAsn),
+				Config: testAccDxPublicVirtualInterfaceConfig_tags(connectionId, vifName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxPublicVirtualInterfaceExists("aws_dx_public_virtual_interface.foo"),
 					resource.TestCheckResourceAttr("aws_dx_public_virtual_interface.foo", "name", vifName),
@@ -89,13 +90,13 @@ func testAccCheckAwsDxPublicVirtualInterfaceExists(name string) resource.TestChe
 	}
 }
 
-func testAccDxPublicVirtualInterfaceConfig_noTags(cid, n string, bgpAsn int) string {
+func testAccDxPublicVirtualInterfaceConfig_noTags(cid, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_public_virtual_interface" "foo" {
   connection_id    = "%s"
 
   name           = "%s"
-  vlan           = 4094
+  vlan           = %d
   address_family = "ipv4"
   bgp_asn        = %d
 
@@ -106,16 +107,16 @@ resource "aws_dx_public_virtual_interface" "foo" {
 	"175.45.176.0/22"
   ]
 }
-`, cid, n, bgpAsn)
+`, cid, n, vlan, bgpAsn)
 }
 
-func testAccDxPublicVirtualInterfaceConfig_tags(cid, n string, bgpAsn int) string {
+func testAccDxPublicVirtualInterfaceConfig_tags(cid, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_public_virtual_interface" "foo" {
   connection_id    = "%s"
 
   name           = "%s"
-  vlan           = 4094
+  vlan           = %d
   address_family = "ipv4"
   bgp_asn        = %d
 
@@ -130,5 +131,5 @@ resource "aws_dx_public_virtual_interface" "foo" {
     Environment = "test"
   }
 }
-`, cid, n, bgpAsn)
+`, cid, n, vlan, bgpAsn)
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6244.
Acceptance tests:

```console
$ DX_CONNECTION_ID=dxcon-xxxxxxxx AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAwsDxPrivateVirtualInterface_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsDxPrivateVirtualInterface_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsDxPrivateVirtualInterface_basic
=== PAUSE TestAccAwsDxPrivateVirtualInterface_basic
=== RUN   TestAccAwsDxPrivateVirtualInterface_dxGateway
=== PAUSE TestAccAwsDxPrivateVirtualInterface_dxGateway
=== RUN   TestAccAwsDxPrivateVirtualInterface_mtuUpdate
=== PAUSE TestAccAwsDxPrivateVirtualInterface_mtuUpdate
=== CONT  TestAccAwsDxPrivateVirtualInterface_basic
=== CONT  TestAccAwsDxPrivateVirtualInterface_mtuUpdate
=== CONT  TestAccAwsDxPrivateVirtualInterface_dxGateway
--- PASS: TestAccAwsDxPrivateVirtualInterface_basic (514.47s)
--- PASS: TestAccAwsDxPrivateVirtualInterface_dxGateway (525.06s)
--- PASS: TestAccAwsDxPrivateVirtualInterface_mtuUpdate (1181.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1182.206s

$ DX_CONNECTION_ID=dxcon-xxxxxxxx AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAwsDxPublicVirtualInterface_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsDxPublicVirtualInterface_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsDxPublicVirtualInterface_basic
=== PAUSE TestAccAwsDxPublicVirtualInterface_basic
=== CONT  TestAccAwsDxPublicVirtualInterface_basic
--- PASS: TestAccAwsDxPublicVirtualInterface_basic (45.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	45.975s

$ DX_HOSTED_VIF_OWNER_ACCOUNT=000000000000 DX_CONNECTION_ID=dxcon-xxxxxxxx AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAwsDxHostedPrivateVirtualInterface_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsDxHostedPrivateVirtualInterface_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsDxHostedPrivateVirtualInterface_basic
=== PAUSE TestAccAwsDxHostedPrivateVirtualInterface_basic
=== RUN   TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate
=== PAUSE TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate
=== CONT  TestAccAwsDxHostedPrivateVirtualInterface_basic
=== CONT  TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate
--- PASS: TestAccAwsDxHostedPrivateVirtualInterface_basic (32.75s)
--- PASS: TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate (89.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	90.375s

$ DX_HOSTED_VIF_OWNER_ACCOUNT=000000000000 DX_CONNECTION_ID=dxcon-xxxxxxxx AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccAwsDxHostedPublicVirtualInterface_'
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsDxHostedPublicVirtualInterface_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsDxHostedPublicVirtualInterface_basic
=== PAUSE TestAccAwsDxHostedPublicVirtualInterface_basic
=== CONT  TestAccAwsDxHostedPublicVirtualInterface_basic
--- PASS: TestAccAwsDxHostedPublicVirtualInterface_basic (35.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.147s
```
