### PR TITLE
service/codebuild: Enable Bitbucket Report Build Status and Document Bitbucket Webhooks

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -727,9 +727,9 @@ func expandProjectSourceData(data map[string]interface{}) codebuild.ProjectSourc
 		projectSource.Location = aws.String(data["location"].(string))
 	}
 
-	// Only valid for GITHUB source type, e.g.
+	// Only valid for BITBUCKET and GITHUB source type, e.g.
 	// InvalidInputException: Source type GITHUB_ENTERPRISE does not support ReportBuildStatus
-	if sourceType == codebuild.SourceTypeGithub {
+	if sourceType == codebuild.SourceTypeBitbucket || sourceType == codebuild.SourceTypeGithub {
 		projectSource.ReportBuildStatus = aws.Bool(data["report_build_status"].(bool))
 	}
 

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 // This is used for testing aws_codebuild_webhook as well as aws_codebuild_project.
-// The Terraform AWS user must have done the manual GitHub OAuth dance for this
-// functionality to work. Additionally, the GitHub user that the Terraform AWS
-// user logs in as must have access to the GitHub repository.
+// The Terraform AWS user must have done the manual Bitbucket OAuth dance for this
+// functionality to work. Additionally, the Bitbucket user that the Terraform AWS
+// user logs in as must have access to the Bitbucket repository.
 func testAccAWSCodeBuildBitbucketSourceLocationFromEnv() string {
 	sourceLocation := os.Getenv("AWS_CODEBUILD_BITBUCKET_SOURCE_LOCATION")
 	if sourceLocation == "" {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -14,9 +14,21 @@ import (
 )
 
 // This is used for testing aws_codebuild_webhook as well as aws_codebuild_project.
-// In order for that resource to work the Terraform AWS user must have done a GitHub
-// OAuth dance. Additionally, the GitHub user that the Terraform AWS user logs in as
-// must have access to the GitHub repository.
+// The Terraform AWS user must have done the manual GitHub OAuth dance for this
+// functionality to work. Additionally, the GitHub user that the Terraform AWS
+// user logs in as must have access to the GitHub repository.
+func testAccAWSCodeBuildBitbucketSourceLocationFromEnv() string {
+	sourceLocation := os.Getenv("AWS_CODEBUILD_BITBUCKET_SOURCE_LOCATION")
+	if sourceLocation == "" {
+		return "https://terraform@bitbucket.org/terraform/aws-test.git"
+	}
+	return sourceLocation
+}
+
+// This is used for testing aws_codebuild_webhook as well as aws_codebuild_project.
+// The Terraform AWS user must have done the manual GitHub OAuth dance for this
+// functionality to work. Additionally, the GitHub user that the Terraform AWS
+// user logs in as must have access to the GitHub repository.
 func testAccAWSCodeBuildGitHubSourceLocationFromEnv() string {
 	sourceLocation := os.Getenv("AWS_CODEBUILD_GITHUB_SOURCE_LOCATION")
 	if sourceLocation == "" {
@@ -392,7 +404,7 @@ func TestAccAWSCodeBuildProject_Source_InsecureSSL(t *testing.T) {
 	})
 }
 
-func TestAccAWSCodeBuildProject_Source_ReportBuildStatus(t *testing.T) {
+func TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket(t *testing.T) {
 	var project codebuild.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_codebuild_project.test"
@@ -403,14 +415,42 @@ func TestAccAWSCodeBuildProject_Source_ReportBuildStatus(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus(rName, true),
+				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_Bitbucket(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "source.2876219937.report_build_status", "true"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_Bitbucket(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "source.3210444828.report_build_status", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHub(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.4215890488.report_build_status", "true"),
 				),
 			},
 			{
-				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus(rName, false),
+				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHub(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "source.3680505372.report_build_status", "false"),
@@ -434,7 +474,7 @@ func TestAccAWSCodeBuildProject_Source_Type_Bitbucket(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
-					resource.TestCheckResourceAttr(resourceName, "source.2806293607.type", "BITBUCKET"),
+					resource.TestCheckResourceAttr(resourceName, "source.3210444828.type", "BITBUCKET"),
 				),
 			},
 		},
@@ -1212,7 +1252,32 @@ resource "aws_codebuild_project" "test" {
 `, rName, insecureSSL)
 }
 
-func testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus(rName string, reportBuildStatus bool) string {
+func testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_Bitbucket(rName string, reportBuildStatus bool) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = %q
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    location            = "https://terraform@bitbucket.org/terraform/aws-test.git"
+    report_build_status = %t
+    type                = "BITBUCKET"
+  }
+}
+`, rName, reportBuildStatus)
+}
+
+func testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHub(rName string, reportBuildStatus bool) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = %q
@@ -1254,11 +1319,11 @@ resource "aws_codebuild_project" "test" {
   }
 
   source {
-    location = "https://bitbucket.org/organization/repository.git"
+    location = %q
     type     = "BITBUCKET"
   }
 }
-`, rName)
+`, rName, testAccAWSCodeBuildBitbucketSourceLocationFromEnv())
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_CodeCommit(rName string) string {

--- a/aws/resource_aws_codebuild_webhook_test.go
+++ b/aws/resource_aws_codebuild_webhook_test.go
@@ -12,6 +12,37 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAWSCodeBuildWebhook_Bitbucket(t *testing.T) {
+	var webhook codebuild.Webhook
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_webhook.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildWebhookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildWebhookConfig_Bitbucket(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildWebhookExists(resourceName, &webhook),
+					resource.TestCheckResourceAttr(resourceName, "branch_filter", ""),
+					resource.TestCheckResourceAttr(resourceName, "project_name", rName),
+					resource.TestMatchResourceAttr(resourceName, "payload_url", regexp.MustCompile(`^https://`)),
+					resource.TestCheckResourceAttr(resourceName, "secret", ""),
+					resource.TestMatchResourceAttr(resourceName, "url", regexp.MustCompile(`^https://`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret"},
+			},
+		},
+	})
+}
+
 func TestAccAWSCodeBuildWebhook_GitHub(t *testing.T) {
 	var webhook codebuild.Webhook
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -187,6 +218,14 @@ func testAccCheckAWSCodeBuildWebhookExists(name string, webhook *codebuild.Webho
 
 		return nil
 	}
+}
+
+func testAccAWSCodeBuildWebhookConfig_Bitbucket(rName string) string {
+	return fmt.Sprintf(testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName) + `
+resource "aws_codebuild_webhook" "test" {
+  project_name = "${aws_codebuild_project.test.name}"
+}
+`)
 }
 
 func testAccAWSCodeBuildWebhookConfig_GitHub(rName string) string {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -198,7 +198,7 @@ The following arguments are supported:
 * `git_clone_depth` - (Optional) Truncate git history to this many commits.
 * `insecure_ssl` - (Optional) Ignore SSL warnings when connecting to source control.
 * `location` - (Optional) The location of the source code from git or s3.
-* `report_build_status` - (Optional) Set to `true` to report the status of a build's start and finish to your source provider. This option is only valid when your source provider is GitHub.
+* `report_build_status` - (Optional) Set to `true` to report the status of a build's start and finish to your source provider. This option is only valid when the `type` is `BITBUCKET` or `GITHUB`.
 
 `auth` supports the following:
 

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -12,13 +12,13 @@ Manages a CodeBuild webhook, which is an endpoint accepted by the CodeBuild serv
 
 ## Example Usage
 
-### GitHub
+### Bitbucket and GitHub
 
-When working with [GitHub](https://github.com) source CodeBuild webhooks, the CodeBuild service will automatically create (on `aws_codebuild_webhook` resource creation) and delete (on `aws_codebuild_webhook` resource deletion) the GitHub repository webhook using its granted OAuth permissions. This behavior cannot be controlled by Terraform.
+When working with [Bitbucket](https://bitbucket.org) and [GitHub](https://github.com) source CodeBuild webhooks, the CodeBuild service will automatically create (on `aws_codebuild_webhook` resource creation) and delete (on `aws_codebuild_webhook` resource deletion) the Bitbucket/GitHub repository webhook using its granted OAuth permissions. This behavior cannot be controlled by Terraform.
 
-~> **Note:** The AWS account that Terraform uses to create this resource *must* have authorized CodeBuild to access GitHub's OAuth API in each applicable region. This is a manual step that must be done *before* creating webhooks with this resource. If OAuth is not configured, AWS will return an error similar to `ResourceNotFoundException: Could not find access token for server type github`. More information can be found in the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-pull-request.html).
+~> **Note:** The AWS account that Terraform uses to create this resource *must* have authorized CodeBuild to access Bitbucket/GitHub's OAuth API in each applicable region. This is a manual step that must be done *before* creating webhooks with this resource. If OAuth is not configured, AWS will return an error similar to `ResourceNotFoundException: Could not find access token for server type github`. More information can be found in the CodeBuild User Guide for [Bitbucket](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-bitbucket-pull-request.html) and [GitHub](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-github-pull-request.html).
 
-~> **Note:** Further managing the automatically created GitHub webhook with the `github_repository_webhook` resource is only possible with importing that resource after creation of the `aws_codebuild_webhook` resource. The CodeBuild API does not ever provide the `secret` attribute for the `aws_codebuild_webhook` resource in this scenario.
+~> **Note:** Further managing the automatically created Bitbucket/GitHub webhook with the `bitbucket_hook`/`github_repository_webhook` resource is only possible with importing that resource after creation of the `aws_codebuild_webhook` resource. The CodeBuild API does not ever provide the `secret` attribute for the `aws_codebuild_webhook` resource in this scenario.
 
 ```hcl
 resource "aws_codebuild_webhook" "example" {


### PR DESCRIPTION
Closes #6296 

Changes proposed in this pull request:

* resource/aws_codebuild_project: Support `source` `report_build_status` for Bitbucket
* resource/aws_codebuild_webhook: Test and document Bitbucket support

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (31.71s)
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (19.70s)
--- PASS: TestAccAWSCodeBuildProject_basic (20.21s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (26.73s)
--- PASS: TestAccAWSCodeBuildProject_Cache (50.39s)
--- PASS: TestAccAWSCodeBuildProject_Description (30.49s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (47.71s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (32.76s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (28.80s)
--- PASS: TestAccAWSCodeBuildProject_importBasic (22.80s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (31.29s)
--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (32.24s)
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (32.05s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (30.16s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (29.03s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (36.98s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (37.17s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (22.15s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (28.85s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (28.08s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (22.01s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (22.26s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (8.84s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (22.34s)
--- PASS: TestAccAWSCodeBuildProject_Tags (39.12s)
--- PASS: TestAccAWSCodeBuildProject_VpcConfig (55.53s)
--- PASS: TestAccAWSCodeBuildWebhook_Bitbucket (36.75s)
--- PASS: TestAccAWSCodeBuildWebhook_BranchFilter (35.13s)
--- PASS: TestAccAWSCodeBuildWebhook_GitHub (26.14s)
--- PASS: TestAccAWSCodeBuildWebhook_GitHubEnterprise (36.14s)
```
