### PR TITLE
Update acmpca_certificate_authority.html.markdown

### DIFF
--- a/website/docs/r/acmpca_certificate_authority.html.markdown
+++ b/website/docs/r/acmpca_certificate_authority.html.markdown
@@ -77,7 +77,7 @@ resource "aws_acmpca_certificate_authority" "example" {
       custom_cname       = "crl.example.com"
       enabled            = true
       expiration_in_days = 7
-      s3_bucket_name     = "${aws_s3_bucket.example.name}"
+      s3_bucket_name     = "${aws_s3_bucket.example.id}"
     }
   }
 


### PR DESCRIPTION
Usage of wrong attribute of aws_s3_bucket

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6367

Changes proposed in this pull request:

* Change 
Example Documentation


Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

*Documentation only*
```
