### PR TITLE
Cloudfront Distribution Data Source (#6586)

### DIFF
--- a/aws/data_source_aws_cloudfront_distribution.go
+++ b/aws/data_source_aws_cloudfront_distribution.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsCloudFrontDistribution() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCloudFrontDistributionRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"active_trusted_signers": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"in_progress_validation_batches": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"hosted_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func dataSourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("id").(string))
+	err := resourceAwsCloudFrontDistributionReadBase(d, meta, false)
+	if err != nil {
+		return err
+	}
+	d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)
+	return nil
+}

--- a/aws/data_source_aws_cloudfront_distribution.go
+++ b/aws/data_source_aws_cloudfront_distribution.go
@@ -1,7 +1,12 @@
 package aws
 
 import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
 func dataSourceAwsCloudFrontDistribution() *schema.Resource {
@@ -12,10 +17,6 @@ func dataSourceAwsCloudFrontDistribution() *schema.Resource {
 			"id": {
 				Type:     schema.TypeString,
 				Required: true,
-			},
-			"active_trusted_signers": {
-				Type:     schema.TypeMap,
-				Computed: true,
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -57,10 +58,37 @@ func dataSourceAwsCloudFrontDistribution() *schema.Resource {
 
 func dataSourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(d.Get("id").(string))
-	err := resourceAwsCloudFrontDistributionReadBase(d, meta, false)
-	if err != nil {
-		return err
+	conn := meta.(*AWSClient).cloudfrontconn
+	input := &cloudfront.GetDistributionInput{
+		Id: aws.String(d.Id()),
 	}
+
+	output, err := conn.GetDistribution(input)
+	if err != nil {
+		return fmt.Errorf("error getting CloudFront Distribution (%s): %w", d.Id(), err)
+	}
+	if output == nil {
+		return fmt.Errorf("error getting CloudFront Distribution (%s): empty response", d.Id())
+	}
+	d.Set("etag", output.ETag)
+	if distribution := output.Distribution; distribution != nil {
+		d.Set("arn", distribution.ARN)
+		d.Set("domain_name", distribution.DomainName)
+		d.Set("in_progress_validation_batches", distribution.InProgressInvalidationBatches)
+		d.Set("last_modified_time", aws.String(distribution.LastModifiedTime.String()))
+		d.Set("status", distribution.Status)
+		if distributionConfig := distribution.DistributionConfig; distributionConfig != nil {
+			d.Set("enabled", distributionConfig.Enabled)
+		}
+	}
+	tags, err := keyvaluetags.CloudfrontListTags(conn, d.Get("arn").(string))
+	if err != nil {
+		return fmt.Errorf("error listing tags for CloudFront Distribution (%s): %w", d.Id(), err)
+	}
+	if err := d.Set("tags", tags.IgnoreAws().Map()); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	d.Set("hosted_zone_id", cloudFrontRoute53ZoneID)
 	return nil
 }

--- a/aws/data_source_aws_cloudfront_distribution_test.go
+++ b/aws/data_source_aws_cloudfront_distribution_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAWSDataSourceCloudFrontDistribution_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontDistributionData,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.aws_cloudfront_distribution.test",
+						"domain_name",
+						regexp.MustCompile(`^[a-z0-9]+\.cloudfront\.net$`),
+					),
+					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "domain_name"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "etag"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "hosted_zone_id"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "in_progress_validation_batches"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "last_modified_time"),
+					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "status"),
+				),
+			},
+		},
+	})
+}
+
+var testAccAWSCloudFrontDistributionData = fmt.Sprintf(`
+%s
+
+data "aws_cloudfront_distribution" "test" {
+	id = "${aws_cloudfront_distribution.s3_distribution.id}"
+}
+`, fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTags, acctest.RandInt(), originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig()))

--- a/aws/data_source_aws_cloudfront_distribution_test.go
+++ b/aws/data_source_aws_cloudfront_distribution_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -10,6 +9,9 @@ import (
 )
 
 func TestAccAWSDataSourceCloudFrontDistribution_basic(t *testing.T) {
+	dataSourceName := "data.aws_cloudfront_distribution.test"
+	resourceName := "aws_cloudfront_distribution.s3_distribution"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -17,18 +19,13 @@ func TestAccAWSDataSourceCloudFrontDistribution_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudFrontDistributionData,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"data.aws_cloudfront_distribution.test",
-						"domain_name",
-						regexp.MustCompile(`^[a-z0-9]+\.cloudfront\.net$`),
-					),
-					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "domain_name"),
-					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "etag"),
-					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "hosted_zone_id"),
-					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "in_progress_validation_batches"),
-					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "last_modified_time"),
-					resource.TestCheckResourceAttrSet("data.aws_cloudfront_distribution.test", "status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etag", resourceName, "etag"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "hosted_zone_id", resourceName, "hosted_zone_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "in_progress_validation_batches", resourceName, "in_progress_validation_batches"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "status", resourceName, "status"),
 				),
 			},
 		},
@@ -38,7 +35,7 @@ func TestAccAWSDataSourceCloudFrontDistribution_basic(t *testing.T) {
 var testAccAWSCloudFrontDistributionData = fmt.Sprintf(`
 %s
 
-data "aws_cloudfront_distribution" "test" {
-	id = "${aws_cloudfront_distribution.s3_distribution.id}"
+data aws_cloudfront_distribution test {
+	id = aws_cloudfront_distribution.s3_distribution.id
 }
 `, fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTags, acctest.RandInt(), originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig()))

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -177,6 +177,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_canonical_user_id":                         dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_export":                     dataSourceAwsCloudFormationExport(),
 			"aws_cloudformation_stack":                      dataSourceAwsCloudFormationStack(),
+			"aws_cloudfront_distribution":                   dataSourceAwsCloudFrontDistribution(),
 			"aws_cloudhsm_v2_cluster":                       dataSourceCloudHsmV2Cluster(),
 			"aws_cloudtrail_service_account":                dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":                      dataSourceAwsCloudwatchLogGroup(),

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -799,7 +799,7 @@ func resourceAwsCloudFrontDistributionCreate(d *schema.ResourceData, meta interf
 	return resourceAwsCloudFrontDistributionRead(d, meta)
 }
 
-func resourceAwsCloudFrontDistributionReadBase(d *schema.ResourceData, meta interface{}, flatten bool) error {
+func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudfrontconn
 	params := &cloudfront.GetDistributionInput{
 		Id: aws.String(d.Id()),
@@ -817,11 +817,9 @@ func resourceAwsCloudFrontDistributionReadBase(d *schema.ResourceData, meta inte
 	}
 
 	// Update attributes from DistributionConfig
-	if flatten {
-		err = flattenDistributionConfig(d, resp.Distribution.DistributionConfig)
-		if err != nil {
-			return err
-		}
+	err = flattenDistributionConfig(d, resp.Distribution.DistributionConfig)
+	if err != nil {
+		return err
 	}
 
 	// Update other attributes outside of DistributionConfig
@@ -845,10 +843,6 @@ func resourceAwsCloudFrontDistributionReadBase(d *schema.ResourceData, meta inte
 	}
 
 	return nil
-}
-
-func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interface{}) error {
-	return resourceAwsCloudFrontDistributionReadBase(d, meta, true)
 }
 
 func resourceAwsCloudFrontDistributionUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -799,7 +799,7 @@ func resourceAwsCloudFrontDistributionCreate(d *schema.ResourceData, meta interf
 	return resourceAwsCloudFrontDistributionRead(d, meta)
 }
 
-func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsCloudFrontDistributionReadBase(d *schema.ResourceData, meta interface{}, flatten bool) error {
 	conn := meta.(*AWSClient).cloudfrontconn
 	params := &cloudfront.GetDistributionInput{
 		Id: aws.String(d.Id()),
@@ -817,10 +817,13 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 	}
 
 	// Update attributes from DistributionConfig
-	err = flattenDistributionConfig(d, resp.Distribution.DistributionConfig)
-	if err != nil {
-		return err
+	if flatten {
+		err = flattenDistributionConfig(d, resp.Distribution.DistributionConfig)
+		if err != nil {
+			return err
+		}
 	}
+
 	// Update other attributes outside of DistributionConfig
 	err = d.Set("active_trusted_signers", flattenActiveTrustedSigners(resp.Distribution.ActiveTrustedSigners))
 	if err != nil {
@@ -842,6 +845,10 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 	}
 
 	return nil
+}
+
+func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interface{}) error {
+	return resourceAwsCloudFrontDistributionReadBase(d, meta, true)
 }
 
 func resourceAwsCloudFrontDistributionUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -461,6 +461,14 @@
                     <a href="#">CloudFront</a>
                     <ul class="nav">
                         <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/cloudfront_distribution.html">aws_cloudfront_distribution</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>

--- a/website/docs/d/cloudfront_distribution.html.markdown
+++ b/website/docs/d/cloudfront_distribution.html.markdown
@@ -35,10 +35,6 @@ The following attributes are exported:
     distribution's information is fully propagated throughout the Amazon
     CloudFront system.
 
-  * `active_trusted_signers` - The key pair IDs that CloudFront is aware of for
-    each trusted signer, if the distribution is set up to serve private content
-    with signed URLs.
-
   * `domain_name` - The domain name corresponding to the distribution. For
     example: `d604721fxaaqy9.cloudfront.net`.
 

--- a/website/docs/d/cloudfront_distribution.html.markdown
+++ b/website/docs/d/cloudfront_distribution.html.markdown
@@ -14,7 +14,7 @@ Use this data source to retrieve information about a CloudFront distribution.
 
 ```hcl
 data "aws_cloudfront_distribution" "test" {
-  id = "${aws_cloudfront_distribution.s3_distribution.id}"
+  id = "EDFDVBD632BHDS5"
 }
 
 ```

--- a/website/docs/d/cloudfront_distribution.html.markdown
+++ b/website/docs/d/cloudfront_distribution.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_distribution"
+description: |-
+  Provides a CloudFront web distribution data source.
+---
+
+# Data source: aws_cloudfront_distribution
+
+Use this data source to retrieve information about a CloudFront distribution.
+
+## Example Usage
+
+```hcl
+data "aws_cloudfront_distribution" "test" {
+  id = "${aws_cloudfront_distribution.s3_distribution.id}"
+}
+
+```
+
+## Argument Reference
+
+  * `id` - The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
+
+  * `arn` - The ARN (Amazon Resource Name) for the distribution. For example: arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5, where 123456789012 is your AWS account ID.
+
+  * `status` - The current status of the distribution. `Deployed` if the
+    distribution's information is fully propagated throughout the Amazon
+    CloudFront system.
+
+  * `active_trusted_signers` - The key pair IDs that CloudFront is aware of for
+    each trusted signer, if the distribution is set up to serve private content
+    with signed URLs.
+
+  * `domain_name` - The domain name corresponding to the distribution. For
+    example: `d604721fxaaqy9.cloudfront.net`.
+
+  * `last_modified_time` - The date and time the distribution was last modified.
+
+  * `in_progress_validation_batches` - The number of invalidation batches
+    currently in progress.
+
+  * `etag` - The current version of the distribution's information. For example:
+    `E2QWRUHAPOMQZL`.
+
+  * `hosted_zone_id` - The CloudFront Route 53 zone ID that can be used to
+     route an [Alias Resource Record Set][7] to. This attribute is simply an
+     alias for the zone ID `Z2FDTNDATAQYW2`.


### PR DESCRIPTION
Changes proposed in this pull request:

* Added support for a CloudFront distribution data source

Output from acceptance testing:
```
$  make testacc TESTARGS='-run=TestAccAWSDataSourceCloudFrontDistribution_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDataSourceCloudFrontDistribution_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDataSourceCloudFrontDistribution_basic
=== PAUSE TestAccAWSDataSourceCloudFrontDistribution_basic
=== CONT  TestAccAWSDataSourceCloudFrontDistribution_basic
--- PASS: TestAccAWSDataSourceCloudFrontDistribution_basic (1292.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1292.781s
```
