### PR TITLE
service/ec2: Treat empty TGW Route Table IDs when searching for associations/propagations as missing

### DIFF
--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -156,6 +156,10 @@ func ec2DescribeTransitGatewayRouteTable(conn *ec2.EC2, transitGatewayRouteTable
 }
 
 func ec2DescribeTransitGatewayRouteTableAssociation(conn *ec2.EC2, transitGatewayRouteTableID, transitGatewayAttachmentID string) (*ec2.TransitGatewayRouteTableAssociation, error) {
+	if transitGatewayRouteTableID == "" {
+		return nil, nil
+	}
+
 	input := &ec2.GetTransitGatewayRouteTableAssociationsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -180,6 +184,10 @@ func ec2DescribeTransitGatewayRouteTableAssociation(conn *ec2.EC2, transitGatewa
 }
 
 func ec2DescribeTransitGatewayRouteTablePropagation(conn *ec2.EC2, transitGatewayRouteTableID, transitGatewayAttachmentID string) (*ec2.TransitGatewayRouteTablePropagation, error) {
+	if transitGatewayRouteTableID == "" {
+		return nil, nil
+	}
+
 	input := &ec2.GetTransitGatewayRouteTablePropagationsInput{
 		Filters: []*ec2.Filter{
 			{

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -134,6 +134,32 @@ func TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments(t *testing.T) {
 	})
 }
 
+func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled(t *testing.T) {
+	var transitGateway1 ec2.TransitGateway
+	resourceName := "aws_ec2_transit_gateway.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayConfigDefaultRouteTableAssociationAndPropagationDisabled(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEc2TransitGatewayExists(resourceName, &transitGateway1),
+					resource.TestCheckResourceAttr(resourceName, "default_route_table_association", ec2.DefaultRouteTableAssociationValueDisable),
+					resource.TestCheckResourceAttr(resourceName, "default_route_table_propagation", ec2.DefaultRouteTablePropagationValueDisable),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation(t *testing.T) {
 	var transitGateway1, transitGateway2 ec2.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -545,6 +571,15 @@ resource "aws_ec2_transit_gateway" "test" {
   auto_accept_shared_attachments = %q
 }
 `, autoAcceptSharedAttachments)
+}
+
+func testAccAWSEc2TransitGatewayConfigDefaultRouteTableAssociationAndPropagationDisabled() string {
+	return fmt.Sprintf(`
+resource "aws_ec2_transit_gateway" "test" {
+  default_route_table_association = "disable"
+  default_route_table_propagation = "disable"
+}
+`)
 }
 
 func testAccAWSEc2TransitGatewayConfigDefaultRouteTableAssociation(defaultRouteTableAssociation string) string {


### PR DESCRIPTION
Fixes #6664 

When creating an EC2 Transit Gateway with both flags set to disable default route table association and propagation, presumably it is no longer creating a default route table, which would cause issues downstream when determining if the VPC attachment was associated with said (now non-existent) default route table. This logic now returns that the association/propagation doesn't exist if there is not a provided route table ID to check.

Previously:

```
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (87.32s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_ec2_transit_gateway_vpc_attachment.test: 1 error occurred:
        	* aws_ec2_transit_gateway_vpc_attachment.test: error updating EC2 Transit Gateway Attachment (tgw-attach-0e5e1795143bd2b2e) Route Table () association: error determining EC2 Transit Gateway Attachment Route Table () association (tgw-attach-0e5e1795143bd2b2e): MissingParameter: Missing required parameter in request: TransitGatewayRouteTableId.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEc2TransitGateway_AmazonSideASN (282.51s)
--- PASS: TestAccAWSEc2TransitGateway_AutoAcceptSharedAttachments (282.79s)
--- PASS: TestAccAWSEc2TransitGateway_basic (119.74s)
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociation (304.57s)
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTableAssociationAndPropagationDisabled (97.26s)
--- PASS: TestAccAWSEc2TransitGateway_DefaultRouteTablePropagation (292.85s)
--- PASS: TestAccAWSEc2TransitGateway_Description (303.75s)
--- PASS: TestAccAWSEc2TransitGateway_disappears (133.04s)
--- PASS: TestAccAWSEc2TransitGateway_DnsSupport (294.91s)
--- PASS: TestAccAWSEc2TransitGateway_Tags (142.00s)
--- PASS: TestAccAWSEc2TransitGateway_VpnEcmpSupport (262.29s)
--- PASS: TestAccAWSEc2TransitGatewayDataSource_Filter (149.81s)
--- PASS: TestAccAWSEc2TransitGatewayDataSource_ID (150.09s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_basic (199.22s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears (274.00s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_basic (180.87s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears (222.99s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway (151.50s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_Tags (207.50s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableAssociation_basic (274.40s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter (194.26s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_ID (182.70s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTablePropagation_basic (237.60s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_basic (205.70s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_disappears (210.35s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport (241.30s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support (267.59s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds (370.24s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Tags (294.68s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation (330.97s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (212.14s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation (275.11s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (206.94s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (207.48s)
```

