### PR TITLE
Feature/add import aws iam group policy attachment

### DIFF
--- a/aws/resource_aws_iam_group_policy_attachment.go
+++ b/aws/resource_aws_iam_group_policy_attachment.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -16,6 +17,9 @@ func resourceAwsIamGroupPolicyAttachment() *schema.Resource {
 		Create: resourceAwsIamGroupPolicyAttachmentCreate,
 		Read:   resourceAwsIamGroupPolicyAttachmentRead,
 		Delete: resourceAwsIamGroupPolicyAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIamGroupPolicyAttachmentImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"group": {
@@ -99,6 +103,19 @@ func resourceAwsIamGroupPolicyAttachmentDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error removing policy %s from IAM Group %s: %v", arn, group, err)
 	}
 	return nil
+}
+
+func resourceAwsIamGroupPolicyAttachmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <group-name>/<policy_arn>", d.Id())
+	}
+	groupName := idParts[0]
+	policyARN := idParts[1]
+	d.Set("group", groupName)
+	d.Set("policy_arn", policyARN)
+	d.SetId(fmt.Sprintf("%s-%s", groupName, policyARN))
+	return []*schema.ResourceData{d}, nil
 }
 
 func attachPolicyToGroup(conn *iam.IAM, group string, arn string) error {

--- a/website/docs/r/iam_group_policy_attachment.markdown
+++ b/website/docs/r/iam_group_policy_attachment.markdown
@@ -37,3 +37,9 @@ The following arguments are supported:
 
 * `group`  (Required) - The group the policy should be applied to
 * `policy_arn`  (Required) - The ARN of the policy you want to apply
+
+## Import
+ IAM group policy attachments can be imported using the group name and policy arn separated by `/`.
+ ```
+$ terraform import aws_iam_group_policy_attachment.test-attach test-group/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixed #6602 

Changes proposed in this pull request:

* Add import `aws_iam_group_policy_attachment` without changing create behavior.
* Update Document

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIAMGroupPolicyAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMGroupPolicyAttachment_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIAMGroupPolicyAttachment_basic
=== PAUSE TestAccAWSIAMGroupPolicyAttachment_basic
=== CONT  TestAccAWSIAMGroupPolicyAttachment_basic
--- PASS: TestAccAWSIAMGroupPolicyAttachment_basic (59.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.769s
```
