### PR TITLE
r/aws_rds_cluster_endpoint: New Resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -559,6 +559,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_placement_group":                              resourceAwsPlacementGroup(),
 			"aws_proxy_protocol_policy":                        resourceAwsProxyProtocolPolicy(),
 			"aws_rds_cluster":                                  resourceAwsRDSCluster(),
+			"aws_rds_cluster_endpoint":                         resourceAwsRDSClusterEndpoint(),
 			"aws_rds_cluster_instance":                         resourceAwsRDSClusterInstance(),
 			"aws_rds_cluster_parameter_group":                  resourceAwsRDSClusterParameterGroup(),
 			"aws_redshift_cluster":                             resourceAwsRedshiftCluster(),

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -74,7 +74,6 @@ func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{
 	endpointId := d.Get("cluster_endpoint_identifier").(string)
 	endpointType := d.Get("custom_endpoint_type").(string)
 
-
 	createClusterEndpointInput := &rds.CreateDBClusterEndpointInput{
 		DBClusterIdentifier:         aws.String(clusterId),
 		DBClusterEndpointIdentifier: aws.String(endpointId),

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -70,20 +70,10 @@ func resourceAwsRDSClusterEndpoint() *schema.Resource {
 func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 
-	var clusterId string
-	if v, ok := d.GetOk("cluster_identifier"); ok {
-		clusterId = v.(string)
-	}
+	clusterId := d.Get("cluster_identifier").(string)
+	endpointId := d.Get("cluster_endpoint_identifier").(string)
+	endpointType := d.Get("custom_endpoint_type").(string)
 
-	var endpointId string
-	if v, ok := d.GetOk("cluster_endpoint_identifier"); ok {
-		endpointId = v.(string)
-	}
-
-	var endpointType string
-	if v, ok := d.GetOk("custom_endpoint_type"); ok {
-		endpointType = v.(string)
-	}
 
 	createClusterEndpointInput := &rds.CreateDBClusterEndpointInput{
 		DBClusterIdentifier:         aws.String(clusterId),
@@ -91,21 +81,11 @@ func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{
 		EndpointType:                aws.String(endpointType),
 	}
 
-	var staticMembers []*string
 	if v := d.Get("static_members"); v != nil {
-		for _, v := range v.(*schema.Set).List() {
-			str := v.(string)
-			staticMembers = append(staticMembers, aws.String(str))
-		}
-		createClusterEndpointInput.StaticMembers = staticMembers
+		createClusterEndpointInput.StaticMembers = expandStringSet(v.(*schema.Set))
 	}
-	var excludedMembers []*string
 	if v := d.Get("excluded_members"); v != nil {
-		for _, v := range v.(*schema.Set).List() {
-			str := v.(string)
-			excludedMembers = append(excludedMembers, aws.String(str))
-		}
-		createClusterEndpointInput.ExcludedMembers = excludedMembers
+		createClusterEndpointInput.ExcludedMembers = expandStringSet(v.(*schema.Set))
 	}
 
 	_, err := conn.CreateDBClusterEndpoint(createClusterEndpointInput)

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -133,17 +133,13 @@ func resourceAwsRDSClusterEndpointRead(d *schema.ResourceData, meta interface{})
 	d.Set("endpoint", clusterEp.Endpoint)
 	d.Set("custom_endpoint_type", clusterEp.CustomEndpointType)
 
-	excludeMembers := make([]string, 0)
-	for _, member := range clusterEp.ExcludedMembers {
-		excludeMembers = append(excludeMembers, aws.StringValue(member))
+	if err := d.Set("excluded_members", flattenStringList(clusterEp.ExcludedMembers)); err != nil {
+		return fmt.Errorf("error setting excluded_members: %s", err)
 	}
-	d.Set("excluded_members", excludeMembers)
 
-	staticMembers := make([]string, 0)
-	for _, member := range clusterEp.StaticMembers {
-		staticMembers = append(staticMembers, aws.StringValue(member))
+	if err := d.Set("static_members", flattenStringList(clusterEp.StaticMembers)); err != nil {
+		return fmt.Errorf("error setting static_members: %s", err)
 	}
-	d.Set("static_members", staticMembers)
 
 	return nil
 }

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -101,7 +101,7 @@ func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{
 
 	d.SetId(endpointId)
 
-	_, err = resourceAwsRDSClusterEndpointWaitForAvailable(d.Timeout(schema.TimeoutDelete), d.Id(), conn)
+	err = resourceAwsRDSClusterEndpointWaitForAvailable(d.Timeout(schema.TimeoutDelete), d.Id(), conn)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func resourceAwsRDSClusterEndpointWaitForDestroy(timeout time.Duration, id strin
 	return nil
 }
 
-func resourceAwsRDSClusterEndpointWaitForAvailable(timeout time.Duration, id string, conn *rds.RDS) (*rds.DBClusterEndpoint, error) {
+func resourceAwsRDSClusterEndpointWaitForAvailable(timeout time.Duration, id string, conn *rds.RDS) error {
 	log.Printf("Waiting for RDS Cluster Endpoint %s to become available...", id)
 
 	stateConf := &resource.StateChangeConf{
@@ -233,11 +233,11 @@ func resourceAwsRDSClusterEndpointWaitForAvailable(timeout time.Duration, id str
 		MinTimeout: AWSRDSClusterEndpointRetryMinTimeout,
 	}
 
-	info, err := stateConf.WaitForState()
+	_, err := stateConf.WaitForState()
 	if err != nil {
-		return nil, fmt.Errorf("Error waiting for RDS Cluster Endpoint (%s) to be ready: %v", id, err)
+		return fmt.Errorf("Error waiting for RDS Cluster Endpoint (%s) to be ready: %v", id, err)
 	}
-	return info.(*rds.DBClusterEndpoint), nil
+	return nil
 }
 
 func DBClusterEndpointStateRefreshFunc(conn *rds.RDS, id string) resource.StateRefreshFunc {

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -3,11 +3,9 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -110,13 +108,7 @@ func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{
 		createClusterEndpointInput.ExcludedMembers = excludedMembers
 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		_, err := conn.CreateDBClusterEndpoint(createClusterEndpointInput)
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
+	_, err := conn.CreateDBClusterEndpoint(createClusterEndpointInput)
 	if err != nil {
 		return fmt.Errorf("Error creating RDS Cluster Endpoint: %s", err)
 	}
@@ -199,13 +191,7 @@ func resourceAwsRDSClusterEndpointUpdate(d *schema.ResourceData, meta interface{
 		input.StaticMembers = make([]*string, 0)
 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		_, err := conn.ModifyDBClusterEndpoint(input)
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
+	_, err := conn.ModifyDBClusterEndpoint(input)
 	if err != nil {
 		return fmt.Errorf("Error modifying RDS Cluster Endpoint: %s", err)
 	}
@@ -218,13 +204,7 @@ func resourceAwsRDSClusterEndpointDelete(d *schema.ResourceData, meta interface{
 	input := &rds.DeleteDBClusterEndpointInput{
 		DBClusterEndpointIdentifier: aws.String(d.Id()),
 	}
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteDBClusterEndpoint(input)
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
+	_, err := conn.DeleteDBClusterEndpoint(input)
 	if err != nil {
 		return fmt.Errorf("Error deleting RDS Cluster Endpoint: %s", err)
 	}

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -1,0 +1,232 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsRDSClusterEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRDSClusterEndpointCreate,
+		Read:   resourceAwsRDSClusterEndpointRead,
+		Update: resourceAwsRDSClusterEndpointUpdate,
+		Delete: resourceAwsRDSClusterEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_endpoint_identifier": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateRdsIdentifier,
+			},
+			"cluster_identifier": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateRdsIdentifier,
+			},
+			"custom_endpoint_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"READER",
+					"ANY",
+				}, false),
+			},
+			"excluded_members": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ConflictsWith: []string{"static_members"},
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
+			},
+			"static_members": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ConflictsWith: []string{"excluded_members"},
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	var clusterId string
+	if v, ok := d.GetOk("cluster_identifier"); ok {
+		clusterId = v.(string)
+	}
+
+	var endpointId string
+	if v, ok := d.GetOk("cluster_endpoint_identifier"); ok {
+		endpointId = v.(string)
+	}
+
+	var endpointType string
+	if v, ok := d.GetOk("custom_endpoint_type"); ok {
+		endpointType = v.(string)
+	}
+
+	createClusterEndpointInput := &rds.CreateDBClusterEndpointInput{
+		DBClusterIdentifier:         aws.String(clusterId),
+		DBClusterEndpointIdentifier: aws.String(endpointId),
+		EndpointType:                aws.String(endpointType),
+	}
+
+	var staticMembers []*string
+	if v := d.Get("static_members"); v != nil {
+		for _, v := range v.(*schema.Set).List() {
+			str := v.(string)
+			staticMembers = append(staticMembers, aws.String(str))
+		}
+		createClusterEndpointInput.StaticMembers = staticMembers
+	}
+	var excludedMembers []*string
+	if v := d.Get("excluded_members"); v != nil {
+		for _, v := range v.(*schema.Set).List() {
+			str := v.(string)
+			excludedMembers = append(excludedMembers, aws.String(str))
+		}
+		createClusterEndpointInput.ExcludedMembers = excludedMembers
+	}
+
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.CreateDBClusterEndpoint(createClusterEndpointInput)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error creating RDS Cluster Endpoint: %s", err)
+	}
+
+	d.SetId(endpointId)
+	return resourceAwsRDSClusterEndpointRead(d, meta)
+}
+
+func resourceAwsRDSClusterEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	input := &rds.DescribeDBClusterEndpointsInput{
+		DBClusterEndpointIdentifier: aws.String(d.Id()),
+	}
+	log.Printf("[DEBUG] Describing RDS Cluster: %s", input)
+	resp, err := conn.DescribeDBClusterEndpoints(input)
+
+	if err != nil {
+		return fmt.Errorf("error describing RDS Cluster Endpoints (%s): %s", d.Id(), err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("Error retrieving RDS Cluster Endpoints: empty response for: %s", input)
+	}
+
+	var clusterEp *rds.DBClusterEndpoint
+	for _, e := range resp.DBClusterEndpoints {
+		if aws.StringValue(e.DBClusterEndpointIdentifier) == d.Id() {
+			clusterEp = e
+			break
+		}
+	}
+
+	if clusterEp == nil {
+		log.Printf("[WARN] RDS Cluster Endpoint (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("cluster_endpoint_identifier", clusterEp.DBClusterEndpointIdentifier)
+	d.Set("cluster_identifier", clusterEp.DBClusterIdentifier)
+	d.Set("arn", clusterEp.DBClusterEndpointArn)
+	d.Set("endpoint", clusterEp.Endpoint)
+	d.Set("custom_endpoint_type", clusterEp.CustomEndpointType)
+
+	excludeMembers := make([]string, 0)
+	for _, member := range clusterEp.ExcludedMembers {
+		excludeMembers = append(excludeMembers, aws.StringValue(member))
+	}
+	d.Set("excluded_members", excludeMembers)
+
+	staticMembers := make([]string, 0)
+	for _, member := range clusterEp.StaticMembers {
+		staticMembers = append(staticMembers, aws.StringValue(member))
+	}
+	d.Set("static_members", staticMembers)
+
+	return nil
+}
+
+func resourceAwsRDSClusterEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+	input := &rds.ModifyDBClusterEndpointInput{
+		DBClusterEndpointIdentifier: aws.String(d.Id()),
+	}
+
+	if v, ok := d.GetOk("custom_endpoint_type"); ok {
+		input.EndpointType = aws.String(v.(string))
+	}
+
+	if attr := d.Get("excluded_members").(*schema.Set); attr.Len() > 0 {
+		input.ExcludedMembers = expandStringList(attr.List())
+	} else {
+		input.ExcludedMembers = make([]*string, 0)
+	}
+
+	if attr := d.Get("static_members").(*schema.Set); attr.Len() > 0 {
+		input.StaticMembers = expandStringList(attr.List())
+	} else {
+		input.StaticMembers = make([]*string, 0)
+	}
+
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.ModifyDBClusterEndpoint(input)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error modifying RDS Cluster Endpoint: %s", err)
+	}
+
+	return resourceAwsRDSClusterEndpointRead(d, meta)
+}
+
+func resourceAwsRDSClusterEndpointDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+	input := &rds.DeleteDBClusterEndpointInput{
+		DBClusterEndpointIdentifier: aws.String(d.Id()),
+	}
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteDBClusterEndpoint(input)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error deleting RDS Cluster Endpoint: %s", err)
+	}
+	return nil
+}

--- a/aws/resource_aws_rds_cluster_endpoint.go
+++ b/aws/resource_aws_rds_cluster_endpoint.go
@@ -3,11 +3,18 @@ package aws
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+)
+
+const (
+	AWSRDSClusterEndpointRetryDelay      = 5 * time.Second
+	AWSRDSClusterEndpointRetryMinTimeout = 3 * time.Second
 )
 
 func resourceAwsRDSClusterEndpoint() *schema.Resource {
@@ -93,6 +100,12 @@ func resourceAwsRDSClusterEndpointCreate(d *schema.ResourceData, meta interface{
 	}
 
 	d.SetId(endpointId)
+
+	_, err = resourceAwsRDSClusterEndpointWaitForAvailable(d.Timeout(schema.TimeoutDelete), d.Id(), conn)
+	if err != nil {
+		return err
+	}
+
 	return resourceAwsRDSClusterEndpointRead(d, meta)
 }
 
@@ -183,5 +196,72 @@ func resourceAwsRDSClusterEndpointDelete(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("Error deleting RDS Cluster Endpoint: %s", err)
 	}
+
+	if err := resourceAwsRDSClusterEndpointWaitForDestroy(d.Timeout(schema.TimeoutDelete), d.Id(), conn); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func resourceAwsRDSClusterEndpointWaitForDestroy(timeout time.Duration, id string, conn *rds.RDS) error {
+	log.Printf("Waiting for RDS Cluster Endpoint %s to be deleted...", id)
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"available", "deleting"},
+		Target:     []string{"destroyed"},
+		Refresh:    DBClusterEndpointStateRefreshFunc(conn, id),
+		Timeout:    timeout,
+		Delay:      AWSRDSClusterEndpointRetryDelay,
+		MinTimeout: AWSRDSClusterEndpointRetryMinTimeout,
+	}
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for RDS Cluster Endpoint (%s) to be deleted: %v", id, err)
+	}
+	return nil
+}
+
+func resourceAwsRDSClusterEndpointWaitForAvailable(timeout time.Duration, id string, conn *rds.RDS) (*rds.DBClusterEndpoint, error) {
+	log.Printf("Waiting for RDS Cluster Endpoint %s to become available...", id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"available"},
+		Refresh:    DBClusterEndpointStateRefreshFunc(conn, id),
+		Timeout:    timeout,
+		Delay:      AWSRDSClusterEndpointRetryDelay,
+		MinTimeout: AWSRDSClusterEndpointRetryMinTimeout,
+	}
+
+	info, err := stateConf.WaitForState()
+	if err != nil {
+		return nil, fmt.Errorf("Error waiting for RDS Cluster Endpoint (%s) to be ready: %v", id, err)
+	}
+	return info.(*rds.DBClusterEndpoint), nil
+}
+
+func DBClusterEndpointStateRefreshFunc(conn *rds.RDS, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		emptyResp := &rds.DescribeDBClusterEndpointsOutput{}
+
+		resp, err := conn.DescribeDBClusterEndpoints(
+			&rds.DescribeDBClusterEndpointsInput{
+				DBClusterEndpointIdentifier: aws.String(id),
+			})
+		if err != nil {
+			if isAWSErr(err, rds.ErrCodeDBClusterNotFoundFault, "") {
+				return emptyResp, "destroyed", nil
+			} else if resp != nil && len(resp.DBClusterEndpoints) == 0 {
+				return emptyResp, "destroyed", nil
+			} else {
+				return emptyResp, "", fmt.Errorf("Error on refresh: %+v", err)
+			}
+		}
+
+		if resp == nil || resp.DBClusterEndpoints == nil || len(resp.DBClusterEndpoints) == 0 {
+			return emptyResp, "destroyed", nil
+		}
+
+		return resp.DBClusterEndpoints[0], *resp.DBClusterEndpoints[0].Status, nil
+	}
 }

--- a/aws/resource_aws_rds_cluster_endpoint_test.go
+++ b/aws/resource_aws_rds_cluster_endpoint_test.go
@@ -9,33 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAWSRDSClusterEndpoint_importBasic(t *testing.T) {
-	ri := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSClusterEndpointConfig(ri),
-			},
-
-			{
-				ResourceName:      "aws_rds_cluster_endpoint.reader",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-
-			{
-				ResourceName:      "aws_rds_cluster_endpoint.default",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSRDSClusterEndpoint_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	readerResourceName := "aws_rds_cluster_endpoint.reader"
@@ -55,6 +28,18 @@ func TestAccAWSRDSClusterEndpoint_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(defaultResourceName, "endpoint"),
 				),
 			},
+			{
+				ResourceName:      "aws_rds_cluster_endpoint.reader",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			{
+				ResourceName:      "aws_rds_cluster_endpoint.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
 		},
 	})
 }

--- a/aws/resource_aws_rds_cluster_endpoint_test.go
+++ b/aws/resource_aws_rds_cluster_endpoint_test.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSRDSClusterEndpoint_importBasic(t *testing.T) {
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterEndpointConfig(ri),
+			},
+
+			{
+				ResourceName:      "aws_rds_cluster_endpoint.reader",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			{
+				ResourceName:      "aws_rds_cluster_endpoint.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterEndpoint_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	readerResourceName := "aws_rds_cluster_endpoint.reader"
+	defaultResourceName := "aws_rds_cluster_endpoint.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterEndpointConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(readerResourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-endpoint:.+`)),
+					resource.TestCheckResourceAttrSet(readerResourceName, "endpoint"),
+					resource.TestMatchResourceAttr(defaultResourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-endpoint:.+`)),
+					resource.TestCheckResourceAttrSet(defaultResourceName, "endpoint"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSClusterEndpointConfig(n int) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.aurora5.6"
+  skip_final_snapshot = true
+}
+
+resource "aws_rds_cluster_instance" "test1" {
+  apply_immediately = true
+  cluster_identifier = "${aws_rds_cluster.default.id}"
+  identifier = "tf-aurora-cluster-instance-test1-%d"
+  instance_class = "db.t2.small"
+}
+
+resource "aws_rds_cluster_instance" "test2" {
+  apply_immediately = true
+  cluster_identifier = "${aws_rds_cluster.default.id}"
+  identifier = "tf-aurora-cluster-instance-test2-%d"
+  instance_class = "db.t2.small"
+}
+
+resource "aws_rds_cluster_endpoint" "reader" {
+  cluster_identifier = "${aws_rds_cluster.default.id}"
+  cluster_endpoint_identifier = "reader-%d"
+  custom_endpoint_type = "READER"
+
+  static_members = ["${aws_rds_cluster_instance.test2.id}"]
+}
+
+resource "aws_rds_cluster_endpoint" "default" {
+  cluster_identifier = "${aws_rds_cluster.default.id}"
+  cluster_endpoint_identifier = "default-%d"
+  custom_endpoint_type = "ANY"
+
+  excluded_members = ["${aws_rds_cluster_instance.test2.id}"]
+}
+`, n, n, n, n, n)
+}

--- a/aws/resource_aws_rds_cluster_endpoint_test.go
+++ b/aws/resource_aws_rds_cluster_endpoint_test.go
@@ -22,9 +22,9 @@ func TestAccAWSRDSClusterEndpoint_basic(t *testing.T) {
 			{
 				Config: testAccAWSClusterEndpointConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(readerResourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-endpoint:.+`)),
+					testAccMatchResourceAttrRegionalARN(readerResourceName, "arn", "rds", regexp.MustCompile(`cluster-endpoint:.+`)),
 					resource.TestCheckResourceAttrSet(readerResourceName, "endpoint"),
-					resource.TestMatchResourceAttr(defaultResourceName, "arn", regexp.MustCompile(`^arn:[^:]+:rds:[^:]+:\d{12}:cluster-endpoint:.+`)),
+					testAccMatchResourceAttrRegionalARN(defaultResourceName, "arn", "rds", regexp.MustCompile(`cluster-endpoint:.+`)),
 					resource.TestCheckResourceAttrSet(defaultResourceName, "endpoint"),
 				),
 			},

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1815,6 +1815,10 @@
                             <a href="/docs/providers/aws/r/rds_cluster.html">aws_rds_cluster</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-rds-cluster-endpoint") %>>
+                            <a href="/docs/providers/aws/r/rds_cluster_endpoint.html">aws_rds_cluster_endpoint</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-rds-cluster-instance") %>>
                             <a href="/docs/providers/aws/r/rds_cluster_instance.html">aws_rds_cluster_instance</a>
                         </li>

--- a/website/docs/r/rds_cluster_endpoint.html.markdown
+++ b/website/docs/r/rds_cluster_endpoint.html.markdown
@@ -1,0 +1,102 @@
+---
+layout: "aws"
+page_title: "AWS: aws_rds_cluster_endpoint"
+sidebar_current: "docs-aws-resource-rds-cluster-endpoint"
+description: |-
+  Manages a RDS Aurora Cluster Endpoint
+---
+
+# aws_rds_cluster_endpoint
+
+Manages a RDS Aurora Cluster Endpoint.
+You can refer to the [User Guide][1].
+
+
+## Example Usage
+
+```hcl
+resource "aws_rds_cluster" "default" {
+  cluster_identifier      = "aurora-cluster-demo"
+  availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  database_name           = "mydb"
+  master_username         = "foo"
+  master_password         = "bar"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+}
+
+resource "aws_rds_cluster_instance" "test1" {
+  apply_immediately       = true
+  cluster_identifier      = "${aws_rds_cluster.default.id}"
+  identifier              = "test1"
+  instance_class          = "db.t2.small"
+}
+
+resource "aws_rds_cluster_instance" "test2" {
+  apply_immediately       = true
+  cluster_identifier      = "${aws_rds_cluster.default.id}"
+  identifier              = "test2"
+  instance_class          = "db.t2.small"
+}
+
+resource "aws_rds_cluster_instance" "test3" {
+  apply_immediately       = true
+  cluster_identifier      = "${aws_rds_cluster.default.id}"
+  identifier              = "test3"
+  instance_class          = "db.t2.small"
+}
+
+resource "aws_rds_cluster_endpoint" "eligible" {
+  cluster_identifier          = "${aws_rds_cluster.default.id}"
+  cluster_endpoint_identifier = "reader"
+  custom_endpoint_type        = "READER"
+  
+  excluded_members = [
+    "${aws_rds_cluster_instance.test1.id}",
+    "${aws_rds_cluster_instance.test2.id}",
+  ]
+}
+
+resource "aws_rds_cluster_endpoint" "static" {
+  cluster_identifier          = "${aws_rds_cluster.default.id}"
+  cluster_endpoint_identifier = "static"
+  custom_endpoint_type        = "READER"
+  
+  static_members = [
+    "${aws_rds_cluster_instance.test1.id}",
+    "${aws_rds_cluster_instance.test3.id}",
+  ]
+}
+```
+
+## Argument Reference
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster-endpoint.html).
+
+The following arguments are supported:
+
+* `cluster_identifier` - (Required, Forces new resources) The cluster identifier.
+* `cluster_endpoint_identifier` - (Required, Forces new resources) The identifier to use for the new endpoint. This parameter is stored as a lowercase string.
+* `custom_endpoint_type` - (Required) The type of the endpoint. One of: READER , ANY .
+* `static_members` - (Optional) List of DB instance identifiers that are part of the custom endpoint group. Conflicts with `excluded_members`.
+* `excluded_members` - (Optional) List of DB instance identifiers that aren't part of the custom endpoint group. All other eligible instances are reachable through the custom endpoint. Only relevant if the list of static members is empty. Conflicts with `static_members`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of cluster
+* `id` - The RDS Cluster Endpoint Identifier
+* `endpoint` - A custom endpoint for the Aurora cluster
+
+
+## Import
+
+RDS Clusters Endpoint can be imported using the `cluster_endpoint_identifier`, e.g.
+
+```
+$ terraform import aws_rds_cluster_endpoint.custom_reader aurora-prod-cluster-custom-reader
+```
+
+[1]: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.Endpoints.html#Aurora.Endpoints.Cluster


### PR DESCRIPTION
Changes proposed in this pull request:

* Adds `aws_rds_cluster_endpoint` resource.
    * [Official User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.Endpoints.html#Aurora.Endpoints.Cluster)
    * [Announcement: Amazon Aurora Simplifies Workload Management with Custom Endpoints](https://forums.aws.amazon.com/ann.jspa?annID=6304)

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRDSClusterEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSRDSClusterEndpoint -timeout 120m
=== RUN   TestAccAWSRDSClusterEndpoint_importBasic
=== PAUSE TestAccAWSRDSClusterEndpoint_importBasic
=== RUN   TestAccAWSRDSClusterEndpoint_basic
=== PAUSE TestAccAWSRDSClusterEndpoint_basic
=== CONT  TestAccAWSRDSClusterEndpoint_importBasic
=== CONT  TestAccAWSRDSClusterEndpoint_basic
--- PASS: TestAccAWSRDSClusterEndpoint_basic (912.30s)
--- PASS: TestAccAWSRDSClusterEndpoint_importBasic (999.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       999.313s
```
