### PR TITLE
docs/service/iam: Further clarify issues with aws_iam_policy_attachment resource

### DIFF
--- a/website/docs/r/iam_group_policy_attachment.markdown
+++ b/website/docs/r/iam_group_policy_attachment.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Attaches a Managed IAM Policy to an IAM group
 
+~> **NOTE:** The usage of this resource conflicts with the `aws_iam_policy_attachment` resource and will permanently show a difference if both are defined.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/iam_policy_attachment.html.markdown
+++ b/website/docs/r/iam_policy_attachment.html.markdown
@@ -10,7 +10,9 @@ description: |-
 
 Attaches a Managed IAM Policy to user(s), role(s), and/or group(s)
 
-!> **WARNING:** The aws_iam_policy_attachment resource creates **exclusive** attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via some mechanism other than Terraform will have that attached policy revoked by Terraform. Consider `aws_iam_role_policy_attachment`, `aws_iam_user_policy_attachment`, or `aws_iam_group_policy_attachment` instead. These resources do not enforce exclusive attachment of an IAM policy.
+!> **WARNING:** The aws_iam_policy_attachment resource creates **exclusive** attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via any other mechanism (including other Terraform resources) will have that attached policy revoked by this resource. Consider `aws_iam_role_policy_attachment`, `aws_iam_user_policy_attachment`, or `aws_iam_group_policy_attachment` instead. These resources do not enforce exclusive attachment of an IAM policy.
+
+~> **NOTE:** The usage of this resource conflicts with the `aws_iam_group_policy_attachment`, `aws_iam_role_policy_attachment`, and `aws_iam_user_policy_attachment` resources and will permanently show a difference if both are defined.
 
 ## Example Usage
 

--- a/website/docs/r/iam_role_policy_attachment.markdown
+++ b/website/docs/r/iam_role_policy_attachment.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Attaches a Managed IAM Policy to an IAM role
 
+~> **NOTE:** The usage of this resource conflicts with the `aws_iam_policy_attachment` resource and will permanently show a difference if both are defined.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/iam_user_policy_attachment.markdown
+++ b/website/docs/r/iam_user_policy_attachment.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Attaches a Managed IAM Policy to an IAM user
 
+~> **NOTE:** The usage of this resource conflicts with the `aws_iam_policy_attachment` resource and will permanently show a difference if both are defined.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Reference (among lots of others 😄): #6397

The `aws_iam_policy_attachment` resource should likely be deprecated in the future as its usage is limited and confusing, but that discussion will happen outside of this documentation fix.

Changes proposed in this pull request:

* Clarify warning in `aws_iam_policy_attachment` to include Terraform resources as well
* Add notes in each affected resource about the conflicting management

Output from acceptance testing: N/A
