### PR TITLE
B elastictranscoder preset import

### DIFF
--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -594,14 +594,14 @@ func flattenETVideoParams(video *elastictranscoder.VideoParameters) []map[string
 	return m.MapList()
 }
 
-func flattenETVideoCodecOptions(opts map[string]*string) []map[string]interface{} {
+func flattenETVideoCodecOptions(opts map[string]*string) map[string]interface{} {
 	codecOpts := setMap(make(map[string]interface{}))
 
 	for k, v := range opts {
 		codecOpts.SetString(k, v)
 	}
 
-	return codecOpts.MapList()
+	return codecOpts.Map()
 }
 
 func flattenETWatermarks(watermarks []*elastictranscoder.PresetWatermark) []map[string]interface{} {

--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -327,7 +327,7 @@ func resourceAwsElasticTranscoderPresetCreate(d *schema.ResourceData, meta inter
 		Container:   aws.String(d.Get("container").(string)),
 		Description: getStringPtr(d, "description"),
 		Thumbnails:  expandETThumbnails(d),
-		Video:       exapandETVideoParams(d),
+		Video:       expandETVideoParams(d),
 	}
 
 	if name, ok := d.GetOk("name"); ok {
@@ -418,7 +418,7 @@ func expandETAudioCodecOptions(d *schema.ResourceData) *elastictranscoder.AudioC
 	return codecOpts
 }
 
-func exapandETVideoParams(d *schema.ResourceData) *elastictranscoder.VideoParameters {
+func expandETVideoParams(d *schema.ResourceData) *elastictranscoder.VideoParameters {
 	s := d.Get("video").(*schema.Set)
 	if s == nil || s.Len() == 0 {
 		return nil

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -86,16 +86,31 @@ func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: awsElasticTranscoderPresetConfig2,
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(true),
 				),
 			},
 			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: awsElasticTranscoderPresetConfig3,
 				Check: resource.ComposeTestCheckFunc(
 					checkExists(true),
 				),
+			},
+			{
+				ResourceName:      name,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -247,7 +247,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     Profile                  = "main"
     Level                    = "2.2"
     MaxReferenceFrames       = 3
-    InterlaceMode            = "Progressive"
+    InterlacedMode           = "Progressive"
     ColorSpaceConversionMode = "None"
   }
 

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -195,9 +195,11 @@ resource "aws_elastictranscoder_preset" "bar" {
   }
 
   video_codec_options = {
-    Profile            = "main"
-    Level              = "4.1"
-    MaxReferenceFrames = 4
+    Profile                  = "main"
+    Level                    = "4.1"
+    MaxReferenceFrames       = 4
+    InterlacedMode           = "Auto"
+    ColorSpaceConversionMode = "None"
   }
 
   thumbnails {

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -194,7 +194,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     sizing_policy        = "Fit"
   }
 
-  video_codec_options {
+  video_codec_options = {
     Profile            = "main"
     Level              = "4.1"
     MaxReferenceFrames = 4
@@ -243,7 +243,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     sizing_policy        = "Fit"
   }
 
-  video_codec_options {
+  video_codec_options = {
     Profile                  = "main"
     Level                    = "2.2"
     MaxReferenceFrames       = 3


### PR DESCRIPTION
Fixes #6539 

Changes proposed in this pull request:

* Fixed import for VideoCodecOptions

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSElasticTranscoder'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticTranscoder -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSElasticTranscoderPipeline_basic
=== PAUSE TestAccAWSElasticTranscoderPipeline_basic
=== RUN   TestAccAWSElasticTranscoderPipeline_kmsKey
=== PAUSE TestAccAWSElasticTranscoderPipeline_kmsKey
=== RUN   TestAccAWSElasticTranscoderPipeline_notifications
=== PAUSE TestAccAWSElasticTranscoderPipeline_notifications
=== RUN   TestAccAWSElasticTranscoderPipeline_withContentConfig
=== PAUSE TestAccAWSElasticTranscoderPipeline_withContentConfig
=== RUN   TestAccAWSElasticTranscoderPipeline_withPermissions
=== PAUSE TestAccAWSElasticTranscoderPipeline_withPermissions
=== RUN   TestAccAWSElasticTranscoderPipeline_import
=== PAUSE TestAccAWSElasticTranscoderPipeline_import
=== RUN   TestAccAWSElasticTranscoderPreset_import
=== PAUSE TestAccAWSElasticTranscoderPreset_import
=== RUN   TestAccAWSElasticTranscoderPreset_basic
=== PAUSE TestAccAWSElasticTranscoderPreset_basic
=== CONT  TestAccAWSElasticTranscoderPipeline_basic
=== CONT  TestAccAWSElasticTranscoderPipeline_import
=== CONT  TestAccAWSElasticTranscoderPreset_basic
=== CONT  TestAccAWSElasticTranscoderPreset_import
=== CONT  TestAccAWSElasticTranscoderPipeline_withContentConfig
=== CONT  TestAccAWSElasticTranscoderPipeline_withPermissions
=== CONT  TestAccAWSElasticTranscoderPipeline_kmsKey
=== CONT  TestAccAWSElasticTranscoderPipeline_notifications
--- PASS: TestAccAWSElasticTranscoderPreset_import (18.13s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (41.72s)
--- PASS: TestAccAWSElasticTranscoderPipeline_import (44.49s)
--- PASS: TestAccAWSElasticTranscoderPreset_basic (45.73s)
--- PASS: TestAccAWSElasticTranscoderPipeline_basic (68.37s)
--- PASS: TestAccAWSElasticTranscoderPipeline_notifications (70.32s)
--- PASS: TestAccAWSElasticTranscoderPipeline_withContentConfig (70.32s)
--- PASS: TestAccAWSElasticTranscoderPipeline_kmsKey (123.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	123.577s
```
