### PR TITLE
Add import for aws_ecs_task_definition

### DIFF
--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -16,6 +16,7 @@ func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 
 	rString := acctest.RandString(8)
 	tdName := fmt.Sprintf("tf_acc_td_basic_%s", rString)
+	resourceName := "aws_ecs_task_definition.jenkins"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,14 +26,20 @@ func TestAccAWSEcsTaskDefinition_basic(t *testing.T) {
 			{
 				Config: testAccAWSEcsTaskDefinition(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins", &def),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 				),
 			},
 			{
 				Config: testAccAWSEcsTaskDefinitionModified(tdName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSEcsTaskDefinitionExists("aws_ecs_task_definition.jenkins", &def),
+					testAccCheckAWSEcsTaskDefinitionExists(resourceName, &def),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1532,4 +1539,15 @@ DEFINITION
   }
 }
 `, rName, rName, tag1Key, tag1Value, tag2Key, tag2Value)
+}
+
+func testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes["arn"], nil
+	}
 }

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -142,3 +142,11 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Full ARN of the Task Definition (including both `family` and `revision`).
 * `family` - The family of the Task Definition.
 * `revision` - The revision of the task in a particular family.
+
+## Import
+
+ECS Task Definitions can be imported via their Amazon Resource Name (ARN):
+
+```
+$ terraform import aws_ecs_task_definition.example arn:aws:ecs:us-east-1:012345678910:task-definition/mytaskfamily:123
+```


### PR DESCRIPTION
Fixes #5008

Changes proposed in this pull request:

* Add import for aws_ecs_task_definition

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEcsTaskDefinition_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEcsTaskDefinition_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEcsTaskDefinition_basic
=== PAUSE TestAccAWSEcsTaskDefinition_basic
=== CONT  TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (47.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.898s
```