### PR TITLE
update the elastic_transcoder_preset example for InterlacedMode

### DIFF
--- a/website/docs/r/elastic_transcoder_preset.html.markdown
+++ b/website/docs/r/elastic_transcoder_preset.html.markdown
@@ -48,7 +48,7 @@ resource "aws_elastictranscoder_preset" "bar" {
     Profile                  = "main"
     Level                    = "2.2"
     MaxReferenceFrames       = 3
-    InterlaceMode            = "Progressive"
+    InterlacedMode           = "Progressive"
     ColorSpaceConversionMode = "None"
   }
 


### PR DESCRIPTION
The docs correctly says the `video_codec_preset` option is `InterlacedMode` in the `The video_codec_options map supports the following:` section but the example says `InterlaceMode` - fixing the example so it reads `InterlacedMode` as well.

Fixes #6615 