### PR TITLE
r/iam_user: support tags

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -186,7 +186,7 @@ func resourceAwsIamUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})
 		n := nraw.(map[string]interface{})
-		_, r := diffTagsIAM(tagsFromMapIAM(o), tagsFromMapIAM(n))
+		c, r := diffTagsIAM(tagsFromMapIAM(o), tagsFromMapIAM(n))
 
 		_, untagErr := iamconn.UntagUser(&iam.UntagUserInput{
 			UserName: aws.String(d.Id()),
@@ -196,10 +196,9 @@ func resourceAwsIamUserUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error deleting IAM user tags: %s", untagErr)
 		}
 
-		tags := tagsFromMapIAM(d.Get("tags").(map[string]interface{}))
 		input := &iam.TagUserInput{
 			UserName: aws.String(d.Id()),
-			Tags:     tags,
+			Tags:     c,
 		}
 		_, tagErr := iamconn.TagUser(input)
 		if tagErr != nil {

--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -62,6 +62,7 @@ func resourceAwsIamUser() *schema.Resource {
 				Default:     false,
 				Description: "Delete user even if it has non-Terraform-managed IAM access keys, login profile or MFA devices",
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -78,6 +79,11 @@ func resourceAwsIamUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("permissions_boundary"); ok && v.(string) != "" {
 		request.PermissionsBoundary = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		tags := tagsFromMapIAM(v.(map[string]interface{}))
+		request.Tags = tags
 	}
 
 	log.Println("[DEBUG] Create IAM User request:", request)
@@ -121,6 +127,7 @@ func resourceAwsIamUserRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("permissions_boundary", output.User.PermissionsBoundary.PermissionsBoundaryArn)
 	}
 	d.Set("unique_id", output.User.UserId)
+	d.Set("tags", tagsToMapIAM(output.User.Tags))
 
 	return nil
 }
@@ -171,6 +178,32 @@ func resourceAwsIamUserUpdate(d *schema.ResourceData, meta interface{}) error {
 			if err != nil {
 				return fmt.Errorf("error deleting IAM User permissions boundary: %s", err)
 			}
+		}
+	}
+
+	if d.HasChange("tags") {
+		// Reset all tags to empty set
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		_, r := diffTagsIAM(tagsFromMapIAM(o), tagsFromMapIAM(n))
+
+		_, untagErr := iamconn.UntagUser(&iam.UntagUserInput{
+			UserName: aws.String(d.Id()),
+			TagKeys:  tagKeysIam(r),
+		})
+		if untagErr != nil {
+			return fmt.Errorf("error deleting IAM user tags: %s", untagErr)
+		}
+
+		tags := tagsFromMapIAM(d.Get("tags").(map[string]interface{}))
+		input := &iam.TagUserInput{
+			UserName: aws.String(d.Id()),
+			Tags:     tags,
+		}
+		_, tagErr := iamconn.TagUser(input)
+		if tagErr != nil {
+			return fmt.Errorf("error update IAM user tags: %s", tagErr)
 		}
 	}
 

--- a/aws/tagsIAM.go
+++ b/aws/tagsIAM.go
@@ -25,6 +25,8 @@ func diffTagsIAM(oldTags, newTags []*iam.Tag) ([]*iam.Tag, []*iam.Tag) {
 		if !ok || old != aws.StringValue(t.Value) {
 			// Delete it!
 			remove = append(remove, t)
+		} else if ok {
+			delete(create, aws.StringValue(t.Key))
 		}
 	}
 

--- a/aws/tagsIAM.go
+++ b/aws/tagsIAM.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsIAM(oldTags, newTags []*iam.Tag) ([]*iam.Tag, []*iam.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*iam.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapIAM(create), remove
+}
+
+// tagsFromMapIAM returns the tags for the given map of data for IAM.
+func tagsFromMapIAM(m map[string]interface{}) []*iam.Tag {
+	result := make([]*iam.Tag, 0, len(m))
+	for k, v := range m {
+		t := &iam.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredIAM(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMapIAM turns the list of IAM tags into a map.
+func tagsToMapIAM(ts []*iam.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredIAM(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredIAM(t *iam.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}
+
+// tagKeysIam returns the keys for the list of IAM tags
+func tagKeysIam(ts []*iam.Tag) []*string {
+	result := make([]*string, 0, len(ts))
+	for _, t := range ts {
+		result = append(result, t.Key)
+	}
+	return result
+}

--- a/aws/tagsIAM_test.go
+++ b/aws/tagsIAM_test.go
@@ -14,20 +14,19 @@ func TestDiffIAMTags(t *testing.T) {
 		Old, New       map[string]interface{}
 		Create, Remove map[string]string
 	}{
-		// Basic add/remove
+		// Add
 		{
 			Old: map[string]interface{}{
 				"foo": "bar",
 			},
 			New: map[string]interface{}{
+				"foo": "bar",
 				"bar": "baz",
 			},
 			Create: map[string]string{
 				"bar": "baz",
 			},
-			Remove: map[string]string{
-				"foo": "bar",
-			},
+			Remove: map[string]string{},
 		},
 
 		// Modify
@@ -43,6 +42,39 @@ func TestDiffIAMTags(t *testing.T) {
 			},
 			Remove: map[string]string{
 				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
 			},
 		},
 	}

--- a/aws/tagsIAM_test.go
+++ b/aws/tagsIAM_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+// go test -v -run="TestDiffIAMTags"
+func TestDiffIAMTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsIAM(tagsFromMapIAM(tc.Old), tagsFromMapIAM(tc.New))
+		cm := tagsToMapIAM(c)
+		rm := tagsToMapIAM(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsIAM"
+func TestIgnoringTagsIAM(t *testing.T) {
+	var ignoredTags []*iam.Tag
+	ignoredTags = append(ignoredTags, &iam.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &iam.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredIAM(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/iam_user.html.markdown
+++ b/website/docs/r/iam_user.html.markdown
@@ -16,6 +16,9 @@ Provides an IAM user.
 resource "aws_iam_user" "lb" {
   name = "loadbalancer"
   path = "/system/"
+  tags {
+    tag-key = "tag-value"
+  }
 }
 
 resource "aws_iam_access_key" "lb" {
@@ -53,6 +56,7 @@ The following arguments are supported:
 * `force_destroy` - (Optional, default false) When destroying this user, destroy even if it
   has non-Terraform-managed IAM access keys, login profile or MFA devices. Without `force_destroy`
   a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
+* `tags` - Tags for the IAM user
 
 ## Attributes Reference
 

--- a/website/docs/r/iam_user.html.markdown
+++ b/website/docs/r/iam_user.html.markdown
@@ -16,7 +16,7 @@ Provides an IAM user.
 resource "aws_iam_user" "lb" {
   name = "loadbalancer"
   path = "/system/"
-  tags {
+  tags = {
     tag-key = "tag-value"
   }
 }
@@ -56,7 +56,7 @@ The following arguments are supported:
 * `force_destroy` - (Optional, default false) When destroying this user, destroy even if it
   has non-Terraform-managed IAM access keys, login profile or MFA devices. Without `force_destroy`
   a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
-* `tags` - Tags for the IAM user
+* `tags` - Key-value mapping of tags for the IAM user
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* support for tags

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSUser_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSUser_ -timeout 120m
=== RUN   TestAccAWSUser_importBasic
=== PAUSE TestAccAWSUser_importBasic
=== RUN   TestAccAWSUser_basic
=== PAUSE TestAccAWSUser_basic
=== RUN   TestAccAWSUser_disappears
=== PAUSE TestAccAWSUser_disappears
=== RUN   TestAccAWSUser_ForceDestroy_AccessKey
=== PAUSE TestAccAWSUser_ForceDestroy_AccessKey
=== RUN   TestAccAWSUser_ForceDestroy_LoginProfile
=== PAUSE TestAccAWSUser_ForceDestroy_LoginProfile
=== RUN   TestAccAWSUser_ForceDestroy_MFADevice
=== PAUSE TestAccAWSUser_ForceDestroy_MFADevice
=== RUN   TestAccAWSUser_ForceDestroy_SSHKey
=== PAUSE TestAccAWSUser_ForceDestroy_SSHKey
=== RUN   TestAccAWSUser_nameChange
=== PAUSE TestAccAWSUser_nameChange
=== RUN   TestAccAWSUser_pathChange
=== PAUSE TestAccAWSUser_pathChange
=== RUN   TestAccAWSUser_permissionsBoundary
=== PAUSE TestAccAWSUser_permissionsBoundary
=== RUN   TestAccAWSUser_tags
=== PAUSE TestAccAWSUser_tags
=== CONT  TestAccAWSUser_importBasic
=== CONT  TestAccAWSUser_ForceDestroy_SSHKey
=== CONT  TestAccAWSUser_ForceDestroy_AccessKey
=== CONT  TestAccAWSUser_ForceDestroy_MFADevice
=== CONT  TestAccAWSUser_ForceDestroy_LoginProfile
=== CONT  TestAccAWSUser_disappears
=== CONT  TestAccAWSUser_pathChange
=== CONT  TestAccAWSUser_permissionsBoundary
=== CONT  TestAccAWSUser_nameChange
=== CONT  TestAccAWSUser_basic
=== CONT  TestAccAWSUser_tags
--- PASS: TestAccAWSUser_disappears (6.95s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (8.92s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (8.98s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (9.04s)
--- PASS: TestAccAWSUser_importBasic (9.09s)
--- PASS: TestAccAWSUser_pathChange (13.52s)
--- PASS: TestAccAWSUser_basic (13.58s)
--- PASS: TestAccAWSUser_nameChange (13.60s)
--- PASS: TestAccAWSUser_tags (14.04s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (24.69s)
--- PASS: TestAccAWSUser_permissionsBoundary (31.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	31.618s
```
