### PR TITLE
remove maximum=1 for cloudwatch destination

### DIFF
--- a/aws/resource_aws_ses_event_destination.go
+++ b/aws/resource_aws_ses_event_destination.go
@@ -63,7 +63,6 @@ func resourceAwsSesEventDestination() *schema.Resource {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				ForceNew:      true,
-				MaxItems:      1,
 				ConflictsWith: []string{"kinesis_destination", "sns_destination"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_ses_event_destination_test.go
+++ b/aws/resource_aws_ses_event_destination_test.go
@@ -203,6 +203,12 @@ resource "aws_ses_event_destination" "cloudwatch" {
 	dimension_name = "dimension"
 	value_source = "emailHeader"
   }
+
+  cloudwatch_destination {
+    default_value = "default"
+	dimension_name = "ses:source-ip"
+	value_source = "messageTag"
+  }
 }
 
 resource "aws_ses_event_destination" "sns" {


### PR DESCRIPTION
<!--- https://github.com/terraform-providers/terraform-provider-aws/issues/6689 --->
Fixes #6689 
Fixes #5620

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
