### PR TITLE
docs/resource/aws_datasync_task: Fix example oversight

### DIFF
--- a/website/docs/r/datasync_task.html.markdown
+++ b/website/docs/r/datasync_task.html.markdown
@@ -16,7 +16,7 @@ Manages an AWS DataSync Task, which represents a configuration for synchronizati
 resource "aws_datasync_task" "example" {
   destination_location_arn = "${aws_datasync_location_s3.destination.arn}"
   name                     = "example"
-  source_location_arn      = "${aws_datasync_location_s3.source.arn}"
+  source_location_arn      = "${aws_datasync_location_nfs.source.arn}"
 
   options {
     bytes_per_second = -1


### PR DESCRIPTION
DataSync does not allow S3 to S3 tasks. 😄 

Output from acceptance testing: N/A
