### PR TITLE
Fix DynamoDB OnDemand GSI behavior

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -294,18 +294,16 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	billingMode := d.Get("billing_mode").(string)
-	if billingMode == dynamodb.BillingModeProvisioned {
-		v_read, ok_read := d.GetOk("read_capacity")
-		v_write, ok_write := d.GetOk("write_capacity")
-		if !ok_read || !ok_write {
-			return fmt.Errorf("Read and Write capacity should be set when billing mode is PROVISIONED")
-		}
-
-		req.ProvisionedThroughput = expandDynamoDbProvisionedThroughput(map[string]interface{}{
-			"read_capacity":  v_read,
-			"write_capacity": v_write,
-		})
+	capacityMap := map[string]interface{}{
+		"write_capacity": d.Get("write_capacity"),
+		"read_capacity":  d.Get("read_capacity"),
 	}
+
+	if err := validateDynamoDbProvisionedThroughput(capacityMap, billingMode); err != nil {
+		return err
+	}
+
+	req.ProvisionedThroughput = expandDynamoDbProvisionedThroughput(capacityMap, billingMode)
 
 	if v, ok := d.GetOk("attribute"); ok {
 		aSet := v.(*schema.Set)
@@ -323,11 +321,8 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 
 		for _, gsiObject := range gsiSet.List() {
 			gsi := gsiObject.(map[string]interface{})
-
-			_, writeCapacitySet := gsi["write_capacity"]
-			_, readCapacitySet := gsi["read_capacity"]
-			if billingMode == dynamodb.BillingModeProvisioned && (!writeCapacitySet || !readCapacitySet) {
-				return fmt.Errorf("Read and Write capacity should be set for GSIs when billing mode is %s", dynamodb.BillingModeProvisioned)
+			if err := validateDynamoDbProvisionedThroughput(gsi, billingMode); err != nil {
+				return fmt.Errorf("Failed to create GSI: %v", err)
 			}
 
 			gsiObject := expandDynamoDbGlobalSecondaryIndex(gsi, billingMode)
@@ -388,24 +383,22 @@ func resourceAwsDynamoDbTableCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dynamodbconn
+	billingMode := d.Get("billing_mode").(string)
+
 	if d.HasChange("billing_mode") && !d.IsNewResource() {
 		req := &dynamodb.UpdateTableInput{
 			TableName:   aws.String(d.Id()),
-			BillingMode: aws.String(d.Get("billing_mode").(string)),
+			BillingMode: aws.String(billingMode),
 		}
-		if d.Get("billing_mode").(string) == dynamodb.BillingModeProvisioned {
-
-			v_read, ok_read := d.GetOk("read_capacity")
-			v_write, ok_write := d.GetOk("write_capacity")
-			if !ok_read || !ok_write {
-				return fmt.Errorf("Read and Write capacity should be set when billing mode is PROVISIONED")
-			}
-
-			req.ProvisionedThroughput = expandDynamoDbProvisionedThroughput(map[string]interface{}{
-				"read_capacity":  v_read,
-				"write_capacity": v_write,
-			})
+		capacityMap := map[string]interface{}{
+			"write_capacity": d.Get("write_capacity"),
+			"read_capacity":  d.Get("read_capacity"),
 		}
+
+		if err := validateDynamoDbProvisionedThroughput(capacityMap, billingMode); err != nil {
+			return err
+		}
+
 		_, err := conn.UpdateTable(req)
 		if err != nil {
 			return fmt.Errorf("Error updating DynamoDB Table (%s) billing mode: %s", d.Id(), err)
@@ -422,7 +415,7 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 			ProvisionedThroughput: expandDynamoDbProvisionedThroughput(map[string]interface{}{
 				"read_capacity":  d.Get("read_capacity"),
 				"write_capacity": d.Get("write_capacity"),
-			}),
+			}, billingMode),
 		})
 		if err != nil {
 			return err
@@ -460,7 +453,7 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 		attributes := d.Get("attribute").(*schema.Set).List()
 
 		o, n := d.GetChange("global_secondary_index")
-		ops, err := diffDynamoDbGSI(o.(*schema.Set).List(), n.(*schema.Set).List())
+		ops, err := diffDynamoDbGSI(o.(*schema.Set).List(), n.(*schema.Set).List(), billingMode)
 		if err != nil {
 			return fmt.Errorf("Computing difference for global_secondary_index failed: %s", err)
 		}

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -315,7 +315,7 @@ func TestDiffDynamoDbGSI(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		ops, err := diffDynamoDbGSI(tc.Old, tc.New)
+		ops, err := diffDynamoDbGSI(tc.Old, tc.New, dynamodb.BillingModeProvisioned)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -500,6 +500,15 @@ func TestAccAWSDynamoDbTable_BillingMode(t *testing.T) {
 					testAccCheckDynamoDbTableHasBilling_PayPerRequest("aws_dynamodb_table.basic-dynamodb-table"),
 				),
 			},
+			{
+				Config: testAccAWSDynamoDbBilling_PayPerRequestWithGSI(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynamoDbTableHasBilling_PayPerRequest("aws_dynamodb_table.basic-dynamodb-table"),
+					resource.TestCheckResourceAttr("aws_dynamodb_table.basic-dynamodb-table", "global_secondary_index.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_dynamodb_table.basic-dynamodb-table", "global_secondary_index.427641302.name", "TestTableGSI"),
+				),
+			},
 		},
 	})
 }
@@ -1260,6 +1269,32 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
   attribute {
     name = "TestTableHashKey"
     type = "S"
+  }
+}
+`, rName)
+}
+
+func testAccAWSDynamoDbBilling_PayPerRequestWithGSI(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "basic-dynamodb-table" {
+  name = "%s"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  attribute {
+    name = "TestTableGSIKey"
+    type = "S"
+  }
+
+  global_secondary_index {
+	name 			= "TestTableGSI"
+	hash_key        = "TestTableGSIKey"
+    projection_type = "KEYS_ONLY"
   }
 }
 `, rName)

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4308,13 +4308,18 @@ func expandDynamoDbLocalSecondaryIndexes(cfg []interface{}, keySchemaM map[strin
 	return indexes
 }
 
-func expandDynamoDbGlobalSecondaryIndex(data map[string]interface{}) *dynamodb.GlobalSecondaryIndex {
-	return &dynamodb.GlobalSecondaryIndex{
-		IndexName:             aws.String(data["name"].(string)),
-		KeySchema:             expandDynamoDbKeySchema(data),
-		Projection:            expandDynamoDbProjection(data),
-		ProvisionedThroughput: expandDynamoDbProvisionedThroughput(data),
+func expandDynamoDbGlobalSecondaryIndex(data map[string]interface{}, billingMode string) *dynamodb.GlobalSecondaryIndex {
+	gsi := &dynamodb.GlobalSecondaryIndex{
+		IndexName:  aws.String(data["name"].(string)),
+		KeySchema:  expandDynamoDbKeySchema(data),
+		Projection: expandDynamoDbProjection(data),
 	}
+
+	if billingMode == dynamodb.BillingModeProvisioned {
+		gsi.ProvisionedThroughput = expandDynamoDbProvisionedThroughput(data)
+	}
+
+	return gsi
 }
 
 func expandDynamoDbProvisionedThroughput(data map[string]interface{}) *dynamodb.ProvisionedThroughput {

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -133,8 +133,8 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 #### `global_secondary_index`
 
 * `name` - (Required) The name of the index
-* `write_capacity` - (Required) The number of write units for this index
-* `read_capacity` - (Required) The number of read units for this index
+* `write_capacity` - (Optional) The number of write units for this index. Must be set if billing_mode is set to PROVISIONED.
+* `read_capacity` - (Optional) The number of read units for this index. Must be set if billing_mode is set to PROVISIONED.
 * `hash_key` - (Required) The name of the hash key in the index; must be
   defined as an attribute in the resource.
 * `range_key` - (Optional) The name of the range key; must be defined


### PR DESCRIPTION
allow GSIs to be created with no throughput capacity specified if they correspond to a table with PAY_PER_REQUEST billing enabled

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6736

Changes proposed in this pull request:

* Update dynamodb_table resource schema to make read & write_capacity inputs to GSI blocks optional
* Return an error if billing_mode is set to PROVISIONED and capacity units aren't set

I also wouldn't mind some input about how to handle the update scenario. It feels like the code should short circuit as early as possible, so maybe extracting the logic currently being used for table creation, and using it to validate the new GSI block before we compute the diff. 

Thoughts?

UPDATE: I implemented the fix for updates as well, and added an acceptance test validating that the creation succeeds with a GSI. 

Output from acceptance testing: 

```
TF_ACC=1 go test -v -timeout=30m -run=TestAccAWSDynamoDbTable
=== RUN   TestAccAWSDynamoDbTableItem_basic
=== PAUSE TestAccAWSDynamoDbTableItem_basic
=== RUN   TestAccAWSDynamoDbTableItem_rangeKey
=== PAUSE TestAccAWSDynamoDbTableItem_rangeKey
=== RUN   TestAccAWSDynamoDbTableItem_withMultipleItems
=== PAUSE TestAccAWSDynamoDbTableItem_withMultipleItems
=== RUN   TestAccAWSDynamoDbTableItem_update
=== PAUSE TestAccAWSDynamoDbTableItem_update
=== RUN   TestAccAWSDynamoDbTableItem_updateWithRangeKey
=== PAUSE TestAccAWSDynamoDbTableItem_updateWithRangeKey
=== RUN   TestAccAWSDynamoDbTable_importBasic
=== PAUSE TestAccAWSDynamoDbTable_importBasic
=== RUN   TestAccAWSDynamoDbTable_importTags
=== PAUSE TestAccAWSDynamoDbTable_importTags
=== RUN   TestAccAWSDynamoDbTable_importTimeToLive
=== PAUSE TestAccAWSDynamoDbTable_importTimeToLive
=== RUN   TestAccAWSDynamoDbTable_basic
=== PAUSE TestAccAWSDynamoDbTable_basic
=== RUN   TestAccAWSDynamoDbTable_extended
=== PAUSE TestAccAWSDynamoDbTable_extended
=== RUN   TestAccAWSDynamoDbTable_enablePitr
=== PAUSE TestAccAWSDynamoDbTable_enablePitr
=== RUN   TestAccAWSDynamoDbTable_BillingMode
=== PAUSE TestAccAWSDynamoDbTable_BillingMode
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
=== PAUSE TestAccAWSDynamoDbTable_streamSpecification
=== RUN   TestAccAWSDynamoDbTable_streamSpecificationValidation
=== PAUSE TestAccAWSDynamoDbTable_streamSpecificationValidation
=== RUN   TestAccAWSDynamoDbTable_tags
=== PAUSE TestAccAWSDynamoDbTable_tags
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccAWSDynamoDbTable_ttl
=== PAUSE TestAccAWSDynamoDbTable_ttl
=== RUN   TestAccAWSDynamoDbTable_attributeUpdate
=== PAUSE TestAccAWSDynamoDbTable_attributeUpdate
=== RUN   TestAccAWSDynamoDbTable_attributeUpdateValidation
=== PAUSE TestAccAWSDynamoDbTable_attributeUpdateValidation
=== RUN   TestAccAWSDynamoDbTable_encryption
=== PAUSE TestAccAWSDynamoDbTable_encryption
=== CONT  TestAccAWSDynamoDbTableItem_basic
=== CONT  TestAccAWSDynamoDbTable_streamSpecification
=== CONT  TestAccAWSDynamoDbTable_encryption
=== CONT  TestAccAWSDynamoDbTable_attributeUpdateValidation
=== CONT  TestAccAWSDynamoDbTable_attributeUpdate
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== CONT  TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (3.95s)
=== CONT  TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (62.32s)
=== CONT  TestAccAWSDynamoDbTable_streamSpecificationValidation
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (1.64s)
=== CONT  TestAccAWSDynamoDbTable_BillingMode
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (107.46s)
=== CONT  TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_importTags (131.60s)
=== CONT  TestAccAWSDynamoDbTable_enablePitr
--- PASS: TestAccAWSDynamoDbTable_tags (142.71s)
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
--- PASS: TestAccAWSDynamoDbTable_encryption (219.32s)
=== CONT  TestAccAWSDynamoDbTable_extended
--- PASS: TestAccAWSDynamoDbTableItem_basic (255.43s)
=== CONT  TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_ttl (149.86s)
=== CONT  TestAccAWSDynamoDbTableItem_update
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (199.27s)
=== CONT  TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_extended (125.14s)
=== CONT  TestAccAWSDynamoDbTableItem_updateWithRangeKey
--- PASS: TestAccAWSDynamoDbTable_basic (111.65s)
=== CONT  TestAccAWSDynamoDbTableItem_withMultipleItems
--- PASS: TestAccAWSDynamoDbTableItem_update (124.02s)
=== CONT  TestAccAWSDynamoDbTable_importTimeToLive
--- PASS: TestAccAWSDynamoDbTable_enablePitr (268.90s)
=== CONT  TestAccAWSDynamoDbTableItem_rangeKey
--- PASS: TestAccAWSDynamoDbTableItem_updateWithRangeKey (120.05s)
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (106.17s)
--- PASS: TestAccAWSDynamoDbTable_importBasic (134.69s)
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (105.37s)
--- PASS: TestAccAWSDynamoDbTable_importTimeToLive (165.22s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode (515.16s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (648.84s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (650.99s)
PASS
ok  	github.com/sbogacz/terraform-provider-aws/aws	651.632s
```
