### PR TITLE
Support issuance of ACM private certificate

### DIFF
--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -32,6 +32,15 @@ func testAccAwsAcmCertificateDomainFromEnv(t *testing.T) string {
 	return os.Getenv("ACM_CERTIFICATE_ROOT_DOMAIN")
 }
 
+func testAccAwsAcmCAARNFromEnv(t *testing.T) string {
+	if os.Getenv("ACM_CA_ARN") == "" {
+		t.Skip(
+			"Environment variable ACM_CA_ARN is not set. " +
+				"This must to be a valid PCA")
+	}
+	return os.Getenv("ACM_CA_ARN")
+}
+
 func TestAccAWSAcmCertificate_emailValidation(t *testing.T) {
 	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
 
@@ -122,6 +131,36 @@ func TestAccAWSAcmCertificate_root(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "0"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
 					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", acm.ValidationMethodDns),
+				),
+			},
+			{
+				ResourceName:      "aws_acm_certificate.cert",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSAcmCertificate_privateCert(t *testing.T) {
+	rootDomain := testAccAwsAcmCertificateDomainFromEnv(t)
+	caARN := testAccAwsAcmCAARNFromEnv(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAcmCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAcmCertificateConfig_privateCert(rootDomain, caARN),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("aws_acm_certificate.cert", "arn", certificateArnRegex),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_name", rootDomain),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "domain_validation_options.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "subject_alternative_names.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_emails.#", "0"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "validation_method", "NONE"),
+					resource.TestCheckResourceAttr("aws_acm_certificate.cert", "certificate_authority_arn", caARN),
 				),
 			},
 			{
@@ -526,6 +565,16 @@ resource "aws_acm_certificate" "cert" {
   validation_method = "%s"
 }
 `, domainName, validationMethod)
+
+}
+
+func testAccAcmCertificateConfig_privateCert(domainName, caARN string) string {
+	return fmt.Sprintf(`
+resource "aws_acm_certificate" "cert" {
+  domain_name               = "%s"
+  certificate_authority_arn = "%s"
+}
+`, domainName, caARN)
 
 }
 

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -88,6 +88,10 @@ The following arguments are supported:
   * `private_key` - (Required) The certificate's PEM-formatted private key
   * `certificate_body` - (Required) The certificate's PEM-formatted public key
   * `certificate_chain` - (Optional) The certificate's PEM-formatted chain
+* Creating a private CA issued certificate
+  * `domain_name` - (Required) A domain name for which the certificate should be issued
+  * `certificate_authority_arn` - (Required) ARN of an ACMPCA
+  * `subject_alternative_names` - (Optional) A list of domains that should be SANs in the issued certificate
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes partial of #5550
For certificates issued by PCA, need a separate resource, and not covered in this PR

Changes proposed in this pull request:

* Support issuance of ACM private certificate

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAcmCertificate_privateCert'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAcmCertificate_privateCert -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAcmCertificate_privateCert
=== PAUSE TestAccAWSAcmCertificate_privateCert
=== CONT  TestAccAWSAcmCertificate_privateCert
--- PASS: TestAccAWSAcmCertificate_privateCert (12.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	12.965s
```