### PR TITLE
New resource: aws_ses_email_identity

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -636,6 +636,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ses_domain_identity_verification":                    resourceAwsSesDomainIdentityVerification(),
 			"aws_ses_domain_dkim":                                     resourceAwsSesDomainDkim(),
 			"aws_ses_domain_mail_from":                                resourceAwsSesDomainMailFrom(),
+			"aws_ses_email_identity":                                  resourceAwsSesEmailIdentity(),
 			"aws_ses_receipt_filter":                                  resourceAwsSesReceiptFilter(),
 			"aws_ses_receipt_rule":                                    resourceAwsSesReceiptRule(),
 			"aws_ses_receipt_rule_set":                                resourceAwsSesReceiptRuleSet(),

--- a/aws/resource_aws_ses_email_identity.go
+++ b/aws/resource_aws_ses_email_identity.go
@@ -1,0 +1,111 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSesEmailIdentity() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSesEmailIdentityCreate,
+		Read:   resourceAwsSesEmailIdentityRead,
+		Delete: resourceAwsSesEmailIdentityDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					return strings.TrimSuffix(v.(string), ".")
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsSesEmailIdentityCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	email := d.Get("email").(string)
+	email = strings.TrimSuffix(email, ".")
+
+	createOpts := &ses.VerifyEmailIdentityInput{
+		EmailAddress: aws.String(email),
+	}
+
+	_, err := conn.VerifyEmailIdentity(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error requesting SES email identity verification: %s", err)
+	}
+
+	d.SetId(email)
+
+	return resourceAwsSesEmailIdentityRead(d, meta)
+}
+
+func resourceAwsSesEmailIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	email := d.Id()
+	d.Set("email", email)
+
+	readOpts := &ses.GetIdentityVerificationAttributesInput{
+		Identities: []*string{
+			aws.String(email),
+		},
+	}
+
+	response, err := conn.GetIdentityVerificationAttributes(readOpts)
+	if err != nil {
+		log.Printf("[WARN] Error fetching identity verification attributes for %s: %s", d.Id(), err)
+		return err
+	}
+
+	_, ok := response.VerificationAttributes[email]
+	if !ok {
+		log.Printf("[WARN] Email not listed in response when fetching verification attributes for %s", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "ses",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("identity/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+	return nil
+}
+
+func resourceAwsSesEmailIdentityDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sesConn
+
+	email := d.Get("email").(string)
+
+	deleteOpts := &ses.DeleteIdentityInput{
+		Identity: aws.String(email),
+	}
+
+	_, err := conn.DeleteIdentity(deleteOpts)
+	if err != nil {
+		return fmt.Errorf("Error deleting SES email identity: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_ses_email_identity.go
+++ b/aws/resource_aws_ses_email_identity.go
@@ -83,11 +83,11 @@ func resourceAwsSesEmailIdentityRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Service:   "ses",
-		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
 		Resource:  fmt.Sprintf("identity/%s", d.Id()),
+		Service:   "ses",
 	}.String()
 	d.Set("arn", arn)
 	return nil

--- a/aws/resource_aws_ses_email_identity_test.go
+++ b/aws/resource_aws_ses_email_identity_test.go
@@ -1,0 +1,146 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSSESEmailIdentity_basic(t *testing.T) {
+	email := fmt.Sprintf(
+		"%s@terraformtesting.com",
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSESEmailIdentityConfig(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailIdentityExists("aws_ses_email_identity.test"),
+					testAccCheckAwsSESEmailIdentityArn("aws_ses_email_identity.test", email),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSESEmailIdentity_trailingPeriod(t *testing.T) {
+	email := fmt.Sprintf(
+		"%s@terraformtesting.com.",
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESEmailIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsSESEmailIdentityConfig(email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsSESEmailIdentityExists("aws_ses_email_identity.test"),
+					testAccCheckAwsSESEmailIdentityArn("aws_ses_email_identity.test", email),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsSESEmailIdentityDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sesConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ses_email_identity" {
+			continue
+		}
+
+		email := rs.Primary.ID
+		params := &ses.GetIdentityVerificationAttributesInput{
+			Identities: []*string{
+				aws.String(email),
+			},
+		}
+
+		response, err := conn.GetIdentityVerificationAttributes(params)
+		if err != nil {
+			return err
+		}
+
+		if response.VerificationAttributes[email] != nil {
+			return fmt.Errorf("SES Email Identity %s still exists. Failing!", email)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsSESEmailIdentityExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("SES Email Identity not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("SES Email Identity name not set")
+		}
+
+		email := rs.Primary.ID
+		conn := testAccProvider.Meta().(*AWSClient).sesConn
+
+		params := &ses.GetIdentityVerificationAttributesInput{
+			Identities: []*string{
+				aws.String(email),
+			},
+		}
+
+		response, err := conn.GetIdentityVerificationAttributes(params)
+		if err != nil {
+			return err
+		}
+
+		if response.VerificationAttributes[email] == nil {
+			return fmt.Errorf("SES Email Identity %s not found in AWS", email)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsSESEmailIdentityArn(n string, email string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.RootModule().Resources[n]
+		awsClient := testAccProvider.Meta().(*AWSClient)
+
+		expected := arn.ARN{
+			AccountID: awsClient.accountid,
+			Partition: awsClient.partition,
+			Region:    awsClient.region,
+			Resource:  fmt.Sprintf("identity/%s", strings.TrimSuffix(email, ".")),
+			Service:   "ses",
+		}
+
+		if rs.Primary.Attributes["arn"] != expected.String() {
+			return fmt.Errorf("Incorrect ARN: expected %q, got %q", expected, rs.Primary.Attributes["arn"])
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsSESEmailIdentityConfig(email string) string {
+	return fmt.Sprintf(`
+resource "aws_ses_email_identity" "test" {
+	email = "%s"
+}
+`, email)
+}

--- a/aws/resource_aws_ses_email_identity_test.go
+++ b/aws/resource_aws_ses_email_identity_test.go
@@ -30,6 +30,11 @@ func TestAccAWSSESEmailIdentity_basic(t *testing.T) {
 					testAccCheckAwsSESEmailIdentityArn("aws_ses_email_identity.test", email),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -50,6 +55,11 @@ func TestAccAWSSESEmailIdentity_trailingPeriod(t *testing.T) {
 					testAccCheckAwsSESEmailIdentityExists("aws_ses_email_identity.test"),
 					testAccCheckAwsSESEmailIdentityArn("aws_ses_email_identity.test", email),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -140,7 +150,7 @@ func testAccCheckAwsSESEmailIdentityArn(n string, email string) resource.TestChe
 func testAccAwsSESEmailIdentityConfig(email string) string {
 	return fmt.Sprintf(`
 resource "aws_ses_email_identity" "test" {
-	email = "%s"
+	email = %q
 }
 `, email)
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2341,6 +2341,10 @@
                         </li>
 
                         <li>
+                            <a href="/docs/providers/aws/r/ses_email_identity.html">aws_ses_email_identity</a>
+                        </li>
+
+                        <li>
                             <a href="/docs/providers/aws/r/ses_receipt_filter.html">aws_ses_receipt_filter</a>
                         </li>
 

--- a/website/docs/r/ses_email_identity.html.markdown
+++ b/website/docs/r/ses_email_identity.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "aws"
+page_title: "AWS: ses_email_identity"
+sidebar_current: "docs-aws-resource-ses-email-identity"
+description: |-
+  Provides an SES email identity resource
+---
+
+# aws_ses_email_identity
+
+Provides an SES email identity resource
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `email` - (Required) The email address to assign to SES
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN of the email identity.
+
+## Example Usage
+
+```hcl
+resource "aws_ses_email_identity" "example" {
+  email = "email@example.com"
+}
+```
+
+## Import
+
+SES email identities can be imported using the email address.
+
+```
+$ terraform import aws_ses_email_identity.example email@example.com
+```


### PR DESCRIPTION
Fixes #469

Changes proposed in this pull request:

* Add the resource aws_ses_email_identity

  This resource replicates the relevant functionality of the existing aws_ses_domain_identity resource.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSESEmailIdentity'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSESEmailIdentity -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSESEmailIdentity_basic
=== PAUSE TestAccAWSSESEmailIdentity_basic
=== RUN   TestAccAWSSESEmailIdentity_trailingPeriod
=== PAUSE TestAccAWSSESEmailIdentity_trailingPeriod
=== CONT  TestAccAWSSESEmailIdentity_basic
=== CONT  TestAccAWSSESEmailIdentity_trailingPeriod
--- PASS: TestAccAWSSESEmailIdentity_trailingPeriod (11.96s)
--- PASS: TestAccAWSSESEmailIdentity_basic (11.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       11.990s

```

Edit: I had accidentally pushed my follow-on resources to this branch. I've removed them for now to try and limit the scope of this PR.
