### PR TITLE
Support python3.7 runtime validation

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -116,6 +116,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 					lambda.RuntimeNodejs810,
 					lambda.RuntimePython27,
 					lambda.RuntimePython36,
+					lambda.RuntimePython37,
 				}, false),
 			},
 			"timeout": {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6620 

Changes proposed in this pull request:

* support python3.7 in runtime validation

Output from acceptance testing: Trivial plan-time validation update

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
