### PR TITLE
tests/resource/aws_ecs_service: Fix TestAccAWSEcsService_withLaunchTypeFargate for parallelization and configuration updates

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -557,7 +557,7 @@ func TestAccAWSEcsService_withLaunchTypeFargate(t *testing.T) {
 	tdName := fmt.Sprintf("tf-acc-td-svc-w-ltf-%s", rString)
 	svcName := fmt.Sprintf("tf-acc-svc-w-ltf-%s", rString)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
@@ -572,13 +572,6 @@ func TestAccAWSEcsService_withLaunchTypeFargate(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ecs_service.main", "network_configuration.0.subnets.#", "2"),
 				),
 			},
-		},
-	})
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
-		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEcsServiceWithLaunchTypeFargate(sg1Name, sg2Name, clusterName, tdName, svcName, "true"),
 				Check: resource.ComposeTestCheckFunc(
@@ -586,13 +579,6 @@ func TestAccAWSEcsService_withLaunchTypeFargate(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ecs_service.main", "network_configuration.0.assign_public_ip", "true"),
 				),
 			},
-		},
-	})
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
-		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSEcsServiceWithLaunchTypeFargate(sg1Name, sg2Name, clusterName, tdName, svcName, "false"),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
Previously, it this acceptance test was not parallelized with the other tests and was creating/destroying the AWS resources between each step. This now tests via updates, which verifies that functionality and runs much faster (~300s -> ~100s).

Output from acceptance testing:

```
--- PASS: TestAccAWSEcsService_basicImport (31.52s)
--- PASS: TestAccAWSEcsService_disappears (20.52s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (249.26s)
--- PASS: TestAccAWSEcsService_ManagedTags (40.42s)
--- PASS: TestAccAWSEcsService_PropagateTags (76.33s)
--- PASS: TestAccAWSEcsService_Tags (39.68s)
--- PASS: TestAccAWSEcsService_withAlb (250.49s)
--- PASS: TestAccAWSEcsService_withARN (37.60s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (49.10s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (16.55s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (355.17s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (40.75s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (30.13s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (39.48s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (35.50s)
--- PASS: TestAccAWSEcsService_withIamRole (177.26s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (56.07s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (112.72s)
--- PASS: TestAccAWSEcsService_withLbChanges (277.71s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (24.62s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (30.15s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (119.51s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (52.67s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (28.76s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (211.01s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (201.62s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (40.50s)
```
