### PR TITLE
data-source/aws_ebs_snapshot: Fix most_recent ordering and add covering acceptance test

### DIFF
--- a/aws/data_source_aws_ebs_snapshot.go
+++ b/aws/data_source_aws_ebs_snapshot.go
@@ -129,7 +129,7 @@ func dataSourceAwsEbsSnapshotRead(d *schema.ResourceData, meta interface{}) erro
 				"specific search criteria, or set `most_recent` attribute to true.")
 		}
 		sort.Slice(resp.Snapshots, func(i, j int) bool {
-			return aws.TimeValue(resp.Snapshots[i].StartTime).Unix() < aws.TimeValue(resp.Snapshots[j].StartTime).Unix()
+			return aws.TimeValue(resp.Snapshots[i].StartTime).Unix() > aws.TimeValue(resp.Snapshots[j].StartTime).Unix()
 		})
 	}
 

--- a/aws/data_source_aws_ebs_snapshot_test.go
+++ b/aws/data_source_aws_ebs_snapshot_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAccAWSEbsSnapshotDataSource_basic(t *testing.T) {
+	dataSourceName := "data.aws_ebs_snapshot.test"
+	resourceName := "aws_ebs_snapshot.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -16,27 +19,54 @@ func TestAccAWSEbsSnapshotDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsEbsSnapshotDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsEbsSnapshotDataSourceID("data.aws_ebs_snapshot.snapshot"),
-					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "volume_size", "40"),
-					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "tags.%", "0"),
+					testAccCheckAwsEbsSnapshotDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encrypted", resourceName, "encrypted"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_id", resourceName, "kms_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_alias", resourceName, "owner_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "volume_id", resourceName, "volume_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "volume_size", resourceName, "volume_size"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSEbsSnapshotDataSource_multipleFilters(t *testing.T) {
+func TestAccAWSEbsSnapshotDataSource_Filter(t *testing.T) {
+	dataSourceName := "data.aws_ebs_snapshot.test"
+	resourceName := "aws_ebs_snapshot.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsEbsSnapshotDataSourceConfigWithMultipleFilters,
+				Config: testAccCheckAwsEbsSnapshotDataSourceConfigFilter,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsEbsSnapshotDataSourceID("data.aws_ebs_snapshot.snapshot"),
-					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "volume_size", "10"),
-					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "tags.%", "1"),
-					resource.TestCheckResourceAttr("data.aws_ebs_snapshot.snapshot", "tags.Name", "TF ACC Snapshot"),
+					testAccCheckAwsEbsSnapshotDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEbsSnapshotDataSource_MostRecent(t *testing.T) {
+	dataSourceName := "data.aws_ebs_snapshot.test"
+	resourceName := "aws_ebs_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsEbsSnapshotDataSourceConfigMostRecent,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEbsSnapshotDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 				),
 			},
 		},
@@ -58,48 +88,75 @@ func testAccCheckAwsEbsSnapshotDataSourceID(n string) resource.TestCheckFunc {
 }
 
 const testAccCheckAwsEbsSnapshotDataSourceConfig = `
-resource "aws_ebs_volume" "example" {
-  availability_zone = "us-west-2a"
+data "aws_availability_zones" "available" {}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
-  size = 40
-  tags {
-    Name = "External Volume"
-  }
+  size = 1
 }
 
-resource "aws_ebs_snapshot" "snapshot" {
-  volume_id = "${aws_ebs_volume.example.id}"
+resource "aws_ebs_snapshot" "test" {
+  volume_id = "${aws_ebs_volume.test.id}"
 }
 
-data "aws_ebs_snapshot" "snapshot" {
-  most_recent = true
-  snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
+data "aws_ebs_snapshot" "test" {
+  snapshot_ids = ["${aws_ebs_snapshot.test.id}"]
 }
 `
 
-const testAccCheckAwsEbsSnapshotDataSourceConfigWithMultipleFilters = `
-resource "aws_ebs_volume" "external1" {
-  availability_zone = "us-west-2a"
+const testAccCheckAwsEbsSnapshotDataSourceConfigFilter = `
+data "aws_availability_zones" "available" {}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
-  size = 10
-  tags {
-    Name = "External Volume 1"
-  }
+  size = 1
 }
 
-resource "aws_ebs_snapshot" "snapshot" {
-  volume_id = "${aws_ebs_volume.external1.id}"
-  tags {
-    Name = "TF ACC Snapshot"
-  }
+resource "aws_ebs_snapshot" "test" {
+  volume_id = "${aws_ebs_volume.test.id}"
 }
 
-data "aws_ebs_snapshot" "snapshot" {
-  most_recent = true
-  snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
+data "aws_ebs_snapshot" "test" {
   filter {
-    name = "volume-size"
-    values = ["10"]
+    name = "snapshot-id"
+    values = ["${aws_ebs_snapshot.test.id}"]
+  }
+}
+`
+
+const testAccCheckAwsEbsSnapshotDataSourceConfigMostRecent = `
+data "aws_availability_zones" "available" {}
+
+resource "aws_ebs_volume" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  type = "gp2"
+  size = 1
+}
+
+resource "aws_ebs_snapshot" "incorrect" {
+  volume_id = "${aws_ebs_volume.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-ec2-ebs-snapshot-data-source-most-recent"
+  }
+}
+
+resource "aws_ebs_snapshot" "test" {
+  volume_id = "${aws_ebs_snapshot.incorrect.volume_id}"
+
+  tags = {
+    Name = "tf-acc-test-ec2-ebs-snapshot-data-source-most-recent"
+  }
+}
+
+data "aws_ebs_snapshot" "test" {
+  most_recent = true
+
+  filter {
+    name   = "tag:Name"
+    values = ["${aws_ebs_snapshot.test.tags.Name}"]
   }
 }
 `


### PR DESCRIPTION
Unfortunately the `most_recent` functionality of the `aws_ebs_snapshot` data source was missing an acceptance test with multiple EBS snapshots so this was broken in version 1.43.0 and 1.43.1

Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/6321#issuecomment-437470133

Changes proposed in this pull request:

* data-source/aws_ebs_snapshot: Fix most_recent ordering
* resource/aws_ebs_snapshot: Allow retries for `SnapshotCreationPerVolumeRateExceeded` errors on creation (discovered during development of `TestAccAWSEbsSnapshotDataSource_MostRecent`)

Output from acceptance testing:

```
--- PASS: TestAccAWSEBSSnapshot_withDescription (26.62s)
--- PASS: TestAccAWSEbsSnapshotDataSource_basic (28.90s)
--- PASS: TestAccAWSEbsSnapshotDataSource_Filter (43.31s)
--- PASS: TestAccAWSEBSSnapshot_withKms (67.28s)
--- PASS: TestAccAWSEbsSnapshotDataSource_MostRecent (68.51s)
--- PASS: TestAccAWSEBSSnapshot_basic (85.15s)
```
