### PR TITLE
resource/aws_s3_bucket_policy: add import ability

### DIFF
--- a/aws/resource_aws_s3_bucket_policy.go
+++ b/aws/resource_aws_s3_bucket_policy.go
@@ -19,6 +19,9 @@ func resourceAwsS3BucketPolicy() *schema.Resource {
 		Read:   resourceAwsS3BucketPolicyRead,
 		Update: resourceAwsS3BucketPolicyPut,
 		Delete: resourceAwsS3BucketPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"bucket": {
@@ -84,6 +87,9 @@ func resourceAwsS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) err
 		v = *pol.Policy
 	}
 	if err := d.Set("policy", v); err != nil {
+		return err
+	}
+	if err := d.Set("bucket", d.Id()); err != nil {
 		return err
 	}
 

--- a/aws/resource_aws_s3_bucket_policy_test.go
+++ b/aws/resource_aws_s3_bucket_policy_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/jen20/awspolicyequivalence"
+	awspolicy "github.com/jen20/awspolicyequivalence"
 )
 
 func TestAccAWSS3BucketPolicy_basic(t *testing.T) {
@@ -38,6 +38,11 @@ func TestAccAWSS3BucketPolicy_basic(t *testing.T) {
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketHasPolicy("aws_s3_bucket.bucket", expectedPolicyText),
 				),
+			},
+			{
+				ResourceName:      "aws_s3_bucket_policy.bucket",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -88,6 +93,12 @@ func TestAccAWSS3BucketPolicy_policyUpdate(t *testing.T) {
 					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
 					testAccCheckAWSS3BucketHasPolicy("aws_s3_bucket.bucket", expectedPolicyText2),
 				),
+			},
+
+			{
+				ResourceName:      "aws_s3_bucket_policy.bucket",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -35,8 +35,8 @@ resource "aws_s3_bucket_policy" "b" {
       "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
       "Condition": {
          "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
-      } 
-    } 
+      }
+    }
   ]
 }
 POLICY
@@ -49,3 +49,9 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to which to apply the policy.
 * `policy` - (Required) The text of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](/docs/providers/aws/guides/iam-policy-documents.html).
+
+## Import
+ S3 bucket policies can be imported using the bucket name, e.g.
+ ```
+$ terraform import aws_s3_bucket_policy.example my-bucket-name
+```


### PR DESCRIPTION
closes #6519

Changes proposed in this pull request:

* Add import ability for aws_s3_bucket_policy

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSS3BucketPolicy'
=== RUN   TestAccAWSS3BucketPolicy_basic
=== PAUSE TestAccAWSS3BucketPolicy_basic
=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
=== PAUSE TestAccAWSS3BucketPolicy_policyUpdate
=== CONT  TestAccAWSS3BucketPolicy_basic
=== CONT  TestAccAWSS3BucketPolicy_policyUpdate
--- PASS: TestAccAWSS3BucketPolicy_basic (22.30s)
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (32.38s)
PASS
```
