### PR TITLE
resource/aws_vpc: Wait for IPv6 association on Create

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -159,6 +159,13 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 			d.Id(), err)
 	}
 
+	if len(vpc.Ipv6CidrBlockAssociationSet) > 0 && vpc.Ipv6CidrBlockAssociationSet[0] != nil {
+		log.Printf("[DEBUG] Waiting for EC2 VPC (%s) IPv6 CIDR to become associated", d.Id())
+		if err := waitForEc2VpcIpv6CidrBlockAssociationCreate(conn, d.Id(), aws.StringValue(vpcResp.Vpc.Ipv6CidrBlockAssociationSet[0].AssociationId)); err != nil {
+			return fmt.Errorf("error waiting for EC2 VPC (%s) IPv6 CIDR to become associated: %s", d.Id(), err)
+		}
+	}
+
 	// Update our attributes and return
 	return resourceAwsVpcUpdate(d, meta)
 }
@@ -202,7 +209,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ipv6_cidr_block", "")
 
 	for _, a := range vpc.Ipv6CidrBlockAssociationSet {
-		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
+		if aws.StringValue(a.Ipv6CidrBlockState.State) == ec2.VpcCidrBlockStateCodeAssociated { //we can only ever have 1 IPv6 block associated at once
 			d.Set("assign_generated_ipv6_cidr_block", true)
 			d.Set("ipv6_association_id", a.AssociationId)
 			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
@@ -407,24 +414,14 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 
-			// Wait for the CIDR to become available
-			log.Printf(
-				"[DEBUG] Waiting for IPv6 CIDR (%s) to become associated",
-				d.Id())
-			stateConf := &resource.StateChangeConf{
-				Pending: []string{"associating", "disassociated"},
-				Target:  []string{"associated"},
-				Refresh: Ipv6CidrStateRefreshFunc(conn, d.Id(), *resp.Ipv6CidrBlockAssociation.AssociationId),
-				Timeout: 1 * time.Minute,
-			}
-			if _, err := stateConf.WaitForState(); err != nil {
-				return fmt.Errorf(
-					"Error waiting for IPv6 CIDR (%s) to become associated: %s",
-					d.Id(), err)
+			log.Printf("[DEBUG] Waiting for EC2 VPC (%s) IPv6 CIDR to become associated", d.Id())
+			if err := waitForEc2VpcIpv6CidrBlockAssociationCreate(conn, d.Id(), aws.StringValue(resp.Ipv6CidrBlockAssociation.AssociationId)); err != nil {
+				return fmt.Errorf("error waiting for EC2 VPC (%s) IPv6 CIDR to become associated: %s", d.Id(), err)
 			}
 		} else {
+			associationID := d.Get("ipv6_association_id").(string)
 			modifyOpts := &ec2.DisassociateVpcCidrBlockInput{
-				AssociationId: aws.String(d.Get("ipv6_association_id").(string)),
+				AssociationId: aws.String(associationID),
 			}
 			log.Printf("[INFO] Disabling assign_generated_ipv6_cidr_block vpc attribute for %s: %#v",
 				d.Id(), modifyOpts)
@@ -432,20 +429,9 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 				return err
 			}
 
-			// Wait for the CIDR to become available
-			log.Printf(
-				"[DEBUG] Waiting for IPv6 CIDR (%s) to become disassociated",
-				d.Id())
-			stateConf := &resource.StateChangeConf{
-				Pending: []string{"disassociating", "associated"},
-				Target:  []string{"disassociated"},
-				Refresh: Ipv6CidrStateRefreshFunc(conn, d.Id(), d.Get("ipv6_association_id").(string)),
-				Timeout: 1 * time.Minute,
-			}
-			if _, err := stateConf.WaitForState(); err != nil {
-				return fmt.Errorf(
-					"Error waiting for IPv6 CIDR (%s) to become disassociated: %s",
-					d.Id(), err)
+			log.Printf("[DEBUG] Waiting for EC2 VPC (%s) IPv6 CIDR to become disassociated", d.Id())
+			if err := waitForEc2VpcIpv6CidrBlockAssociationDelete(conn, d.Id(), associationID); err != nil {
+				return fmt.Errorf("error waiting for EC2 VPC (%s) IPv6 CIDR to become disassociated: %s", d.Id(), err)
 			}
 		}
 
@@ -552,28 +538,24 @@ func Ipv6CidrStateRefreshFunc(conn *ec2.EC2, id string, associationId string) re
 			VpcIds: []*string{aws.String(id)},
 		}
 		resp, err := conn.DescribeVpcs(describeVpcOpts)
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpcID.NotFound" {
-				resp = nil
-			} else {
-				log.Printf("Error on VPCStateRefresh: %s", err)
-				return nil, "", err
-			}
+
+		if isAWSErr(err, "InvalidVpcID.NotFound", "") {
+			return nil, "", nil
 		}
 
-		if resp == nil {
+		if err != nil {
+			return nil, "", err
+		}
+
+		if resp == nil || len(resp.Vpcs) == 0 || resp.Vpcs[0] == nil || resp.Vpcs[0].Ipv6CidrBlockAssociationSet == nil {
 			// Sometimes AWS just has consistency issues and doesn't see
 			// our instance yet. Return an empty state.
 			return nil, "", nil
 		}
 
-		if resp.Vpcs[0].Ipv6CidrBlockAssociationSet == nil {
-			return nil, "", nil
-		}
-
 		for _, association := range resp.Vpcs[0].Ipv6CidrBlockAssociationSet {
-			if *association.AssociationId == associationId {
-				return association, *association.Ipv6CidrBlockState.State, nil
+			if aws.StringValue(association.AssociationId) == associationId {
+				return association, aws.StringValue(association.Ipv6CidrBlockState.State), nil
 			}
 		}
 
@@ -732,4 +714,35 @@ func vpcDescribe(conn *ec2.EC2, vpcId string) (*ec2.Vpc, error) {
 	default:
 		return nil, fmt.Errorf("Found %d VPCs for %s, expected 1", n, vpcId)
 	}
+}
+
+func waitForEc2VpcIpv6CidrBlockAssociationCreate(conn *ec2.EC2, vpcID, associationID string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			ec2.VpcCidrBlockStateCodeAssociating,
+			ec2.VpcCidrBlockStateCodeDisassociated,
+		},
+		Target:  []string{ec2.VpcCidrBlockStateCodeAssociated},
+		Refresh: Ipv6CidrStateRefreshFunc(conn, vpcID, associationID),
+		Timeout: 1 * time.Minute,
+	}
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitForEc2VpcIpv6CidrBlockAssociationDelete(conn *ec2.EC2, vpcID, associationID string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			ec2.VpcCidrBlockStateCodeAssociated,
+			ec2.VpcCidrBlockStateCodeDisassociating,
+		},
+		Target:         []string{ec2.VpcCidrBlockStateCodeDisassociated},
+		Refresh:        Ipv6CidrStateRefreshFunc(conn, vpcID, associationID),
+		Timeout:        1 * time.Minute,
+		NotFoundChecks: 1,
+	}
+	_, err := stateConf.WaitForState()
+
+	return err
 }

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 	"time"
 
@@ -88,8 +89,9 @@ func testSweepVPCs(region string) error {
 	return nil
 }
 
-func TestAccAWSVpc_importBasic(t *testing.T) {
-	resourceName := "aws_vpc.foo"
+func TestAccAWSVpc_basic(t *testing.T) {
+	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,8 +100,20 @@ func TestAccAWSVpc_importBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcExists(resourceName, &vpc),
+					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ec2", regexp.MustCompile(`vpc/vpc-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "assign_generated_ipv6_cidr_block", "false"),
+					resource.TestMatchResourceAttr(resourceName, "default_route_table_id", regexp.MustCompile(`^rtb-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns_support", "true"),
+					resource.TestCheckResourceAttr(resourceName, "instance_tenancy", "default"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_association_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
+					resource.TestMatchResourceAttr(resourceName, "main_route_table_id", regexp.MustCompile(`^rtb-.+`)),
+				),
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -109,8 +123,9 @@ func TestAccAWSVpc_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSVpc_basic(t *testing.T) {
+func TestAccAWSVpc_AssignGeneratedIpv6CidrBlock(t *testing.T) {
 	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -118,107 +133,51 @@ func TestAccAWSVpc_basic(t *testing.T) {
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
+				Config: testAccVpcConfigAssignGeneratedIpv6CidrBlock(true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVpcExists(resourceName, &vpc),
 					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "instance_tenancy", "default"),
-					// ipv6 should be empty if disabled so we can still use the property in conditionals
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "ipv6_cidr_block", ""),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "default_route_table_id"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "main_route_table_id"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "enable_dns_support", "true"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "assign_generated_ipv6_cidr_block", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.0.0/16"),
+					resource.TestMatchResourceAttr(resourceName, "ipv6_association_id", regexp.MustCompile(`^vpc-cidr-assoc-.+`)),
+					resource.TestMatchResourceAttr(resourceName, "ipv6_cidr_block", regexp.MustCompile(`/56$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccVpcConfigAssignGeneratedIpv6CidrBlock(false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVpcExists(resourceName, &vpc),
+					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "assign_generated_ipv6_cidr_block", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_association_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_cidr_block", ""),
+				),
+			},
+			{
+				Config: testAccVpcConfigAssignGeneratedIpv6CidrBlock(true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVpcExists(resourceName, &vpc),
+					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "assign_generated_ipv6_cidr_block", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.0.0/16"),
+					resource.TestMatchResourceAttr(resourceName, "ipv6_association_id", regexp.MustCompile(`^vpc-cidr-assoc-.+`)),
+					resource.TestMatchResourceAttr(resourceName, "ipv6_cidr_block", regexp.MustCompile(`/56$`)),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSVpc_enableIpv6(t *testing.T) {
-	var vpc ec2.Vpc
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVpcDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVpcConfigIpv6Enabled,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "ipv6_association_id"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "ipv6_cidr_block"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "true"),
-				),
-			},
-			{
-				Config: testAccVpcConfigIpv6Disabled,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "false"),
-				),
-			},
-			{
-				Config: testAccVpcConfigIpv6Enabled,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "ipv6_association_id"),
-					resource.TestCheckResourceAttrSet(
-						"aws_vpc.foo", "ipv6_cidr_block"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSVpc_dedicatedTenancy(t *testing.T) {
-	var vpc ec2.Vpc
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVpcDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVpcDedicatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "instance_tenancy", "dedicated"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSVpc_modifyTenancy(t *testing.T) {
+func TestAccAWSVpc_Tenancy(t *testing.T) {
 	var vpcDedicated ec2.Vpc
 	var vpcDefault ec2.Vpc
+	resourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -228,26 +187,28 @@ func TestAccAWSVpc_modifyTenancy(t *testing.T) {
 			{
 				Config: testAccVpcDedicatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpcDedicated),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "instance_tenancy", "dedicated"),
+					testAccCheckVpcExists(resourceName, &vpcDedicated),
+					resource.TestCheckResourceAttr(resourceName, "instance_tenancy", "dedicated"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccVpcConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpcDefault),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "instance_tenancy", "default"),
+					testAccCheckVpcExists(resourceName, &vpcDefault),
+					resource.TestCheckResourceAttr(resourceName, "instance_tenancy", "default"),
 					testAccCheckVpcIdsEqual(&vpcDedicated, &vpcDefault),
 				),
 			},
 			{
 				Config: testAccVpcDedicatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpcDedicated),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "instance_tenancy", "dedicated"),
+					testAccCheckVpcExists(resourceName, &vpcDedicated),
+					resource.TestCheckResourceAttr(resourceName, "instance_tenancy", "dedicated"),
 					testAccCheckVpcIdsNotEqual(&vpcDedicated, &vpcDefault),
 				),
 			},
@@ -257,6 +218,7 @@ func TestAccAWSVpc_modifyTenancy(t *testing.T) {
 
 func TestAccAWSVpc_tags(t *testing.T) {
 	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -266,18 +228,21 @@ func TestAccAWSVpc_tags(t *testing.T) {
 			{
 				Config: testAccVpcConfigTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
+					testAccCheckVpcExists(resourceName, &vpc),
 					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.0.0/16"),
 					testAccCheckTags(&vpc.Tags, "foo", "bar"),
 				),
 			},
-
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccVpcConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
+					testAccCheckVpcExists(resourceName, &vpc),
 					testAccCheckTags(&vpc.Tags, "foo", ""),
 					testAccCheckTags(&vpc.Tags, "bar", "baz"),
 				),
@@ -288,6 +253,7 @@ func TestAccAWSVpc_tags(t *testing.T) {
 
 func TestAccAWSVpc_update(t *testing.T) {
 	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -297,18 +263,16 @@ func TestAccAWSVpc_update(t *testing.T) {
 			{
 				Config: testAccVpcConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
+					testAccCheckVpcExists(resourceName, &vpc),
 					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "cidr_block", "10.1.0.0/16"),
 				),
 			},
 			{
 				Config: testAccVpcConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists("aws_vpc.foo", &vpc),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.foo", "enable_dns_hostnames", "true"),
+					testAccCheckVpcExists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns_hostnames", "true"),
 				),
 			},
 		},
@@ -351,9 +315,8 @@ func testAccCheckVpcDestroy(s *terraform.State) error {
 
 func testAccCheckVpcCidr(vpc *ec2.Vpc, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		CIDRBlock := vpc.CidrBlock
-		if *CIDRBlock != expected {
-			return fmt.Errorf("Bad cidr: %s", *vpc.CidrBlock)
+		if aws.StringValue(vpc.CidrBlock) != expected {
+			return fmt.Errorf("Bad cidr: %s", aws.StringValue(vpc.CidrBlock))
 		}
 
 		return nil
@@ -362,7 +325,7 @@ func testAccCheckVpcCidr(vpc *ec2.Vpc, expected string) resource.TestCheckFunc {
 
 func testAccCheckVpcIdsEqual(vpc1, vpc2 *ec2.Vpc) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *vpc1.VpcId != *vpc2.VpcId {
+		if aws.StringValue(vpc1.VpcId) != aws.StringValue(vpc2.VpcId) {
 			return fmt.Errorf("VPC IDs not equal")
 		}
 
@@ -372,7 +335,7 @@ func testAccCheckVpcIdsEqual(vpc1, vpc2 *ec2.Vpc) resource.TestCheckFunc {
 
 func testAccCheckVpcIdsNotEqual(vpc1, vpc2 *ec2.Vpc) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *vpc1.VpcId == *vpc2.VpcId {
+		if aws.StringValue(vpc1.VpcId) == aws.StringValue(vpc2.VpcId) {
 			return fmt.Errorf("VPC IDs are equal")
 		}
 
@@ -399,7 +362,7 @@ func testAccCheckVpcExists(n string, vpc *ec2.Vpc) resource.TestCheckFunc {
 		if err != nil {
 			return err
 		}
-		if len(resp.Vpcs) == 0 {
+		if len(resp.Vpcs) == 0 || resp.Vpcs[0] == nil {
 			return fmt.Errorf("VPC not found")
 		}
 
@@ -411,6 +374,9 @@ func testAccCheckVpcExists(n string, vpc *ec2.Vpc) resource.TestCheckFunc {
 
 // https://github.com/hashicorp/terraform/issues/1301
 func TestAccAWSVpc_bothDnsOptionsSet(t *testing.T) {
+	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -419,11 +385,15 @@ func TestAccAWSVpc_bothDnsOptionsSet(t *testing.T) {
 			{
 				Config: testAccVpcConfig_BothDnsOptions,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_vpc.bar", "enable_dns_hostnames", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_vpc.bar", "enable_dns_support", "true"),
+					testAccCheckVpcExists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns_hostnames", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns_support", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -431,6 +401,9 @@ func TestAccAWSVpc_bothDnsOptionsSet(t *testing.T) {
 
 // https://github.com/hashicorp/terraform/issues/10168
 func TestAccAWSVpc_DisabledDnsSupport(t *testing.T) {
+	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -439,15 +412,23 @@ func TestAccAWSVpc_DisabledDnsSupport(t *testing.T) {
 			{
 				Config: testAccVpcConfig_DisabledDnsSupport,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_vpc.bar", "enable_dns_support", "false"),
+					testAccCheckVpcExists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns_support", "false"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSVpc_classiclinkOptionSet(t *testing.T) {
+	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -456,15 +437,23 @@ func TestAccAWSVpc_classiclinkOptionSet(t *testing.T) {
 			{
 				Config: testAccVpcConfig_ClassiclinkOption,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_vpc.bar", "enable_classiclink", "true"),
+					testAccCheckVpcExists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "enable_classiclink", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSVpc_classiclinkDnsSupportOptionSet(t *testing.T) {
+	var vpc ec2.Vpc
+	resourceName := "aws_vpc.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -473,16 +462,21 @@ func TestAccAWSVpc_classiclinkDnsSupportOptionSet(t *testing.T) {
 			{
 				Config: testAccVpcConfig_ClassiclinkDnsSupportOption,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"aws_vpc.bar", "enable_classiclink_dns_support", "true"),
+					testAccCheckVpcExists(resourceName, &vpc),
+					resource.TestCheckResourceAttr(resourceName, "enable_classiclink_dns_support", "true"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 const testAccVpcConfig = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags {
 		Name = "terraform-testacc-vpc"
@@ -490,27 +484,21 @@ resource "aws_vpc" "foo" {
 }
 `
 
-const testAccVpcConfigIpv6Enabled = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	assign_generated_ipv6_cidr_block = true
-	tags {
-		Name = "terraform-testacc-vpc-ipv6"
-	}
-}
-`
+func testAccVpcConfigAssignGeneratedIpv6CidrBlock(assignGeneratedIpv6CidrBlock bool) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  assign_generated_ipv6_cidr_block = %t
+  cidr_block                       = "10.1.0.0/16"
 
-const testAccVpcConfigIpv6Disabled = `
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "terraform-testacc-vpc-ipv6"
-	}
+  tags {
+    Name = "terraform-testacc-vpc-ipv6"
+  }
 }
-`
+`, assignGeneratedIpv6CidrBlock)
+}
 
 const testAccVpcConfigUpdate = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	enable_dns_hostnames = true
 	tags {
@@ -520,7 +508,7 @@ resource "aws_vpc" "foo" {
 `
 
 const testAccVpcConfigTags = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 
 	tags {
@@ -531,7 +519,7 @@ resource "aws_vpc" "foo" {
 `
 
 const testAccVpcConfigTagsUpdate = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 
 	tags {
@@ -541,7 +529,7 @@ resource "aws_vpc" "foo" {
 }
 `
 const testAccVpcDedicatedConfig = `
-resource "aws_vpc" "foo" {
+resource "aws_vpc" "test" {
 	instance_tenancy = "dedicated"
 	cidr_block = "10.1.0.0/16"
 	tags {
@@ -551,11 +539,7 @@ resource "aws_vpc" "foo" {
 `
 
 const testAccVpcConfig_BothDnsOptions = `
-provider "aws" {
-	region = "eu-central-1"
-}
-
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.2.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
@@ -566,7 +550,7 @@ resource "aws_vpc" "bar" {
 `
 
 const testAccVpcConfig_DisabledDnsSupport = `
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "test" {
 	cidr_block = "10.2.0.0/16"
 	enable_dns_support = false
 	tags {
@@ -576,7 +560,7 @@ resource "aws_vpc" "bar" {
 `
 
 const testAccVpcConfig_ClassiclinkOption = `
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "test" {
 	cidr_block = "172.2.0.0/16"
 	enable_classiclink = true
 	tags {
@@ -586,7 +570,7 @@ resource "aws_vpc" "bar" {
 `
 
 const testAccVpcConfig_ClassiclinkDnsSupportOption = `
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "test" {
 	cidr_block = "172.2.0.0/16"
 	enable_classiclink = true
 	enable_classiclink_dns_support = true


### PR DESCRIPTION
Fixes #3398

Changes:
* resource/aws_vpc: Add IPv6 CIDR block association waiter during VPC creation
* resource/aws_vpc: Refactor IPv6 CIDR block association waiters into separate functions
* tests/resource/aws_vpc: Stronger IPv6 checks and general refactoring

Output from acceptance testing:

```
--- PASS: TestAccAWSVpc_coreMismatchedDiffs (22.74s)
--- PASS: TestAccAWSVpc_DisabledDnsSupport (27.42s)
--- PASS: TestAccAWSVpc_classiclinkOptionSet (28.19s)
--- PASS: TestAccAWSVpc_classiclinkDnsSupportOptionSet (28.40s)
--- PASS: TestAccAWSVpc_basic (28.41s)
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (36.09s)
--- PASS: TestAccAWSVpc_update (40.07s)
--- PASS: TestAccAWSVpc_tags (45.86s)
--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlock (64.86s)
--- PASS: TestAccAWSVpc_Tenancy (65.81s)
```
