### PR TITLE
resource/aws_flow_log: Automatically trim :* suffix from log_destination argument

### DIFF
--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -34,6 +34,10 @@ func resourceAwsFlowLog() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"log_group_name"},
 				ValidateFunc:  validateArn,
+				StateFunc: func(arn interface{}) string {
+					// aws_cloudwatch_log_group arn attribute references contain a trailing `:*`, which breaks functionality
+					return strings.TrimSuffix(arn.(string), ":*")
+				},
 			},
 
 			"log_destination_type": {
@@ -124,7 +128,7 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("log_destination"); ok && v != "" {
-		opts.LogDestination = aws.String(v.(string))
+		opts.LogDestination = aws.String(strings.TrimSuffix(v.(string), ":*"))
 	}
 
 	if v, ok := d.GetOk("log_group_name"); ok && v != "" {

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -58,7 +58,7 @@ func TestAccAWSFlowLog_SubnetID(t *testing.T) {
 	subnetResourceName := "aws_subnet.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFlowLogDestroy,
@@ -91,7 +91,7 @@ func TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs(t *testing.T) {
 	resourceName := "aws_flow_log.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFlowLogDestroy,
@@ -101,9 +101,10 @@ func TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFlowLogExists(resourceName, &flowLog),
 					testAccCheckAWSFlowLogAttributes(&flowLog),
-					resource.TestCheckResourceAttrPair(resourceName, "log_destination", cloudwatchLogGroupResourceName, "arn"),
+					// We automatically trim :* from ARNs if present
+					testAccCheckResourceAttrRegionalARN(resourceName, "log_destination", "logs", fmt.Sprintf("log-group:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "log_destination_type", "cloud-watch-logs"),
-					resource.TestCheckResourceAttr(resourceName, "log_group_name", fmt.Sprintf("%s:*", rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "log_group_name", cloudwatchLogGroupResourceName, "name"),
 				),
 			},
 			{
@@ -121,7 +122,7 @@ func TestAccAWSFlowLog_LogDestinationType_S3(t *testing.T) {
 	resourceName := "aws_flow_log.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFlowLogDestroy,


### PR DESCRIPTION
`aws_cloudwatch_log_group` `arn` attribute references will automatically contain `:*` due to the CloudWatch Logs API implementation. This resource will accept that attribute as-is, however it will report access denied issues (presumably because the log group name now incorrectly contains the `:*` suffix.

While we may in the future trim that attribute in the `aws_cloudwatch_log_group` resource in a major release, this provides a quick band aid for issues when using it with this resource.

Fixes #6360
Fixes #6373

Changes:
* resource/aws_flow_log: Automatically trim `:*` suffix from `log_destination` argument
* tests/resource/aws_flow_log: Switch acceptance testing to `resource.ParallelTest()`

Output from acceptance testing:

```
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (25.45s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (28.20s)
--- PASS: TestAccAWSFlowLog_SubnetID (30.30s)
--- PASS: TestAccAWSFlowLog_VPCID (41.48s)
```