### PR TITLE
Create new resource for changed aws_iam_user_ssh_key public_key and encoding

### DIFF
--- a/aws/resource_aws_iam_user_ssh_key.go
+++ b/aws/resource_aws_iam_user_ssh_key.go
@@ -36,11 +36,13 @@ func resourceAwsIamUserSshKey() *schema.Resource {
 			"public_key": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"encoding": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					iam.EncodingTypeSsh,
 					iam.EncodingTypePem,


### PR DESCRIPTION
Fixes #378

Changes proposed in this pull request:

* Create a new `aws_iam_user_ssh_key` resource when either `public_key` or `encoding` changes.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSUserSSHKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSUserSSHKey -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSUserSSHKey_basic
=== PAUSE TestAccAWSUserSSHKey_basic
=== RUN   TestAccAWSUserSSHKey_pemEncoding
=== PAUSE TestAccAWSUserSSHKey_pemEncoding
=== CONT  TestAccAWSUserSSHKey_basic
=== CONT  TestAccAWSUserSSHKey_pemEncoding
--- PASS: TestAccAWSUserSSHKey_pemEncoding (13.64s)
--- PASS: TestAccAWSUserSSHKey_basic (15.12s)
PASS
```

According to the [AWS API docs](https://docs.aws.amazon.com/cli/latest/reference/iam/update-ssh-public-key.html), you cannot edit `public_key` or `encoding`. Therefore Terraform should create a new resource.