### PR TITLE
 resource/aws_organizations_organization: Support managing AWS service access principals and refactor testing

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -14,6 +14,7 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsOrganizationsOrganizationCreate,
 		Read:   resourceAwsOrganizationsOrganizationRead,
+		Update: resourceAwsOrganizationsOrganizationUpdate,
 		Delete: resourceAwsOrganizationsOrganizationDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -35,6 +36,11 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 			"master_account_id": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"aws_service_access_principals": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"feature_set": {
 				Type:     schema.TypeString,
@@ -66,6 +72,21 @@ func resourceAwsOrganizationsOrganizationCreate(d *schema.ResourceData, meta int
 	org := resp.Organization
 	d.SetId(*org.Id)
 
+	awsServiceAccessPrincipals := d.Get("aws_service_access_principals").(*schema.Set).List()
+	for _, principalRaw := range awsServiceAccessPrincipals {
+		principal := principalRaw.(string)
+		input := &organizations.EnableAWSServiceAccessInput{
+			ServicePrincipal: aws.String(principal),
+		}
+
+		log.Printf("[DEBUG] Enabling AWS Service Access in Organization: %s", input)
+		_, err := conn.EnableAWSServiceAccess(input)
+
+		if err != nil {
+			return fmt.Errorf("error enabling AWS Service Access (%s) in Organization: %s", principal, err)
+		}
+	}
+
 	return resourceAwsOrganizationsOrganizationRead(d, meta)
 }
 
@@ -74,13 +95,15 @@ func resourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta inter
 
 	log.Printf("[INFO] Reading Organization: %s", d.Id())
 	org, err := conn.DescribeOrganization(&organizations.DescribeOrganizationInput{})
+
+	if isAWSErr(err, organizations.ErrCodeAWSOrganizationsNotInUseException, "") {
+		log.Printf("[WARN] Organization does not exist, removing from state: %s", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, organizations.ErrCodeAWSOrganizationsNotInUseException, "") {
-			log.Printf("[WARN] Organization does not exist, removing from state: %s", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error describing Organization: %s", err)
 	}
 
 	d.Set("arn", org.Organization.Arn)
@@ -88,7 +111,68 @@ func resourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta inter
 	d.Set("master_account_arn", org.Organization.MasterAccountArn)
 	d.Set("master_account_email", org.Organization.MasterAccountEmail)
 	d.Set("master_account_id", org.Organization.MasterAccountId)
+
+	awsServiceAccessPrincipals := make([]string, 0)
+
+	// ConstraintViolationException: The request failed because the organization does not have all features enabled. Please enable all features in your organization and then retry.
+	if aws.StringValue(org.Organization.FeatureSet) == organizations.OrganizationFeatureSetAll {
+		err = conn.ListAWSServiceAccessForOrganizationPages(&organizations.ListAWSServiceAccessForOrganizationInput{}, func(page *organizations.ListAWSServiceAccessForOrganizationOutput, lastPage bool) bool {
+			for _, enabledServicePrincipal := range page.EnabledServicePrincipals {
+				awsServiceAccessPrincipals = append(awsServiceAccessPrincipals, aws.StringValue(enabledServicePrincipal.ServicePrincipal))
+			}
+			return !lastPage
+		})
+
+		if err != nil {
+			return fmt.Errorf("error listing AWS Service Access for Organization (%s): %s", d.Id(), err)
+		}
+	}
+
+	if err := d.Set("aws_service_access_principals", awsServiceAccessPrincipals); err != nil {
+		return fmt.Errorf("error setting aws_service_access_principals: %s", err)
+	}
+
 	return nil
+}
+
+func resourceAwsOrganizationsOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+
+	if d.HasChange("aws_service_access_principals") {
+		oldRaw, newRaw := d.GetChange("aws_service_access_principals")
+		oldSet := oldRaw.(*schema.Set)
+		newSet := newRaw.(*schema.Set)
+
+		for _, disablePrincipalRaw := range oldSet.Difference(newSet).List() {
+			principal := disablePrincipalRaw.(string)
+			input := &organizations.DisableAWSServiceAccessInput{
+				ServicePrincipal: aws.String(principal),
+			}
+
+			log.Printf("[DEBUG] Disabling AWS Service Access in Organization: %s", input)
+			_, err := conn.DisableAWSServiceAccess(input)
+
+			if err != nil {
+				return fmt.Errorf("error disabling AWS Service Access (%s) in Organization: %s", principal, err)
+			}
+		}
+
+		for _, enablePrincipalRaw := range newSet.Difference(oldSet).List() {
+			principal := enablePrincipalRaw.(string)
+			input := &organizations.EnableAWSServiceAccessInput{
+				ServicePrincipal: aws.String(principal),
+			}
+
+			log.Printf("[DEBUG] Enabling AWS Service Access in Organization: %s", input)
+			_, err := conn.EnableAWSServiceAccess(input)
+
+			if err != nil {
+				return fmt.Errorf("error enabling AWS Service Access (%s) in Organization: %s", principal, err)
+			}
+		}
+	}
+
+	return resourceAwsOrganizationsOrganizationRead(d, meta)
 }
 
 func resourceAwsOrganizationsOrganizationDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -24,6 +24,7 @@ func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "organizations", regexp.MustCompile(`organization/o-.+`)),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "feature_set", organizations.OrganizationFeatureSetAll),
 					testAccMatchResourceAttrGlobalARN(resourceName, "master_account_arn", "organizations", regexp.MustCompile(`account/o-.+/.+`)),
 					resource.TestMatchResourceAttr(resourceName, "master_account_email", regexp.MustCompile(`.+@.+`)),
@@ -34,6 +35,49 @@ func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals(t *testing.T) {
+	var organization organizations.Organization
+	resourceName := "aws_organizations_organization.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsOrganizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsOrganizationConfigAwsServiceAccessPrincipals1("config.amazonaws.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.553690328", "config.amazonaws.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsOrganizationsOrganizationConfigAwsServiceAccessPrincipals2("config.amazonaws.com", "ds.amazonaws.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.553690328", "config.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.3567899500", "ds.amazonaws.com"),
+				),
+			},
+			{
+				Config: testAccAwsOrganizationsOrganizationConfigAwsServiceAccessPrincipals1("fms.amazonaws.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.4066123156", "fms.amazonaws.com"),
+				),
 			},
 		},
 	})
@@ -123,6 +167,22 @@ func testAccCheckAwsOrganizationsOrganizationExists(n string, a *organizations.O
 }
 
 const testAccAwsOrganizationsOrganizationConfig = "resource \"aws_organizations_organization\" \"test\" {}"
+
+func testAccAwsOrganizationsOrganizationConfigAwsServiceAccessPrincipals1(principal1 string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = [%q]
+}
+`, principal1)
+}
+
+func testAccAwsOrganizationsOrganizationConfigAwsServiceAccessPrincipals2(principal1, principal2 string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {
+  aws_service_access_principals = [%q, %q]
+}
+`, principal1, principal2)
+}
 
 func testAccAwsOrganizationsOrganizationConfigFeatureSet(featureSet string) string {
 	return fmt.Sprintf(`

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -7,9 +7,8 @@ import (
 func TestAccAWSOrganizations(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Organization": {
-			"basic":               testAccAwsOrganizationsOrganization_basic,
-			"importBasic":         testAccAwsOrganizationsOrganization_importBasic,
-			"consolidatedBilling": testAccAwsOrganizationsOrganization_consolidatedBilling,
+			"basic":      testAccAwsOrganizationsOrganization_basic,
+			"FeatureSet": testAccAwsOrganizationsOrganization_FeatureSet,
 		},
 		"Account": {
 			"basic": testAccAwsOrganizationsAccount_basic,

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -7,8 +7,9 @@ import (
 func TestAccAWSOrganizations(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Organization": {
-			"basic":      testAccAwsOrganizationsOrganization_basic,
-			"FeatureSet": testAccAwsOrganizationsOrganization_FeatureSet,
+			"basic":                      testAccAwsOrganizationsOrganization_basic,
+			"AwsServiceAccessPrincipals": testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals,
+			"FeatureSet":                 testAccAwsOrganizationsOrganization_FeatureSet,
 		},
 		"Account": {
 			"basic": testAccAwsOrganizationsAccount_basic,

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -14,6 +14,11 @@ Provides a resource to create an organization.
 
 ```hcl
 resource "aws_organizations_organization" "org" {
+  aws_service_access_principals = [
+    "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+  ]
+
   feature_set = "ALL"
 }
 ```
@@ -22,6 +27,7 @@ resource "aws_organizations_organization" "org" {
 
 The following arguments are supported:
 
+* `aws_service_access_principals` - (Optional) List of AWS service principal names for which you want to enable integration with your organization. This is typically in the form of a URL, such as service-abbreviation.amazonaws.com. Organization must have `feature_set` set to `ALL`. For additional information, see the [AWS Organizations User Guide](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html).
 * `feature_set` - (Optional) Specify "ALL" (default) or "CONSOLIDATED_BILLING".
 
 ## Attributes Reference


### PR DESCRIPTION
Prerequisite for #6580 testing

Changes:
* tests/resource/aws_organizations_organization: Perform stricter attribute checking
* tests/resource/aws_organizations_organization: Perform import testing in all acceptance tests
* resource/aws_organizations_organization: Add `aws_service_access_principals` argument

Output from acceptance testing:

```
--- PASS: TestAccAWSOrganizations (58.72s)
    --- PASS: TestAccAWSOrganizations/Organization (58.72s)
        --- PASS: TestAccAWSOrganizations/Organization/basic (16.86s)
        --- PASS: TestAccAWSOrganizations/Organization/AwsServiceAccessPrincipals (29.94s)
        --- PASS: TestAccAWSOrganizations/Organization/FeatureSet (11.93s)
```
