### PR TITLE
Support S3 Inventory Apache Parquet format reports

### DIFF
--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -73,6 +73,7 @@ func resourceAwsS3BucketInventory() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{
 											s3.InventoryFormatCsv,
 											s3.InventoryFormatOrc,
+											s3.InventoryFormatParquet,
 										}, false),
 									},
 									"bucket_arn": {

--- a/aws/resource_aws_s3_bucket_inventory_test.go
+++ b/aws/resource_aws_s3_bucket_inventory_test.go
@@ -281,7 +281,7 @@ resource "aws_s3_bucket_inventory" "test" {
 
   destination {
     bucket {
-      format = "ORC"
+      format = "Parquet"
       bucket_arn = "${aws_s3_bucket.bucket.arn}"
 
       encryption {

--- a/website/docs/r/s3_bucket_inventory.html.markdown
+++ b/website/docs/r/s3_bucket_inventory.html.markdown
@@ -105,7 +105,7 @@ The `destination` configuration supports the following:
 The `bucket` configuration supports the following:
 
 * `bucket_arn` - (Required) The Amazon S3 bucket ARN of the destination.
-* `format` - (Required) Specifies the output format of the inventory results. Can be `CSV` or [`ORC`](https://orc.apache.org/).
+* `format` - (Required) Specifies the output format of the inventory results. Can be `CSV`, [`ORC`](https://orc.apache.org/) or [`Parquet`](https://parquet.apache.org/).
 * `account_id` - (Optional) The ID of the account that owns the destination bucket. Recommended to be set to prevent problems if the destination bucket ownership changes.
 * `prefix` - (Optional) The prefix that is prepended to all inventory results.
 * `encryption` - (Optional) Contains the type of server-side encryption to use to encrypt the inventory (documented below).


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6728.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3BucketInventory_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3BucketInventory_ -timeout 120m
=== RUN   TestAccAWSS3BucketInventory_basic
=== PAUSE TestAccAWSS3BucketInventory_basic
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSES3
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSES3
=== RUN   TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== PAUSE TestAccAWSS3BucketInventory_encryptWithSSEKMS
=== CONT  TestAccAWSS3BucketInventory_basic
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSES3
=== CONT  TestAccAWSS3BucketInventory_encryptWithSSEKMS
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSES3 (32.42s)
--- PASS: TestAccAWSS3BucketInventory_basic (37.72s)
--- PASS: TestAccAWSS3BucketInventory_encryptWithSSEKMS (54.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	73.788s
```