### PR TITLE
Minor fixes to api_gateway_method request_parameters documentation

### DIFF
--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -86,14 +86,7 @@ The following arguments are supported:
   and value is either `Error`, `Empty` (built-in models) or `aws_api_gateway_model`'s `name`.
 * `request_validator_id` - (Optional) The ID of a `aws_api_gateway_request_validator`
 * `request_parameters` - (Optional) A map of request query string parameters and headers that should be passed to the integration.
-  For example:
-```hcl
-request_parameters = {
-  "method.request.header.X-Some-Header"         = true
-  "method.request.querystring.some-query-param" = true
-}
-```
-would define that the header `X-Some-Header` and the query string `some-query-param` must be provided in the request
+  For example: `request_parameters = {"method.request.header.X-Some-Header" = true "method.request.querystring.some-query-param" = true}` would define that the header `X-Some-Header` and the query string `some-query-param` must be provided in the request
 * `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
 
 ## Import

--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -93,7 +93,7 @@ request_parameters = {
   "method.request.querystring.some-query-param" = true
 }
 ```
-would define that the header `X-Some-Header` and the query string `some-query-param` must be provided on the request
+would define that the header `X-Some-Header` and the query string `some-query-param` must be provided in the request
 * `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
 
 ## Import

--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -93,7 +93,7 @@ request_parameters = {
   "method.request.querystring.some-query-param" = true
 }
 ```
-would define that the header `X-Some-Header` and the query string `some-query-param` must be provided on the request, or
+would define that the header `X-Some-Header` and the query string `some-query-param` must be provided on the request
 * `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
 
 ## Import


### PR DESCRIPTION
Changes proposed in this pull request:

* Delete trailing "or"
* Change "provided on the request" to "provided in the request"
* Change from HCL code block to inline code formatting (looked fine on Github, but the website actually renders "hcl")

Mainly that first change is what this is about, since it left me thinking, "or _what_?" Now if there _is_ supposed to be more to that statement please feel free to reject this and fill it in.