### PR TITLE
Add lambda target type for alb target group

### DIFF
--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -504,6 +504,27 @@ func testAccCheckAWSALBTargetGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccAWSALBTargetGroup_lambda(t *testing.T) {
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_lambda(targetGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "target_type", "lambda"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSALBTargetGroupConfig_basic(targetGroupName string) string {
 	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
   name = "%s"
@@ -855,3 +876,10 @@ resource "aws_vpc" "test" {
 	}
 }
 `
+
+func testAccAWSALBTargetGroupConfig_lambda(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+	name = "%s"
+	target_type = "lambda"
+}`, targetGroupName)
+}

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -866,7 +866,17 @@ const testAccAWSALBTargetGroupConfig_generatedName = `
 resource "aws_alb_target_group" "test" {
   port = 80
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.test.id}"
+	vpc_id = "${aws_vpc.test.id}"
+	
+	health_check {
+    path = "/health"
+    interval = 60
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+
 }
 
 resource "aws_vpc" "test" {

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -229,10 +229,7 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	params := &elbv2.CreateTargetGroupInput{
-		Name: aws.String(groupName),
-		// Port:       aws.Int64(int64(d.Get("port").(int))),
-		// Protocol:   aws.String(d.Get("protocol").(string)),
-		// VpcId:      aws.String(d.Get("vpc_id").(string)),
+		Name:       aws.String(groupName),
 		TargetType: aws.String(d.Get("target_type").(string)),
 	}
 

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -57,14 +57,14 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 
 			"port": {
 				Type:         schema.TypeInt,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(1, 65535),
 			},
 
 			"protocol": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					elbv2.ProtocolEnumHttp,
@@ -75,7 +75,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 
 			"vpc_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -102,8 +102,13 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 			"target_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "instance",
+				Default:  elbv2.TargetTypeEnumInstance,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					elbv2.TargetTypeEnumInstance,
+					elbv2.TargetTypeEnumIp,
+					elbv2.TargetTypeEnumLambda,
+				}, false),
 			},
 
 			"stickiness": {
@@ -224,11 +229,25 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	params := &elbv2.CreateTargetGroupInput{
-		Name:       aws.String(groupName),
-		Port:       aws.Int64(int64(d.Get("port").(int))),
-		Protocol:   aws.String(d.Get("protocol").(string)),
-		VpcId:      aws.String(d.Get("vpc_id").(string)),
+		Name: aws.String(groupName),
+		// Port:       aws.Int64(int64(d.Get("port").(int))),
+		// Protocol:   aws.String(d.Get("protocol").(string)),
+		// VpcId:      aws.String(d.Get("vpc_id").(string)),
 		TargetType: aws.String(d.Get("target_type").(string)),
+	}
+
+	if d.Get("target_type").(string) != elbv2.TargetTypeEnumLambda {
+		if _, ok := d.GetOk("port"); !ok {
+			return fmt.Errorf("port should be set when target type is %s", d.Get("target_type").(string))
+		}
+
+		if _, ok := d.GetOk("protocol"); !ok {
+			return fmt.Errorf("protocol should be set when target type is %s", d.Get("target_type").(string))
+		}
+
+		if _, ok := d.GetOk("vpc_id"); !ok {
+			return fmt.Errorf("vpc_id should be set when target type is %s", d.Get("target_type").(string))
+		}
 	}
 
 	if healthChecks := d.Get("health_check").([]interface{}); len(healthChecks) == 1 {
@@ -267,9 +286,7 @@ func resourceAwsLbTargetGroupCreate(d *schema.ResourceData, meta interface{}) er
 	if len(resp.TargetGroups) == 0 {
 		return errors.New("Error creating LB Target Group: no groups returned in response")
 	}
-
 	d.SetId(aws.StringValue(resp.TargetGroups[0].TargetGroupArn))
-
 	return resourceAwsLbTargetGroupUpdate(d, meta)
 }
 
@@ -343,68 +360,70 @@ func resourceAwsLbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	var attrs []*elbv2.TargetGroupAttribute
+	if d.Get("target_type").(string) != elbv2.TargetTypeEnumLambda {
+		var attrs []*elbv2.TargetGroupAttribute
 
-	if d.HasChange("deregistration_delay") {
-		attrs = append(attrs, &elbv2.TargetGroupAttribute{
-			Key:   aws.String("deregistration_delay.timeout_seconds"),
-			Value: aws.String(fmt.Sprintf("%d", d.Get("deregistration_delay").(int))),
-		})
-	}
-
-	if d.HasChange("slow_start") {
-		attrs = append(attrs, &elbv2.TargetGroupAttribute{
-			Key:   aws.String("slow_start.duration_seconds"),
-			Value: aws.String(fmt.Sprintf("%d", d.Get("slow_start").(int))),
-		})
-	}
-
-	if d.HasChange("proxy_protocol_v2") {
-		attrs = append(attrs, &elbv2.TargetGroupAttribute{
-			Key:   aws.String("proxy_protocol_v2.enabled"),
-			Value: aws.String(strconv.FormatBool(d.Get("proxy_protocol_v2").(bool))),
-		})
-	}
-
-	// In CustomizeDiff we allow LB stickiness to be declared for TCP target
-	// groups, so long as it's not enabled. This allows for better support for
-	// modules, but also means we need to completely skip sending the data to the
-	// API if it's defined on a TCP target group.
-	if d.HasChange("stickiness") && d.Get("protocol") != "TCP" {
-		stickinessBlocks := d.Get("stickiness").([]interface{})
-		if len(stickinessBlocks) == 1 {
-			stickiness := stickinessBlocks[0].(map[string]interface{})
-
-			attrs = append(attrs,
-				&elbv2.TargetGroupAttribute{
-					Key:   aws.String("stickiness.enabled"),
-					Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
-				},
-				&elbv2.TargetGroupAttribute{
-					Key:   aws.String("stickiness.type"),
-					Value: aws.String(stickiness["type"].(string)),
-				},
-				&elbv2.TargetGroupAttribute{
-					Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
-					Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
-				})
-		} else if len(stickinessBlocks) == 0 {
+		if d.HasChange("deregistration_delay") {
 			attrs = append(attrs, &elbv2.TargetGroupAttribute{
-				Key:   aws.String("stickiness.enabled"),
-				Value: aws.String("false"),
+				Key:   aws.String("deregistration_delay.timeout_seconds"),
+				Value: aws.String(fmt.Sprintf("%d", d.Get("deregistration_delay").(int))),
 			})
 		}
-	}
 
-	if len(attrs) > 0 {
-		params := &elbv2.ModifyTargetGroupAttributesInput{
-			TargetGroupArn: aws.String(d.Id()),
-			Attributes:     attrs,
+		if d.HasChange("slow_start") {
+			attrs = append(attrs, &elbv2.TargetGroupAttribute{
+				Key:   aws.String("slow_start.duration_seconds"),
+				Value: aws.String(fmt.Sprintf("%d", d.Get("slow_start").(int))),
+			})
 		}
 
-		_, err := elbconn.ModifyTargetGroupAttributes(params)
-		if err != nil {
-			return fmt.Errorf("Error modifying Target Group Attributes: %s", err)
+		if d.HasChange("proxy_protocol_v2") {
+			attrs = append(attrs, &elbv2.TargetGroupAttribute{
+				Key:   aws.String("proxy_protocol_v2.enabled"),
+				Value: aws.String(strconv.FormatBool(d.Get("proxy_protocol_v2").(bool))),
+			})
+		}
+
+		// In CustomizeDiff we allow LB stickiness to be declared for TCP target
+		// groups, so long as it's not enabled. This allows for better support for
+		// modules, but also means we need to completely skip sending the data to the
+		// API if it's defined on a TCP target group.
+		if d.HasChange("stickiness") && d.Get("protocol") != "TCP" {
+			stickinessBlocks := d.Get("stickiness").([]interface{})
+			if len(stickinessBlocks) == 1 {
+				stickiness := stickinessBlocks[0].(map[string]interface{})
+
+				attrs = append(attrs,
+					&elbv2.TargetGroupAttribute{
+						Key:   aws.String("stickiness.enabled"),
+						Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
+					},
+					&elbv2.TargetGroupAttribute{
+						Key:   aws.String("stickiness.type"),
+						Value: aws.String(stickiness["type"].(string)),
+					},
+					&elbv2.TargetGroupAttribute{
+						Key:   aws.String("stickiness.lb_cookie.duration_seconds"),
+						Value: aws.String(fmt.Sprintf("%d", stickiness["cookie_duration"].(int))),
+					})
+			} else if len(stickinessBlocks) == 0 {
+				attrs = append(attrs, &elbv2.TargetGroupAttribute{
+					Key:   aws.String("stickiness.enabled"),
+					Value: aws.String("false"),
+				})
+			}
+		}
+
+		if len(attrs) > 0 {
+			params := &elbv2.ModifyTargetGroupAttributesInput{
+				TargetGroupArn: aws.String(d.Id()),
+				Attributes:     attrs,
+			}
+
+			_, err := elbconn.ModifyTargetGroupAttributes(params)
+			if err != nil {
+				return fmt.Errorf("Error modifying Target Group Attributes: %s", err)
+			}
 		}
 	}
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -33,16 +33,16 @@ The following arguments are supported:
 
 * `name` - (Optional, Forces new resource) The name of the target group. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
-* `port` - (Required) The port on which targets receive traffic, unless overridden when registering a specific target.
-* `protocol` - (Required) The protocol to use for routing traffic to the targets. Should be one of "TCP", "HTTP", "HTTPS" or "TLS".
-* `vpc_id` - (Required) The identifier of the VPC in which to create the target group.
+* `port` - (Optional) The port on which targets receive traffic, unless overridden when registering a specific target. Required when `target_type` is `instance` or `ip`. 
+* `protocol` - (Optional) The protocol to use for routing traffic to the targets. Should be one of "TCP", "HTTP", "HTTPS" or "TLS". Required when `target_type` is `instance` or `ip`.
+* `vpc_id` - (Optional) The identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.
 * `proxy_protocol_v2` - (Optional) Boolean to enable / disable support for proxy protocol v2 on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) for more information.
 * `stickiness` - (Optional) A Stickiness block. Stickiness blocks are documented below. `stickiness` is only valid if used with Load Balancers of type `Application`
 * `health_check` - (Optional) A Health Check block. Health Check blocks are documented below.
 * `target_type` - (Optional) The type of target that you must specify when registering targets with this target group.
-The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address).
+The possible values are `instance` (targets are specified by instance ID) or `ip` (targets are specified by IP address) or `lambda` (targets are specified by lambda arn).
 The default is `instance`. Note that you can't specify targets for a target group using both instance IDs and IP addresses.
 If the target type is `ip`, specify IP addresses from the subnets of the virtual private cloud (VPC) for the target group,
 the RFC 1918 range (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10).
@@ -68,7 +68,7 @@ for a complete reference.
 * `interval` - (Optional) The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds.
 * `path` - (Required for HTTP/HTTPS ALB) The destination for the health check request. Applies to Application Load Balancers only (HTTP/HTTPS), not Network Load Balancers (TCP).
 * `port` - (Optional) The port to use to connect with the target. Valid values are either ports 1-65536, or `traffic-port`. Defaults to `traffic-port`.
-* `protocol` - (Optional) The protocol to use to connect with the target. Defaults to `HTTP`.
+* `protocol` - (Optional) The protocol to use to connect with the target. Defaults to `HTTP`. Not applicable when `target_type` is `lambda`.
 * `timeout` - (Optional) The amount of time, in seconds, during which no response means a failed health check. For Application Load Balancers, the range is 2 to 60 seconds and the default is 5 seconds. For Network Load Balancers, you cannot set a custom value, and the default is 10 seconds for TCP and HTTPS health checks and 6 seconds for HTTP health checks.
 * `healthy_threshold` - (Optional) The number of consecutive health checks successes required before considering an unhealthy target healthy. Defaults to 3.
 * `unhealthy_threshold` - (Optional) The number of consecutive health check failures required before considering the target unhealthy . For Network Load Balancers, this value must be the same as the `healthy_threshold`. Defaults to 3.

--- a/website/docs/r/lb_target_group_attachment.html.markdown
+++ b/website/docs/r/lb_target_group_attachment.html.markdown
@@ -36,7 +36,7 @@ resource "aws_instance" "test" {
 The following arguments are supported:
 
 * `target_group_arn` - (Required) The ARN of the target group with which to register targets
-* `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container. If the target type is ip, specify an IP address.
+* `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container. If the target type is ip, specify an IP address. If the target type is lambda, specify the arn of lambda.
 * `port` - (Optional) The port on which targets receive traffic.
 * `availability_zone` - (Optional) The Availability Zone where the IP address of the target is to be registered.
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6693

Changes proposed in this pull request:

* Add support for lambda target type

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSALBTargetGroup_lambda'

$ make testacc TESTARGS='-run=TestAccAWSALBTargetGroup_missingPortProtocolVpc'

...
```
