### PR TITLE
F addlambda provided

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -114,6 +114,7 @@ func resourceAwsLambdaFunction() *schema.Resource {
 					lambda.RuntimeNodejs43Edge,
 					lambda.RuntimeNodejs610,
 					lambda.RuntimeNodejs810,
+					lambda.RuntimeProvided,
 					lambda.RuntimePython27,
 					lambda.RuntimePython36,
 					lambda.RuntimePython37,

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1179,29 +1179,29 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 }
 
 func TestAccAWSLambdaFunction_runtimeValidation_provided(t *testing.T) {
-        var conf lambda.GetFunctionOutput
+	var conf lambda.GetFunctionOutput
 
-        rString := acctest.RandString(8)
+	rString := acctest.RandString(8)
 
-        funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_provided_%s", rString)
-        policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_provided_%s", rString)
-        roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_provided_%s", rString)
-        sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_provided_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_provided_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_provided_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_provided_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_provided_%s", rString)
 
-        resource.ParallelTest(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckLambdaFunctionDestroy,
-                Steps: []resource.TestStep{
-                        {
-                                Config: testAccAWSLambdaConfigProvidedRuntime(funcName, policyName, roleName, sgName),
-                                Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-                                        resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeProvided,
-                                ),
-                        },
-                },
-        })
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaConfigProvidedRuntime(funcName, policyName, roleName, sgName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeProvided),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAWSLambdaFunction_runtimeValidation_python36(t *testing.T) {

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1178,6 +1178,32 @@ func TestAccAWSLambdaFunction_tags(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaFunction_runtimeValidation_provided(t *testing.T) {
+        var conf lambda.GetFunctionOutput
+
+        rString := acctest.RandString(8)
+
+        funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_provided_%s", rString)
+        policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_provided_%s", rString)
+        roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_provided_%s", rString)
+        sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_provided_%s", rString)
+
+        resource.ParallelTest(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckLambdaFunctionDestroy,
+                Steps: []resource.TestStep{
+                        {
+                                Config: testAccAWSLambdaConfigProvidedRuntime(funcName, policyName, roleName, sgName),
+                                Check: resource.ComposeTestCheckFunc(
+                                        testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+                                        resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeProvided,
+                                ),
+                        },
+                },
+        })
+}
+
 func TestAccAWSLambdaFunction_runtimeValidation_python36(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -2088,6 +2088,18 @@ resource "aws_lambda_function" "lambda_function_test" {
 `, funcName)
 }
 
+func testAccAWSLambdaConfigProvidedRuntime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "provided"
+}
+`, funcName)
+}
+
 func testAccAWSLambdaConfigPython36Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {


### PR DESCRIPTION
Implement runtime `provided` in aws lambda

https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#API_CreateFunction_RequestSyntax

```
Runtime
The runtime version for the function.

Type: String

Valid Values: nodejs | nodejs4.3 | nodejs6.10 | nodejs8.10 | java8 | python2.7 | python3.6 | python3.7 | dotnetcore1.0 | dotnetcore2.0 | dotnetcore2.1 | nodejs4.3-edge | go1.x | ruby2.5 | provided

Required: Yes
```

Changes proposed in this pull request:

* Add test `func TestAccAWSLambdaFunction_runtimeValidation_provided()`
* Add test `func testAccAWSLambdaConfigProvidedRuntime()`
* Add `lambda.RuntimeProvided` as valid runtime to `func resourceAwsLambdaFunction()`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_runtimeValidation_provided'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaFunction_runtimeValidation_provided -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_provided
=== PAUSE TestAccAWSLambdaFunction_runtimeValidation_provided
=== CONT  TestAccAWSLambdaFunction_runtimeValidation_provided
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (40.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	41.435s
```

Thanks!
alvaro.