### PR TITLE
Elastic Transcoder imports

### DIFF
--- a/aws/resource_aws_elastic_transcoder_pipeline.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline.go
@@ -18,6 +18,9 @@ func resourceAwsElasticTranscoderPipeline() *schema.Resource {
 		Read:   resourceAwsElasticTranscoderPipelineRead,
 		Update: resourceAwsElasticTranscoderPipelineUpdate,
 		Delete: resourceAwsElasticTranscoderPipelineDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -26,7 +26,7 @@ func TestAccAWSElasticTranscoderPipeline_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckElasticTranscoderPipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: awsElasticTranscoderPipelineConfigBasic,
+				Config: fmt.Sprintf(awsElasticTranscoderPipelineConfigBasic, "basic"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticTranscoderPipelineExists("aws_elastictranscoder_pipeline.bar", pipeline),
 				),
@@ -238,7 +238,7 @@ func TestAccAWSElasticTranscoderPipeline_import(t *testing.T) {
 		CheckDestroy: testAccCheckElasticTranscoderPipelineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: awsElasticTranscoderPipelineConfigBasic,
+				Config: fmt.Sprintf(awsElasticTranscoderPipelineConfigBasic, "import"),
 			},
 
 			{
@@ -254,12 +254,12 @@ const awsElasticTranscoderPipelineConfigBasic = `
 resource "aws_elastictranscoder_pipeline" "bar" {
   input_bucket  = "${aws_s3_bucket.test_bucket.bucket}"
   output_bucket = "${aws_s3_bucket.test_bucket.bucket}"
-  name          = "aws_elastictranscoder_pipeline_tf_test_"
+  name          = "aws_ets_pipeline_tf_test_%[1]s"
   role          = "${aws_iam_role.test_role.arn}"
 }
 
 resource "aws_iam_role" "test_role" {
-  name = "aws_elastictranscoder_pipeline_tf_test_role_"
+  name = "aws_elastictranscoder_pipeline_tf_test_role_%[1]s"
 
   assume_role_policy = <<EOF
 {
@@ -279,7 +279,7 @@ EOF
 }
 
 resource "aws_s3_bucket" "test_bucket" {
-  bucket = "aws-elasticencoder-pipeline-tf-test-bucket"
+  bucket = "aws-elasticencoder-pipeline-tf-test-bucket-%[1]s"
   acl    = "private"
 }
 `

--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -229,6 +229,27 @@ func testAccCheckElasticTranscoderPipelineDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccAWSElasticTranscoderPipeline_import(t *testing.T) {
+	resourceName := "aws_elastictranscoder_pipeline.bar"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckElasticTranscoderPipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: awsElasticTranscoderPipelineConfigBasic,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 const awsElasticTranscoderPipelineConfigBasic = `
 resource "aws_elastictranscoder_pipeline" "bar" {
   input_bucket  = "${aws_s3_bucket.test_bucket.bucket}"

--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -16,6 +16,9 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 		Create: resourceAwsElasticTranscoderPresetCreate,
 		Read:   resourceAwsElasticTranscoderPresetRead,
 		Delete: resourceAwsElasticTranscoderPresetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
@@ -500,6 +503,7 @@ func resourceAwsElasticTranscoderPresetRead(d *schema.ResourceData, meta interfa
 
 	d.Set("container", *preset.Container)
 	d.Set("name", *preset.Name)
+	d.Set("description", *preset.Description)
 
 	if preset.Thumbnails != nil {
 		err := d.Set("thumbnails", flattenETThumbnails(preset.Thumbnails))

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -11,6 +11,27 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAWSElasticTranscoderPreset_import(t *testing.T) {
+	resourceName := "aws_elastictranscoder_preset.bar"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckElasticTranscoderPresetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: awsElasticTranscoderPresetConfig,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 	preset := &elastictranscoder.Preset{}
 	name := "aws_elastictranscoder_preset.bar"

--- a/website/docs/r/elastic_transcoder_pipeline.html.markdown
+++ b/website/docs/r/elastic_transcoder_pipeline.html.markdown
@@ -93,3 +93,11 @@ The `thumbnail_config_permissions` object supports the following:
 * `access` - The permission that you want to give to the AWS user that you specified in `thumbnail_config_permissions.grantee`.
 * `grantee` - The AWS user or group that you want to have access to thumbnail files.
 * `grantee_type` - Specify the type of value that appears in the `thumbnail_config_permissions.grantee` object.
+
+## Import
+
+Elastic Transcoder pipelines can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_elastic_transcoder_pipeline.basic_pipeline 1407981661351-cttk8b
+```

--- a/website/docs/r/elastic_transcoder_preset.html.markdown
+++ b/website/docs/r/elastic_transcoder_preset.html.markdown
@@ -158,3 +158,11 @@ The `video_codec_options` map supports the following:
 * `ColorSpaceConversion` - The color space conversion Elastic Transcoder applies to the output video. Valid values are `None`, `Bt709toBt601`, `Bt601toBt709`, and `Auto`. (Optional, H.264/MPEG2 Only)
 * `ChromaSubsampling` - The sampling pattern for the chroma (color) channels of the output video. Valid values are `yuv420p` and `yuv422p`.
 * `LoopCount` - The number of times you want the output gif to loop (Gif only)
+
+## Import
+
+Elastic Transcoder presets can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_elastic_transcoder_preset.basic_preset 1407981661351-cttk8b
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Allow importing of elastic transcoder pipelines
* Allow importing of elastic transcoder presets

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSElasticTranscoderPipeline_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticTranscoderPipeline_import -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSElasticTranscoderPipeline_import
=== PAUSE TestAccAWSElasticTranscoderPipeline_import
=== CONT  TestAccAWSElasticTranscoderPipeline_import
--- PASS: TestAccAWSElasticTranscoderPipeline_import (62.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	62.725s

$ make testacc TESTARGS='-run=TestAccAWSElasticTranscoderPreset_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticTranscoderPreset_import -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSElasticTranscoderPreset_import
=== PAUSE TestAccAWSElasticTranscoderPreset_import
=== CONT  TestAccAWSElasticTranscoderPreset_import
--- PASS: TestAccAWSElasticTranscoderPreset_import (27.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	(cached)
...
```
