### PR TITLE
Add API Gateway API Key data source

### DIFF
--- a/aws/data_source_aws_api_gateway_api_key.go
+++ b/aws/data_source_aws_api_gateway_api_key.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsApiGatewayApiKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsApiGatewayApiKeyRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsApiGatewayApiKeyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+	apiKey, err := conn.GetApiKey(&apigateway.GetApiKeyInput{
+		ApiKey:       aws.String(d.Get("id").(string)),
+		IncludeValue: aws.Bool(true),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(aws.StringValue(apiKey.Id))
+	d.Set("name", apiKey.Name)
+	d.Set("value", apiKey.Value)
+	return nil
+}

--- a/aws/data_source_aws_api_gateway_api_key_test.go
+++ b/aws/data_source_aws_api_gateway_api_key_test.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsApiGatewayApiKey(t *testing.T) {
+	rName := acctest.RandString(8)
+	resourceName1 := "aws_api_gateway_api_key.example_key"
+	dataSourceName1 := "data.aws_api_gateway_api_key.test_key"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsApiGatewayApiKeyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName1, "id", dataSourceName1, "id"),
+					resource.TestCheckResourceAttrPair(resourceName1, "name", dataSourceName1, "name"),
+					resource.TestCheckResourceAttrPair(resourceName1, "value", dataSourceName1, "value"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsApiGatewayApiKeyConfig(r string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "example" {
+    name = "example"
+}
+
+resource "aws_api_gateway_resource" "example_v1" {
+    rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+    parent_id   = "${aws_api_gateway_rest_api.example.root_resource_id}"
+    path_part   = "v1"
+}
+
+resource "aws_api_gateway_method" "example_v1_method" {
+    rest_api_id   = "${aws_api_gateway_rest_api.example.id}"
+    resource_id   = "${aws_api_gateway_resource.example_v1.id}"
+    http_method   = "GET"
+    authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "example_v1_integration" {
+    rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+    resource_id = "${aws_api_gateway_resource.example_v1.id}"
+    http_method = "${aws_api_gateway_method.example_v1_method.http_method}"
+    type        = "MOCK"
+}
+
+resource "aws_api_gateway_deployment" "example_deployment" {
+    rest_api_id = "${aws_api_gateway_rest_api.example.id}"
+    stage_name  = "example"
+    depends_on  = ["aws_api_gateway_resource.example_v1", "aws_api_gateway_method.example_v1_method", "aws_api_gateway_integration.example_v1_integration"]
+}
+
+resource "aws_api_gateway_api_key" "example_key" {
+    name = "%s"
+}
+
+resource "aws_api_gateway_usage_plan" "example_plan" {
+    name = "example"
+
+    api_stages {
+        api_id = "${aws_api_gateway_rest_api.example.id}"
+        stage  = "${aws_api_gateway_deployment.example_deployment.stage_name}"
+    }
+}
+
+resource "aws_api_gateway_usage_plan_key" "plan_key" {
+    key_id = "${aws_api_gateway_api_key.example_key.id}"
+    key_type = "API_KEY"
+    usage_plan_id = "${aws_api_gateway_usage_plan.example_plan.id}"
+}
+
+data "aws_api_gateway_api_key" "test_key" {
+    id = "${aws_api_gateway_api_key.example_key.id}"
+}
+`, r)
+}

--- a/aws/data_source_aws_api_gateway_api_key_test.go
+++ b/aws/data_source_aws_api_gateway_api_key_test.go
@@ -31,53 +31,8 @@ func TestAccDataSourceAwsApiGatewayApiKey(t *testing.T) {
 
 func testAccDataSourceAwsApiGatewayApiKeyConfig(r string) string {
 	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "example" {
-    name = "example"
-}
-
-resource "aws_api_gateway_resource" "example_v1" {
-    rest_api_id = "${aws_api_gateway_rest_api.example.id}"
-    parent_id   = "${aws_api_gateway_rest_api.example.root_resource_id}"
-    path_part   = "v1"
-}
-
-resource "aws_api_gateway_method" "example_v1_method" {
-    rest_api_id   = "${aws_api_gateway_rest_api.example.id}"
-    resource_id   = "${aws_api_gateway_resource.example_v1.id}"
-    http_method   = "GET"
-    authorization = "NONE"
-}
-
-resource "aws_api_gateway_integration" "example_v1_integration" {
-    rest_api_id = "${aws_api_gateway_rest_api.example.id}"
-    resource_id = "${aws_api_gateway_resource.example_v1.id}"
-    http_method = "${aws_api_gateway_method.example_v1_method.http_method}"
-    type        = "MOCK"
-}
-
-resource "aws_api_gateway_deployment" "example_deployment" {
-    rest_api_id = "${aws_api_gateway_rest_api.example.id}"
-    stage_name  = "example"
-    depends_on  = ["aws_api_gateway_resource.example_v1", "aws_api_gateway_method.example_v1_method", "aws_api_gateway_integration.example_v1_integration"]
-}
-
 resource "aws_api_gateway_api_key" "example_key" {
     name = "%s"
-}
-
-resource "aws_api_gateway_usage_plan" "example_plan" {
-    name = "example"
-
-    api_stages {
-        api_id = "${aws_api_gateway_rest_api.example.id}"
-        stage  = "${aws_api_gateway_deployment.example_deployment.stage_name}"
-    }
-}
-
-resource "aws_api_gateway_usage_plan_key" "plan_key" {
-    key_id = "${aws_api_gateway_api_key.example_key.id}"
-    key_type = "API_KEY"
-    usage_plan_id = "${aws_api_gateway_usage_plan.example_plan.id}"
 }
 
 data "aws_api_gateway_api_key" "test_key" {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -164,6 +164,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_acmpca_certificate_authority":     dataSourceAwsAcmpcaCertificateAuthority(),
 			"aws_ami":                              dataSourceAwsAmi(),
 			"aws_ami_ids":                          dataSourceAwsAmiIds(),
+			"aws_api_gateway_api_key":              dataSourceAwsApiGatewayApiKey(),
 			"aws_api_gateway_resource":             dataSourceAwsApiGatewayResource(),
 			"aws_api_gateway_rest_api":             dataSourceAwsApiGatewayRestApi(),
 			"aws_arn":                              dataSourceAwsArn(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -58,6 +58,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ami-ids") %>>
                             <a href="/docs/providers/aws/d/ami_ids.html">aws_ami_ids</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws_api_gateway_api_key") %>>
+                            <a href="/docs/providers/aws/d/api_gateway_api_key.html">aws_api_gateway_api_key</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws_api_gateway_resource") %>>
                             <a href="/docs/providers/aws/d/api_gateway_resource.html">aws_api_gateway_resource</a>
                         </li>

--- a/website/docs/d/api_gateway_api_key.html.markdown
+++ b/website/docs/d/api_gateway_api_key.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_api_key"
+sidebar_current: "docs-aws_api_gateway_api_key"
+description: |-
+  Get information on an API Gateway API Key
+---
+
+# Data Source: aws_api_gateway_api_key
+
+Use this data source to get the name and value of a pre-existing API Key, for
+example to supply credentials for a dependency microservice.
+
+## Example Usage
+
+```hcl
+data "aws_api_gateway_api_key" "my_api_key" {
+  id = "my-rest-api-key"
+}
+```
+
+## Argument Reference
+
+ * `id` - (Required) The ID of the API Key to look up. If no API Key is found with this name, an error will be returned.
+
+## Attributes Reference
+
+ * `id` - Set to the ID of the API Key.
+ * `name` - Set to the name of the API Key.
+ * `value` - Set to the value of the API Key.

--- a/website/docs/d/api_gateway_api_key.html.markdown
+++ b/website/docs/d/api_gateway_api_key.html.markdown
@@ -15,13 +15,13 @@ example to supply credentials for a dependency microservice.
 
 ```hcl
 data "aws_api_gateway_api_key" "my_api_key" {
-  id = "my-rest-api-key"
+  id = "ru3mpjgse6"
 }
 ```
 
 ## Argument Reference
 
- * `id` - (Required) The ID of the API Key to look up. If no API Key is found with this name, an error will be returned.
+ * `id` - (Required) The ID of the API Key to look up.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Add a data source for API Gateway API Keys - When deploying a micro-service, if it has a dependency on some other micro-service, it will need to have an API Gateway API Key made available for injecting into configs (for example, Lambda environment variables).  Creating a data source allows us to fetch the appropriate API Key without having to duplicate it or script it somehow.

**Output from acceptance testing:**
```
$  make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsApiGatewayApiKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAwsApiGatewayApiKey -timeout 120m
=== RUN   TestAccDataSourceAwsApiGatewayApiKey
=== PAUSE TestAccDataSourceAwsApiGatewayApiKey
=== CONT  TestAccDataSourceAwsApiGatewayApiKey
--- PASS: TestAccDataSourceAwsApiGatewayApiKey (185.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       185.603s
```
