### PR TITLE
Add copy_tags option to the resource_aws_dlm_lifecycle_policy

### DIFF
--- a/aws/resource_aws_dlm_lifecycle_policy.go
+++ b/aws/resource_aws_dlm_lifecycle_policy.go
@@ -50,6 +50,12 @@ func resourceAwsDlmLifecyclePolicy() *schema.Resource {
 							Required: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"copy_tags": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
 									"create_rule": {
 										Type:     schema.TypeList,
 										Required: true,
@@ -257,6 +263,9 @@ func expandDlmSchedules(cfg []interface{}) []*dlm.Schedule {
 	for i, c := range cfg {
 		schedule := &dlm.Schedule{}
 		m := c.(map[string]interface{})
+		if v, ok := m["copy_tags"]; ok {
+			schedule.CopyTags = aws.Bool(v.(bool))
+		}
 		if v, ok := m["create_rule"]; ok {
 			schedule.CreateRule = expandDlmCreateRule(v.([]interface{}))
 		}
@@ -279,6 +288,7 @@ func flattenDlmSchedules(schedules []*dlm.Schedule) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(schedules))
 	for i, s := range schedules {
 		m := make(map[string]interface{})
+		m["copy_tags"] = aws.BoolValue(s.CopyTags)
 		m["create_rule"] = flattenDlmCreateRule(s.CreateRule)
 		m["name"] = aws.StringValue(s.Name)
 		m["retain_rule"] = flattenDlmRetainRule(s.RetainRule)

--- a/aws/resource_aws_dlm_lifecycle_policy_test.go
+++ b/aws/resource_aws_dlm_lifecycle_policy_test.go
@@ -68,6 +68,7 @@ func TestAccAWSDlmLifecyclePolicy_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.create_rule.0.times.0", "21:42"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.retain_rule.0.count", "10"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.tags_to_add.tf-acc-test-added", "full"),
+					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.copy_tags", "true"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.target_tags.tf-acc-test", "full"),
 				),
 			},
@@ -85,6 +86,7 @@ func TestAccAWSDlmLifecyclePolicy_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.create_rule.0.times.0", "09:42"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.retain_rule.0.count", "100"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.tags_to_add.tf-acc-test-added", "full-updated"),
+					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.copy_tags", "true"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.target_tags.tf-acc-test", "full-updated"),
 				),
 			},
@@ -240,6 +242,8 @@ resource "aws_dlm_lifecycle_policy" "full" {
       tags_to_add {
         tf-acc-test-added = "full"
       }
+
+      copy_tags = true
     }
 
     target_tags {
@@ -296,6 +300,7 @@ resource "aws_dlm_lifecycle_policy" "full" {
       tags_to_add {
         tf-acc-test-added = "full-updated"
       }
+      copy_tags = true
     }
 
     target_tags {

--- a/aws/resource_aws_dlm_lifecycle_policy_test.go
+++ b/aws/resource_aws_dlm_lifecycle_policy_test.go
@@ -68,7 +68,7 @@ func TestAccAWSDlmLifecyclePolicy_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.create_rule.0.times.0", "21:42"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.retain_rule.0.count", "10"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.tags_to_add.tf-acc-test-added", "full"),
-					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.copy_tags", "true"),
+					resource.TestCheckResourceAttr(resourceName, "policy_details.0.schedule.0.copy_tags", "false"),
 					resource.TestCheckResourceAttr(resourceName, "policy_details.0.target_tags.tf-acc-test", "full"),
 				),
 			},
@@ -243,7 +243,7 @@ resource "aws_dlm_lifecycle_policy" "full" {
         tf-acc-test-added = "full"
       }
 
-      copy_tags = true
+      copy_tags = false
     }
 
     target_tags {
@@ -300,6 +300,7 @@ resource "aws_dlm_lifecycle_policy" "full" {
       tags_to_add {
         tf-acc-test-added = "full-updated"
       }
+
       copy_tags = true
     }
 

--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -57,6 +57,8 @@ resource "aws_dlm_lifecycle_policy" "example" {
       tags_to_add {
         SnapshotCreator = "DLM"
       }
+
+      copy_tags = false
     }
 
     target_tags {
@@ -85,6 +87,7 @@ The following arguments are supported:
 
 #### Schedule arguments
 
+* `copy_tags` - (Optional) Copy all user-defined tags on a source volume to snapshots of the volume created by this policy.
 * `create_rule` - (Required) See the [`create_rule`](#create-rule-arguments) block. Max of 1 per schedule.
 * `name` - (Required) A name for the schedule.
 * `retain_rule` - (Required) See the [`create_rule`](#create-rule-arguments) block. Max of 1 per schedule.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6442

Changes proposed in this pull request:

* Add copy_tags option to the resource_aws_dlm_lifecycle_policy

Output from acceptance testing:

```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./... -timeout=30s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1.970s

$ make testacc TESTARGS="-run=TestAccAWSDlmLifecyclePolicy_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDlmLifecyclePolicy_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDlmLifecyclePolicy_Basic
=== PAUSE TestAccAWSDlmLifecyclePolicy_Basic
=== RUN   TestAccAWSDlmLifecyclePolicy_Full
=== PAUSE TestAccAWSDlmLifecyclePolicy_Full
=== CONT  TestAccAWSDlmLifecyclePolicy_Basic
=== CONT  TestAccAWSDlmLifecyclePolicy_Full
--- PASS: TestAccAWSDlmLifecyclePolicy_Basic (23.30s)
--- PASS: TestAccAWSDlmLifecyclePolicy_Full (31.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	32.038s
...
```
