### PR TITLE
Add missing data prefix to documentation

### DIFF
--- a/website/docs/d/db_cluster_snapshot.html.markdown
+++ b/website/docs/d/db_cluster_snapshot.html.markdown
@@ -25,7 +25,7 @@ data "aws_db_cluster_snapshot" "development_final_snapshot" {
 # a new dev database.
 resource "aws_rds_cluster" "aurora" {
   cluster_identifier   = "development_cluster"
-  snapshot_identifier  = "${aws_db_cluster_snapshot.development_final_snapshot.id}"
+  snapshot_identifier  = "${data.aws_db_cluster_snapshot.development_final_snapshot.id}"
   db_subnet_group_name = "my_db_subnet_group"
 
   lifecycle {


### PR DESCRIPTION
In Data Source: aws_db_cluster_snapshot - Example:
Using the data attribute requires the data prefix

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Documentation fix

