### PR TITLE
Support S3 Intelligent-Tiering storage class

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -295,7 +295,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 									"storage_class": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validateS3BucketLifecycleStorageClass(),
+										ValidateFunc: validateS3BucketLifecycleTransitionStorageClass(),
 									},
 								},
 							},
@@ -314,7 +314,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 									"storage_class": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validateS3BucketLifecycleStorageClass(),
+										ValidateFunc: validateS3BucketLifecycleTransitionStorageClass(),
 									},
 								},
 							},
@@ -393,9 +393,10 @@ func resourceAwsS3Bucket() *schema.Resource {
 													Optional: true,
 													ValidateFunc: validation.StringInSlice([]string{
 														s3.StorageClassStandard,
-														s3.StorageClassOnezoneIa,
-														s3.StorageClassStandardIa,
 														s3.StorageClassReducedRedundancy,
+														s3.StorageClassStandardIa,
+														s3.StorageClassOnezoneIa,
+														s3.StorageClassIntelligentTiering,
 													}, false),
 												},
 												"replica_kms_key_id": {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -106,10 +106,11 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					s3.StorageClassStandard,
-					s3.StorageClassReducedRedundancy,
-					s3.StorageClassOnezoneIa,
-					s3.StorageClassStandardIa,
+					s3.ObjectStorageClassStandard,
+					s3.ObjectStorageClassReducedRedundancy,
+					s3.ObjectStorageClassStandardIa,
+					s3.ObjectStorageClassOnezoneIa,
+					s3.ObjectStorageClassIntelligentTiering,
 				}, false),
 			},
 

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -481,6 +481,21 @@ func TestAccAWSS3BucketObject_storageClass(t *testing.T) {
 						"REDUCED_REDUNDANCY"),
 				),
 			},
+			{
+				Config: testAccAWSS3BucketObjectConfig_storageClass(rInt, "INTELLIGENT_TIERING"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(
+						"aws_s3_bucket_object.object",
+						&obj),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket_object.object",
+						"storage_class",
+						"INTELLIGENT_TIERING"),
+					testAccCheckAWSS3BucketObjectStorageClass(
+						"aws_s3_bucket_object.object",
+						"INTELLIGENT_TIERING"),
+				),
+			},
 		},
 	})
 }

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -783,17 +783,23 @@ func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.2000431762.storage_class", "STANDARD_IA"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3008443917.date", ""),
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3601168188.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3008443917.days", "60"),
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3601168188.days", "60"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3008443917.storage_class", "ONEZONE_IA"),
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3601168188.storage_class", "INTELLIGENT_TIERING"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.2476382906.date", ""),
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3854926587.date", ""),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.2476382906.days", "90"),
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3854926587.days", "90"),
 					resource.TestCheckResourceAttr(
-						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.2476382906.storage_class", "GLACIER"),
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.3854926587.storage_class", "ONEZONE_IA"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.962205413.date", ""),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.962205413.days", "120"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.962205413.storage_class", "GLACIER"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.id", "id2"),
 					resource.TestCheckResourceAttr(
@@ -2272,11 +2278,16 @@ resource "aws_s3_bucket" "bucket" {
 
 		transition {
 			days = 60
-			storage_class = "ONEZONE_IA"
+			storage_class = "INTELLIGENT_TIERING"
 		}
 
 		transition {
 			days = 90
+			storage_class = "ONEZONE_IA"
+		}
+
+		transition {
+			days = 120
 			storage_class = "GLACIER"
 		}
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -644,11 +644,12 @@ func validateS3BucketLifecycleTimestamp(v interface{}, k string) (ws []string, e
 	return
 }
 
-func validateS3BucketLifecycleStorageClass() schema.SchemaValidateFunc {
+func validateS3BucketLifecycleTransitionStorageClass() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
-		s3.TransitionStorageClassOnezoneIa,
-		s3.TransitionStorageClassStandardIa,
 		s3.TransitionStorageClassGlacier,
+		s3.TransitionStorageClassStandardIa,
+		s3.TransitionStorageClassOnezoneIa,
+		s3.TransitionStorageClassIntelligentTiering,
 	}, false)
 }
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -387,7 +387,7 @@ The `transition` object supports the following
 
 * `date` (Optional) Specifies the date after which you want the corresponding action to take effect.
 * `days` (Optional) Specifies the number of days after object creation when the specific rule action takes effect.
-* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, or `GLACIER`.
+* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, or `GLACIER`.
 
 The `noncurrent_version_expiration` object supports the following
 
@@ -396,7 +396,7 @@ The `noncurrent_version_expiration` object supports the following
 The `noncurrent_version_transition` object supports the following
 
 * `days` (Required) Specifies the number of days an object is noncurrent object versions expire.
-* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the noncurrent versions object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, or `GLACIER`.
+* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the noncurrent versions object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, or `GLACIER`.
 
 The `replication_configuration` object supports the following:
 
@@ -423,7 +423,7 @@ Replication configuration V1 supports filtering based on only the `prefix` attri
 The `destination` object supports the following:
 
 * `bucket` - (Required) The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
-* `storage_class` - (Optional) The class of storage used to store the object.
+* `storage_class` - (Optional) The class of storage used to store the object. Can be `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`, `ONEZONE_IA`, or `INTELLIGENT_TIERING`.
 * `replica_kms_key_id` - (Optional) Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
   `sse_kms_encrypted_objects` source selection criteria.
 * `access_control_translation` - (Optional) Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
 * `website_redirect` - (Optional) Specifies a target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
 * `storage_class` - (Optional) Specifies the desired [Storage Class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)
-for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", "`ONEZONE_IA`", or "`STANDARD_IA`". Defaults to "`STANDARD`".
+for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", "`ONEZONE_IA`", "`INTELLIGENT_TIERING`", or "`STANDARD_IA`". Defaults to "`STANDARD`".
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`.
 This attribute is not compatible with KMS encryption, `kms_key_id` or `server_side_encryption = "aws:kms"`.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6588.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3BucketObject_storageClass'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3BucketObject_storageClass -timeout 120m
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_storageClass
--- PASS: TestAccAWSS3BucketObject_storageClass (75.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	94.751s
$ make testacc TEST=./aws/ TESTARGS='-run=^TestAccAWSS3Bucket_Lifecycle$'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=^TestAccAWSS3Bucket_Lifecycle -timeout 120m
=== RUN   TestAccAWSS3Bucket_Lifecycle
=== PAUSE TestAccAWSS3Bucket_Lifecycle
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== CONT  TestAccAWSS3Bucket_Lifecycle
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (53.31s)
--- PASS: TestAccAWSS3Bucket_Lifecycle (76.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	94.304s
```