### PR TITLE
Documentation: Change DLM resource_type allowed value

### DIFF
--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 #### Policy Details arguments
 
-* `resource_types` - (Required) A list of resource types that should be targeted by the lifecycle policy. `VOLUMES` is currently the only allowed value.
+* `resource_types` - (Required) A list of resource types that should be targeted by the lifecycle policy. `VOLUME` is currently the only allowed value.
 * `schedule` - (Required) See the [`schedule` configuration](#schedule-arguments) block.
 * `target_tags` (Required) A mapping of tag keys and their values. Any resources that match the `resource_types` and are tagged with _any_ of these tags will be targeted.
 


### PR DESCRIPTION
### Reason:
If `VOLUMES` is used instead of `VOLUME`, the API will reject the resource with

```
aws_dlm_lifecycle_policy.example: error creating DLM Lifecycle Policy: InvalidRequestException: The following parameter(s) are invalid: ResourceTypes {["VOLUMES"]}
	status code: 400, request id: xxxx-xxxxx-xxxxxx
```

The AWS API documentation and user guide documentation corroborates this fact.
https://docs.aws.amazon.com/dlm/latest/APIReference/API_PolicyDetails.html
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html

### Relevant Terraform version:
This documentation issue has been a problem since it was released in v1.43.0