### PR TITLE
resource/aws_lambda_event_source_mapping: Add starting_position_timestamp argument

### DIFF
--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -284,6 +284,38 @@ func TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected(t *testing.T
 	})
 }
 
+func TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp(t *testing.T) {
+	var conf lambda.EventSourceMappingConfiguration
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_lambda_event_source_mapping.test"
+	startingPositionTimestamp := time.Now().UTC().Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfigKinesisStartingPositionTimestamp(rName, startingPositionTimestamp),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaEventSourceMappingExists(resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "starting_position", "AT_TIMESTAMP"),
+					resource.TestCheckResourceAttr(resourceName, "starting_position_timestamp", startingPositionTimestamp),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"starting_position",
+					"starting_position_timestamp",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckAWSLambdaEventSourceMappingIsBeingDisabled(conf *lambda.EventSourceMappingConfiguration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
@@ -447,6 +479,84 @@ func testAccCheckAWSLambdaEventSourceMappingAttributes(mapping *lambda.EventSour
 
 		return nil
 	}
+}
+
+func testAccAWSLambdaEventSourceMappingConfigKinesisBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = "${aws_iam_role.test.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+            "kinesis:GetRecords",
+            "kinesis:GetShardIterator",
+            "kinesis:DescribeStream"
+          ],
+          "Resource": "*"
+      },
+      {
+          "Effect": "Allow",
+          "Action": [
+            "kinesis:ListStreams"
+          ],
+          "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_kinesis_stream" "test" {
+  name        = %q
+  shard_count = 1
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %q
+  handler       = "exports.example"
+  role          = "${aws_iam_role.test.arn}"
+  runtime       = "nodejs4.3"
+}
+`, rName, rName, rName)
+}
+
+func testAccAWSLambdaEventSourceMappingConfigKinesisStartingPositionTimestamp(rName, startingPositionTimestamp string) string {
+	return testAccAWSLambdaEventSourceMappingConfigKinesisBase(rName) + fmt.Sprintf(`
+resource "aws_lambda_event_source_mapping" "test" {
+  batch_size                  = 100
+  enabled                     = true
+  event_source_arn            = "${aws_kinesis_stream.test.arn}"
+  function_name               = "${aws_lambda_function.test.arn}"
+  starting_position           = "AT_TIMESTAMP"
+  starting_position_timestamp = %q
+}
+`, startingPositionTimestamp)
 }
 
 func testAccAWSLambdaEventSourceMappingConfig_kinesis(roleName, policyName, attName, streamName,

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -15,13 +15,32 @@ For information about event source mappings, see [CreateEventSourceMapping][2] i
 
 ## Example Usage
 
+### DynamoDB
+
 ```hcl
-resource "aws_lambda_event_source_mapping" "event_source_mapping" {
-  batch_size        = 100
-  event_source_arn  = "arn:aws:kinesis:REGION:123456789012:stream/stream_name"
-  enabled           = true
-  function_name     = "arn:aws:lambda:REGION:123456789012:function:function_name"
-  starting_position = "TRIM_HORIZON|LATEST"
+resource "aws_lambda_event_source_mapping" "example" {
+  event_source_arn  = "${aws_dynamodb_table.example.stream_arn}"
+  function_name     = "${aws_lambda_function.example.arn}"
+  starting_position = "LATEST"
+}
+```
+
+### Kinesis
+
+```hcl
+resource "aws_lambda_event_source_mapping" "example" {
+  event_source_arn  = "${aws_kinesis_stream.example.arn}"
+  function_name     = "${aws_lambda_function.example.arn}"
+  starting_position = "LATEST"
+}
+```
+
+### SQS
+
+```hcl
+resource "aws_lambda_event_source_mapping" "example" {
+  event_source_arn = "${aws_sqs_queue.sqs_queue_test.arn}"
+  function_name    = "${aws_lambda_function.example.arn}"
 }
 ```
 
@@ -31,7 +50,8 @@ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
 * `event_source_arn` - (Required) The event source ARN - can either be a Kinesis or DynamoDB stream.
 * `enabled` - (Optional) Determines if the mapping will be enabled on creation. Defaults to `true`.
 * `function_name` - (Required) The name or the ARN of the Lambda function that will be subscribing to events.
-* `starting_position` - (Optional) The position in the stream where AWS Lambda should start reading. Must be one of either `TRIM_HORIZON` or `LATEST` if getting events from Kinesis or DynamoDB.  Must not be provided if getting events from SQS.
+* `starting_position` - (Optional) The position in the stream where AWS Lambda should start reading. Must be one of `AT_TIMESTAMP` (Kinesis only), `LATEST` or `TRIM_HORIZON` if getting events from Kinesis or DynamoDB. Must not be provided if getting events from SQS. More information about these positions can be found in the [AWS DynamoDB Streams API Reference](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_GetShardIterator.html) and [AWS Kinesis API Reference](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#Kinesis-GetShardIterator-request-ShardIteratorType).
+* `starting_position_timestamp` - (Optional) A timestamp in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) of the data record which to start reading when using `starting_position` set to `AT_TIMESTAMP`. If a record with this exact timestamp does not exist, the next later record is chosen. If the timestamp is older than the current trim horizon, the oldest available record is chosen.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This argument, like `starting_position`, is only used during resource creation and therefore cannot be updated or read from the Lambda API.

Changes proposed in this pull request:

* resource/aws_lambda_event_source_mapping: Add `starting_position_timestamp` argument
* docs/resource/aws_lambda_event_source_mapping: Show DynamoDB, Kinesis, and SQS example usage

Output from acceptance testing:

```
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName (43.90s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_disappears (85.32s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_import (87.35s)
--- PASS: TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp (87.99s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (92.56s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (94.66s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (108.48s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqsDisappears (121.69s)
--- PASS: TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected (122.55s)
```
