### PR TITLE
API Gateway deployment resource, field stage_name not required #2918

### DIFF
--- a/aws/resource_aws_api_gateway_deployment.go
+++ b/aws/resource_aws_api_gateway_deployment.go
@@ -28,7 +28,7 @@ func resourceAwsApiGatewayDeployment() *schema.Resource {
 
 			"stage_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 

--- a/aws/resource_aws_api_gateway_deployment_test.go
+++ b/aws/resource_aws_api_gateway_deployment_test.go
@@ -37,6 +37,74 @@ func TestAccAWSAPIGatewayDeployment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSAPIGatewayDeployment_basicEmptyStage(t *testing.T) {
+	var conf apigateway.Deployment
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: buildAPIGatewayDeploymentConfig(
+					"This is a test", "https://www.google.de", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
+					resource.TestCheckNoResourceAttr(
+						"aws_api_gateway_deployment.test", "stage_name"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "description", "This is a test"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "variables.a", "2"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_deployment.test", "created_date"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDeployment_namedToEmptyStage(t *testing.T) {
+	var conf apigateway.Deployment
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayDeploymentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "stage_name", "test"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "description", "This is a test"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "variables.a", "2"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_deployment.test", "created_date"),
+				),
+			},
+			{
+				Config: buildAPIGatewayDeploymentConfig(
+					"This is a test", "https://www.google.de", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
+					resource.TestCheckNoResourceAttr(
+						"aws_api_gateway_deployment.test", "stage_name"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "description", "This is a test"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_deployment.test", "variables.a", "2"),
+					resource.TestCheckResourceAttrSet(
+						"aws_api_gateway_deployment.test", "created_date"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSAPIGatewayDeployment_createBeforeDestoryUpdate(t *testing.T) {
 	var conf apigateway.Deployment
 	var stage apigateway.Stage
@@ -217,11 +285,10 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "test"
-	description = "%s"
-	stage_description = "%s"
+  description = "%s"
+  stage_description = "%s"
 
-	%s
+  %s
 
   variables = {
     "a" = "2"
@@ -230,12 +297,17 @@ resource "aws_api_gateway_deployment" "test" {
 `, url, description, description, extras)
 }
 
-var testAccAWSAPIGatewayDeploymentConfig = buildAPIGatewayDeploymentConfig("This is a test", "https://www.google.de", "")
+var testAccAWSAPIGatewayDeploymentConfig = buildAPIGatewayDeploymentConfig(
+	"This is a test", "https://www.google.de", `
+  stage_name = "test"
+`)
 
 func testAccAWSAPIGatewayDeploymentCreateBeforeDestroyConfig(description string, url string) string {
 	return buildAPIGatewayDeploymentConfig(description, url, `
-		lifecycle {
-			create_before_destroy = true
-		}
-	`)
+  stage_name = "test"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+`)
 }

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -58,7 +58,7 @@ resource "aws_api_gateway_deployment" "MyDemoDeployment" {
 The following arguments are supported:
 
 * `rest_api_id` - (Required) The ID of the associated REST API
-* `stage_name` - (Required) The name of the stage. If the specified stage already exists, it will be updated to point to the new deployment. If the stage does not exist, a new one will be created and point to this deployment. Use `""` to point at the default stage.
+* `stage_name` - (Optional) The name of the stage. If the specified stage already exists, it will be updated to point to the new deployment. If the stage does not exist, a new one will be created and point to this deployment.
 * `description` - (Optional) The description of the deployment
 * `stage_description` - (Optional) The description of the stage
 * `variables` - (Optional) A map that defines variables for the stage


### PR DESCRIPTION
Fixes #2918

Changes proposed in this pull request:

* Field stage_name changed from required to optional