### PR TITLE
gosimple: Fix validator issues

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -976,8 +976,8 @@ func validateIamRolePolicyName(v interface{}, k string) (ws []string, errors []e
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 128 characters", k))
 	}
-	if !regexp.MustCompile("^[\\w+=,.@-]+$").MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q must match [\\w+=,.@-]", k))
+	if !regexp.MustCompile(`^[\w+=,.@-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(`%q must match [\w+=,.@-]`, k))
 	}
 	return
 }
@@ -988,8 +988,8 @@ func validateIamRolePolicyNamePrefix(v interface{}, k string) (ws []string, erro
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 100 characters", k))
 	}
-	if !regexp.MustCompile("^[\\w+=,.@-]+$").MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q must match [\\w+=,.@-]", k))
+	if !regexp.MustCompile(`^[\w+=,.@-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(`%q must match [\w+=,.@-]`, k))
 	}
 	return
 }
@@ -1161,7 +1161,7 @@ func validateAwsKmsGrantName(v interface{}, k string) (ws []string, es []error) 
 
 func validateCognitoIdentityPoolName(v interface{}, k string) (ws []string, errors []error) {
 	val := v.(string)
-	if !regexp.MustCompile("^[\\w _]+$").MatchString(val) {
+	if !regexp.MustCompile(`^[\w _]+$`).MatchString(val) {
 		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters and spaces", k))
 	}
 
@@ -1174,7 +1174,7 @@ func validateCognitoProviderDeveloperName(v interface{}, k string) (ws []string,
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 100 characters", k))
 	}
 
-	if !regexp.MustCompile("^[\\w._-]+$").MatchString(value) {
+	if !regexp.MustCompile(`^[\w._-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters, dots, underscores and hyphens", k))
 	}
 
@@ -1191,7 +1191,7 @@ func validateCognitoSupportedLoginProviders(v interface{}, k string) (ws []strin
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 128 characters", k))
 	}
 
-	if !regexp.MustCompile("^[\\w.;_/-]+$").MatchString(value) {
+	if !regexp.MustCompile(`^[\w.;_/-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters, dots, semicolons, underscores, slashes and hyphens", k))
 	}
 
@@ -1208,7 +1208,7 @@ func validateCognitoIdentityProvidersClientId(v interface{}, k string) (ws []str
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 128 characters", k))
 	}
 
-	if !regexp.MustCompile("^[\\w_]+$").MatchString(value) {
+	if !regexp.MustCompile(`^[\w_]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters and underscores", k))
 	}
 
@@ -1225,7 +1225,7 @@ func validateCognitoIdentityProvidersProviderName(v interface{}, k string) (ws [
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 128 characters", k))
 	}
 
-	if !regexp.MustCompile("^[\\w._:/-]+$").MatchString(value) {
+	if !regexp.MustCompile(`^[\w._:/-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters, dots, underscores, colons, slashes and hyphens", k))
 	}
 
@@ -1243,7 +1243,7 @@ func validateCognitoUserGroupName(v interface{}, k string) (ws []string, es []er
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+", k))
+		es = append(es, fmt.Errorf(`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}]+`, k))
 	}
 	return
 }
@@ -1347,7 +1347,7 @@ func validateCognitoUserPoolTemplateEmailMessageByLink(v interface{}, k string) 
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{##[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*##\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*\\{##[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*##\\}[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*", k))
+		es = append(es, fmt.Errorf(`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*\{##[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*##\}[\p{L}\p{M}\p{S}\p{N}\p{P}\s*]*`, k))
 	}
 	return
 }
@@ -1363,7 +1363,7 @@ func validateCognitoUserPoolTemplateEmailSubject(v interface{}, k string) (ws []
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+", k))
+		es = append(es, fmt.Errorf(`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`, k))
 	}
 	return
 }
@@ -1379,7 +1379,7 @@ func validateCognitoUserPoolTemplateEmailSubjectByLink(v interface{}, k string) 
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+", k))
+		es = append(es, fmt.Errorf(`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`, k))
 	}
 	return
 }
@@ -1445,7 +1445,7 @@ func validateCognitoUserPoolReplyEmailAddress(v interface{}, k string) (ws []str
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+@[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+@[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+", k))
+			`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}]+@[\p{L}\p{M}\p{S}\p{N}\p{P}]+`, k))
 	}
 	return
 }
@@ -1461,7 +1461,7 @@ func validateCognitoUserPoolSchemaName(v interface{}, k string) (ws []string, es
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+", k))
+		es = append(es, fmt.Errorf(`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}]+`, k))
 	}
 	return
 }
@@ -1477,7 +1477,7 @@ func validateCognitoUserPoolClientURL(v interface{}, k string) (ws []string, es 
 	}
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {
-		es = append(es, fmt.Errorf("%q must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+", k))
+		es = append(es, fmt.Errorf(`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}]+`, k))
 	}
 	return
 }
@@ -1492,7 +1492,7 @@ func validateCognitoResourceServerScopeName(v interface{}, k string) (ws []strin
 		errors = append(errors, fmt.Errorf("%q cannot be longer than 256 character", k))
 	}
 	if !regexp.MustCompile(`[\x21\x23-\x2E\x30-\x5B\x5D-\x7E]+`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q must satisfy regular expression pattern: [\\x21\\x23-\\x2E\\x30-\\x5B\\x5D-\\x7E]+", k))
+		errors = append(errors, fmt.Errorf(`%q must satisfy regular expression pattern: [\x21\x23-\x2E\x30-\x5B\x5D-\x7E]+`, k))
 	}
 	return
 }
@@ -1528,7 +1528,7 @@ func validateIamRoleDescription(v interface{}, k string) (ws []string, errors []
 
 	if !regexp.MustCompile(`[\p{L}\p{M}\p{Z}\p{S}\p{N}\p{P}]*`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"Only alphanumeric & accented characters allowed in %q: %q (Must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{Z}\\p{S}\\p{N}\\p{P}]*)",
+			`Only alphanumeric & accented characters allowed in %q: %q (Must satisfy regular expression pattern: [\p{L}\p{M}\p{Z}\p{S}\p{N}\p{P}]*)`,
 			k, value))
 	}
 	return
@@ -1540,7 +1540,7 @@ func validateAwsSSMName(v interface{}, k string) (ws []string, errors []error) {
 
 	if !regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"Only alphanumeric characters, hyphens, dots & underscores allowed in %q: %q (Must satisfy regular expression pattern: ^[a-zA-Z0-9_\\-.]{3,128}$)",
+			`Only alphanumeric characters, hyphens, dots & underscores allowed in %q: %q (Must satisfy regular expression pattern: ^[a-zA-Z0-9_\-.]{3,128}$)`,
 			k, value))
 	}
 
@@ -1636,7 +1636,7 @@ func validateIoTTopicRuleFirehoseSeparator(v interface{}, s string) ([]string, [
 		return nil, nil
 	}
 
-	return nil, []error{fmt.Errorf("Separator must be one of ',' (comma), '\\t' (tab) '\\n' (newline) or '\\r\\n' (Windows newline)")}
+	return nil, []error{fmt.Errorf(`Separator must be one of ',' (comma), '\t' (tab) '\n' (newline) or '\r\n' (Windows newline)`)}
 }
 
 func validateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(v map[string]interface{}) (errors []error) {
@@ -1644,7 +1644,7 @@ func validateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(v map[string]
 	isRequired := t == cognitoidentity.RoleMappingTypeToken || t == cognitoidentity.RoleMappingTypeRules
 
 	if value, ok := v["ambiguous_role_resolution"]; (!ok || value == "") && isRequired {
-		errors = append(errors, fmt.Errorf("Ambiguous Role Resolution must be defined when \"type\" equals \"Token\" or \"Rules\""))
+		errors = append(errors, fmt.Errorf(`Ambiguous Role Resolution must be defined when "type" equals "Token" or "Rules"`))
 	}
 
 	return
@@ -1671,7 +1671,7 @@ func validateCognitoRoleMappingsRulesConfiguration(v map[string]interface{}) (er
 func validateCognitoRoleMappingsRulesClaim(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
-	if !regexp.MustCompile("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+$").MatchString(value) {
+	if !regexp.MustCompile(`^[\p{L}\p{M}\p{S}\p{N}\p{P}]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q must contain only alphanumeric characters, dots, underscores, colons, slashes and hyphens", k))
 	}
 
@@ -1783,9 +1783,9 @@ func validateIotThingTypeDescription(v interface{}, k string) (ws []string, erro
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 2028 characters", k))
 	}
-	if !regexp.MustCompile(`[\\p{Graph}\\x20]*`).MatchString(value) {
+	if !regexp.MustCompile(`[\p{Graph}\x20]*`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must match pattern [\\p{Graph}\\x20]*", k))
+			`%q must match pattern [\p{Graph}\x20]*`, k))
 	}
 	return
 }

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -629,12 +629,12 @@ func TestValidateIntegerInSlice(t *testing.T) {
 		{
 			val:         42,
 			f:           validateIntegerInSlice([]int{0, 43}),
-			expectedErr: regexp.MustCompile("expected [\\w]+ to be one of \\[0 43\\], got 42"),
+			expectedErr: regexp.MustCompile(`expected [\w]+ to be one of \[0 43\], got 42`),
 		},
 		{
 			val:         "42",
 			f:           validateIntegerInSlice([]int{0, 42}),
-			expectedErr: regexp.MustCompile("expected type of [\\w]+ to be int"),
+			expectedErr: regexp.MustCompile(`expected type of [\w]+ to be int`),
 		},
 	}
 	matchErr := func(errs []error, r *regexp.Regexp) bool {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Related to #6343 technical debt

Changes proposed in this pull request:

* Fixes for `validators.go` and `validators_test.go`

Resolves all issues:

```
aws/validators.go:979:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators.go:991:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators.go:1164:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators.go:1177:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators.go:1194:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators.go:1211:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators.go:1228:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators.go:1674:6:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators_test.go:632:17:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/validators_test.go:637:17:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
```

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestValidate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestValidate -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestValidateCloudWatchLogStreamName
--- PASS: TestValidateCloudWatchLogStreamName (0.00s)
=== RUN   TestValidateAwsEcsTaskDefinitionContainerDefinitions
--- PASS: TestValidateAwsEcsTaskDefinitionContainerDefinitions (0.00s)
=== RUN   TestValidateIamGroupName
--- PASS: TestValidateIamGroupName (0.00s)
=== RUN   TestValidateIamUserName
--- PASS: TestValidateIamUserName (0.00s)
=== RUN   TestValidateRedshiftClusterDbName
--- PASS: TestValidateRedshiftClusterDbName (0.00s)
=== RUN   TestValidateTypeStringNullableBoolean
--- PASS: TestValidateTypeStringNullableBoolean (0.00s)
=== RUN   TestValidateCloudWatchDashboardName
--- PASS: TestValidateCloudWatchDashboardName (0.00s)
=== RUN   TestValidateCloudWatchEventRuleName
--- PASS: TestValidateCloudWatchEventRuleName (0.00s)
=== RUN   TestValidateLambdaFunctionName
--- PASS: TestValidateLambdaFunctionName (0.00s)
=== RUN   TestValidateLambdaQualifier
--- PASS: TestValidateLambdaQualifier (0.00s)
=== RUN   TestValidateLambdaPermissionAction
--- PASS: TestValidateLambdaPermissionAction (0.00s)
=== RUN   TestValidateLambdaPermissionEventSourceToken
--- PASS: TestValidateLambdaPermissionEventSourceToken (0.00s)
=== RUN   TestValidateAwsAccountId
--- PASS: TestValidateAwsAccountId (0.00s)
=== RUN   TestValidateArn
--- PASS: TestValidateArn (0.00s)
=== RUN   TestValidateEC2AutomateARN
--- PASS: TestValidateEC2AutomateARN (0.00s)
=== RUN   TestValidatePolicyStatementId
--- PASS: TestValidatePolicyStatementId (0.00s)
=== RUN   TestValidateCIDRNetworkAddress
--- PASS: TestValidateCIDRNetworkAddress (0.00s)
=== RUN   TestValidateLogMetricFilterName
--- PASS: TestValidateLogMetricFilterName (0.00s)
=== RUN   TestValidateLogMetricTransformationName
--- PASS: TestValidateLogMetricTransformationName (0.00s)
=== RUN   TestValidateLogGroupName
--- PASS: TestValidateLogGroupName (0.00s)
=== RUN   TestValidateLogGroupNamePrefix
--- PASS: TestValidateLogGroupNamePrefix (0.00s)
=== RUN   TestValidateS3BucketLifecycleTimestamp
--- PASS: TestValidateS3BucketLifecycleTimestamp (0.00s)
=== RUN   TestValidateIntegerInSlice
--- PASS: TestValidateIntegerInSlice (0.00s)
=== RUN   TestValidateDbEventSubscriptionName
--- PASS: TestValidateDbEventSubscriptionName (0.00s)
=== RUN   TestValidateIAMPolicyJsonString
--- PASS: TestValidateIAMPolicyJsonString (0.00s)
=== RUN   TestValidateCloudFormationTemplate
--- PASS: TestValidateCloudFormationTemplate (0.00s)
=== RUN   TestValidateSQSQueueName
--- PASS: TestValidateSQSQueueName (0.00s)
=== RUN   TestValidateSQSFifoQueueName
--- PASS: TestValidateSQSFifoQueueName (0.00s)
=== RUN   TestValidateOnceAWeekWindowFormat
--- PASS: TestValidateOnceAWeekWindowFormat (0.00s)
=== RUN   TestValidateOnceADayWindowFormat
--- PASS: TestValidateOnceADayWindowFormat (0.00s)
=== RUN   TestValidateEcsPlacementConstraint
--- PASS: TestValidateEcsPlacementConstraint (0.00s)
=== RUN   TestValidateEcsPlacementStrategy
--- PASS: TestValidateEcsPlacementStrategy (0.00s)
=== RUN   TestValidateStepFunctionStateMachineName
--- PASS: TestValidateStepFunctionStateMachineName (0.00s)
=== RUN   TestValidateEmrCustomAmiId
--- PASS: TestValidateEmrCustomAmiId (0.00s)
=== RUN   TestValidateDmsEndpointId
--- PASS: TestValidateDmsEndpointId (0.00s)
=== RUN   TestValidateDmsCertificateId
--- PASS: TestValidateDmsCertificateId (0.00s)
=== RUN   TestValidateDmsReplicationInstanceId
--- PASS: TestValidateDmsReplicationInstanceId (0.00s)
=== RUN   TestValidateDmsReplicationSubnetGroupId
--- PASS: TestValidateDmsReplicationSubnetGroupId (0.00s)
=== RUN   TestValidateDmsReplicationTaskId
--- PASS: TestValidateDmsReplicationTaskId (0.00s)
=== RUN   TestValidateAccountAlias
--- PASS: TestValidateAccountAlias (0.00s)
=== RUN   TestValidateIamRoleProfileName
--- PASS: TestValidateIamRoleProfileName (0.00s)
=== RUN   TestValidateIamRoleProfileNamePrefix
--- PASS: TestValidateIamRoleProfileNamePrefix (0.00s)
=== RUN   TestValidateApiGatewayUsagePlanQuotaSettings
--- PASS: TestValidateApiGatewayUsagePlanQuotaSettings (0.00s)
=== RUN   TestValidateElbName
--- PASS: TestValidateElbName (0.00s)
=== RUN   TestValidateElbNamePrefix
--- PASS: TestValidateElbNamePrefix (0.00s)
=== RUN   TestValidateNeptuneEventSubscriptionName
--- PASS: TestValidateNeptuneEventSubscriptionName (0.00s)
=== RUN   TestValidateNeptuneEventSubscriptionNamePrefix
--- PASS: TestValidateNeptuneEventSubscriptionNamePrefix (0.00s)
=== RUN   TestValidateDbSubnetGroupName
--- PASS: TestValidateDbSubnetGroupName (0.00s)
=== RUN   TestValidateNeptuneSubnetGroupName
--- PASS: TestValidateNeptuneSubnetGroupName (0.00s)
=== RUN   TestValidateDbSubnetGroupNamePrefix
--- PASS: TestValidateDbSubnetGroupNamePrefix (0.00s)
=== RUN   TestValidateNeptuneSubnetGroupNamePrefix
--- PASS: TestValidateNeptuneSubnetGroupNamePrefix (0.00s)
=== RUN   TestValidateDbOptionGroupName
--- PASS: TestValidateDbOptionGroupName (0.00s)
=== RUN   TestValidateDbOptionGroupNamePrefix
--- PASS: TestValidateDbOptionGroupNamePrefix (0.00s)
=== RUN   TestValidateDbParamGroupName
--- PASS: TestValidateDbParamGroupName (0.00s)
=== RUN   TestValidateOpenIdURL
--- PASS: TestValidateOpenIdURL (0.00s)
=== RUN   TestValidateAwsKmsName
--- PASS: TestValidateAwsKmsName (0.00s)
=== RUN   TestValidateAwsKmsGrantName
--- PASS: TestValidateAwsKmsGrantName (0.00s)
=== RUN   TestValidateCognitoIdentityPoolName
--- PASS: TestValidateCognitoIdentityPoolName (0.00s)
=== RUN   TestValidateCognitoProviderDeveloperName
--- PASS: TestValidateCognitoProviderDeveloperName (0.00s)
=== RUN   TestValidateCognitoSupportedLoginProviders
--- PASS: TestValidateCognitoSupportedLoginProviders (0.00s)
=== RUN   TestValidateCognitoIdentityProvidersClientId
--- PASS: TestValidateCognitoIdentityProvidersClientId (0.00s)
=== RUN   TestValidateCognitoIdentityProvidersProviderName
--- PASS: TestValidateCognitoIdentityProvidersProviderName (0.00s)
=== RUN   TestValidateCognitoUserPoolEmailVerificationMessage
--- PASS: TestValidateCognitoUserPoolEmailVerificationMessage (0.01s)
=== RUN   TestValidateCognitoUserPoolEmailVerificationSubject
--- PASS: TestValidateCognitoUserPoolEmailVerificationSubject (0.00s)
=== RUN   TestValidateCognitoUserPoolSmsAuthenticationMessage
--- PASS: TestValidateCognitoUserPoolSmsAuthenticationMessage (0.00s)
=== RUN   TestValidateCognitoUserPoolSmsVerificationMessage
--- PASS: TestValidateCognitoUserPoolSmsVerificationMessage (0.00s)
=== RUN   TestValidateWafMetricName
--- PASS: TestValidateWafMetricName (0.00s)
=== RUN   TestValidateIamRoleDescription
--- PASS: TestValidateIamRoleDescription (0.00s)
=== RUN   TestValidateAwsSSMName
--- PASS: TestValidateAwsSSMName (0.00s)
=== RUN   TestValidateBatchName
--- PASS: TestValidateBatchName (0.00s)
=== RUN   TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType
--- PASS: TestValidateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType (0.00s)
=== RUN   TestValidateCognitoRoleMappingsRulesConfiguration
--- PASS: TestValidateCognitoRoleMappingsRulesConfiguration (0.00s)
=== RUN   TestValidateSecurityGroupRuleDescription
--- PASS: TestValidateSecurityGroupRuleDescription (0.00s)
=== RUN   TestValidateCognitoRoles
--- PASS: TestValidateCognitoRoles (0.00s)
=== RUN   TestValidateKmsKey
--- PASS: TestValidateKmsKey (0.00s)
=== RUN   TestValidateCognitoUserPoolReplyEmailAddress
--- PASS: TestValidateCognitoUserPoolReplyEmailAddress (0.00s)
=== RUN   TestValidateCognitoUserGroupName
--- PASS: TestValidateCognitoUserGroupName (0.00s)
=== RUN   TestValidateCognitoUserPoolId
--- PASS: TestValidateCognitoUserPoolId (0.00s)
=== RUN   TestValidateAmazonSideAsn
--- PASS: TestValidateAmazonSideAsn (0.00s)
=== RUN   TestValidateLaunchTemplateName
--- PASS: TestValidateLaunchTemplateName (0.00s)
=== RUN   TestValidateLaunchTemplateId
--- PASS: TestValidateLaunchTemplateId (0.00s)
=== RUN   TestValidateNeptuneParamGroupName
--- PASS: TestValidateNeptuneParamGroupName (0.00s)
=== RUN   TestValidateNeptuneParamGroupNamePrefix
--- PASS: TestValidateNeptuneParamGroupNamePrefix (0.00s)
=== RUN   TestValidateCloudFrontPublicKeyName
--- PASS: TestValidateCloudFrontPublicKeyName (0.00s)
=== RUN   TestValidateCloudFrontPublicKeyNamePrefix
--- PASS: TestValidateCloudFrontPublicKeyNamePrefix (0.00s)
=== RUN   TestValidateDxConnectionBandWidth
--- PASS: TestValidateDxConnectionBandWidth (0.00s)
=== RUN   TestValidateLbTargetGroupName
--- PASS: TestValidateLbTargetGroupName (0.00s)
=== RUN   TestValidateLbTargetGroupNamePrefix
--- PASS: TestValidateLbTargetGroupNamePrefix (0.00s)
=== RUN   TestValidateSecretManagerSecretName
--- PASS: TestValidateSecretManagerSecretName (0.00s)
=== RUN   TestValidateSecretManagerSecretNamePrefix
--- PASS: TestValidateSecretManagerSecretNamePrefix (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.059s
```