### PR TITLE
Fix assume_role not using STS endpoint configuration

### DIFF
--- a/aws/auth_helpers.go
+++ b/aws/auth_helpers.go
@@ -253,6 +253,9 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 		HTTPClient:       cleanhttp.DefaultClient(),
 		S3ForcePathStyle: aws.Bool(c.S3ForcePathStyle),
 	}
+	if c.StsEndpoint != "" {
+		awsConfig.Endpoint = aws.String(c.StsEndpoint)
+	}
 
 	stsclient := sts.New(session.New(awsConfig))
 	assumeRoleProvider := &stscreds.AssumeRoleProvider{


### PR DESCRIPTION
fixes #6424 

Changes proposed in this pull request:

* Set the `Endpoint` in the config used by the sts client to assume the role

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
=== PAUSE TestAccAWSAvailabilityZones_basic
=== RUN   TestAccAWSAvailabilityZones_stateFilter
=== PAUSE TestAccAWSAvailabilityZones_stateFilter
=== CONT  TestAccAWSAvailabilityZones_basic
=== CONT  TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_stateFilter (22.79s)
--- PASS: TestAccAWSAvailabilityZones_basic (22.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	22.852s
```
