### PR TITLE
r/eip, d/eip: add extra computed attributes and BYOIP feature support

### DIFF
--- a/aws/data_source_aws_eip.go
+++ b/aws/data_source_aws_eip.go
@@ -14,15 +14,43 @@ func dataSourceAwsEip() *schema.Resource {
 		Read: dataSourceAwsEipRead,
 
 		Schema: map[string]*schema.Schema{
+			"association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"filter": ec2CustomFiltersSchema(),
 			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_interface_owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"public_ip": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+			"public_ipv4_pool": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"tags": tagsSchemaComputed(),
@@ -79,7 +107,14 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId(aws.StringValue(eip.PublicIp))
 	}
 
+	d.Set("association_id", eip.AssociationId)
+	d.Set("domain", eip.Domain)
+	d.Set("instance_id", eip.InstanceId)
+	d.Set("network_interface_id", eip.NetworkInterfaceId)
+	d.Set("network_interface_owner_id", eip.NetworkInterfaceOwnerId)
+	d.Set("private_ip", eip.PrivateIpAddress)
 	d.Set("public_ip", eip.PublicIp)
+	d.Set("public_ipv4_pool", eip.PublicIpv4Pool)
 	d.Set("tags", tagsToMap(eip.Tags))
 
 	return nil

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -81,6 +81,7 @@ func TestAccDataSourceAwsEip_PublicIP_VPC(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_ip", resourceName, "public_ip"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "domain", resourceName, "domain"),
 				),
 			},
 		},
@@ -101,6 +102,47 @@ func TestAccDataSourceAwsEip_Tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "public_ip", resourceName, "public_ip"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsEip_NetworkInterface(t *testing.T) {
+	dataSourceName := "data.aws_eip.test"
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsEipConfigNetworkInterface,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "network_interface_id", resourceName, "network_interface"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "private_ip", resourceName, "private_ip"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "domain", resourceName, "domain"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsEip_Instance(t *testing.T) {
+	dataSourceName := "data.aws_eip.test"
+	resourceName := "aws_eip.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsEipConfigInstance,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "instance_id", resourceName, "instance"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "association_id", resourceName, "association_id"),
 				),
 			},
 		},
@@ -175,3 +217,76 @@ data "aws_eip" "test" {
 }
 `, rName)
 }
+
+const testAccDataSourceAwsEipConfigNetworkInterface = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.1.0.0/24"
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id = "${aws_subnet.test.id}"
+}
+
+resource "aws_eip" "test" {
+  vpc = true
+  network_interface = "${aws_network_interface.test.id}"
+}
+
+data "aws_eip" "test" {
+  filter {
+    name   = "network-interface-id"
+    values = ["${aws_eip.test.network_interface}"]
+  }
+}
+`
+
+const testAccDataSourceAwsEipConfigInstance = `
+resource "aws_vpc" "test" {
+  cidr_block = "10.2.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.2.0.0/24"
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+data "aws_ami" "test" {
+  most_recent = true
+  name_regex  = "^amzn-ami.*ecs-optimized$"
+
+  owners = [
+    "amazon",
+  ]
+}
+
+resource "aws_instance" "test" {
+  ami = "${data.aws_ami.test.id}"
+  subnet_id = "${aws_subnet.test.id}"
+  instance_type = "t2.micro"
+}
+
+resource "aws_eip" "test" {
+  vpc = true
+  instance = "${aws_instance.test.id}"
+}
+
+data "aws_eip" "test" {
+  filter {
+    name = "instance-id"
+    values = ["${aws_eip.test.instance}"]
+  }
+}
+`

--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -80,6 +80,13 @@ func resourceAwsEip() *schema.Resource {
 				Optional: true,
 			},
 
+			"public_ipv4_pool": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -96,6 +103,10 @@ func resourceAwsEipCreate(d *schema.ResourceData, meta interface{}) error {
 
 	allocOpts := &ec2.AllocateAddressInput{
 		Domain: aws.String(domainOpt),
+	}
+
+	if v := d.Get("public_ipv4_pool"); v != nil && v.(string) != "" {
+		allocOpts.PublicIpv4Pool = aws.String(d.Get("public_ipv4_pool").(string))
 	}
 
 	log.Printf("[DEBUG] EIP create configuration: %#v", allocOpts)
@@ -211,6 +222,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("private_ip", address.PrivateIpAddress)
 	d.Set("public_ip", address.PublicIp)
+	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
 
 	// On import (domain never set, which it must've been if we created),
 	// set the 'vpc' attribute depending on if we're in a VPC.

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -64,6 +64,13 @@ Elastic IP whose data will be exported as attributes.
 
 In addition to all arguments above, the following attributes are exported:
 
+* `association_id` - The ID representing the association of the address with an instance in a VPC.
+* `domain` - Indicates whether the address is for use in EC2-Classic (standard) or in a VPC (vpc).
 * `id` - If VPC Elastic IP, the allocation identifier. If EC2-Classic Elastic IP, the public IP address.
+* `instance_id` - The ID of the instance that the address is associated with (if any).
+* `network_interface_id` - The ID of the network interface.
+* `network_interface_owner_id` - The ID of the AWS account that owns the network interface.
+* `private_ip` - The private IP address associated with the Elastic IP address.
 * `public_ip` - Public IP address of Elastic IP.
+* `public_ipv4_pool` - The ID of an address pool.
 * `tags` - Key-value map of tags associated with Elastic IP.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -84,6 +84,15 @@ resource "aws_eip" "bar" {
 }
 ```
 
+Allocating EIP from the BYOIP pool:
+
+```hcl
+resource "aws_eip" "byoip-ip" {
+  vpc              = true
+  public_ipv4_pool = "ipv4pool-ec2-012345"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -95,6 +104,7 @@ The following arguments are supported:
   associate with the Elastic IP address. If no private IP address is specified,
   the Elastic IP address is associated with the primary private IP address.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `public_ipv4_pool` - (Optional) IPv4 address pool
 
 ~> **NOTE:** You can specify either the `instance` ID or the `network_interface` ID,
 but not both. Including both will **not** return an error from the AWS API, but will
@@ -112,6 +122,7 @@ In addition to all arguments above, the following attributes are exported:
 * `public_ip` - Contains the public IP address.
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
+* `public_ipv4_pool` - IPv4 address pool.
 
 ## Timeouts
 `aws_eip` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:


### PR DESCRIPTION
Fixes #6251
Fixes #4551

supersedes #6463
Credits to @kl4w for data attributes work

Changes proposed in this pull request:

- add extra computed attributes:
  - association_id
  - domain
  - instance_id
  - network_interface_id
  - network_interface_owner_id
  - private_ip
  - public_ipv4_pool
- allow to define public_ipv4_pool when EIP gets allocated

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEip_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAwsEip_ -timeout 120m
=== RUN   TestAccDataSourceAwsEip_Filter
=== PAUSE TestAccDataSourceAwsEip_Filter
=== RUN   TestAccDataSourceAwsEip_Id
=== PAUSE TestAccDataSourceAwsEip_Id
=== RUN   TestAccDataSourceAwsEip_PublicIP_EC2Classic
--- PASS: TestAccDataSourceAwsEip_PublicIP_EC2Classic (7.71s)
=== RUN   TestAccDataSourceAwsEip_PublicIP_VPC
=== PAUSE TestAccDataSourceAwsEip_PublicIP_VPC
=== RUN   TestAccDataSourceAwsEip_Tags
=== PAUSE TestAccDataSourceAwsEip_Tags
=== RUN   TestAccDataSourceAwsEip_NetworkInterface
=== PAUSE TestAccDataSourceAwsEip_NetworkInterface
=== RUN   TestAccDataSourceAwsEip_Instance
=== PAUSE TestAccDataSourceAwsEip_Instance
=== CONT  TestAccDataSourceAwsEip_Filter
=== CONT  TestAccDataSourceAwsEip_NetworkInterface
=== CONT  TestAccDataSourceAwsEip_Instance
=== CONT  TestAccDataSourceAwsEip_PublicIP_VPC
=== CONT  TestAccDataSourceAwsEip_Tags
=== CONT  TestAccDataSourceAwsEip_Id
--- PASS: TestAccDataSourceAwsEip_PublicIP_VPC (6.13s)
--- PASS: TestAccDataSourceAwsEip_Id (6.22s)
--- PASS: TestAccDataSourceAwsEip_Filter (6.40s)
--- PASS: TestAccDataSourceAwsEip_Tags (6.51s)
--- PASS: TestAccDataSourceAwsEip_NetworkInterface (23.00s)
--- PASS: TestAccDataSourceAwsEip_Instance (231.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	239.469s
```

By default `amazon` Public IPV4 Pool is used. If you want to test this with your own pool, please provide its name and AWS region where it is located via environment variables.

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsEip_' AWS_REGION=us-east-1  AWS_EIP_PUBLIC_IPV4_POOL=ipv4pool-ec2-xxxxxxx
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEIP_PublicIpv4Pool -timeout 120m
=== RUN   TestAccAWSEIP_PublicIpv4Pool
=== PAUSE TestAccAWSEIP_PublicIpv4Pool
=== CONT  TestAccAWSEIP_PublicIpv4Pool
--- PASS: TestAccAWSEIP_PublicIpv4Pool (11.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       11.714s
```
