### PR TITLE
resource/aws_route53_health_check: Various small improvements

### DIFF
--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -32,6 +32,15 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				StateFunc: func(val interface{}) string {
 					return strings.ToUpper(val.(string))
 				},
+				ValidateFunc: validation.StringInSlice([]string{
+					route53.HealthCheckTypeCalculated,
+					route53.HealthCheckTypeCloudwatchMetric,
+					route53.HealthCheckTypeHttp,
+					route53.HealthCheckTypeHttpStrMatch,
+					route53.HealthCheckTypeHttps,
+					route53.HealthCheckTypeHttpsStrMatch,
+					route53.HealthCheckTypeTcp,
+				}, true),
 			},
 			"failure_threshold": {
 				Type:     schema.TypeInt,
@@ -333,7 +342,11 @@ func resourceAwsRoute53HealthCheckRead(d *schema.ResourceData, meta interface{})
 	d.Set("resource_path", updated.ResourcePath)
 	d.Set("measure_latency", updated.MeasureLatency)
 	d.Set("invert_healthcheck", updated.Inverted)
-	d.Set("child_healthchecks", updated.ChildHealthChecks)
+
+	if err := d.Set("child_healthchecks", flattenStringList(updated.ChildHealthChecks)); err != nil {
+		return fmt.Errorf("error setting child_healthchecks: %s", err)
+	}
+
 	d.Set("child_health_threshold", updated.HealthThreshold)
 	d.Set("insufficient_data_health_status", updated.InsufficientDataHealthStatus)
 	d.Set("enable_sni", updated.EnableSNI)

--- a/aws/resource_aws_route53_health_check_test.go
+++ b/aws/resource_aws_route53_health_check_test.go
@@ -4,32 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
-	"github.com/aws/aws-sdk-go/service/route53"
 )
-
-func TestAccAWSRoute53HealthCheck_importBasic(t *testing.T) {
-	resourceName := "aws_route53_health_check.foo"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRoute53HealthCheckDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoute53HealthCheckConfig,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
 
 func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
@@ -47,6 +25,11 @@ func TestAccAWSRoute53HealthCheck_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_route53_health_check.foo", "invert_healthcheck", "true"),
 				),
+			},
+			{
+				ResourceName:      "aws_route53_health_check.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccRoute53HealthCheckConfigUpdate,
@@ -80,6 +63,11 @@ func TestAccAWSRoute53HealthCheck_withSearchString(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_route53_health_check.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccRoute53HealthCheckConfigWithSearchStringUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
@@ -105,6 +93,11 @@ func TestAccAWSRoute53HealthCheck_withChildHealthChecks(t *testing.T) {
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.foo"),
 				),
 			},
+			{
+				ResourceName:      "aws_route53_health_check.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -123,6 +116,11 @@ func TestAccAWSRoute53HealthCheck_withHealthCheckRegions(t *testing.T) {
 						"aws_route53_health_check.foo", "regions.#", "3"),
 				),
 			},
+			{
+				ResourceName:      "aws_route53_health_check.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -138,6 +136,11 @@ func TestAccAWSRoute53HealthCheck_IpConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53HealthCheckExists("aws_route53_health_check.bar"),
 				),
+			},
+			{
+				ResourceName:      "aws_route53_health_check.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -157,6 +160,11 @@ func TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck(t *testing.T) {
 						"aws_route53_health_check.foo", "cloudwatch_alarm_name", "cloudwatch-healthcheck-alarm"),
 				),
 			},
+			{
+				ResourceName:      "aws_route53_health_check.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -175,6 +183,11 @@ func TestAccAWSRoute53HealthCheck_withSNI(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_route53_health_check.foo", "enable_sni", "true"),
 				),
+			},
+			{
+				ResourceName:      "aws_route53_health_check.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccRoute53HealthCheckConfigWithSNIDisabled,
@@ -232,8 +245,6 @@ func testAccCheckRoute53HealthCheckExists(n string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
-
-		fmt.Print(rs.Primary.ID)
 
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No health check ID is set")

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -11,9 +11,11 @@ Provides a Route53 health check.
 
 ## Example Usage
 
+### Connectivity and HTTP Status Code Check
+
 ```hcl
-resource "aws_route53_health_check" "child1" {
-  fqdn              = "foobar.terraform.com"
+resource "aws_route53_health_check" "example" {
+  fqdn              = "example.com"
   port              = 80
   type              = "HTTP"
   resource_path     = "/"
@@ -24,11 +26,29 @@ resource "aws_route53_health_check" "child1" {
     Name = "tf-test-health-check"
   }
 }
+```
 
-resource "aws_route53_health_check" "foo" {
+### Connectivity and String Matching Check
+
+```hcl
+resource "aws_route53_health_check" "example" {
+  failure_threshold = "5"
+  fqdn              = "example.com"
+  port              = 443
+  request_interval  = "30"
+  resource_path     = "/"
+  search_string     = "example"
+  type              = "HTTPS_STR_MATCH"
+}
+```
+
+### Aggregate Check
+
+```hcl
+resource "aws_route53_health_check" "parent" {
   type                   = "CALCULATED"
   child_health_threshold = 1
-  child_healthchecks     = ["${aws_route53_health_check.child1.id}"]
+  child_healthchecks     = ["${aws_route53_health_check.child.id}"]
 
   tags = {
     Name = "tf-test-calculated-health-check"
@@ -36,7 +56,7 @@ resource "aws_route53_health_check" "foo" {
 }
 ```
 
-## CloudWatch Alarm Example
+### CloudWatch Alarm Check
 
 ```hcl
 resource "aws_cloudwatch_metric_alarm" "foobar" {
@@ -72,7 +92,7 @@ The following arguments are supported:
 * `failure_threshold` - (Required) The number of consecutive health checks that an endpoint must pass or fail.
 * `request_interval` - (Required) The number of seconds between the time that Amazon Route 53 gets a response from your endpoint and the time that it sends the next health-check request.
 * `resource_path` - (Optional) The path that you want Amazon Route 53 to request when performing health checks.
-* `search_string` - (Optional) String searched in the first 5120 bytes of the response body for check to be considered healthy.
+* `search_string` - (Optional) String searched in the first 5120 bytes of the response body for check to be considered healthy. Only valid with `HTTP_STR_MATCH` and `HTTPS_STR_MATCH`.
 * `measure_latency` - (Optional) A Boolean value that indicates whether you want Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint and to display CloudWatch latency graphs in the Route 53 console.
 * `invert_healthcheck` - (Optional) A boolean value that indicates whether the status of health check should be inverted. For example, if a health check is healthy but Inverted is True , then Route 53 considers the health check to be unhealthy.
 * `enable_sni` - (Optional) A boolean value that indicates whether Route53 should send the `fqdn` to the endpoint when performing the health check. This defaults to AWS' defaults: when the `type` is "HTTPS" `enable_sni` defaults to `true`, when `type` is anything else `enable_sni` defaults to `false`.


### PR DESCRIPTION
Closes #6346 
Closes #6393

Changes proposed in this pull request:

* docs/resource/aws_route53_health_check: Improve examples and note valid `search_string` usage
* resource/aws_route53_health_check: Provide plan-time validation for `type`
* resource/aws_route53_health_check: Properly read `child_healthchecks` into Terraform state
* tests/resource/aws_route53_health_check: Verify resource import in all acceptance tests

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53HealthCheck_IpConfig (11.58s)
--- PASS: TestAccAWSRoute53HealthCheck_withChildHealthChecks (13.70s)
--- PASS: TestAccAWSRoute53HealthCheck_withHealthCheckRegions (15.13s)
--- PASS: TestAccAWSRoute53HealthCheck_CloudWatchAlarmCheck (17.18s)
--- PASS: TestAccAWSRoute53HealthCheck_basic (17.91s)
--- PASS: TestAccAWSRoute53HealthCheck_withSearchString (18.99s)
--- PASS: TestAccAWSRoute53HealthCheck_withSNI (32.58s)
```