### PR TITLE
resource/aws_route53_record: Prevent scanning entire zone for missing record

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -681,6 +681,18 @@ func findRecord(d *schema.ResourceData, meta interface{}) (*route53.ResourceReco
 			record = recordSet
 			return false
 		}
+
+		nextRecordName := strings.ToLower(cleanRecordName(aws.StringValue(resp.NextRecordName)))
+		nextRecordType := strings.ToUpper(aws.StringValue(resp.NextRecordType))
+
+		if nextRecordName != recordName {
+			return false
+		}
+
+		if nextRecordType != recordType {
+			return false
+		}
+
 		return !lastPage
 	})
 

--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -148,6 +148,8 @@ func TestAccAWSRoute53Record_importUnderscored(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_basic(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.default",
@@ -157,7 +159,7 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
 				),
 			},
 		},
@@ -165,6 +167,8 @@ func TestAccAWSRoute53Record_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.default",
@@ -174,7 +178,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfig_fqdn,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
 				),
 			},
 
@@ -187,7 +191,7 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfig_fqdn_no_op,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record2),
 				),
 			},
 		},
@@ -195,6 +199,8 @@ func TestAccAWSRoute53Record_basic_fqdn(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshName:   "aws_route53_record.default",
@@ -205,7 +211,7 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigTXT,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
 				),
 			},
 		},
@@ -213,6 +219,8 @@ func TestAccAWSRoute53Record_txtSupport(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.default",
@@ -222,7 +230,7 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigSPF,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
 					resource.TestCheckResourceAttr(
 						"aws_route53_record.default", "records.2930149397", "include:notexample.com"),
 				),
@@ -232,6 +240,8 @@ func TestAccAWSRoute53Record_spfSupport(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.default",
@@ -241,7 +251,7 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigCAA,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
 					resource.TestCheckResourceAttr(
 						"aws_route53_record.default", "records.2965463512", "0 issue \"exampleca.com;\""),
 				),
@@ -251,6 +261,8 @@ func TestAccAWSRoute53Record_caaSupport(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.default",
@@ -260,7 +272,7 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigSuffix,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
 				),
 			},
 		},
@@ -268,6 +280,8 @@ func TestAccAWSRoute53Record_generatesSuffix(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_wildcard(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.wildcard",
@@ -277,7 +291,7 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 			{
 				Config: testAccRoute53WildCardRecordConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.wildcard"),
+					testAccCheckRoute53RecordExists("aws_route53_record.wildcard", &record1),
 				),
 			},
 
@@ -285,7 +299,7 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 			{
 				Config: testAccRoute53WildCardRecordConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.wildcard"),
+					testAccCheckRoute53RecordExists("aws_route53_record.wildcard", &record2),
 				),
 			},
 		},
@@ -293,6 +307,8 @@ func TestAccAWSRoute53Record_wildcard(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_failover(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.www-primary",
@@ -302,8 +318,8 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 			{
 				Config: testAccRoute53FailoverCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.www-primary"),
-					testAccCheckRoute53RecordExists("aws_route53_record.www-secondary"),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-primary", &record1),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-secondary", &record2),
 				),
 			},
 		},
@@ -311,6 +327,8 @@ func TestAccAWSRoute53Record_failover(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
+	var record1, record2, record3 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.www-live",
@@ -320,9 +338,9 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 			{
 				Config: testAccRoute53WeightedCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.www-dev"),
-					testAccCheckRoute53RecordExists("aws_route53_record.www-live"),
-					testAccCheckRoute53RecordExists("aws_route53_record.www-off"),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-dev", &record1),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-live", &record2),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-off", &record3),
 				),
 			},
 		},
@@ -330,6 +348,8 @@ func TestAccAWSRoute53Record_weighted_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_alias(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53ElbAliasRecord, rs)
 	resource.ParallelTest(t, resource.TestCase{
@@ -341,7 +361,7 @@ func TestAccAWSRoute53Record_alias(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.alias"),
+					testAccCheckRoute53RecordExists("aws_route53_record.alias", &record1),
 				),
 			},
 		},
@@ -349,6 +369,8 @@ func TestAccAWSRoute53Record_alias(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_aliasUppercase(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	rs := acctest.RandString(10)
 	config := fmt.Sprintf(testAccRoute53ElbAliasRecordUppercase, rs)
 	resource.ParallelTest(t, resource.TestCase{
@@ -360,7 +382,7 @@ func TestAccAWSRoute53Record_aliasUppercase(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.alias"),
+					testAccCheckRoute53RecordExists("aws_route53_record.alias", &record1),
 				),
 			},
 		},
@@ -368,6 +390,8 @@ func TestAccAWSRoute53Record_aliasUppercase(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_s3_alias(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -376,7 +400,7 @@ func TestAccAWSRoute53Record_s3_alias(t *testing.T) {
 			{
 				Config: testAccRoute53S3AliasRecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.alias"),
+					testAccCheckRoute53RecordExists("aws_route53_record.alias", &record1),
 				),
 			},
 		},
@@ -384,6 +408,8 @@ func TestAccAWSRoute53Record_s3_alias(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
+	var record1, record2, record3, record4, record5, record6 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.elb_weighted_alias_live",
@@ -393,18 +419,18 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 			{
 				Config: testAccRoute53WeightedElbAliasRecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_live"),
-					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_dev"),
+					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_live", &record1),
+					testAccCheckRoute53RecordExists("aws_route53_record.elb_weighted_alias_dev", &record2),
 				),
 			},
 
 			{
 				Config: testAccRoute53WeightedR53AliasRecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.green_origin"),
-					testAccCheckRoute53RecordExists("aws_route53_record.r53_weighted_alias_live"),
-					testAccCheckRoute53RecordExists("aws_route53_record.blue_origin"),
-					testAccCheckRoute53RecordExists("aws_route53_record.r53_weighted_alias_dev"),
+					testAccCheckRoute53RecordExists("aws_route53_record.green_origin", &record3),
+					testAccCheckRoute53RecordExists("aws_route53_record.r53_weighted_alias_live", &record4),
+					testAccCheckRoute53RecordExists("aws_route53_record.blue_origin", &record5),
+					testAccCheckRoute53RecordExists("aws_route53_record.r53_weighted_alias_dev", &record6),
 				),
 			},
 		},
@@ -412,6 +438,8 @@ func TestAccAWSRoute53Record_weighted_alias(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
+	var record1, record2, record3, record4 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -420,10 +448,10 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 			{
 				Config: testAccRoute53GeolocationCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.default"),
-					testAccCheckRoute53RecordExists("aws_route53_record.california"),
-					testAccCheckRoute53RecordExists("aws_route53_record.oceania"),
-					testAccCheckRoute53RecordExists("aws_route53_record.denmark"),
+					testAccCheckRoute53RecordExists("aws_route53_record.default", &record1),
+					testAccCheckRoute53RecordExists("aws_route53_record.california", &record2),
+					testAccCheckRoute53RecordExists("aws_route53_record.oceania", &record3),
+					testAccCheckRoute53RecordExists("aws_route53_record.denmark", &record4),
 				),
 			},
 		},
@@ -431,6 +459,8 @@ func TestAccAWSRoute53Record_geolocation_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
+	var record1, record2, record3 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -439,9 +469,9 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 			{
 				Config: testAccRoute53LatencyCNAMERecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.us-east-1"),
-					testAccCheckRoute53RecordExists("aws_route53_record.eu-west-1"),
-					testAccCheckRoute53RecordExists("aws_route53_record.ap-northeast-1"),
+					testAccCheckRoute53RecordExists("aws_route53_record.us-east-1", &record1),
+					testAccCheckRoute53RecordExists("aws_route53_record.eu-west-1", &record2),
+					testAccCheckRoute53RecordExists("aws_route53_record.ap-northeast-1", &record3),
 				),
 			},
 		},
@@ -449,6 +479,8 @@ func TestAccAWSRoute53Record_latency_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.sample",
@@ -458,7 +490,7 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 			{
 				Config: testAccRoute53RecordTypeChangePre,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.sample"),
+					testAccCheckRoute53RecordExists("aws_route53_record.sample", &record1),
 				),
 			},
 
@@ -466,7 +498,7 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 			{
 				Config: testAccRoute53RecordTypeChangePost,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.sample"),
+					testAccCheckRoute53RecordExists("aws_route53_record.sample", &record2),
 				),
 			},
 		},
@@ -474,6 +506,8 @@ func TestAccAWSRoute53Record_TypeChange(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_SetIdentiferChange(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.basic_to_weighted",
@@ -483,7 +517,7 @@ func TestAccAWSRoute53Record_SetIdentiferChange(t *testing.T) {
 			{
 				Config: testAccRoute53RecordSetIdentifierChangePre,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.basic_to_weighted"),
+					testAccCheckRoute53RecordExists("aws_route53_record.basic_to_weighted", &record1),
 				),
 			},
 
@@ -491,7 +525,7 @@ func TestAccAWSRoute53Record_SetIdentiferChange(t *testing.T) {
 			{
 				Config: testAccRoute53RecordSetIdentifierChangePost,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.basic_to_weighted"),
+					testAccCheckRoute53RecordExists("aws_route53_record.basic_to_weighted", &record2),
 				),
 			},
 		},
@@ -499,6 +533,8 @@ func TestAccAWSRoute53Record_SetIdentiferChange(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.elb_alias_change",
@@ -508,7 +544,7 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 			{
 				Config: testAccRoute53RecordAliasChangePre,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.elb_alias_change"),
+					testAccCheckRoute53RecordExists("aws_route53_record.elb_alias_change", &record1),
 				),
 			},
 
@@ -516,7 +552,7 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 			{
 				Config: testAccRoute53RecordAliasChangePost,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.elb_alias_change"),
+					testAccCheckRoute53RecordExists("aws_route53_record.elb_alias_change", &record2),
 				),
 			},
 		},
@@ -524,6 +560,8 @@ func TestAccAWSRoute53Record_AliasChange(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_empty(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.empty",
@@ -533,7 +571,7 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigEmptyName,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.empty"),
+					testAccCheckRoute53RecordExists("aws_route53_record.empty", &record1),
 				),
 			},
 		},
@@ -542,6 +580,8 @@ func TestAccAWSRoute53Record_empty(t *testing.T) {
 
 // Regression test for https://github.com/hashicorp/terraform/issues/8423
 func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route53_record.long_txt",
@@ -551,7 +591,7 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 			{
 				Config: testAccRoute53RecordConfigLongTxtRecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.long_txt"),
+					testAccCheckRoute53RecordExists("aws_route53_record.long_txt", &record1),
 				),
 			},
 		},
@@ -559,6 +599,8 @@ func TestAccAWSRoute53Record_longTXTrecord(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
+	var record1, record2 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -567,8 +609,8 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 			{
 				Config: testAccRoute53MultiValueAnswerARecord,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53RecordExists("aws_route53_record.www-server1"),
-					testAccCheckRoute53RecordExists("aws_route53_record.www-server2"),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-server1", &record1),
+					testAccCheckRoute53RecordExists("aws_route53_record.www-server2", &record2),
 				),
 			},
 		},
@@ -576,6 +618,8 @@ func TestAccAWSRoute53Record_multivalue_answer_basic(t *testing.T) {
 }
 
 func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
+	var record1 route53.ResourceRecordSet
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -587,7 +631,7 @@ func TestAccAWSRoute53Record_allowOverwrite(t *testing.T) {
 			},
 			{
 				Config: testAccRoute53RecordConfig_allowOverwrite(true),
-				Check:  resource.ComposeTestCheckFunc(testAccCheckRoute53RecordExists("aws_route53_record.overwriting")),
+				Check:  resource.ComposeTestCheckFunc(testAccCheckRoute53RecordExists("aws_route53_record.overwriting", &record1)),
 			},
 		},
 	})
@@ -634,7 +678,7 @@ func testAccCheckRoute53RecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckRoute53RecordExists(n string) resource.TestCheckFunc {
+func testAccCheckRoute53RecordExists(n string, resourceRecordSet *route53.ResourceRecordSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).r53conn
 		rs, ok := s.RootModule().Resources[n]
@@ -671,6 +715,8 @@ func testAccCheckRoute53RecordExists(n string) resource.TestCheckFunc {
 		for _, rec := range resp.ResourceRecordSets {
 			recName := cleanRecordName(*rec.Name)
 			if FQDN(strings.ToLower(recName)) == FQDN(strings.ToLower(en)) && *rec.Type == rType {
+				*resourceRecordSet = *rec
+
 				return nil
 			}
 		}


### PR DESCRIPTION
Route53 only provides a sorted List-type API call with a starting name and type for reading records. If a record was deleted outside of Terraform, the resource did not previously have logic to stop reading from the zone when the record name and type no longer match the original query. In practice, this meant scanning the rest of the zone 1 record per API call until the last record of the zone.

To provide simple empirical evidence of this working (not testable without rewriting `findRecord()`), we count the occurances of `ListResourceRecordSetsResponse` for `TestAccAWSRoute53Record_disappears_MultipleRecords`. Before (39) / After (37).

Changes:

* resource/aws_route53_record: Use `NextRecordName` and `NextRecordType` in `ListResourceRecordSets` to determine if record finding should continue
* tests/resource/aws_route53_record: Return matching `route53.ResourceRecordSet` in `testAccCheckRoute53RecordExists()`
* tests/resource/aws_route53_record: Add `_disappears` acceptance testing

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53Record_alias (146.56s)
--- PASS: TestAccAWSRoute53Record_AliasChange (158.36s)
--- PASS: TestAccAWSRoute53Record_aliasUppercase (108.53s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (164.81s)
--- PASS: TestAccAWSRoute53Record_basic (109.86s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (119.37s)
--- PASS: TestAccAWSRoute53Record_caaSupport (126.61s)
--- PASS: TestAccAWSRoute53Record_disappears (111.17s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (210.58s)
--- PASS: TestAccAWSRoute53Record_empty (118.09s)
--- PASS: TestAccAWSRoute53Record_failover (133.92s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (130.93s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (129.61s)
--- PASS: TestAccAWSRoute53Record_importBasic (144.73s)
--- PASS: TestAccAWSRoute53Record_importUnderscored (127.50s)
--- PASS: TestAccAWSRoute53Record_latency_basic (112.86s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (110.76s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (114.46s)
--- PASS: TestAccAWSRoute53Record_s3_alias (120.63s)
--- PASS: TestAccAWSRoute53Record_SetIdentiferChange (165.49s)
--- PASS: TestAccAWSRoute53Record_spfSupport (137.76s)
--- PASS: TestAccAWSRoute53Record_txtSupport (131.46s)
--- PASS: TestAccAWSRoute53Record_TypeChange (159.15s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (283.85s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (138.54s)
--- PASS: TestAccAWSRoute53Record_wildcard (177.44s)
```
