### PR TITLE
Performance Insights configuration for aws_db_instance

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -180,6 +180,9 @@ is provided) Username for the master DB user.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to
 associate.
 * `s3_import` - (Optional) Restore from a Percona Xtrabackup in S3.  See [Importing Data into an Amazon RDS MySQL DB Instance](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.html)
+* `performance_insights_enabled` - (Optional) Specifies whether Performance Insights are enabled. Defaults to false.
+* `performance_insights_kms_key_id` - (Optional) The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true. Once KMS key is set, it can never be changed.
+* `performance_insights_retention_period` - (Optional) The amount of time in days to retain Performance Insights data. Either 7 (7 days) or 731 (2 years). When specifying `performance_insights_retention_period`, `performance_insights_enabled` needs to be set to true. Defaults to '7'.
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5259

Changes proposed in this pull request:

* Add `performance_insights_enabled` to aws_db_instance
* Add `performance_insights_kms_key_id` to aws_db_instance
* Add `performance_insights_retention_period` to aws_db_instance

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSDBInstance_withPerformanceInsights'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSRDSDBInstance_withPerformanceInsights -timeout 120m
=== RUN   TestAccAWSRDSDBInstance_withPerformanceInsights
=== PAUSE TestAccAWSRDSDBInstance_withPerformanceInsights
=== CONT  TestAccAWSRDSDBInstance_withPerformanceInsights
--- PASS: TestAccAWSRDSDBInstance_withPerformanceInsights (596.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	596.419s
```
