### PR TITLE
Fix diffTags to actually create a diff instead of unnecessarily recre…

### DIFF
--- a/aws/tags_test.go
+++ b/aws/tags_test.go
@@ -64,10 +64,8 @@ func TestDiffTags(t *testing.T) {
 
 	for i, tc := range cases {
 		c, r := diffTags(tagsFromMap(tc.Old), tagsFromMap(tc.New))
-		t.Logf("create: %v remove: %v", c, r)
 		cm := tagsToMap(c)
 		rm := tagsToMap(r)
-		t.Logf("maps: create: %v remove: %v", cm, rm)
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}

--- a/aws/tags_test.go
+++ b/aws/tags_test.go
@@ -16,20 +16,19 @@ func TestDiffTags(t *testing.T) {
 		Old, New       map[string]interface{}
 		Create, Remove map[string]string
 	}{
-		// Basic add/remove
+		// Add
 		{
 			Old: map[string]interface{}{
 				"foo": "bar",
 			},
 			New: map[string]interface{}{
+				"foo": "bar",
 				"bar": "baz",
 			},
 			Create: map[string]string{
 				"bar": "baz",
 			},
-			Remove: map[string]string{
-				"foo": "bar",
-			},
+			Remove: map[string]string{},
 		},
 
 		// Modify
@@ -47,12 +46,28 @@ func TestDiffTags(t *testing.T) {
 				"foo": "bar",
 			},
 		},
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
 	}
 
 	for i, tc := range cases {
 		c, r := diffTags(tagsFromMap(tc.Old), tagsFromMap(tc.New))
+		t.Logf("create: %v remove: %v", c, r)
 		cm := tagsToMap(c)
 		rm := tagsToMap(r)
+		t.Logf("maps: create: %v remove: %v", cm, rm)
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}


### PR DESCRIPTION
…ating existing tags.

Solves Issue  [#6363](https://github.com/terraform-providers/terraform-provider-aws/issues/6363)

Changes proposed in this pull request:

Modify diffTags to behave as explained in its comment:

// diffTags takes our tags locally and the ones remotely and returns
// the set of tags that must be created, and the set of tags that must
// be destroyed.

Many similar functions exist for other aws elements, which all seem to have the same erroneous behavior and can be fixed analogously.