### PR TITLE
docs/r/aws_autoscaling_group: Update docs to specify mixed_instances_policy

### DIFF
--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -183,7 +183,7 @@ The following arguments are supported:
 * `default_cooldown` - (Optional) The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
 * `launch_configuration` - (Optional) The name of the launch configuration to use.
 * `launch_template` - (Optional) Nested argument with Launch template specification to use to launch instances. Defined below.
-* `mixed_instance_policy` (Optional) Configuration block containing settings to define launch targets for Auto Scaling groups. Defined below.
+* `mixed_instances_policy` (Optional) Configuration block containing settings to define launch targets for Auto Scaling groups. Defined below.
 * `initial_lifecycle_hook` - (Optional) One or more
   [Lifecycle Hooks](http://docs.aws.amazon.com/autoscaling/latest/userguide/lifecycle-hooks.html)
   to attach to the autoscaling group **before** instances are launched. The
@@ -242,12 +242,12 @@ The top-level `launch_template` block supports the following:
 * `name` - (Optional) The name of the launch template. Conflicts with `id`.
 * `version` - (Optional) Template version. Can be version number, `$Latest`, or `$Default`. (Default: `$Default`).
 
-### mixed_instance_policy
+### mixed_instances_policy
 
 * `instances_distribution` - (Optional) Nested argument containing settings on how to mix on-demand and Spot instances in the Auto Scaling group. Defined below.
 * `launch_template` - (Optional) Nested argument containing launch template settings along with the overrides to specify multiple instance types. Defined below.
 
-#### mixed_instance_policy instances_distribution
+#### mixed_instances_policy instances_distribution
 
 This configuration block supports the following:
 
@@ -258,14 +258,14 @@ This configuration block supports the following:
 * `spot_instance_pools` - (Optional) Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify. Default: `1`.
 * `spot_max_price` - (Optional) Maximum price per unit hour that the user is willing to pay for the Spot instances. Default: on-demand price.
 
-#### mixed_instance_policy launch_template
+#### mixed_instances_policy launch_template
 
 This configuration block supports the following:
 
 * `launch_template_specification` - (Optional) Nested argument defines the Launch Template. Defined below.
 * `overrides` - (Optional) List of nested arguments provides the ability to specify multiple instance types. This will override the same parameter in the launch template. For on-demand instances, Auto Scaling considers the order of preference of instance types to launch based on the order specified in the overrides list. Defined below.
 
-##### mixed_instance_policy launch_template launch_template_specification
+##### mixed_instances_policy launch_template launch_template_specification
 
 ~> **NOTE:** Either `launch_template_id` or `launch_template_name` must be specified.
 
@@ -275,7 +275,7 @@ This configuration block supports the following:
 * `launch_template_name` - (Optional) The name of the launch template. Conflicts with `launch_template_id`.
 * `version` - (Optional) Template version. Can be version number, `$Latest`, or `$Default`. (Default: `$Default`).
 
-##### mixed_instance_policy launch_template overrides
+##### mixed_instances_policy launch_template overrides
 
 This configuration block supports the following:
 


### PR DESCRIPTION


<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6504 

Updates the documentation to specify the correct key.
