### PR TITLE
docs/resource/aws_elasticsearch_domain: Add example for Log Publishing to CloudWatch Logs

### DIFF
--- a/website/docs/r/cloudwatch_log_resource_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_resource_policy.html.markdown
@@ -12,6 +12,32 @@ Provides a resource to manage a CloudWatch log resource policy.
 
 ## Example Usage
 
+### Elasticsearch Log Publishing
+
+```hcl
+data "aws_iam_policy_document" "elasticsearch-log-publishing-policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+
+    resources = ["arn:aws:logs:*"]
+
+    principals {
+      identifiers = ["es.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "elasticsearch-log-publishing-policy" {
+  policy_document = "${data.aws_iam_policy_document.elasticsearch-log-publishing-policy.json}"
+  policy_name     = "elasticsearch-log-publishing-policy"
+}
+```
+
 ### Route53 Query Logging
 
 ```hcl


### PR DESCRIPTION
Reference: #6606

Changes proposed in this pull request:

* On the tin.
* docs/resource/aws_cloudwatch_log_resource_policy: Add Elasticsearch Log Publishing example

Output from acceptance testing: N/A
