### PR TITLE
resource/aws_cloudwatch_metric_alarm: Accept EC2 automate reboot ARN

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -54,7 +54,7 @@ func TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudWatchMetricAlarmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudWatchMetricAlarmConfigAlarmActionsEC2Automate(rName, "recover"),
+				Config: testAccAWSCloudWatchMetricAlarmConfigAlarmActionsEC2Automate(rName, "reboot"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
 					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
@@ -64,6 +64,27 @@ func TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCloudWatchMetricAlarmConfigAlarmActionsEC2Automate(rName, "recover"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSCloudWatchMetricAlarmConfigAlarmActionsEC2Automate(rName, "stop"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSCloudWatchMetricAlarmConfigAlarmActionsEC2Automate(rName, "terminate"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists(resourceName, &alarm),
+					resource.TestCheckResourceAttr(resourceName, "alarm_actions.#", "1"),
+				),
 			},
 		},
 	})

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -473,7 +473,7 @@ func validateEC2AutomateARN(v interface{}, k string) (ws []string, errors []erro
 	value := v.(string)
 
 	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html
-	pattern := `^arn:[\w-]+:automate:[\w-]+:ec2:(recover|stop|terminate)$`
+	pattern := `^arn:[\w-]+:automate:[\w-]+:ec2:(reboot|recover|stop|terminate)$`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q does not match EC2 automation ARN (%q): %q",

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -369,6 +369,7 @@ func TestValidateArn(t *testing.T) {
 
 func TestValidateEC2AutomateARN(t *testing.T) {
 	validNames := []string{
+		"arn:aws:automate:us-east-1:ec2:reboot",
 		"arn:aws:automate:us-east-1:ec2:recover",
 		"arn:aws:automate:us-east-1:ec2:stop",
 		"arn:aws:automate:us-east-1:ec2:terminate",


### PR DESCRIPTION
Fixes #6386 

`reboot` was documented under OKActions but not AlarmActions in  https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html, but turns out _is_ supported in AlarmActions.

Previously:

```
--- FAIL: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (9.08s)
    testing.go:538: Step 0 error: Error planning: 2 errors occurred:
        	* aws_cloudwatch_metric_alarm.test: "alarm_actions.0" doesn't look like a valid ARN ("^arn:[\\w-]+:([a-zA-Z0-9\\-])+:([a-z]{2}-(gov-)?[a-z]+-\\d{1})?:(\\d{12})?:(.*)$"): "arn:aws:automate:us-west-2:ec2:reboot"
        	* aws_cloudwatch_metric_alarm.test: "alarm_actions.0" does not match EC2 automation ARN ("^arn:[\\w-]+:automate:[\\w-]+:ec2:(recover|stop|terminate)$"): "arn:aws:automate:us-west-2:ec2:reboot"
```

```
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (194.97s)
```
