### PR TITLE
resource/aws_db_instance: allow configuring-iam-database-auth as pending state

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1612,6 +1612,7 @@ func diffCloudwatchLogsExportConfiguration(old, new []interface{}) ([]interface{
 var resourceAwsDbInstanceCreatePendingStates = []string{
 	"backing-up",
 	"configuring-enhanced-monitoring",
+	"configuring-iam-database-auth",
 	"configuring-log-exports",
 	"creating",
 	"maintenance",
@@ -1642,6 +1643,7 @@ var resourceAwsDbInstanceDeletePendingStates = []string{
 var resourceAwsDbInstanceUpdatePendingStates = []string{
 	"backing-up",
 	"configuring-enhanced-monitoring",
+	"configuring-iam-database-auth",
 	"configuring-log-exports",
 	"creating",
 	"maintenance",


### PR DESCRIPTION
Currently, terraform errors if you try to enable iam db auth and it takes over 30 seconds. This triggers the default waiter, which throws:
```
* aws_db_instance.default: error waiting for DB Instance (dbname) to be available: unexpected state 'configuring-iam-database-auth', wanted target 'available, storage-optimization'. last error: %!s(<nil>)
```

This state is not listed in the AWS documentation, but I've opened a separate [issue](https://github.com/awsdocs/amazon-rds-user-guide/issues/44) for that.

---

I tried to follow along #3708 which was the most similar change I could find - likewise I didn't see any good place to write tests for this.