### PR TITLE
r/aws_s3_bucket: Fix 'Error putting S3 replication configuration: MalformedXML' error

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1783,9 +1783,6 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 		if rrid, ok := rr["id"]; ok && rrid != "" {
 			rcRule.ID = aws.String(rrid.(string))
 		}
-		if prefix, ok := rr["prefix"]; ok && prefix != "" {
-			rcRule.Prefix = aws.String(prefix.(string))
-		}
 
 		ruleDestination := &s3.Destination{}
 		if dest, ok := rr["destination"].(*schema.Set); ok && dest.Len() > 0 {
@@ -1849,6 +1846,9 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 			rcRule.DeleteMarkerReplication = &s3.DeleteMarkerReplication{
 				Status: aws.String(s3.DeleteMarkerReplicationStatusDisabled),
 			}
+		} else {
+			// XML schema V1.
+			rcRule.Prefix = aws.String(rr["prefix"].(string))
 		}
 
 		rules = append(rules, rcRule)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6340:
- Always pass the replication rule prefix value (even if empty) when using XML schema V1
- Add acceptance test for XML schema V1 replication rule with no prefix
- Change `TestAccAWSS3Bucket_ReplicationSchemaV2` to run in parallel

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3Bucket_Replication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3Bucket_Replication -timeout 120m
=== RUN   TestAccAWSS3Bucket_Replication
=== PAUSE TestAccAWSS3Bucket_Replication
=== RUN   TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== PAUSE TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== PAUSE TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== RUN   TestAccAWSS3Bucket_ReplicationSchemaV2
=== PAUSE TestAccAWSS3Bucket_ReplicationSchemaV2
=== CONT  TestAccAWSS3Bucket_Replication
=== CONT  TestAccAWSS3Bucket_ReplicationSchemaV2
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== CONT  TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== CONT  TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (30.96s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (55.88s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (56.67s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (126.47s)
--- PASS: TestAccAWSS3Bucket_Replication (152.85s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (183.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	183.406s
```