### PR TITLE
resource/aws_vpc: Set ipv6_association_id and ipv6_cidr_block attributes as updated for assign_generated_ipv6_cidr_block updates

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -501,6 +501,14 @@ func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsVpcCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
+	if diff.HasChange("assign_generated_ipv6_cidr_block") {
+		if err := diff.SetNewComputed("ipv6_association_id"); err != nil {
+			return fmt.Errorf("error setting ipv6_association_id to computed: %s", err)
+		}
+		if err := diff.SetNewComputed("ipv6_cidr_block"); err != nil {
+			return fmt.Errorf("error setting ipv6_cidr_block to computed: %s", err)
+		}
+	}
 	if diff.HasChange("instance_tenancy") {
 		old, new := diff.GetChange("instance_tenancy")
 		if old.(string) != ec2.TenancyDedicated || new.(string) != ec2.TenancyDefault {


### PR DESCRIPTION
Fixes #6710 

~NOTE: This requires an upstream Terraform change: https://github.com/hashicorp/terraform/pull/19548~ Provider dependencies are good now. 😄 

Previously:

```
--- FAIL: TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate (36.59s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
        	* aws_network_acl_rule.test: aws_network_acl_rule.test: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.

        Please include the following information in your report:

            Terraform Version: 0.11.9
            Resource ID: aws_network_acl_rule.test
            Mismatch reason: extra attributes: ipv6_cidr_block
            Diff One (usually from plan): *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"egress":*terraform.ResourceAttrDiff{Old:"", New:"false", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "rule_number":*terraform.ResourceAttrDiff{Old:"", New:"150", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "protocol":*terraform.ResourceAttrDiff{Old:"", New:"tcp", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "rule_action":*terraform.ResourceAttrDiff{Old:"", New:"allow", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "from_port":*terraform.ResourceAttrDiff{Old:"", New:"22", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "to_port":*terraform.ResourceAttrDiff{Old:"", New:"22", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "network_acl_id":*terraform.ResourceAttrDiff{Old:"", New:"acl-0af5440f0c4b982b2", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}
            Diff Two (usually from apply): *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"from_port":*terraform.ResourceAttrDiff{Old:"", New:"22", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "rule_action":*terraform.ResourceAttrDiff{Old:"", New:"allow", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "ipv6_cidr_block":*terraform.ResourceAttrDiff{Old:"", New:"2600:1f14:3b0:c100::/56", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "rule_number":*terraform.ResourceAttrDiff{Old:"", New:"150", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "egress":*terraform.ResourceAttrDiff{Old:"", New:"false", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "to_port":*terraform.ResourceAttrDiff{Old:"", New:"22", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "network_acl_id":*terraform.ResourceAttrDiff{Old:"", New:"acl-0af5440f0c4b982b2", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}, "protocol":*terraform.ResourceAttrDiff{Old:"", New:"tcp", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:true, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}

        Also include as much context as you can about your config, state, and the steps you performed to trigger this error.
```

With upstream updates:

```
--- PASS: TestAccAWSNetworkAclRule_ipv6VpcAssignGeneratedIpv6CidrBlockUpdate (47.27s)
```

