### PR TITLE
Ecs-Add support for ECS IPC Mode/PID Mode

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -192,12 +192,21 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ecs.IpcModeHost,
+					ecs.IpcModeNone,
+					ecs.IpcModeTask,
+				}, false),
 			},
 
 			"pid_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ecs.PidModeHost,
+					ecs.PidModeTask,
+				}, false),
 			},
 
 			"tags": tagsSchema(),

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -188,6 +188,18 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"ipc_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"pid_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -239,6 +251,14 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("network_mode"); ok {
 		input.NetworkMode = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ipc_mode"); ok {
+		input.IpcMode = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("pid_mode"); ok {
+		input.PidMode = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("volume"); ok {

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -243,6 +243,56 @@ func TestAccAWSEcsTaskDefinition_withNetworkMode(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsTaskDefinition_withIPCMode(t *testing.T) {
+	var def ecs.TaskDefinition
+
+	rString := acctest.RandString(8)
+	roleName := fmt.Sprintf("tf_acc_ecs_td_with_ipc_mode_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_ecs_td_with_ipc_mode_%s", rString)
+	tdName := fmt.Sprintf("tf_acc_td_with_ipc_mode_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsTaskDefinitionWithIpcMode(roleName, policyName, tdName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "ipc_mode", "host"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsTaskDefinition_withPidMode(t *testing.T) {
+	var def ecs.TaskDefinition
+
+	rString := acctest.RandString(8)
+	roleName := fmt.Sprintf("tf_acc_ecs_td_with_pid_mode_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_ecs_td_with_pid_mode_%s", rString)
+	tdName := fmt.Sprintf("tf_acc_td_with_pid_mode_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsTaskDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsTaskDefinitionWithPidMode(roleName, policyName, tdName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.sleep", &def),
+					resource.TestCheckResourceAttr(
+						"aws_ecs_task_definition.sleep", "pid_mode", "host"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSEcsTaskDefinition_constraint(t *testing.T) {
 	var def ecs.TaskDefinition
 
@@ -1081,6 +1131,138 @@ TASK_DEFINITION
 		name = "database_scratch"
 	}
 }`, roleName, policyName, tdName)
+}
+
+func testAccAWSEcsTaskDefinitionWithIpcMode(roleName, policyName, tdName string) string {
+	return fmt.Sprintf(`
+ resource "aws_iam_role" "role_test" {
+	 name = "%s"
+	 path = "/test/"
+	 assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+	 {
+		 "Action": "sts:AssumeRole",
+		 "Principal": {
+			 "Service": "ec2.amazonaws.com"
+		 },
+		 "Effect": "Allow",
+		 "Sid": ""
+	 }
+ ]
+}
+EOF
+ }
+
+ resource "aws_iam_role_policy" "role_test" {
+	 name = "%s"
+	 role = "${aws_iam_role.role_test.id}"
+	 policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+	 {
+		 "Effect": "Allow",
+		 "Action": [
+			 "s3:GetBucketLocation",
+			 "s3:ListAllMyBuckets"
+		 ],
+		 "Resource": "arn:aws:s3:::*"
+	 }
+ ]
+}
+ EOF
+ }
+
+ resource "aws_ecs_task_definition" "sleep" {
+	 family = "%s"
+	 task_role_arn = "${aws_iam_role.role_test.arn}"
+	 network_mode = "bridge"
+	 ipc_mode = "host"
+	 container_definitions = <<TASK_DEFINITION
+[
+ {
+	 "name": "sleep",
+	 "image": "busybox",
+	 "cpu": 10,
+	 "command": ["sleep","360"],
+	 "memory": 10,
+	 "essential": true
+ }
+]
+TASK_DEFINITION
+
+	 volume {
+		 name = "database_scratch"
+	 }
+ }`, roleName, policyName, tdName)
+}
+
+func testAccAWSEcsTaskDefinitionWithPidMode(roleName, policyName, tdName string) string {
+	return fmt.Sprintf(`
+ resource "aws_iam_role" "role_test" {
+	 name = "%s"
+	 path = "/test/"
+	 assume_role_policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+	 {
+		 "Action": "sts:AssumeRole",
+		 "Principal": {
+			 "Service": "ec2.amazonaws.com"
+		 },
+		 "Effect": "Allow",
+		 "Sid": ""
+	 }
+ ]
+}
+EOF
+ }
+
+ resource "aws_iam_role_policy" "role_test" {
+	 name = "%s"
+	 role = "${aws_iam_role.role_test.id}"
+	 policy = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+	 {
+		 "Effect": "Allow",
+		 "Action": [
+			 "s3:GetBucketLocation",
+			 "s3:ListAllMyBuckets"
+		 ],
+		 "Resource": "arn:aws:s3:::*"
+	 }
+ ]
+}
+ EOF
+ }
+
+ resource "aws_ecs_task_definition" "sleep" {
+	 family = "%s"
+	 task_role_arn = "${aws_iam_role.role_test.arn}"
+	 network_mode = "bridge"
+	 pid_mode = "host"
+	 container_definitions = <<TASK_DEFINITION
+[
+ {
+	 "name": "sleep",
+	 "image": "busybox",
+	 "cpu": 10,
+	 "command": ["sleep","360"],
+	 "memory": 10,
+	 "essential": true
+ }
+]
+TASK_DEFINITION
+
+	 volume {
+		 name = "database_scratch"
+	 }
+ }`, roleName, policyName, tdName)
 }
 
 func testAccAWSEcsTaskDefinitionWithNetworkMode(roleName, policyName, tdName string) string {

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -83,7 +83,7 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 * `execution_role_arn` - (Optional) The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
 * `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, `awsvpc`, and `host`.
 * `ipc_mode` - (Optional) The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
-* `pid_mode` - (Optional) TheThe process namespace to use for the containers in the task. The valid values are `host` and `task`.
+* `pid_mode` - (Optional) The process namespace to use for the containers in the task. The valid values are `host` and `task`.
 * `volume` - (Optional) A set of [volume blocks](#volume-block-arguments) that containers in your task may use.
 * `placement_constraints` - (Optional) A set of [placement constraints](#placement-constraints-arguments) rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`.
 * `cpu` - (Optional) The number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -82,6 +82,8 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 * `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 * `execution_role_arn` - (Optional) The Amazon Resource Name (ARN) of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
 * `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, `awsvpc`, and `host`.
+* `ipc_mode` - (Optional) The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+* `pid_mode` - (Optional) TheThe process namespace to use for the containers in the task. The valid values are `host` and `task`.
 * `volume` - (Optional) A set of [volume blocks](#volume-block-arguments) that containers in your task may use.
 * `placement_constraints` - (Optional) A set of [placement constraints](#placement-constraints-arguments) rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`.
 * `cpu` - (Optional) The number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6511

Changes proposed in this pull request:

* Feature Request: Support for ECS IPC Mode/PID Mode

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAvailabilityZones -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
=== PAUSE TestAccAWSAvailabilityZones_basic
=== RUN   TestAccAWSAvailabilityZones_stateFilter
=== PAUSE TestAccAWSAvailabilityZones_stateFilter
=== CONT  TestAccAWSAvailabilityZones_basic
=== CONT  TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_basic (20.07s)
--- PASS: TestAccAWSAvailabilityZones_stateFilter (20.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       20.380s
```
