### PR TITLE
gosimple: Fix CloudFront-related issues

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -56,7 +56,7 @@ func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionCo
 		distributionConfig.CacheBehaviors = expandCacheBehaviorsDeprecated(d.Get("cache_behavior").(*schema.Set))
 	}
 	// This sets CallerReference if it's still pending computation (ie: new resource)
-	if v, ok := d.GetOk("caller_reference"); ok == false {
+	if v, ok := d.GetOk("caller_reference"); !ok {
 		distributionConfig.CallerReference = aws.String(time.Now().Format(time.RFC3339Nano))
 	} else {
 		distributionConfig.CallerReference = aws.String(v.(string))
@@ -524,7 +524,7 @@ func lambdaFunctionAssociationHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["event_type"].(string)))
-	buf.WriteString(fmt.Sprintf("%s", m["lambda_arn"].(string)))
+	buf.WriteString(m["lambda_arn"].(string))
 	buf.WriteString(fmt.Sprintf("%t", m["include_body"].(bool)))
 	return hashcode.String(buf.String())
 }
@@ -1259,7 +1259,7 @@ func simpleCopyStruct(src, dst interface{}) {
 	d := reflect.ValueOf(dst).Elem()
 
 	for i := 0; i < s.NumField(); i++ {
-		if s.Field(i).CanSet() == true {
+		if s.Field(i).CanSet() {
 			if s.Field(i).Interface() != nil {
 				for j := 0; j < d.NumField(); j++ {
 					if d.Type().Field(j).Name == s.Type().Field(i).Name {

--- a/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/aws/cloudfront_distribution_configuration_structure_test.go
@@ -261,7 +261,7 @@ func TestCloudFrontStructure_expandDefaultCacheBehavior(t *testing.T) {
 	if dcb == nil {
 		t.Fatalf("ExpandDefaultCacheBehavior returned nil")
 	}
-	if *dcb.Compress != true {
+	if !*dcb.Compress {
 		t.Fatalf("Expected Compress to be true, got %v", *dcb.Compress)
 	}
 	if *dcb.ViewerProtocolPolicy != "allow-all" {
@@ -270,19 +270,19 @@ func TestCloudFrontStructure_expandDefaultCacheBehavior(t *testing.T) {
 	if *dcb.TargetOriginId != "myS3Origin" {
 		t.Fatalf("Expected TargetOriginId to be allow-all, got %v", *dcb.TargetOriginId)
 	}
-	if reflect.DeepEqual(dcb.ForwardedValues.Headers.Items, expandStringList(headersConf())) != true {
+	if !reflect.DeepEqual(dcb.ForwardedValues.Headers.Items, expandStringList(headersConf())) {
 		t.Fatalf("Expected Items to be %v, got %v", headersConf(), dcb.ForwardedValues.Headers.Items)
 	}
 	if *dcb.MinTTL != 0 {
 		t.Fatalf("Expected MinTTL to be 0, got %v", *dcb.MinTTL)
 	}
-	if reflect.DeepEqual(dcb.TrustedSigners.Items, expandStringList(trustedSignersConf())) != true {
+	if !reflect.DeepEqual(dcb.TrustedSigners.Items, expandStringList(trustedSignersConf())) {
 		t.Fatalf("Expected TrustedSigners.Items to be %v, got %v", trustedSignersConf(), dcb.TrustedSigners.Items)
 	}
 	if *dcb.MaxTTL != 31536000 {
 		t.Fatalf("Expected MaxTTL to be 31536000, got %v", *dcb.MaxTTL)
 	}
-	if *dcb.SmoothStreaming != false {
+	if *dcb.SmoothStreaming {
 		t.Fatalf("Expected SmoothStreaming to be false, got %v", *dcb.SmoothStreaming)
 	}
 	if *dcb.DefaultTTL != 86400 {
@@ -291,10 +291,10 @@ func TestCloudFrontStructure_expandDefaultCacheBehavior(t *testing.T) {
 	if *dcb.LambdaFunctionAssociations.Quantity != 2 {
 		t.Fatalf("Expected LambdaFunctionAssociations to be 2, got %v", *dcb.LambdaFunctionAssociations.Quantity)
 	}
-	if reflect.DeepEqual(dcb.AllowedMethods.Items, expandStringList(allowedMethodsConf())) != true {
+	if !reflect.DeepEqual(dcb.AllowedMethods.Items, expandStringList(allowedMethodsConf())) {
 		t.Fatalf("Expected AllowedMethods.Items to be %v, got %v", allowedMethodsConf(), dcb.AllowedMethods.Items)
 	}
-	if reflect.DeepEqual(dcb.AllowedMethods.CachedMethods.Items, expandStringList(cachedMethodsConf())) != true {
+	if !reflect.DeepEqual(dcb.AllowedMethods.CachedMethods.Items, expandStringList(cachedMethodsConf())) {
 		t.Fatalf("Expected AllowedMethods.CachedMethods.Items to be %v, got %v", cachedMethodsConf(), dcb.AllowedMethods.CachedMethods.Items)
 	}
 }
@@ -313,7 +313,7 @@ func TestCloudFrontStructure_flattenDefaultCacheBehavior(t *testing.T) {
 func TestCloudFrontStructure_expandCacheBehavior(t *testing.T) {
 	data := cacheBehaviorConf1()
 	cb := expandCacheBehaviorDeprecated(data)
-	if *cb.Compress != true {
+	if !*cb.Compress {
 		t.Fatalf("Expected Compress to be true, got %v", *cb.Compress)
 	}
 	if *cb.ViewerProtocolPolicy != "allow-all" {
@@ -322,19 +322,19 @@ func TestCloudFrontStructure_expandCacheBehavior(t *testing.T) {
 	if *cb.TargetOriginId != "myS3Origin" {
 		t.Fatalf("Expected TargetOriginId to be myS3Origin, got %v", *cb.TargetOriginId)
 	}
-	if reflect.DeepEqual(cb.ForwardedValues.Headers.Items, expandStringList(headersConf())) != true {
+	if !reflect.DeepEqual(cb.ForwardedValues.Headers.Items, expandStringList(headersConf())) {
 		t.Fatalf("Expected Items to be %v, got %v", headersConf(), cb.ForwardedValues.Headers.Items)
 	}
 	if *cb.MinTTL != 0 {
 		t.Fatalf("Expected MinTTL to be 0, got %v", *cb.MinTTL)
 	}
-	if reflect.DeepEqual(cb.TrustedSigners.Items, expandStringList(trustedSignersConf())) != true {
+	if !reflect.DeepEqual(cb.TrustedSigners.Items, expandStringList(trustedSignersConf())) {
 		t.Fatalf("Expected TrustedSigners.Items to be %v, got %v", trustedSignersConf(), cb.TrustedSigners.Items)
 	}
 	if *cb.MaxTTL != 31536000 {
 		t.Fatalf("Expected MaxTTL to be 31536000, got %v", *cb.MaxTTL)
 	}
-	if *cb.SmoothStreaming != false {
+	if *cb.SmoothStreaming {
 		t.Fatalf("Expected SmoothStreaming to be false, got %v", *cb.SmoothStreaming)
 	}
 	if *cb.DefaultTTL != 86400 {
@@ -343,10 +343,10 @@ func TestCloudFrontStructure_expandCacheBehavior(t *testing.T) {
 	if *cb.LambdaFunctionAssociations.Quantity != 2 {
 		t.Fatalf("Expected LambdaFunctionAssociations to be 2, got %v", *cb.LambdaFunctionAssociations.Quantity)
 	}
-	if reflect.DeepEqual(cb.AllowedMethods.Items, expandStringList(allowedMethodsConf())) != true {
+	if !reflect.DeepEqual(cb.AllowedMethods.Items, expandStringList(allowedMethodsConf())) {
 		t.Fatalf("Expected AllowedMethods.Items to be %v, got %v", allowedMethodsConf(), cb.AllowedMethods.Items)
 	}
-	if reflect.DeepEqual(cb.AllowedMethods.CachedMethods.Items, expandStringList(cachedMethodsConf())) != true {
+	if !reflect.DeepEqual(cb.AllowedMethods.CachedMethods.Items, expandStringList(cachedMethodsConf())) {
 		t.Fatalf("Expected AllowedMethods.CachedMethods.Items to be %v, got %v", cachedMethodsConf(), cb.AllowedMethods.CachedMethods.Items)
 	}
 	if *cb.PathPattern != "/path1" {
@@ -359,7 +359,7 @@ func TestCloudFrontStructure_flattenCacheBehavior(t *testing.T) {
 	cb := expandCacheBehaviorDeprecated(in)
 	out := flattenCacheBehaviorDeprecated(cb)
 	var diff *schema.Set
-	if out["compress"] != true {
+	if !out["compress"].(bool) {
 		t.Fatalf("Expected out[compress] to be true, got %v", out["compress"])
 	}
 	if out["viewer_protocol_policy"] != "allow-all" {
@@ -390,22 +390,22 @@ func TestCloudFrontStructure_flattenCacheBehavior(t *testing.T) {
 	if out["min_ttl"] != int(0) {
 		t.Fatalf("Expected out[min_ttl] to be 0 (int), got %v", out["min_ttl"])
 	}
-	if reflect.DeepEqual(out["trusted_signers"], in["trusted_signers"]) != true {
+	if !reflect.DeepEqual(out["trusted_signers"], in["trusted_signers"]) {
 		t.Fatalf("Expected out[trusted_signers] to be %v, got %v", in["trusted_signers"], out["trusted_signers"])
 	}
 	if out["max_ttl"] != int(31536000) {
 		t.Fatalf("Expected out[max_ttl] to be 31536000 (int), got %v", out["max_ttl"])
 	}
-	if out["smooth_streaming"] != false {
+	if out["smooth_streaming"].(bool) {
 		t.Fatalf("Expected out[smooth_streaming] to be false, got %v", out["smooth_streaming"])
 	}
 	if out["default_ttl"] != int(86400) {
 		t.Fatalf("Expected out[default_ttl] to be 86400 (int), got %v", out["default_ttl"])
 	}
-	if reflect.DeepEqual(out["allowed_methods"], in["allowed_methods"]) != true {
+	if !reflect.DeepEqual(out["allowed_methods"], in["allowed_methods"]) {
 		t.Fatalf("Expected out[allowed_methods] to be %v, got %v", in["allowed_methods"], out["allowed_methods"])
 	}
-	if reflect.DeepEqual(out["cached_methods"], in["cached_methods"]) != true {
+	if !reflect.DeepEqual(out["cached_methods"], in["cached_methods"]) {
 		t.Fatalf("Expected out[cached_methods] to be %v, got %v", in["cached_methods"], out["cached_methods"])
 	}
 	if out["path_pattern"] != "/path1" {
@@ -441,10 +441,10 @@ func TestCloudFrontStructure_expandTrustedSigners(t *testing.T) {
 	if *ts.Quantity != 2 {
 		t.Fatalf("Expected Quantity to be 2, got %v", *ts.Quantity)
 	}
-	if *ts.Enabled != true {
+	if !*ts.Enabled {
 		t.Fatalf("Expected Enabled to be true, got %v", *ts.Enabled)
 	}
-	if reflect.DeepEqual(ts.Items, expandStringList(data)) != true {
+	if !reflect.DeepEqual(ts.Items, expandStringList(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, ts.Items)
 	}
 }
@@ -454,7 +454,7 @@ func TestCloudFrontStructure_flattenTrustedSigners(t *testing.T) {
 	ts := expandTrustedSigners(in)
 	out := flattenTrustedSigners(ts)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -465,7 +465,7 @@ func TestCloudFrontStructure_expandTrustedSigners_empty(t *testing.T) {
 	if *ts.Quantity != 0 {
 		t.Fatalf("Expected Quantity to be 0, got %v", *ts.Quantity)
 	}
-	if *ts.Enabled != false {
+	if *ts.Enabled {
 		t.Fatalf("Expected Enabled to be true, got %v", *ts.Enabled)
 	}
 	if ts.Items != nil {
@@ -495,7 +495,7 @@ func TestCloudFrontStructure_flattenlambdaFunctionAssociations(t *testing.T) {
 	lfa := expandLambdaFunctionAssociations(in.List())
 	out := flattenLambdaFunctionAssociations(lfa)
 
-	if reflect.DeepEqual(in.List(), out.List()) != true {
+	if !reflect.DeepEqual(in.List(), out.List()) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -509,7 +509,7 @@ func TestCloudFrontStructure_expandlambdaFunctionAssociations_empty(t *testing.T
 	if len(lfa.Items) != 0 {
 		t.Fatalf("Expected Items to be len 0, got %v", len(lfa.Items))
 	}
-	if reflect.DeepEqual(lfa.Items, []*cloudfront.LambdaFunctionAssociation{}) != true {
+	if !reflect.DeepEqual(lfa.Items, []*cloudfront.LambdaFunctionAssociation{}) {
 		t.Fatalf("Expected Items to be empty, got %v", lfa.Items)
 	}
 }
@@ -517,13 +517,13 @@ func TestCloudFrontStructure_expandlambdaFunctionAssociations_empty(t *testing.T
 func TestCloudFrontStructure_expandForwardedValues(t *testing.T) {
 	data := forwardedValuesConf()
 	fv := expandForwardedValues(data)
-	if *fv.QueryString != true {
+	if !*fv.QueryString {
 		t.Fatalf("Expected QueryString to be true, got %v", *fv.QueryString)
 	}
-	if reflect.DeepEqual(fv.Cookies.WhitelistedNames.Items, expandStringList(cookieNamesConf())) != true {
+	if !reflect.DeepEqual(fv.Cookies.WhitelistedNames.Items, expandStringList(cookieNamesConf())) {
 		t.Fatalf("Expected Cookies.WhitelistedNames.Items to be %v, got %v", cookieNamesConf(), fv.Cookies.WhitelistedNames.Items)
 	}
-	if reflect.DeepEqual(fv.Headers.Items, expandStringList(headersConf())) != true {
+	if !reflect.DeepEqual(fv.Headers.Items, expandStringList(headersConf())) {
 		t.Fatalf("Expected Headers.Items to be %v, got %v", headersConf(), fv.Headers.Items)
 	}
 }
@@ -533,13 +533,13 @@ func TestCloudFrontStructure_flattenForwardedValues(t *testing.T) {
 	fv := expandForwardedValues(in)
 	out := flattenForwardedValues(fv)
 
-	if out["query_string"] != true {
+	if !out["query_string"].(bool) {
 		t.Fatalf("Expected out[query_string] to be true, got %v", out["query_string"])
 	}
-	if out["cookies"].(*schema.Set).Equal(in["cookies"].(*schema.Set)) != true {
+	if !out["cookies"].(*schema.Set).Equal(in["cookies"].(*schema.Set)) {
 		t.Fatalf("Expected out[cookies] to be %v, got %v", in["cookies"], out["cookies"])
 	}
-	if reflect.DeepEqual(out["headers"], in["headers"]) != true {
+	if !reflect.DeepEqual(out["headers"], in["headers"]) {
 		t.Fatalf("Expected out[headers] to be %v, got %v", in["headers"], out["headers"])
 	}
 }
@@ -550,7 +550,7 @@ func TestCloudFrontStructure_expandHeaders(t *testing.T) {
 	if *h.Quantity != 2 {
 		t.Fatalf("Expected Quantity to be 2, got %v", *h.Quantity)
 	}
-	if reflect.DeepEqual(h.Items, expandStringList(data)) != true {
+	if !reflect.DeepEqual(h.Items, expandStringList(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, h.Items)
 	}
 }
@@ -560,7 +560,7 @@ func TestCloudFrontStructure_flattenHeaders(t *testing.T) {
 	h := expandHeaders(in)
 	out := flattenHeaders(h)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -571,7 +571,7 @@ func TestCloudFrontStructure_expandQueryStringCacheKeys(t *testing.T) {
 	if *k.Quantity != 2 {
 		t.Fatalf("Expected Quantity to be 2, got %v", *k.Quantity)
 	}
-	if reflect.DeepEqual(k.Items, expandStringList(data)) != true {
+	if !reflect.DeepEqual(k.Items, expandStringList(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, k.Items)
 	}
 }
@@ -581,7 +581,7 @@ func TestCloudFrontStructure_flattenQueryStringCacheKeys(t *testing.T) {
 	k := expandQueryStringCacheKeys(in)
 	out := flattenQueryStringCacheKeys(k)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -592,7 +592,7 @@ func TestCloudFrontStructure_expandCookiePreference(t *testing.T) {
 	if *cp.Forward != "whitelist" {
 		t.Fatalf("Expected Forward to be whitelist, got %v", *cp.Forward)
 	}
-	if reflect.DeepEqual(cp.WhitelistedNames.Items, expandStringList(cookieNamesConf())) != true {
+	if !reflect.DeepEqual(cp.WhitelistedNames.Items, expandStringList(cookieNamesConf())) {
 		t.Fatalf("Expected WhitelistedNames.Items to be %v, got %v", cookieNamesConf(), cp.WhitelistedNames.Items)
 	}
 }
@@ -602,7 +602,7 @@ func TestCloudFrontStructure_flattenCookiePreference(t *testing.T) {
 	cp := expandCookiePreference(in)
 	out := flattenCookiePreference(cp)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -613,7 +613,7 @@ func TestCloudFrontStructure_expandCookieNames(t *testing.T) {
 	if *cn.Quantity != 2 {
 		t.Fatalf("Expected Quantity to be 2, got %v", *cn.Quantity)
 	}
-	if reflect.DeepEqual(cn.Items, expandStringList(data)) != true {
+	if !reflect.DeepEqual(cn.Items, expandStringList(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, cn.Items)
 	}
 }
@@ -623,7 +623,7 @@ func TestCloudFrontStructure_flattenCookieNames(t *testing.T) {
 	cn := expandCookieNames(in)
 	out := flattenCookieNames(cn)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -634,7 +634,7 @@ func TestCloudFrontStructure_expandAllowedMethods(t *testing.T) {
 	if *am.Quantity != 7 {
 		t.Fatalf("Expected Quantity to be 7, got %v", *am.Quantity)
 	}
-	if reflect.DeepEqual(am.Items, expandStringList(data)) != true {
+	if !reflect.DeepEqual(am.Items, expandStringList(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, am.Items)
 	}
 }
@@ -644,7 +644,7 @@ func TestCloudFrontStructure_flattenAllowedMethods(t *testing.T) {
 	am := expandAllowedMethodsDeprecated(in)
 	out := flattenAllowedMethodsDeprecated(am)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -655,7 +655,7 @@ func TestCloudFrontStructure_expandCachedMethods(t *testing.T) {
 	if *cm.Quantity != 3 {
 		t.Fatalf("Expected Quantity to be 3, got %v", *cm.Quantity)
 	}
-	if reflect.DeepEqual(cm.Items, expandStringList(data)) != true {
+	if !reflect.DeepEqual(cm.Items, expandStringList(data)) {
 		t.Fatalf("Expected Items to be %v, got %v", data, cm.Items)
 	}
 }
@@ -665,7 +665,7 @@ func TestCloudFrontStructure_flattenCachedMethods(t *testing.T) {
 	cm := expandCachedMethodsDeprecated(in)
 	out := flattenCachedMethodsDeprecated(cm)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -726,7 +726,7 @@ func TestCloudFrontStructure_flattenOrigin(t *testing.T) {
 	if out["origin_path"] != "/" {
 		t.Fatalf("Expected out[origin_path] to be /, got %v", out["origin_path"])
 	}
-	if out["custom_origin_config"].(*schema.Set).Equal(in["custom_origin_config"].(*schema.Set)) != true {
+	if !out["custom_origin_config"].(*schema.Set).Equal(in["custom_origin_config"].(*schema.Set)) {
 		t.Fatalf("Expected out[custom_origin_config] to be %v, got %v", in["custom_origin_config"], out["custom_origin_config"])
 	}
 }
@@ -803,7 +803,7 @@ func TestCloudFrontStructure_flattenCustomOriginConfig(t *testing.T) {
 	co := expandCustomOriginConfig(in)
 	out := flattenCustomOriginConfig(co)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -824,7 +824,7 @@ func TestCloudFrontStructure_flattenCustomOriginConfigSSL(t *testing.T) {
 	ocs := expandCustomOriginConfigSSL(in)
 	out := flattenCustomOriginConfigSSL(ocs)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -842,7 +842,7 @@ func TestCloudFrontStructure_flattenS3OriginConfig(t *testing.T) {
 	s3o := expandS3OriginConfig(in)
 	out := flattenS3OriginConfig(s3o)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -863,7 +863,7 @@ func TestCloudFrontStructure_flattenCustomErrorResponses(t *testing.T) {
 	ers := expandCustomErrorResponses(in)
 	out := flattenCustomErrorResponses(ers)
 
-	if in.Equal(out) != true {
+	if !in.Equal(out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -901,7 +901,7 @@ func TestCloudFrontStructure_flattenCustomErrorResponse(t *testing.T) {
 	er := expandCustomErrorResponse(in)
 	out := flattenCustomErrorResponse(er)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -910,7 +910,7 @@ func TestCloudFrontStructure_expandLoggingConfig(t *testing.T) {
 	data := loggingConfigConf()
 
 	lc := expandLoggingConfig(data)
-	if *lc.Enabled != true {
+	if !*lc.Enabled {
 		t.Fatalf("Expected Enabled to be true, got %v", *lc.Enabled)
 	}
 	if *lc.Prefix != "myprefix" {
@@ -919,14 +919,14 @@ func TestCloudFrontStructure_expandLoggingConfig(t *testing.T) {
 	if *lc.Bucket != "mylogs.s3.amazonaws.com" {
 		t.Fatalf("Expected Bucket to be mylogs.s3.amazonaws.com, got %v", *lc.Bucket)
 	}
-	if *lc.IncludeCookies != false {
+	if *lc.IncludeCookies {
 		t.Fatalf("Expected IncludeCookies to be false, got %v", *lc.IncludeCookies)
 	}
 }
 
 func TestCloudFrontStructure_expandLoggingConfig_nilValue(t *testing.T) {
 	lc := expandLoggingConfig(nil)
-	if *lc.Enabled != false {
+	if *lc.Enabled {
 		t.Fatalf("Expected Enabled to be false, got %v", *lc.Enabled)
 	}
 	if *lc.Prefix != "" {
@@ -935,7 +935,7 @@ func TestCloudFrontStructure_expandLoggingConfig_nilValue(t *testing.T) {
 	if *lc.Bucket != "" {
 		t.Fatalf("Expected Bucket to be blank, got %v", *lc.Bucket)
 	}
-	if *lc.IncludeCookies != false {
+	if *lc.IncludeCookies {
 		t.Fatalf("Expected IncludeCookies to be false, got %v", *lc.IncludeCookies)
 	}
 }
@@ -957,7 +957,7 @@ func TestCloudFrontStructure_expandAliases(t *testing.T) {
 	if *a.Quantity != 2 {
 		t.Fatalf("Expected Quantity to be 2, got %v", *a.Quantity)
 	}
-	if reflect.DeepEqual(a.Items, expandStringList(data.List())) != true {
+	if !reflect.DeepEqual(a.Items, expandStringList(data.List())) {
 		t.Fatalf("Expected Items to be [example.com www.example.com], got %v", a.Items)
 	}
 }
@@ -1001,7 +1001,7 @@ func TestCloudFrontStructure_expandGeoRestriction_whitelist(t *testing.T) {
 	if *gr.Quantity != 3 {
 		t.Fatalf("Expected Quantity to be 3, got %v", *gr.Quantity)
 	}
-	if reflect.DeepEqual(gr.Items, aws.StringSlice([]string{"CA", "GB", "US"})) != true {
+	if !reflect.DeepEqual(gr.Items, aws.StringSlice([]string{"CA", "GB", "US"})) {
 		t.Fatalf("Expected Items be [CA, GB, US], got %v", gr.Items)
 	}
 }
@@ -1011,7 +1011,7 @@ func TestCloudFrontStructure_flattenGeoRestriction_whitelist(t *testing.T) {
 	gr := expandGeoRestriction(in)
 	out := flattenGeoRestriction(gr)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -1035,7 +1035,7 @@ func TestCloudFrontStructure_flattenGeoRestriction_no_items(t *testing.T) {
 	gr := expandGeoRestriction(in)
 	out := flattenGeoRestriction(gr)
 
-	if reflect.DeepEqual(in, out) != true {
+	if !reflect.DeepEqual(in, out) {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
@@ -1046,7 +1046,7 @@ func TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certific
 	if vc.ACMCertificateArn != nil {
 		t.Fatalf("Expected ACMCertificateArn to be unset, got %v", *vc.ACMCertificateArn)
 	}
-	if *vc.CloudFrontDefaultCertificate != true {
+	if !*vc.CloudFrontDefaultCertificate {
 		t.Fatalf("Expected CloudFrontDefaultCertificate to be true, got %v", *vc.CloudFrontDefaultCertificate)
 	}
 	if vc.IAMCertificateId != nil {

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -32,9 +32,7 @@ func testSweepCloudFrontDistributions(region string) error {
 
 	input := &cloudfront.ListDistributionsInput{}
 	err = conn.ListDistributionsPages(input, func(page *cloudfront.ListDistributionsOutput, lastPage bool) bool {
-		for _, distributionSummary := range page.DistributionList.Items {
-			distributionSummaries = append(distributionSummaries, distributionSummary)
-		}
+		distributionSummaries = append(distributionSummaries, page.DistributionList.Items...)
 		return !lastPage
 	})
 	if err != nil {
@@ -433,7 +431,7 @@ func testAccCheckCloudFrontDistributionDestroy(s *terraform.State) error {
 		dist, err := testAccAuxCloudFrontGetDistributionConfig(s, k)
 		if err == nil {
 			if _, ok := os.LookupEnv("TF_TEST_CLOUDFRONT_RETAIN"); ok {
-				if *dist.DistributionConfig.Enabled != false {
+				if *dist.DistributionConfig.Enabled {
 					return fmt.Errorf("CloudFront distribution should be disabled")
 				}
 				return nil

--- a/aws/resource_aws_cloudfront_origin_access_identity.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity.go
@@ -115,11 +115,8 @@ func resourceAwsCloudFrontOriginAccessIdentityDelete(d *schema.ResourceData, met
 	}
 
 	_, err := conn.DeleteCloudFrontOriginAccessIdentity(params)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func expandOriginAccessIdentityConfig(d *schema.ResourceData) *cloudfront.OriginAccessIdentityConfig {
@@ -127,7 +124,7 @@ func expandOriginAccessIdentityConfig(d *schema.ResourceData) *cloudfront.Origin
 		Comment: aws.String(d.Get("comment").(string)),
 	}
 	// This sets CallerReference if it's still pending computation (ie: new resource)
-	if v, ok := d.GetOk("caller_reference"); ok == false {
+	if v, ok := d.GetOk("caller_reference"); !ok {
 		originAccessIdentityConfig.CallerReference = aws.String(time.Now().Format(time.RFC3339Nano))
 	} else {
 		originAccessIdentityConfig.CallerReference = aws.String(v.(string))


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Related to #6343 technical debt

Changes proposed in this pull request:

* Fixes for CloudFront-related issues

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestCloudFrontStructure_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestCloudFrontStructure_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestCloudFrontStructure_expandDefaultCacheBehavior
--- PASS: TestCloudFrontStructure_expandDefaultCacheBehavior (0.00s)
=== RUN   TestCloudFrontStructure_flattenDefaultCacheBehavior
--- PASS: TestCloudFrontStructure_flattenDefaultCacheBehavior (0.00s)
=== RUN   TestCloudFrontStructure_expandCacheBehavior
--- PASS: TestCloudFrontStructure_expandCacheBehavior (0.00s)
=== RUN   TestCloudFrontStructure_flattenCacheBehavior
--- PASS: TestCloudFrontStructure_flattenCacheBehavior (0.00s)
=== RUN   TestCloudFrontStructure_expandCacheBehaviors
--- PASS: TestCloudFrontStructure_expandCacheBehaviors (0.00s)
=== RUN   TestCloudFrontStructure_flattenCacheBehaviors
--- PASS: TestCloudFrontStructure_flattenCacheBehaviors (0.00s)
=== RUN   TestCloudFrontStructure_expandTrustedSigners
--- PASS: TestCloudFrontStructure_expandTrustedSigners (0.00s)
=== RUN   TestCloudFrontStructure_flattenTrustedSigners
--- PASS: TestCloudFrontStructure_flattenTrustedSigners (0.00s)
=== RUN   TestCloudFrontStructure_expandTrustedSigners_empty
--- PASS: TestCloudFrontStructure_expandTrustedSigners_empty (0.00s)
=== RUN   TestCloudFrontStructure_expandLambdaFunctionAssociations
--- PASS: TestCloudFrontStructure_expandLambdaFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_flattenlambdaFunctionAssociations
--- PASS: TestCloudFrontStructure_flattenlambdaFunctionAssociations (0.00s)
=== RUN   TestCloudFrontStructure_expandlambdaFunctionAssociations_empty
--- PASS: TestCloudFrontStructure_expandlambdaFunctionAssociations_empty (0.00s)
=== RUN   TestCloudFrontStructure_expandForwardedValues
--- PASS: TestCloudFrontStructure_expandForwardedValues (0.00s)
=== RUN   TestCloudFrontStructure_flattenForwardedValues
--- PASS: TestCloudFrontStructure_flattenForwardedValues (0.00s)
=== RUN   TestCloudFrontStructure_expandHeaders
--- PASS: TestCloudFrontStructure_expandHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenHeaders
--- PASS: TestCloudFrontStructure_flattenHeaders (0.00s)
=== RUN   TestCloudFrontStructure_expandQueryStringCacheKeys
--- PASS: TestCloudFrontStructure_expandQueryStringCacheKeys (0.00s)
=== RUN   TestCloudFrontStructure_flattenQueryStringCacheKeys
--- PASS: TestCloudFrontStructure_flattenQueryStringCacheKeys (0.00s)
=== RUN   TestCloudFrontStructure_expandCookiePreference
--- PASS: TestCloudFrontStructure_expandCookiePreference (0.00s)
=== RUN   TestCloudFrontStructure_flattenCookiePreference
--- PASS: TestCloudFrontStructure_flattenCookiePreference (0.00s)
=== RUN   TestCloudFrontStructure_expandCookieNames
--- PASS: TestCloudFrontStructure_expandCookieNames (0.00s)
=== RUN   TestCloudFrontStructure_flattenCookieNames
--- PASS: TestCloudFrontStructure_flattenCookieNames (0.00s)
=== RUN   TestCloudFrontStructure_expandAllowedMethods
--- PASS: TestCloudFrontStructure_expandAllowedMethods (0.00s)
=== RUN   TestCloudFrontStructure_flattenAllowedMethods
--- PASS: TestCloudFrontStructure_flattenAllowedMethods (0.00s)
=== RUN   TestCloudFrontStructure_expandCachedMethods
--- PASS: TestCloudFrontStructure_expandCachedMethods (0.00s)
=== RUN   TestCloudFrontStructure_flattenCachedMethods
--- PASS: TestCloudFrontStructure_flattenCachedMethods (0.00s)
=== RUN   TestCloudFrontStructure_expandOrigins
--- PASS: TestCloudFrontStructure_expandOrigins (0.00s)
=== RUN   TestCloudFrontStructure_flattenOrigins
--- PASS: TestCloudFrontStructure_flattenOrigins (0.00s)
=== RUN   TestCloudFrontStructure_expandOrigin
--- PASS: TestCloudFrontStructure_expandOrigin (0.00s)
=== RUN   TestCloudFrontStructure_flattenOrigin
--- PASS: TestCloudFrontStructure_flattenOrigin (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomHeaders
--- PASS: TestCloudFrontStructure_expandCustomHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomHeaders
--- PASS: TestCloudFrontStructure_flattenCustomHeaders (0.00s)
=== RUN   TestCloudFrontStructure_flattenOriginCustomHeader
--- PASS: TestCloudFrontStructure_flattenOriginCustomHeader (0.00s)
=== RUN   TestCloudFrontStructure_expandOriginCustomHeader
--- PASS: TestCloudFrontStructure_expandOriginCustomHeader (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomOriginConfig
--- PASS: TestCloudFrontStructure_expandCustomOriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomOriginConfig
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomOriginConfigSSL
--- PASS: TestCloudFrontStructure_expandCustomOriginConfigSSL (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomOriginConfigSSL
--- PASS: TestCloudFrontStructure_flattenCustomOriginConfigSSL (0.00s)
=== RUN   TestCloudFrontStructure_expandS3OriginConfig
--- PASS: TestCloudFrontStructure_expandS3OriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_flattenS3OriginConfig
--- PASS: TestCloudFrontStructure_flattenS3OriginConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponses
--- PASS: TestCloudFrontStructure_expandCustomErrorResponses (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomErrorResponses
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponses (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponse
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse (0.00s)
=== RUN   TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode
--- PASS: TestCloudFrontStructure_expandCustomErrorResponse_emptyResponseCode (0.00s)
=== RUN   TestCloudFrontStructure_flattenCustomErrorResponse
--- PASS: TestCloudFrontStructure_flattenCustomErrorResponse (0.00s)
=== RUN   TestCloudFrontStructure_expandLoggingConfig
--- PASS: TestCloudFrontStructure_expandLoggingConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandLoggingConfig_nilValue
--- PASS: TestCloudFrontStructure_expandLoggingConfig_nilValue (0.00s)
=== RUN   TestCloudFrontStructure_flattenLoggingConfig
--- PASS: TestCloudFrontStructure_flattenLoggingConfig (0.00s)
=== RUN   TestCloudFrontStructure_expandAliases
--- PASS: TestCloudFrontStructure_expandAliases (0.00s)
=== RUN   TestCloudFrontStructure_flattenAliases
--- PASS: TestCloudFrontStructure_flattenAliases (0.00s)
=== RUN   TestCloudFrontStructure_expandRestrictions
--- PASS: TestCloudFrontStructure_expandRestrictions (0.00s)
=== RUN   TestCloudFrontStructure_flattenRestrictions
--- PASS: TestCloudFrontStructure_flattenRestrictions (0.00s)
=== RUN   TestCloudFrontStructure_expandGeoRestriction_whitelist
--- PASS: TestCloudFrontStructure_expandGeoRestriction_whitelist (0.00s)
=== RUN   TestCloudFrontStructure_flattenGeoRestriction_whitelist
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_whitelist (0.00s)
=== RUN   TestCloudFrontStructure_expandGeoRestriction_no_items
--- PASS: TestCloudFrontStructure_expandGeoRestriction_no_items (0.00s)
=== RUN   TestCloudFrontStructure_flattenGeoRestriction_no_items
--- PASS: TestCloudFrontStructure_flattenGeoRestriction_no_items (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate
--- PASS: TestCloudFrontStructure_expandViewerCertificate_cloudfront_default_certificate (0.00s)
=== RUN   TestCloudFrontStructure_flattenViewerCertificate_cloudfront_default_certificate
--- PASS: TestCloudFrontStructure_flattenViewerCertificate_cloudfront_default_certificate (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id
--- PASS: TestCloudFrontStructure_expandViewerCertificate_iam_certificate_id (0.00s)
=== RUN   TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn
--- PASS: TestCloudFrontStructure_expandViewerCertificate_acm_certificate_arn (0.00s)
=== RUN   TestCloudFrontStructure_falttenViewerCertificate_iam_certificate_id
--- PASS: TestCloudFrontStructure_falttenViewerCertificate_iam_certificate_id (0.00s)
=== RUN   TestCloudFrontStructure_falttenViewerCertificate_acm_certificate_arn
--- PASS: TestCloudFrontStructure_falttenViewerCertificate_acm_certificate_arn (0.00s)
=== RUN   TestCloudFrontStructure_viewerCertificateHash_IAM
--- PASS: TestCloudFrontStructure_viewerCertificateHash_IAM (0.00s)
=== RUN   TestCloudFrontStructure_viewerCertificateHash_ACM
--- PASS: TestCloudFrontStructure_viewerCertificateHash_ACM (0.00s)
=== RUN   TestCloudFrontStructure_viewerCertificateHash_default
--- PASS: TestCloudFrontStructure_viewerCertificateHash_default (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.041s

$ make testacc TESTARGS='-run=TestAccAWSCloudFrontDistribution_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudFrontDistribution_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
=== PAUSE TestAccAWSCloudFrontDistribution_importBasic
=== CONT  TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (886.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	886.874s

$ make testacc TESTARGS='-run=TestAccAWSCloudFrontOriginAccessIdentity_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudFrontOriginAccessIdentity_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudFrontOriginAccessIdentity_basic
=== PAUSE TestAccAWSCloudFrontOriginAccessIdentity_basic
=== CONT  TestAccAWSCloudFrontOriginAccessIdentity_basic
--- PASS: TestAccAWSCloudFrontOriginAccessIdentity_basic (14.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	14.262s
```