### PR TITLE
service/ecs: Tagging support

### DIFF
--- a/aws/resource_aws_ecs_cluster.go
+++ b/aws/resource_aws_ecs_cluster.go
@@ -17,6 +17,7 @@ func resourceAwsEcsCluster() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsEcsClusterCreate,
 		Read:   resourceAwsEcsClusterRead,
+		Update: resourceAwsEcsClusterUpdate,
 		Delete: resourceAwsEcsClusterDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceAwsEcsClusterImport,
@@ -28,7 +29,7 @@ func resourceAwsEcsCluster() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
+			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -57,6 +58,7 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 	out, err := conn.CreateCluster(&ecs.CreateClusterInput{
 		ClusterName: aws.String(clusterName),
+		Tags:        tagsFromMapECS(d.Get("tags").(map[string]interface{})),
 	})
 	if err != nil {
 		return err
@@ -64,42 +66,118 @@ func resourceAwsEcsClusterCreate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[DEBUG] ECS cluster %s created", *out.Cluster.ClusterArn)
 
 	d.SetId(*out.Cluster.ClusterArn)
-	d.Set("arn", out.Cluster.ClusterArn)
-	d.Set("name", out.Cluster.ClusterName)
-	return nil
+
+	return resourceAwsEcsClusterRead(d, meta)
 }
 
 func resourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecsconn
 
-	clusterName := d.Get("name").(string)
-	log.Printf("[DEBUG] Reading ECS cluster %s", clusterName)
-	out, err := conn.DescribeClusters(&ecs.DescribeClustersInput{
-		Clusters: []*string{aws.String(clusterName)},
-	})
-	if err != nil {
-		return err
+	input := &ecs.DescribeClustersInput{
+		Clusters: []*string{aws.String(d.Id())},
+		Include:  []*string{aws.String(ecs.ClusterFieldTags)},
 	}
-	log.Printf("[DEBUG] Received ECS clusters: %s", out.Clusters)
 
-	for _, c := range out.Clusters {
-		if *c.ClusterName == clusterName {
-			// Status==INACTIVE means deleted cluster
-			if *c.Status == "INACTIVE" {
-				log.Printf("[DEBUG] Removing ECS cluster %q because it's INACTIVE", *c.ClusterArn)
-				d.SetId("")
-				return nil
+	log.Printf("[DEBUG] Reading ECS Cluster: %s", input)
+	var out *ecs.DescribeClustersOutput
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		out, err = conn.DescribeClusters(input)
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		if out == nil || len(out.Failures) > 0 {
+			if d.IsNewResource() {
+				return resource.RetryableError(&resource.NotFoundError{})
 			}
+			return resource.NonRetryableError(&resource.NotFoundError{})
+		}
 
-			d.SetId(*c.ClusterArn)
-			d.Set("arn", c.ClusterArn)
-			d.Set("name", c.ClusterName)
-			return nil
+		return nil
+	})
+
+	if isResourceNotFoundError(err) {
+		log.Printf("[WARN] ECS Cluster (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading ECS Cluster (%s): %s", d.Id(), err)
+	}
+
+	var cluster *ecs.Cluster
+	for _, c := range out.Clusters {
+		if aws.StringValue(c.ClusterArn) == d.Id() {
+			cluster = c
+			break
 		}
 	}
 
-	log.Printf("[ERR] No matching ECS Cluster found for (%s)", d.Id())
-	d.SetId("")
+	if cluster == nil {
+		log.Printf("[WARN] ECS Cluster (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	// Status==INACTIVE means deleted cluster
+	if aws.StringValue(cluster.Status) == "INACTIVE" {
+		log.Printf("[WARN] ECS Cluster (%s) deleted, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("arn", cluster.ClusterArn)
+	d.Set("name", cluster.ClusterName)
+
+	if err := d.Set("tags", tagsToMapECS(cluster.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsEcsClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecsconn
+
+	if d.HasChange("tags") {
+		oldTagsRaw, newTagsRaw := d.GetChange("tags")
+		oldTagsMap := oldTagsRaw.(map[string]interface{})
+		newTagsMap := newTagsRaw.(map[string]interface{})
+		createTags, removeTags := diffTagsECS(tagsFromMapECS(oldTagsMap), tagsFromMapECS(newTagsMap))
+
+		if len(removeTags) > 0 {
+			removeTagKeys := make([]*string, len(removeTags))
+			for i, removeTag := range removeTags {
+				removeTagKeys[i] = removeTag.Key
+			}
+
+			input := &ecs.UntagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				TagKeys:     removeTagKeys,
+			}
+
+			log.Printf("[DEBUG] Untagging ECS Cluster: %s", input)
+			if _, err := conn.UntagResource(input); err != nil {
+				return fmt.Errorf("error untagging ECS Cluster (%s): %s", d.Id(), err)
+			}
+		}
+
+		if len(createTags) > 0 {
+			input := &ecs.TagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				Tags:        createTags,
+			}
+
+			log.Printf("[DEBUG] Tagging ECS Cluster: %s", input)
+			if _, err := conn.TagResource(input); err != nil {
+				return fmt.Errorf("error tagging ECS Cluster (%s): %s", d.Id(), err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,8 +12,9 @@ import (
 )
 
 func TestAccAWSEcsCluster_basic(t *testing.T) {
-	rString := acctest.RandString(8)
-	clusterName := fmt.Sprintf("tf-acc-cluster-basic-%s", rString)
+	var cluster1 ecs.Cluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecs_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,22 +22,28 @@ func TestAccAWSEcsCluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsCluster(clusterName),
+				Config: testAccAWSEcsClusterConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsClusterExists("aws_ecs_cluster.foo"),
-					resource.TestMatchResourceAttr("aws_ecs_cluster.foo", "arn",
-						regexp.MustCompile("^arn:aws:ecs:[a-z0-9-]+:[0-9]{12}:cluster/"+clusterName+"$")),
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "ecs", fmt.Sprintf("cluster/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     rName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSEcsCluster_importBasic(t *testing.T) {
-	rString := acctest.RandString(8)
-	clusterName := fmt.Sprintf("tf-acc-cluster-import-%s", rString)
-
-	resourceName := "aws_ecs_cluster.foo"
+func TestAccAWSEcsCluster_disappears(t *testing.T) {
+	var cluster1 ecs.Cluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecs_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -45,13 +51,57 @@ func TestAccAWSEcsCluster_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEcsCluster(clusterName),
+				Config: testAccAWSEcsClusterConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+					testAccCheckAWSEcsClusterDisappears(&cluster1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsCluster_Tags(t *testing.T) {
+	var cluster1 ecs.Cluster
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecs_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsClusterConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     clusterName,
+				ImportStateId:     rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEcsClusterConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSEcsClusterConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
 			},
 		},
 	})
@@ -83,21 +133,82 @@ func testAccCheckAWSEcsClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSEcsClusterExists(name string) resource.TestCheckFunc {
+func testAccCheckAWSEcsClusterExists(resourceName string, cluster *ecs.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ecsconn
+
+		input := &ecs.DescribeClustersInput{
+			Clusters: []*string{aws.String(rs.Primary.ID)},
+			Include:  []*string{aws.String(ecs.ClusterFieldTags)},
+		}
+
+		output, err := conn.DescribeClusters(input)
+
+		if err != nil {
+			return fmt.Errorf("error reading ECS Cluster (%s): %s", rs.Primary.ID, err)
+		}
+
+		for _, c := range output.Clusters {
+			if aws.StringValue(c.ClusterArn) == rs.Primary.ID && aws.StringValue(c.Status) != "INACTIVE" {
+				*cluster = *c
+				return nil
+			}
+		}
+
+		return fmt.Errorf("ECS Cluster (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSEcsClusterDisappears(cluster *ecs.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ecsconn
+
+		input := &ecs.DeleteClusterInput{
+			Cluster: cluster.ClusterArn,
+		}
+
+		if _, err := conn.DeleteCluster(input); err != nil {
+			return fmt.Errorf("error deleting ECS Cluster (%s): %s", aws.StringValue(cluster.ClusterArn), err)
 		}
 
 		return nil
 	}
 }
 
-func testAccAWSEcsCluster(clusterName string) string {
+func testAccAWSEcsClusterConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ecs_cluster" "foo" {
-	name = "%s"
+resource "aws_ecs_cluster" "test" {
+  name = %q
 }
-`, clusterName)
+`, rName)
+}
+
+func testAccAWSEcsClusterConfigTags1(rName, tag1Key, tag1Value string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %q
+
+  tags {
+    %q = %q
+  }
+}
+`, rName, tag1Key, tag1Value)
+}
+
+func testAccAWSEcsClusterConfigTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %q
+
+  tags {
+    %q = %q
+    %q = %q
+  }
+}
+`, rName, tag1Key, tag1Value, tag2Key, tag2Value)
 }

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -297,6 +297,7 @@ func resourceAwsEcsService() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -331,6 +332,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 		ClientToken:        aws.String(resource.UniqueId()),
 		SchedulingStrategy: aws.String(schedulingStrategy),
 		ServiceName:        aws.String(d.Get("name").(string)),
+		Tags:               tagsFromMapECS(d.Get("tags").(map[string]interface{})),
 		TaskDefinition:     aws.String(d.Get("task_definition").(string)),
 	}
 
@@ -468,8 +470,9 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Reading ECS service %s", d.Id())
 	input := ecs.DescribeServicesInput{
-		Services: []*string{aws.String(d.Id())},
 		Cluster:  aws.String(d.Get("cluster").(string)),
+		Include:  []*string{aws.String(ecs.ServiceFieldTags)},
+		Services: []*string{aws.String(d.Id())},
 	}
 
 	var out *ecs.DescribeServicesOutput
@@ -582,6 +585,10 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("service_registries", flattenServiceRegistries(service.ServiceRegistries)); err != nil {
 		return fmt.Errorf("Error setting service_registries for (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tagsToMapECS(service.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil
@@ -759,8 +766,8 @@ func flattenServiceRegistries(srs []*ecs.ServiceRegistry) []map[string]interface
 
 func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecsconn
+	updateService := false
 
-	log.Printf("[DEBUG] Updating ECS service %s", d.Id())
 	input := ecs.UpdateServiceInput{
 		Service: aws.String(d.Id()),
 		Cluster: aws.String(d.Get("cluster").(string)),
@@ -770,16 +777,19 @@ func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if schedulingStrategy == ecs.SchedulingStrategyDaemon {
 		if d.HasChange("deployment_minimum_healthy_percent") {
+			updateService = true
 			input.DeploymentConfiguration = &ecs.DeploymentConfiguration{
 				MinimumHealthyPercent: aws.Int64(int64(d.Get("deployment_minimum_healthy_percent").(int))),
 			}
 		}
 	} else if schedulingStrategy == ecs.SchedulingStrategyReplica {
 		if d.HasChange("desired_count") {
+			updateService = true
 			input.DesiredCount = aws.Int64(int64(d.Get("desired_count").(int)))
 		}
 
 		if d.HasChange("deployment_maximum_percent") || d.HasChange("deployment_minimum_healthy_percent") {
+			updateService = true
 			input.DeploymentConfiguration = &ecs.DeploymentConfiguration{
 				MaximumPercent:        aws.Int64(int64(d.Get("deployment_maximum_percent").(int))),
 				MinimumHealthyPercent: aws.Int64(int64(d.Get("deployment_minimum_healthy_percent").(int))),
@@ -788,36 +798,77 @@ func resourceAwsEcsServiceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("health_check_grace_period_seconds") {
-		_, n := d.GetChange("health_check_grace_period_seconds")
-		input.HealthCheckGracePeriodSeconds = aws.Int64(int64(n.(int)))
+		updateService = true
+		input.HealthCheckGracePeriodSeconds = aws.Int64(int64(d.Get("health_check_grace_period_seconds").(int)))
 	}
+
 	if d.HasChange("task_definition") {
-		_, n := d.GetChange("task_definition")
-		input.TaskDefinition = aws.String(n.(string))
+		updateService = true
+		input.TaskDefinition = aws.String(d.Get("task_definition").(string))
 	}
 
 	if d.HasChange("network_configuration") {
+		updateService = true
 		input.NetworkConfiguration = expandEcsNetworkConfiguration(d.Get("network_configuration").([]interface{}))
 	}
 
-	// Retry due to IAM eventual consistency
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		out, err := conn.UpdateService(&input)
+	if updateService {
+		log.Printf("[DEBUG] Updating ECS Service (%s): %s", d.Id(), input)
+		// Retry due to IAM eventual consistency
+		err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+			out, err := conn.UpdateService(&input)
+			if err != nil {
+				if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "Please verify that the ECS service role being passed has the proper permissions.") {
+					return resource.RetryableError(err)
+				}
+				if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "does not have an associated load balancer") {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+
+			log.Printf("[DEBUG] Updated ECS service %s", out.Service)
+			return nil
+		})
 		if err != nil {
-			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "Please verify that the ECS service role being passed has the proper permissions.") {
-				return resource.RetryableError(err)
+			return fmt.Errorf("error updating ECS Service (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		oldTagsRaw, newTagsRaw := d.GetChange("tags")
+		oldTagsMap := oldTagsRaw.(map[string]interface{})
+		newTagsMap := newTagsRaw.(map[string]interface{})
+		createTags, removeTags := diffTagsECS(tagsFromMapECS(oldTagsMap), tagsFromMapECS(newTagsMap))
+
+		if len(removeTags) > 0 {
+			removeTagKeys := make([]*string, len(removeTags))
+			for i, removeTag := range removeTags {
+				removeTagKeys[i] = removeTag.Key
 			}
-			if isAWSErr(err, ecs.ErrCodeInvalidParameterException, "does not have an associated load balancer") {
-				return resource.RetryableError(err)
+
+			input := &ecs.UntagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				TagKeys:     removeTagKeys,
 			}
-			return resource.NonRetryableError(err)
+
+			log.Printf("[DEBUG] Untagging ECS Cluster: %s", input)
+			if _, err := conn.UntagResource(input); err != nil {
+				return fmt.Errorf("error untagging ECS Cluster (%s): %s", d.Id(), err)
+			}
 		}
 
-		log.Printf("[DEBUG] Updated ECS service %s", out.Service)
-		return nil
-	})
-	if err != nil {
-		return err
+		if len(createTags) > 0 {
+			input := &ecs.TagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				Tags:        createTags,
+			}
+
+			log.Printf("[DEBUG] Tagging ECS Cluster: %s", input)
+			if _, err := conn.TagResource(input); err != nil {
+				return fmt.Errorf("error tagging ECS Cluster (%s): %s", d.Id(), err)
+			}
+		}
 	}
 
 	return resourceAwsEcsServiceRead(d, meta)

--- a/aws/tagsECS.go
+++ b/aws/tagsECS.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsECS(oldTags, newTags []*ecs.Tag) ([]*ecs.Tag, []*ecs.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*ecs.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapECS(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapECS(tagMap map[string]interface{}) []*ecs.Tag {
+	tags := make([]*ecs.Tag, 0, len(tagMap))
+	for tagKey, tagValueRaw := range tagMap {
+		tag := &ecs.Tag{
+			Key:   aws.String(tagKey),
+			Value: aws.String(tagValueRaw.(string)),
+		}
+		if !tagIgnoredECS(tag) {
+			tags = append(tags, tag)
+		}
+	}
+
+	return tags
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapECS(tags []*ecs.Tag) map[string]string {
+	tagMap := make(map[string]string)
+	for _, tag := range tags {
+		if !tagIgnoredECS(tag) {
+			tagMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+		}
+	}
+
+	return tagMap
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredECS(t *ecs.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		if r, _ := regexp.MatchString(v, aws.StringValue(t.Key)); r == true {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsECS_test.go
+++ b/aws/tagsECS_test.go
@@ -1,0 +1,110 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+func TestDiffECSTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Add
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsECS(tagsFromMapECS(tc.Old), tagsFromMapECS(tc.New))
+		cm := tagsToMapECS(c)
+		rm := tagsToMapECS(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+func TestIgnoringTagsECS(t *testing.T) {
+	ignoredTags := []*ecs.Tag{
+		{
+			Key:   aws.String("aws:cloudformation:logical-id"),
+			Value: aws.String("foo"),
+		},
+		{
+			Key:   aws.String("aws:foo:bar"),
+			Value: aws.String("baz"),
+		},
+	}
+	for _, tag := range ignoredTags {
+		if !tagIgnoredECS(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -23,6 +23,7 @@ resource "aws_ecs_cluster" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the cluster (up to 255 letters, numbers, hyphens, and underscores)
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -93,6 +93,7 @@ The following arguments are supported:
 `placement_constraints` is `10`. Defined below.
 * `network_configuration` - (Optional) The network configuration for the service. This parameter is required for task definitions that use the `awsvpc` network mode to receive their own Elastic Network Interface, and it is not supported for other network modes.
 * `service_registries` - (Optional) The service discovery registries for the service. The maximum number of `service_registries` blocks is `1`.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## load_balancer
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -87,6 +87,7 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 * `cpu` - (Optional) The number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
 * `memory` - (Optional) The amount (in MiB) of memory used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
 * `requires_compatibilities` - (Optional) A set of launch types required by the task. The valid values are `EC2` and `FARGATE`.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 #### Volume Block Arguments
 


### PR DESCRIPTION
Closes #6481 

`aws_ecs_cluster` resource refactoring was due to it not performing `Read` after `Create`. 

Changes:
* resource/aws_ecs_cluster: Add `tags` argument
* resource/aws_ecs_service: Add `tags` argument
* resource/aws_ecs_task_definition: Add `tags` argument
* resource/aws_ecs_cluster: Refactoring to call `Read` after `Create` to ensure proper creation
* tests/resource/aws_ecs_cluster: Add `_disappears` acceptance test
* tests/resource/aws_ecs_cluster: Ensure `testAccCheckAWSEcsClusterExists` actually checks existence in API

Without account setting update to newer ARNs (test failure expected):

```
--- PASS: TestAccAWSEcsCluster_basic (11.17s)
--- PASS: TestAccAWSEcsCluster_disappears (7.16s)
--- PASS: TestAccAWSEcsCluster_Tags (26.76s)
--- PASS: TestAccAWSEcsDataSource_ecsCluster (31.49s)
--- PASS: TestAccAWSEcsDataSource_ecsContainerDefinition (41.57s)
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (13.08s)
--- PASS: TestAccAWSEcsService_basicImport (26.50s)
--- PASS: TestAccAWSEcsService_disappears (34.44s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (348.42s)
--- PASS: TestAccAWSEcsService_withAlb (389.07s)
--- PASS: TestAccAWSEcsService_withARN (48.69s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (40.07s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (17.27s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (39.65s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (16.66s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (14.49s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (46.79s)
--- PASS: TestAccAWSEcsService_withIamRole (115.51s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (76.90s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (154.78s)
--- PASS: TestAccAWSEcsService_withLbChanges (220.54s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (41.21s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (29.47s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (78.79s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (56.19s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (40.89s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (42.00s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (50.34s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (30.06s)

--- FAIL: TestAccAWSEcsService_Tags (6.57s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_ecs_service.test: 1 error occurred:
          * aws_ecs_service.test: InvalidParameterException: The new ARN and resource ID format must be enabled to add tags to the service. Opt in to the new format and try again.

--- PASS: TestAccAWSEcsServiceDataSource_basic (42.88s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (10.51s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (16.31s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (17.57s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (10.68s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (10.89s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (13.56s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (17.45s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (24.18s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (10.60s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (9.50s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (71.29s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (11.40s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (10.58s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (11.65s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (9.24s)
```

With account settings update to newer ARNs:

```
--- PASS: TestAccAWSEcsCluster_basic (11.24s)
--- PASS: TestAccAWSEcsCluster_disappears (6.97s)
--- PASS: TestAccAWSEcsCluster_Tags (25.11s)
--- PASS: TestAccAWSEcsDataSource_ecsCluster (41.26s)
--- PASS: TestAccAWSEcsDataSource_ecsContainerDefinition (77.07s)
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (13.00s)
--- PASS: TestAccAWSEcsService_basicImport (33.62s)
--- PASS: TestAccAWSEcsService_disappears (20.62s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (260.87s)
--- PASS: TestAccAWSEcsService_Tags (40.60s)
--- PASS: TestAccAWSEcsService_withAlb (251.52s)
--- PASS: TestAccAWSEcsService_withARN (37.32s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (28.73s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (17.14s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (25.08s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (40.52s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (41.37s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (47.26s)
--- PASS: TestAccAWSEcsService_withIamRole (131.40s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (85.49s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (157.27s)
--- PASS: TestAccAWSEcsService_withLbChanges (220.89s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (40.17s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (75.42s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (100.87s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (57.42s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (40.44s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (50.57s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (54.97s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (19.74s)
--- PASS: TestAccAWSEcsServiceDataSource_basic (34.22s)
--- PASS: TestAccAWSEcsTaskDefinition_arrays (11.26s)
--- PASS: TestAccAWSEcsTaskDefinition_basic (33.55s)
--- PASS: TestAccAWSEcsTaskDefinition_changeVolumesForcesNewResource (24.14s)
--- PASS: TestAccAWSEcsTaskDefinition_constraint (9.49s)
--- PASS: TestAccAWSEcsTaskDefinition_ExecutionRole (10.83s)
--- PASS: TestAccAWSEcsTaskDefinition_Fargate (14.78s)
--- PASS: TestAccAWSEcsTaskDefinition_Inactive (17.59s)
--- PASS: TestAccAWSEcsTaskDefinition_Tags (24.01s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (22.39s)
--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolumeMinimalConfig (9.48s)
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (70.93s)
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (10.23s)
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (13.30s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (10.80s)
--- PASS: TestAccAWSEcsTaskDefinition_withTaskScopedDockerVolume (14.35s)
```
