### PR TITLE
Fix docs link for dlm_lifecycle_policy retain_rule

### DIFF
--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -119,7 +119,7 @@ The following arguments are supported:
 * `copy_tags` - (Optional) Copy all user-defined tags on a source volume to snapshots of the volume created by this policy.
 * `create_rule` - (Required) See the [`create_rule`](#create-rule-arguments) block. Max of 1 per schedule.
 * `name` - (Required) A name for the schedule.
-* `retain_rule` - (Required) See the [`create_rule`](#create-rule-arguments) block. Max of 1 per schedule.
+* `retain_rule` - (Required) See the [`retain_rule`](#retain-rule-arguments) block. Max of 1 per schedule.
 * `tags_to_add` - (Optional) A mapping of tag keys and their values. DLM lifecycle policies will already tag the snapshot with the tags on the volume. This configuration adds extra tags on top of these.
 
 #### Create Rule arguments


### PR DESCRIPTION
## Reason:

The link from the `retain_rule` in the resource docs is incorrect.

## Relevant Terraform version:

Has been incorrect since the release of this resource in provider v1.43.0.