### PR TITLE
Adding support for CPU Options to resource aws_launch_template

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -147,11 +147,11 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"core_count": {
 							Type:     schema.TypeInt,
-							Optional: false,
+							Optional: true,
 						},
 						"threads_per_core": {
 							Type:     schema.TypeInt,
-							Optional: false,
+							Optional: true,
 						},
 					},
 				},
@@ -784,12 +784,12 @@ func getCapacityReservationTarget(crt *ec2.CapacityReservationTargetResponse) []
 	return s
 }
 
-func getCpuOptions(cs *ec2.CpuOptions) []interface{} {
+func getCpuOptions(cs *ec2.LaunchTemplateCpuOptions) []interface{} {
 	s := []interface{}{}
 	if cs != nil {
 		s = append(s, map[string]interface{}{
-			"core_count":       aws.StringValue(cs.CoreCount),
-			"threads_per_core": aws.StringValue(cs.ThreadsPerCore),
+			"core_count":       aws.Int64Value(cs.CoreCount),
+			"threads_per_core": aws.Int64Value(cs.ThreadsPerCore),
 		})
 	}
 	return s
@@ -1031,10 +1031,10 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 	}
 
 	if v, ok := d.GetOk("cpu_options"); ok {
-		cs := v.([]interface{})
+		co := v.([]interface{})
 
-		if len(cs) > 0 {
-			opts.CpuOptions = readCpuOptionsFromConfig(cs[0].(map[string]interface{}))
+		if len(co) > 0 {
+			opts.CpuOptions = readCpuOptionsFromConfig(co[0].(map[string]interface{}))
 		}
 	}
 
@@ -1307,15 +1307,15 @@ func readCapacityReservationTargetFromConfig(crt map[string]interface{}) *ec2.Ca
 	return capacityReservationTarget
 }
 
-func readCpuOptionsFromConfig(cs map[string]interface{}) *ec2.CreditSpecificationRequest {
-	cpuOptions := &ec2.CpuOptionsRequest{}
+func readCpuOptionsFromConfig(co map[string]interface{}) *ec2.LaunchTemplateCpuOptionsRequest {
+	cpuOptions := &ec2.LaunchTemplateCpuOptionsRequest{}
 
-	if v, ok := cs["core_count"].(string); ok && v != "" {
-		cpuOptions.CoreCount = aws.String(v)
+	if v, ok := co["core_count"].(int); ok && v != 0 {
+		cpuOptions.CoreCount = aws.Int64(int64(v))
 	}
 
-	if v, ok := cs["threads_per_core"].(string); ok && v != "" {
-		cpuOptions.ThreadsPerCore = aws.String(v)
+	if v, ok := co["threads_per_core"].(int); ok && v != 0 {
+		cpuOptions.ThreadsPerCore = aws.Int64(int64(v))
 	}
 
 	return cpuOptions

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -366,6 +366,30 @@ func TestAccAWSLaunchTemplate_capacityReservation_target(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchTemplate_cpuOptions(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resName := "aws_launch_template.foo"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_cpuOptions(rName, rInt, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					resource.TestCheckResourceAttr(resName, "cpu_options.#", "1"),
+					resource.TestCheckResourceAttr(resName, "cpu_options.0.core_count", rInt),
+					resource.TestCheckResourceAttr(resName, "cpu_options.0.threads_per_core", 2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplate_creditSpecification_nonBurstable(t *testing.T) {
 	var template ec2.LaunchTemplate
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -844,6 +868,18 @@ resource "aws_launch_template" "foo" {
 	}
 }
 `, rInt)
+}
+
+func testAccAWSLaunchTemplateConfig_cpuOptions(coreCount, threadsPerCore int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "foo" {
+
+  cpu_options {
+		core_count = %d
+		threads_per_core = %d
+  }
+}
+`, coreCount, threadsPerCore)
 }
 
 func testAccAWSLaunchTemplateConfig_creditSpecification(rName, instanceType, cpuCredits string) string {

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -370,7 +370,6 @@ func TestAccAWSLaunchTemplate_cpuOptions(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resName := "aws_launch_template.foo"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -378,12 +377,9 @@ func TestAccAWSLaunchTemplate_cpuOptions(t *testing.T) {
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLaunchTemplateConfig_cpuOptions(rName, rInt, 2),
+				Config: testAccAWSLaunchTemplateConfig_cpuOptions(rName, 4, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchTemplateExists(resName, &template),
-					resource.TestCheckResourceAttr(resName, "cpu_options.#", "1"),
-					resource.TestCheckResourceAttr(resName, "cpu_options.0.core_count", rInt),
-					resource.TestCheckResourceAttr(resName, "cpu_options.0.threads_per_core", 2),
 				),
 			},
 		},
@@ -870,16 +866,17 @@ resource "aws_launch_template" "foo" {
 `, rInt)
 }
 
-func testAccAWSLaunchTemplateConfig_cpuOptions(coreCount, threadsPerCore int) string {
+func testAccAWSLaunchTemplateConfig_cpuOptions(rName string, coreCount, threadsPerCore int) string {
 	return fmt.Sprintf(`
 resource "aws_launch_template" "foo" {
+	name = %q
 
   cpu_options {
 		core_count = %d
 		threads_per_core = %d
   }
 }
-`, coreCount, threadsPerCore)
+`, rName, coreCount, threadsPerCore)
 }
 
 func testAccAWSLaunchTemplateConfig_creditSpecification(rName, instanceType, cpuCredits string) string {

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -28,6 +28,11 @@ resource "aws_launch_template" "foo" {
     capacity_reservation_preference = "open"
   }
 
+  cpu_options {
+    core_count = 4
+    threads_per_core = 2
+  }
+
   credit_specification {
     cpu_credits = "standard"
   }
@@ -96,6 +101,7 @@ The following arguments are supported:
 * `block_device_mappings` - Specify volumes to attach to the instance besides the volumes specified by the AMI.
   See [Block Devices](#block-devices) below for details.
 * `capacity_reservation_specification` - Targeting for EC2 capacity reservations. See [Capacity Reservation Specification](#capacity-reservation-specification) below for more details.
+* `cpu_options` - The CPU options for the instance. See [CPU Options](#cpu-options) below for more details.
 * `credit_specification` - Customize the credit specification of the instance. See [Credit
   Specification](#credit-specification) below for more details.
 * `disable_api_termination` - If `true`, enables [EC2 Instance
@@ -166,6 +172,16 @@ The `capacity_reservation_specification` block supports the following:
 The `capacity_reservation_target` block supports the following:
 
 * `capacity_reservation_id` - The ID of the Capacity Reservation to target.
+
+### CPU Options
+
+The `cpu_options` block supports the following:
+
+* `core_count` - The number of CPU cores for the instance.
+* `threads_per_core` - The number of threads per CPU core. To disable Intel Hyper-Threading Technology for the instance, specify a value of 1.
+Otherwise, specify the default value of 2.
+
+Both number of CPU cores and threads per core must be specified. Valid number of CPU cores and threads per core for the instance type can be found in the [CPU Options Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html?shortFooter=true#cpu-options-supported-instances-values)
 
 ### Credit Specification
 


### PR DESCRIPTION
Fixes #6522

Changes proposed in this pull request:

* Adding support for CPU Options to resource aws_launch_template

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLaunchTemplate_cpuOptions'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_cpuOptions -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_cpuOptions
=== PAUSE TestAccAWSLaunchTemplate_cpuOptions
=== CONT  TestAccAWSLaunchTemplate_cpuOptions
--- PASS: TestAccAWSLaunchTemplate_cpuOptions (13.73s)
PASS
ok  	github.com/praveensastry/terraform-provider-aws/aws	14.583s
...
```
