### PR TITLE
Fix Kinesis Analytics typo

### DIFF
--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -1282,7 +1282,7 @@ func flattenKinesisAnalyticsInputs(inputs []*kinesisanalytics.InputDescription) 
 			ipcd := id.InputProcessingConfigurationDescription
 
 			if ipcd.InputLambdaProcessorDescription != nil {
-				input["processing_configurations"] = []interface{}{
+				input["processing_configuration"] = []interface{}{
 					map[string]interface{}{
 						"lambda": []interface{}{
 							map[string]interface{}{


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix typo in new Kinesis Analytics Application resource

Was getting the following error:
```
Error: aws_kinesis_analytics_application.detection: inputs.0: invalid or unknown key: processing_configurations
```
Where `processing_configuration` (singular) is required, and the change resolves the error.

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisAnalyticsApplication*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSKinesisAnalyticsApplication* -timeout 120m
=== RUN   TestAccAWSKinesisAnalyticsApplication_basic
=== PAUSE TestAccAWSKinesisAnalyticsApplication_basic
=== RUN   TestAccAWSKinesisAnalyticsApplication_update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_update
=== RUN   TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_basic
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_update
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (9.08s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (13.92s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (15.23s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (22.49s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (26.38s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (27.60s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (83.59s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (83.67s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (87.29s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (99.56s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (160.50s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (160.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       160.547s
```
