### PR TITLE
Add Route 53 Resolver endpoint resource

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -269,6 +269,7 @@ type AWSClient struct {
 	pinpointconn                        *pinpoint.Pinpoint
 	pricingconn                         *pricing.Pricing
 	r53conn                             *route53.Route53
+	r53resolverconn                     *route53resolver.Route53Resolver
 	ramconn                             *ram.RAM
 	rdsconn                             *rds.RDS
 	redshiftconn                        *redshift.Redshift

--- a/aws/config.go
+++ b/aws/config.go
@@ -269,7 +269,6 @@ type AWSClient struct {
 	pinpointconn                        *pinpoint.Pinpoint
 	pricingconn                         *pricing.Pricing
 	r53conn                             *route53.Route53
-	r53resolverconn                     *route53resolver.Route53Resolver
 	ramconn                             *ram.RAM
 	rdsconn                             *rds.RDS
 	redshiftconn                        *redshift.Redshift

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -604,6 +604,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route53_zone_association":                     resourceAwsRoute53ZoneAssociation(),
 			"aws_route53_zone":                                 resourceAwsRoute53Zone(),
 			"aws_route53_health_check":                         resourceAwsRoute53HealthCheck(),
+			"aws_route53_resolver_endpoint":                    resourceAwsRoute53ResolverEndpoint(),
 			"aws_route":                                        resourceAwsRoute(),
 			"aws_route_table":                                  resourceAwsRouteTable(),
 			"aws_default_route_table":                          resourceAwsDefaultRouteTable(),

--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -103,7 +103,7 @@ func resourceAwsRoute53ResolverEndpoint() *schema.Resource {
 }
 
 func resourceAwsRoute53ResolverEndpointCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).r53resolverconn
+	conn := meta.(*AWSClient).route53resolverconn
 
 	req := &route53resolver.CreateResolverEndpointInput{
 		CreatorRequestId: aws.String(resource.PrefixedUniqueId("tf-r53-resolver-")),
@@ -137,7 +137,7 @@ func resourceAwsRoute53ResolverEndpointCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).r53resolverconn
+	conn := meta.(*AWSClient).route53resolverconn
 
 	epRaw, state, err := route53ResolverEndpointRefresh(conn, d.Id())()
 	if err != nil {
@@ -187,7 +187,7 @@ func resourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).r53resolverconn
+	conn := meta.(*AWSClient).route53resolverconn
 
 	d.Partial(true)
 	if d.HasChange("name") {
@@ -267,7 +267,7 @@ func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceAwsRoute53ResolverEndpointDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).r53resolverconn
+	conn := meta.(*AWSClient).route53resolverconn
 
 	log.Printf("[DEBUG] Deleting Route53 Resolver endpoint: %s", d.Id())
 	_, err := conn.DeleteResolverEndpoint(&route53resolver.DeleteResolverEndpointInput{

--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	Route53ResolverEndpointStatusDeleted = "DELETED"
+	route53ResolverEndpointStatusDeleted = "DELETED"
 )
 
 func resourceAwsRoute53ResolverEndpoint() *schema.Resource {
@@ -143,7 +143,7 @@ func resourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interfa
 	if err != nil {
 		return fmt.Errorf("error getting Route53 Resolver endpoint (%s): %s", d.Id(), err)
 	}
-	if state == Route53ResolverEndpointStatusDeleted {
+	if state == route53ResolverEndpointStatusDeleted {
 		log.Printf("[WARN] Route53 Resolver endpoint (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -283,7 +283,7 @@ func resourceAwsRoute53ResolverEndpointDelete(d *schema.ResourceData, meta inter
 
 	err = route53ResolverEndpointWaitUntilTargetState(conn, d.Id(), d.Timeout(schema.TimeoutDelete),
 		[]string{route53resolver.ResolverEndpointStatusDeleting},
-		[]string{Route53ResolverEndpointStatusDeleted})
+		[]string{route53ResolverEndpointStatusDeleted})
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func route53ResolverEndpointRefresh(conn *route53resolver.Route53Resolver, epId 
 		})
 		if err != nil {
 			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-				return &route53resolver.ResolverEndpoint{}, Route53ResolverEndpointStatusDeleted, nil
+				return &route53resolver.ResolverEndpoint{}, route53ResolverEndpointStatusDeleted, nil
 			}
 
 			return nil, "", err

--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -296,11 +296,10 @@ func route53ResolverEndpointRefresh(conn *route53resolver.Route53Resolver, epId 
 		resp, err := conn.GetResolverEndpoint(&route53resolver.GetResolverEndpointInput{
 			ResolverEndpointId: aws.String(epId),
 		})
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			return &route53resolver.ResolverEndpoint{}, route53ResolverEndpointStatusDeleted, nil
+		}
 		if err != nil {
-			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-				return &route53resolver.ResolverEndpoint{}, route53ResolverEndpointStatusDeleted, nil
-			}
-
 			return nil, "", err
 		}
 
@@ -328,14 +327,5 @@ func route53ResolverHashIPAddress(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
-	// TODO
-	// TODO * "ip" may be computed - Blank on input, set by API on output; How to handle?
-	// TODO * Multiple "ip_address" values per "subnet_id" are allowed in the API
-	// TODO   but a List (instead of a Set) won't work because of non-deterministic order
-	// TODO   on listing ip_address, plus how to determine diffs for update?
-	// TODO
-	// if v, ok := m["ip"]; ok {
-	// 	buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-	// }
 	return hashcode.String(buf.String())
 }

--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -1,0 +1,338 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+const (
+	Route53ResolverEndpointStatusDeleted = "DELETED"
+)
+
+func resourceAwsRoute53ResolverEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53ResolverEndpointCreate,
+		Read:   resourceAwsRoute53ResolverEndpointRead,
+		Update: resourceAwsRoute53ResolverEndpointUpdate,
+		Delete: resourceAwsRoute53ResolverEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"direction": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{route53resolver.ResolverEndpointDirectionInbound, route53resolver.ResolverEndpointDirectionOutbound}, false),
+			},
+
+			"ip_address": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 2,
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"ip": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.SingleIP(),
+						},
+						"ip_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Set: route53ResolverHashIPAddress,
+			},
+
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				MinItems: 1,
+				MaxItems: 64,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateRoute53ResolverEndpointName,
+			},
+
+			"tags": tagsSchema(),
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"host_vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func resourceAwsRoute53ResolverEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	req := &route53resolver.CreateResolverEndpointInput{
+		CreatorRequestId: aws.String(resource.PrefixedUniqueId("tf-r53-resolver-")),
+		Direction:        aws.String(d.Get("direction").(string)),
+		IpAddresses:      expandRoute53ResolverIpAddresses(d.Get("ip_address").(*schema.Set)),
+		SecurityGroupIds: expandStringSet(d.Get("security_group_ids").(*schema.Set)),
+	}
+	if v, ok := d.GetOk("name"); ok && v.(string) != "" {
+		req.Name = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
+		req.Tags = tagsFromMapRoute53Resolver(v.(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] Creating Route53 Resolver endpoint: %#v", req)
+	resp, err := conn.CreateResolverEndpoint(req)
+	if err != nil {
+		return fmt.Errorf("Error creating Route53 Resolver endpoint: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.ResolverEndpoint.Id))
+
+	err = route53ResolverEndpointWaitUntilTargetState(conn, d.Id(), d.Timeout(schema.TimeoutCreate),
+		[]string{route53resolver.ResolverEndpointStatusCreating},
+		[]string{route53resolver.ResolverEndpointStatusOperational})
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsRoute53ResolverEndpointRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	epRaw, state, err := route53ResolverEndpointRefresh(conn, d.Id())()
+	if err != nil {
+		return fmt.Errorf("Error getting Route53 Resolver endpoint (%s): %s", d.Id(), err)
+	}
+	if state == Route53ResolverEndpointStatusDeleted {
+		log.Printf("[WARN] Route53 Resolver endpoint (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	ep := epRaw.(*route53resolver.ResolverEndpoint)
+	d.Set("arn", ep.Arn)
+	d.Set("direction", ep.Direction)
+	d.Set("host_vpc_id", ep.HostVPCId)
+	d.Set("name", ep.Name)
+	if err := d.Set("security_group_ids", flattenStringSet(ep.SecurityGroupIds)); err != nil {
+		return err
+	}
+
+	ipAddresses := []interface{}{}
+	req := &route53resolver.ListResolverEndpointIpAddressesInput{
+		ResolverEndpointId: aws.String(d.Id()),
+	}
+	for {
+		resp, err := conn.ListResolverEndpointIpAddresses(req)
+		if err != nil {
+			return fmt.Errorf("Error getting Route53 Resolver endpoint (%s) IP addresses: %s", d.Id(), err)
+		}
+
+		ipAddresses = append(ipAddresses, flattenRoute53ResolverIpAddresses(resp.IpAddresses)...)
+
+		if resp.NextToken == nil {
+			break
+		}
+		req.NextToken = resp.NextToken
+	}
+	if err := d.Set("ip_address", schema.NewSet(route53ResolverHashIPAddress, ipAddresses)); err != nil {
+		return err
+	}
+
+	if err := getTagsRoute53Resolver(conn, d, d.Get("arn").(string)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	d.Partial(true)
+	if d.HasChange("name") {
+		req := &route53resolver.UpdateResolverEndpointInput{
+			ResolverEndpointId: aws.String(d.Id()),
+			Name:               aws.String(d.Get("name").(string)),
+		}
+
+		log.Printf("[DEBUG] Updating Route53 Resolver endpoint: %#v", req)
+		_, err := conn.UpdateResolverEndpoint(req)
+		if err != nil {
+			return fmt.Errorf("Error updating Route53 Resolver endpoint (%s): %s", d.Id(), err)
+		}
+
+		err = route53ResolverEndpointWaitUntilTargetState(conn, d.Id(), d.Timeout(schema.TimeoutUpdate),
+			[]string{route53resolver.ResolverEndpointStatusUpdating},
+			[]string{route53resolver.ResolverEndpointStatusOperational})
+		if err != nil {
+			return err
+		}
+
+		d.SetPartial("name")
+	}
+
+	if d.HasChange("ip_address") {
+		oraw, nraw := d.GetChange("ip_address")
+		o := oraw.(*schema.Set)
+		n := nraw.(*schema.Set)
+		del := o.Difference(n).List()
+		add := n.Difference(o).List()
+
+		// Add new before deleting old so number of IP addresses doesn't drop below 2.
+		for _, v := range add {
+			_, err := conn.AssociateResolverEndpointIpAddress(&route53resolver.AssociateResolverEndpointIpAddressInput{
+				ResolverEndpointId: aws.String(d.Id()),
+				IpAddress:          expandRoute53ResolverIpAddressUpdate(v),
+			})
+			if err != nil {
+				return fmt.Errorf("Error associating Route53 Resolver endpoint (%s) IP address: %s", d.Id(), err)
+			}
+
+			err = route53ResolverEndpointWaitUntilTargetState(conn, d.Id(), d.Timeout(schema.TimeoutUpdate),
+				[]string{route53resolver.ResolverEndpointStatusUpdating},
+				[]string{route53resolver.ResolverEndpointStatusOperational})
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, v := range del {
+			_, err := conn.DisassociateResolverEndpointIpAddress(&route53resolver.DisassociateResolverEndpointIpAddressInput{
+				ResolverEndpointId: aws.String(d.Id()),
+				IpAddress:          expandRoute53ResolverIpAddressUpdate(v),
+			})
+			if err != nil {
+				return fmt.Errorf("Error disassociating Route53 Resolver endpoint (%s) IP address: %s", d.Id(), err)
+			}
+
+			err = route53ResolverEndpointWaitUntilTargetState(conn, d.Id(), d.Timeout(schema.TimeoutUpdate),
+				[]string{route53resolver.ResolverEndpointStatusUpdating},
+				[]string{route53resolver.ResolverEndpointStatusOperational})
+			if err != nil {
+				return err
+			}
+		}
+
+		d.SetPartial("ip_address")
+	}
+
+	if err := setTagsRoute53Resolver(conn, d, d.Get("arn").(string)); err != nil {
+		return err
+	}
+	d.SetPartial("tags")
+
+	d.Partial(false)
+	return resourceAwsRoute53ResolverEndpointRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverEndpointDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	log.Printf("[DEBUG] Deleting Route53 Resolver endpoint: %s", d.Id())
+	_, err := conn.DeleteResolverEndpoint(&route53resolver.DeleteResolverEndpointInput{
+		ResolverEndpointId: aws.String(d.Id()),
+	})
+	if err != nil {
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+
+		return fmt.Errorf("Error deleting Route53 Resolver endpoint (%s): %s", d.Id(), err)
+	}
+
+	err = route53ResolverEndpointWaitUntilTargetState(conn, d.Id(), d.Timeout(schema.TimeoutDelete),
+		[]string{route53resolver.ResolverEndpointStatusDeleting},
+		[]string{Route53ResolverEndpointStatusDeleted})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func route53ResolverEndpointRefresh(conn *route53resolver.Route53Resolver, epId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.GetResolverEndpoint(&route53resolver.GetResolverEndpointInput{
+			ResolverEndpointId: aws.String(epId),
+		})
+		if err != nil {
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return &route53resolver.ResolverEndpoint{}, Route53ResolverEndpointStatusDeleted, nil
+			}
+
+			return nil, "", err
+		}
+
+		return resp.ResolverEndpoint, aws.StringValue(resp.ResolverEndpoint.Status), nil
+	}
+}
+
+func route53ResolverEndpointWaitUntilTargetState(conn *route53resolver.Route53Resolver, epId string, timeout time.Duration, pending, target []string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    pending,
+		Target:     target,
+		Refresh:    route53ResolverEndpointRefresh(conn, epId),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Route53 Resolver endpoint (%s) to reach target state: %s", epId, err)
+	}
+
+	return nil
+}
+
+func route53ResolverHashIPAddress(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
+	// TODO
+	// TODO * "ip" may be computed - Blank on input, set by API on output; How to handle?
+	// TODO * Multiple "ip_address" values per "subnet_id" are allowed in the API
+	// TODO   but a List (instead of a Set) won't work because of non-deterministic order
+	// TODO   on listing ip_address, plus how to determine diffs for update?
+	// TODO
+	// if v, ok := m["ip"]; ok {
+	// 	buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+	// }
+	return hashcode.String(buf.String())
+}

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -136,7 +136,7 @@ resource "aws_vpc" "foo" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-r53-resolver-vpc-%d"
   }
 }
@@ -148,7 +148,7 @@ resource "aws_subnet" "sn1" {
   cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
-  tags {
+  tags = {
     Name = "tf-acc-r53-resolver-sn1-%d"
   }
 }
@@ -158,7 +158,7 @@ resource "aws_subnet" "sn2" {
   cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
-  tags {
+  tags = {
     Name = "tf-acc-r53-resolver-sn2-%d"
   }
 }
@@ -168,7 +168,7 @@ resource "aws_subnet" "sn3" {
   cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
   availability_zone = "${data.aws_availability_zones.available.names[2]}"
 
-  tags {
+  tags = {
     Name = "tf-acc-r53-resolver-sn3-%d"
   }
 }
@@ -177,7 +177,7 @@ resource "aws_security_group" "sg1" {
   vpc_id = "${aws_vpc.foo.id}"
   name   = "tf-acc-r53-resolver-sg1-%d"
 
-  tags {
+  tags = {
     Name = "tf-acc-r53-resolver-sg1-%d"
   }
 }
@@ -186,7 +186,7 @@ resource "aws_security_group" "sg2" {
   vpc_id = "${aws_vpc.foo.id}"
   name   = "tf-acc-r53-resolver-sg2-%d"
 
-  tags {
+  tags = {
     Name = "tf-acc-r53-resolver-sg2-%d"
   }
 }
@@ -215,7 +215,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
     ip        = "${cidrhost(aws_subnet.sn2.cidr_block, 8)}"
   }
 
-  tags {
+  tags = {
     Environment = "production"
     Usage = "original"
   }
@@ -244,7 +244,7 @@ resource "aws_route53_resolver_endpoint" "foo" {
     subnet_id = "${aws_subnet.sn3.id}"
   }
 
-  tags {
+  tags = {
     Usage = "changed"
   }
 }

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -39,11 +39,10 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 			_, err := conn.DeleteResolverEndpoint(&route53resolver.DeleteResolverEndpointInput{
 				ResolverEndpointId: aws.String(id),
 			})
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				continue
+			}
 			if err != nil {
-				if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-					continue
-				}
-
 				log.Printf("[ERROR] Error deleting Route53 Resolver endpoint (%s): %s", id, err)
 				continue
 			}
@@ -150,11 +149,11 @@ func testAccCheckRoute53ResolverEndpointDestroy(s *terraform.State) error {
 		_, err := conn.GetResolverEndpoint(&route53resolver.GetResolverEndpointInput{
 			ResolverEndpointId: aws.String(rs.Primary.ID),
 		})
+		// Verify the error is what we want
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
 		if err != nil {
-			// Verify the error is what we want
-			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-				return nil
-			}
 			return err
 		}
 	}

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -50,7 +50,7 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 
 			err = route53ResolverEndpointWaitUntilTargetState(conn, id, 10*time.Minute,
 				[]string{route53resolver.ResolverEndpointStatusDeleting},
-				[]string{Route53ResolverEndpointStatusDeleted})
+				[]string{route53ResolverEndpointStatusDeleted})
 			if err != nil {
 				log.Printf("[ERROR] %s", err)
 			}

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -1,0 +1,252 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsRoute53ResolverEndpoint_basicInbound(t *testing.T) {
+	var ep route53resolver.ResolverEndpoint
+	resourceName := "aws_route53_resolver_endpoint.foo"
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverEndpointConfig_initial(rInt, "INBOUND", name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverEndpointExists(resourceName, &ep),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
+	var ep route53resolver.ResolverEndpoint
+	resourceName := "aws_route53_resolver_endpoint.foo"
+	rInt := acctest.RandInt()
+	initialName := fmt.Sprintf("terraform-testacc-r53-resolver-%d", rInt)
+	updatedName := fmt.Sprintf("terraform-testacc-r53-rupdated-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverEndpointConfig_initial(rInt, "OUTBOUND", initialName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverEndpointExists(resourceName, &ep),
+					resource.TestCheckResourceAttr(resourceName, "name", initialName),
+					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
+				),
+			},
+			{
+				Config: testAccRoute53ResolverEndpointConfig_updated(rInt, "OUTBOUND", updatedName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverEndpointExists(resourceName, &ep),
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRoute53ResolverEndpointDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_resolver_endpoint" {
+			continue
+		}
+
+		// Try to find the resource
+		_, err := conn.GetResolverEndpoint(&route53resolver.GetResolverEndpointInput{
+			ResolverEndpointId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			// Verify the error is what we want
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckRoute53ResolverEndpointExists(n string, ep *route53resolver.ResolverEndpoint) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Route 53 Resolver Endpoint ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+		resp, err := conn.GetResolverEndpoint(&route53resolver.GetResolverEndpointInput{
+			ResolverEndpointId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		*ep = *resp.ResolverEndpoint
+
+		return nil
+	}
+}
+
+func testAccRoute53ResolverEndpointConfig_base(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "foo" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags {
+    Name = "terraform-testacc-r53-resolver-vpc-%d"
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "sn1" {
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
+  tags {
+    Name = "tf-acc-r53-resolver-sn1-%d"
+  }
+}
+
+resource "aws_subnet" "sn2" {
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+
+  tags {
+    Name = "tf-acc-r53-resolver-sn2-%d"
+  }
+}
+
+resource "aws_subnet" "sn3" {
+  vpc_id            = "${aws_vpc.foo.id}"
+  cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
+  availability_zone = "${data.aws_availability_zones.available.names[2]}"
+
+  tags {
+    Name = "tf-acc-r53-resolver-sn3-%d"
+  }
+}
+
+resource "aws_security_group" "sg1" {
+  vpc_id = "${aws_vpc.foo.id}"
+  name   = "tf-acc-r53-resolver-sg1-%d"
+
+  tags {
+    Name = "tf-acc-r53-resolver-sg1-%d"
+  }
+}
+
+resource "aws_security_group" "sg2" {
+  vpc_id = "${aws_vpc.foo.id}"
+  name   = "tf-acc-r53-resolver-sg2-%d"
+
+  tags {
+    Name = "tf-acc-r53-resolver-sg2-%d"
+  }
+}
+`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccRoute53ResolverEndpointConfig_initial(rInt int, direction, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_route53_resolver_endpoint" "foo" {
+  direction = "%s"
+  name      = "%s"
+
+  security_group_ids = [
+    "${aws_security_group.sg1.id}",
+    "${aws_security_group.sg2.id}",
+  ]
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn1.id}"
+  }
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn2.id}"
+    ip        = "${cidrhost(aws_subnet.sn2.cidr_block, 8)}"
+  }
+
+  tags {
+    Environment = "production"
+    Usage = "original"
+  }
+}
+`, testAccRoute53ResolverEndpointConfig_base(rInt), direction, name)
+}
+
+func testAccRoute53ResolverEndpointConfig_updated(rInt int, direction, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_route53_resolver_endpoint" "foo" {
+  direction = "%s"
+  name      = "%s"
+
+  security_group_ids = [
+    "${aws_security_group.sg1.id}",
+    "${aws_security_group.sg2.id}",
+  ]
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn1.id}"
+  }
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn3.id}"
+  }
+
+  tags {
+    Usage = "changed"
+  }
+}
+`, testAccRoute53ResolverEndpointConfig_base(rInt), direction, name)
+}

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 	"time"
 
@@ -34,10 +33,6 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 		}
 
 		for _, resolverEndpoint := range page.ResolverEndpoints {
-			if !strings.HasPrefix(aws.StringValue(resolverEndpoint.Name), "terraform-testacc-") {
-				continue
-			}
-
 			id := aws.StringValue(resolverEndpoint.Id)
 
 			log.Printf("[INFO] Deleting Route53 Resolver endpoint: %s", id)

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -25,7 +25,7 @@ func testSweepRoute53ResolverEndpoints(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	conn := client.(*AWSClient).r53resolverconn
+	conn := client.(*AWSClient).route53resolverconn
 
 	err = conn.ListResolverEndpointsPages(&route53resolver.ListResolverEndpointsInput{}, func(page *route53resolver.ListResolverEndpointsOutput, isLast bool) bool {
 		if page == nil {
@@ -139,7 +139,7 @@ func TestAccAwsRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 }
 
 func testAccCheckRoute53ResolverEndpointDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+	conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route53_resolver_endpoint" {
@@ -173,7 +173,7 @@ func testAccCheckRoute53ResolverEndpointExists(n string, ep *route53resolver.Res
 			return fmt.Errorf("No Route 53 Resolver Endpoint ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
 		resp, err := conn.GetResolverEndpoint(&route53resolver.GetResolverEndpointInput{
 			ResolverEndpointId: aws.String(rs.Primary.ID),
 		})

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -37,6 +37,7 @@ func init() {
 			"aws_mq_broker",
 			"aws_network_interface",
 			"aws_redshift_cluster",
+			"aws_route53_resolver_endpoint",
 			"aws_spot_fleet_request",
 			"aws_vpc_endpoint",
 		},

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/worklink"
@@ -5053,4 +5054,63 @@ func flattenAppmeshRouteSpec(spec *appmesh.RouteSpec) []interface{} {
 	}
 
 	return []interface{}{mSpec}
+}
+
+func expandRoute53ResolverIpAddresses(vIpAddresses *schema.Set) []*route53resolver.IpAddressRequest {
+	ipAddressRequests := []*route53resolver.IpAddressRequest{}
+
+	for _, vIpAddress := range vIpAddresses.List() {
+		ipAddressRequest := &route53resolver.IpAddressRequest{}
+
+		mIpAddress := vIpAddress.(map[string]interface{})
+
+		if vSubnetId, ok := mIpAddress["subnet_id"].(string); ok && vSubnetId != "" {
+			ipAddressRequest.SubnetId = aws.String(vSubnetId)
+		}
+		if vIp, ok := mIpAddress["ip"].(string); ok && vIp != "" {
+			ipAddressRequest.Ip = aws.String(vIp)
+		}
+
+		ipAddressRequests = append(ipAddressRequests, ipAddressRequest)
+	}
+
+	return ipAddressRequests
+}
+
+func flattenRoute53ResolverIpAddresses(ipAddresses []*route53resolver.IpAddressResponse) []interface{} {
+	if ipAddresses == nil {
+		return []interface{}{}
+	}
+
+	vIpAddresses := []interface{}{}
+
+	for _, ipAddress := range ipAddresses {
+		mIpAddress := map[string]interface{}{}
+
+		mIpAddress["subnet_id"] = aws.StringValue(ipAddress.SubnetId)
+		mIpAddress["ip"] = aws.StringValue(ipAddress.Ip)
+		mIpAddress["ip_id"] = aws.StringValue(ipAddress.IpId)
+
+		vIpAddresses = append(vIpAddresses, mIpAddress)
+	}
+
+	return vIpAddresses
+}
+
+func expandRoute53ResolverIpAddressUpdate(vIpAddress interface{}) *route53resolver.IpAddressUpdate {
+	ipAddressUpdate := &route53resolver.IpAddressUpdate{}
+
+	mIpAddress := vIpAddress.(map[string]interface{})
+
+	if vSubnetId, ok := mIpAddress["subnet_id"].(string); ok && vSubnetId != "" {
+		ipAddressUpdate.SubnetId = aws.String(vSubnetId)
+	}
+	if vIp, ok := mIpAddress["ip"].(string); ok && vIp != "" {
+		ipAddressUpdate.Ip = aws.String(vIp)
+	}
+	if vIpId, ok := mIpAddress["ip_id"].(string); ok && vIpId != "" {
+		ipAddressUpdate.IpId = aws.String(vIpId)
+	}
+
+	return ipAddressUpdate
 }

--- a/aws/tagsRoute53Resolver.go
+++ b/aws/tagsRoute53Resolver.go
@@ -11,7 +11,6 @@ import (
 
 // getTags is a helper to get the tags for a resource. It expects the
 // tags field to be named "tags"
-// nolint
 func getTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.ResourceData, arn string) error {
 	tags := make([]*route53resolver.Tag, 0)
 	req := &route53resolver.ListTagsForResourceInput{
@@ -42,7 +41,6 @@ func getTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.Res
 
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags"
-// nolint
 func setTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.ResourceData, arn string) error {
 	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")

--- a/aws/tagsRoute53Resolver.go
+++ b/aws/tagsRoute53Resolver.go
@@ -1,0 +1,147 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// getTags is a helper to get the tags for a resource. It expects the
+// tags field to be named "tags"
+// nolint
+func getTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.ResourceData, arn string) error {
+	tags := make([]*route53resolver.Tag, 0)
+	req := &route53resolver.ListTagsForResourceInput{
+		ResourceArn: aws.String(arn),
+	}
+	for {
+		resp, err := conn.ListTagsForResource(req)
+		if err != nil {
+			return err
+		}
+
+		for _, tag := range resp.Tags {
+			tags = append(tags, tag)
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+		req.NextToken = resp.NextToken
+	}
+
+	if err := d.Set("tags", tagsToMapRoute53Resolver(tags)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+// nolint
+func setTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsRoute53Resolver(tagsFromMapRoute53Resolver(o), tagsFromMapRoute53Resolver(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove), len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&route53resolver.UntagResourceInput{
+				ResourceArn: aws.String(arn),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&route53resolver.TagResourceInput{
+				ResourceArn: aws.String(arn),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsRoute53Resolver(oldTags, newTags []*route53resolver.Tag) ([]*route53resolver.Tag, []*route53resolver.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*route53resolver.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapRoute53Resolver(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapRoute53Resolver(m map[string]interface{}) []*route53resolver.Tag {
+	result := make([]*route53resolver.Tag, 0, len(m))
+	for k, v := range m {
+		t := &route53resolver.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredRoute53Resolver(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapRoute53Resolver(ts []*route53resolver.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredRoute53Resolver(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredRoute53Resolver(t *route53resolver.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsRoute53Resolver.go
+++ b/aws/tagsRoute53Resolver.go
@@ -22,9 +22,7 @@ func getTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.Res
 			return err
 		}
 
-		for _, tag := range resp.Tags {
-			tags = append(tags, tag)
-		}
+		tags = append(tags, resp.Tags...)
 
 		if resp.NextToken == nil {
 			break
@@ -51,7 +49,7 @@ func setTagsRoute53Resolver(conn *route53resolver.Route53Resolver, d *schema.Res
 		// Set tags
 		if len(remove) > 0 {
 			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			k := make([]*string, len(remove), len(remove))
+			k := make([]*string, len(remove))
 			for i, t := range remove {
 				k[i] = t.Key
 			}
@@ -138,7 +136,7 @@ func tagIgnoredRoute53Resolver(t *route53resolver.Tag) bool {
 	filter := []string{"^aws:"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
-		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+		if r, _ := regexp.MatchString(v, *t.Key); r {
 			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
 			return true
 		}

--- a/aws/tagsRoute53Resolver_test.go
+++ b/aws/tagsRoute53Resolver_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+)
+
+// go test -v -run="TestDiffRoute53ResolverTags"
+func TestDiffRoute53ResolverTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsRoute53Resolver(tagsFromMapRoute53Resolver(tc.Old), tagsFromMapRoute53Resolver(tc.New))
+		cm := tagsToMapRoute53Resolver(c)
+		rm := tagsToMapRoute53Resolver(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsRoute53Resolver"
+func TestIgnoringTagsRoute53Resolver(t *testing.T) {
+	var ignoredTags []*route53resolver.Tag
+	ignoredTags = append(ignoredTags, &route53resolver.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &route53resolver.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredRoute53Resolver(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/aws/tagsRoute53Resolver_test.go
+++ b/aws/tagsRoute53Resolver_test.go
@@ -14,20 +14,19 @@ func TestDiffRoute53ResolverTags(t *testing.T) {
 		Old, New       map[string]interface{}
 		Create, Remove map[string]string
 	}{
-		// Basic add/remove
+		// Add
 		{
 			Old: map[string]interface{}{
 				"foo": "bar",
 			},
 			New: map[string]interface{}{
+				"foo": "bar",
 				"bar": "baz",
 			},
 			Create: map[string]string{
 				"bar": "baz",
 			},
-			Remove: map[string]string{
-				"foo": "bar",
-			},
+			Remove: map[string]string{},
 		},
 
 		// Modify
@@ -43,6 +42,39 @@ func TestDiffRoute53ResolverTags(t *testing.T) {
 			},
 			Remove: map[string]string{
 				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
 			},
 		},
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2381,3 +2381,26 @@ func validateWorklinkFleetName(v interface{}, k string) (ws []string, errors []e
 
 	return
 }
+
+func validateRoute53ResolverEndpointName(v interface{}, k string) (ws []string, errors []error) {
+	// Type: String
+	// Length Constraints: Maximum length of 64.
+	// Pattern: (?!^[0-9]+$)([a-zA-Z0-9-_' ']+)
+	value := v.(string)
+
+	// re2 doesn't support negative lookaheads so check for single numeric character explicitly.
+	if regexp.MustCompile(`^[0-9]$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be a single digit", k))
+	}
+	if !regexp.MustCompile(`^[a-zA-Z0-9-_' ']+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters, '-', '_' and ' ' are allowed in %q", k))
+	}
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 64 characters", k))
+	}
+
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3098,3 +3098,41 @@ func TestValidateSecretManagerSecretNamePrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateRoute53ResolverEndpointName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing - 123__",
+			ErrCount: 0,
+		},
+		{
+			Value:    randomString(65),
+			ErrCount: 1,
+		},
+		{
+			Value:    "1",
+			ErrCount: 1,
+		},
+		{
+			Value:    "10",
+			ErrCount: 0,
+		},
+		{
+			Value:    "A",
+			ErrCount: 0,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := validateRoute53ResolverEndpointName(tc.Value, "aws_route53_resolver_endpoint")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the AWS Route 53 Resolver Endpoint Name to not trigger a validation error for %q", tc.Value)
+		}
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2267,6 +2267,18 @@
                 </li>
 
 
+                <li<%= sidebar_current("docs-aws-resource-route53-resolver") %>>
+                    <a href="#">Route53 Resolver Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-resolver-endpoint") %>>
+                            <a href="/docs/providers/aws/r/route53_resolver_endpoint.html">aws_route53_resolver_endpoint</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+
                 <li<%= sidebar_current("docs-aws-resource-s3") %>>
                     <a href="#">S3 Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/r/route53_resolver_endpoint.html.markdown
@@ -1,0 +1,81 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_endpoint"
+sidebar_current: "docs-aws-resource-route53-resolver-endpoint"
+description: |-
+  Provides a Route 53 Resolver endpoint resource.
+---
+
+# aws_route53_resolver_endpoint
+
+Provides a Route 53 Resolver endpoint resource.
+
+## Example Usage
+
+```hcl
+resource "aws_route53_resolver_endpoint" "foo" {
+  name      = "foo"
+  direction = "INBOUND"
+
+  security_group_ids = [
+    "${aws_security_group.sg1.id}",
+    "${aws_security_group.sg2.id}",
+  ]
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn1.id}"
+  }
+
+  ip_address {
+    subnet_id = "${aws_subnet.sn2.id}"
+    ip        = "10.0.64.4"
+  }
+
+  tags {
+    Environment = "Prod"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `direction` - (Required) The direction of DNS queries to or from the Route 53 Resolver endpoint.
+Valid values are `INBOUND` (resolver forwards DNS queries to the DNS service for a VPC from your network or another VPC)
+or `OUTBOUND` (resolver forwards DNS queries from the DNS service for a VPC to your network or another VPC).
+* `ip_address` - (Required) The subnets and IP addresses in your VPC that you want DNS queries to pass through on the way from your VPCs
+to your network (for outbound endpoints) or on the way from your network to your VPCs (for inbound endpoints). Described below.
+* `security_group_ids` - (Required) The ID of one or more security groups that you want to use to control access to this VPC.
+* `name` - (Optional) The friendly name of the Route 53 Resolver endpoint.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `ip_address` object supports the following:
+
+* `subnet_id` - (Required) The ID of the subnet that contains the IP address.
+* `ip` - (Optional) The IP address in the subnet that you want to use for DNS queries.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Route 53 Resolver endpoint.
+* `arn` - The ARN of the Route 53 Resolver endpoint.
+* `host_vpc_id` - The ID of the VPC that you want to create the resolver endpoint in.
+
+## Timeouts
+
+`aws_route53_resolver_endpoint` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating Route 53 Resolver endpoint
+- `update` - (Default `10 minutes`) Used for updating Route 53 Resolver endpoint
+- `delete` - (Default `10 minutes`) Used for destroying Route 53 Resolver endpoint
+
+## Import
+
+ Route 53 Resolver endpoints can be imported using the Route 53 Resolver endpoint ID, e.g.
+
+```
+$ terraform import aws_route53_resolver_endpoint.foo rslvr-in-abcdef01234567890
+```


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6563.
Includes:
* https://github.com/terraform-providers/terraform-provider-aws/pull/6549
* https://github.com/terraform-providers/terraform-provider-aws/pull/6554

Acceptance tests (so far):

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsRoute53ResolverEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsRoute53ResolverEndpoint_ -timeout 120m
=== RUN   TestAccAwsRoute53ResolverEndpoint_importBasic
=== PAUSE TestAccAwsRoute53ResolverEndpoint_importBasic
=== RUN   TestAccAwsRoute53ResolverEndpoint_basicInbound
=== PAUSE TestAccAwsRoute53ResolverEndpoint_basicInbound
=== RUN   TestAccAwsRoute53ResolverEndpoint_updateOutbound
=== PAUSE TestAccAwsRoute53ResolverEndpoint_updateOutbound
=== CONT  TestAccAwsRoute53ResolverEndpoint_importBasic
=== CONT  TestAccAwsRoute53ResolverEndpoint_updateOutbound
=== CONT  TestAccAwsRoute53ResolverEndpoint_basicInbound
--- PASS: TestAccAwsRoute53ResolverEndpoint_importBasic (108.99s)
--- PASS: TestAccAwsRoute53ResolverEndpoint_basicInbound (129.35s)
--- PASS: TestAccAwsRoute53ResolverEndpoint_updateOutbound (503.80s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	503.819s
```