### PR TITLE
Set ipv6 properties even if no ipv6 is enabled in subnet 

### DIFF
--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -155,14 +155,16 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", subnet.CidrBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)
+
+	// Make sure those values are set, if an IPv6 block exists it'll be set in the loop
+	d.Set("ipv6_cidr_block_association_id", "")
+	d.Set("ipv6_cidr_block", "")
+
 	for _, a := range subnet.Ipv6CidrBlockAssociationSet {
 		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
 			d.Set("ipv6_cidr_block_association_id", a.AssociationId)
 			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
 			break
-		} else {
-			d.Set("ipv6_cidr_block_association_id", "") // we blank these out to remove old entries
-			d.Set("ipv6_cidr_block", "")
 		}
 	}
 

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -135,6 +135,9 @@ func TestAccAWSSubnet_basic(t *testing.T) {
 					testAccCheckSubnetExists(
 						"aws_subnet.foo", &v),
 					testCheck,
+					// ipv6 should be empty if disabled so we can still use the property in conditionals
+					resource.TestCheckResourceAttr(
+						"aws_subnet.foo", "ipv6_cidr_block", ""),
 					resource.TestMatchResourceAttr(
 						"aws_subnet.foo",
 						"arn",


### PR DESCRIPTION
This allows usage in conditionals.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Fixes #688 but for subnet instead of VPC

Changes proposed in this pull request:

* Set ipv6 properties even if no ipv6 is enabled in subnet

Output from acceptance testing:

```
# make testacc TESTARGS='-run=TestAccAWSSubnet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSubnet_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSubnet_basic
=== PAUSE TestAccAWSSubnet_basic
=== CONT  TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (53.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       53.231s
```
