### PR TITLE
New Datasource: aws_ssm_document

### DIFF
--- a/aws/data_source_aws_ssm_document.go
+++ b/aws/data_source_aws_ssm_document.go
@@ -1,0 +1,90 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func dataSourceAwsSsmDocument() *schema.Resource {
+	return &schema.Resource{
+		Read: dataAwsSsmDocumentRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"document_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  ssm.DocumentFormatJson,
+				ValidateFunc: validation.StringInSlice([]string{
+					ssm.DocumentFormatJson,
+					ssm.DocumentFormatYaml,
+				}, false),
+			},
+			"document_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"document_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error {
+	ssmconn := meta.(*AWSClient).ssmconn
+
+	name := d.Get("name").(string)
+
+	docInput := &ssm.GetDocumentInput{
+		Name:           aws.String(name),
+		DocumentFormat: aws.String(d.Get("document_format").(string)),
+	}
+
+	if docVersion, ok := d.GetOk("document_version"); ok {
+		docInput.DocumentVersion = aws.String(docVersion.(string))
+	}
+
+	log.Printf("[DEBUG] Reading SSM Document: %s", docInput)
+	resp, err := ssmconn.GetDocument(docInput)
+
+	if err != nil {
+		return fmt.Errorf("Error reading SSM Document: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.Name))
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ssm",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("document/%s", aws.StringValue(resp.Name)),
+	}.String()
+
+	d.Set("arn", arn)
+	d.Set("name", resp.Name)
+	d.Set("content", resp.Content)
+	d.Set("document_version", resp.DocumentVersion)
+	d.Set("document_format", resp.DocumentFormat)
+	d.Set("document_type", resp.DocumentType)
+
+	return nil
+}

--- a/aws/data_source_aws_ssm_document_test.go
+++ b/aws/data_source_aws_ssm_document_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -19,24 +18,22 @@ func TestAccAWSSsmDocumentDataSource_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsSsmDocumentDataSourceConfig(name, "JSON"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn",
-						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:document/%s$", name))),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "document_format", "JSON"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_ssm_document.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", "aws_ssm_document.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "document_format", "aws_ssm_document.test", "document_format"),
 					resource.TestCheckResourceAttr(resourceName, "document_version", "1"),
-					resource.TestCheckResourceAttr(resourceName, "document_type", "Command"),
+					resource.TestCheckResourceAttrPair(resourceName, "document_type", "aws_ssm_document.test", "document_type"),
 					resource.TestCheckResourceAttrPair(resourceName, "content", "aws_ssm_document.test", "content"),
 				),
 			},
 			{
 				Config: testAccCheckAwsSsmDocumentDataSourceConfig(name, "YAML"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceName, "arn",
-						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:document/%s$", name))),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", "aws_ssm_document.test", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", "aws_ssm_document.test", "name"),
 					resource.TestCheckResourceAttr(resourceName, "document_format", "YAML"),
 					resource.TestCheckResourceAttr(resourceName, "document_version", "1"),
-					resource.TestCheckResourceAttr(resourceName, "document_type", "Command"),
+					resource.TestCheckResourceAttrPair(resourceName, "document_type", "aws_ssm_document.test", "document_type"),
 					resource.TestCheckResourceAttrSet(resourceName, "content"),
 				),
 			},

--- a/aws/data_source_aws_ssm_document_test.go
+++ b/aws/data_source_aws_ssm_document_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSSsmDocumentDataSource_basic(t *testing.T) {
+	resourceName := "data.aws_ssm_document.test"
+	name := "test_document"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsSsmDocumentDataSourceConfig(name, "JSON"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:document/%s$", name))),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "document_format", "JSON"),
+					resource.TestCheckResourceAttr(resourceName, "document_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "document_type", "Command"),
+					resource.TestCheckResourceAttrPair(resourceName, "content", "aws_ssm_document.test", "content"),
+				),
+			},
+			{
+				Config: testAccCheckAwsSsmDocumentDataSourceConfig(name, "YAML"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceName, "arn",
+						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:document/%s$", name))),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "document_format", "YAML"),
+					resource.TestCheckResourceAttr(resourceName, "document_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "document_type", "Command"),
+					resource.TestCheckResourceAttrSet(resourceName, "content"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsSsmDocumentDataSourceConfig(name string, documentFormat string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "test" {
+  name          = "%s"
+  document_type = "Command"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["ifconfig"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+data "aws_ssm_document" "test" {
+  name = "${aws_ssm_document.test.name}"
+  document_format = "%s"
+}
+`, name, documentFormat)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -254,6 +254,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_secretsmanager_secret_version":    dataSourceAwsSecretsManagerSecretVersion(),
 			"aws_sns_topic":                        dataSourceAwsSnsTopic(),
 			"aws_sqs_queue":                        dataSourceAwsSqsQueue(),
+			"aws_ssm_document":                     dataSourceAwsSsmDocument(),
 			"aws_ssm_parameter":                    dataSourceAwsSsmParameter(),
 			"aws_storagegateway_local_disk":        dataSourceAwsStorageGatewayLocalDisk(),
 			"aws_subnet":                           dataSourceAwsSubnet(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -346,6 +346,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-sns-topic") %>>
                          <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-ssm-document") %>>
+                         <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_parameter</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-ssm-parameter") %>>
                          <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>
                         </li>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -347,7 +347,7 @@
                          <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-ssm-document") %>>
-                         <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_parameter</a>
+                         <a href="/docs/providers/aws/d/ssm_document.html">aws_ssm_document</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-ssm-parameter") %>>
                          <a href="/docs/providers/aws/d/ssm_parameter.html">aws_ssm_parameter</a>

--- a/website/docs/d/ssm_document.html.markdown
+++ b/website/docs/d/ssm_document.html.markdown
@@ -27,31 +27,6 @@ output "content" {
 To get the contents of the custom document.
 
 ```hcl
-resource "aws_ssm_document" "test" {
-  name          = "test-document"
-  document_type = "Command"
-
-  content = <<DOC
-  {
-    "schemaVersion": "1.2",
-    "description": "Check ip configuration of a Linux instance.",
-    "parameters": {
-
-    },
-    "runtimeConfig": {
-      "aws:runShellScript": {
-        "properties": [
-          {
-            "id": "0.aws:runShellScript",
-            "runCommand": ["ifconfig"]
-          }
-        ]
-      }
-    }
-  }
-DOC
-}
-
 data "aws_ssm_document" "test" {
   name = "${aws_ssm_document.test.name}"
   document_format = "JSON"
@@ -66,6 +41,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the Systems Manager document.
 * `document_format` - (Optional) Returns the document in the specified format. The document format can be either JSON or YAML. JSON is the default format.
 * `document_version` - (Optional) The document version for which you want information.
+
+## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/website/docs/d/ssm_document.html.markdown
+++ b/website/docs/d/ssm_document.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ssm_document"
+sidebar_current: "docs-aws-datasource-ssm-document"
+description: |-
+  Provides a SSM Document datasource
+---
+
+# Data Source: aws_ssm_document
+
+Gets the contents of the specified Systems Manager document.
+
+## Example Usage
+
+To get the contents of the document owned by AWS.
+
+```hcl
+data "aws_ssm_document" "foo" {
+  name = "AWS-GatherSoftwareInventory"
+  document_format = "YAML"
+}
+
+output "content" {
+  value = "${data.aws_ssm_document.foo.content}"
+}
+```
+To get the contents of the custom document.
+
+```hcl
+resource "aws_ssm_document" "test" {
+  name          = "test-document"
+  document_type = "Command"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "parameters": {
+
+    },
+    "runtimeConfig": {
+      "aws:runShellScript": {
+        "properties": [
+          {
+            "id": "0.aws:runShellScript",
+            "runCommand": ["ifconfig"]
+          }
+        ]
+      }
+    }
+  }
+DOC
+}
+
+data "aws_ssm_document" "test" {
+  name = "${aws_ssm_document.test.name}"
+  document_format = "JSON"
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Systems Manager document.
+* `document_format` - (Optional) Returns the document in the specified format. The document format can be either JSON or YAML. JSON is the default format.
+* `document_version` - (Optional) The document version for which you want information.
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the document.
+* `content` - The contents of the document.
+* `document_type` - The type of the document.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6418 

Change1:
- Created new datasource for aws_ssm_document

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSsmDocumentDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSsmDocumentDataSource_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSsmDocumentDataSource_basic
=== PAUSE TestAccAWSSsmDocumentDataSource_basic
=== CONT  TestAccAWSSsmDocumentDataSource_basic
--- PASS: TestAccAWSSsmDocumentDataSource_basic (88.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	88.855s
...
```
