### PR TITLE
Add ability to import aws_iam_user_ssh_key

### DIFF
--- a/aws/resource_aws_iam_user_ssh_key.go
+++ b/aws/resource_aws_iam_user_ssh_key.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -18,6 +19,9 @@ func resourceAwsIamUserSshKey() *schema.Resource {
 		Read:   resourceAwsIamUserSshKeyRead,
 		Update: resourceAwsIamUserSshKeyUpdate,
 		Delete: resourceAwsIamUserSshKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsIamUserSshKeyImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"ssh_public_key_id": {
@@ -37,6 +41,13 @@ func resourceAwsIamUserSshKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("encoding").(string) == "SSH" {
+						old = cleanSshKey(old)
+						new = cleanSshKey(new)
+					}
+					return strings.Trim(old, "\n") == strings.Trim(new, "\n")
+				},
 			},
 
 			"encoding": {
@@ -82,10 +93,11 @@ func resourceAwsIamUserSshKeyCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAwsIamUserSshKeyRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 	username := d.Get("username").(string)
+	encoding := d.Get("encoding").(string)
 	request := &iam.GetSSHPublicKeyInput{
 		UserName:       aws.String(username),
 		SSHPublicKeyId: aws.String(d.Id()),
-		Encoding:       aws.String(d.Get("encoding").(string)),
+		Encoding:       aws.String(encoding),
 	}
 
 	getResp, err := iamconn.GetSSHPublicKey(request)
@@ -98,9 +110,15 @@ func resourceAwsIamUserSshKeyRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error reading IAM User SSH Key %s: %s", d.Id(), err)
 	}
 
+	publicKey := *getResp.SSHPublicKey.SSHPublicKeyBody
+	if encoding == "SSH" {
+		publicKey = cleanSshKey(publicKey)
+	}
+
 	d.Set("fingerprint", getResp.SSHPublicKey.Fingerprint)
 	d.Set("status", getResp.SSHPublicKey.Status)
 	d.Set("ssh_public_key_id", getResp.SSHPublicKey.SSHPublicKeyId)
+	d.Set("public_key", publicKey)
 	return nil
 }
 
@@ -141,4 +159,33 @@ func resourceAwsIamUserSshKeyDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error deleting IAM User SSH Key %s: %s", d.Id(), err)
 	}
 	return nil
+}
+
+func resourceAwsIamUserSshKeyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), ":", 3)
+
+	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), UserName:SSHPublicKeyId:Encoding", d.Id())
+	}
+
+	username := idParts[0]
+	sshPublicKeyId := idParts[1]
+	encoding := idParts[2]
+
+	d.Set("username", username)
+	d.Set("ssh_public_key_id", sshPublicKeyId)
+	d.Set("encoding", encoding)
+	d.SetId(sshPublicKeyId)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func cleanSshKey(key string) string {
+	// Remove comments from SSH Keys
+	// Comments are anything after "ssh-rsa XXXX" where XXXX is the key.
+	parts := strings.Split(key, " ")
+	if len(parts) > 2 {
+		parts = parts[0:2]
+	}
+	return strings.Join(parts, " ")
 }

--- a/aws/resource_aws_iam_user_ssh_key_test.go
+++ b/aws/resource_aws_iam_user_ssh_key_test.go
@@ -17,6 +17,7 @@ func TestAccAWSUserSSHKey_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAWSSSHKeyConfig_sshEncoding, ri)
+	resourceName := "aws_iam_user_ssh_key.user"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -26,8 +27,14 @@ func TestAccAWSUserSSHKey_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSUserSSHKeyExists("aws_iam_user_ssh_key.user", "Inactive", &conf),
+					testAccCheckAWSUserSSHKeyExists(resourceName, "Inactive", &conf),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSUserSSHKeyImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -38,6 +45,7 @@ func TestAccAWSUserSSHKey_pemEncoding(t *testing.T) {
 
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAWSSSHKeyConfig_pemEncoding, ri)
+	resourceName := "aws_iam_user_ssh_key.user"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -47,8 +55,14 @@ func TestAccAWSUserSSHKey_pemEncoding(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSUserSSHKeyExists("aws_iam_user_ssh_key.user", "Active", &conf),
+					testAccCheckAWSUserSSHKeyExists(resourceName, "Active", &conf),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSUserSSHKeyImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -122,6 +136,21 @@ func testAccCheckAWSUserSSHKeyExists(n, status string, res *iam.GetSSHPublicKeyO
 	}
 }
 
+func testAccAWSUserSSHKeyImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		username := rs.Primary.Attributes["username"]
+		sshPublicKeyId := rs.Primary.Attributes["ssh_public_key_id"]
+		encoding := rs.Primary.Attributes["encoding"]
+
+		return fmt.Sprintf("%s:%s:%s", username, sshPublicKeyId, encoding), nil
+	}
+}
+
 const testAccAWSSSHKeyConfig_sshEncoding = `
 resource "aws_iam_user" "user" {
 	name = "test-user-%d"
@@ -145,6 +174,16 @@ resource "aws_iam_user" "user" {
 resource "aws_iam_user_ssh_key" "user" {
 	username = "${aws_iam_user.user.name}"
 	encoding = "PEM"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+	public_key = <<EOF
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9xercjxBRM1dC191/AbF
+3TLEM9cdnBIpCgxGNGiI+NaoMTAj/4rXp3ql0iBWQaeb4sz72qCEd1JvcSuzxqFv
+IIrqRp/hD7sSAOHAzOL8zqjpIjD4c+VytMIRI5Fc06OPktKbrw2bsCLHYlvZsYSX
+O7YATS9HGJVkmFZM+Bv37JTX0T1uZmADOPX+H4bcT2+aJOENi4PXTylRzvwYHruc
+KDHO0WNKdXo+g+AihROpcpkgyaVtGB1/8KhPfnHxGroe8WXBtKvbdrWuhen5l9Go
+L6RcmaPGhW13lAa+6LEgiTYL2r1mzP9Op4lqzr2F9scFnYV5l0q21/GW2m1aIQSu
+NQIDAQAB
+-----END PUBLIC KEY-----
+EOF
 }
 `

--- a/website/docs/r/iam_user_ssh_key.html.markdown
+++ b/website/docs/r/iam_user_ssh_key.html.markdown
@@ -41,3 +41,10 @@ In addition to all arguments above, the following attributes are exported:
 * `ssh_public_key_id` - The unique identifier for the SSH public key.
 * `fingerprint` - The MD5 message digest of the SSH public key.
 
+## Import
+
+SSH public keys can be imported using the `username`, `ssh_public_key_id`, and `encoding` e.g.
+
+```
+$ terraform import aws_iam_user_ssh_key.user user:APKAJNCNNJICVN7CFKCA:SSH
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Add ability to import aws_iam_user_ssh_key
* Ignore newlines and comments in aws_iam_user_ssh_key.public_key diffs

While testing importing, I noticed that AWS strips out any comments in SSH formatted keys. Comments are anything after the key itself (usually a username or email). I think it makes sense to ignore these since they're extremely common, and Terraform will perpetually think there is a diff if present. I also ignored newlines since AWS strips those as well.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSUserSSHKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSUserSSHKey -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSUserSSHKey_basic
=== PAUSE TestAccAWSUserSSHKey_basic
=== RUN   TestAccAWSUserSSHKey_pemEncoding
=== PAUSE TestAccAWSUserSSHKey_pemEncoding
=== CONT  TestAccAWSUserSSHKey_basic
=== CONT  TestAccAWSUserSSHKey_pemEncoding
--- PASS: TestAccAWSUserSSHKey_pemEncoding (12.66s)
--- PASS: TestAccAWSUserSSHKey_basic (12.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	15.713s
```