### PR TITLE
r/ecs_service: add propagate_tags attribute

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -301,6 +301,17 @@ func resourceAwsEcsService() *schema.Resource {
 				},
 			},
 
+			"propagate_tags": {
+				Type:     schema.TypeString,
+				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "NONE" && new == "" {
+						return true
+					}
+					return false
+				},
+			},
+
 			"service_registries": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -393,6 +404,10 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("launch_type"); ok {
 		input.LaunchType = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("propagate_tags"); ok {
+		input.PropagateTags = aws.String(v.(string))
 	}
 
 	loadBalancers := expandEcsLoadBalancers(d.Get("load_balancer").(*schema.Set).List())
@@ -574,6 +589,7 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("health_check_grace_period_seconds", service.HealthCheckGracePeriodSeconds)
 	d.Set("launch_type", service.LaunchType)
 	d.Set("enable_ecs_managed_tags", service.EnableECSManagedTags)
+	d.Set("propagate_tags", service.PropagateTags)
 
 	// Save cluster in the same format
 	if strings.HasPrefix(d.Get("cluster").(string), "arn:"+meta.(*AWSClient).partition+":ecs:") {

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -304,12 +304,18 @@ func resourceAwsEcsService() *schema.Resource {
 			"propagate_tags": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if old == "NONE" && new == "" {
 						return true
 					}
 					return false
 				},
+				ValidateFunc: validation.StringInSlice([]string{
+					ecs.PropagateTagsService,
+					ecs.PropagateTagsTaskDefinition,
+					"",
+				}, false),
 			},
 
 			"service_registries": {

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -824,7 +824,42 @@ func TestAccAWSEcsService_ManagedTags(t *testing.T) {
 					testAccCheckAWSEcsServiceExists(resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "enable_ecs_managed_tags", "true"),
-					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "SERVICE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEcsService_PropagateTags(t *testing.T) {
+	var first, second, third ecs.Service
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecs_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsServiceConfigPropagateTags(rName, "SERVICE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists(resourceName, &first),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", ecs.PropagateTagsService),
+				),
+			},
+			{
+				Config: testAccAWSEcsServiceConfigPropagateTags(rName, "TASK_DEFINITION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists(resourceName, &second),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", ecs.PropagateTagsTaskDefinition),
+				),
+			},
+			{
+				Config: testAccAWSEcsServiceConfigManagedTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists(resourceName, &third),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "NONE"),
 				),
 			},
 		},
@@ -2512,13 +2547,53 @@ resource "aws_ecs_service" "test" {
   name                               = %q
   task_definition                    = "${aws_ecs_task_definition.test.arn}"
   enable_ecs_managed_tags            = true
-  propagate_tags                     = "SERVICE"
 
   tags {
     tag-key = "tag-value"
   }
 }
 `, rName, rName, rName)
+}
+
+func testAccAWSEcsServiceConfigPropagateTags(rName, propagate string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  name = %q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family = %q
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+
+  tags {
+    tag-key = "task-def"
+  }
+}
+
+resource "aws_ecs_service" "test" {
+  cluster                            = "${aws_ecs_cluster.test.id}"
+  desired_count                      = 0
+  name                               = %q
+  task_definition                    = "${aws_ecs_task_definition.test.arn}"
+  enable_ecs_managed_tags            = true
+  propagate_tags                     = "%s"
+
+  tags {
+    tag-key = "service"
+  }
+}
+`, rName, rName, rName, propagate)
 }
 
 func testAccAWSEcsServiceWithReplicaSchedulingStrategy(clusterName, tdName, svcName string) string {

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -824,6 +824,7 @@ func TestAccAWSEcsService_ManagedTags(t *testing.T) {
 					testAccCheckAWSEcsServiceExists(resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "enable_ecs_managed_tags", "true"),
+					resource.TestCheckResourceAttr(resourceName, "propagate_tags", "SERVICE"),
 				),
 			},
 		},
@@ -2511,6 +2512,7 @@ resource "aws_ecs_service" "test" {
   name                               = %q
   task_definition                    = "${aws_ecs_task_definition.test.arn}"
   enable_ecs_managed_tags            = true
+  propagate_tags                     = "SERVICE"
 
   tags {
     tag-key = "tag-value"

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -87,6 +87,7 @@ The following arguments are supported:
 * `deployment_maximum_percent` - (Optional) The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment. Not valid when using the `DAEMON` scheduling strategy.
 * `deployment_minimum_healthy_percent` - (Optional) The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
 * `enable_ecs_managed_tags` - (Optional) Specifies whether to enable Amazon ECS managed tags for the tasks within the service.
+* `propagate_tags` - (Optional) Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`.
 * `placement_strategy` - (Optional) **Deprecated**, use `ordered_placement_strategy` instead.
 * `ordered_placement_strategy` - (Optional) Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy` blocks is `5`. Defined below.
 * `health_check_grace_period_seconds` - (Optional) Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6601 

Changes proposed in this pull request:

* add `propagate_tags` attribute

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEcsService_ -timeout 120m
=== RUN   TestAccAWSEcsService_withARN
=== PAUSE TestAccAWSEcsService_withARN
=== RUN   TestAccAWSEcsService_basicImport
=== PAUSE TestAccAWSEcsService_basicImport
=== RUN   TestAccAWSEcsService_disappears
=== PAUSE TestAccAWSEcsService_disappears
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== PAUSE TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
=== PAUSE TestAccAWSEcsService_withFamilyAndRevision
=== RUN   TestAccAWSEcsService_withRenamedCluster
=== PAUSE TestAccAWSEcsService_withRenamedCluster
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== PAUSE TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== RUN   TestAccAWSEcsService_withIamRole
=== PAUSE TestAccAWSEcsService_withIamRole
=== RUN   TestAccAWSEcsService_withDeploymentValues
=== PAUSE TestAccAWSEcsService_withDeploymentValues
=== RUN   TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== PAUSE TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== RUN   TestAccAWSEcsService_withLbChanges
=== PAUSE TestAccAWSEcsService_withLbChanges
=== RUN   TestAccAWSEcsService_withEcsClusterName
=== PAUSE TestAccAWSEcsService_withEcsClusterName
=== RUN   TestAccAWSEcsService_withAlb
=== PAUSE TestAccAWSEcsService_withAlb
=== RUN   TestAccAWSEcsService_withPlacementStrategy
=== PAUSE TestAccAWSEcsService_withPlacementStrategy
=== RUN   TestAccAWSEcsService_withPlacementConstraints
=== PAUSE TestAccAWSEcsService_withPlacementConstraints
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== PAUSE TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (219.74s)
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== PAUSE TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategy
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== RUN   TestAccAWSEcsService_withReplicaSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withReplicaSchedulingStrategy
=== RUN   TestAccAWSEcsService_withServiceRegistries
=== PAUSE TestAccAWSEcsService_withServiceRegistries
=== RUN   TestAccAWSEcsService_withServiceRegistries_container
=== PAUSE TestAccAWSEcsService_withServiceRegistries_container
=== RUN   TestAccAWSEcsService_Tags
=== PAUSE TestAccAWSEcsService_Tags
=== RUN   TestAccAWSEcsService_ManagedTags
=== PAUSE TestAccAWSEcsService_ManagedTags
=== CONT  TestAccAWSEcsService_withARN
=== CONT  TestAccAWSEcsService_withPlacementStrategy
=== CONT  TestAccAWSEcsService_withReplicaSchedulingStrategy
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategy
=== CONT  TestAccAWSEcsService_withEcsClusterName
=== CONT  TestAccAWSEcsService_withIamRole
=== CONT  TestAccAWSEcsService_Tags
=== CONT  TestAccAWSEcsService_withServiceRegistries_container
=== CONT  TestAccAWSEcsService_withAlb
=== CONT  TestAccAWSEcsService_withFamilyAndRevision
=== CONT  TestAccAWSEcsService_ManagedTags
=== CONT  TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== CONT  TestAccAWSEcsService_withRenamedCluster
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== CONT  TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== CONT  TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== CONT  TestAccAWSEcsService_withDeploymentValues
=== CONT  TestAccAWSEcsService_withPlacementConstraints
=== CONT  TestAccAWSEcsService_withLbChanges
=== CONT  TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (24.06s)
=== CONT  TestAccAWSEcsService_disappears
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (31.84s)
=== CONT  TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_withEcsClusterName (32.10s)
=== CONT  TestAccAWSEcsService_withServiceRegistries
--- PASS: TestAccAWSEcsService_withARN (32.49s)
=== CONT  TestAccAWSEcsService_basicImport
--- PASS: TestAccAWSEcsService_Tags (36.98s)
--- PASS: TestAccAWSEcsService_disappears (14.85s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (39.27s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (42.09s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (42.55s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (42.72s)
--- PASS: TestAccAWSEcsService_ManagedTags (42.75s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (42.79s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (43.00s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (15.51s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (59.43s)
--- PASS: TestAccAWSEcsService_basicImport (33.39s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (95.08s)
--- PASS: TestAccAWSEcsService_withIamRole (121.84s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (162.22s)
--- PASS: TestAccAWSEcsService_withLbChanges (236.45s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (251.39s)
--- PASS: TestAccAWSEcsService_withAlb (255.85s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (244.20s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (330.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	550.678s
```
