### PR TITLE
resource/aws_lambda_function: Handle slower code uploads on creation with configurable timeout

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -395,7 +395,7 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		return nil
 	})
 	if err != nil {
-		if !isResourceTimeoutErrorLastError(err, nil) && !isAWSErr(err, "InvalidParameterValueException", "Your request has been throttled by EC2") {
+		if !isResourceTimeoutError(err) && !isAWSErr(err, "InvalidParameterValueException", "Your request has been throttled by EC2") {
 			return fmt.Errorf("Error creating Lambda function: %s", err)
 		}
 		// Allow additional time for slower uploads or EC2 throttling

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -27,6 +27,9 @@ func resourceAwsLambdaFunction() *schema.Resource {
 		Read:   resourceAwsLambdaFunctionRead,
 		Update: resourceAwsLambdaFunctionUpdate,
 		Delete: resourceAwsLambdaFunctionDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+		},
 
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
@@ -392,11 +395,11 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		return nil
 	})
 	if err != nil {
-		if !isAWSErr(err, "InvalidParameterValueException", "Your request has been throttled by EC2") {
+		if !isResourceTimeoutErrorLastError(err, nil) && !isAWSErr(err, "InvalidParameterValueException", "Your request has been throttled by EC2") {
 			return fmt.Errorf("Error creating Lambda function: %s", err)
 		}
-		// Allow 9 more minutes for EC2 throttling
-		err := resource.Retry(9*time.Minute, func() *resource.RetryError {
+		// Allow additional time for slower uploads or EC2 throttling
+		err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			_, err := conn.CreateFunction(params)
 			if err != nil {
 				log.Printf("[DEBUG] Error creating Lambda Function: %s", err)

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -47,3 +47,8 @@ func isResourceNotFoundError(err error) bool {
 	_, ok := err.(*resource.NotFoundError)
 	return ok
 }
+
+func isResourceTimeoutErrorLastError(err, lastError error) bool {
+	timeoutErr, ok := err.(*resource.TimeoutError)
+	return ok && timeoutErr.LastError == lastError
+}

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -48,7 +48,7 @@ func isResourceNotFoundError(err error) bool {
 	return ok
 }
 
-func isResourceTimeoutErrorLastError(err, lastError error) bool {
+func isResourceTimeoutError(err error) bool {
 	timeoutErr, ok := err.(*resource.TimeoutError)
-	return ok && timeoutErr.LastError == lastError
+	return ok && timeoutErr.LastError == nil
 }

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -134,6 +134,12 @@ For **environment** the following attributes are supported:
 [8]: https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html
 [9]: https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html
 
+## Timeouts
+
+`aws_lambda_function` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `10m`) How long to wait for slow uploads or EC2 throttling errors.
+
 ## Import
 
 Lambda Functions can be imported using the `function_name`, e.g.


### PR DESCRIPTION
Fixes #4516 

Tested by adding a deliberate 2 minute sleep inside the first `resource.Retry()` function before the CreateFunction call. Prior to this update, slow ZIP file uploads would have no chance of being successful. Now they can have a configurable timeout. This is not a problem on update since we call `UpdateFunctionCode` outside any `resource.Retry()`/`StateChangeConf` context.

Previously:

```
--- FAIL: TestAccAWSLambdaFunction_basic (104.02s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_lambda_function.lambda_function_test: 1 error occurred:
        	* aws_lambda_function.lambda_function_test: Error creating Lambda function: timeout while waiting for state to become 'success' (timeout: 1m0s)
```

Now:

```
--- PASS: TestAccAWSLambdaFunction_basic (113.77s)
```
