### PR TITLE
Use correct hash to check lambda source zip in Lambda example

### DIFF
--- a/examples/lambda/main.tf
+++ b/examples/lambda/main.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "hello_lambda"
 
   filename         = "${data.archive_file.zip.output_path}"
-  source_code_hash = "${data.archive_file.zip.output_sha}"
+  source_code_hash = "${data.archive_file.zip.output_base64sha256}"
 
   role    = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "hello_lambda.lambda_handler"


### PR DESCRIPTION
Without this change, running `terraform apply` twice in the lambda example produces the following output:
```
$ terraform apply
data.archive_file.zip: Refreshing state...
data.aws_iam_policy_document.policy: Refreshing state...
aws_iam_role.iam_for_lambda: Refreshing state... (ID: iam_for_lambda)
aws_lambda_function.lambda: Refreshing state... (ID: hello_lambda)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_lambda_function.lambda
      last_modified:    "2018-11-19T20:07:09.725+0000" => <computed>
      source_code_hash: "gg0jKs+fIU7fAXzl8ctqRMyVOqy2DZ3EpHMxpy+LCew=" => "3214d758ed7b48f0a982c9624c4ab126d91b49de"


Plan: 0 to add, 1 to change, 0 to destroy.
```

Output with PR:
```
terraform apply
data.archive_file.zip: Refreshing state...
data.aws_iam_policy_document.policy: Refreshing state...
aws_iam_role.iam_for_lambda: Refreshing state... (ID: iam_for_lambda)
aws_lambda_function.lambda: Refreshing state... (ID: hello_lambda)

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```