### PR TITLE
r/launch_template: default network_interfaces.delete_on_termination to true

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -334,6 +334,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 						"delete_on_termination": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 						"description": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -447,6 +447,7 @@ func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "network_interfaces.0.network_interface_id"),
 					resource.TestCheckResourceAttr(resName, "network_interfaces.0.associate_public_ip_address", "false"),
 					resource.TestCheckResourceAttr(resName, "network_interfaces.0.ipv4_address_count", "2"),
+					resource.TestCheckResourceAttr(resName, "network_interfaces.0.delete_on_termination", "true"),
 				),
 			},
 		},

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -226,7 +226,7 @@ Check limitations for autoscaling group in [Creating an Auto Scaling Group Using
 Each `network_interfaces` block supports the following:
 
 * `associate_public_ip_address` - Associate a public ip address with the network interface.  Boolean value.
-* `delete_on_termination` - Whether the network interface should be destroyed on instance termination.
+* `delete_on_termination` - Whether the network interface should be destroyed on instance termination (Default: `true`).
 * `description` - Description of the network interface.
 * `device_index` - The integer index of the network interface attachment.
 * `ipv6_addresses` - One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. Conflicts with `ipv6_address_count`


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6080

Changes proposed in this pull request:

* defaults network_interfaces.delete_on_termination to true

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
=== PAUSE TestAccAWSLaunchTemplate_importBasic
=== RUN   TestAccAWSLaunchTemplate_importData
=== PAUSE TestAccAWSLaunchTemplate_importData
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_importBasic
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== CONT  TestAccAWSLaunchTemplate_networkInterface
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
=== CONT  TestAccAWSLaunchTemplate_update
=== CONT  TestAccAWSLaunchTemplate_tags
=== CONT  TestAccAWSLaunchTemplate_disappears
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== CONT  TestAccAWSLaunchTemplate_importData
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
--- PASS: TestAccAWSLaunchTemplate_disappears (9.22s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (11.63s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (11.66s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (11.69s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (11.72s)
--- PASS: TestAccAWSLaunchTemplate_data (11.73s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (11.73s)
--- PASS: TestAccAWSLaunchTemplate_basic (12.19s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (12.23s)
--- PASS: TestAccAWSLaunchTemplate_importData (12.92s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (13.20s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (17.23s)
--- PASS: TestAccAWSLaunchTemplate_tags (21.27s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (30.38s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (44.07s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (45.74s)
--- PASS: TestAccAWSLaunchTemplate_update (47.16s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (48.07s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (48.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	(cached)
```
