### PR TITLE
Add support for aws_ssm_maintenance_window import and documentation

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -14,6 +14,9 @@ func resourceAwsSsmMaintenanceWindow() *schema.Resource {
 		Read:   resourceAwsSsmMaintenanceWindowRead,
 		Update: resourceAwsSsmMaintenanceWindowUpdate,
 		Delete: resourceAwsSsmMaintenanceWindowDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -32,6 +32,11 @@ func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.1", "acceptance_test2"),
 				),
 			},
+			{
+				ResourceName:      "aws_ssm_maintenance_window.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -36,3 +36,9 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the maintenance window.
+
+## Import
+SSM  Maintenance Windows can be imported using the `maintenance window id`, e.g.
+```
+$ terraform import aws_ssm_maintenance_window.imported-window mw-0123456789
+```


### PR DESCRIPTION
Changes proposed in this pull request:

* Add the standard ImportStatePassthrough to the aws_ssm_maintenance_window
* Update aws_ssm_maintenance_window docs
