### PR TITLE
r/aws_vpc: gosimple fixes

### DIFF
--- a/aws/resource_aws_vpc_dhcp_options_association.go
+++ b/aws/resource_aws_vpc_dhcp_options_association.go
@@ -87,12 +87,10 @@ func resourceAwsVpcDhcpOptionsAssociationDelete(d *schema.ResourceData, meta int
 	conn := meta.(*AWSClient).ec2conn
 
 	log.Printf("[INFO] Disassociating DHCP Options Set %s from VPC %s...", d.Get("dhcp_options_id"), d.Get("vpc_id"))
-	if _, err := conn.AssociateDhcpOptions(&ec2.AssociateDhcpOptionsInput{
+	_, err := conn.AssociateDhcpOptions(&ec2.AssociateDhcpOptionsInput{
 		DhcpOptionsId: aws.String("default"),
 		VpcId:         aws.String(d.Get("vpc_id").(string)),
-	}); err != nil {
-		return err
-	}
+	})
 
-	return nil
+	return err
 }

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -78,10 +78,8 @@ func TestAccAWSVpcEndpointService_removed(t *testing.T) {
 		_, err := conn.DeleteVpcEndpointServiceConfigurations(&ec2.DeleteVpcEndpointServiceConfigurationsInput{
 			ServiceIds: []*string{svcCfg.ServiceId},
 		})
-		if err != nil {
-			return err
-		}
-		return nil
+
+		return err
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -201,10 +201,8 @@ func TestAccAWSVpcEndpoint_removed(t *testing.T) {
 		}
 
 		_, err := conn.DeleteVpcEndpoints(input)
-		if err != nil {
-			return err
-		}
-		return nil
+
+		return err
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -213,11 +213,9 @@ func resourceAwsVpcPeeringConnectionModifyOptions(d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[DEBUG] Modifying VPC Peering Connection options: %#v", req)
-	if _, err := conn.ModifyVpcPeeringConnectionOptions(req); err != nil {
-		return err
-	}
+	_, err := conn.ModifyVpcPeeringConnectionOptions(req)
 
-	return nil
+	return err
 }
 
 func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -71,10 +71,8 @@ func TestAccAWSVPCPeeringConnection_plan(t *testing.T) {
 			&ec2.DeleteVpcPeeringConnectionInput{
 				VpcPeeringConnectionId: connection.VpcPeeringConnectionId,
 			})
-		if err != nil {
-			return err
-		}
-		return nil
+
+		return err
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -135,10 +133,8 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 					AllowDnsResolutionFromRemoteVpc: aws.Bool(false),
 				},
 			})
-		if err != nil {
-			return err
-		}
-		return nil
+
+		return err
 	}
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
Related to #6343 technical debt

Changes proposed in this pull request:

- Fixes gosimple vpc issues

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSDHCPOptionsAssociation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDHCPOptionsAssociation_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDHCPOptionsAssociation_basic
=== PAUSE TestAccAWSDHCPOptionsAssociation_basic
=== CONT  TestAccAWSDHCPOptionsAssociation_basic
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (27.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.549s
$ make testacc TESTARGS='-run=TestAccAWSVpcEndpointService_removed'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVpcEndpointService_removed -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVpcEndpointService_removed
=== PAUSE TestAccAWSVpcEndpointService_removed
=== CONT  TestAccAWSVpcEndpointService_removed
--- PASS: TestAccAWSVpcEndpointService_removed (248.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	248.687s
$ make testacc TESTARGS='-run=TestAccAWSVpcEndpoint_removed'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVpcEndpoint_removed -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVpcEndpoint_removed
=== PAUSE TestAccAWSVpcEndpoint_removed
=== CONT  TestAccAWSVpcEndpoint_removed
--- PASS: TestAccAWSVpcEndpoint_removed (34.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.103s
$ make testacc TESTARGS='-run=TestAccAWSVPCPeeringConnection_plan'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVPCPeeringConnection_plan -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVPCPeeringConnection_plan
=== PAUSE TestAccAWSVPCPeeringConnection_plan
=== CONT  TestAccAWSVPCPeeringConnection_plan
--- PASS: TestAccAWSVPCPeeringConnection_plan (29.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	29.514s
$ make testacc TESTARGS='-run=TestAccAWSVPCPeeringConnection_options'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVPCPeeringConnection_options -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVPCPeeringConnection_options
=== PAUSE TestAccAWSVPCPeeringConnection_options
=== CONT  TestAccAWSVPCPeeringConnection_options
--- PASS: TestAccAWSVPCPeeringConnection_options (49.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.097s
```