### PR TITLE
Add import for aws_iam_user_policy_attachment

### DIFF
--- a/aws/resource_aws_iam_user_policy_attachment.go
+++ b/aws/resource_aws_iam_user_policy_attachment.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -16,6 +17,9 @@ func resourceAwsIamUserPolicyAttachment() *schema.Resource {
 		Create: resourceAwsIamUserPolicyAttachmentCreate,
 		Read:   resourceAwsIamUserPolicyAttachmentRead,
 		Delete: resourceAwsIamUserPolicyAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIamUserPolicyAttachmentImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"user": {
@@ -98,6 +102,22 @@ func resourceAwsIamUserPolicyAttachmentDelete(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error removing policy %s from IAM User %s: %v", arn, user, err)
 	}
 	return nil
+}
+
+func resourceAwsIamUserPolicyAttachmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <user-name>/<policy_arn>", d.Id())
+	}
+
+	userName := idParts[0]
+	policyARN := idParts[1]
+
+	d.Set("user", userName)
+	d.Set("policy_arn", policyARN)
+	d.SetId(fmt.Sprintf("%s-%s", userName, policyARN))
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func attachPolicyToUser(conn *iam.IAM, user string, arn string) error {

--- a/aws/resource_aws_iam_user_policy_attachment_test.go
+++ b/aws/resource_aws_iam_user_policy_attachment_test.go
@@ -32,6 +32,27 @@ func TestAccAWSUserPolicyAttachment_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_iam_user_policy_attachment.test-attach",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSIAMUserPolicyAttachmentImportStateIdFunc("aws_iam_user_policy_attachment.test-attach"),
+				// We do not have a way to align IDs since the Create function uses resource.PrefixedUniqueId()
+				// Failed state verification, resource with ID USER-POLICYARN not found
+				// ImportStateVerify: true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %#v", s)
+					}
+
+					rs := s[0]
+
+					if !strings.HasPrefix(rs.Attributes["policy_arn"], "arn:") {
+						return fmt.Errorf("expected policy_arn attribute to be set and begin with arn:, received: %s", rs.Attributes["policy_arn"])
+					}
+
+					return nil
+				},
+			},
+			{
 				Config: testAccAWSUserPolicyAttachConfigUpdate(rName, policyName1, policyName2, policyName3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserPolicyAttachmentExists("aws_iam_user_policy_attachment.test-attach", 2, &out),
@@ -90,6 +111,17 @@ func testAccCheckAWSUserPolicyAttachmentAttributes(policies []string, out *iam.L
 			return fmt.Errorf("Error: Number of attached policies was incorrect: expected %d matched policies, matched %d of %d", len(policies), matched, len(out.AttachedPolicies))
 		}
 		return nil
+	}
+}
+
+func testAccAWSIAMUserPolicyAttachmentImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["user"], rs.Primary.Attributes["policy_arn"]), nil
 	}
 }
 

--- a/website/docs/r/iam_user_policy_attachment.markdown
+++ b/website/docs/r/iam_user_policy_attachment.markdown
@@ -37,3 +37,11 @@ The following arguments are supported:
 
 * `user`        (Required) - The user the policy should be applied to
 * `policy_arn`  (Required) - The ARN of the policy you want to apply
+
+## Import
+
+IAM user policy attachments can be imported using the user name and policy arn separated by `/`.
+
+```
+$ terraform import aws_iam_user_policy_attachment.test-attach test-user/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixed #6602 

Changes proposed in this pull request:

* Add import `aws_iam_user_policy_attachment` without changing create behavior.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSUserPolicyAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSUserPolicyAttachment_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSUserPolicyAttachment_basic
=== PAUSE TestAccAWSUserPolicyAttachment_basic
=== CONT  TestAccAWSUserPolicyAttachment_basic
--- PASS: TestAccAWSUserPolicyAttachment_basic (59.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.569s
```
