### PR TITLE
gosimple: Fix WAF-related issues

### DIFF
--- a/aws/resource_aws_waf_byte_match_set.go
+++ b/aws/resource_aws_waf_byte_match_set.go
@@ -175,7 +175,7 @@ func updateByteMatchSetResource(id string, oldT, newT []interface{}, conn *waf.W
 }
 
 func flattenWafByteMatchTuples(bmt []*waf.ByteMatchTuple) []interface{} {
-	out := make([]interface{}, len(bmt), len(bmt))
+	out := make([]interface{}, len(bmt))
 	for i, t := range bmt {
 		m := make(map[string]interface{})
 

--- a/aws/resource_aws_waf_rule_group.go
+++ b/aws/resource_aws_waf_rule_group.go
@@ -140,11 +140,8 @@ func resourceAwsWafRuleGroupDelete(d *schema.ResourceData, meta interface{}) err
 
 	oldRules := d.Get("activated_rule").(*schema.Set).List()
 	err := deleteWafRuleGroup(d.Id(), oldRules, conn)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func deleteWafRuleGroup(id string, oldRules []interface{}, conn *waf.WAF) error {

--- a/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/aws/resource_aws_waf_size_constraint_set_test.go
@@ -219,10 +219,8 @@ func testAccCheckAWSWafSizeConstraintSetDisappears(v *waf.SizeConstraintSet) res
 			}
 			return conn.DeleteSizeConstraintSet(opts)
 		})
-		if err != nil {
-			return err
-		}
-		return nil
+
+		return err
 	}
 }
 

--- a/aws/resource_aws_waf_sql_injection_match_set.go
+++ b/aws/resource_aws_waf_sql_injection_match_set.go
@@ -168,7 +168,7 @@ func updateSqlInjectionMatchSetResource(id string, oldT, newT []interface{}, con
 }
 
 func flattenWafSqlInjectionMatchTuples(ts []*waf.SqlInjectionMatchTuple) []interface{} {
-	out := make([]interface{}, len(ts), len(ts))
+	out := make([]interface{}, len(ts))
 	for i, t := range ts {
 		m := make(map[string]interface{})
 		m["text_transformation"] = *t.TextTransformation

--- a/aws/resource_aws_waf_xss_match_set.go
+++ b/aws/resource_aws_waf_xss_match_set.go
@@ -168,7 +168,7 @@ func updateXssMatchSetResource(id string, oldT, newT []interface{}, conn *waf.WA
 }
 
 func flattenWafXssMatchTuples(ts []*waf.XssMatchTuple) []interface{} {
-	out := make([]interface{}, len(ts), len(ts))
+	out := make([]interface{}, len(ts))
 	for i, t := range ts {
 		m := make(map[string]interface{})
 		m["field_to_match"] = flattenFieldToMatch(t.FieldToMatch)

--- a/aws/resource_aws_wafregional_ipset.go
+++ b/aws/resource_aws_wafregional_ipset.go
@@ -103,7 +103,7 @@ func resourceAwsWafRegionalIPSetRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func flattenWafIpSetDescriptorWR(in []*waf.IPSetDescriptor) []interface{} {
-	descriptors := make([]interface{}, len(in), len(in))
+	descriptors := make([]interface{}, len(in))
 
 	for i, descriptor := range in {
 		d := map[string]interface{}{

--- a/aws/resource_aws_wafregional_rule.go
+++ b/aws/resource_aws_wafregional_rule.go
@@ -168,7 +168,7 @@ func updateWafRegionalRuleResource(id string, oldP, newP []interface{}, meta int
 }
 
 func flattenWafPredicates(ts []*waf.Predicate) []interface{} {
-	out := make([]interface{}, len(ts), len(ts))
+	out := make([]interface{}, len(ts))
 	for i, p := range ts {
 		m := make(map[string]interface{})
 		m["negated"] = *p.Negated

--- a/aws/resource_aws_wafregional_rule_group.go
+++ b/aws/resource_aws_wafregional_rule_group.go
@@ -144,11 +144,8 @@ func resourceAwsWafRegionalRuleGroupDelete(d *schema.ResourceData, meta interfac
 
 	oldRules := d.Get("activated_rule").(*schema.Set).List()
 	err := deleteWafRegionalRuleGroup(d.Id(), oldRules, conn, region)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func deleteWafRegionalRuleGroup(id string, oldRules []interface{}, conn *wafregional.WAFRegional, region string) error {

--- a/aws/resource_aws_wafregional_size_constraint_set_test.go
+++ b/aws/resource_aws_wafregional_size_constraint_set_test.go
@@ -220,10 +220,8 @@ func testAccCheckAWSWafRegionalSizeConstraintSetDisappears(constraints *waf.Size
 			}
 			return conn.DeleteSizeConstraintSet(opts)
 		})
-		if err != nil {
-			return err
-		}
-		return nil
+
+		return err
 	}
 }
 

--- a/aws/resource_aws_wafregional_web_acl_association.go
+++ b/aws/resource_aws_wafregional_web_acl_association.go
@@ -113,11 +113,7 @@ func resourceAwsWafRegionalWebAclAssociationDelete(d *schema.ResourceData, meta 
 
 	// If action successful HTTP 200 response with an empty body
 	_, err := conn.DisassociateWebACL(params)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func resourceAwsWafRegionalWebAclAssociationParseId(id string) (webAclId, resourceArn string) {

--- a/aws/waf_helpers.go
+++ b/aws/waf_helpers.go
@@ -98,7 +98,7 @@ func diffWafSizeConstraints(oldS, newS []interface{}) []*waf.SizeConstraintSetUp
 }
 
 func flattenWafSizeConstraints(sc []*waf.SizeConstraint) []interface{} {
-	out := make([]interface{}, len(sc), len(sc))
+	out := make([]interface{}, len(sc))
 	for i, c := range sc {
 		m := make(map[string]interface{})
 		m["comparison_operator"] = *c.ComparisonOperator
@@ -113,7 +113,7 @@ func flattenWafSizeConstraints(sc []*waf.SizeConstraint) []interface{} {
 }
 
 func flattenWafGeoMatchConstraint(ts []*waf.GeoMatchConstraint) []interface{} {
-	out := make([]interface{}, len(ts), len(ts))
+	out := make([]interface{}, len(ts))
 	for i, t := range ts {
 		m := make(map[string]interface{})
 		m["type"] = *t.Type
@@ -256,7 +256,7 @@ func diffWafRuleGroupActivatedRules(oldRules, newRules []interface{}) []*waf.Rul
 }
 
 func flattenWafActivatedRules(activatedRules []*waf.ActivatedRule) []interface{} {
-	out := make([]interface{}, len(activatedRules), len(activatedRules))
+	out := make([]interface{}, len(activatedRules))
 	for i, ar := range activatedRules {
 		rule := map[string]interface{}{
 			"priority": int(*ar.Priority),
@@ -292,7 +292,7 @@ func expandWafActivatedRule(rule map[string]interface{}) *waf.ActivatedRule {
 }
 
 func flattenWafRegexMatchTuples(tuples []*waf.RegexMatchTuple) []interface{} {
-	out := make([]interface{}, len(tuples), len(tuples))
+	out := make([]interface{}, len(tuples))
 	for i, t := range tuples {
 		m := make(map[string]interface{})
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Related to #6343 technical debt

Changes proposed in this pull request:

* Fixes for all WAF-related tests and resources

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSWafByteMatchSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafByteMatchSet_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafByteMatchSet_basic
=== PAUSE TestAccAWSWafByteMatchSet_basic
=== CONT  TestAccAWSWafByteMatchSet_basic
--- PASS: TestAccAWSWafByteMatchSet_basic (16.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.916s

$ make testacc TESTARGS='-run=TestAccAWSWafRuleGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafRuleGroup_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafRuleGroup_basic
=== PAUSE TestAccAWSWafRuleGroup_basic
=== CONT  TestAccAWSWafRuleGroup_basic
--- PASS: TestAccAWSWafRuleGroup_basic (21.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	21.154s

$ make testacc TESTARGS='-run=TestAccAWSWafSizeConstraintSet_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafSizeConstraintSet_disappears -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafSizeConstraintSet_disappears
=== PAUSE TestAccAWSWafSizeConstraintSet_disappears
=== CONT  TestAccAWSWafSizeConstraintSet_disappears
--- PASS: TestAccAWSWafSizeConstraintSet_disappears (16.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	16.865s

$ make testacc TESTARGS='-run=TestAccAWSWafRegionalSqlInjectionMatchSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafRegionalSqlInjectionMatchSet_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== PAUSE TestAccAWSWafRegionalSqlInjectionMatchSet_basic
=== CONT  TestAccAWSWafRegionalSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafRegionalSqlInjectionMatchSet_basic (18.14s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.188s

$ make testacc TESTARGS='-run=TestAccAWSWafXssMatchSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafXssMatchSet_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafXssMatchSet_basic
=== PAUSE TestAccAWSWafXssMatchSet_basic
=== CONT  TestAccAWSWafXssMatchSet_basic
--- PASS: TestAccAWSWafXssMatchSet_basic (18.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.068s

$ make testacc TESTARGS='-run=TestAccAWSWafRegionalIPSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafRegionalIPSet_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafRegionalIPSet_basic
=== PAUSE TestAccAWSWafRegionalIPSet_basic
=== CONT  TestAccAWSWafRegionalIPSet_basic
--- PASS: TestAccAWSWafRegionalIPSet_basic (17.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	17.384s

$ make testacc TESTARGS='-run=TestAccAWSWafRegionalRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafRegionalRule_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafRegionalRule_basic
=== PAUSE TestAccAWSWafRegionalRule_basic
=== CONT  TestAccAWSWafRegionalRule_basic
--- PASS: TestAccAWSWafRegionalRule_basic (31.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	31.368s

$ make testacc TESTARGS='-run=TestAccAWSWafRegionalRuleGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafRegionalRuleGroup_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafRegionalRuleGroup_basic
=== PAUSE TestAccAWSWafRegionalRuleGroup_basic
=== CONT  TestAccAWSWafRegionalRuleGroup_basic
--- PASS: TestAccAWSWafRegionalRuleGroup_basic (24.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.707s

$ make testacc TESTARGS='-run=TestAccAWSWafRegionalSizeConstraintSet_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafRegionalSizeConstraintSet_disappears -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafRegionalSizeConstraintSet_disappears
=== PAUSE TestAccAWSWafRegionalSizeConstraintSet_disappears
=== CONT  TestAccAWSWafRegionalSizeConstraintSet_disappears
--- PASS: TestAccAWSWafRegionalSizeConstraintSet_disappears (15.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	15.170s

$ make testacc TESTARGS='-run=TestAccAWSWafRegionalWebAclAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWafRegionalWebAclAssociation -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSWafRegionalWebAclAssociation_basic
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_basic
=== RUN   TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
=== PAUSE TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
=== CONT  TestAccAWSWafRegionalWebAclAssociation_basic
=== CONT  TestAccAWSWafRegionalWebAclAssociation_multipleAssociations
--- PASS: TestAccAWSWafRegionalWebAclAssociation_multipleAssociations (255.93s)
--- PASS: TestAccAWSWafRegionalWebAclAssociation_basic (265.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	265.754s
```