### PR TITLE
Support CodeDeploy ECS Blue/Green Deployment

### DIFF
--- a/aws/resource_aws_codedeploy_app.go
+++ b/aws/resource_aws_codedeploy_app.go
@@ -64,8 +64,9 @@ func resourceAwsCodeDeployApp() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					codedeploy.ComputePlatformServer,
+					codedeploy.ComputePlatformEcs,
 					codedeploy.ComputePlatformLambda,
+					codedeploy.ComputePlatformServer,
 				}, false),
 				Default: codedeploy.ComputePlatformServer,
 			},

--- a/aws/resource_aws_codedeploy_app_test.go
+++ b/aws/resource_aws_codedeploy_app_test.go
@@ -65,17 +65,64 @@ func TestAccAWSCodeDeployApp_computePlatform(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Server"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployAppExists(resourceName, &application2),
 					testAccCheckAWSCodeDeployAppRecreated(&application1, &application2),
 					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Server"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployApp_computePlatform_ECS(t *testing.T) {
+	var application1 codedeploy.ApplicationInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codedeploy_app.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "ECS"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists(resourceName, &application1),
+					resource.TestCheckResourceAttr(resourceName, "compute_platform", "ECS"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployApp_computePlatform_Lambda(t *testing.T) {
+	var application1 codedeploy.ApplicationInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codedeploy_app.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployAppConfigComputePlatform(rName, "Lambda"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployAppExists(resourceName, &application1),
+					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Lambda"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1633,6 +1633,47 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete(t *testing
 	})
 }
 
+func TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	ecsClusterResourceName := "aws_ecs_cluster.test"
+	ecsServiceResourceName := "aws_ecs_service.test"
+	lbTargetGroupBlueResourceName := "aws_lb_target_group.blue"
+	lbTargetGroupGreenResourceName := "aws_lb_target_group.green"
+	resourceName := "aws_codedeploy_deployment_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployDeploymentGroupConfigEcsBlueGreen(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "ecs_service.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "ecs_service.0.cluster_name", ecsClusterResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "ecs_service.0.service_name", ecsServiceResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.prod_traffic_route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.prod_traffic_route.0.listener_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.#", "2"),
+					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.0.name", lbTargetGroupBlueResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_info.0.target_group_pair_info.0.target_group.1.name", lbTargetGroupGreenResourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_info.0.target_group_pair_info.0.test_traffic_route.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCodeDeployDeploymentGroupImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
@@ -1875,7 +1916,7 @@ func TestAWSCodeDeployDeploymentGroup_flattenLoadBalancerInfo(t *testing.T) {
 		}),
 	}
 
-	actual := flattenLoadBalancerInfo(input)[0]
+	actual := flattenLoadBalancerInfo(input)[0].(map[string]interface{})
 
 	fatal := false
 
@@ -3023,9 +3064,30 @@ func test_config_blue_green_deployment_config_create_with_asg(rName string) stri
 
   %s
 
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_subnet" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  default_for_az    = "true"
+}
+
 resource "aws_launch_configuration" "foo_lc" {
-  image_id = "ami-21f78e11"
-  instance_type = "t1.micro"
+  image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
   "name_prefix" = "foo-lc-"
 
   lifecycle {
@@ -3039,7 +3101,7 @@ resource "aws_autoscaling_group" "foo_asg" {
   min_size = 0
   desired_capacity = 1
 
-  availability_zones = ["us-west-2a"]
+  vpc_zone_identifier = ["${data.aws_subnet.test.id}"]
 
   launch_configuration = "${aws_launch_configuration.foo_lc.name}"
 
@@ -3078,9 +3140,30 @@ func test_config_blue_green_deployment_config_update_with_asg(rName string) stri
 
   %s
 
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_subnet" "test" {
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  default_for_az    = "true"
+}
+
 resource "aws_launch_configuration" "foo_lc" {
-  image_id = "ami-21f78e11"
-  instance_type = "t1.micro"
+  image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
   "name_prefix" = "foo-lc-"
 
   lifecycle {
@@ -3094,7 +3177,7 @@ resource "aws_autoscaling_group" "foo_asg" {
   min_size = 0
   desired_capacity = 1
 
-  availability_zones = ["us-west-2a"]
+  vpc_zone_identifier = ["${data.aws_subnet.test.id}"]
 
   launch_configuration = "${aws_launch_configuration.foo_lc.name}"
 
@@ -3254,4 +3337,241 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
     }
   }
 }`, baseCodeDeployConfig(rName), rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroupConfigEcsBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-codedeploy-deployment-group-ecs"
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "${cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)}"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-codedeploy-deployment-group-ecs"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name   = %q
+  vpc_id = "${aws_vpc.test.id}"
+
+  ingress {
+    cidr_blocks = ["${aws_vpc.test.cidr_block}"]
+    from_port   = 80
+    protocol    = "6"
+    to_port     = 8000
+  }
+}
+
+resource "aws_lb_target_group" "blue" {
+  name        = "${aws_lb.test.name}-blue"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${aws_vpc.test.id}"
+}
+
+resource "aws_lb_target_group" "green" {
+  name        = "${aws_lb.test.name}-green"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${aws_vpc.test.id}"
+}
+
+resource "aws_lb" "test" {
+  internal = true
+  name     = %q
+  subnets  = ["${aws_subnet.test.*.id}"]
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = "${aws_lb.test.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.blue.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_ecs_cluster" "test" {
+  name = %q
+}
+
+resource "aws_ecs_task_definition" "test" {
+  cpu                      = "256"
+  family                   = %q
+  memory                   = "512"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 256,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 512,
+    "name": "test",
+    "networkMode": "awsvpc",
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80
+      }
+    ]
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "test" {
+  cluster         = "${aws_ecs_cluster.test.id}"
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  name            = %q
+  task_definition = "${aws_ecs_task_definition.test.arn}"
+
+  deployment_controller {
+    type = "CODE_DEPLOY"
+  }
+
+  load_balancer {
+    container_name   = "test"
+    container_port   = "80"
+    target_group_arn = "${aws_lb_target_group.blue.id}"
+  }
+
+  network_configuration {
+    assign_public_ip = true
+    security_groups  = ["${aws_security_group.test.id}"]
+    subnets          = ["${aws_subnet.test.*.id}"]
+  }
+}
+
+resource "aws_codedeploy_app" "test" {
+  compute_platform = "ECS"
+  name             = %q
+}
+
+resource "aws_iam_role" "test" {
+  name = %q
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["codedeploy.amazonaws.com"]
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test" {
+  role = "${aws_iam_role.test.name}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "cloudwatch:DescribeAlarms",
+        "ecs:CreateTaskSet",
+        "ecs:DeleteTaskSet",
+        "ecs:DescribeServices",
+        "ecs:UpdateServicePrimaryTaskSet",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyRule",
+        "lambda:InvokeFunction",
+        "s3:GetObject",
+        "s3:GetObjectMetadata",
+        "s3:GetObjectVersion",
+        "sns:Publish"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+`, rName, rName, rName, rName, rName, rName, rName)
+}
+
+func testAccAWSCodeDeployDeploymentGroupConfigEcsBlueGreen(rName string) string {
+	return testAccAWSCodeDeployDeploymentGroupConfigEcsBase(rName) + fmt.Sprintf(`
+resource "aws_codedeploy_deployment_group" "test" {
+  app_name               = "${aws_codedeploy_app.test.name}"
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  deployment_group_name  = %q
+  service_role_arn       = "${aws_iam_role.test.arn}"
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 5
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = "${aws_ecs_cluster.test.name}"
+    service_name = "${aws_ecs_service.test.name}"
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = ["${aws_lb_listener.test.arn}"]
+      }
+
+      target_group {
+        name = "${aws_lb_target_group.blue.name}"
+      }
+
+      target_group {
+        name = "${aws_lb_target_group.green.name}"
+      }
+    }
+  }
+}
+`, rName)
 }

--- a/website/docs/r/codedeploy_app.html.markdown
+++ b/website/docs/r/codedeploy_app.html.markdown
@@ -12,9 +12,30 @@ Provides a CodeDeploy application to be used as a basis for deployments
 
 ## Example Usage
 
+### ECS Application
+
 ```hcl
-resource "aws_codedeploy_app" "foo" {
-  name = "foo"
+resource "aws_codedeploy_app" "example" {
+  compute_platform = "ECS"
+  name             = "example"
+}
+```
+
+### Lambda Application
+
+```hcl
+resource "aws_codedeploy_app" "example" {
+  compute_platform = "Lambda"
+  name             = "example"
+}
+```
+
+### Server Application
+
+```hcl
+resource "aws_codedeploy_app" "example" {
+  compute_platform = "Server"
+  name             = "example"
 }
 ```
 
@@ -23,7 +44,7 @@ resource "aws_codedeploy_app" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the application.
-* `compute_platform` - (Optional) The compute platform can either be `Server` or `Lambda`. Default is `Server`.
+* `compute_platform` - (Optional) The compute platform can either be `ECS`, `Lambda`, or `Server`. Default is `Server`.
 
 ## Attribute Reference
 

--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -83,7 +83,60 @@ resource "aws_codedeploy_deployment_group" "example" {
 }
 ```
 
-### Using Blue Green Deployments
+### Blue Green Deployments with ECS
+
+```hcl
+resource "aws_codedeploy_deployment_group" "example" {
+  app_name               = "${aws_codedeploy_app.example.name}"
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  deployment_group_name  = "example"
+  service_role_arn       = "${aws_iam_role.example.arn}"
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 5
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = "${aws_ecs_cluster.example.name}"
+    service_name = "${aws_ecs_service.example.name}"
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = ["${aws_lb_listener.example.arn}"]
+      }
+
+      target_group {
+        name = "${aws_lb_target_group.blue.name}"
+      }
+
+      target_group {
+        name = "${aws_lb_target_group.green.name}"
+      }
+    }
+  }
+}
+```
+
+### Blue Green Deployments with Servers
 
 ```hcl
 resource "aws_codedeploy_app" "example" {
@@ -130,92 +183,46 @@ The following arguments are supported:
 * `app_name` - (Required) The name of the application.
 * `deployment_group_name` - (Required) The name of the deployment group.
 * `service_role_arn` - (Required) The service role ARN that allows deployments.
+* `alarm_configuration` - (Optional) Configuration block of alarms associated with the deployment group (documented below).
+* `auto_rollback_configuration` - (Optional) Configuration block of the automatic rollback configuration associated with the deployment group (documented below).
 * `autoscaling_groups` - (Optional) Autoscaling groups associated with the deployment group.
+* `blue_green_deployment_config` - (Optional) Configuration block of the blue/green deployment options for a deployment group (documented below).
 * `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
+* `deployment_style` - (Optional) Configuration block of the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
 * `ec2_tag_filter` - (Optional) Tag filters associated with the deployment group. See the AWS docs for details.
-* `ec2_tag_set` - (Optional) Sets of Tag filters associated with the deployment group, which are referred to as *tag groups* in the document.  See the AWS docs for details.
+* `ec2_tag_set` - (Optional) Configuration block(s) of Tag filters associated with the deployment group, which are also referred to as tag groups (documented below). See the AWS docs for details.
+* `ecs_service` - (Optional) Configuration block(s) of the ECS services for a deployment group (documented below).
+* `load_balancer_info` - (Optional) Configuration block of the load balancer to use in a blue/green deployment (documented below).
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
-* `trigger_configuration` - (Optional) Trigger Configurations for the deployment group (documented below).
-* `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group (documented below).
-* `alarm_configuration` - (Optional) Information about alarms associated with the deployment group (documented below).
-* `deployment_style` - (Optional) Information about the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
-* `load_balancer_info` - (Optional) Information about the load balancer to use in a blue/green deployment (documented below).
-* `blue_green_deployment_config` - (Optional) Information about blue/green deployment options for a deployment group (documented below).
+* `trigger_configuration` - (Optional) Configuration block(s) of the triggers for the deployment group (documented below).
 
-### Tag Filters
-Both `ec2_tag_filter` and `on_premises_tag_filter` support the following:
+### alarm_configuration Argument Reference
 
-* `key` - (Optional) The key of the tag filter.
-* `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
-* `value` - (Optional) The value of the tag filter.
-
-Multiple occurrences of `ec2_tag_filter` are allowed, where any instance that matches to at least one of the tag filters is selected.
-
-
-### Tag Groups
-You can form a tag group by putting a set of tag filters into `ec2_tag_set`. If multiple tag groups are specified, any instance that matches to at least one tag filter of every tag group is selected.
-
-
-### Trigger Configuration
-Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the **SNS** topic associated with the trigger. _CodeDeploy must have permission to publish to the topic from this deployment group_. `trigger_configuration` supports the following:
-
- * `trigger_events` - (Required) The event type or types for which notifications are triggered. Some values that are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, `DeploymentRollback`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.  See [the CodeDeploy documentation][1] for all possible values.
- * `trigger_name` - (Required) The name of the notification trigger.
- * `trigger_target_arn` - (Required) The ARN of the SNS topic through which notifications are sent.
-
-### Auto Rollback Configuration
-You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. `auto_rollback_configuration` supports the following:
-
- * `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
- * `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
-
-_Only one `auto_rollback_ configuration` is allowed_.
-
-### Alarm Configuration
 You can configure a deployment to stop when a **CloudWatch** alarm detects that a metric has fallen below or exceeded a defined threshold. `alarm_configuration` supports the following:
 
- * `alarms` - (Optional) A list of alarms configured for the deployment group. _A maximum of 10 alarms can be added to a deployment group_.
- * `enabled` - (Optional) Indicates whether the alarm configuration is enabled. This option is useful when you want to temporarily deactivate alarm monitoring for a deployment group without having to add the same alarms again later.
- * `ignore_poll_alarm_failure` - (Optional) Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch. The default value is `false`.
-    * `true`: The deployment will proceed even if alarm status information can't be retrieved.
-    * `false`: The deployment will stop if alarm status information can't be retrieved.
+* `alarms` - (Optional) A list of alarms configured for the deployment group. _A maximum of 10 alarms can be added to a deployment group_.
+* `enabled` - (Optional) Indicates whether the alarm configuration is enabled. This option is useful when you want to temporarily deactivate alarm monitoring for a deployment group without having to add the same alarms again later.
+* `ignore_poll_alarm_failure` - (Optional) Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch. The default value is `false`.
+  * `true`: The deployment will proceed even if alarm status information can't be retrieved.
+  * `false`: The deployment will stop if alarm status information can't be retrieved.
 
 _Only one `alarm_configuration` is allowed_.
 
-### Deployment Style
-You can configure the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
+### auto_rollback_configuration Argument Reference
 
-* `deployment_option` - (Optional) Indicates whether to route deployment traffic behind a load balancer. Valid Values are `WITH_TRAFFIC_CONTROL` or `WITHOUT_TRAFFIC_CONTROL`.
+You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. `auto_rollback_configuration` supports the following:
 
-* `deployment_type` - (Optional) Indicates whether to run an in-place deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
+* `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
+* `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
 
-_Only one `deployment_style` is allowed_.
+_Only one `auto_rollback_ configuration` is allowed_.
 
-### Load Balancer Info
-You can configure the **Load Balancer** to use in a deployment. `load_balancer_info` supports the following:
+### blue_green_deployment_config Argument Reference
 
-* `elb_info` - (Optional) The load balancer to use in a deployment.
-* `target_group_info` - (Optional) The target group to use in a deployment.
-
-_Only one `load_balancer_info` is supported per deployment group.
-
-`elb_info` supports the following:
-
-* `name` - (Optional) The name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment. For in-place deployments, the name of the load balancer that instances are deregistered from so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.
-
-`target_group_info` supports the following:
-
-* `name` - (Optional) The name of the target group that instances in the original environment are deregistered from, and instances in the replacement environment registered with. For in-place deployments, the name of the target group that instances are deregistered from, so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.
-
-_Only a single `elb_info` or `target_group_info` can be used in a deployment._
-
-### Blue Green Deployment Configuration
 You can configure options for a blue/green deployment. `blue_green_deployment_config` supports the following:
 
 * `deployment_ready_option` - (Optional) Information about the action to take when newly provisioned instances are ready to receive traffic in a blue/green deployment (documented below).
-
 * `green_fleet_provisioning_option` - (Optional) Information about how instances are provisioned for a replacement environment in a blue/green deployment (documented below).
-
 * `terminate_blue_instances_on_deployment_success` - (Optional) Information about whether to terminate instances in the original fleet during a blue/green deployment (documented below).
 
 _Only one `blue_green_deployment_config` is allowed_.
@@ -223,39 +230,117 @@ _Only one `blue_green_deployment_config` is allowed_.
 You can configure how traffic is rerouted to instances in a replacement environment in a blue/green deployment. `deployment_ready_option` supports the following:
 
 * `action_on_timeout` - (Optional) When to reroute traffic from an original environment to a replacement environment in a blue/green deployment.
-
   * `CONTINUE_DEPLOYMENT`: Register new instances with the load balancer immediately after the new application revision is installed on the instances in the replacement environment.
   * `STOP_DEPLOYMENT`: Do not register new instances with load balancer unless traffic is rerouted manually. If traffic is not rerouted manually before the end of the specified wait period, the deployment status is changed to Stopped.
-
 * `wait_time_in_minutes` - (Optional) The number of minutes to wait before the status of a blue/green deployment changed to Stopped if rerouting is not started manually. Applies only to the `STOP_DEPLOYMENT` option for `action_on_timeout`.
 
 You can configure how instances will be added to the replacement environment in a blue/green deployment. `green_fleet_provisioning_option` supports the following:
 
 * `action` - (Optional) The method used to add instances to a replacement environment.
-
   * `DISCOVER_EXISTING`: Use instances that already exist or will be created manually.
   * `COPY_AUTO_SCALING_GROUP`: Use settings from a specified **Auto Scaling** group to define and create instances in a new Auto Scaling group. _Exactly one Auto Scaling group must be specified_ when selecting `COPY_AUTO_SCALING_GROUP`. Use `autoscaling_groups` to specify the Auto Scaling group.
 
 You can configure how instances in the original environment are terminated when a blue/green deployment is successful. `terminate_blue_instances_on_deployment_success` supports the following:
 
 * `action` - (Optional) The action to take on instances in the original environment after a successful blue/green deployment.
-
   * `TERMINATE`: Instances are terminated after a specified wait time.
-
   * `KEEP_ALIVE`: Instances are left running after they are deregistered from the load balancer and removed from the deployment group.
-
 * `termination_wait_time_in_minutes` - (Optional) The number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment.
+
+### deployment_style Argument Reference
+
+You can configure the type of deployment, either in-place or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
+
+* `deployment_option` - (Optional) Indicates whether to route deployment traffic behind a load balancer. Valid Values are `WITH_TRAFFIC_CONTROL` or `WITHOUT_TRAFFIC_CONTROL`.
+* `deployment_type` - (Optional) Indicates whether to run an in-place deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
+
+_Only one `deployment_style` is allowed_.
+
+### ec2_tag_filter Argument Reference
+
+The `ec2_tag_filter` configuration block supports the following:
+
+* `key` - (Optional) The key of the tag filter.
+* `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
+* `value` - (Optional) The value of the tag filter.
+
+Multiple occurrences of `ec2_tag_filter` are allowed, where any instance that matches to at least one of the tag filters is selected.
+
+### ec2_tag_set Argument Reference
+
+You can form a tag group by putting a set of tag filters into `ec2_tag_set`. If multiple tag groups are specified, any instance that matches to at least one tag filter of every tag group is selected.
+
+### load_balancer_info Argument Reference
+
+You can configure the **Load Balancer** to use in a deployment. `load_balancer_info` supports the following:
+
+* `elb_info` - (Optional) The load balancer to use in a deployment.
+* `target_group_info` - (Optional) The target group to use in a deployment.
+* `target_group_pair_info` - (Optional) The target group pair to use in a deployment.
+
+_Only one `load_balancer_info` is supported per deployment group._
+
+_Only one of `elb_info`, `target_group_info`, `target_group_pair_info` can be used in a deployment._
+
+#### load_balancer_info elb_info Argument Reference
+
+The `elb_info` configuration block supports the following:
+
+* `name` - (Optional) The name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment. For in-place deployments, the name of the load balancer that instances are deregistered from so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.
+
+#### load_balancer_info target_group_info Argument Reference
+
+The `target_group_info` configuration block supports the following:
+
+* `name` - (Optional) The name of the target group that instances in the original environment are deregistered from, and instances in the replacement environment registered with. For in-place deployments, the name of the target group that instances are deregistered from, so they are not serving traffic during a deployment, and then re-registered with after the deployment completes.
+
+#### load_balancer_info target_group_pair_info Argument Reference
+
+The `target_group_pair_info` configuration block supports the following:
+
+* `prod_traffic_route` - (Required) Configuration block for the production traffic route (documented below).
+* `target_group` - (Required) Configuration blocks for a target group within a target group pair (documented below).
+* `test_traffic_route` - (Optional) Configuration block for the test traffic route (documented below).
+
+##### load_balancer_info target_group_pair_info prod_traffic_route Argument Reference
+
+The `prod_traffic_route` configuration block supports the following:
+
+* `listener_arns` - (Required) List of Amazon Resource Names (ARNs) of the load balancer listeners.
+
+##### load_balancer_info target_group_pair_info target_group Argument Reference
+
+The `target_group` configuration block supports the following:
+
+* `name` - (Required) Name of the target group.
+
+##### load_balancer_info target_group_pair_info test_traffic_route Argument Reference
+
+The `test_traffic_route` configuration block supports the following:
+
+* `listener_arns` - (Required) List of Amazon Resource Names (ARNs) of the load balancer listeners.
+
+### on_premises_tag_filter Argument Reference
+
+The `on_premises_tag_filter` configuration block supports the following:
+
+* `key` - (Optional) The key of the tag filter.
+* `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
+* `value` - (Optional) The value of the tag filter.
+
+### trigger_configuration Argument Reference
+
+Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the **SNS** topic associated with the trigger. _CodeDeploy must have permission to publish to the topic from this deployment group_. `trigger_configuration` supports the following:
+
+* `trigger_events` - (Required) The event type or types for which notifications are triggered. Some values that are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, `DeploymentRollback`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.  See [the CodeDeploy documentation][1] for all possible values.
+* `trigger_name` - (Required) The name of the notification trigger.
+* `trigger_target_arn` - (Required) The ARN of the SNS topic through which notifications are sent.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The deployment group's ID.
-* `app_name` - The group's assigned application.
-* `deployment_group_name` - The group's name.
-* `service_role_arn` - The group's service role ARN.
-* `autoscaling_groups` - The autoscaling groups associated with the deployment group.
-* `deployment_config_name` - The name of the group's deployment config.
+* `id` - Application name and deployment group name.
 
 ## Import
 

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -83,6 +83,7 @@ The following arguments are supported:
 * `scheduling_strategy` - (Optional) The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Defaults to `REPLICA`. Note that [*Fargate tasks do not support the `DAEMON` scheduling strategy*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html).
 * `cluster` - (Optional) ARN of an ECS cluster
 * `iam_role` - (Optional) ARN of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the `awsvpc` network mode. If using `awsvpc` network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here.
+* `deployment_controller` - (Optional) Configuration block containing deployment controller configuration. Defined below.
 * `deployment_maximum_percent` - (Optional) The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment. Not valid when using the `DAEMON` scheduling strategy.
 * `deployment_minimum_healthy_percent` - (Optional) The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
 * `enable_ecs_managed_tasks` - (Optional) Specifies whether to enable Amazon ECS managed tags for the tasks within the service.
@@ -95,6 +96,12 @@ The following arguments are supported:
 * `network_configuration` - (Optional) The network configuration for the service. This parameter is required for task definitions that use the `awsvpc` network mode to receive their own Elastic Network Interface, and it is not supported for other network modes.
 * `service_registries` - (Optional) The service discovery registries for the service. The maximum number of `service_registries` blocks is `1`.
 * `tags` - (Optional) Key-value mapping of resource tags
+
+## deployment_controller
+
+The `deployment_controller` configuration block supports the following:
+
+* `type` - (Optional) Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`. Default: `ECS`.
 
 ## load_balancer
 


### PR DESCRIPTION
Changes:

* resource/aws_codedeploy_app: Support `ECS` `compute_platform`
* resource/aws_codedeploy_deployment_group: Add `ecs_service` argument and `load_balancer_info` configuration block `target_group_pair_info` argument (Support ECS Blue/Green Deployment)
* resource/aws_ecs_service: Add `deployment_controller` argument
* tests/resource/aws_codedeploy_deployment_group: Make acceptance testing region agnostic
* tests/resource/aws_ecs_service: Make acceptance testing region agnostic

Output from acceptance testing:

```
--- PASS: TestAccAWSEcsService_basicImport (41.81s)
--- PASS: TestAccAWSEcsService_disappears (20.08s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (252.36s)
--- PASS: TestAccAWSEcsService_ManagedTags (39.25s)
--- PASS: TestAccAWSEcsService_Tags (48.17s)
--- PASS: TestAccAWSEcsService_withAlb (216.50s)
--- PASS: TestAccAWSEcsService_withARN (48.40s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (39.43s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (13.89s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (236.62s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (30.96s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (39.54s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (39.07s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (36.30s)
--- PASS: TestAccAWSEcsService_withIamRole (202.62s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (85.05s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (362.01s)
--- PASS: TestAccAWSEcsService_withLbChanges (301.40s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (17.60s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (39.40s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (139.42s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (65.68s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (39.03s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (201.82s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (205.77s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (32.21s)

--- PASS: TestAccAWSCodeDeployApp_computePlatform_ECS (14.63s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform_Lambda (14.64s)
--- PASS: TestAccAWSCodeDeployApp_basic (16.66s)
--- PASS: TestAccAWSCodeDeployApp_computePlatform (21.95s)
--- PASS: TestAccAWSCodeDeployApp_name (23.20s)

--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_create (37.92s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_delete (42.46s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable (45.11s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_update (36.76s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_create (41.38s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_delete (40.84s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_disable (36.02s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_autoRollbackConfiguration_update (41.17s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic (81.27s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_basic_tagSet (58.51s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeployment_complete (36.28s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (168.43s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (49.82s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (37.54s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (162.85s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create (43.88s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default (36.53s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete (36.82s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update (43.72s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_disappears (27.19s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (231.22s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_create (34.03s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_in_place_deployment_with_traffic_control_update (38.46s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_create (34.04s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete (48.20s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_create (38.61s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_delete (31.60s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_targetGroupInfo_update (33.90s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update (36.51s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_onPremiseTag (32.17s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_basic (37.42s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_triggerConfiguration_multiple (42.46s)
```