### PR TITLE
r/aws_vpn_connection_route: Fix gosimple issues

### DIFF
--- a/aws/resource_aws_vpn_connection_route.go
+++ b/aws/resource_aws_vpn_connection_route.go
@@ -128,11 +128,7 @@ func resourceAwsVpnConnectionRouteDelete(d *schema.ResourceData, meta interface{
 		},
 	}
 	_, err = stateConf.WaitForState()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func findConnectionRoute(conn *ec2.EC2, cidrBlock, vpnConnectionId string) (*ec2.VpnStaticRoute, error) {

--- a/aws/resource_aws_vpn_connection_route_test.go
+++ b/aws/resource_aws_vpn_connection_route_test.go
@@ -137,11 +137,7 @@ func testAccAwsVpnConnectionRoute(
 		_, err := ec2conn.DescribeVpnConnections(&ec2.DescribeVpnConnectionsInput{
 			Filters: routeFilters,
 		})
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }
 


### PR DESCRIPTION
Related to #6343 technical debt

Changes proposed in this pull request:

- Fixes gosimple vpn issues

Output from acceptance testing:
```console
$ make testacc TESTARGS='-run=TestAccAWSVpnConnectionRoute_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVpnConnectionRoute_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVpnConnectionRoute_basic
=== PAUSE TestAccAWSVpnConnectionRoute_basic
=== CONT  TestAccAWSVpnConnectionRoute_basic
--- PASS: TestAccAWSVpnConnectionRoute_basic (201.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	201.833s
```