### PR TITLE
Fix NotFound not detected during a read on aws sns platform applications

### DIFF
--- a/aws/resource_aws_sns_platform_application.go
+++ b/aws/resource_aws_sns_platform_application.go
@@ -203,6 +203,11 @@ func resourceAwsSnsPlatformApplicationRead(d *schema.ResourceData, meta interfac
 	})
 
 	if err != nil {
+		if isAWSErr(err, sns.ErrCodeNotFoundException, "") {
+			log.Printf("[WARN] SNS Topic (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/aws/resource_aws_sns_platform_application.go
+++ b/aws/resource_aws_sns_platform_application.go
@@ -204,7 +204,7 @@ func resourceAwsSnsPlatformApplicationRead(d *schema.ResourceData, meta interfac
 
 	if err != nil {
 		if isAWSErr(err, sns.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] SNS Topic (%s) not found, error code (404)", d.Id())
+			log.Printf("[WARN] SNS Platform Application (%s) not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
We've seen some issues with terraform where the sns platform application has been created via Terraform, but deleted via another mean (ie: webui).
Terraform wouldn't detect that the SNS platform application has been deleted and would error out. To fix this we had to manually remove the impacted resources from the state.

```
Error: Error refreshing state: 2 error(s) occurred:

* module.redacted.aws_sns_platform_application.my_apn1: 1 error(s) occurred:

* module.redacted.aws_sns_platform_application.my_apn1: aws_sns_platform_application.my_apn1: NotFound: PlatformApplication does not exist
    status code: 404, request id: <redacted>
* module.redacted.aws_sns_platform_application.my_apn2: 1 error(s) occurred:

* module.redacted.aws_sns_platform_application.my_apn2: aws_sns_platform_application.my_apn2: NotFound: PlatformApplication does not exist
    status code: 404, request id: <redacted>
```

This error was already present on other resources, but have been fixed a while ago : https://github.com/hashicorp/terraform/pull/4891
Code can now be found at :
https://github.com/terraform-providers/terraform-provider-aws/blob/20151d7b332763952f44209e7356ebb661d9add0/aws/resource_aws_sns_topic.go#L198-L202

Looking at how it is done for the SNS topics, I figured it wouldn't be super difficult to fix and could make a small PR to help.

Tests are running fine
```
make test                                                                                                                                                                                                 bugfix-snsplatformapp-notfound
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.994s
```