### PR TITLE
resource/aws_elasticache_parameter_group: Handle API reset issues with reserved-memory parameter

### DIFF
--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -212,12 +212,6 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 					// can attempt to workaround the API issue by switching it to
 					// reserved-memory-percentage first then reset that temporary parameter.
 
-					// The reserved-memory-percentage parameter does not exist in redis2.6 and redis2.8
-					family := d.Get("family").(string)
-					if family == "redis2.6" || family == "redis2.8" {
-						break
-					}
-
 					tryReservedMemoryPercentageWorkaround := true
 
 					allConfiguredParameters, err := expandElastiCacheParameters(d.Get("parameter").(*schema.Set).List())
@@ -233,6 +227,13 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 					}
 
 					if !tryReservedMemoryPercentageWorkaround {
+						break
+					}
+
+					// The reserved-memory-percentage parameter does not exist in redis2.6 and redis2.8
+					family := d.Get("family").(string)
+					if family == "redis2.6" || family == "redis2.8" {
+						log.Printf("[WARN] Cannot reset Elasticache Parameter Group (%s) reserved-memory parameter with %s family", d.Id(), family)
 						break
 					}
 

--- a/aws/resource_aws_elasticache_parameter_group.go
+++ b/aws/resource_aws_elasticache_parameter_group.go
@@ -188,6 +188,100 @@ func resourceAwsElasticacheParameterGroupUpdate(d *schema.ResourceData, meta int
 				}
 				return nil
 			})
+
+			// When attempting to reset the reserved-memory parameter, the API
+			// can return the below 500 error, which causes the AWS Go SDK to
+			// automatically retry and hence timeout resource.Retry():
+			//   InternalFailure: An internal error has occurred. Please try your query again at a later time.
+			// Instead of hardcoding the reserved-memory parameter removal
+			// above, which may become out of date, here we add logic to
+			// workaround this API behavior
+
+			if isResourceTimeoutError(err) {
+				for i, paramToModify := range paramsToModify {
+					if aws.StringValue(paramToModify.ParameterName) != "reserved-memory" {
+						continue
+					}
+
+					// Always reset the top level error and remove the reset for reserved-memory
+					err = nil
+					paramsToModify = append(paramsToModify[:i], paramsToModify[i+1:]...)
+
+					// If we are only trying to remove reserved-memory and not perform
+					// an update to reserved-memory or reserved-memory-percentage, we
+					// can attempt to workaround the API issue by switching it to
+					// reserved-memory-percentage first then reset that temporary parameter.
+
+					// The reserved-memory-percentage parameter does not exist in redis2.6 and redis2.8
+					family := d.Get("family").(string)
+					if family == "redis2.6" || family == "redis2.8" {
+						break
+					}
+
+					tryReservedMemoryPercentageWorkaround := true
+
+					allConfiguredParameters, err := expandElastiCacheParameters(d.Get("parameter").(*schema.Set).List())
+					if err != nil {
+						return fmt.Errorf("error expanding parameter configuration: %s", err)
+					}
+
+					for _, configuredParameter := range allConfiguredParameters {
+						if aws.StringValue(configuredParameter.ParameterName) == "reserved-memory" || aws.StringValue(configuredParameter.ParameterName) == "reserved-memory-percentage" {
+							tryReservedMemoryPercentageWorkaround = false
+							break
+						}
+					}
+
+					if !tryReservedMemoryPercentageWorkaround {
+						break
+					}
+
+					modifyInput := &elasticache.ModifyCacheParameterGroupInput{
+						CacheParameterGroupName: aws.String(d.Get("name").(string)),
+						ParameterNameValues: []*elasticache.ParameterNameValue{
+							{
+								ParameterName:  aws.String("reserved-memory-percentage"),
+								ParameterValue: aws.String("0"),
+							},
+						},
+					}
+					_, err = conn.ModifyCacheParameterGroup(modifyInput)
+
+					if err != nil {
+						log.Printf("[WARN] Error attempting reserved-memory workaround to switch to reserved-memory-percentage: %s", err)
+						break
+					}
+
+					resetInput := &elasticache.ResetCacheParameterGroupInput{
+						CacheParameterGroupName: aws.String(d.Get("name").(string)),
+						ParameterNameValues: []*elasticache.ParameterNameValue{
+							{
+								ParameterName:  aws.String("reserved-memory-percentage"),
+								ParameterValue: aws.String("0"),
+							},
+						},
+					}
+
+					_, err = conn.ResetCacheParameterGroup(resetInput)
+
+					if err != nil {
+						log.Printf("[WARN] Error attempting reserved-memory workaround to reset reserved-memory-percentage: %s", err)
+					}
+
+					break
+				}
+
+				// Retry any remaining parameter resets with reserved-memory potentially removed
+				if len(paramsToModify) > 0 {
+					resetOpts = elasticache.ResetCacheParameterGroupInput{
+						CacheParameterGroupName: aws.String(d.Get("name").(string)),
+						ParameterNameValues:     paramsToModify,
+					}
+					// Reset top level error with potentially any new errors
+					_, err = conn.ResetCacheParameterGroup(&resetOpts)
+				}
+			}
+
 			if err != nil {
 				return fmt.Errorf("Error resetting Cache Parameter Group: %s", err)
 			}

--- a/website/docs/r/elasticache_parameter_group.html.markdown
+++ b/website/docs/r/elasticache_parameter_group.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an ElastiCache parameter group resource.
 
+~> **NOTE:** Attempting to remove the `reserved-memory` parameter when `family` is set to `redis2.6` or `redis2.8` may show a perpetual difference in Terraform due to an Elasticache API limitation. Leave that parameter configured with any value to workaround the issue.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
The Elasticache API is currently always returning an `InternalFailure` error when attempting to reset the `reserved-memory` parameter. The Terraform resource previously provided an unhelpful timeout error with no way to workaround the behavior to properly update `reserved-memory` to a new value or switch to the `reserved-memory-percentage` parameter.

The resource now employs some handling to skip the problematic `reserved-memory` reset, but only after its attempted before, in case the Elasticache API is fixed in the future.

Changes:

* resource/aws_elasticache_parameter_group: Code and acceptance test workarounds for `reserved-memory` parameter always returning an error during update
* tests/resource/aws_elasticache_parameter_group: Switch from bespoke import test to always testing import
* tests/resource/aws_elasticache_parameter_group: Other minor refactoring to clean acceptance testing

Previously failing acceptance testing:

```
--- FAIL: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter (76.81s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
        	* aws_elasticache_parameter_group.bar: 1 error occurred:
        	* aws_elasticache_parameter_group.bar: Error resetting Cache Parameter Group: timeout while waiting for state to become 'success' (timeout: 30s)

--- FAIL: TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter (76.81s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
        	* aws_elasticache_parameter_group.bar: 1 error occurred:
        	* aws_elasticache_parameter_group.bar: Error resetting Cache Parameter Group: timeout while waiting for state to become 'success' (timeout: 30s)

--- FAIL: TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter (77.01s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
        	* aws_elasticache_parameter_group.bar: 1 error occurred:
        	* aws_elasticache_parameter_group.bar: Error resetting Cache Parameter Group: timeout while waiting for state to become 'success' (timeout: 30s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticacheParameterGroup_basic (19.94s)
--- PASS: TestAccAWSElasticacheParameterGroup_UppercaseName (23.09s)
--- PASS: TestAccAWSElasticacheParameterGroup_Description (33.43s)
--- PASS: TestAccAWSElasticacheParameterGroup_addParameter (34.66s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeAllParameters (43.51s)
--- PASS: TestAccAWSElasticacheParameterGroup_removeReservedMemoryParameter (43.57s)
--- PASS: TestAccAWSElasticacheParameterGroup_updateReservedMemoryParameter (86.12s)
--- PASS: TestAccAWSElasticacheParameterGroup_switchReservedMemoryParameter (95.82s)
```
