### PR TITLE
docs/resource/aws_security_group*: Add note and link to AWS documentation about VPC peering restrictions

### DIFF
--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -17,6 +17,8 @@ defined in-line. At this time you cannot use a Security Group with in-line rules
 in conjunction with any Security Group Rule resources. Doing so will cause
 a conflict of rule settings and will overwrite rules.
 
+~> **NOTE:** Referencing Security Groups across VPC peering has certain restrictions. More information is available in the [VPC Peering User Guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-security-groups.html).
+
 ## Example Usage
 
 Basic usage

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -20,6 +20,8 @@ a conflict of rule settings and will overwrite rules.
 
 ~> **NOTE:** Setting `protocol = "all"` or `protocol = -1` with `from_port` and `to_port` will result in the EC2 API creating a security group rule with all ports open. This API behavior cannot be controlled by Terraform and may generate warnings in the future.
 
+~> **NOTE:** Referencing Security Groups across VPC peering has certain restrictions. More information is available in the [VPC Peering User Guide](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-security-groups.html).
+
 ## Example Usage
 
 Basic usage


### PR DESCRIPTION
Closes #6324

Changes proposed in this pull request:

* docs/resource/aws_security_group: Add note about VPC peering restrictions
* docs/resource/aws_security_group_rule: Add note about VPC peering restrictions

Output from acceptance testing: N/A
