### PR TITLE
Fix typo in aws_codebuild_webook docs

### DIFF
--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -22,7 +22,7 @@ When working with [GitHub](https://github.com) source CodeBuild webhooks, the Co
 
 ```hcl
 resource "aws_codebuild_webhook" "example" {
-  name = "${aws_codebuild_project.example.name}"
+  project_name = "${aws_codebuild_project.example.name}"
 }
 ```
 


### PR DESCRIPTION
One of the examples in the `aws_codebuild_webhook` doc uses the `name` attribute, when it should be using `project_name`.

Changes proposed in this pull request:

* Update `aws_codebuild_webhook` docs example to use the correct attribute
