### PR TITLE
Add Batching to Modifying Systems Manager Documents to Work Around Limits

### DIFF
--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -108,6 +108,26 @@ func TestAccAWSSSMDocument_permission_private(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMDocument_permission_batching(t *testing.T) {
+	name := acctest.RandString(10)
+	ids := "123456789012,123456789013,123456789014,123456789015,123456789016,123456789017,123456789018,123456789019,123456789020,123456789021,123456789022,123456789023,123456789024,123456789025,123456789026,123456789027,123456789028,123456789029,123456789030,123456789031,123456789032"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMDocumentPrivatePermissionConfig(name, ids),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "permissions.type", "Share"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMDocument_permission_change(t *testing.T) {
 	name := acctest.RandString(10)
 	idsInitial := "123456789012,123456789013"


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #5328

Changes proposed in this pull request:

* Add Batching to Modifying Systems Manager Documents to Work Around Limits

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSSMDocument_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSSMDocument_* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSSMDocument_basic
=== PAUSE TestAccAWSSSMDocument_basic
=== RUN   TestAccAWSSSMDocument_update
=== PAUSE TestAccAWSSSMDocument_update
=== RUN   TestAccAWSSSMDocument_permission_public
=== PAUSE TestAccAWSSSMDocument_permission_public
=== RUN   TestAccAWSSSMDocument_permission_private
=== PAUSE TestAccAWSSSMDocument_permission_private
=== RUN   TestAccAWSSSMDocument_permission_batching
=== PAUSE TestAccAWSSSMDocument_permission_batching
=== RUN   TestAccAWSSSMDocument_permission_change
=== PAUSE TestAccAWSSSMDocument_permission_change
=== RUN   TestAccAWSSSMDocument_params
=== PAUSE TestAccAWSSSMDocument_params
=== RUN   TestAccAWSSSMDocument_automation
=== PAUSE TestAccAWSSSMDocument_automation
=== RUN   TestAccAWSSSMDocument_session
=== PAUSE TestAccAWSSSMDocument_session
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
=== PAUSE TestAccAWSSSMDocument_DocumentFormat_YAML
=== RUN   TestAccAWSSSMDocument_Tags
=== PAUSE TestAccAWSSSMDocument_Tags
=== CONT  TestAccAWSSSMDocument_basic
=== CONT  TestAccAWSSSMDocument_params
=== CONT  TestAccAWSSSMDocument_update
=== CONT  TestAccAWSSSMDocument_permission_private
=== CONT  TestAccAWSSSMDocument_permission_change
=== CONT  TestAccAWSSSMDocument_permission_public
=== CONT  TestAccAWSSSMDocument_permission_batching
=== CONT  TestAccAWSSSMDocument_DocumentFormat_YAML
=== CONT  TestAccAWSSSMDocument_session
=== CONT  TestAccAWSSSMDocument_automation
=== CONT  TestAccAWSSSMDocument_Tags
--- PASS: TestAccAWSSSMDocument_params (32.52s)
--- PASS: TestAccAWSSSMDocument_session (32.52s)
--- PASS: TestAccAWSSSMDocument_basic (33.96s)
--- PASS: TestAccAWSSSMDocument_permission_private (33.98s)
--- PASS: TestAccAWSSSMDocument_permission_batching (35.40s)
--- PASS: TestAccAWSSSMDocument_permission_public (43.07s)
--- PASS: TestAccAWSSSMDocument_automation (53.78s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (62.84s)
--- PASS: TestAccAWSSSMDocument_update (67.94s)
--- PASS: TestAccAWSSSMDocument_Tags (78.67s)
--- PASS: TestAccAWSSSMDocument_permission_change (78.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	78.696s
```
