### PR TITLE
resource/aws_cloudtrail: Add is_organization_trail argument and refactor import testing

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -59,6 +59,11 @@ func resourceAwsCloudTrail() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"is_organization_trail": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"sns_topic_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -150,6 +155,9 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	if v, ok := d.GetOk("is_multi_region_trail"); ok {
 		input.IsMultiRegionTrail = aws.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("is_organization_trail"); ok {
+		input.IsOrganizationTrail = aws.Bool(v.(bool))
 	}
 	if v, ok := d.GetOk("enable_log_file_validation"); ok {
 		input.EnableLogFileValidation = aws.Bool(v.(bool))
@@ -243,6 +251,7 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cloud_watch_logs_group_arn", trail.CloudWatchLogsLogGroupArn)
 	d.Set("include_global_service_events", trail.IncludeGlobalServiceEvents)
 	d.Set("is_multi_region_trail", trail.IsMultiRegionTrail)
+	d.Set("is_organization_trail", trail.IsOrganizationTrail)
 	d.Set("sns_topic_name", trail.SnsTopicName)
 	d.Set("enable_log_file_validation", trail.LogFileValidationEnabled)
 
@@ -319,6 +328,9 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 	if d.HasChange("is_multi_region_trail") {
 		input.IsMultiRegionTrail = aws.Bool(d.Get("is_multi_region_trail").(bool))
+	}
+	if d.HasChange("is_organization_trail") {
+		input.IsOrganizationTrail = aws.Bool(d.Get("is_organization_trail").(bool))
 	}
 	if d.HasChange("enable_log_file_validation") {
 		input.EnableLogFileValidation = aws.Bool(d.Get("enable_log_file_validation").(bool))

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -906,7 +906,9 @@ POLICY
 
 func testAccAWSCloudTrailConfigOrganization(cloudTrailRandInt int) string {
 	return fmt.Sprintf(`
-resource "aws_organizations_organization" "test" {}
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = ["cloudtrail.amazonaws.com"]
+}
 
 resource "aws_cloudtrail" "foobar" {
   is_organization_trail = true

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -17,14 +17,15 @@ import (
 func TestAccAWSCloudTrail(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Trail": {
-			"basic":         testAccAWSCloudTrail_basic,
-			"cloudwatch":    testAccAWSCloudTrail_cloudwatch,
-			"enableLogging": testAccAWSCloudTrail_enable_logging,
-			"isMultiRegion": testAccAWSCloudTrail_is_multi_region,
-			"logValidation": testAccAWSCloudTrail_logValidation,
-			"kmsKey":        testAccAWSCloudTrail_kmsKey,
-			"tags":          testAccAWSCloudTrail_tags,
-			"eventSelector": testAccAWSCloudTrail_event_selector,
+			"basic":                      testAccAWSCloudTrail_basic,
+			"cloudwatch":                 testAccAWSCloudTrail_cloudwatch,
+			"enableLogging":              testAccAWSCloudTrail_enable_logging,
+			"includeGlobalServiceEvents": testAccAWSCloudTrail_include_global_service_events,
+			"isMultiRegion":              testAccAWSCloudTrail_is_multi_region,
+			"logValidation":              testAccAWSCloudTrail_logValidation,
+			"kmsKey":                     testAccAWSCloudTrail_kmsKey,
+			"tags":                       testAccAWSCloudTrail_tags,
+			"eventSelector":              testAccAWSCloudTrail_event_selector,
 		},
 	}
 
@@ -39,29 +40,6 @@ func TestAccAWSCloudTrail(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestAccAWSCloudTrail_importBasic(t *testing.T) {
-	resourceName := "aws_cloudtrail.foobar"
-	cloudTrailRandInt := acctest.RandInt()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudTrailDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enable_log_file_validation", "is_multi_region_trail", "include_global_service_events", "enable_logging"},
-			},
-		},
-	})
 }
 
 func testAccAWSCloudTrail_basic(t *testing.T) {
@@ -81,6 +59,11 @@ func testAccAWSCloudTrail_basic(t *testing.T) {
 					testAccCheckCloudTrailLogValidationEnabled("aws_cloudtrail.foobar", false, &trail),
 					testAccCheckCloudTrailKmsKeyIdEquals("aws_cloudtrail.foobar", "", &trail),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
@@ -114,6 +97,11 @@ func testAccAWSCloudTrail_cloudwatch(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_cloudtrail.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCloudTrailConfigCloudWatchModified(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.test", &trail),
@@ -144,6 +132,11 @@ func testAccAWSCloudTrail_enable_logging(t *testing.T) {
 					testAccCheckCloudTrailLogValidationEnabled("aws_cloudtrail.foobar", false, &trail),
 					testAccCheckCloudTrailKmsKeyIdEquals("aws_cloudtrail.foobar", "", &trail),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCloudTrailConfigModified(cloudTrailRandInt),
@@ -195,6 +188,11 @@ func testAccAWSCloudTrail_is_multi_region(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCloudTrailConfig(cloudTrailRandInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
@@ -225,6 +223,11 @@ func testAccAWSCloudTrail_logValidation(t *testing.T) {
 					testAccCheckCloudTrailLogValidationEnabled("aws_cloudtrail.foobar", true, &trail),
 					testAccCheckCloudTrailKmsKeyIdEquals("aws_cloudtrail.foobar", "", &trail),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCloudTrailConfig_logValidationModified(cloudTrailRandInt),
@@ -260,6 +263,11 @@ func testAccAWSCloudTrail_kmsKey(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_cloudtrail.foobar", "kms_key_id", keyRegex),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -287,6 +295,11 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
@@ -312,7 +325,7 @@ func testAccAWSCloudTrail_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSCloudTrail_include_global_service_events(t *testing.T) {
+func testAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 	var trail cloudtrail.Trail
 	cloudTrailRandInt := acctest.RandInt()
 
@@ -327,6 +340,11 @@ func TestAccAWSCloudTrail_include_global_service_events(t *testing.T) {
 					testAccCheckCloudTrailExists("aws_cloudtrail.foobar", &trail),
 					resource.TestCheckResourceAttr("aws_cloudtrail.foobar", "include_global_service_events", "false"),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -352,6 +370,11 @@ func testAccAWSCloudTrail_event_selector(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudtrail.foobar", "event_selector.0.include_management_events", "false"),
 					resource.TestCheckResourceAttr("aws_cloudtrail.foobar", "event_selector.0.read_write_type", "ReadOnly"),
 				),
+			},
+			{
+				ResourceName:      "aws_cloudtrail.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSCloudTrailConfig_eventSelectorModified(cloudTrailRandInt),

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Provides a CloudTrail resource.
 
+~> *NOTE:* For a multi-region trail, this resource must be in the home region of the trail.
+
+~> *NOTE:* For an organization trail, this resource must be in the master account of the organization.
+
 ## Example Usage
 
 ### Basic
@@ -145,6 +149,7 @@ The following arguments are supported:
     from global services such as IAM to the log files. Defaults to `true`.
 * `is_multi_region_trail` - (Optional) Specifies whether the trail is created in the current
     region or in all regions. Defaults to `false`.
+* `is_organization_trail` - (Optional) Specifies whether the trail is an AWS Organizations trail. Organization trails log events for the master account and all member accounts. Can only be created in the organization master account. Defaults to `false`.
 * `sns_topic_name` - (Optional) Specifies the name of the Amazon SNS topic
     defined for notification of log file delivery.
 * `enable_log_file_validation` - (Optional) Specifies whether log file integrity validation is enabled.


### PR DESCRIPTION
Closes #6579 

Changes proposed in this pull request:

* resource/aws_cloudtrail: Add `is_organization_trail` argument
* tests/resource/aws_cloudtrail: Add import TestStep to all acceptance tests and add include_global_service_events to serialization

Output from acceptance testing (regular acceptance testing account):

```
--- PASS: TestAccAWSCloudTrail (612.66s)
    --- PASS: TestAccAWSCloudTrail/Trail (612.66s)
        --- PASS: TestAccAWSCloudTrail/Trail/cloudwatch (77.06s)
        --- SKIP: TestAccAWSCloudTrail/Trail/isOrganization (0.96s)
            provider_test.go:242: skipping tests; this AWS account must not be an existing member of an AWS Organization
        --- PASS: TestAccAWSCloudTrail/Trail/logValidation (62.78s)
        --- PASS: TestAccAWSCloudTrail/Trail/eventSelector (67.81s)
        --- PASS: TestAccAWSCloudTrail/Trail/basic (58.55s)
        --- PASS: TestAccAWSCloudTrail/Trail/enableLogging (83.97s)
        --- PASS: TestAccAWSCloudTrail/Trail/includeGlobalServiceEvents (38.29s)
        --- PASS: TestAccAWSCloudTrail/Trail/isMultiRegion (80.90s)
        --- PASS: TestAccAWSCloudTrail/Trail/kmsKey (59.54s)
        --- PASS: TestAccAWSCloudTrail/Trail/tags (82.79s)
```

Output from acceptance testing (Organizations acceptance testing account):

```
--- PASS: TestAccAWSCloudTrail (61.47s)
    --- PASS: TestAccAWSCloudTrail/Trail (61.47s)
        --- PASS: TestAccAWSCloudTrail/Trail/isOrganization (61.47s)
```
