### PR TITLE
Convert HCL references of tags configuration block syntax to map syntax

### DIFF
--- a/aws/core_acceptance_test.go
+++ b/aws/core_acceptance_test.go
@@ -31,7 +31,7 @@ func TestAccAWSVpc_coreMismatchedDiffs(t *testing.T) {
 const testMatchedDiffs = `resource "aws_vpc" "test" {
     cidr_block = "10.0.0.0/16"
 
-    tags {
+  tags = {
         Name = "terraform-testacc-repro-GH-4965"
     }
 

--- a/aws/data_source_aws_cloudformation_export_test.go
+++ b/aws/data_source_aws_cloudformation_export_test.go
@@ -55,7 +55,7 @@ resource "aws_cloudformation_stack" "cfs" {
   }
 }
 STACK
-  tags {
+  tags = {
     TestExport = "waiter"
     Second = "meh"
   }
@@ -88,7 +88,7 @@ Outputs:
     Export:
       Name: MyVpcId
 STACK
-  tags {
+  tags = {
     TestExport = "MyVpcId"
     Second = "meh"
   }

--- a/aws/data_source_aws_cloudformation_stack_test.go
+++ b/aws/data_source_aws_cloudformation_stack_test.go
@@ -72,7 +72,7 @@ resource "aws_cloudformation_stack" "cfs" {
   }
 }
 STACK
-  tags {
+  tags = {
     Name = "Form the Cloud"
     Second = "meh"
   }
@@ -141,7 +141,7 @@ Outputs:
     Value: !Ref myvpc
     Description: VPC ID
 STACK
-  tags {
+  tags = {
     Name = "Form the Cloud"
     Second = "meh"
   }

--- a/aws/data_source_aws_cloudhsm2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm2_cluster_test.go
@@ -42,7 +42,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "cloudhsm2_test_vpc" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-aws_cloudhsm_v2_cluster-data-source-basic"
   }
 }
@@ -54,7 +54,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
   map_public_ip_on_launch = false
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-data-source-basic"
   }
 }
@@ -62,7 +62,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type = "hsm1.medium"  
   subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-data-source-basic-%d"
   }
 }

--- a/aws/data_source_aws_db_cluster_snapshot_test.go
+++ b/aws/data_source_aws_db_cluster_snapshot_test.go
@@ -121,7 +121,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
-  tags {
+  tags = {
    Name = %q
   }
 }
@@ -133,7 +133,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "192.168.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -169,7 +169,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
-  tags {
+  tags = {
    Name = %q
   }
 }
@@ -181,7 +181,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "192.168.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -217,7 +217,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
-  tags {
+  tags = {
    Name = %q
   }
 }
@@ -229,7 +229,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "192.168.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/data_source_aws_dynamodb_table_test.go
+++ b/aws/data_source_aws_dynamodb_table_test.go
@@ -68,7 +68,7 @@ func testAccDataSourceAwsDynamoDbTableConfigBasic(tableName string) string {
     non_key_attributes = ["UserId"]
   }
 
-  tags {
+  tags = {
     Name        = "dynamodb-table-1"
     Environment = "test"
   }

--- a/aws/data_source_aws_ebs_volume_test.go
+++ b/aws/data_source_aws_ebs_volume_test.go
@@ -67,7 +67,7 @@ resource "aws_ebs_volume" "example" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
   size = 40
-  tags {
+  tags = {
     Name = "External Volume"
   }
 }
@@ -92,7 +92,7 @@ resource "aws_ebs_volume" "external1" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
   size = 10
-  tags {
+  tags = {
     Name = "External Volume 1"
   }
 }

--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -62,7 +62,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigFilter() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -71,7 +71,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -98,7 +98,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigID() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -107,7 +107,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }

--- a/aws/data_source_aws_efs_mount_target_test.go
+++ b/aws/data_source_aws_efs_mount_target_test.go
@@ -42,7 +42,7 @@ resource "aws_efs_mount_target" "alpha" {
 
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-efs-mount-target"
 	}
 }
@@ -51,7 +51,7 @@ resource "aws_subnet" "alpha" {
 	vpc_id = "${aws_vpc.foo.id}"
 	availability_zone = "us-west-2a"
 	cidr_block = "10.0.1.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-efs-mount-target"
 	}
 }

--- a/aws/data_source_aws_eip_test.go
+++ b/aws/data_source_aws_eip_test.go
@@ -154,7 +154,7 @@ func testAccDataSourceAwsEipConfigFilter(rName string) string {
 resource "aws_eip" "test" {
   vpc = true
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -205,13 +205,13 @@ func testAccDataSourceAwsEipConfigTags(rName string) string {
 resource "aws_eip" "test" {
   vpc = true
 
-  tags {
+  tags = {
     Name = %q
   }
 }
 
 data "aws_eip" "test" {
-  tags {
+  tags = {
     Name = "${aws_eip.test.tags["Name"]}"
   }
 }

--- a/aws/data_source_aws_elb_test.go
+++ b/aws/data_source_aws_elb_test.go
@@ -52,7 +52,7 @@ resource "aws_elb" "elb_test" {
     lb_protocol       = "http"
   }
 
-  tags {
+  tags = {
     TestName = "%[2]s"
   }
 }
@@ -67,7 +67,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "elb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-elb-data-source"
   }
 }
@@ -79,7 +79,7 @@ resource "aws_subnet" "elb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-elb-data-source"
   }
 }
@@ -103,7 +103,7 @@ resource "aws_security_group" "elb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "%[2]s"
   }
 }

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -309,7 +309,7 @@ resource "aws_instance" "web" {
   # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }
@@ -329,7 +329,7 @@ resource "aws_instance" "web" {
   # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
-  tags {
+  tags = {
     Name = "HelloWorld"
     TestSeed = "%d"
   }
@@ -353,7 +353,7 @@ resource "aws_instance" "foo" {
 
   instance_type = "m1.small"
   user_data = "foo:-with-character's"
-  tags {
+  tags = {
     TFAccTest = "YesThisIsATest"
   }
 }
@@ -433,7 +433,7 @@ data "aws_instance" "foo" {
 const testAccInstanceDataSourceConfig_privateIP = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-ds-private-ip"
   }
 }
@@ -441,7 +441,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-instance-ds-private-ip"
   }
 }
@@ -473,7 +473,7 @@ resource "aws_instance" "foo" {
   ami = "ami-408c7f28"
   instance_type = "t1.micro"
   key_name = "${aws_key_pair.debugging.key_name}"
-  tags {
+  tags = {
     Name = "testAccInstanceDataSourceConfigKeyPair_TestAMI"
   }
 }
@@ -493,7 +493,7 @@ data "aws_instance" "foo" {
 const testAccInstanceDataSourceConfig_VPC = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-data-source-vpc"
   }
 }
@@ -501,7 +501,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
    Name = "tf-acc-instance-data-source-vpc"
   }
 }
@@ -526,7 +526,7 @@ func testAccInstanceDataSourceConfig_PlacementGroup(rStr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-data-source-placement-group"
   }
 }
@@ -534,7 +534,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-instance-data-source-placement-group"
   }
 }
@@ -597,14 +597,14 @@ const testAccInstanceDataSourceConfig_VPCSecurityGroups = `
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-data-source-vpc-sgs"
   }
 }
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-data-source-vpc-sgs"
   }
 }
@@ -625,7 +625,7 @@ resource "aws_security_group" "tf_test_foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-instance-data-source-vpc-sgs"
   }
 }

--- a/aws/data_source_aws_instances_test.go
+++ b/aws/data_source_aws_instances_test.go
@@ -80,7 +80,7 @@ resource "aws_instance" "test" {
   count = 3
   ami = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
-  tags {
+  tags = {
     Name = "TfAccTest"
   }
 }
@@ -115,7 +115,7 @@ resource "aws_instance" "test" {
   count = 5
   ami = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
-  tags {
+  tags = {
     Name = "TfAccTest-HelloWorld"
     TestSeed = "%[1]d"
   }
@@ -152,7 +152,7 @@ resource "aws_instance" "test" {
   count = 2
   ami = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
-  tags {
+  tags = {
     Name = "TfAccTest-HelloWorld"
     TestSeed = "%[1]d"
   }

--- a/aws/data_source_aws_internet_gateway_test.go
+++ b/aws/data_source_aws_internet_gateway_test.go
@@ -46,7 +46,7 @@ provider "aws" {
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-igw-data-source"
   }
 }
@@ -54,7 +54,7 @@ resource "aws_vpc" "test" {
 resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-data-source-igw"
   }
 }
@@ -64,7 +64,7 @@ data "aws_internet_gateway" "by_id" {
 }
 
 data "aws_internet_gateway" "by_tags" {
-  tags {
+  tags = {
     Name = "${aws_internet_gateway.test.tags["Name"]}"
   }
 }

--- a/aws/data_source_aws_kinesis_stream_test.go
+++ b/aws/data_source_aws_kinesis_stream_test.go
@@ -77,7 +77,7 @@ resource "aws_kinesis_stream" "test_stream" {
 	name = "%s"
 	shard_count = 2
 	retention_period = 72
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 	shard_level_metrics = [

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -127,7 +127,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout               = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }
@@ -160,7 +160,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-data-source-basic"
   }
 }
@@ -172,7 +172,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-data-source-basic"
   }
 }
@@ -196,7 +196,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }
@@ -246,7 +246,7 @@ resource "aws_alb" "alb_test" {
   idle_timeout               = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }
@@ -279,7 +279,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-data-source-bc"
   }
 }
@@ -291,7 +291,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-data-source-bc"
   }
 }
@@ -315,7 +315,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }
@@ -354,7 +354,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout               = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 
@@ -389,7 +389,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-data-source-https"
   }
 }
@@ -397,7 +397,7 @@ resource "aws_vpc" "alb_test" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.alb_test.id}"
 
-  tags {
+  tags = {
     Name     = "terraform-testacc-lb-listener-data-source-https"
     TestName = "TestAccAWSALB_basic"
   }
@@ -410,7 +410,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-data-source-https"
   }
 }
@@ -434,7 +434,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }

--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -143,7 +143,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
   }
 }
@@ -165,7 +165,7 @@ resource "aws_lb_target_group" "test" {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
   }
 }
@@ -180,7 +180,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-data-source-target-group-basic"
   }
 }
@@ -192,7 +192,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-data-source-target-group-basic"
   }
 }
@@ -216,7 +216,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
   }
 }
@@ -251,7 +251,7 @@ resource "aws_alb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
   }
 }
@@ -273,7 +273,7 @@ resource "aws_alb_target_group" "test" {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
   }
 }
@@ -288,7 +288,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-data-source-target-group-bc"
   }
 }
@@ -300,7 +300,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-data-source-target-group-bc"
   }
 }
@@ -324,7 +324,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "TestAccDataSourceAWSALBTargetGroup_basic"
   }
 }

--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -98,7 +98,7 @@ func testAccDataSourceAWSLBConfigBasic(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }
@@ -113,7 +113,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-data-source-basic"
   }
 }
@@ -125,7 +125,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-data-source-basic"
   }
 }
@@ -149,7 +149,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }
@@ -173,7 +173,7 @@ func testAccDataSourceAWSLBConfigBackardsCompatibility(albName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }
@@ -188,7 +188,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-data-source-bc"
   }
 }
@@ -200,7 +200,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-data-source-bc"
   }
 }
@@ -224,7 +224,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALB_basic"
   }
 }

--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -93,7 +93,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "acctest" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "${var.prefix}"
   }
 }
@@ -117,7 +117,7 @@ resource "aws_subnet" "acctest" {
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id            = "${aws_vpc.acctest.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}"
   }
 }

--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -49,7 +49,7 @@ provider "aws" {
 
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-data-source"
   }
 }
@@ -59,7 +59,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "172.%d.123.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-nat-gw-data-source"
   }
 }
@@ -72,7 +72,7 @@ resource "aws_eip" "test" {
 # IGWs are required for an NGW to spin up; manual dependency
 resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gateway-data-source-%d"
   }
 }
@@ -81,7 +81,7 @@ resource "aws_nat_gateway" "test" {
   subnet_id     = "${aws_subnet.test.id}"
   allocation_id = "${aws_eip.test.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-data-source-%d"
     OtherTag = "some-value"
   }
@@ -98,7 +98,7 @@ data "aws_nat_gateway" "test_by_subnet_id" {
 }
 
 data "aws_nat_gateway" "test_by_tags" {
-  tags {
+  tags = {
     Name = "${aws_nat_gateway.test.tags["Name"]}"
   }
 }

--- a/aws/data_source_aws_network_acls_test.go
+++ b/aws/data_source_aws_network_acls_test.go
@@ -88,7 +88,7 @@ func testAccDataSourceAwsNetworkAclsConfig_Base(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "testacc-acl-%s"
   }
 }
@@ -98,7 +98,7 @@ resource "aws_network_acl" "acl" {
 
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "testacc-acl-%s"
   }
 }
@@ -125,7 +125,7 @@ data "aws_network_acls" "test" {
 func testAccDataSourceAwsNetworkAclsConfig_Tags(rName string) string {
 	return testAccDataSourceAwsNetworkAclsConfig_Base(rName) + `
 data "aws_network_acls" "test" {
-  tags {
+  tags = {
     Name = "${aws_network_acl.acl.0.tags.Name}"
   }
 }

--- a/aws/data_source_aws_network_interface_test.go
+++ b/aws/data_source_aws_network_interface_test.go
@@ -38,7 +38,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-eni-data-source-basic"
   }
 }
@@ -47,7 +47,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-eni-data-source-basic"
   }
 }
@@ -92,7 +92,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-eni-data-source-filters"
   }
 }
@@ -101,7 +101,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-eni-data-source-filters"
   }
 }

--- a/aws/data_source_aws_network_interfaces_test.go
+++ b/aws/data_source_aws_network_interfaces_test.go
@@ -46,7 +46,7 @@ func testAccDataSourceAwsNetworkInterfacesConfig_Base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-eni-data-source-basic-%s"
   }
 }
@@ -54,7 +54,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-eni-data-source-basic-%s"
   }
 }
@@ -65,7 +65,7 @@ resource "aws_network_interface" "test" {
 
 resource "aws_network_interface" "test1" {
   subnet_id = "${aws_subnet.test.id}"
-  tags {
+  tags = {
   	Name = "${aws_vpc.test.tags.Name}"
   }
 }
@@ -87,7 +87,7 @@ data "aws_network_interfaces" "test" {
 func testAccDataSourceAwsNetworkInterfacesConfig_Tags(rName string) string {
 	return testAccDataSourceAwsNetworkInterfacesConfig_Base(rName) + `
 data "aws_network_interfaces" "test" {
-  tags {
+  tags = {
     Name = "${aws_network_interface.test1.tags.Name}"
   }
 }

--- a/aws/data_source_aws_rds_cluster_test.go
+++ b/aws/data_source_aws_rds_cluster_test.go
@@ -43,13 +43,13 @@ func testAccDataSourceAwsRdsClusterConfigBasic(clusterName string) string {
 	master_password = "mustbeeightcharacters"
 	master_username = "foo"
 	skip_final_snapshot = true
-	tags {
+	tags = {
 		Environment = "test"
 	}
 }
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 	  Name = "terraform-testacc-rds-cluster-data-source-basic"
 	}
 }
@@ -58,7 +58,7 @@ resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.0.0.0/24"
 	availability_zone = "us-west-2a"
-	tags {
+	tags = {
 		Name = "tf-acc-rds-cluster-data-source-basic"
 	}
 }
@@ -67,7 +67,7 @@ resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.0.1.0/24"
 	availability_zone = "us-west-2b"
-	tags {
+	tags = {
 		Name = "tf-acc-rds-cluster-data-source-basic"
 	}
 }

--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -78,7 +78,7 @@ func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
 
 	resource "aws_vpc" "test" {
 		cidr_block = "172.16.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-r53-zone-data-source"
 		}
 	}
@@ -86,7 +86,7 @@ func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
 	resource "aws_route53_zone" "test_private" {
 		name = "test.acc-%d."
 		vpc_id = "${aws_vpc.test.id}"
-		tags {
+	tags = {
 			Environment = "dev-%d"
 		}
 	}

--- a/aws/data_source_aws_route_table_test.go
+++ b/aws/data_source_aws_route_table_test.go
@@ -110,7 +110,7 @@ provider "aws" {
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-data-source"
   }
 }
@@ -118,14 +118,14 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   cidr_block = "172.16.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-route-table-data-source"
   }
 }
 
 resource "aws_route_table" "test" {
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-routetable-data-source"
   }
 }
@@ -144,7 +144,7 @@ data "aws_route_table" "by_filter" {
 }
 
 data "aws_route_table" "by_tag" {
-  tags {
+  tags = {
     Name = "${aws_route_table.test.tags["Name"]}"
   }
   depends_on = ["aws_route_table_association.a"]
@@ -170,7 +170,7 @@ provider "aws" {
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-data-source-main-route"
   }
 }

--- a/aws/data_source_aws_route_tables_test.go
+++ b/aws/data_source_aws_route_tables_test.go
@@ -36,7 +36,7 @@ func testAccDataSourceAwsRouteTablesConfigWithDataSource(rInt int) string {
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-tables-data-source"
   }
 }
@@ -44,7 +44,7 @@ resource "aws_vpc" "test" {
 resource "aws_vpc" "test2" {
   cidr_block = "172.%d.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-test2acc-route-tables-data-source"
   }
 }
@@ -52,7 +52,7 @@ resource "aws_vpc" "test2" {
 resource "aws_route_table" "test_public_a" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-public-a"
     Tier = "Public"
     Component = "Frontend"
@@ -62,7 +62,7 @@ resource "aws_route_table" "test_public_a" {
 resource "aws_route_table" "test_private_a" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-private-a"
     Tier = "Private"
     Component = "Database"
@@ -72,7 +72,7 @@ resource "aws_route_table" "test_private_a" {
 resource "aws_route_table" "test_private_b" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-private-b"
     Tier = "Private"
     Component = "Backend-1"
@@ -82,7 +82,7 @@ resource "aws_route_table" "test_private_b" {
 resource "aws_route_table" "test_private_c" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-private-c"
     Tier = "Private"
     Component = "Backend-2"
@@ -99,7 +99,7 @@ data "aws_route_tables" "test2" {
 
 data "aws_route_tables" "private" {
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Tier = "Private"
   }
 }
@@ -120,7 +120,7 @@ func testAccDataSourceAwsRouteTablesConfig(rInt int) string {
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-tables-data-source"
   }
 }
@@ -128,7 +128,7 @@ resource "aws_vpc" "test" {
 resource "aws_route_table" "test_public_a" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-public-a"
     Tier = "Public"
     Component = "Frontend"
@@ -138,7 +138,7 @@ resource "aws_route_table" "test_public_a" {
 resource "aws_route_table" "test_private_a" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-private-a"
     Tier = "Private"
     Component = "Database"
@@ -148,7 +148,7 @@ resource "aws_route_table" "test_private_a" {
 resource "aws_route_table" "test_private_b" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-private-b"
     Tier = "Private"
     Component = "Backend-1"
@@ -158,7 +158,7 @@ resource "aws_route_table" "test_private_b" {
 resource "aws_route_table" "test_private_c" {
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-route-tables-data-source-private-c"
     Tier = "Private"
     Component = "Backend-2"

--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -93,7 +93,7 @@ const testAccDataSourceAwsRouteGroupConfig = `
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-data-source"
   }
 }
@@ -101,7 +101,7 @@ resource "aws_vpc" "test" {
 resource "aws_vpc" "dest" {
 	cidr_block = "172.17.0.0/16"
   
-	tags {
+	tags = {
 	  Name = "terraform-testacc-route-table-data-source"
 	}
 }
@@ -115,14 +115,14 @@ resource "aws_vpc_peering_connection" "test" {
 resource "aws_subnet" "test" {
   cidr_block = "172.16.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-route-table-data-source"
   }
 }
 
 resource "aws_route_table" "test" {
 	vpc_id = "${aws_vpc.test.id}"
-	tags {
+	tags = {
 	  Name = "terraform-testacc-routetable-data-source"
 	}
 }
@@ -158,7 +158,7 @@ data "aws_ami" "ubuntu" {
 	ami           = "${data.aws_ami.ubuntu.id}"
 	instance_type = "t2.micro"
 	subnet_id = "${aws_subnet.test.id}"
-	tags {
+	tags = {
 	  Name = "HelloWorld"
 	}
   }
@@ -198,7 +198,7 @@ func testAccAWSRouteDataSourceConfigTransitGatewayID() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-route-datasource-transit-gateway-id"
   }
 }
@@ -207,7 +207,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-route-datasource-transit-gateway-id"
   }
 }

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -285,7 +285,7 @@ CONTENT
 	content_disposition = "attachment"
 	content_encoding = "identity"
 	content_language = "en-GB"
-	tags {
+	tags = {
 		Key1 = "Value 1"
 	}
 }

--- a/aws/data_source_aws_security_group_test.go
+++ b/aws/data_source_aws_security_group_test.go
@@ -107,7 +107,7 @@ func testAccDataSourceAwsSecurityGroupConfig(rInt int) string {
 	resource "aws_vpc" "test" {
 		cidr_block = "172.16.0.0/16"
 
-		tags {
+	tags = {
 			Name = "terraform-testacc-security-group-data-source"
 		}
 	}
@@ -115,7 +115,7 @@ func testAccDataSourceAwsSecurityGroupConfig(rInt int) string {
 	resource "aws_security_group" "test" {
 		vpc_id = "${aws_vpc.test.id}"
 		name = "test-%d"
-		tags {
+	tags = {
 			Name = "tf-acctest"
 			Seed = "%d"
 		}
@@ -136,7 +136,7 @@ func testAccDataSourceAwsSecurityGroupConfig(rInt int) string {
 	}
 
 	data "aws_security_group" "by_tag" {
-		tags {
+	tags = {
 			Seed = "${aws_security_group.test.tags["Seed"]}"
 		}
 	}

--- a/aws/data_source_aws_security_groups_test.go
+++ b/aws/data_source_aws_security_groups_test.go
@@ -46,7 +46,7 @@ func testAccDataSourceAwsSecurityGroupsConfig_tag(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "test_tag" {
 		cidr_block = "172.16.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-security-group-data-source"
 		}
 	}
@@ -55,13 +55,13 @@ func testAccDataSourceAwsSecurityGroupsConfig_tag(rInt int) string {
 		count = 3
 		vpc_id = "${aws_vpc.test_tag.id}"
 		name = "tf-%[1]d-${count.index}"
-		tags {
+	tags = {
 			Seed = "%[1]d"
 		}
 	}
 
 	data "aws_security_groups" "by_tag" {
-		tags {
+	tags = {
 			Seed = "${aws_security_group.test.0.tags["Seed"]}"
 		}
 	}
@@ -72,7 +72,7 @@ func testAccDataSourceAwsSecurityGroupsConfig_filter(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "test_filter" {
 		cidr_block = "172.16.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-security-group-data-source"
 		}
 	}
@@ -81,7 +81,7 @@ func testAccDataSourceAwsSecurityGroupsConfig_filter(rInt int) string {
 		count = 3
 		vpc_id = "${aws_vpc.test_filter.id}"
 		name = "tf-%[1]d-${count.index}"
-		tags {
+	tags = {
 			Seed = "%[1]d"
 		}
 	}

--- a/aws/data_source_aws_storagegateway_local_disk_test.go
+++ b/aws/data_source_aws_storagegateway_local_disk_test.go
@@ -74,7 +74,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -100,7 +100,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -126,7 +126,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -152,7 +152,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/data_source_aws_subnet_ids_test.go
+++ b/aws/data_source_aws_subnet_ids_test.go
@@ -53,7 +53,7 @@ func testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt int) string {
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet-ids-data-source"
   }
 }
@@ -63,7 +63,7 @@ resource "aws_subnet" "test_public_a" {
   cidr_block        = "172.%d.123.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-ids-data-source-public-a"
     Tier = "Public"
   }
@@ -74,7 +74,7 @@ resource "aws_subnet" "test_private_a" {
   cidr_block        = "172.%d.125.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-ids-data-source-private-a"
     Tier = "Private"
   }
@@ -85,7 +85,7 @@ resource "aws_subnet" "test_private_b" {
   cidr_block        = "172.%d.126.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-ids-data-source-private-b"
     Tier = "Private"
   }
@@ -97,7 +97,7 @@ data "aws_subnet_ids" "selected" {
 
 data "aws_subnet_ids" "private" {
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Tier = "Private"
   }
 }
@@ -109,7 +109,7 @@ func testAccDataSourceAwsSubnetIDsConfig(rInt int) string {
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet-ids-data-source"
   }
 }
@@ -119,7 +119,7 @@ resource "aws_subnet" "test_public_a" {
   cidr_block        = "172.%d.123.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-ids-data-source-public-a"
     Tier = "Public"
   }
@@ -130,7 +130,7 @@ resource "aws_subnet" "test_private_a" {
   cidr_block        = "172.%d.125.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-ids-data-source-private-a"
     Tier = "Private"
   }
@@ -141,7 +141,7 @@ resource "aws_subnet" "test_private_b" {
   cidr_block        = "172.%d.126.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-ids-data-source-private-b"
     Tier = "Private"
   }
@@ -153,7 +153,7 @@ func testAccDataSourceAwsSubnetIDs_filter(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet-ids-data-source"
   }
 }

--- a/aws/data_source_aws_subnet_test.go
+++ b/aws/data_source_aws_subnet_test.go
@@ -188,7 +188,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet-data-source"
   }
 }
@@ -198,7 +198,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "172.%d.123.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-data-source"
   }
 }
@@ -215,7 +215,7 @@ data "aws_subnet" "by_cidr" {
 data "aws_subnet" "by_tag" {
   vpc_id = "${aws_subnet.test.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${aws_subnet.test.tags["Name"]}"
   }
 }
@@ -246,7 +246,7 @@ resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet-data-source-ipv6"
   }
 }
@@ -257,7 +257,7 @@ resource "aws_subnet" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-data-source-ipv6"
   }
 }
@@ -272,7 +272,7 @@ resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet-data-source-ipv6-with-ds-filter"
   }
 }
@@ -283,7 +283,7 @@ resource "aws_subnet" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-data-source-ipv6-with-ds-filter"
   }
 }
@@ -305,7 +305,7 @@ resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet-data-source-ipv6-cidr-block"
   }
 }
@@ -316,7 +316,7 @@ resource "aws_subnet" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-subnet-data-source-ipv6-cidr-block"
   }
 }

--- a/aws/data_source_aws_vpc_dhcp_options_test.go
+++ b/aws/data_source_aws_vpc_dhcp_options_test.go
@@ -96,7 +96,7 @@ resource "aws_vpc_dhcp_options" "test" {
   netbios_node_type    = 2
   ntp_servers          = ["127.0.0.1"]
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -121,7 +121,7 @@ resource "aws_vpc_dhcp_options" "test" {
   netbios_node_type    = 2
   ntp_servers          = ["127.0.0.1"]
 
-  tags {
+  tags = {
     Name = "tf-acc-test-%d"
   }
 }

--- a/aws/data_source_aws_vpc_endpoint_service_test.go
+++ b/aws/data_source_aws_vpc_endpoint_service_test.go
@@ -141,7 +141,7 @@ func testAccDataSourceAwsVpcEndpointServiceCustomConfig(lbName string) string {
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-service-custom"
   }
 }
@@ -159,7 +159,7 @@ resource "aws_lb" "nlb_test_1" {
   idle_timeout               = 60
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "testAccVpcEndpointServiceBasicConfig_nlb1"
   }
 }
@@ -169,7 +169,7 @@ resource "aws_subnet" "nlb_test_1" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-custom"
   }
 }
@@ -179,7 +179,7 @@ resource "aws_subnet" "nlb_test_2" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-custom"
   }
 }

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -122,7 +122,7 @@ provider "aws" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-data-source-gw-basic"
   }
 }
@@ -147,7 +147,7 @@ provider "aws" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-data-source-by-id"
   }
 }
@@ -170,7 +170,7 @@ provider "aws" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-data-source-with-route-table"
   }
 }
@@ -200,7 +200,7 @@ provider "aws" {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-data-source-interface"
   }
 }
@@ -209,7 +209,7 @@ resource "aws_subnet" "sn" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "${aws_vpc.foo.cidr_block}"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-data-source-interface"
   }
 }

--- a/aws/data_source_aws_vpc_peering_connection_test.go
+++ b/aws/data_source_aws_vpc_peering_connection_test.go
@@ -71,7 +71,7 @@ const testAccDataSourceAwsVpcPeeringConnectionConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
 	  Name = "terraform-testacc-vpc-peering-connection-data-source-foo"
   }
 }
@@ -79,7 +79,7 @@ resource "aws_vpc" "foo" {
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
 
-  tags {
+  tags = {
 	  Name = "terraform-testacc-vpc-peering-connection-data-source-bar"
   }
 }
@@ -89,7 +89,7 @@ resource "aws_vpc_peering_connection" "test" {
 	peer_vpc_id = "${aws_vpc.bar.id}"
 	auto_accept = true
 
-    tags {
+  tags = {
       Name = "terraform-testacc-vpc-peering-connection-data-source-foo-to-bar"
     }
 }

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -140,7 +140,7 @@ resource "aws_vpc" "test" {
   cidr_block = "%s"
   assign_generated_ipv6_cidr_block = true
 
-  tags {
+  tags = {
     Name = "%s"
   }
 }
@@ -159,7 +159,7 @@ provider "aws" {
 resource "aws_vpc" "test" {
   cidr_block = "%s"
 
-  tags {
+  tags = {
     Name = "%s"
   }
 }
@@ -173,7 +173,7 @@ data "aws_vpc" "by_cidr" {
 }
 
 data "aws_vpc" "by_tag" {
-  tags {
+  tags = {
     Name = "${aws_vpc.test.tags["Name"]}"
   }
 }

--- a/aws/data_source_aws_vpcs_test.go
+++ b/aws/data_source_aws_vpcs_test.go
@@ -124,7 +124,7 @@ func testAccDataSourceAwsVpcsConfig_tags(rName string) string {
 	}
 
 	data "aws_vpcs" "selected" {
-		tags {
+	tags = {
 			Name = "testacc-vpc-%s"
 			Service = "${aws_vpc.test-vpc.tags["Service"]}"
 		}

--- a/aws/data_source_aws_vpn_gateway_test.go
+++ b/aws/data_source_aws_vpn_gateway_test.go
@@ -64,7 +64,7 @@ func TestAccDataSourceAwsVpnGateway_attached(t *testing.T) {
 func testAccDataSourceAwsVpnGatewayUnattachedConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "unattached" {
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-data-source-unattached-%d"
     ABC  = "testacc-%d"
     XYZ  = "testacc-%d"
@@ -92,13 +92,13 @@ func testAccDataSourceAwsVpnGatewayAttachedConfig(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-data-source-attached-%d"
   }
 }
 
 resource "aws_vpn_gateway" "attached" {
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-data-source-attached-%d"
   }
 }

--- a/aws/import_aws_route_table_test.go
+++ b/aws/import_aws_route_table_test.go
@@ -69,7 +69,7 @@ resource "aws_vpc" "default" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-import-complex-default"
   }
 }
@@ -79,7 +79,7 @@ resource "aws_subnet" "tf_test_subnet" {
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
 
-  tags {
+  tags = {
     Name = "tf-acc-route-table-import-complex-default"
   }
 }
@@ -92,7 +92,7 @@ resource "aws_eip" "nat" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.default.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-import-complex-default"
   }
 }
@@ -106,7 +106,7 @@ resource "aws_nat_gateway" "nat" {
   allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
   subnet_id     = "${aws_subnet.tf_test_subnet.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-import-complex-default"
   }
 }
@@ -115,7 +115,7 @@ resource "aws_route_table" "mod" {
   count  = "${length(split(",", var.private_subnet_cidrs))}"
   vpc_id = "${aws_vpc.default.id}"
 
-  tags {
+  tags = {
     Name = "tf-rt-import-test"
   }
 
@@ -145,7 +145,7 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_vpc" "bar" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-import-complex-bar"
   }
 }
@@ -153,7 +153,7 @@ resource "aws_vpc" "bar" {
 resource "aws_internet_gateway" "ogw" {
   vpc_id = "${aws_vpc.bar.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-import-complex-bar"
   }
 }
@@ -165,7 +165,7 @@ resource "aws_vpc_peering_connection" "foo" {
   peer_vpc_id   = "${aws_vpc.bar.id}"
   peer_owner_id = "187416307283"
 
-  tags {
+  tags = {
     Name = "tf-rt-import-test"
   }
 

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -407,7 +407,7 @@ resource "aws_acm_certificate" "cert" {
   domain_name       = "%s"
   validation_method = "%s"
 
-  tags {
+  tags = {
     "%s" = "%s"
   }
 }
@@ -420,7 +420,7 @@ resource "aws_acm_certificate" "cert" {
   domain_name       = "%s"
   validation_method = "%s"
 
-  tags {
+  tags = {
     "%s" = "%s"
     "%s" = "%s"
   }

--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -529,7 +529,7 @@ func testAccAWSALBTargetGroupConfig_basic(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALBTargetGroup_basic"
   }
 }
@@ -537,7 +537,7 @@ func testAccAWSALBTargetGroupConfig_basic(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
@@ -568,7 +568,7 @@ func testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALBTargetGroup_basic"
   }
 }
@@ -576,7 +576,7 @@ func testAccAWSALBTargetGroupConfig_updatedPort(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
@@ -607,7 +607,7 @@ func testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName string) stri
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALBTargetGroup_basic"
   }
 }
@@ -615,7 +615,7 @@ func testAccAWSALBTargetGroupConfig_updatedProtocol(targetGroupName string) stri
 resource "aws_vpc" "test2" {
   cidr_block = "10.10.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-basic-2"
   }
 }
@@ -623,7 +623,7 @@ resource "aws_vpc" "test2" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
@@ -654,7 +654,7 @@ func testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALBTargetGroup_basic"
   }
 }
@@ -662,7 +662,7 @@ func testAccAWSALBTargetGroupConfig_updatedVpc(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
@@ -693,7 +693,7 @@ func testAccAWSALBTargetGroupConfig_updateTags(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     Environment = "Production"
     Type = "ALB Target Group"
   }
@@ -702,7 +702,7 @@ func testAccAWSALBTargetGroupConfig_updateTags(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
@@ -737,7 +737,7 @@ func testAccAWSALBTargetGroupConfig_updateHealthCheck(targetGroupName string) st
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-basic"
   }
 }`, targetGroupName)
@@ -779,7 +779,7 @@ func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addSticki
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-stickiness"
   }
 }`, targetGroupName, stickinessBlock)
@@ -811,7 +811,7 @@ func testAccAWSALBTargetGroupConfig_updateSlowStart(targetGroupName string, slow
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSALBTargetGroup_SlowStart"
   }
 }
@@ -819,7 +819,7 @@ func testAccAWSALBTargetGroupConfig_updateSlowStart(targetGroupName string, slow
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-alb-target-group-slowstart"
   }
 }`, targetGroupName, slowStartDuration)
@@ -835,7 +835,7 @@ resource "aws_alb_target_group" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-alb-target-group-name-prefix"
 	}
 }
@@ -850,7 +850,7 @@ resource "aws_alb_target_group" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-alb-target-group-generated-name"
 	}
 }

--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -160,7 +160,7 @@ provider "aws" {
 
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-ami-copy"
 	}
 }
@@ -168,7 +168,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-ami-copy"
 	}
 }
@@ -180,7 +180,7 @@ resource "aws_instance" "test" {
     // because paravirtual images cannot be copied between accounts.
     ami = "ami-0f8bce65"
     instance_type = "t2.micro"
-    tags {
+  tags = {
         Name = "terraform-acc-ami-copy-victim"
     }
 
@@ -210,7 +210,7 @@ resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size              = 1
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -218,7 +218,7 @@ resource "aws_ebs_volume" "test" {
 resource "aws_ebs_snapshot" "test" {
   volume_id = "${aws_ebs_volume.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_ami_from_instance_test.go
+++ b/aws/resource_aws_ami_from_instance_test.go
@@ -150,7 +150,7 @@ func testAccAWSAMIFromInstanceConfig(rInt int) string {
 			// one snapshot in our created AMI.
 			ami = "ami-408c7f28"
 			instance_type = "t1.micro"
-			tags {
+	tags = {
 				Name = "testAccAWSAMIFromInstanceConfig_TestAMI"
 			}
 	}

--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -219,7 +219,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_ebs_volume" "foo" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size = 8
-  tags {
+  tags = {
     Name = "testAccAmiConfig_basic"
   }
 }
@@ -227,7 +227,7 @@ resource "aws_ebs_volume" "foo" {
 resource "aws_ebs_snapshot" "foo" {
   volume_id = "${aws_ebs_volume.foo.id}"
 
-  tags {
+  tags = {
     Name = "testAccAmiConfig_basic"
   }
 }
@@ -253,7 +253,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_ebs_volume" "foo" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size = 20
-  tags {
+  tags = {
     Name = "testAccAmiConfig_snapshotSize"
   }
 }
@@ -261,7 +261,7 @@ resource "aws_ebs_volume" "foo" {
 resource "aws_ebs_snapshot" "foo" {
   volume_id = "${aws_ebs_volume.foo.id}"
 
-  tags {
+  tags = {
     Name = "TestAccAWSAMI_snapshotSize"
   }
 }

--- a/aws/resource_aws_api_gateway_integration_test.go
+++ b/aws/resource_aws_api_gateway_integration_test.go
@@ -685,7 +685,7 @@ data "aws_availability_zones" "test" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
 
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }

--- a/aws/resource_aws_api_gateway_stage_test.go
+++ b/aws/resource_aws_api_gateway_stage_test.go
@@ -270,7 +270,7 @@ resource "aws_api_gateway_stage" "test" {
     one = "1"
     two = "2"
   }
-  tags {
+  tags = {
     Name = "tf-test"
   }
 }
@@ -290,7 +290,7 @@ resource "aws_api_gateway_stage" "test" {
     one = "1"
     three = "3"
   }
-  tags {
+  tags = {
     Name = "tf-test"
     ExtraName = "tf-test"
   }
@@ -314,7 +314,7 @@ resource "aws_api_gateway_stage" "test" {
     one = "1"
     two = "2"
   }
-  tags {
+  tags = {
     Name = "tf-test"
 	}
   access_log_settings {

--- a/aws/resource_aws_api_gateway_vpc_link_test.go
+++ b/aws/resource_aws_api_gateway_vpc_link_test.go
@@ -127,7 +127,7 @@ resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.10.0.0/21"
   availability_zone = "${data.aws_availability_zones.test.names[0]}"
-  tags {
+  tags = {
     Name = "tf-acc-api-gateway-vpc-link"
   }
 }

--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -222,7 +222,7 @@ resource "aws_emr_cluster" "hoge" {
   core_instance_type   = "c4.large"
   core_instance_count  = 2
 
-  tags {
+  tags = {
     role = "rolename"
     dns_zone = "env_zone"
     env = "env"
@@ -280,7 +280,7 @@ resource "aws_security_group" "hoge" {
 resource "aws_vpc" "hoge" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-appautoscaling-scheduled-action-emr"
   }
 }
@@ -288,7 +288,7 @@ resource "aws_vpc" "hoge" {
 resource "aws_subnet" "hoge" {
   vpc_id     = "${aws_vpc.hoge.id}"
   cidr_block = "168.31.0.0/20"
-  tags {
+  tags = {
     Name = "tf-acc-appautoscaling-scheduled-action"
   }
 }

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -316,7 +316,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "m3.xlarge"
   core_instance_count  = 2
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -370,7 +370,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -379,7 +379,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-appautoscaling-target-emr-cluster"
   }
 }
@@ -388,7 +388,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-appautoscaling-target-emr-cluster"
   }
 }

--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -173,7 +173,7 @@ resource "aws_lb_target_group" "test" {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSLBTargetGroup_basic"
   }
 }
@@ -202,7 +202,7 @@ resource "aws_lb_target_group" "another_test" {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSLBTargetGroup_basic"
   }
 }
@@ -233,7 +233,7 @@ resource "aws_launch_configuration" "as_conf" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-attachment-alb"
   }
 }

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -1760,7 +1760,7 @@ resource "aws_autoscaling_group" "bar" {
 const testAccAWSAutoScalingGroupConfigWithLoadBalancer = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-with-lb"
   }
 }
@@ -1772,7 +1772,7 @@ resource "aws_internet_gateway" "gw" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-autoscaling-group-with-load-balancer"
 	}
 }
@@ -1853,7 +1853,7 @@ resource "aws_autoscaling_group" "bar" {
 const testAccAWSAutoScalingGroupConfigWithAZ = `
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-with-az"
   }
 }
@@ -1862,7 +1862,7 @@ resource "aws_subnet" "main" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-with-az"
   }
 }
@@ -1900,7 +1900,7 @@ resource "aws_autoscaling_group" "bar" {
 const testAccAWSAutoScalingGroupConfigWithVPCIdent = `
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-with-vpc-id"
   }
 }
@@ -1909,7 +1909,7 @@ resource "aws_subnet" "main" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-with-vpc-id"
   }
 }
@@ -2113,7 +2113,7 @@ const testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_pre = `
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-alb-target-group"
   }
 }
@@ -2130,7 +2130,7 @@ resource "aws_subnet" "main" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-main"
   }
 }
@@ -2140,7 +2140,7 @@ resource "aws_subnet" "alt" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-alt"
   }
 }
@@ -2194,7 +2194,7 @@ resource "aws_security_group" "tf_test_self" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
   }
 }
@@ -2204,7 +2204,7 @@ const testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_post = `
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-alb-target-group"
   }
 }
@@ -2221,7 +2221,7 @@ resource "aws_subnet" "main" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-main"
   }
 }
@@ -2231,7 +2231,7 @@ resource "aws_subnet" "alt" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-alt"
   }
 }
@@ -2287,7 +2287,7 @@ resource "aws_security_group" "tf_test_self" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
   }
 }
@@ -2301,7 +2301,7 @@ provider "aws" {
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-alb-target-group"
   }
 }
@@ -2325,7 +2325,7 @@ resource "aws_subnet" "main" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-main"
   }
 }
@@ -2335,7 +2335,7 @@ resource "aws_subnet" "alt" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-alt"
   }
 }
@@ -2394,7 +2394,7 @@ resource "aws_security_group" "tf_test_self" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup"
   }
 }
@@ -2454,7 +2454,7 @@ resource "aws_vpc" "default" {
   enable_dns_hostnames = "true"
   enable_dns_support   = "true"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-alb-target-group-elb-capacity"
   }
 }
@@ -2462,7 +2462,7 @@ resource "aws_vpc" "default" {
 resource "aws_lb" "test_lb" {
   subnets = ["${aws_subnet.main.id}", "${aws_subnet.alt.id}"]
 
-  tags {
+  tags = {
     Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_ELBCapacity"
   }
 }
@@ -2491,7 +2491,7 @@ resource "aws_lb_target_group" "test" {
     matcher           = "200"
   }
 
-  tags {
+  tags = {
     Name = "testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_ELBCapacity"
   }
 }
@@ -2501,7 +2501,7 @@ resource "aws_subnet" "main" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-elb-capacity-main"
   }
 }
@@ -2511,7 +2511,7 @@ resource "aws_subnet" "alt" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-alb-target-group-elb-capacity-alt"
   }
 }
@@ -2719,7 +2719,7 @@ resource "aws_launch_configuration" "test" {
 const testAccAWSAutoScalingGroupConfig_emptyAvailabilityZones = `
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-autoscaling-group-empty-azs"
   }
 }
@@ -2727,7 +2727,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   vpc_id     = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acc-autoscaling-group-empty-availability-zones"
   }
 }

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -454,7 +454,7 @@ resource "aws_security_group" "test_acc" {
 
 resource "aws_vpc" "test_acc" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-batch-compute-environment"
   }
 }
@@ -462,7 +462,7 @@ resource "aws_vpc" "test_acc" {
 resource "aws_subnet" "test_acc" {
   vpc_id = "${aws_vpc.test_acc.id}"
   cidr_block = "10.1.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-batch-compute-environment"
   }
 }
@@ -513,7 +513,7 @@ resource "aws_batch_compute_environment" "ec2" {
       "${aws_subnet.test_acc.id}"
     ]
     type = "EC2"
-    tags {
+  tags = {
       Key1 = "Value1"
     }
   }

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -292,7 +292,7 @@ resource "aws_security_group" "test_acc" {
 
 resource "aws_vpc" "test_acc" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-batch-job-queue"
   }
 }
@@ -300,7 +300,7 @@ resource "aws_vpc" "test_acc" {
 resource "aws_subnet" "test_acc" {
   vpc_id = "${aws_vpc.test_acc.id}"
   cidr_block = "10.1.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-batch-job-queue"
   }
 }

--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -203,7 +203,7 @@ resource "aws_cloud9_environment_ec2" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-cloud9-environment-ec2-all-fields"
   }
 }
@@ -211,7 +211,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.10.0.0/19"
-  tags {
+  tags = {
     Name = "tf-acc-cloud9-environment-ec2-all-fields"
   }
 }

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -471,7 +471,7 @@ POLICY
   notification_arns = ["${aws_sns_topic.cf-updates.arn}"]
   on_failure = "DELETE"
   timeout_in_minutes = 10
-  tags {
+  tags = {
     First = "Mickey"
     Second = "Mouse"
   }

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -592,7 +592,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
-	tags {
+	tags = {
             environment = "production"
             account = "main"
 	}
@@ -644,7 +644,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 	viewer_certificate {
 		cloudfront_default_certificate = true
 	}
-	tags {
+	tags = {
             environment = "dev"
 	}
 	%s

--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -48,7 +48,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "cloudhsm2_test_vpc" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-aws_cloudhsm_v2_cluster-resource-basic"
   }
 }
@@ -60,7 +60,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
   map_public_ip_on_launch = false
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-resource-basic"
   }
 }
@@ -68,7 +68,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type = "hsm1.medium"  
   subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-resource-basic-%d"
   }
 }

--- a/aws/resource_aws_cloudhsm2_hsm_test.go
+++ b/aws/resource_aws_cloudhsm2_hsm_test.go
@@ -47,7 +47,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "cloudhsm2_test_vpc" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-aws_cloudhsm_v2_hsm-resource-basic"
   }
 }
@@ -59,7 +59,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
   map_public_ip_on_launch = false
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-aws_cloudhsm_v2_hsm-resource-basic"
   }
 }
@@ -67,7 +67,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
 resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
   hsm_type = "hsm1.medium"  
   subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-aws_cloudhsm_v2_hsm-resource-basic-%d"
   }
 }

--- a/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/aws/resource_aws_cloudwatch_log_group_test.go
@@ -342,7 +342,7 @@ func testAccAWSCloudWatchLogGroupConfigWithTags(rInt int) string {
 resource "aws_cloudwatch_log_group" "foobar" {
     name = "foo-bar-%d"
 
-    tags {
+  tags = {
     	Environment = "Production"
     	Foo = "Bar"
     	Empty = ""
@@ -356,7 +356,7 @@ func testAccAWSCloudWatchLogGroupConfigWithTagsAdded(rInt int) string {
 resource "aws_cloudwatch_log_group" "foobar" {
     name = "foo-bar-%d"
 
-    tags {
+  tags = {
     	Environment = "Development"
     	Foo = "Bar"
     	Empty = ""
@@ -371,7 +371,7 @@ func testAccAWSCloudWatchLogGroupConfigWithTagsUpdated(rInt int) string {
 resource "aws_cloudwatch_log_group" "foobar" {
     name = "foo-bar-%d"
 
-    tags {
+  tags = {
     	Environment = "Development"
     	Foo = "UpdatedBar"
     	Empty = "NotEmpty"

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -499,7 +499,7 @@ data "aws_region" "current" {}
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -508,7 +508,7 @@ resource "aws_subnet" "test" {
   vpc_id     = "${aws_vpc.test.id}"
   cidr_block = "172.16.0.0/24"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -518,7 +518,7 @@ resource "aws_instance" "test" {
   instance_type = "t2.micro"
   subnet_id     = "${aws_subnet.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -1467,7 +1467,7 @@ resource "aws_codebuild_project" "test" {
     type     = "GITHUB"
   }
 
-  tags {
+  tags = {
     tag1 = "tag1value"
     %s = "%s"
   }
@@ -1487,7 +1487,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.${count.index}.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-codebuild-project"
   }
 }

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -791,7 +791,7 @@ func testAccAWSCognitoUserPoolConfig_withTags(name string) string {
 resource "aws_cognito_user_pool" "pool" {
   name = "terraform-test-pool-%s"
 
-  tags {
+  tags = {
     "Name" = "Foo"
   }
 }`, name)
@@ -876,7 +876,7 @@ func testAccAWSCognitoUserPoolConfig_withTagsUpdated(name string) string {
 resource "aws_cognito_user_pool" "pool" {
   name = "terraform-test-pool-%s"
 
-  tags {
+  tags = {
     "Name"    = "FooBar"
     "Project" = "Terraform"
   }
@@ -1233,7 +1233,7 @@ resource "aws_cognito_user_pool" "pool" {
     sns_caller_arn = "${aws_iam_role.main.arn}"
   }
 
-  tags {
+  tags = {
     "Name" = "Foo"
   }
 }`, name, name, name, mfaconfig, smsAuthMsg)

--- a/aws/resource_aws_customer_gateway_test.go
+++ b/aws/resource_aws_customer_gateway_test.go
@@ -226,7 +226,7 @@ func testAccCustomerGatewayConfig(rInt, rBgpAsn int) string {
 			bgp_asn = %d
 			ip_address = "172.0.0.1"
 			type = "ipsec.1"
-			tags {
+	tags = {
 				Name = "foo-gateway-%d"
 			}
 		}
@@ -239,7 +239,7 @@ func testAccCustomerGatewayConfigIdentical(randInt, rBgpAsn int) string {
 			bgp_asn = %d
 			ip_address = "172.0.0.1"
 			type = "ipsec.1"
-			tags {
+	tags = {
 				Name = "foo-gateway-%d"
 			}
 		}
@@ -247,7 +247,7 @@ func testAccCustomerGatewayConfigIdentical(randInt, rBgpAsn int) string {
 			bgp_asn = %d
 			ip_address = "172.0.0.1"
 			type = "ipsec.1"
-			tags {
+	tags = {
 				Name = "foo-gateway-identical-%d"
 			}
 		}
@@ -261,7 +261,7 @@ func testAccCustomerGatewayConfigUpdateTags(rInt, rBgpAsn int) string {
 		bgp_asn = %d
 		ip_address = "172.0.0.1"
 		type = "ipsec.1"
-		tags {
+	tags = {
 			Name = "foo-gateway-%d"
 			Another = "tag"
 		}
@@ -276,7 +276,7 @@ func testAccCustomerGatewayConfigForceReplace(rInt, rBgpAsn int) string {
 			bgp_asn = %d
 			ip_address = "172.10.10.1"
 			type = "ipsec.1"
-			tags {
+	tags = {
 				Name = "foo-gateway-%d"
 				Another = "tag"
 			}

--- a/aws/resource_aws_datasync_agent_test.go
+++ b/aws/resource_aws_datasync_agent_test.go
@@ -303,7 +303,7 @@ data "aws_ami" "aws-thinstaller" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-agent"
   }
 }
@@ -312,7 +312,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-agent"
   }
 }
@@ -320,7 +320,7 @@ resource "aws_subnet" "test" {
 resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-agent"
   }
 }
@@ -333,7 +333,7 @@ resource "aws_route_table" "test" {
     gateway_id = "${aws_internet_gateway.test.id}"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-agent"
   }
 }
@@ -360,7 +360,7 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-agent"
   }
 }
@@ -375,7 +375,7 @@ resource "aws_instance" "test" {
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   subnet_id                   = "${aws_subnet.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-agent"
   }
 }
@@ -404,7 +404,7 @@ func testAccAWSDataSyncAgentConfigTags1(key1, value1 string) string {
 resource "aws_datasync_agent" "test" {
   ip_address = "${aws_instance.test.public_ip}"
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -416,7 +416,7 @@ func testAccAWSDataSyncAgentConfigTags2(key1, value1, key2, value2 string) strin
 resource "aws_datasync_agent" "test" {
   ip_address = "${aws_instance.test.public_ip}"
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_datasync_location_efs_test.go
+++ b/aws/resource_aws_datasync_location_efs_test.go
@@ -289,7 +289,7 @@ func testAccAWSDataSyncLocationEfsConfigBase() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-efs"
   }
 }
@@ -298,7 +298,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-efs"
   }
 }
@@ -306,7 +306,7 @@ resource "aws_subnet" "test" {
 resource "aws_security_group" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-efs"
   }
 }
@@ -357,7 +357,7 @@ resource "aws_datasync_location_efs" "test" {
     subnet_arn          = "${aws_subnet.test.arn}"
   }
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -374,7 +374,7 @@ resource "aws_datasync_location_efs" "test" {
     subnet_arn          = "${aws_subnet.test.arn}"
   }
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_datasync_location_nfs_test.go
+++ b/aws/resource_aws_datasync_location_nfs_test.go
@@ -329,7 +329,7 @@ data "aws_ami" "aws-thinstaller" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-nfs"
   }
 }
@@ -338,7 +338,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-nfs"
   }
 }
@@ -346,7 +346,7 @@ resource "aws_subnet" "test" {
 resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-nfs"
   }
 }
@@ -359,7 +359,7 @@ resource "aws_route_table" "test" {
     gateway_id = "${aws_internet_gateway.test.id}"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-nfs"
   }
 }
@@ -386,7 +386,7 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-nfs"
   }
 }
@@ -401,7 +401,7 @@ resource "aws_instance" "test" {
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   subnet_id                   = "${aws_subnet.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-nfs"
   }
 }
@@ -438,7 +438,7 @@ resource "aws_instance" "test2" {
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   subnet_id                   = "${aws_subnet.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-location-nfs"
   }
 }
@@ -485,7 +485,7 @@ resource "aws_datasync_location_nfs" "test" {
     agent_arns = ["${aws_datasync_agent.test.arn}"]
   }
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -502,7 +502,7 @@ resource "aws_datasync_location_nfs" "test" {
     agent_arns = ["${aws_datasync_agent.test.arn}"]
   }
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_datasync_location_s3_test.go
+++ b/aws/resource_aws_datasync_location_s3_test.go
@@ -312,7 +312,7 @@ resource "aws_datasync_location_s3" "test" {
     bucket_access_role_arn = "${aws_iam_role.test.arn}"
   }
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -329,7 +329,7 @@ resource "aws_datasync_location_s3" "test" {
     bucket_access_role_arn = "${aws_iam_role.test.arn}"
   }
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_datasync_task_test.go
+++ b/aws/resource_aws_datasync_task_test.go
@@ -644,7 +644,7 @@ resource "aws_vpc" "source" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-task"
   }
 }
@@ -662,7 +662,7 @@ resource "aws_subnet" "source" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.source.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-task"
   }
 }
@@ -670,7 +670,7 @@ resource "aws_subnet" "source" {
 resource "aws_internet_gateway" "source" {
   vpc_id = "${aws_vpc.source.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-task"
   }
 }
@@ -683,7 +683,7 @@ resource "aws_route_table" "source" {
     gateway_id = "${aws_internet_gateway.source.id}"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-task"
   }
 }
@@ -710,7 +710,7 @@ resource "aws_security_group" "source" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-task"
   }
 }
@@ -734,7 +734,7 @@ resource "aws_instance" "source" {
   vpc_security_group_ids      = ["${aws_security_group.source.id}"]
   subnet_id                   = "${aws_subnet.source.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-datasync-task"
   }
 }
@@ -903,7 +903,7 @@ resource "aws_datasync_task" "test" {
   name                     = %q
   source_location_arn      = "${aws_datasync_location_nfs.source.arn}"
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -917,7 +917,7 @@ resource "aws_datasync_task" "test" {
   name                     = %q
   source_location_arn      = "${aws_datasync_location_nfs.source.arn}"
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -117,7 +117,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
 
-  tags {
+  tags = {
    Name = %q
   }
 }
@@ -129,7 +129,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "192.168.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_db_event_subscription_test.go
+++ b/aws/resource_aws_db_event_subscription_test.go
@@ -265,7 +265,7 @@ resource "aws_db_event_subscription" "bar" {
     "deletion",
     "maintenance"
   ]
-  tags {
+  tags = {
     Name = "name"
   }
 }`, rInt, rInt)
@@ -288,7 +288,7 @@ resource "aws_db_event_subscription" "bar" {
     "deletion",
     "maintenance"
   ]
-  tags {
+  tags = {
     Name = "name"
   }
 }`, rInt)
@@ -308,7 +308,7 @@ resource "aws_db_event_subscription" "bar" {
   event_categories = [
     "configuration change"
   ]
-  tags {
+  tags = {
     Name = "new-name"
   }
 }`, rInt, rInt)
@@ -334,7 +334,7 @@ resource "aws_db_event_subscription" "bar" {
   event_categories = [
     "configuration change"
   ]
-  tags {
+  tags = {
     Name = "name"
   }
 }`, rInt, rInt, rInt)
@@ -366,7 +366,7 @@ func testAccAWSDBEventSubscriptionConfigUpdateSourceIds(rInt int) string {
 		event_categories = [
 			"configuration change"
 		]
-		tags {
+	tags = {
 			Name = "name"
 		}
 	}`, rInt, rInt, rInt, rInt)
@@ -385,7 +385,7 @@ resource "aws_db_event_subscription" "bar" {
   event_categories = [
     "availability",
   ]
-  tags {
+  tags = {
     Name = "name"
   }
 }`, rInt, rInt)

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -2168,7 +2168,7 @@ resource "aws_iam_policy_attachment" "test-attach" {
 //  Make sure EVERYTHING required is here...
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-instance-with-subnet-group"
 	}
 }
@@ -2177,7 +2177,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-1"
 	}
 }
@@ -2186,7 +2186,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-2"
 	}
 }
@@ -2194,7 +2194,7 @@ resource "aws_subnet" "bar" {
 resource "aws_db_subnet_group" "foo" {
 	name = "%s-subnet-group"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-dbsubnet-group-test"
 	}
 }
@@ -2250,7 +2250,7 @@ resource "aws_db_instance" "snapshot" {
 
 	copy_tags_to_snapshot = true
 	final_snapshot_identifier = "foobarbaz-test-terraform-final-snapshot-%d"
-	tags {
+	tags = {
 		Name = "tf-tags-db"
 	}
 }
@@ -2408,7 +2408,7 @@ func testAccAWSDBInstanceConfigWithSubnetGroup(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-instance-with-subnet-group"
 	}
 }
@@ -2417,7 +2417,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-1"
 	}
 }
@@ -2426,7 +2426,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-2"
 	}
 }
@@ -2434,7 +2434,7 @@ resource "aws_subnet" "bar" {
 resource "aws_db_subnet_group" "foo" {
 	name = "foo-%s"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-dbsubnet-group-test"
 	}
 }
@@ -2462,14 +2462,14 @@ func testAccAWSDBInstanceConfigWithSubnetGroupUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-instance-with-subnet-group-updated-foo"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.10.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-instance-with-subnet-group-updated-bar"
 	}
 }
@@ -2478,7 +2478,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-1"
 	}
 }
@@ -2487,7 +2487,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-2"
 	}
 }
@@ -2496,7 +2496,7 @@ resource "aws_subnet" "test" {
 	cidr_block = "10.10.3.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.bar.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-3"
 	}
 }
@@ -2505,7 +2505,7 @@ resource "aws_subnet" "another_test" {
 	cidr_block = "10.10.4.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.bar.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-instance-with-subnet-group-4"
 	}
 }
@@ -2513,7 +2513,7 @@ resource "aws_subnet" "another_test" {
 resource "aws_db_subnet_group" "foo" {
 	name = "foo-%s"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-dbsubnet-group-test"
 	}
 }
@@ -2521,7 +2521,7 @@ resource "aws_db_subnet_group" "foo" {
 resource "aws_db_subnet_group" "bar" {
 	name = "bar-%s"
 	subnet_ids = ["${aws_subnet.test.id}", "${aws_subnet.another_test.id}"]
-	tags {
+	tags = {
 		Name = "tf-dbsubnet-group-test-updated"
 	}
 }
@@ -2551,7 +2551,7 @@ func testAccAWSDBMSSQL_timezone(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-db-instance-mssql-timezone"
   }
 }
@@ -2567,7 +2567,7 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.1.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-timezone-main"
   }
 }
@@ -2576,7 +2576,7 @@ resource "aws_subnet" "other" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.1.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-timezone-other"
   }
 }
@@ -2623,7 +2623,7 @@ func testAccAWSDBMSSQL_timezone_AKST(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-db-instance-mssql-timezone-akst"
   }
 }
@@ -2639,7 +2639,7 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.1.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-timezone-akst-main"
   }
 }
@@ -2648,7 +2648,7 @@ resource "aws_subnet" "other" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.1.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-timezone-akst-other"
   }
 }
@@ -2696,7 +2696,7 @@ func testAccAWSDBMSSQLDomain(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-db-instance-mssql-domain"
   }
 }
@@ -2712,7 +2712,7 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.1.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-domain-main"
   }
 }
@@ -2721,7 +2721,7 @@ resource "aws_subnet" "other" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.1.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-domain-other"
   }
 }
@@ -2818,7 +2818,7 @@ func testAccAWSDBMSSQLUpdateDomain(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-db-instance-mssql-domain"
   }
 }
@@ -2834,7 +2834,7 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.1.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-domain-main"
   }
 }
@@ -2843,7 +2843,7 @@ resource "aws_subnet" "other" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.1.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-domain-other"
   }
 }
@@ -2941,7 +2941,7 @@ func testAccAWSDBMSSQLDomainSnapshotRestore(rInt int) string {
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-db-instance-mssql-domain"
   }
 }
@@ -2957,7 +2957,7 @@ resource "aws_subnet" "main" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.1.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-domain-main"
   }
 }
@@ -2966,7 +2966,7 @@ resource "aws_subnet" "other" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2b"
   cidr_block        = "10.1.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-db-instance-mssql-domain-other"
   }
 }
@@ -3083,7 +3083,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfiguration(rInt int) strin
 	resource "aws_vpc" "foo" {
 		cidr_block           = "10.1.0.0/16"
 		enable_dns_hostnames = true
-		tags {
+	tags = {
 		  Name = "terraform-testacc-db-instance-enable-cloudwatch"
 		}
 	  }
@@ -3099,7 +3099,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfiguration(rInt int) strin
 		vpc_id            = "${aws_vpc.foo.id}"
 		availability_zone = "us-west-2a"
 		cidr_block        = "10.1.1.0/24"
-		tags {
+	tags = {
 		  Name = "tf-acc-db-instance-enable-cloudwatch-main"
 		}
 	  }
@@ -3108,7 +3108,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfiguration(rInt int) strin
 		vpc_id            = "${aws_vpc.foo.id}"
 		availability_zone = "us-west-2b"
 		cidr_block        = "10.1.2.0/24"
-		tags {
+	tags = {
 		  Name = "tf-acc-db-instance-enable-cloudwatch-other"
 		}
 	  }
@@ -3140,7 +3140,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationAdd(rInt int) st
 		resource "aws_vpc" "foo" {
 			cidr_block           = "10.1.0.0/16"
 			enable_dns_hostnames = true
-			tags {
+	tags = {
 			  Name = "terraform-testacc-db-instance-enable-cloudwatch"
 			}
 		  }
@@ -3156,7 +3156,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationAdd(rInt int) st
 			vpc_id            = "${aws_vpc.foo.id}"
 			availability_zone = "us-west-2a"
 			cidr_block        = "10.1.1.0/24"
-			tags {
+	tags = {
 			  Name = "tf-acc-db-instance-enable-cloudwatch-main"
 			}
 		  }
@@ -3165,7 +3165,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationAdd(rInt int) st
 			vpc_id            = "${aws_vpc.foo.id}"
 			availability_zone = "us-west-2b"
 			cidr_block        = "10.1.2.0/24"
-			tags {
+	tags = {
 			  Name = "tf-acc-db-instance-enable-cloudwatch-other"
 			}
 		  }
@@ -3200,7 +3200,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationModify(rInt int)
 		resource "aws_vpc" "foo" {
 			cidr_block           = "10.1.0.0/16"
 			enable_dns_hostnames = true
-			tags {
+	tags = {
 			  Name = "terraform-testacc-db-instance-enable-cloudwatch"
 			}
 		  }
@@ -3216,7 +3216,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationModify(rInt int)
 			vpc_id            = "${aws_vpc.foo.id}"
 			availability_zone = "us-west-2a"
 			cidr_block        = "10.1.1.0/24"
-			tags {
+	tags = {
 			  Name = "tf-acc-db-instance-enable-cloudwatch-main"
 			}
 		  }
@@ -3225,7 +3225,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationModify(rInt int)
 			vpc_id            = "${aws_vpc.foo.id}"
 			availability_zone = "us-west-2b"
 			cidr_block        = "10.1.2.0/24"
-			tags {
+	tags = {
 			  Name = "tf-acc-db-instance-enable-cloudwatch-other"
 			}
 		  }
@@ -3260,7 +3260,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationDelete(rInt int)
 		resource "aws_vpc" "foo" {
 			cidr_block           = "10.1.0.0/16"
 			enable_dns_hostnames = true
-			tags {
+	tags = {
 			  Name = "terraform-testacc-db-instance-enable-cloudwatch"
 			}
 		  }
@@ -3276,7 +3276,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationDelete(rInt int)
 			vpc_id            = "${aws_vpc.foo.id}"
 			availability_zone = "us-west-2a"
 			cidr_block        = "10.1.1.0/24"
-			tags {
+	tags = {
 			  Name = "tf-acc-db-instance-enable-cloudwatch-main"
 			}
 		  }
@@ -3285,7 +3285,7 @@ func testAccAWSDBInstanceConfigCloudwatchLogsExportConfigurationDelete(rInt int)
 			vpc_id            = "${aws_vpc.foo.id}"
 			availability_zone = "us-west-2b"
 			cidr_block        = "10.1.2.0/24"
-			tags {
+	tags = {
 			  Name = "tf-acc-db-instance-enable-cloudwatch-other"
 			}
 		  }
@@ -4235,7 +4235,7 @@ resource "aws_db_instance" "test" {
   snapshot_identifier = "${aws_db_snapshot.test.id}"
   skip_final_snapshot = true
 
-  tags {
+  tags = {
     key1 = "value1"
   }
 }
@@ -4253,7 +4253,7 @@ resource "aws_db_instance" "source" {
   username            = "tfacctest"
   skip_final_snapshot = true
 
-  tags {
+  tags = {
     key1 = "value1"
   }
 }
@@ -4269,7 +4269,7 @@ resource "aws_db_instance" "test" {
   snapshot_identifier = "${aws_db_snapshot.test.id}"
   skip_final_snapshot = true
 
-  tags {}
+  tags = {}
 }
 `, rName, rName, rName)
 }
@@ -4343,7 +4343,7 @@ resource "aws_db_instance" "test" {
   skip_final_snapshot    = true
   vpc_security_group_ids = ["${aws_security_group.test.id}"]
 
-  tags {
+  tags = {
     key1 = "value1"
   }
 }

--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -588,7 +588,7 @@ resource "aws_db_parameter_group" "bar" {
 	  name = "character_set_results"
 	  value = "utf8"
 	}
-	tags {
+	tags = {
 		foo = "bar"
 	}
 }`, n)
@@ -608,7 +608,7 @@ resource "aws_db_parameter_group" "bar" {
 	  value = "utf8"
 	  apply_method = "pending-reboot"
 	}
-	tags {
+	tags = {
 		foo = "bar"
 	}
 }`, n)
@@ -640,7 +640,7 @@ resource "aws_db_parameter_group" "bar" {
 	  name = "collation_connection"
 	  value = "utf8_unicode_ci"
 	}
-	tags {
+	tags = {
 		foo = "bar"
 		baz = "foo"
 	}

--- a/aws/resource_aws_db_security_group_test.go
+++ b/aws/resource_aws_db_security_group_test.go
@@ -176,7 +176,7 @@ resource "aws_db_security_group" "bar" {
         cidr = "10.0.0.1/24"
     }
 
-    tags {
+  tags = {
 		foo = "bar"
     }
 }

--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -235,7 +235,7 @@ func testAccDBSubnetGroupConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-subnet-group"
 	}
 }
@@ -244,7 +244,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-1"
 	}
 }
@@ -253,7 +253,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-2"
 	}
 }
@@ -261,7 +261,7 @@ resource "aws_subnet" "bar" {
 resource "aws_db_subnet_group" "foo" {
 	name = "%s"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-dbsubnet-group-test"
 	}
 }`, rName)
@@ -271,7 +271,7 @@ func testAccDBSubnetGroupConfig_updatedDescription(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-subnet-group-updated-description"
 	}
 }
@@ -280,7 +280,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-1"
 	}
 }
@@ -289,7 +289,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-2"
 	}
 }
@@ -298,7 +298,7 @@ resource "aws_db_subnet_group" "foo" {
 	name = "%s"
 	description = "foo description updated"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-dbsubnet-group-test"
 	}
 }`, rName)
@@ -307,7 +307,7 @@ resource "aws_db_subnet_group" "foo" {
 const testAccDBSubnetGroupConfig_namePrefix = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-subnet-group-name-prefix"
 	}
 }
@@ -316,7 +316,7 @@ resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-name-prefix-a"
 	}
 }
@@ -325,7 +325,7 @@ resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-name-prefix-b"
 	}
 }
@@ -338,7 +338,7 @@ resource "aws_db_subnet_group" "test" {
 const testAccDBSubnetGroupConfig_generatedName = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-db-subnet-group-generated-name"
 	}
 }
@@ -347,7 +347,7 @@ resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-generated-name-a"
 	}
 }
@@ -356,7 +356,7 @@ resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
-	tags {
+	tags = {
 		Name = "tf-acc-db-subnet-group-generated-name-a"
 	}
 }
@@ -368,7 +368,7 @@ resource "aws_db_subnet_group" "test" {
 const testAccDBSubnetGroupConfig_withUnderscoresAndPeriodsAndSpaces = `
 resource "aws_vpc" "main" {
     cidr_block = "192.168.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-db-subnet-group-w-underscores-etc"
 		}
 }
@@ -377,7 +377,7 @@ resource "aws_subnet" "frontend" {
     vpc_id = "${aws_vpc.main.id}"
     availability_zone = "us-west-2b"
     cidr_block = "192.168.1.0/24"
-    tags {
+  tags = {
         Name = "tf-acc-db-subnet-group-w-underscores-etc-front"
     }
 }
@@ -386,7 +386,7 @@ resource "aws_subnet" "backend" {
     vpc_id = "${aws_vpc.main.id}"
     availability_zone = "us-west-2c"
     cidr_block = "192.168.2.0/24"
-    tags {
+  tags = {
         Name = "tf-acc-db-subnet-group-w-underscores-etc-back"
     }
 }

--- a/aws/resource_aws_default_network_acl_test.go
+++ b/aws/resource_aws_default_network_acl_test.go
@@ -233,7 +233,7 @@ const testAccAWSDefaultNetworkConfig_basic = `
 resource "aws_vpc" "tftestvpc" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-network-acl-basic"
   }
 }
@@ -241,7 +241,7 @@ resource "aws_vpc" "tftestvpc" {
 resource "aws_default_network_acl" "default" {
   default_network_acl_id = "${aws_vpc.tftestvpc.default_network_acl_id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-basic"
   }
 }
@@ -251,7 +251,7 @@ const testAccAWSDefaultNetworkConfig_includingIpv6Rule = `
 resource "aws_vpc" "tftestvpc" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-network-acl-including-ipv6-rule"
   }
 }
@@ -268,7 +268,7 @@ resource "aws_default_network_acl" "default" {
     to_port    = 0
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-basic-including-ipv6-rule"
   }
 }
@@ -278,7 +278,7 @@ const testAccAWSDefaultNetworkConfig_deny_ingress = `
 resource "aws_vpc" "tftestvpc" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-network-acl-deny-ingress"
   }
 }
@@ -295,7 +295,7 @@ resource "aws_default_network_acl" "default" {
     to_port    = 0
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-deny-ingress"
   }
 }
@@ -305,7 +305,7 @@ const testAccAWSDefaultNetworkConfig_Subnets = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-network-acl-subnets"
   }
 }
@@ -314,7 +314,7 @@ resource "aws_subnet" "one" {
   cidr_block = "10.1.111.0/24"
   vpc_id     = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-network-acl-one"
   }
 }
@@ -323,7 +323,7 @@ resource "aws_subnet" "two" {
   cidr_block = "10.1.1.0/24"
   vpc_id     = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-network-acl-two"
   }
 }
@@ -331,7 +331,7 @@ resource "aws_subnet" "two" {
 resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-subnets"
   }
 }
@@ -341,7 +341,7 @@ resource "aws_default_network_acl" "default" {
 
   subnet_ids = ["${aws_subnet.one.id}", "${aws_subnet.two.id}"]
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-subnets"
   }
 }
@@ -351,7 +351,7 @@ const testAccAWSDefaultNetworkConfig_Subnets_remove = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-network-acl-subnets-remove"
   }
 }
@@ -360,7 +360,7 @@ resource "aws_subnet" "one" {
   cidr_block = "10.1.111.0/24"
   vpc_id     = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-network-acl-subnets-remove-one"
   }
 }
@@ -369,7 +369,7 @@ resource "aws_subnet" "two" {
   cidr_block = "10.1.1.0/24"
   vpc_id     = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-network-acl-subnets-remove-two"
   }
 }
@@ -377,7 +377,7 @@ resource "aws_subnet" "two" {
 resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-subnets-remove"
   }
 }
@@ -385,7 +385,7 @@ resource "aws_network_acl" "bar" {
 resource "aws_default_network_acl" "default" {
   default_network_acl_id = "${aws_vpc.foo.default_network_acl_id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-subnets-remove"
   }
 }
@@ -395,7 +395,7 @@ const testAccAWSDefaultNetworkConfig_Subnets_move = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-network-acl-subnets-move"
   }
 }
@@ -404,7 +404,7 @@ resource "aws_subnet" "one" {
   cidr_block = "10.1.111.0/24"
   vpc_id     = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-network-acl-subnets-move-one"
   }
 }
@@ -413,7 +413,7 @@ resource "aws_subnet" "two" {
   cidr_block = "10.1.1.0/24"
   vpc_id     = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-network-acl-subnets-move-two"
   }
 }
@@ -423,7 +423,7 @@ resource "aws_network_acl" "bar" {
 
   subnet_ids = ["${aws_subnet.one.id}", "${aws_subnet.two.id}"]
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-subnets-move"
   }
 }
@@ -433,7 +433,7 @@ resource "aws_default_network_acl" "default" {
 
   depends_on = ["aws_network_acl.bar"]
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-subnets-move"
   }
 }
@@ -448,7 +448,7 @@ resource "aws_vpc" "tftestvpc" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-default-network-acl-basic-ipv6-vpc"
 	}
 }
@@ -456,7 +456,7 @@ resource "aws_vpc" "tftestvpc" {
 resource "aws_default_network_acl" "default" {
   default_network_acl_id = "${aws_vpc.tftestvpc.default_network_acl_id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-default-acl-subnets-basic-ipv6-vpc"
   }
 }

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -143,7 +143,7 @@ resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-route-table"
   }
 }
@@ -156,7 +156,7 @@ resource "aws_default_route_table" "foo" {
     gateway_id = "${aws_internet_gateway.gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "tf-default-route-table-test"
   }
 }
@@ -164,7 +164,7 @@ resource "aws_default_route_table" "foo" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-default-route-table-test"
   }
 }`
@@ -178,7 +178,7 @@ resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-route-table-change"
   }
 }
@@ -191,7 +191,7 @@ resource "aws_default_route_table" "foo" {
     gateway_id = "${aws_internet_gateway.gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "this was the first main"
   }
 }
@@ -199,7 +199,7 @@ resource "aws_default_route_table" "foo" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "main-igw"
   }
 }
@@ -213,7 +213,7 @@ resource "aws_route_table" "r" {
     gateway_id = "${aws_internet_gateway.gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "other"
   }
 }
@@ -228,7 +228,7 @@ resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-default-route-table-change"
   }
 }
@@ -241,7 +241,7 @@ resource "aws_default_route_table" "foo" {
     gateway_id = "${aws_internet_gateway.gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "this was the first main"
   }
 }
@@ -249,7 +249,7 @@ resource "aws_default_route_table" "foo" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "main-igw"
   }
 }
@@ -263,7 +263,7 @@ resource "aws_route_table" "r" {
     gateway_id = "${aws_internet_gateway.gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "other"
   }
 }
@@ -279,7 +279,7 @@ func testAccAWSDefaultRouteTableConfigRouteTransitGatewayID() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
   }
 }
@@ -288,7 +288,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-default-route-table-transit-gateway-id"
   }
 }
@@ -320,7 +320,7 @@ provider "aws" {
 resource "aws_vpc" "test" {
     cidr_block = "10.0.0.0/16"
 
-    tags {
+  tags = {
         Name = "terraform-testacc-default-route-table-vpc-endpoint"
     }
 }
@@ -328,7 +328,7 @@ resource "aws_vpc" "test" {
 resource "aws_internet_gateway" "igw" {
     vpc_id = "${aws_vpc.test.id}"
 
-    tags {
+  tags = {
         Name = "test"
     }
 }
@@ -344,7 +344,7 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_default_route_table" "foo" {
     default_route_table_id = "${aws_vpc.test.default_route_table_id}"
 
-    tags {
+  tags = {
         Name = "test"
     }
 

--- a/aws/resource_aws_default_security_group_test.go
+++ b/aws/resource_aws_default_security_group_test.go
@@ -141,7 +141,7 @@ func testAccCheckAWSDefaultSecurityGroupAttributes(group *ec2.SecurityGroup) res
 const testAccAWSDefaultSecurityGroupConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-default-security-group"
 	}
 }
@@ -163,7 +163,7 @@ resource "aws_default_security_group" "web" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -182,7 +182,7 @@ resource "aws_default_security_group" "web" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`

--- a/aws/resource_aws_default_subnet_test.go
+++ b/aws/resource_aws_default_subnet_test.go
@@ -89,7 +89,7 @@ func testAccCheckAWSDefaultSubnetDestroy(s *terraform.State) error {
 const testAccAWSDefaultSubnetConfigBasic = `
 resource "aws_default_subnet" "foo" {
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "terraform-testacc-default-subnet"
   }
 }
@@ -99,7 +99,7 @@ const testAccAWSDefaultSubnetConfigPublicIp = `
 resource "aws_default_subnet" "foo" {
   availability_zone = "us-west-2b"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "terraform-testacc-default-subnet"
   }
 }
@@ -109,7 +109,7 @@ const testAccAWSDefaultSubnetConfigNoPublicIp = `
 resource "aws_default_subnet" "foo" {
   availability_zone = "us-west-2b"
   map_public_ip_on_launch = false
-  tags {
+  tags = {
     Name = "terraform-testacc-default-subnet"
   }
 }

--- a/aws/resource_aws_default_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_default_vpc_dhcp_options_test.go
@@ -46,7 +46,7 @@ provider "aws" {
 }
 
 resource "aws_default_vpc_dhcp_options" "foo" {
-	tags {
+	tags = {
 		Name = "Default DHCP Option Set"
 	}
 }

--- a/aws/resource_aws_default_vpc_test.go
+++ b/aws/resource_aws_default_vpc_test.go
@@ -53,7 +53,7 @@ provider "aws" {
 }
 
 resource "aws_default_vpc" "foo" {
-	tags {
+	tags = {
 		Name = "Default VPC"
 	}
 }

--- a/aws/resource_aws_directory_service_conditional_forwarder_test.go
+++ b/aws/resource_aws_directory_service_conditional_forwarder_test.go
@@ -148,14 +148,14 @@ resource "aws_directory_service_directory" "bar" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
   }
 
-  tags {
+  tags = {
     Name = "terraform-testacc-directory-service-conditional-forwarder"
   }
 }
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-directory-service-conditional-forwarder"
   }
 }
@@ -164,7 +164,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "terraform-testacc-directory-service-conditional-forwarder"
   }
 }
@@ -173,7 +173,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "terraform-testacc-directory-service-conditional-forwarder"
   }
 }

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -408,7 +408,7 @@ resource "aws_directory_service_directory" "bar" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory"
 	}
 }
@@ -417,7 +417,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-foo"
   }
 }
@@ -425,7 +425,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-bar"
   }
 }
@@ -442,7 +442,7 @@ resource "aws_directory_service_directory" "bar" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
   }
 
-	tags {
+	tags = {
 		foo = "bar"
 		project = "test"
 	}
@@ -450,7 +450,7 @@ resource "aws_directory_service_directory" "bar" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory-tags"
 	}
 }
@@ -459,7 +459,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-tags-foo"
   }
 }
@@ -467,7 +467,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-tags-bar"
   }
 }
@@ -501,7 +501,7 @@ resource "aws_directory_service_directory" "connector" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory-connector"
 	}
 }
@@ -510,7 +510,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-connector-foo"
   }
 }
@@ -518,7 +518,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-connector-bar"
   }
 }
@@ -538,7 +538,7 @@ resource "aws_directory_service_directory" "bar" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory-microsoft"
 	}
 }
@@ -547,7 +547,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-microsoft-foo"
   }
 }
@@ -555,7 +555,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-microsoft-bar"
   }
 }
@@ -576,7 +576,7 @@ resource "aws_directory_service_directory" "bar" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory-microsoft"
 	}
 }
@@ -585,7 +585,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-microsoft-foo"
   }
 }
@@ -593,7 +593,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-microsoft-bar"
   }
 }
@@ -615,7 +615,7 @@ resource "aws_directory_service_directory" "bar_a" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory-with-alias"
 	}
 }
@@ -624,7 +624,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-with-alias-foo"
   }
 }
@@ -632,7 +632,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-with-alias-bar"
   }
 }
@@ -654,7 +654,7 @@ resource "aws_directory_service_directory" "bar_a" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory-with-sso"
 	}
 }
@@ -663,7 +663,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-with-sso-foo"
   }
 }
@@ -671,7 +671,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-with-sso-bar"
   }
 }
@@ -693,7 +693,7 @@ resource "aws_directory_service_directory" "bar_a" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-directory-service-directory-with-sso-modified"
 	}
 }
@@ -702,7 +702,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-with-sso-foo"
   }
 }
@@ -710,7 +710,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.main.id}"
   availability_zone = "us-west-2b"
   cidr_block = "10.0.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-directory-service-directory-with-sso-bar"
   }
 }

--- a/aws/resource_aws_dms_endpoint_test.go
+++ b/aws/resource_aws_dms_endpoint_test.go
@@ -232,7 +232,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	port = 3306
 	server_name = "tftest"
 	ssl_mode = "none"
-	tags {
+	tags = {
 		Name = "tf-test-dms-endpoint-%[1]s"
 		Update = "to-update"
 		Remove = "to-remove"
@@ -254,7 +254,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	port = 3303
 	server_name = "tftestupdate"
 	ssl_mode = "none"
-	tags {
+	tags = {
 		Name = "tf-test-dms-endpoint-%[1]s"
 		Update = "updated"
 		Add = "added"
@@ -272,7 +272,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	engine_name = "dynamodb"
 	service_access_role = "${aws_iam_role.iam_role.arn}"
 	ssl_mode = "none"
-	tags {
+	tags = {
 		Name = "tf-test-dynamodb-endpoint-%[1]s"
 		Update = "to-update"
 		Remove = "to-remove"
@@ -335,7 +335,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	engine_name = "dynamodb"
 	service_access_role = "${aws_iam_role.iam_role.arn}"
 	ssl_mode = "none"
-	tags {
+	tags = {
 		Name = "tf-test-dynamodb-endpoint-%[1]s"
 		Update = "updated"
 		Add = "added"
@@ -396,7 +396,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	engine_name = "s3"
 	ssl_mode = "none"
 	extra_connection_attributes = ""
-	tags {
+	tags = {
 		Name = "tf-test-s3-endpoint-%[1]s"
 		Update = "to-update"
 		Remove = "to-remove"
@@ -468,7 +468,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	engine_name = "s3"
 	ssl_mode = "none"
 	extra_connection_attributes = "key=value;"
-	tags {
+	tags = {
 		Name = "tf-test-s3-endpoint-%[1]s"
 		Update = "updated"
 		Add = "added"
@@ -553,7 +553,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	ssl_mode = "none"
 	extra_connection_attributes = ""
 	kms_key_arn = "${data.aws_kms_alias.dms.target_key_arn}"
-	tags {
+	tags = {
 		Name = "tf-test-dms-endpoint-%[1]s"
 		Update = "to-update"
 		Remove = "to-remove"
@@ -588,7 +588,7 @@ resource "aws_dms_endpoint" "dms_endpoint" {
 	ssl_mode = "require"
 	extra_connection_attributes = "key=value;"
 	kms_key_arn = "${data.aws_kms_alias.dms.target_key_arn}"
-	tags {
+	tags = {
 		Name = "tf-test-dms-endpoint-%[1]s"
 		Update = "updated"
 		Add = "added"

--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -618,7 +618,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -630,7 +630,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "${aws_vpc.test.tags["Name"]}"
   }
 }
@@ -657,7 +657,7 @@ resource "aws_dms_replication_instance" "test" {
   replication_instance_class   = "dms.t2.micro"
   replication_instance_id      = %q
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -671,7 +671,7 @@ resource "aws_dms_replication_instance" "test" {
   replication_instance_class   = "dms.t2.micro"
   replication_instance_id      = %q
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }
@@ -686,7 +686,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -703,7 +703,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.1.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "${aws_vpc.test.tags["Name"]}"
   }
 }

--- a/aws/resource_aws_dms_replication_subnet_group_test.go
+++ b/aws/resource_aws_dms_replication_subnet_group_test.go
@@ -103,7 +103,7 @@ func dmsReplicationSubnetGroupConfig(randId string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-dms-replication-subnet-group"
 	}
 }
@@ -112,7 +112,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-subnet-group-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -122,7 +122,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-subnet-group-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -132,7 +132,7 @@ resource "aws_subnet" "dms_subnet_3" {
 	cidr_block = "10.1.3.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-subnet-group-3"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -142,7 +142,7 @@ resource "aws_dms_replication_subnet_group" "dms_replication_subnet_group" {
 	replication_subnet_group_id = "tf-test-dms-replication-subnet-group-%[1]s"
 	replication_subnet_group_description = "terraform test for replication subnet group"
 	subnet_ids = ["${aws_subnet.dms_subnet_1.id}", "${aws_subnet.dms_subnet_2.id}"]
-	tags {
+	tags = {
 		Name = "tf-test-dms-replication-subnet-group-%[1]s"
 		Update = "to-update"
 		Remove = "to-remove"
@@ -155,7 +155,7 @@ func dmsReplicationSubnetGroupConfigUpdate(randId string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-dms-replication-subnet-group"
 	}
 }
@@ -164,7 +164,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-subnet-group-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -174,7 +174,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-subnet-group-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -184,7 +184,7 @@ resource "aws_subnet" "dms_subnet_3" {
 	cidr_block = "10.1.3.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-subnet-group-3"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -194,7 +194,7 @@ resource "aws_dms_replication_subnet_group" "dms_replication_subnet_group" {
 	replication_subnet_group_id = "tf-test-dms-replication-subnet-group-%[1]s"
 	replication_subnet_group_description = "terraform test for replication subnet group"
 	subnet_ids = ["${aws_subnet.dms_subnet_1.id}", "${aws_subnet.dms_subnet_3.id}"]
-	tags {
+	tags = {
 		Name = "tf-test-dms-replication-subnet-group-%[1]s"
 		Update = "updated"
 		Add = "added"

--- a/aws/resource_aws_dms_replication_task_test.go
+++ b/aws/resource_aws_dms_replication_task_test.go
@@ -106,7 +106,7 @@ func dmsReplicationTaskConfig(randId string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-dms-replication-task"
 	}
 }
@@ -115,7 +115,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-task-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -125,7 +125,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-task-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -176,7 +176,7 @@ resource "aws_dms_replication_task" "dms_replication_task" {
 	replication_task_settings = "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":false,\"LobChunkSize\":0,\"LimitedSizeLobMode\":true,\"LobMaxSize\":32,\"LoadMaxFileSize\":0,\"ParallelLoadThreads\":0,\"BatchApplyEnabled\":false},\"FullLoadSettings\":{\"FullLoadEnabled\":true,\"ApplyChangesEnabled\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"ResumeEnabled\":false,\"ResumeMinTableSize\":100000,\"ResumeOnlyClusteredPKTables\":true,\"MaxFullLoadSubTasks\":8,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false,\"LogComponents\":[{\"Id\":\"SOURCE_UNLOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_LOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_CAPTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_APPLY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TASK_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"}],\"CloudWatchLogGroup\":null,\"CloudWatchLogStream\":null},\"ControlTablesSettings\":{\"historyTimeslotInMinutes\":5,\"ControlSchema\":\"\",\"HistoryTimeslotInMinutes\":5,\"HistoryTableEnabled\":false,\"SuspendedTablesTableEnabled\":false,\"StatusTableEnabled\":false},\"StreamBufferSettings\":{\"StreamBufferCount\":3,\"StreamBufferSizeInMB\":8,\"CtrlStreamBufferSizeInMB\":5},\"ChangeProcessingDdlHandlingPolicy\":{\"HandleSourceTableDropped\":true,\"HandleSourceTableTruncated\":true,\"HandleSourceTableAltered\":true},\"ErrorBehavior\":{\"DataErrorPolicy\":\"LOG_ERROR\",\"DataTruncationErrorPolicy\":\"LOG_ERROR\",\"DataErrorEscalationPolicy\":\"SUSPEND_TABLE\",\"DataErrorEscalationCount\":0,\"TableErrorPolicy\":\"SUSPEND_TABLE\",\"TableErrorEscalationPolicy\":\"STOP_TASK\",\"TableErrorEscalationCount\":0,\"RecoverableErrorCount\":-1,\"RecoverableErrorInterval\":5,\"RecoverableErrorThrottling\":true,\"RecoverableErrorThrottlingMax\":1800,\"ApplyErrorDeletePolicy\":\"IGNORE_RECORD\",\"ApplyErrorInsertPolicy\":\"LOG_ERROR\",\"ApplyErrorUpdatePolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationPolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationCount\":0,\"FullLoadIgnoreConflicts\":true},\"ChangeProcessingTuning\":{\"BatchApplyPreserveTransaction\":true,\"BatchApplyTimeoutMin\":1,\"BatchApplyTimeoutMax\":30,\"BatchApplyMemoryLimit\":500,\"BatchSplitSize\":0,\"MinTransactionSize\":1000,\"CommitTimeout\":1,\"MemoryLimitTotal\":1024,\"MemoryKeepTime\":60,\"StatementCacheSize\":50}}"
 	source_endpoint_arn = "${aws_dms_endpoint.dms_endpoint_source.endpoint_arn}"
 	table_mappings = "{\"rules\":[{\"rule-type\":\"selection\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"object-locator\":{\"schema-name\":\"%%\",\"table-name\":\"%%\"},\"rule-action\":\"include\"}]}"
-	tags {
+	tags = {
 		Name = "tf-test-dms-replication-task-%[1]s"
 		Update = "to-update"
 		Remove = "to-remove"
@@ -190,7 +190,7 @@ func dmsReplicationTaskConfigUpdate(randId string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "dms_vpc" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-dms-replication-task"
 	}
 }
@@ -199,7 +199,7 @@ resource "aws_subnet" "dms_subnet_1" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-task-1"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -209,7 +209,7 @@ resource "aws_subnet" "dms_subnet_2" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.dms_vpc.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-dms-replication-task-2"
 	}
 	depends_on = ["aws_vpc.dms_vpc"]
@@ -260,7 +260,7 @@ resource "aws_dms_replication_task" "dms_replication_task" {
 	replication_task_settings = "{\"TargetMetadata\":{\"TargetSchema\":\"\",\"SupportLobs\":true,\"FullLobMode\":false,\"LobChunkSize\":0,\"LimitedSizeLobMode\":true,\"LobMaxSize\":32,\"LoadMaxFileSize\":0,\"ParallelLoadThreads\":0,\"BatchApplyEnabled\":false},\"FullLoadSettings\":{\"FullLoadEnabled\":true,\"ApplyChangesEnabled\":false,\"TargetTablePrepMode\":\"DROP_AND_CREATE\",\"CreatePkAfterFullLoad\":false,\"StopTaskCachedChangesApplied\":false,\"StopTaskCachedChangesNotApplied\":false,\"ResumeEnabled\":false,\"ResumeMinTableSize\":100000,\"ResumeOnlyClusteredPKTables\":true,\"MaxFullLoadSubTasks\":7,\"TransactionConsistencyTimeout\":600,\"CommitRate\":10000},\"Logging\":{\"EnableLogging\":false,\"LogComponents\":[{\"Id\":\"SOURCE_UNLOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_LOAD\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"SOURCE_CAPTURE\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TARGET_APPLY\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"},{\"Id\":\"TASK_MANAGER\",\"Severity\":\"LOGGER_SEVERITY_DEFAULT\"}],\"CloudWatchLogGroup\":null,\"CloudWatchLogStream\":null},\"ControlTablesSettings\":{\"historyTimeslotInMinutes\":5,\"ControlSchema\":\"\",\"HistoryTimeslotInMinutes\":5,\"HistoryTableEnabled\":false,\"SuspendedTablesTableEnabled\":false,\"StatusTableEnabled\":false},\"StreamBufferSettings\":{\"StreamBufferCount\":3,\"StreamBufferSizeInMB\":8,\"CtrlStreamBufferSizeInMB\":5},\"ChangeProcessingDdlHandlingPolicy\":{\"HandleSourceTableDropped\":true,\"HandleSourceTableTruncated\":true,\"HandleSourceTableAltered\":true},\"ErrorBehavior\":{\"DataErrorPolicy\":\"LOG_ERROR\",\"DataTruncationErrorPolicy\":\"LOG_ERROR\",\"DataErrorEscalationPolicy\":\"SUSPEND_TABLE\",\"DataErrorEscalationCount\":0,\"TableErrorPolicy\":\"SUSPEND_TABLE\",\"TableErrorEscalationPolicy\":\"STOP_TASK\",\"TableErrorEscalationCount\":0,\"RecoverableErrorCount\":-1,\"RecoverableErrorInterval\":5,\"RecoverableErrorThrottling\":true,\"RecoverableErrorThrottlingMax\":1800,\"ApplyErrorDeletePolicy\":\"IGNORE_RECORD\",\"ApplyErrorInsertPolicy\":\"LOG_ERROR\",\"ApplyErrorUpdatePolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationPolicy\":\"LOG_ERROR\",\"ApplyErrorEscalationCount\":0,\"FullLoadIgnoreConflicts\":true},\"ChangeProcessingTuning\":{\"BatchApplyPreserveTransaction\":true,\"BatchApplyTimeoutMin\":1,\"BatchApplyTimeoutMax\":30,\"BatchApplyMemoryLimit\":500,\"BatchSplitSize\":0,\"MinTransactionSize\":1000,\"CommitTimeout\":1,\"MemoryLimitTotal\":1024,\"MemoryKeepTime\":60,\"StatementCacheSize\":50}}"
 	source_endpoint_arn = "${aws_dms_endpoint.dms_endpoint_source.endpoint_arn}"
 	table_mappings = "{\"rules\":[{\"rule-type\":\"selection\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"object-locator\":{\"schema-name\":\"%%\",\"table-name\":\"%%\"},\"rule-action\":\"include\"}]}"
-	tags {
+	tags = {
 		Name = "tf-test-dms-replication-task-%[1]s"
 		Update = "updated"
 		Add = "added"

--- a/aws/resource_aws_dx_connection_test.go
+++ b/aws/resource_aws_dx_connection_test.go
@@ -137,7 +137,7 @@ resource "aws_dx_connection" "hoge" {
   bandwidth = "1Gbps"
   location = "EqSe2"
 
-  tags {
+  tags = {
     Environment = "production"
     Usage = "original"
   }
@@ -152,7 +152,7 @@ resource "aws_dx_connection" "hoge" {
   bandwidth = "1Gbps"
   location = "EqSe2"
 
-  tags {
+  tags = {
     Usage = "changed"
   }
 }

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -84,13 +84,13 @@ resource "aws_dx_gateway" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.255.255.0/28"
-  tags {
+  tags = {
     Name = "terraform-testacc-dxgwassoc-%s"
   }
 }
 
 resource "aws_vpn_gateway" "test" {
-  tags {
+  tags = {
     Name = "terraform-testacc-dxgwassoc-%s"
   }
 }
@@ -116,13 +116,13 @@ resource "aws_dx_gateway" "test" {
 
 resource "aws_vpc" "test1" {
   cidr_block = "10.255.255.16/28"
-  tags {
+  tags = {
     Name = "terraform-testacc-dxgwassoc-%s-1"
   }
 }
 
 resource "aws_vpn_gateway" "test1" {
-  tags {
+  tags = {
     Name = "terraform-testacc-dxgwassoc-%s-1"
   }
 }
@@ -139,13 +139,13 @@ resource "aws_dx_gateway_association" "test1" {
 
 resource "aws_vpc" "test2" {
   cidr_block = "10.255.255.32/28"
-  tags {
+  tags = {
     Name = "terraform-testacc-dxgwassoc-%s-2"
   }
 }
 
 resource "aws_vpn_gateway" "test2" {
-  tags {
+  tags = {
     Name = "terraform-testacc-dxgwassoc-%s-2"
   }
 }

--- a/aws/resource_aws_dx_lag_test.go
+++ b/aws/resource_aws_dx_lag_test.go
@@ -160,7 +160,7 @@ resource "aws_dx_lag" "hoge" {
   location = "EqSe2"
   force_destroy = true
 
-  tags {
+  tags = {
     Environment = "production"
     Usage = "original"
   }
@@ -176,7 +176,7 @@ resource "aws_dx_lag" "hoge" {
   location = "EqSe2"
   force_destroy = true
 
-  tags {
+  tags = {
     Usage = "changed"
   }
 }

--- a/aws/resource_aws_dx_private_virtual_interface_test.go
+++ b/aws/resource_aws_dx_private_virtual_interface_test.go
@@ -164,7 +164,7 @@ func testAccCheckAwsDxPrivateVirtualInterfaceExists(name string) resource.TestCh
 func testAccDxPrivateVirtualInterfaceConfig_noTags(cid, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "foo" {
-  tags {
+  tags = {
     Name = "%s"
   }
 }
@@ -184,7 +184,7 @@ resource "aws_dx_private_virtual_interface" "foo" {
 func testAccDxPrivateVirtualInterfaceConfig_tags(cid, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "foo" {
-  tags {
+  tags = {
     Name = "%s"
   }
 }
@@ -198,7 +198,7 @@ resource "aws_dx_private_virtual_interface" "foo" {
   address_family = "ipv4"
   bgp_asn        = %d
 
-  tags {
+  tags = {
     Environment = "test"
   }
 }
@@ -227,7 +227,7 @@ resource "aws_dx_private_virtual_interface" "foo" {
 func testAccDxPrivateVirtualInterfaceConfig_jumboFrames(cid, n string, bgpAsn, vlan int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "foo" {
-  tags {
+  tags = {
     Name = "%s"
   }
 }

--- a/aws/resource_aws_dx_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_public_virtual_interface_test.go
@@ -127,7 +127,7 @@ resource "aws_dx_public_virtual_interface" "foo" {
 	"175.45.176.0/22"
   ]
 
-  tags {
+  tags = {
     Environment = "test"
   }
 }

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -1442,7 +1442,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     projection_type = "KEYS_ONLY"
   }
 
-  tags {
+  tags = {
     Name = "terraform-test-table-%d"
     AccTest = "yes"
     Testing = "absolutely"

--- a/aws/resource_aws_ebs_snapshot_copy_test.go
+++ b/aws/resource_aws_ebs_snapshot_copy_test.go
@@ -142,7 +142,7 @@ resource "aws_ebs_volume" "test" {
 resource "aws_ebs_snapshot" "test" {
   volume_id = "${aws_ebs_volume.test.id}"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfig"
   }
 }
@@ -151,7 +151,7 @@ resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = "${aws_ebs_snapshot.test.id}"
 	source_region      = "us-west-2"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfig"
   }
 }
@@ -162,7 +162,7 @@ resource "aws_ebs_volume" "description_test" {
 	availability_zone = "us-west-2a"
 	size              = 1
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithDescription"
   }
 }
@@ -171,7 +171,7 @@ resource "aws_ebs_snapshot" "description_test" {
 	volume_id   = "${aws_ebs_volume.description_test.id}"
 	description = "EBS Snapshot Acceptance Test"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithDescription"
   }
 }
@@ -181,7 +181,7 @@ resource "aws_ebs_snapshot_copy" "description_test" {
   source_snapshot_id = "${aws_ebs_snapshot.description_test.id}"
 	source_region      = "us-west-2"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithDescription"
   }
 }
@@ -203,7 +203,7 @@ resource "aws_ebs_volume" "region_test" {
   availability_zone = "us-west-2a"
   size              = 1
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithRegions"
   }
 }
@@ -212,7 +212,7 @@ resource "aws_ebs_snapshot" "region_test" {
   provider  = "aws.uswest2"
   volume_id = "${aws_ebs_volume.region_test.id}"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithRegions"
   }
 }
@@ -222,7 +222,7 @@ resource "aws_ebs_snapshot_copy" "region_test" {
   source_snapshot_id = "${aws_ebs_snapshot.region_test.id}"
   source_region      = "us-west-2"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithRegions"
   }
 }
@@ -242,7 +242,7 @@ resource "aws_ebs_volume" "kms_test" {
   availability_zone = "us-west-2a"
   size              = 1
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithKms"
   }
 }
@@ -250,7 +250,7 @@ resource "aws_ebs_volume" "kms_test" {
 resource "aws_ebs_snapshot" "kms_test" {
   volume_id = "${aws_ebs_volume.kms_test.id}"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithKms"
   }
 }
@@ -261,7 +261,7 @@ resource "aws_ebs_snapshot_copy" "kms_test" {
   encrypted          = true
   kms_key_id         = "${aws_kms_key.kms_test.arn}"
 
-  tags {
+  tags = {
     Name = "testAccAwsEbsSnapshotCopyConfigWithKms"
   }
 }

--- a/aws/resource_aws_ebs_snapshot_test.go
+++ b/aws/resource_aws_ebs_snapshot_test.go
@@ -170,7 +170,7 @@ resource "aws_ebs_volume" "test" {
 resource "aws_ebs_snapshot" "test" {
   volume_id = "${aws_ebs_volume.test.id}"
 
-  tags {
+  tags = {
     Name = "%s"
   }
 }
@@ -201,7 +201,7 @@ data "aws_region" "current" {}
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }
@@ -212,7 +212,7 @@ resource "aws_ebs_volume" "test" {
   encrypted         = true
   kms_key_id        = "${aws_kms_key.test.arn}"
 
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }
@@ -220,7 +220,7 @@ resource "aws_ebs_volume" "test" {
 resource "aws_ebs_snapshot" "test" {
   volume_id = "${aws_ebs_volume.test.id}"
 
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -326,7 +326,7 @@ resource "aws_instance" "test" {
     delete_on_termination = true
   }
 
-  tags {
+  tags = {
     Name    = "test-terraform"
   }
 }
@@ -385,7 +385,7 @@ resource "aws_instance" "test" {
     delete_on_termination = true
   }
 
-  tags {
+  tags = {
     Name    = "test-terraform"
   }
 }
@@ -412,7 +412,7 @@ resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "gp2"
   size = 10
-  tags {
+  tags = {
     Name = "tf-acc-test-ebs-volume-test"
   }
 }
@@ -425,7 +425,7 @@ resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   type = "sc1"
   size = 500
-  tags {
+  tags = {
     Name = "tf-acc-test-ebs-volume-test"
   }
 }
@@ -439,7 +439,7 @@ resource "aws_ebs_volume" "test" {
   type = "io1"
   size = 4
   iops = 100
-  tags {
+  tags = {
     Name = "tf-acc-test-ebs-volume-test"
   }
 }
@@ -453,7 +453,7 @@ resource "aws_ebs_volume" "test" {
   type = "io1"
   size = 4
   iops = 200
-  tags {
+  tags = {
     Name = "tf-acc-test-ebs-volume-test"
   }
 }
@@ -497,7 +497,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_ebs_volume" "test" {
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   size = 1
-  tags {
+  tags = {
     Name = "TerraformTest"
   }
 }
@@ -511,7 +511,7 @@ resource "aws_ebs_volume" "test" {
   size = 10
   type = "gp2"
   iops = 0
-  tags {
+  tags = {
     Name = "TerraformTest"
   }
 }

--- a/aws/resource_aws_ec2_capacity_reservation_test.go
+++ b/aws/resource_aws_ec2_capacity_reservation_test.go
@@ -559,7 +559,7 @@ resource "aws_ec2_capacity_reservation" "test" {
   instance_platform = "Linux/UNIX"
   instance_type     = "t2.micro"
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -576,7 +576,7 @@ resource "aws_ec2_capacity_reservation" "test" {
   instance_platform = "Linux/UNIX"
   instance_type     = "t2.micro"
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_ec2_fleet_test.go
+++ b/aws/resource_aws_ec2_fleet_test.go
@@ -1403,7 +1403,7 @@ variable "TestAccNameTag" {
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "${var.TestAccNameTag}"
   }
 }
@@ -1414,7 +1414,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.1.${count.index}.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "${var.TestAccNameTag}"
   }
 }
@@ -1607,7 +1607,7 @@ resource "aws_ec2_fleet" "test" {
     }
   }
 
-  tags {
+  tags = {
     %q = %q
   }
 

--- a/aws/resource_aws_ec2_transit_gateway_route_table_association_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_association_test.go
@@ -113,7 +113,7 @@ func testAccAWSEc2TransitGatewayRouteTableAssociationConfig() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-route"
   }
 }
@@ -122,7 +122,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-route"
   }
 }

--- a/aws/resource_aws_ec2_transit_gateway_route_table_propagation_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_propagation_test.go
@@ -113,7 +113,7 @@ func testAccAWSEc2TransitGatewayRouteTablePropagationConfig() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-route"
   }
 }
@@ -122,7 +122,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-route"
   }
 }

--- a/aws/resource_aws_ec2_transit_gateway_route_table_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_table_test.go
@@ -238,7 +238,7 @@ resource "aws_ec2_transit_gateway" "test" {}
 resource "aws_ec2_transit_gateway_route_table" "test" {
   transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -252,7 +252,7 @@ resource "aws_ec2_transit_gateway" "test" {}
 resource "aws_ec2_transit_gateway_route_table" "test" {
   transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_ec2_transit_gateway_route_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_test.go
@@ -151,7 +151,7 @@ func testAccAWSEc2TransitGatewayRouteConfigDestinationCidrBlock() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-route"
   }
 }
@@ -160,7 +160,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-route"
   }
 }

--- a/aws/resource_aws_ec2_transit_gateway_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_test.go
@@ -625,7 +625,7 @@ resource "aws_ec2_transit_gateway" "test" {
 func testAccAWSEc2TransitGatewayConfigTags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -635,7 +635,7 @@ resource "aws_ec2_transit_gateway" "test" {
 func testAccAWSEc2TransitGatewayConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -444,7 +444,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentConfig() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -453,7 +453,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -473,7 +473,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentConfigDnsSupport(dnsSupport string)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -482,7 +482,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -504,7 +504,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
   cidr_block                       = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -514,7 +514,7 @@ resource "aws_subnet" "test" {
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
   vpc_id          = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -537,7 +537,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -549,7 +549,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -571,7 +571,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -583,7 +583,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -603,7 +603,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentConfigTags1(tagKey1, tagValue1 stri
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -612,7 +612,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -624,7 +624,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
   transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
   vpc_id             = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -636,7 +636,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentConfigTags2(tagKey1, tagValue1, tag
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -645,7 +645,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -657,7 +657,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
   transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
   vpc_id             = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }
@@ -670,7 +670,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTab
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -679,7 +679,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -704,7 +704,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTab
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -713,7 +713,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -734,7 +734,7 @@ func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTab
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }
@@ -743,7 +743,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
   }
 }

--- a/aws/resource_aws_ecs_cluster_test.go
+++ b/aws/resource_aws_ecs_cluster_test.go
@@ -193,7 +193,7 @@ func testAccAWSEcsClusterConfigTags1(rName, tag1Key, tag1Value string) string {
 resource "aws_ecs_cluster" "test" {
   name = %q
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -205,7 +205,7 @@ func testAccAWSEcsClusterConfigTags2(rName, tag1Key, tag1Value, tag2Key, tag2Val
 resource "aws_ecs_cluster" "test" {
   name = %q
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -1246,7 +1246,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-ecs-service-with-launch-type-fargate"
   }
 }
@@ -1256,7 +1256,7 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "tf-acc-ecs-service-with-launch-type-fargate"
   }
 }
@@ -1334,7 +1334,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
     Name = "%s"
   }
 }
@@ -1344,7 +1344,7 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "tf-acc-ecs-service-health-check-grace-period"
   }
 }
@@ -1865,7 +1865,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-ecs-service-with-alb"
   }
 }
@@ -1875,7 +1875,7 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "tf-acc-ecs-service-with-alb"
   }
 }
@@ -2011,7 +2011,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-ecs-service-with-network-config"
   }
 }
@@ -2021,7 +2021,7 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "tf-acc-ecs-service-with-network-config"
   }
 }
@@ -2462,7 +2462,7 @@ resource "aws_ecs_service" "test" {
   name                               = %q
   task_definition                    = "${aws_ecs_task_definition.test.arn}"
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -2497,7 +2497,7 @@ resource "aws_ecs_service" "test" {
   name                               = %q
   task_definition                    = "${aws_ecs_task_definition.test.arn}"
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }
@@ -2534,7 +2534,7 @@ resource "aws_ecs_service" "test" {
   task_definition                    = "${aws_ecs_task_definition.test.arn}"
   enable_ecs_managed_tags            = true
 
-  tags {
+  tags = {
     tag-key = "tag-value"
   }
 }
@@ -2562,7 +2562,7 @@ resource "aws_ecs_task_definition" "test" {
 ]
 DEFINITION
 
-  tags {
+  tags = {
     tag-key = "task-def"
   }
 }
@@ -2575,7 +2575,7 @@ resource "aws_ecs_service" "test" {
   enable_ecs_managed_tags            = true
   propagate_tags                     = "%s"
 
-  tags {
+  tags = {
     tag-key = "service"
   }
 }

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -1505,7 +1505,7 @@ resource "aws_ecs_task_definition" "test" {
 ]
 DEFINITION
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -1533,7 +1533,7 @@ resource "aws_ecs_task_definition" "test" {
 ]
 DEFINITION
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -426,7 +426,7 @@ resource "aws_efs_file_system" "foo" {
 func testAccAWSEFSFileSystemConfigPagedTags(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_efs_file_system" "foo" {
-		tags {
+	tags = {
 			Name = "foo-efs-%d"
 			Another = "tag"
 			Test = "yes"
@@ -446,7 +446,7 @@ func testAccAWSEFSFileSystemConfigPagedTags(rInt int) string {
 func testAccAWSEFSFileSystemConfigWithTags(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_efs_file_system" "foo-with-tags" {
-		tags {
+	tags = {
 			Name = "foo-efs-%d"
 			Another = "tag"
 		}

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -257,7 +257,7 @@ resource "aws_efs_mount_target" "alpha" {
 
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-efs-mount-target"
 	}
 }
@@ -266,7 +266,7 @@ resource "aws_subnet" "alpha" {
 	vpc_id = "${aws_vpc.foo.id}"
 	availability_zone = "us-west-2a"
 	cidr_block = "10.0.1.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-efs-mount-target-alpha"
 	}
 }
@@ -291,7 +291,7 @@ resource "aws_efs_mount_target" "beta" {
 
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-efs-mount-target-modified"
 	}
 }
@@ -300,7 +300,7 @@ resource "aws_subnet" "alpha" {
 	vpc_id = "${aws_vpc.foo.id}"
 	availability_zone = "us-west-2a"
 	cidr_block = "10.0.1.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-efs-mount-target-alpha"
 	}
 }
@@ -309,7 +309,7 @@ resource "aws_subnet" "beta" {
 	vpc_id = "${aws_vpc.foo.id}"
 	availability_zone = "us-west-2b"
 	cidr_block = "10.0.2.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-efs-mount-target-beta"
 	}
 }

--- a/aws/resource_aws_egress_only_internet_gateway_test.go
+++ b/aws/resource_aws_egress_only_internet_gateway_test.go
@@ -84,7 +84,7 @@ const testAccAWSEgressOnlyInternetGatewayConfig_basic = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-egress-only-igw-basic"
 	}
 }

--- a/aws/resource_aws_eip_association_test.go
+++ b/aws/resource_aws_eip_association_test.go
@@ -252,7 +252,7 @@ func testAccCheckAWSEIPAssociationDestroy(s *terraform.State) error {
 const testAccAWSEIPAssociationConfig = `
 resource "aws_vpc" "main" {
 	cidr_block = "192.168.0.0/24"
-	tags {
+	tags = {
 		Name = "terraform-testacc-eip-association"
 	}
 }
@@ -260,7 +260,7 @@ resource "aws_subnet" "sub" {
 	vpc_id = "${aws_vpc.main.id}"
 	cidr_block = "192.168.0.0/25"
 	availability_zone = "us-west-2a"
-	tags {
+	tags = {
 		Name = "tf-acc-eip-association"
 	}
 }
@@ -307,7 +307,7 @@ resource "aws_network_interface" "baz" {
 const testAccAWSEIPAssociationConfigDisappears = `
 resource "aws_vpc" "main" {
 	cidr_block = "192.168.0.0/24"
-	tags {
+	tags = {
 		Name = "terraform-testacc-eip-association-disappears"
 	}
 }
@@ -315,7 +315,7 @@ resource "aws_subnet" "sub" {
 	vpc_id = "${aws_vpc.main.id}"
 	cidr_block = "192.168.0.0/25"
 	availability_zone = "us-west-2a"
-	tags {
+	tags = {
 		Name = "tf-acc-eip-association-disappears"
 	}
 }

--- a/aws/resource_aws_eip_test.go
+++ b/aws/resource_aws_eip_test.go
@@ -496,7 +496,7 @@ resource "aws_eip" "bar" {
 func testAccAWSEIPConfig_tags(rName, testName string) string {
 	return fmt.Sprintf(`
 resource "aws_eip" "bar" {
-  tags {
+  tags = {
     RandomName = "%[1]s"
     TestName   = "%[2]s"
   }
@@ -543,7 +543,7 @@ data "aws_ami" "amzn-ami-minimal-pv" {
 resource "aws_instance" "foo" {
 	ami = "${data.aws_ami.amzn-ami-minimal-pv.id}"
 	instance_type = "m1.small"
-	tags {
+	tags = {
 		Name = "testAccAWSEIPInstanceEc2Classic"
 	}
 }
@@ -628,7 +628,7 @@ resource "aws_vpc" "default" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-eip-instance-associated"
   }
 }
@@ -636,7 +636,7 @@ resource "aws_vpc" "default" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.default.id}"
 
-  tags {
+  tags = {
     Name = "main"
   }
 }
@@ -648,7 +648,7 @@ resource "aws_subnet" "tf_test_subnet" {
 
   depends_on = ["aws_internet_gateway.gw"]
 
-  tags {
+  tags = {
     Name = "tf-acc-eip-instance-associated"
   }
 }
@@ -660,7 +660,7 @@ resource "aws_instance" "foo" {
   private_ip = "10.0.0.12"
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
-  tags {
+  tags = {
     Name = "foo instance"
   }
 }
@@ -673,7 +673,7 @@ resource "aws_instance" "bar" {
   private_ip = "10.0.0.19"
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
-  tags {
+  tags = {
     Name = "bar instance"
   }
 }
@@ -706,7 +706,7 @@ resource "aws_vpc" "default" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-eip-instance-associated"
   }
 }
@@ -714,7 +714,7 @@ resource "aws_vpc" "default" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.default.id}"
 
-  tags {
+  tags = {
     Name = "main"
   }
 }
@@ -726,7 +726,7 @@ resource "aws_subnet" "tf_test_subnet" {
 
   depends_on = ["aws_internet_gateway.gw"]
 
-  tags {
+  tags = {
     Name = "tf-acc-eip-instance-associated"
   }
 }
@@ -738,7 +738,7 @@ resource "aws_instance" "foo" {
   private_ip = "10.0.0.12"
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
-  tags {
+  tags = {
     Name = "foo instance"
   }
 }
@@ -751,7 +751,7 @@ resource "aws_instance" "bar" {
   private_ip = "10.0.0.19"
   subnet_id  = "${aws_subnet.tf_test_subnet.id}"
 
-  tags {
+  tags = {
     Name = "bar instance"
   }
 }
@@ -767,7 +767,7 @@ resource "aws_eip" "bar" {
 const testAccAWSEIPNetworkInterfaceConfig = `
 resource "aws_vpc" "bar" {
 	cidr_block = "10.0.0.0/24"
-	tags {
+	tags = {
 		Name = "terraform-testacc-eip-network-interface"
 	}
 }
@@ -780,7 +780,7 @@ resource "aws_subnet" "bar" {
   vpc_id = "${aws_vpc.bar.id}"
   availability_zone = "us-west-2a"
   cidr_block = "10.0.0.0/24"
-  tags {
+  tags = {
 	Name = "tf-acc-eip-network-interface"
   }
 }
@@ -801,7 +801,7 @@ resource "aws_eip" "bar" {
 const testAccAWSEIPMultiNetworkInterfaceConfig = `
 resource "aws_vpc" "bar" {
   cidr_block = "10.0.0.0/24"
-	tags {
+	tags = {
 		Name = "terraform-testacc-eip-multi-network-interface"
 	}
 }
@@ -814,7 +814,7 @@ resource "aws_subnet" "bar" {
   vpc_id            = "${aws_vpc.bar.id}"
   availability_zone = "us-west-2a"
   cidr_block        = "10.0.0.0/24"
-  tags {
+  tags = {
 	Name = "tf-acc-eip-multi-network-interface"
   }
 }
@@ -881,7 +881,7 @@ resource "aws_instance" "example" {
   subnet_id                   = "${aws_subnet.us-east-1b-public.id}"
   availability_zone           = "${aws_subnet.us-east-1b-public.availability_zone}"
 
-  tags {
+  tags = {
     Name = "testAccAWSEIP_classic_disassociate"
   }
 
@@ -892,7 +892,7 @@ resource "aws_instance" "example" {
 
 resource "aws_vpc" "example" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-eip-classic-disassociate"
 	}
 }
@@ -906,7 +906,7 @@ resource "aws_subnet" "us-east-1b-public" {
 
   cidr_block        = "10.0.0.0/24"
   availability_zone = "us-east-1b"
-  tags {
+  tags = {
     Name = "tf-acc-eip-classic-disassociate"
   }
 }

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -271,7 +271,7 @@ resource "aws_iam_role_policy_attachment" "test-AmazonEKSServicePolicy" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name                       = "terraform-testacc-eks-cluster-base"
     "kubernetes.io/cluster/%s" = "shared"
   }
@@ -284,7 +284,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name                       = "terraform-testacc-eks-cluster-base"
     "kubernetes.io/cluster/%s" = "shared"
   }
@@ -334,7 +334,7 @@ func testAccAWSEksClusterConfig_VpcConfig_SecurityGroupIds(rName string) string 
 resource "aws_security_group" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-eks-cluster-sg"
   }
 }

--- a/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
+++ b/aws/resource_aws_elastic_beanstalk_configuration_template_test.go
@@ -161,7 +161,7 @@ func testAccBeanstalkConfigurationTemplateConfig_VPC(name string) string {
 resource "aws_vpc" "tf_b_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-elastic-beanstalk-cfg-tpl-vpc"
   }
 }
@@ -170,7 +170,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.tf_b_test.id}"
   cidr_block = "10.0.0.0/24"
 
-  tags {
+  tags = {
     Name = "tf-acc-elastic-beanstalk-cfg-tpl-vpc"
   }
 }

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -1052,7 +1052,7 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 
   wait_for_ready_timeout = "15m"
 
-  tags {
+  tags = {
     firstTag = "%s"
     secondTag = "%s"
   }
@@ -1063,7 +1063,7 @@ func testAccBeanstalkEnv_VPC(sgName, appName, envName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "tf_b_test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-elastic-beanstalk-env-vpc"
 	}
 }
@@ -1081,7 +1081,7 @@ resource "aws_route" "r" {
 resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.tf_b_test.id}"
   cidr_block = "10.0.0.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elastic-beanstalk-env-vpc"
   }
 }

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -982,7 +982,7 @@ resource "aws_security_group" "bar" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 
-		tags {
+	tags = {
 			Name = "TestAccAWSElasticacheCluster_basic"
 		}
 }
@@ -1105,7 +1105,7 @@ resource "aws_elasticache_cluster" "bar" {
 var testAccAWSElasticacheClusterInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-cluster-in-vpc"
     }
 }
@@ -1114,7 +1114,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-cluster-in-vpc"
     }
 }
@@ -1162,7 +1162,7 @@ resource "aws_sns_topic" "topic_example" {
 var testAccAWSElasticacheClusterMultiAZInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-cluster-multi-az-in-vpc"
     }
 }
@@ -1171,7 +1171,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-cluster-multi-az-in-vpc-foo"
     }
 }
@@ -1180,7 +1180,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-cluster-multi-az-in-vpc-bar"
     }
 }

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1022,7 +1022,7 @@ resource "aws_elasticache_replication_group" "bar" {
 var testAccAWSElasticacheReplicationGroupInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-replication-group-in-vpc"
     }
 }
@@ -1031,7 +1031,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-in-vpc"
     }
 }
@@ -1071,7 +1071,7 @@ resource "aws_elasticache_replication_group" "bar" {
 var testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-replication-group-multi-az-in-vpc"
     }
 }
@@ -1080,7 +1080,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-multi-az-in-vpc-foo"
     }
 }
@@ -1089,7 +1089,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-multi-az-in-vpc-bar"
     }
 }
@@ -1133,7 +1133,7 @@ resource "aws_elasticache_replication_group" "bar" {
 var testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-replication-group-redis-cluster-in-vpc"
     }
 }
@@ -1142,7 +1142,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-foo"
     }
 }
@@ -1151,7 +1151,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-redis-cluster-in-vpc-bar"
     }
 }
@@ -1198,7 +1198,7 @@ func testAccAWSElasticacheReplicationGroupNativeRedisClusterErrorConfig(rInt int
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-replication-group-native-redis-cluster-err"
     }
 }
@@ -1207,7 +1207,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-foo"
     }
 }
@@ -1216,7 +1216,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-native-redis-cluster-err-bar"
     }
 }
@@ -1262,7 +1262,7 @@ func testAccAWSElasticacheReplicationGroupNativeRedisClusterConfig(rName string,
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-replication-group-native-redis-cluster"
     }
 }
@@ -1271,7 +1271,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-native-redis-cluster-foo"
     }
 }
@@ -1280,7 +1280,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.16.0/20"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-replication-group-native-redis-cluster-bar"
     }
 }
@@ -1325,7 +1325,7 @@ func testAccAWSElasticacheReplicationGroup_EnableAtRestEncryptionConfig(rInt int
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "192.168.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-elasticache-replication-group-at-rest-encryption"
   }
 }
@@ -1334,7 +1334,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "192.168.0.0/20"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-elasticache-replication-group-at-rest-encryption"
   }
 }
@@ -1379,7 +1379,7 @@ func testAccAWSElasticacheReplicationGroup_EnableAuthTokenTransitEncryptionConfi
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "192.168.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-elasticache-replication-group-auth-token-transit-encryption"
   }
 }
@@ -1388,7 +1388,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "192.168.0.0/20"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-elasticache-replication-group-auth-token-transit-encryption"
   }
 }
@@ -1436,7 +1436,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "192.168.0.0/16"
-  tags {
+  tags = {
       Name = "terraform-testacc-elasticache-replication-group-number-cache-clusters"
   }
 }
@@ -1448,7 +1448,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "192.168.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-elasticache-replication-group-number-cache-clusters"
   }
 }

--- a/aws/resource_aws_elasticache_subnet_group_test.go
+++ b/aws/resource_aws_elasticache_subnet_group_test.go
@@ -167,7 +167,7 @@ func testAccCheckAWSElastiCacheSubnetGroupAttrs(csg *elasticache.CacheSubnetGrou
 var testAccAWSElasticacheSubnetGroupConfig = `
 resource "aws_vpc" "foo" {
     cidr_block = "192.168.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-subnet-group"
     }
 }
@@ -176,7 +176,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-subnet-group"
     }
 }
@@ -192,7 +192,7 @@ resource "aws_elasticache_subnet_group" "bar" {
 var testAccAWSElasticacheSubnetGroupUpdateConfigPre = `
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-subnet-group-update"
     }
 }
@@ -201,7 +201,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "10.0.1.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-subnet-group-update-foo"
     }
 }
@@ -216,7 +216,7 @@ resource "aws_elasticache_subnet_group" "bar" {
 var testAccAWSElasticacheSubnetGroupUpdateConfigPost = `
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-elasticache-subnet-group-update"
     }
 }
@@ -225,7 +225,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "10.0.1.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-subnet-group-update-foo"
     }
 }
@@ -234,7 +234,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "10.0.2.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-elasticache-subnet-group-update-bar"
     }
 }

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -813,7 +813,7 @@ resource "aws_elasticsearch_domain" "example" {
     volume_size = 10
   }
 
-  tags {
+  tags = {
     foo = "bar"
     new = "type"
   }
@@ -963,7 +963,7 @@ resource "aws_elasticsearch_domain" "example" {
     automated_snapshot_start_hour = 23
   }
 
-  tags {
+  tags = {
     bar = "complex"
   }
 }
@@ -991,7 +991,7 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
-  tags {
+  tags = {
     Name = "terraform-testacc-elasticsearch-domain-in-vpc"
   }
 }
@@ -1000,7 +1000,7 @@ resource "aws_subnet" "first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.0.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-in-vpc-first"
   }
 }
@@ -1009,7 +1009,7 @@ resource "aws_subnet" "second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-in-vpc-second"
   }
 }
@@ -1060,7 +1060,7 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
-  tags {
+  tags = {
     Name = "terraform-testacc-elasticsearch-domain-in-vpc-update"
   }
 }
@@ -1069,7 +1069,7 @@ resource "aws_subnet" "az1_first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.0.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-in-vpc-update-az1-first"
   }
 }
@@ -1078,7 +1078,7 @@ resource "aws_subnet" "az2_first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-in-vpc-update-az2-first"
   }
 }
@@ -1087,7 +1087,7 @@ resource "aws_subnet" "az1_second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.2.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-in-vpc-update-az1-second"
   }
 }
@@ -1096,7 +1096,7 @@ resource "aws_subnet" "az2_second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.3.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-in-vpc-update-az2-second"
   }
 }
@@ -1138,7 +1138,7 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "elasticsearch_in_vpc" {
   cidr_block = "192.168.0.0/22"
-  tags {
+  tags = {
     Name = "terraform-testacc-elasticsearch-domain-internet-to-vpc-endpoint"
   }
 }
@@ -1147,7 +1147,7 @@ resource "aws_subnet" "first" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "192.168.0.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-internet-to-vpc-endpoint-first"
   }
 }
@@ -1156,7 +1156,7 @@ resource "aws_subnet" "second" {
   vpc_id            = "${aws_vpc.elasticsearch_in_vpc.id}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "192.168.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-elasticsearch-domain-internet-to-vpc-endpoint-second"
   }
 }

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1222,7 +1222,7 @@ resource "aws_elb" "bar" {
     lb_protocol = "HttP"
   }
 
-	tags {
+	tags = {
 		bar = "baz"
 	}
 
@@ -1420,7 +1420,7 @@ resource "aws_elb" "bar" {
     lb_protocol = "http"
   }
 
-	tags {
+	tags = {
 		foo = "bar"
 		new = "type"
 	}
@@ -1624,7 +1624,7 @@ resource "aws_security_group" "bar" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-	tags {
+	tags = {
 		Name = "tf_elb_sg_test"
 	}
 }
@@ -1700,7 +1700,7 @@ resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-elb-subnets"
   }
 }
@@ -1710,7 +1710,7 @@ resource "aws_subnet" "public_a_one" {
 
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-elb-subnets-a-one"
   }
 }
@@ -1720,7 +1720,7 @@ resource "aws_subnet" "public_b_one" {
 
   cidr_block        = "10.1.7.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-elb-subnets-b-one"
   }
 }
@@ -1730,7 +1730,7 @@ resource "aws_subnet" "public_a_two" {
 
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-elb-subnets-a-two"
   }
 }
@@ -1756,7 +1756,7 @@ resource "aws_elb" "ourapp" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.azelb.id}"
 
-  tags {
+  tags = {
     Name = "main"
   }
 }
@@ -1771,7 +1771,7 @@ resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-elb-subnet-swap"
   }
 }
@@ -1781,7 +1781,7 @@ resource "aws_subnet" "public_a_one" {
 
   cidr_block        = "10.1.1.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-elb-subnet-swap-a-one"
   }
 }
@@ -1791,7 +1791,7 @@ resource "aws_subnet" "public_b_one" {
 
   cidr_block        = "10.1.7.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-elb-subnet-swap-b-one"
   }
 }
@@ -1801,7 +1801,7 @@ resource "aws_subnet" "public_a_two" {
 
   cidr_block        = "10.1.2.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-elb-subnet-swap-a-two"
   }
 }
@@ -1827,7 +1827,7 @@ resource "aws_elb" "ourapp" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.azelb.id}"
 
-  tags {
+  tags = {
     Name = "main"
   }
 }

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -757,7 +757,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-bootstrap"
   }
 }
@@ -766,7 +766,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-bootstrap"
   }
 }
@@ -814,7 +814,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -864,7 +864,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -916,7 +916,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -925,7 +925,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster"
   }
 }
@@ -934,7 +934,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster"
   }
 }
@@ -1177,7 +1177,7 @@ EOF
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -1229,7 +1229,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -1238,7 +1238,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster"
   }
 }
@@ -1247,7 +1247,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster"
   }
 }
@@ -1552,7 +1552,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -1561,7 +1561,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster"
   }
 }
@@ -1570,7 +1570,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster"
   }
 }
@@ -1840,7 +1840,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -1849,7 +1849,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-kerberos-cluster-dedicated-kdc"
   }
 }
@@ -1860,7 +1860,7 @@ resource "aws_subnet" "main" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-kerberos-cluster-dedicated-kdc"
   }
 }
@@ -1868,7 +1868,7 @@ resource "aws_subnet" "main" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-kerberos-cluster-dedicated-kdc"
   }
 }
@@ -1913,7 +1913,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
 
   security_configuration = "${aws_emr_security_configuration.foo.name}"
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -1962,7 +1962,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -1971,7 +1971,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-security-configuration"
   }
 }
@@ -1980,7 +1980,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-security-configuration"
   }
 }
@@ -2336,7 +2336,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -2345,7 +2345,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-step"
   }
 }
@@ -2356,7 +2356,7 @@ resource "aws_subnet" "main" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-step"
   }
 }
@@ -2364,7 +2364,7 @@ resource "aws_subnet" "main" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-step"
   }
 }
@@ -2451,7 +2451,7 @@ EOT
     }
   ]
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -2500,7 +2500,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -2509,7 +2509,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-instance-groups"
   }
 }
@@ -2518,7 +2518,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-instance-groups"
   }
 }
@@ -2801,7 +2801,7 @@ EOT
     }
   ]
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -2848,7 +2848,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -2857,7 +2857,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-instance-groups"
   }
 }
@@ -2866,7 +2866,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-instance-groups"
   }
 }
@@ -3101,7 +3101,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -3150,7 +3150,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -3159,7 +3159,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-termination-policy"
   }
 }
@@ -3168,7 +3168,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-termination-policy"
   }
 }
@@ -3404,7 +3404,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -3463,7 +3463,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -3472,7 +3472,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-termination-policy"
   }
 }
@@ -3481,7 +3481,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-termination-policy"
   }
 }
@@ -3721,7 +3721,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -3770,7 +3770,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -3779,7 +3779,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-visible-to-all-users"
   }
 }
@@ -3788,7 +3788,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-visible-to-all-users"
   }
 }
@@ -4024,7 +4024,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     dns_zone = "new_zone"
     Env      = "production"
     name     = "name-env"
@@ -4072,7 +4072,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -4081,7 +4081,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-updated-tags"
   }
 }
@@ -4090,7 +4090,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-updated-tags"
   }
 }
@@ -4330,7 +4330,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -4380,7 +4380,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -4389,7 +4389,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-updated-root-volume-size"
   }
 }
@@ -4398,7 +4398,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-updated-root-volume-size"
   }
 }
@@ -4624,7 +4624,7 @@ resource "aws_s3_bucket" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/24"
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-s3-logging"
   }
 }
@@ -4632,7 +4632,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-s3-logging"
   }
 }
@@ -4723,7 +4723,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -4774,7 +4774,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     Name = "emr_test"
   }
 }
@@ -4783,7 +4783,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-emr-cluster-custom-ami-id"
   }
 }
@@ -4792,7 +4792,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-cluster-custom-ami-id"
   }
 }

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -150,7 +150,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "c4.large"
   core_instance_count  = 2
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -199,7 +199,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-emr-instance-group"
 	}
 }
@@ -208,7 +208,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     Name = "tf-acc-emr-instance-group"
   }
 }

--- a/aws/resource_aws_flow_log_test.go
+++ b/aws/resource_aws_flow_log_test.go
@@ -204,7 +204,7 @@ func testAccFlowLogConfig_LogDestinationType_CloudWatchLogs(rName string) string
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -250,7 +250,7 @@ func testAccFlowLogConfig_LogDestinationType_S3(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -274,7 +274,7 @@ func testAccFlowLogConfig_SubnetID(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -283,7 +283,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.1.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -328,7 +328,7 @@ func testAccFlowLogConfig_VPCID(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_glacier_vault_test.go
+++ b/aws/resource_aws_glacier_vault_test.go
@@ -251,7 +251,7 @@ resource "aws_glacier_vault" "full" {
   	sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
   	events = ["ArchiveRetrievalCompleted","InventoryRetrievalCompleted"]
   }
-  tags {
+  tags = {
     Test="Test1"
   }
 }
@@ -266,7 +266,7 @@ resource "aws_sns_topic" "aws_sns_topic" {
 
 resource "aws_glacier_vault" "full" {
   name = "my_test_vault_%d"
-  tags {
+  tags = {
     Test="Test1"
   }
 }

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -364,7 +364,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-glue-connection-base"
   }
 }
@@ -388,7 +388,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-glue-connection-base"
   }
 }

--- a/aws/resource_aws_iam_role_test.go
+++ b/aws/resource_aws_iam_role_test.go
@@ -761,7 +761,7 @@ resource "aws_iam_role" "test" {
 }
 EOF
 
-  tags {
+  tags = {
     tag1 = "test-value1"
     tag2 = "test-value2"
   }
@@ -790,7 +790,7 @@ resource "aws_iam_role" "test" {
 }
 EOF
 
-  tags {
+  tags = {
     tag2 = "test-value"
   }
 }

--- a/aws/resource_aws_iam_user_test.go
+++ b/aws/resource_aws_iam_user_test.go
@@ -603,7 +603,7 @@ func testAccAWSUserConfig_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "test" {
   name = %q
-  tags {
+  tags = {
     Name = "test-Name"
     tag2 = "test-tag2"
   }
@@ -615,7 +615,7 @@ func testAccAWSUserConfig_tagsUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_user" "test" {
   name = %q
-  tags {
+  tags = {
     tag2 = "test-tagUpdate"
   }
 }

--- a/aws/resource_aws_inspector_assessment_target_test.go
+++ b/aws/resource_aws_inspector_assessment_target_test.go
@@ -83,7 +83,7 @@ func testAccCheckAWSInspectorTargetExists(name string) resource.TestCheckFunc {
 var testAccAWSInspectorTargetAssessment = `
 
 resource "aws_inspector_resource_group" "foo" {
-	tags {
+	tags = {
 	  Name  = "bar"
   }
 }
@@ -96,7 +96,7 @@ resource "aws_inspector_assessment_target" "foo" {
 var testAccCheckAWSInspectorTargetAssessmentModified = `
 
 resource "aws_inspector_resource_group" "foo" {
-	tags {
+	tags = {
 	  Name  = "bar"
   }
 }
@@ -109,13 +109,13 @@ resource "aws_inspector_assessment_target" "foo" {
 var testAccCheckAWSInspectorTargetAssessmentUpdatedResourceGroup = `
 
 resource "aws_inspector_resource_group" "foo" {
-	tags {
+	tags = {
 	  Name  = "bar"
   }
 }
 
 resource "aws_inspector_resource_group" "bar" {
-	tags {
+	tags = {
 	  Name  = "test"
   }
 }

--- a/aws/resource_aws_inspector_assessment_template_test.go
+++ b/aws/resource_aws_inspector_assessment_template_test.go
@@ -80,7 +80,7 @@ func testAccCheckAWSInspectorTemplateExists(name string) resource.TestCheckFunc 
 func testAccAWSInspectorTemplateAssessment(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_inspector_resource_group" "foo" {
-	tags {
+	tags = {
 	  Name  = "tf-acc-test-%d"
   }
 }
@@ -107,7 +107,7 @@ resource "aws_inspector_assessment_template" "foo" {
 func testAccCheckAWSInspectorTemplatetModified(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_inspector_resource_group" "foo" {
-	tags {
+	tags = {
 	  Name  = "tf-acc-test-%d"
   }
 }

--- a/aws/resource_aws_inspector_resource_group_test.go
+++ b/aws/resource_aws_inspector_resource_group_test.go
@@ -42,14 +42,14 @@ func testAccCheckAWSInspectorResourceGroupExists(name string) resource.TestCheck
 
 var testAccAWSInspectorResourceGroup = `
 resource "aws_inspector_resource_group" "foo" {
-	tags {
+	tags = {
 	  Name  = "foo"
   }
 }`
 
 var testAccCheckAWSInspectorResourceGroupModified = `
 resource "aws_inspector_resource_group" "foo" {
-	tags {
+	tags = {
 	  Name  = "bar"
   }
 }`

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2323,7 +2323,7 @@ resource "aws_instance" "foo" {
 
 	instance_type = "m3.medium"
 
-	tags {
+	tags = {
 	    Name = "tf-acctest"
 	}
 }
@@ -2337,7 +2337,7 @@ resource "aws_instance" "foo" {
 
 	instance_type = "m3.large"
 
-	tags {
+	tags = {
 	    Name = "tf-acctest"
 	}
 }
@@ -2421,7 +2421,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigSourceDestEnable = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-source-dest-enable"
 	}
 }
@@ -2429,7 +2429,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-source-dest-enable"
 	}
 }
@@ -2445,7 +2445,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigSourceDestDisable = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-source-dest-disable"
 	}
 }
@@ -2453,7 +2453,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-source-dest-disable"
 	}
 }
@@ -2471,7 +2471,7 @@ func testAccInstanceConfigDisableAPITermination(val bool) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "foo" {
 		cidr_block = "10.1.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-instance-disable-api-termination"
 		}
 	}
@@ -2479,7 +2479,7 @@ func testAccInstanceConfigDisableAPITermination(val bool) string {
 	resource "aws_subnet" "foo" {
 		cidr_block = "10.1.1.0/24"
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-instance-disable-api-termination"
 		}
 	}
@@ -2497,7 +2497,7 @@ func testAccInstanceConfigDisableAPITermination(val bool) string {
 const testAccInstanceConfigVPC = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-vpc"
 	}
 }
@@ -2505,7 +2505,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-vpc"
 	}
 }
@@ -2526,7 +2526,7 @@ func testAccInstanceConfigPlacementGroup(rStr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-placement-group"
   }
 }
@@ -2534,7 +2534,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
   	Name = "tf-acc-instance-placement-group"
   }
 }
@@ -2562,7 +2562,7 @@ const testAccInstanceConfigIpv6ErrorConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-ipv6-err"
 	}
 }
@@ -2571,7 +2571,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-ipv6-err"
 	}
 }
@@ -2583,7 +2583,7 @@ resource "aws_instance" "foo" {
 	subnet_id = "${aws_subnet.foo.id}"
 	ipv6_addresses = ["2600:1f14:bb2:e501::10"]
 	ipv6_address_count = 1
-	tags {
+	tags = {
 		Name = "tf-ipv6-instance-acc-test"
 	}
 }
@@ -2593,7 +2593,7 @@ const testAccInstanceConfigIpv6Support = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-ipv6-support"
 	}
 }
@@ -2602,7 +2602,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-ipv6-support"
 	}
 }
@@ -2614,7 +2614,7 @@ resource "aws_instance" "foo" {
 	subnet_id = "${aws_subnet.foo.id}"
 
 	ipv6_address_count = 1
-	tags {
+	tags = {
 		Name = "tf-ipv6-instance-acc-test"
 	}
 }
@@ -2624,7 +2624,7 @@ const testAccInstanceConfigIpv6SupportWithIpv4 = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-ipv6-support-with-ipv4"
 	}
 }
@@ -2633,7 +2633,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-ipv6-support-with-ipv4"
 	}
 }
@@ -2646,7 +2646,7 @@ resource "aws_instance" "foo" {
 
 	associate_public_ip_address = true
 	ipv6_address_count = 1
-	tags {
+	tags = {
 		Name = "tf-ipv6-instance-acc-test"
 	}
 }
@@ -2682,7 +2682,7 @@ const testAccCheckInstanceConfigTags = `
 resource "aws_instance" "foo" {
 	ami = "ami-4fccb37f"
 	instance_type = "m1.small"
-	tags {
+	tags = {
 		foo = "bar"
 	}
 }
@@ -2727,7 +2727,7 @@ resource "aws_instance" "foo" {
     delete_on_termination = true
   }
 
-  tags {
+  tags = {
     Name    = "test-terraform"
   }
 }
@@ -2738,7 +2738,7 @@ resource "aws_ebs_volume" "test" {
   type       = "gp2"
   size              = "10"
 
-  tags {
+  tags = {
     Name = "test-terraform"
   }
 }
@@ -2866,7 +2866,7 @@ const testAccCheckInstanceConfigTagsUpdate = `
 resource "aws_instance" "foo" {
 	ami = "ami-4fccb37f"
 	instance_type = "m1.small"
-	tags {
+	tags = {
 		bar = "baz"
 	}
 }
@@ -2882,7 +2882,7 @@ resource "aws_iam_role" "test" {
 resource "aws_instance" "foo" {
 	ami = "ami-4fccb37f"
 	instance_type = "m1.small"
-	tags {
+	tags = {
 		bar = "baz"
 	}
 }`, rName)
@@ -2904,7 +2904,7 @@ resource "aws_instance" "foo" {
 	ami = "ami-4fccb37f"
 	instance_type = "m1.small"
 	iam_instance_profile = "${aws_iam_instance_profile.test.name}"
-	tags {
+	tags = {
 		bar = "baz"
 	}
 }`, rName, rName)
@@ -2913,7 +2913,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigPrivateIP = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-private-ip"
 	}
 }
@@ -2921,7 +2921,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-private-ip"
 	}
 }
@@ -2937,7 +2937,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigAssociatePublicIPAndPrivateIP = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-public-ip-and-private-ip"
 	}
 }
@@ -2945,7 +2945,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-public-ip-and-private-ip"
 	}
 }
@@ -2967,7 +2967,7 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-network-security-groups"
 	}
 }
@@ -2988,7 +2988,7 @@ resource "aws_security_group" "tf_test_foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
   	Name = "tf-acc-instance-network-security-groups"
   }
 }
@@ -3018,7 +3018,7 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-network-vpc-sg-ids"
 	}
 }
@@ -3039,7 +3039,7 @@ resource "aws_security_group" "tf_test_foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
   	Name = "tf-acc-instance-network-vpc-sg-ids"
   }
 }
@@ -3068,7 +3068,7 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-instance-network-vpc-sg-ids"
     }
 }
@@ -3089,7 +3089,7 @@ resource "aws_security_group" "tf_test_foo" {
 resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
   	Name = "tf-acc-instance-network-vpc-sg-ids"
   }
 }
@@ -3125,7 +3125,7 @@ resource "aws_instance" "foo" {
   ami = "ami-408c7f28"
   instance_type = "t1.micro"
   key_name = "${aws_key_pair.debugging.key_name}"
-	tags {
+	tags = {
 		Name = "testAccInstanceConfigKeyPair_TestAMI"
 	}
 }
@@ -3135,7 +3135,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigRootBlockDeviceMismatch = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-root-block-device-mismatch"
 	}
 }
@@ -3143,7 +3143,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-root-block-device-mismatch"
 	}
 }
@@ -3162,7 +3162,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigForceNewAndTagsDrift = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-force-new-and-tags-drift"
 	}
 }
@@ -3170,7 +3170,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-force-new-and-tags-drift"
 	}
 }
@@ -3185,7 +3185,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigForceNewAndTagsDrift_Update = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-instance-force-new-and-tags-drift"
 	}
 }
@@ -3193,7 +3193,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-instance-force-new-and-tags-drift"
 	}
 }
@@ -3208,7 +3208,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigPrimaryNetworkInterface = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-primary-network-iface"
   }
 }
@@ -3217,7 +3217,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-instance-primary-network-iface"
   }
 }
@@ -3225,7 +3225,7 @@ resource "aws_subnet" "foo" {
 resource "aws_network_interface" "bar" {
   subnet_id = "${aws_subnet.foo.id}"
   private_ips = ["172.16.10.100"]
-  tags {
+  tags = {
     Name = "primary_network_interface"
   }
 }
@@ -3243,7 +3243,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigPrimaryNetworkInterfaceSourceDestCheck = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-primary-network-iface-source-dest-check"
   }
 }
@@ -3252,7 +3252,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-instance-primary-network-iface-source-dest-check"
   }
 }
@@ -3261,7 +3261,7 @@ resource "aws_network_interface" "bar" {
   subnet_id = "${aws_subnet.foo.id}"
   private_ips = ["172.16.10.100"]
   source_dest_check = false
-  tags {
+  tags = {
     Name = "primary_network_interface"
   }
 }
@@ -3279,7 +3279,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigAddSecondaryNetworkInterfaceBefore = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-add-secondary-network-iface"
   }
 }
@@ -3288,7 +3288,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-instance-add-secondary-network-iface"
   }
 }
@@ -3296,7 +3296,7 @@ resource "aws_subnet" "foo" {
 resource "aws_network_interface" "primary" {
   subnet_id = "${aws_subnet.foo.id}"
   private_ips = ["172.16.10.100"]
-  tags {
+  tags = {
     Name = "primary_network_interface"
   }
 }
@@ -3304,7 +3304,7 @@ resource "aws_network_interface" "primary" {
 resource "aws_network_interface" "secondary" {
   subnet_id = "${aws_subnet.foo.id}"
   private_ips = ["172.16.10.101"]
-  tags {
+  tags = {
     Name = "secondary_network_interface"
   }
 }
@@ -3322,7 +3322,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigAddSecondaryNetworkInterfaceAfter = `
 resource "aws_vpc" "foo" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-add-secondary-network-iface"
   }
 }
@@ -3331,7 +3331,7 @@ resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "172.16.10.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-instance-add-secondary-network-iface"
   }
 }
@@ -3339,7 +3339,7 @@ resource "aws_subnet" "foo" {
 resource "aws_network_interface" "primary" {
   subnet_id = "${aws_subnet.foo.id}"
   private_ips = ["172.16.10.100"]
-  tags {
+  tags = {
     Name = "primary_network_interface"
   }
 }
@@ -3348,7 +3348,7 @@ resource "aws_network_interface" "primary" {
 resource "aws_network_interface" "secondary" {
   subnet_id = "${aws_subnet.foo.id}"
   private_ips = ["172.16.10.101"]
-  tags {
+  tags = {
     Name = "secondary_network_interface"
   }
   attachment {
@@ -3370,7 +3370,7 @@ resource "aws_instance" "foo" {
 const testAccInstanceConfigAddSecurityGroupBefore = `
 resource "aws_vpc" "foo" {
     cidr_block = "172.16.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-instance-add-security-group"
     }
 }
@@ -3379,7 +3379,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-instance-add-security-group-foo"
     }
 }
@@ -3388,7 +3388,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-instance-add-security-group-bar"
     }
 }
@@ -3413,7 +3413,7 @@ resource "aws_instance" "foo" {
     vpc_security_group_ids = [
       "${aws_security_group.foo.id}"
     ]
-    tags {
+  tags = {
         Name = "foo-instance-sg-add-test"
     }
 }
@@ -3426,7 +3426,7 @@ resource "aws_network_interface" "bar" {
         instance = "${aws_instance.foo.id}"
         device_index = 1
     }
-    tags {
+  tags = {
         Name = "bar_interface"
     }
 }
@@ -3435,7 +3435,7 @@ resource "aws_network_interface" "bar" {
 const testAccInstanceConfigAddSecurityGroupAfter = `
 resource "aws_vpc" "foo" {
     cidr_block = "172.16.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-instance-add-security-group"
     }
 }
@@ -3444,7 +3444,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-instance-add-security-group-foo"
     }
 }
@@ -3453,7 +3453,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-instance-add-security-group-bar"
     }
 }
@@ -3479,7 +3479,7 @@ resource "aws_instance" "foo" {
       "${aws_security_group.foo.id}",
       "${aws_security_group.bar.id}"
     ]
-    tags {
+  tags = {
         Name = "foo-instance-sg-add-test"
     }
 }
@@ -3492,7 +3492,7 @@ resource "aws_network_interface" "bar" {
         instance = "${aws_instance.foo.id}"
         device_index = 1
     }
-    tags {
+  tags = {
         Name = "bar_interface"
     }
 }
@@ -3502,7 +3502,7 @@ func testAccInstanceConfig_associatePublic_defaultPrivate(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-associate-public-default-private"
   }
 }
@@ -3512,7 +3512,7 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = false
-  tags {
+  tags = {
     Name = "tf-acc-instance-associate-public-default-private"
   }
 }
@@ -3521,7 +3521,7 @@ resource "aws_instance" "foo" {
   ami = "ami-22b9a343" # us-west-2
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public_subnet.id}"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }`, rInt)
@@ -3531,7 +3531,7 @@ func testAccInstanceConfig_associatePublic_defaultPublic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-associate-public-default-public"
   }
 }
@@ -3541,7 +3541,7 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-instance-associate-public-default-public"
   }
 }
@@ -3550,7 +3550,7 @@ resource "aws_instance" "foo" {
   ami = "ami-22b9a343" # us-west-2
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public_subnet.id}"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }`, rInt)
@@ -3560,7 +3560,7 @@ func testAccInstanceConfig_associatePublic_explicitPublic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-associate-public-explicit-public"
   }
 }
@@ -3570,7 +3570,7 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-instance-associate-public-explicit-public"
   }
 }
@@ -3580,7 +3580,7 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public_subnet.id}"
   associate_public_ip_address = true
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }`, rInt)
@@ -3590,7 +3590,7 @@ func testAccInstanceConfig_associatePublic_explicitPrivate(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-associate-public-explicit-private"
   }
 }
@@ -3600,7 +3600,7 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = false
-  tags {
+  tags = {
     Name = "tf-acc-instance-associate-public-explicit-private"
   }
 }
@@ -3610,7 +3610,7 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public_subnet.id}"
   associate_public_ip_address = false
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }`, rInt)
@@ -3620,7 +3620,7 @@ func testAccInstanceConfig_associatePublic_overridePublic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-associate-public-override-public"
   }
 }
@@ -3630,7 +3630,7 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = false
-  tags {
+  tags = {
     Name = "tf-acc-instance-associate-public-override-public"
   }
 }
@@ -3640,7 +3640,7 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public_subnet.id}"
   associate_public_ip_address = true
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }`, rInt)
@@ -3650,7 +3650,7 @@ func testAccInstanceConfig_associatePublic_overridePrivate(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-instance-associate-public-override-private"
   }
 }
@@ -3660,7 +3660,7 @@ resource "aws_subnet" "public_subnet" {
   cidr_block = "172.16.20.0/24"
   availability_zone = "us-west-2a"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-instance-associate-public-override-private"
   }
 }
@@ -3670,7 +3670,7 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.public_subnet.id}"
   associate_public_ip_address = false
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }`, rInt)
@@ -3712,7 +3712,7 @@ func testAccInstanceConfig_creditSpecification_unspecified(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3735,7 +3735,7 @@ func testAccInstanceConfig_creditSpecification_unspecified_t3(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3758,7 +3758,7 @@ func testAccInstanceConfig_creditSpecification_standardCpuCredits(rInt int) stri
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3784,7 +3784,7 @@ func testAccInstanceConfig_creditSpecification_standardCpuCredits_t3(rInt int) s
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3810,7 +3810,7 @@ func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits(rInt int) str
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3836,7 +3836,7 @@ func testAccInstanceConfig_creditSpecification_unlimitedCpuCredits_t3(rInt int) 
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3862,7 +3862,7 @@ func testAccInstanceConfig_creditSpecification_isNotAppliedToNonBurstable(rInt i
 	return fmt.Sprintf(`
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3903,7 +3903,7 @@ data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }
@@ -3912,7 +3912,7 @@ resource "aws_subnet" "test" {
   vpc_id     = "${aws_vpc.test.id}"
   cidr_block = "172.16.0.0/24"
 
-  tags {
+  tags = {
     Name = "tf-acctest-%d"
   }
 }

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -291,7 +291,7 @@ func testAccCheckInternetGatewayExists(n string, ig *ec2.InternetGateway) resour
 const testAccNoInternetGatewayConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-no-internet-gateway"
 	}
 }
@@ -300,14 +300,14 @@ resource "aws_vpc" "foo" {
 const testAccInternetGatewayConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway"
 	}
 }
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway"
 	}
 }
@@ -316,21 +316,21 @@ resource "aws_internet_gateway" "foo" {
 const testAccInternetGatewayConfigChangeVPC = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway-change-vpc"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway-change-vpc-other"
 	}
 }
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.bar.id}"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway-change-vpc-other"
 	}
 }
@@ -339,14 +339,14 @@ resource "aws_internet_gateway" "foo" {
 const testAccCheckInternetGatewayConfigTags = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
 	}
 }
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
 		foo = "bar"
 	}
@@ -356,14 +356,14 @@ resource "aws_internet_gateway" "foo" {
 const testAccCheckInternetGatewayConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
 	}
 }
 
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "terraform-testacc-internet-gateway-tags"
 		bar = "baz"
 	}

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1336,7 +1336,7 @@ func testAccKinesisFirehoseDeliveryStreamConfig_s3basicWithTags(rName string, rI
 			role_arn = "${aws_iam_role.firehose.arn}"
 			bucket_arn = "${aws_s3_bucket.bucket.arn}"
 		}
-		tags {
+	tags = {
 			Environment = "production"
 			Usage = "original"
 		}
@@ -1354,7 +1354,7 @@ func testAccKinesisFirehoseDeliveryStreamConfig_s3basicWithTagsChanged(rName str
 			role_arn = "${aws_iam_role.firehose.arn}"
 			bucket_arn = "${aws_s3_bucket.bucket.arn}"
 		}
-		tags {
+	tags = {
 			Usage = "changed"
 		}
 	}`, rName)

--- a/aws/resource_aws_kinesis_stream_test.go
+++ b/aws/resource_aws_kinesis_stream_test.go
@@ -386,7 +386,7 @@ func testAccKinesisStreamConfig(rInt int) string {
 resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 2
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 }`, rInt)
@@ -398,7 +398,7 @@ resource "aws_kinesis_stream" "test_stream" {
         count = 20
 	name = "terraform-kinesis-test-%d-${count.index}"
 	shard_count = 2
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 }`, rInt)
@@ -410,7 +410,7 @@ resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 2
 	encryption_type = "KMS"
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 }`, rInt)
@@ -423,7 +423,7 @@ resource "aws_kinesis_stream" "test_stream" {
 	shard_count = 2
 	encryption_type = "KMS"
 	kms_key_id = "${aws_kms_key.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 }
@@ -458,7 +458,7 @@ func testAccKinesisStreamConfigUpdateShardCount(rInt int) string {
 resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 4
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 }`, rInt)
@@ -470,7 +470,7 @@ resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 2
 	retention_period = 100
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 }`, rInt)
@@ -482,7 +482,7 @@ resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 2
 	retention_period = 28
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 }`, rInt)
@@ -493,7 +493,7 @@ func testAccKinesisStreamConfigAllShardLevelMetrics(rInt int) string {
 resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 2
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 	shard_level_metrics = [
@@ -513,7 +513,7 @@ func testAccKinesisStreamConfigSingleShardLevelMetric(rInt int) string {
 resource "aws_kinesis_stream" "test_stream" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 2
-	tags {
+	tags = {
 		Name = "tf-test"
 	}
 	shard_level_metrics = [
@@ -532,7 +532,7 @@ func testAccKinesisStreamConfig_Tags(rInt, tagCount int) string {
 resource "aws_kinesis_stream" "test" {
 	name = "terraform-kinesis-test-%d"
 	shard_count = 2
-	tags {
+	tags = {
 %s
 	}
 }`, rInt, tagPairs)

--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -366,7 +366,7 @@ resource "aws_kms_key" "foo" {
   ]
 }
 POLICY
-	tags {
+	tags = {
 		Name = "tf-acc-test-kms-key-%s"
 	}
 }`, rName, rName)
@@ -397,7 +397,7 @@ resource "aws_kms_key" "foo" {
   ]
 }
 POLICY
-	tags {
+	tags = {
 		Name = "tf-acc-test-kms-key-%s"
 	}
 }`, rName, rName)
@@ -408,7 +408,7 @@ func testAccAWSKmsKey_removedPolicy(rName string) string {
 resource "aws_kms_key" "foo" {
     description = "Terraform acc test %s"
     deletion_window_in_days = 7
-    tags {
+  tags = {
 		Name = "tf-acc-test-kms-key-%s"
 	}
 }`, rName, rName)
@@ -420,7 +420,7 @@ resource "aws_kms_key" "bar" {
     description = "Terraform acc test is_enabled %s"
     deletion_window_in_days = 7
     enable_key_rotation = true
-    tags {
+  tags = {
 		Name = "tf-acc-test-kms-key-%s"
 	}
 }`, rName, rName)
@@ -433,7 +433,7 @@ resource "aws_kms_key" "bar" {
     deletion_window_in_days = 7
     enable_key_rotation = false
     is_enabled = false
-    tags {
+  tags = {
 		Name = "tf-acc-test-kms-key-%s"
 	}
 }`, rName, rName)
@@ -446,7 +446,7 @@ resource "aws_kms_key" "bar" {
     deletion_window_in_days = 7
     enable_key_rotation = true
     is_enabled = true
-    tags {
+  tags = {
 		Name = "tf-acc-test-kms-key-%s"
 	}
 }`, rName, rName)
@@ -456,7 +456,7 @@ func testAccAWSKmsKey_tags(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "foo" {
     description = "Terraform acc test %s"
-	tags {
+	tags = {
 		Name = "tf-acc-test-kms-key-%s"
 		Key1 = "Value One"
 		Description = "Very interesting"

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1534,7 +1534,7 @@ EOF
 
 resource "aws_vpc" "vpc_for_lambda" {
     cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-lambda-function"
 	}
 }
@@ -1543,7 +1543,7 @@ resource "aws_subnet" "subnet_for_lambda" {
     vpc_id = "${aws_vpc.vpc_for_lambda.id}"
     cidr_block = "10.0.1.0/24"
 
-    tags {
+  tags = {
         Name = "tf-acc-lambda-function-1"
     }
 }
@@ -1923,7 +1923,7 @@ resource "aws_subnet" "subnet_for_lambda_2" {
     vpc_id = "${aws_vpc.vpc_for_lambda.id}"
     cidr_block = "10.0.2.0/24"
 
-    tags {
+  tags = {
         Name = "tf-acc-lambda-function-2"
     }
 }
@@ -2065,7 +2065,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs4.3"
-    tags {
+  tags = {
 		Key1 = "Value One"
 		Description = "Very interesting"
     }
@@ -2081,7 +2081,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs4.3"
-    tags {
+  tags = {
 		Key1 = "Value One Changed"
 		Key2 = "Value Two"
 		Key3 = "Value Three"

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -640,7 +640,7 @@ func testAccAWSLaunchConfigurationConfig_withVpcClassicLink(rInt int) string {
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
     enable_classiclink = true
-    tags {
+  tags = {
         Name = "terraform-testacc-launch-configuration-with-vpc-classic-link"
     }
 }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -610,7 +610,7 @@ func testAccAWSLaunchTemplateConfig_basic(rInt int) string {
 resource "aws_launch_template" "foo" {
   name = "foo_%d"
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -791,7 +791,7 @@ resource "aws_launch_template" "foo" {
 
   tag_specifications {
     resource_type = "instance"
-    tags {
+  tags = {
       Name = "test"
     }
   }
@@ -804,7 +804,7 @@ func testAccAWSLaunchTemplateConfig_tagsUpdate(rInt int) string {
 resource "aws_launch_template" "foo" {
   name = "foo_%d"
 
-  tags {
+  tags = {
     bar = "baz"
   }
 }

--- a/aws/resource_aws_lb_listener_certificate_test.go
+++ b/aws/resource_aws_lb_listener_certificate_test.go
@@ -423,7 +423,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
   	Name = "terraform-testacc-lb-listener-certificate"
   }
 }
@@ -437,7 +437,7 @@ resource "aws_subnet" "test" {
   vpc_id            = "${aws_vpc.test.id}"
   cidr_block        = "${element(var.subnets, count.index)}"
   availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-certificate-${count.index}"
   }
 }`, rName, suffix, suffix, suffix, suffix)

--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -613,7 +613,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -646,7 +646,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-multiple-conditions"
   }
 }
@@ -658,7 +658,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-multiple-conditions-${count.index}"
   }
 }
@@ -682,7 +682,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -724,7 +724,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -757,7 +757,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-basic"
   }
 }
@@ -769,7 +769,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-basic-${count.index}"
   }
 }
@@ -793,7 +793,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -835,7 +835,7 @@ resource "aws_alb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -868,7 +868,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-bc"
   }
 }
@@ -880,7 +880,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-bc-${count.index}"
   }
 }
@@ -904,7 +904,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -954,7 +954,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_redirect"
   }
 }
@@ -969,7 +969,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-redirect"
   }
 }
@@ -981,7 +981,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-redirect-${count.index}"
   }
 }
@@ -1005,7 +1005,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_redirect"
   }
 }`, lbName)
@@ -1055,7 +1055,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_fixedResponse"
   }
 }
@@ -1070,7 +1070,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-fixedresponse"
   }
 }
@@ -1082,7 +1082,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-fixedresponse-${count.index}"
   }
 }
@@ -1106,7 +1106,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_fixedresponse"
   }
 }`, lbName)
@@ -1149,7 +1149,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1182,7 +1182,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-update-rule-priority"
   }
 }
@@ -1194,7 +1194,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-update-rule-priority-${count.index}"
   }
 }
@@ -1218,7 +1218,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -1272,7 +1272,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1305,7 +1305,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-change-rule-arn"
   }
 }
@@ -1317,7 +1317,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-change-rule-arn-${count.index}"
   }
 }
@@ -1341,7 +1341,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -1369,7 +1369,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1402,7 +1402,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-priority"
   }
 }
@@ -1414,7 +1414,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-priority-${count.index}"
   }
 }
@@ -1438,7 +1438,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -1672,7 +1672,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_cognito"
   }
 }
@@ -1705,7 +1705,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-cognito"
   }
 }
@@ -1717,7 +1717,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-cognito-${count.index}"
   }
 }
@@ -1741,7 +1741,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_cognito"
   }
 }
@@ -1850,7 +1850,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_cognito"
   }
 }
@@ -1883,7 +1883,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-rule-cognito"
   }
 }
@@ -1895,7 +1895,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-rule-cognito-${count.index}"
   }
 }
@@ -1919,7 +1919,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_cognito"
   }
 }`, lbName, targetGroupName, certificateName)
@@ -2034,7 +2034,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "${var.rName}"
   }
 }
@@ -2047,7 +2047,7 @@ resource "aws_subnet" "test" {
   map_public_ip_on_launch = true
   vpc_id                  = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "${var.rName}"
   }
 }
@@ -2070,7 +2070,7 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.rName}"
   }
 }`, rName)

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -408,7 +408,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -441,7 +441,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-basic"
   }
 }
@@ -453,7 +453,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-basic-${count.index}"
   }
 }
@@ -477,7 +477,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -504,7 +504,7 @@ resource "aws_alb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -537,7 +537,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-bc"
   }
 }
@@ -549,7 +549,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-bc-${count.index}"
   }
 }
@@ -573,7 +573,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, targetGroupName)
@@ -602,7 +602,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 
@@ -637,7 +637,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-https"
   }
 }
@@ -645,7 +645,7 @@ resource "aws_vpc" "alb_test" {
 resource "aws_internet_gateway" "gw" {
     vpc_id = "${aws_vpc.alb_test.id}"
 
-    tags {
+  tags = {
         Name = "TestAccAWSALB_basic"
     }
 }
@@ -657,7 +657,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-https-${count.index}"
   }
 }
@@ -681,7 +681,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -741,7 +741,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_redirect"
   }
 }
@@ -756,7 +756,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-redirect"
   }
 }
@@ -768,7 +768,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-redirect-${count.index}"
   }
 }
@@ -792,7 +792,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_redirect"
   }
 }`, lbName)
@@ -823,7 +823,7 @@ resource "aws_lb" "alb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_fixedresponse"
   }
 }
@@ -838,7 +838,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-listener-fixedresponse"
   }
 }
@@ -850,7 +850,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-listener-fixedresponse-${count.index}"
   }
 }
@@ -874,7 +874,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_fixedresponse"
   }
 }`, lbName)
@@ -1253,7 +1253,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "${var.rName}"
   }
 }
@@ -1266,7 +1266,7 @@ resource "aws_subnet" "test" {
   map_public_ip_on_launch = true
   vpc_id                  = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "${var.rName}"
   }
 }
@@ -1289,7 +1289,7 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.rName}"
   }
 }`, rName)

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -208,14 +208,14 @@ resource "aws_lb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-lb-target-group-attachment-without-port"
   }
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-lb-target-group-attachment-without-port"
 	}
 }`, targetGroupName)
@@ -260,14 +260,14 @@ resource "aws_lb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-lb-target-group-attachment-basic"
   }
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-lb-target-group-attachment-basic"
 	}
 }`, targetGroupName)
@@ -312,14 +312,14 @@ resource "aws_alb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-lb-target-group-attachment-bc"
   }
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-lb-target-group-attachment-bc"
 	}
 }`, targetGroupName)
@@ -362,13 +362,13 @@ resource "aws_lb_target_group" "test" {
 resource "aws_subnet" "subnet" {
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.test.id}"
-  tags {
+  tags = {
     Name = "tf-acc-lb-target-group-attachment-with-ip-address"
   }
 }
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-lb-target-group-attachment-with-ip-address"
 	}
 }`, targetGroupName)

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -982,7 +982,7 @@ resource "aws_lb_target_group" "test" {
     healthy_threshold = 3
     unhealthy_threshold = 3
   }
-  tags {
+  tags = {
     Name = "TestAccAWSLBTargetGroup_application_LB_defaults"
   }
 }
@@ -990,7 +990,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-alb-defaults"
   }
 }`, name)
@@ -1011,7 +1011,7 @@ resource "aws_lb_target_group" "test" {
                 %s
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSLBTargetGroup_application_LB_defaults"
   }
 }
@@ -1019,7 +1019,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-nlb-defaults"
   }
 }`, name, healthCheckBlock)
@@ -1051,7 +1051,7 @@ func testAccAWSLBTargetGroupConfig_basic(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSLBTargetGroup_basic"
   }
 }
@@ -1059,7 +1059,7 @@ func testAccAWSLBTargetGroupConfig_basic(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-basic"
   }
 }`, targetGroupName)
@@ -1091,7 +1091,7 @@ func testAccAWSLBTargetGroupConfigBackwardsCompatibility(targetGroupName string)
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSLBTargetGroup_basic"
   }
 }
@@ -1099,7 +1099,7 @@ func testAccAWSLBTargetGroupConfigBackwardsCompatibility(targetGroupName string)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-bc"
   }
 }`, targetGroupName)
@@ -1130,7 +1130,7 @@ func testAccAWSLBTargetGroupConfig_updatedPort(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSLBTargetGroup_basic"
   }
 }
@@ -1138,7 +1138,7 @@ func testAccAWSLBTargetGroupConfig_updatedPort(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-basic"
   }
 }`, targetGroupName)
@@ -1169,7 +1169,7 @@ func testAccAWSLBTargetGroupConfig_updatedProtocol(targetGroupName string) strin
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSLBTargetGroup_basic"
   }
 }
@@ -1177,7 +1177,7 @@ func testAccAWSLBTargetGroupConfig_updatedProtocol(targetGroupName string) strin
 resource "aws_vpc" "test2" {
   cidr_block = "10.10.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-basic-2"
   }
 }
@@ -1185,7 +1185,7 @@ resource "aws_vpc" "test2" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-basic"
   }
 }`, targetGroupName)
@@ -1216,7 +1216,7 @@ func testAccAWSLBTargetGroupConfig_updatedVpc(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     TestName = "TestAccAWSLBTargetGroup_basic"
   }
 }
@@ -1224,7 +1224,7 @@ func testAccAWSLBTargetGroupConfig_updatedVpc(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-updated-vpc"
   }
 }`, targetGroupName)
@@ -1255,7 +1255,7 @@ func testAccAWSLBTargetGroupConfig_updateTags(targetGroupName string) string {
     matcher = "200-299"
   }
 
-  tags {
+  tags = {
     Environment = "Production"
     Type = "ALB Target Group"
   }
@@ -1264,7 +1264,7 @@ func testAccAWSLBTargetGroupConfig_updateTags(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-update-tags"
   }
 }`, targetGroupName)
@@ -1299,7 +1299,7 @@ func testAccAWSLBTargetGroupConfig_updateHealthCheck(targetGroupName string) str
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-update-health-check"
   }
 }`, targetGroupName)
@@ -1322,7 +1322,7 @@ func testAccAWSLBTargetGroupConfig_typeTCP(targetGroupName string) string {
     unhealthy_threshold = 3
   }
 
-  tags {
+  tags = {
     Name = "TestAcc_networkLB_TargetGroup"
   }
 }
@@ -1330,7 +1330,7 @@ func testAccAWSLBTargetGroupConfig_typeTCP(targetGroupName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-type-tcp"
   }
 }`, targetGroupName)
@@ -1354,7 +1354,7 @@ func testAccAWSLBTargetGroupConfig_typeTCP_withProxyProtocol(targetGroupName str
     unhealthy_threshold = 3
   }
 
-  tags {
+  tags = {
     Name = "TestAcc_networkLB_TargetGroup"
   }
 }
@@ -1362,7 +1362,7 @@ func testAccAWSLBTargetGroupConfig_typeTCP_withProxyProtocol(targetGroupName str
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-type-tcp"
   }
 }`, targetGroupName)
@@ -1385,7 +1385,7 @@ func testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(targetGroupName strin
     unhealthy_threshold = 4
   }
 
-  tags {
+  tags = {
     Name = "TestAcc_networkLB_TargetGroup"
   }
 }
@@ -1393,7 +1393,7 @@ func testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(targetGroupName strin
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-type-tcp"
   }
 }`, targetGroupName)
@@ -1416,7 +1416,7 @@ func testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(targetGroupName strin
     unhealthy_threshold = 5
   }
 
-  tags {
+  tags = {
     Name = "TestAcc_networkLB_TargetGroup"
   }
 }
@@ -1424,7 +1424,7 @@ func testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(targetGroupName strin
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-type-tcp-threshold-updated"
   }
 }`, targetGroupName)
@@ -1447,7 +1447,7 @@ func testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(targetGroupName string
     unhealthy_threshold = 5
   }
 
-  tags {
+  tags = {
     Name = "TestAcc_networkLB_TargetGroup"
   }
 }
@@ -1455,7 +1455,7 @@ func testAccAWSLBTargetGroupConfig_typeTCPIntervalUpdated(targetGroupName string
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-type-tcp-interval-updated"
   }
 }`, targetGroupName)
@@ -1479,14 +1479,14 @@ func testAccAWSLBTargetGroupConfig_typeTCP_HTTPHealthCheck(targetGroupName, path
     matcher             = "200-399"
   }
 
-  tags {
+  tags = {
     Name = "TestAcc_networkLB_HTTPHealthCheck"
   }
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-target-group-type-tcp-http-health-check"
   }
 }`, targetGroupName, threshold, path)
@@ -1528,7 +1528,7 @@ func testAccAWSLBTargetGroupConfig_stickiness(targetGroupName string, addStickin
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     TestName = "terraform-testacc-lb-target-group-stickiness"
   }
 }`, targetGroupName, stickinessBlock)
@@ -1544,7 +1544,7 @@ resource "aws_lb_target_group" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-lb-target-group-name-prefix"
 	}
 }
@@ -1559,7 +1559,7 @@ resource "aws_lb_target_group" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-lb-target-group-generated-name"
 	}
 }
@@ -1582,7 +1582,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "testAccAWSLBTargetGroupConfig_namePrefix"
   }
 }

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -819,7 +819,7 @@ func testAccAWSLBConfigWithIpAddressTypeUpdated(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -868,7 +868,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-with-ip-address-type-updated"
   }
 }
@@ -884,7 +884,7 @@ resource "aws_subnet" "alb_test_1" {
   availability_zone       = "us-west-2a"
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-with-ip-address-type-updated-1"
   }
 }
@@ -896,7 +896,7 @@ resource "aws_subnet" "alb_test_2" {
   availability_zone       = "us-west-2b"
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-with-ip-address-type-updated-2"
   }
 }
@@ -913,7 +913,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, lbName)
@@ -930,7 +930,7 @@ func testAccAWSLBConfigWithIpAddressType(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -979,7 +979,7 @@ resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-with-ip-address-type"
   }
 }
@@ -995,7 +995,7 @@ resource "aws_subnet" "alb_test_1" {
   availability_zone       = "us-west-2a"
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 1)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-with-ip-address-type-1"
   }
 }
@@ -1007,7 +1007,7 @@ resource "aws_subnet" "alb_test_2" {
   availability_zone       = "us-west-2b"
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.alb_test.ipv6_cidr_block, 8, 2)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-with-ip-address-type-2"
   }
 }
@@ -1024,7 +1024,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, lbName)
@@ -1040,7 +1040,7 @@ func testAccAWSLBConfig_basic(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1055,7 +1055,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-basic"
   }
 }
@@ -1067,7 +1067,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-basic"
   }
 }
@@ -1091,7 +1091,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName)
@@ -1109,7 +1109,7 @@ func testAccAWSLBConfig_enableHttp2(lbName string, http2 bool) string {
 
   enable_http2 = %t
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1124,7 +1124,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-basic"
   }
 }
@@ -1136,7 +1136,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-basic-${count.index}"
   }
 }
@@ -1160,7 +1160,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, http2)
@@ -1176,7 +1176,7 @@ func testAccAWSLBConfig_enableDeletionProtection(lbName string, deletion_protect
   idle_timeout = 30
   enable_deletion_protection = %t
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1191,7 +1191,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-basic"
   }
 }
@@ -1203,7 +1203,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-basic-${count.index}"
   }
 }
@@ -1227,7 +1227,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, deletion_protection)
@@ -1237,7 +1237,7 @@ func testAccAWSLBConfig_networkLoadbalancer_subnets(lbName string) string {
 	return fmt.Sprintf(`resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-network-load-balancer-subnets"
   }
 }
@@ -1257,7 +1257,7 @@ resource "aws_lb" "lb_test" {
   enable_deletion_protection       = false
   enable_cross_zone_load_balancing = false
 
-  tags {
+  tags = {
     Name = "testAccAWSLBConfig_networkLoadbalancer_subnets"
   }
 }
@@ -1267,7 +1267,7 @@ resource "aws_subnet" "alb_test_1" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-network-load-balancer-subnets-1"
   }
 }
@@ -1277,7 +1277,7 @@ resource "aws_subnet" "alb_test_2" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-network-load-balancer-subnets-2"
   }
 }
@@ -1287,7 +1287,7 @@ resource "aws_subnet" "alb_test_3" {
   cidr_block        = "10.0.3.0/24"
   availability_zone = "us-west-2c"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-network-load-balancer-subnets-3"
   }
 }
@@ -1307,7 +1307,7 @@ func testAccAWSLBConfig_networkLoadbalancer(lbName string, cz bool) string {
   	subnet_id = "${aws_subnet.alb_test.id}"
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1315,7 +1315,7 @@ func testAccAWSLBConfig_networkLoadbalancer(lbName string, cz bool) string {
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.10.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-network-load-balancer"
   }
 }
@@ -1326,7 +1326,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-network-load-balancer"
   }
 }
@@ -1340,7 +1340,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
   	Name = "terraform-testacc-lb-network-load-balancer-eip"
   }
 }
@@ -1350,7 +1350,7 @@ resource "aws_subnet" "public" {
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   cidr_block = "10.10.${count.index}.0/24"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "tf-acc-lb-network-load-balancer-eip-${count.index}"
   }
 }
@@ -1404,7 +1404,7 @@ func testAccAWSLBConfigBackwardsCompatibility(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1419,7 +1419,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-bc"
   }
 }
@@ -1431,7 +1431,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-bc-${count.index}"
   }
 }
@@ -1455,7 +1455,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName)
@@ -1471,7 +1471,7 @@ func testAccAWSLBConfig_updateSubnets(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1486,7 +1486,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-update-subnets"
   }
 }
@@ -1498,7 +1498,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-update-subnets-${count.index}"
   }
 }
@@ -1522,7 +1522,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName)
@@ -1538,7 +1538,7 @@ resource "aws_lb" "lb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1553,7 +1553,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-generated-name"
   }
 }
@@ -1561,7 +1561,7 @@ resource "aws_vpc" "alb_test" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.alb_test.id}"
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1573,7 +1573,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-generated-name-${count.index}"
   }
 }
@@ -1597,7 +1597,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`)
@@ -1614,7 +1614,7 @@ resource "aws_lb" "lb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1634,7 +1634,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-zero-value-name"
   }
 }
@@ -1642,7 +1642,7 @@ resource "aws_vpc" "alb_test" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.alb_test.id}"
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1654,7 +1654,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-zero-value-name-${count.index}"
   }
 }
@@ -1678,7 +1678,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`)
@@ -1695,7 +1695,7 @@ resource "aws_lb" "lb_test" {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1710,7 +1710,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-name-prefix"
   }
 }
@@ -1722,7 +1722,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-name-prefix-${count.index}"
   }
 }
@@ -1746,7 +1746,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`)
@@ -1761,7 +1761,7 @@ func testAccAWSLBConfig_updatedTags(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Environment = "Production"
     Type = "Sample Type Tag"
   }
@@ -1777,7 +1777,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-updated-tags"
   }
 }
@@ -1789,7 +1789,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-updated-tags-${count.index}"
   }
 }
@@ -1813,7 +1813,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName)
@@ -1835,7 +1835,7 @@ func testAccAWSLBConfig_accessLogs(enabled bool, lbName, bucketName, bucketPrefi
   	enabled = "%t"
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic1"
   }
 }
@@ -1856,7 +1856,7 @@ resource "aws_s3_bucket" "logs" {
   # dangerous, only here for the test...
   force_destroy = true
 
-  tags {
+  tags = {
     Name = "ALB Logs Bucket Test"
   }
 }
@@ -1890,7 +1890,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-access-logs"
   }
 }
@@ -1902,7 +1902,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-access-logs-${count.index}"
   }
 }
@@ -1926,7 +1926,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName, enabled, bucketName, bucketPrefix)
@@ -1941,7 +1941,7 @@ func testAccAWSLBConfig_nosg(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1956,7 +1956,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-no-sg"
   }
 }
@@ -1968,7 +1968,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-no-sg-${count.index}"
   }
 }`, lbName)
@@ -1984,7 +1984,7 @@ func testAccAWSLBConfig_updateSecurityGroups(lbName string) string {
   idle_timeout = 30
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }
@@ -1999,7 +1999,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "alb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-lb-update-security-groups"
   }
 }
@@ -2011,7 +2011,7 @@ resource "aws_subnet" "alb_test" {
   map_public_ip_on_launch = true
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "tf-acc-lb-update-security-groups-${count.index}"
   }
 }
@@ -2028,7 +2028,7 @@ resource "aws_security_group" "alb_test_2" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic_2"
   }
 }
@@ -2052,7 +2052,7 @@ resource "aws_security_group" "alb_test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "TestAccAWSALB_basic"
   }
 }`, lbName)

--- a/aws/resource_aws_load_balancer_backend_server_policy_test.go
+++ b/aws/resource_aws_load_balancer_backend_server_policy_test.go
@@ -181,7 +181,7 @@ resource "aws_elb" "test-lb" {
     ssl_certificate_id = "${aws_iam_server_certificate.test-iam-cert0.arn}"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -280,7 +280,7 @@ resource "aws_elb" "test-lb" {
     ssl_certificate_id = "${aws_iam_server_certificate.test-iam-cert0.arn}"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -389,7 +389,7 @@ resource "aws_elb" "test-lb" {
     ssl_certificate_id = "${aws_iam_server_certificate.test-iam-cert0.arn}"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }

--- a/aws/resource_aws_load_balancer_listener_policy_test.go
+++ b/aws/resource_aws_load_balancer_listener_policy_test.go
@@ -159,7 +159,7 @@ resource "aws_elb" "test-lb" {
     lb_protocol = "http"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -196,7 +196,7 @@ resource "aws_elb" "test-lb" {
     lb_protocol = "http"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -233,7 +233,7 @@ resource "aws_elb" "test-lb" {
     lb_protocol = "http"
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`, lbName)

--- a/aws/resource_aws_load_balancer_policy_test.go
+++ b/aws/resource_aws_load_balancer_policy_test.go
@@ -250,7 +250,7 @@ func testAccAWSLoadBalancerPolicyConfig_basic(rInt int) string {
 			lb_protocol = "http"
 		}
 
-		tags {
+	tags = {
 			Name = "tf-acc-test"
 		}
 	}
@@ -279,7 +279,7 @@ func testAccAWSLoadBalancerPolicyConfig_updateWhileAssigned0(rInt int) string {
 			lb_protocol = "http"
 		}
 
-		tags {
+	tags = {
 			Name = "tf-acc-test"
 		}
 	}
@@ -316,7 +316,7 @@ func testAccAWSLoadBalancerPolicyConfig_updateWhileAssigned1(rInt int) string {
 			lb_protocol = "http"
 		}
 
-		tags {
+	tags = {
 			Name = "tf-acc-test"
 		}
 	}

--- a/aws/resource_aws_main_route_table_association_test.go
+++ b/aws/resource_aws_main_route_table_association_test.go
@@ -104,7 +104,7 @@ func testAccCheckMainRouteTableAssociation(
 const testAccMainRouteTableAssociationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-main-route-table-association"
 	}
 }
@@ -112,7 +112,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-main-route-table-association"
 	}
 }
@@ -138,7 +138,7 @@ resource "aws_main_route_table_association" "foo" {
 const testAccMainRouteTableAssociationConfigUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-main-route-table-association-update"
 	}
 }
@@ -146,7 +146,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-main-route-table-association-update"
 	}
 }

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -680,7 +680,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.11.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-mq-broker-all-fields-custom-vpc"
   }
 }
@@ -703,7 +703,7 @@ resource "aws_subnet" "private" {
   cidr_block = "10.11.${count.index}.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "tf-acc-mq-broker-all-fields-custom-vpc-${count.index}"
   }
 }

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -196,7 +196,7 @@ func testAccCheckNatGatewayExists(n string, ng *ec2.NatGateway) resource.TestChe
 const testAccNatGatewayConfig = `
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-basic"
   }
 }
@@ -205,7 +205,7 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
   map_public_ip_on_launch = false
-  tags {
+  tags = {
     Name = "tf-acc-nat-gw-basic-private"
   }
 }
@@ -214,7 +214,7 @@ resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.2.0/24"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-nat-gw-basic-public"
   }
 }
@@ -232,7 +232,7 @@ resource "aws_nat_gateway" "gateway" {
   allocation_id = "${aws_eip.nat_gateway.id}"
   subnet_id = "${aws_subnet.public.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-basic"
   }
 
@@ -271,7 +271,7 @@ resource "aws_route_table_association" "public" {
 const testAccNatGatewayConfigTags = `
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-tags"
   }
 }
@@ -280,7 +280,7 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
   map_public_ip_on_launch = false
-  tags {
+  tags = {
     Name = "tf-acc-nat-gw-tags-private"
   }
 }
@@ -289,7 +289,7 @@ resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.2.0/24"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-nat-gw-tags-public"
   }
 }
@@ -307,7 +307,7 @@ resource "aws_nat_gateway" "gateway" {
   allocation_id = "${aws_eip.nat_gateway.id}"
   subnet_id = "${aws_subnet.public.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-tags"
     foo = "bar"
   }
@@ -347,7 +347,7 @@ resource "aws_route_table_association" "public" {
 const testAccNatGatewayConfigTagsUpdate = `
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-tags"
   }
 }
@@ -356,7 +356,7 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.1.0/24"
   map_public_ip_on_launch = false
-  tags {
+  tags = {
     Name = "tf-acc-nat-gw-tags-private"
   }
 }
@@ -365,7 +365,7 @@ resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.vpc.id}"
   cidr_block = "10.0.2.0/24"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-nat-gw-tags-public"
   }
 }
@@ -383,7 +383,7 @@ resource "aws_nat_gateway" "gateway" {
   allocation_id = "${aws_eip.nat_gateway.id}"
   subnet_id = "${aws_subnet.public.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-nat-gw-tags"
     bar = "baz"
   }

--- a/aws/resource_aws_neptune_cluster_instance_test.go
+++ b/aws/resource_aws_neptune_cluster_instance_test.go
@@ -239,7 +239,7 @@ resource "aws_neptune_parameter_group" "bar" {
     value        = "25"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -272,7 +272,7 @@ resource "aws_neptune_parameter_group" "bar" {
     value        = "25"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -307,7 +307,7 @@ resource "aws_neptune_parameter_group" "bar" {
     value        = "25"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -330,7 +330,7 @@ resource "aws_neptune_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-neptune-cluster-instance-name-prefix"
 	}
 }
@@ -339,7 +339,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-a"
   }
 }
@@ -348,7 +348,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-b"
   }
 }
@@ -376,7 +376,7 @@ resource "aws_neptune_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-neptune-cluster-instance-name-prefix"
 	}
 }
@@ -385,7 +385,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-a"
   }
 }
@@ -394,7 +394,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-b"
   }
 }
@@ -421,7 +421,7 @@ resource "aws_neptune_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-neptune-cluster-instance-name-prefix"
 	}
 }
@@ -430,7 +430,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-a"
   }
 }
@@ -439,7 +439,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-neptune-cluster-instance-name-prefix-b"
   }
 }
@@ -499,7 +499,7 @@ resource "aws_neptune_parameter_group" "bar" {
     value        = "25"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }

--- a/aws/resource_aws_neptune_cluster_parameter_group_test.go
+++ b/aws/resource_aws_neptune_cluster_parameter_group_test.go
@@ -320,7 +320,7 @@ resource "aws_neptune_cluster_parameter_group" "bar" {
   family = "neptune1"
   name   = "%s"
 
-  tags {
+  tags = {
     %s = "%s"
   }
 }

--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -431,7 +431,7 @@ resource "aws_neptune_cluster" "default" {
   engine = "neptune"
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot = true
-  tags {
+  tags = {
     Environment = "production"
   }
 }`, n)
@@ -455,7 +455,7 @@ resource "aws_neptune_cluster" "default" {
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   neptune_cluster_parameter_group_name = "default.neptune1"
   final_snapshot_identifier = "tf-acctest-neptunecluster-snapshot-%d"
-  tags {
+  tags = {
     Environment = "production"
   }
 }`, n, n)
@@ -468,7 +468,7 @@ resource "aws_neptune_cluster" "default" {
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot = true
-  tags {
+  tags = {
     Environment = "production"
     AnotherTag = "test"
   }
@@ -548,7 +548,7 @@ resource "aws_neptune_cluster" "default" {
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   neptune_cluster_parameter_group_name = "default.neptune1"
   skip_final_snapshot = true
-  tags {
+  tags = {
     Environment = "production"
   }
   depends_on = ["aws_iam_role.another_neptune_sample_role", "aws_iam_role.neptune_sample_role"]
@@ -629,7 +629,7 @@ resource "aws_neptune_cluster" "default" {
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   skip_final_snapshot = true
   iam_roles = ["${aws_iam_role.neptune_sample_role.arn}","${aws_iam_role.another_neptune_sample_role.arn}"]
-  tags {
+  tags = {
     Environment = "production"
   }
   depends_on = ["aws_iam_role.another_neptune_sample_role", "aws_iam_role.neptune_sample_role"]
@@ -677,7 +677,7 @@ resource "aws_neptune_cluster" "default" {
   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
   skip_final_snapshot = true
   iam_roles = ["${aws_iam_role.another_neptune_sample_role.arn}"]
-  tags {
+  tags = {
     Environment = "production"
   }
 

--- a/aws/resource_aws_neptune_event_subscription_test.go
+++ b/aws/resource_aws_neptune_event_subscription_test.go
@@ -245,7 +245,7 @@ resource "aws_neptune_event_subscription" "bar" {
     "deletion",
     "maintenance"
   ]
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`, rInt, rInt)
@@ -265,7 +265,7 @@ resource "aws_neptune_event_subscription" "bar" {
   event_categories = [
     "configuration change"
   ]
-  tags {
+  tags = {
     Name = "tf-acc-test1"
   }
 }`, rInt, rInt)
@@ -288,7 +288,7 @@ resource "aws_neptune_event_subscription" "bar" {
     "deletion",
     "maintenance"
   ]
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`, rInt)
@@ -314,7 +314,7 @@ resource "aws_neptune_event_subscription" "bar" {
   event_categories = [
     "configuration change"
   ]
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`, rInt, rInt, rInt)
@@ -346,7 +346,7 @@ func testAccAWSNeptuneEventSubscriptionConfigUpdateSourceIds(rInt int) string {
 		event_categories = [
 			"configuration change"
 		]
-		tags {
+	tags = {
 			Name = "tf-acc-test"
 		}
 	}`, rInt, rInt, rInt, rInt)
@@ -365,7 +365,7 @@ resource "aws_neptune_event_subscription" "bar" {
   event_categories = [
     "availability",
   ]
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`, rInt, rInt)

--- a/aws/resource_aws_neptune_parameter_group_test.go
+++ b/aws/resource_aws_neptune_parameter_group_test.go
@@ -275,7 +275,7 @@ resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
   name   = %q
 
-  tags {
+  tags = {
     %s = %q
   }
 }
@@ -288,7 +288,7 @@ resource "aws_neptune_parameter_group" "test" {
   family = "neptune1"
   name   = %q
 
-  tags {
+  tags = {
     %s = %q
     %s = %q
   }

--- a/aws/resource_aws_neptune_subnet_group_test.go
+++ b/aws/resource_aws_neptune_subnet_group_test.go
@@ -195,7 +195,7 @@ func testAccNeptuneSubnetGroupConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-neptune-subnet-group"
 	}
 }
@@ -204,7 +204,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-1"
 	}
 }
@@ -213,7 +213,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-2"
 	}
 }
@@ -221,7 +221,7 @@ resource "aws_subnet" "bar" {
 resource "aws_neptune_subnet_group" "foo" {
 	name = "%s"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-neptunesubnet-group-test"
 	}
 }`, rName)
@@ -231,7 +231,7 @@ func testAccNeptuneSubnetGroupConfig_updatedDescription(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-neptune-subnet-group-updated-description"
 	}
 }
@@ -240,7 +240,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-1"
 	}
 }
@@ -249,7 +249,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-2"
 	}
 }
@@ -258,7 +258,7 @@ resource "aws_neptune_subnet_group" "foo" {
 	name = "%s"
 	description = "foo description updated"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-neptunesubnet-group-test"
 	}
 }`, rName)
@@ -267,7 +267,7 @@ resource "aws_neptune_subnet_group" "foo" {
 const testAccNeptuneSubnetGroupConfig_namePrefix = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-neptune-subnet-group-name-prefix"
 	}
 }
@@ -276,7 +276,7 @@ resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-name-prefix-a"
 	}
 }
@@ -285,7 +285,7 @@ resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-name-prefix-b"
 	}
 }
@@ -298,7 +298,7 @@ resource "aws_neptune_subnet_group" "test" {
 const testAccNeptuneSubnetGroupConfig_generatedName = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-neptune-subnet-group-generated-name"
 	}
 }
@@ -307,7 +307,7 @@ resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-generated-name-a"
 	}
 }
@@ -316,7 +316,7 @@ resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
-	tags {
+	tags = {
 		Name = "tf-acc-neptune-subnet-group-generated-name-a"
 	}
 }

--- a/aws/resource_aws_network_acl_rule_test.go
+++ b/aws/resource_aws_network_acl_rule_test.go
@@ -310,14 +310,14 @@ provider "aws" {
 
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-acl-rule-basic"
 	}
 }
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-acl-rule-basic"
 	}
 }
@@ -361,14 +361,14 @@ provider "aws" {
 
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-acl-rule-missing-param"
 	}
 }
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-acl-rule-missing-param"
 	}
 }
@@ -387,14 +387,14 @@ resource "aws_network_acl_rule" "baz" {
 const testAccAWSNetworkAclRuleAllProtocolConfigNoRealUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-acl-rule-all-proto-no-real-upd"
 	}
 }
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-acl-rule-no-real-update"
 	}
 }
@@ -414,7 +414,7 @@ resource "aws_network_acl_rule" "baz" {
 const testAccAWSNetworkAclRuleTcpProtocolConfigNoRealUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "testAccAWSNetworkAclRuleTcpProtocolConfigNoRealUpdate"
 	}
 }
@@ -436,14 +436,14 @@ resource "aws_network_acl_rule" "baz" {
 const testAccAWSNetworkAclRuleAllProtocolConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-acl-rule-proto"
 	}
 }
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-acl-rule-all-protocol"
 	}
 }
@@ -463,7 +463,7 @@ resource "aws_network_acl_rule" "baz" {
 const testAccAWSNetworkAclRuleTcpProtocolConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "testAccAWSNetworkAclRuleTcpProtocolConfig"
 	}
 }
@@ -485,14 +485,14 @@ resource "aws_network_acl_rule" "baz" {
 const testAccAWSNetworkAclRuleIpv6Config = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-acl-rule-ipv6"
 	}
 }
 
 resource "aws_network_acl" "bar" {
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-acl-rule-ipv6"
 	}
 }
@@ -514,7 +514,7 @@ func testAccAWSNetworkAclRuleConfigIpv6ICMP(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.3.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -522,7 +522,7 @@ resource "aws_vpc" "test" {
 resource "aws_network_acl" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -645,7 +645,7 @@ func testAccAWSNetworkAclConfigIpv6ICMP(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -664,7 +664,7 @@ resource "aws_network_acl" "test" {
     to_port         = 0
   }
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -674,7 +674,7 @@ resource "aws_network_acl" "test" {
 const testAccAWSNetworkAclIpv6Config = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-ipv6"
   }
 }
@@ -683,7 +683,7 @@ resource "aws_subnet" "blob" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-ipv6"
   }
 }
@@ -700,7 +700,7 @@ resource "aws_network_acl" "foos" {
   }
 
   subnet_ids = ["${aws_subnet.blob.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-ipv6"
   }
 }
@@ -715,7 +715,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
 
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-ipv6-vpc-rules"
   }
 }
@@ -730,7 +730,7 @@ resource "aws_network_acl" "foos" {
     from_port = 0
     to_port = 22
   }
-  tags {
+  tags = {
     Name = "tf-acc-acl-ipv6"
   }
 }
@@ -739,7 +739,7 @@ resource "aws_network_acl" "foos" {
 const testAccAWSNetworkAclIngressConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-ingress"
   }
 }
@@ -748,7 +748,7 @@ resource "aws_subnet" "blob" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-ingress"
   }
 }
@@ -773,7 +773,7 @@ resource "aws_network_acl" "foos" {
   }
 
   subnet_ids = ["${aws_subnet.blob.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-ingress"
   }
 }
@@ -782,7 +782,7 @@ resource "aws_network_acl" "foos" {
 const testAccAWSNetworkAclCaseSensitiveConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-ingress"
   }
 }
@@ -791,7 +791,7 @@ resource "aws_subnet" "blob" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-ingress"
   }
 }
@@ -807,7 +807,7 @@ resource "aws_network_acl" "foos" {
     to_port = 22
   }
   subnet_ids = ["${aws_subnet.blob.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-case-sensitive"
   }
 }
@@ -816,7 +816,7 @@ resource "aws_network_acl" "foos" {
 const testAccAWSNetworkAclIngressConfigChange = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-ingress"
   }
 }
@@ -825,7 +825,7 @@ resource "aws_subnet" "blob" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-ingress"
   }
 }
@@ -841,7 +841,7 @@ resource "aws_network_acl" "foos" {
     to_port = 22
   }
   subnet_ids = ["${aws_subnet.blob.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-ingress"
   }
 }
@@ -850,7 +850,7 @@ resource "aws_network_acl" "foos" {
 const testAccAWSNetworkAclEgressConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.2.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-egress"
   }
 }
@@ -859,7 +859,7 @@ resource "aws_subnet" "blob" {
   cidr_block = "10.2.0.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-egress"
   }
 }
@@ -902,7 +902,7 @@ resource "aws_network_acl" "bond" {
     to_port = 22
   }
 
-  tags {
+  tags = {
     foo = "bar"
     Name = "tf-acc-acl-egress"
   }
@@ -912,7 +912,7 @@ resource "aws_network_acl" "bond" {
 const testAccAWSNetworkAclEgressNIngressConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.3.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-egress-and-ingress"
   }
 }
@@ -921,7 +921,7 @@ resource "aws_subnet" "blob" {
   cidr_block = "10.3.0.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-egress-and-ingress"
   }
 }
@@ -945,7 +945,7 @@ resource "aws_network_acl" "bar" {
     from_port = 80
     to_port = 80
   }
-  tags {
+  tags = {
     Name = "tf-acc-acl-egress-and-ingress"
   }
 }
@@ -953,7 +953,7 @@ resource "aws_network_acl" "bar" {
 const testAccAWSNetworkAclSubnetConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-subnet-change"
   }
 }
@@ -962,7 +962,7 @@ resource "aws_subnet" "old" {
   cidr_block = "10.1.111.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-change-old"
   }
 }
@@ -971,7 +971,7 @@ resource "aws_subnet" "new" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-change-new"
   }
 }
@@ -979,7 +979,7 @@ resource "aws_subnet" "new" {
 resource "aws_network_acl" "roll" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.new.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-subnet-change-roll"
   }
 }
@@ -987,7 +987,7 @@ resource "aws_network_acl" "roll" {
 resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.old.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-subnet-change-bar"
   }
 }
@@ -996,7 +996,7 @@ resource "aws_network_acl" "bar" {
 const testAccAWSNetworkAclSubnetConfigChange = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-subnet-change"
   }
 }
@@ -1005,7 +1005,7 @@ resource "aws_subnet" "old" {
   cidr_block = "10.1.111.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-change-old"
   }
 }
@@ -1014,7 +1014,7 @@ resource "aws_subnet" "new" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   map_public_ip_on_launch = true
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-change-new"
   }
 }
@@ -1022,7 +1022,7 @@ resource "aws_subnet" "new" {
 resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.new.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-subnet-change-bar"
   }
 }
@@ -1031,7 +1031,7 @@ resource "aws_network_acl" "bar" {
 const testAccAWSNetworkAclSubnet_SubnetIds = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-subnet-ids"
   }
 }
@@ -1039,7 +1039,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "one" {
   cidr_block = "10.1.111.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-ids-one"
   }
 }
@@ -1047,7 +1047,7 @@ resource "aws_subnet" "one" {
 resource "aws_subnet" "two" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-ids-two"
   }
 }
@@ -1055,7 +1055,7 @@ resource "aws_subnet" "two" {
 resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.one.id}", "${aws_subnet.two.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-subnet-ids"
   }
 }
@@ -1064,7 +1064,7 @@ resource "aws_network_acl" "bar" {
 const testAccAWSNetworkAclSubnet_SubnetIdsUpdate = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-subnet-ids"
   }
 }
@@ -1072,7 +1072,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "one" {
   cidr_block = "10.1.111.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-ids-one"
   }
 }
@@ -1080,7 +1080,7 @@ resource "aws_subnet" "one" {
 resource "aws_subnet" "two" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-ids-two"
   }
 }
@@ -1088,7 +1088,7 @@ resource "aws_subnet" "two" {
 resource "aws_subnet" "three" {
   cidr_block = "10.1.222.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-ids-three"
   }
 }
@@ -1096,7 +1096,7 @@ resource "aws_subnet" "three" {
 resource "aws_subnet" "four" {
   cidr_block = "10.1.4.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-ids-four"
   }
 }
@@ -1108,7 +1108,7 @@ resource "aws_network_acl" "bar" {
     "${aws_subnet.three.id}",
     "${aws_subnet.four.id}",
   ]
-  tags {
+  tags = {
     Name = "tf-acc-acl-subnet-ids"
   }
 }
@@ -1117,7 +1117,7 @@ resource "aws_network_acl" "bar" {
 const testAccAWSNetworkAclSubnet_SubnetIdsDeleteOne = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-subnet-ids"
   }
 }
@@ -1125,7 +1125,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "one" {
   cidr_block = "10.1.111.0/24"
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "tf-acc-network-acl-subnet-ids-one"
   }
 }
@@ -1133,7 +1133,7 @@ resource "aws_subnet" "one" {
 resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
   subnet_ids = ["${aws_subnet.one.id}"]
-  tags {
+  tags = {
     Name = "tf-acc-acl-subnet-ids"
   }
 }
@@ -1142,7 +1142,7 @@ resource "aws_network_acl" "bar" {
 const testAccAWSNetworkAclEsp = `
 resource "aws_vpc" "testespvpc" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-network-acl-esp"
   }
 }
@@ -1159,7 +1159,7 @@ resource "aws_network_acl" "testesp" {
     to_port    = 0
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-acl-esp"
   }
 }

--- a/aws/resource_aws_network_interface_attachment_test.go
+++ b/aws/resource_aws_network_interface_attachment_test.go
@@ -43,7 +43,7 @@ func testAccAWSNetworkInterfaceAttachmentConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
     cidr_block = "172.16.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-iface-attachment-basic"
 	}
 }
@@ -52,7 +52,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-network-iface-attachment-basic"
     }
 }
@@ -75,7 +75,7 @@ resource "aws_network_interface" "bar" {
     private_ips = ["172.16.10.100"]
     security_groups = ["${aws_security_group.foo.id}"]
     description = "Managed by Terraform"
-    tags {
+  tags = {
         Name = "bar_interface"
     }
 }
@@ -84,7 +84,7 @@ resource "aws_instance" "foo" {
     ami = "ami-c5eabbf5"
     instance_type = "t2.micro"
     subnet_id = "${aws_subnet.foo.id}"
-    tags {
+  tags = {
         Name = "foo-%d"
     }
 }

--- a/aws/resource_aws_network_interface_sg_attachment_test.go
+++ b/aws/resource_aws_network_interface_sg_attachment_test.go
@@ -229,7 +229,7 @@ func testAccAwsNetworkInterfaceSGAttachmentConfig(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -238,7 +238,7 @@ resource "aws_subnet" "test" {
   cidr_block = "172.16.10.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -251,7 +251,7 @@ resource "aws_security_group" "test" {
 resource "aws_network_interface" "test" {
   subnet_id = "${aws_subnet.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -357,7 +357,7 @@ const testAccAWSENIConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-interface"
 	}
 }
@@ -366,7 +366,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-network-interface"
     }
 }
@@ -389,7 +389,7 @@ resource "aws_network_interface" "bar" {
     private_ips = ["172.16.10.100"]
     security_groups = ["${aws_security_group.foo.id}"]
     description = "Managed by Terraform"
-    tags {
+  tags = {
         Name = "bar_interface"
     }
 }
@@ -399,7 +399,7 @@ const testAccAWSENIConfigUpdatedDescription = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-interface-update-desc"
 	}
 }
@@ -408,7 +408,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-network-interface-update-desc"
     }
 }
@@ -431,7 +431,7 @@ resource "aws_network_interface" "bar" {
     private_ips = ["172.16.10.100"]
     security_groups = ["${aws_security_group.foo.id}"]
     description = "Updated ENI Description"
-    tags {
+  tags = {
         Name = "bar_interface"
     }
 }
@@ -441,7 +441,7 @@ const testAccAWSENIConfigWithSourceDestCheck = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-interface-w-source-dest-check"
 	}
 }
@@ -450,7 +450,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-network-interface-w-source-dest-check"
     }
 }
@@ -466,7 +466,7 @@ const testAccAWSENIConfigWithNoPrivateIPs = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-network-interface-w-no-private-ips"
 	}
 }
@@ -475,7 +475,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-network-interface-w-no-private-ips"
     }
 }
@@ -490,7 +490,7 @@ const testAccAWSENIConfigWithAttachment = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-    tags {
+  tags = {
         Name = "terraform-testacc-network-interface-w-attachment"
     }
 }
@@ -499,7 +499,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-        tags {
+  tags = {
             Name = "tf-acc-network-interface-w-attachment-foo"
         }
 }
@@ -508,7 +508,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
-        tags {
+  tags = {
             Name = "tf-acc-network-interface-w-attachment-bar"
         }
 }
@@ -525,7 +525,7 @@ resource "aws_instance" "foo" {
     subnet_id = "${aws_subnet.bar.id}"
     associate_public_ip_address = false
     private_ip = "172.16.11.50"
-    tags {
+  tags = {
         Name = "foo-tf-eni-test"
     }
 }
@@ -538,7 +538,7 @@ resource "aws_network_interface" "bar" {
         instance = "${aws_instance.foo.id}"
         device_index = 1
     }
-    tags {
+  tags = {
         Name = "bar_interface"
     }
 }
@@ -548,7 +548,7 @@ const testAccAWSENIConfigExternalAttachment = `
 resource "aws_vpc" "foo" {
 	cidr_block = "172.16.0.0/16"
 	enable_dns_hostnames = true
-    tags {
+  tags = {
         Name = "terraform-testacc-network-interface-external-attachment"
     }
 }
@@ -557,7 +557,7 @@ resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.10.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-network-interface-external-attachment-foo"
     }
 }
@@ -566,7 +566,7 @@ resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "172.16.11.0/24"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-network-interface-external-attachment-bar"
     }
 }
@@ -583,7 +583,7 @@ resource "aws_instance" "foo" {
     subnet_id = "${aws_subnet.bar.id}"
     associate_public_ip_address = false
     private_ip = "172.16.11.50"
-    tags {
+  tags = {
         Name = "tf-eni-test"
     }
 }
@@ -592,7 +592,7 @@ resource "aws_network_interface" "bar" {
     subnet_id = "${aws_subnet.foo.id}"
     private_ips = ["172.16.10.100"]
     security_groups = ["${aws_security_group.foo.id}"]
-    tags {
+  tags = {
         Name = "bar_interface"
     }
 }

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -733,7 +733,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   custom_json = "{\"key\": \"value\"}"
   configuration_manager_version = "11.10"
   use_opsworks_security_groups = false
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -822,7 +822,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   custom_json = "{\"key\": \"value\"}"
   configuration_manager_version = "11.10"
   use_opsworks_security_groups = false
-  tags {
+  tags = {
     wut = "asdf"
   }
 }
@@ -1027,7 +1027,7 @@ func testAccAwsOpsworksStackConfigVpcCreate(name string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "tf-acc" {
   cidr_block = "10.3.5.0/24"
-  tags {
+  tags = {
     Name = "terraform-testacc-opsworks-stack-vpc-create"
   }
 }
@@ -1035,7 +1035,7 @@ resource "aws_subnet" "tf-acc" {
   vpc_id = "${aws_vpc.tf-acc.id}"
   cidr_block = "${aws_vpc.tf-acc.cidr_block}"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-opsworks-stack-vpc-create"
   }
 }
@@ -1124,7 +1124,7 @@ func testAccAWSOpsworksStackConfigVpcUpdate(name string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "tf-acc" {
   cidr_block = "10.3.5.0/24"
-  tags {
+  tags = {
     Name = "terraform-testacc-opsworks-stack-vpc-update"
   }
 }
@@ -1132,7 +1132,7 @@ resource "aws_subnet" "tf-acc" {
   vpc_id = "${aws_vpc.tf-acc.id}"
   cidr_block = "${aws_vpc.tf-acc.cidr_block}"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-opsworks-stack-vpc-update"
   }
 }

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -391,7 +391,7 @@ resource "aws_db_parameter_group" "bar" {
     apply_method = "pending-reboot"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -428,7 +428,7 @@ resource "aws_db_parameter_group" "bar" {
     apply_method = "pending-reboot"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -467,7 +467,7 @@ resource "aws_db_parameter_group" "bar" {
     apply_method = "pending-reboot"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -492,7 +492,7 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-rds-cluster-instance-name-prefix"
 	}
 }
@@ -501,7 +501,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-instance-name-prefix-a"
   }
 }
@@ -510,7 +510,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-instance-name-prefix-b"
   }
 }
@@ -539,7 +539,7 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-rds-cluster-instance-generated-name"
 	}
 }
@@ -548,7 +548,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-instance-generated-name-a"
   }
 }
@@ -557,7 +557,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-instance-generated-name-b"
   }
 }
@@ -621,7 +621,7 @@ resource "aws_db_parameter_group" "bar" {
     apply_method = "pending-reboot"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -718,7 +718,7 @@ resource "aws_db_parameter_group" "bar" {
     apply_method = "pending-reboot"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -779,7 +779,7 @@ resource "aws_db_parameter_group" "bar" {
     value = "10"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }

--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -375,7 +375,7 @@ resource "aws_rds_cluster_parameter_group" "bar" {
     value = "utf8"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -400,7 +400,7 @@ resource "aws_rds_cluster_parameter_group" "bar" {
 		apply_method = "pending-reboot"
   }
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -439,7 +439,7 @@ resource "aws_rds_cluster_parameter_group" "bar" {
     value = "utf8_unicode_ci"
   }
 
-  tags {
+  tags = {
     foo = "bar"
     baz = "foo"
   }

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -1314,7 +1314,7 @@ resource "aws_rds_cluster" "default" {
   master_password = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.aurora5.6"
   skip_final_snapshot = true
-  tags {
+  tags = {
     Environment = "production"
   }
   enabled_cloudwatch_logs_exports = [
@@ -1349,7 +1349,7 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-rds-cluster-name-prefix"
 	}
 }
@@ -1358,7 +1358,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-name-prefix-a"
   }
 }
@@ -1367,7 +1367,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-name-prefix-b"
   }
 }
@@ -1467,7 +1467,7 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "%s-vpc"
 	}
 }
@@ -1476,7 +1476,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "%s-subnet-a"
   }
 }
@@ -1485,7 +1485,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "%s-subnet-b"
   }
 }
@@ -1508,7 +1508,7 @@ resource "aws_rds_cluster" "test" {
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-rds-cluster-generated-name"
 	}
 }
@@ -1517,7 +1517,7 @@ resource "aws_subnet" "a" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.0.0/24"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-generated-name-a"
   }
 }
@@ -1526,7 +1526,7 @@ resource "aws_subnet" "b" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.0.1.0/24"
   availability_zone = "us-west-2b"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-generated-name-b"
   }
 }
@@ -1548,7 +1548,7 @@ resource "aws_rds_cluster" "default" {
   master_password = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.aurora5.6"
   final_snapshot_identifier = "tf-acctest-rdscluster-snapshot-%d"
-  tags {
+  tags = {
     Environment = "production"
   }
 }`, n, n)
@@ -1574,7 +1574,7 @@ resource "aws_rds_cluster" "default" {
   master_password = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.aurora5.6"
   skip_final_snapshot = true
-  tags {
+  tags = {
     Environment = "production"
     AnotherTag = "test"
   }
@@ -1829,7 +1829,7 @@ resource "aws_rds_cluster" "default" {
   master_password = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.aurora5.6"
   skip_final_snapshot = true
-  tags {
+  tags = {
     Environment = "production"
   }
   depends_on = ["aws_iam_role.another_rds_sample_role", "aws_iam_role.rds_sample_role"]
@@ -1914,7 +1914,7 @@ resource "aws_rds_cluster" "default" {
   db_cluster_parameter_group_name = "default.aurora5.6"
   skip_final_snapshot = true
   iam_roles = ["${aws_iam_role.rds_sample_role.arn}","${aws_iam_role.another_rds_sample_role.arn}"]
-  tags {
+  tags = {
     Environment = "production"
   }
   depends_on = ["aws_iam_role.another_rds_sample_role", "aws_iam_role.rds_sample_role"]
@@ -1966,7 +1966,7 @@ resource "aws_rds_cluster" "default" {
   db_cluster_parameter_group_name = "default.aurora5.6"
   skip_final_snapshot = true
   iam_roles = ["${aws_iam_role.another_rds_sample_role.arn}"]
-  tags {
+  tags = {
     Environment = "production"
   }
 
@@ -2053,7 +2053,7 @@ resource "aws_kms_key" "kms_key_east" {
 resource "aws_vpc" "main" {
   provider   = "aws.useast1"
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
   	Name = "terraform-acctest-rds-cluster-encrypted-cross-region-replica"
   }
 }
@@ -2064,7 +2064,7 @@ resource "aws_subnet" "db" {
   vpc_id            = "${aws_vpc.main.id}"
   availability_zone = "${data.aws_availability_zones.us-east-1.names[count.index]}"
   cidr_block        = "10.0.${count.index}.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-rds-cluster-encrypted-cross-region-replica-${count.index}"
   }
 }
@@ -2297,7 +2297,7 @@ resource "aws_rds_cluster" "test" {
   skip_final_snapshot = true
   snapshot_identifier = "${aws_db_cluster_snapshot.test.id}"
 
-  tags {
+  tags = {
     key1 = "value1"
   }
 }
@@ -2365,7 +2365,7 @@ resource "aws_rds_cluster" "test" {
   snapshot_identifier    = "${aws_db_cluster_snapshot.test.id}"
   vpc_security_group_ids = ["${data.aws_security_group.default.id}"]
 
-  tags {
+  tags = {
     key1 = "value1"
   }
 }

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -1153,7 +1153,7 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 7
   allow_version_upgrade = false
   skip_final_snapshot = true
-  tags {
+  tags = {
     environment = "Production"
     cluster = "reader"
     Type = "master"
@@ -1173,7 +1173,7 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 7
   allow_version_upgrade = false
   skip_final_snapshot = true
-  tags {
+  tags = {
     environment = "Production"
   }
 }`, rInt)
@@ -1183,13 +1183,13 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "foo" {
 		cidr_block = "10.1.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-redshift-cluster-not-publicly-accessible"
 		}
 	}
 	resource "aws_internet_gateway" "foo" {
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			foo = "bar"
 		}
 	}
@@ -1197,7 +1197,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 		cidr_block = "10.1.1.0/24"
 		availability_zone = "us-west-2a"
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-redshift-cluster-not-publicly-accessible-foo"
 		}
 	}
@@ -1205,7 +1205,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 		cidr_block = "10.1.2.0/24"
 		availability_zone = "us-west-2b"
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-redshift-cluster-not-publicly-accessible-bar"
 		}
 	}
@@ -1213,7 +1213,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 		cidr_block = "10.1.3.0/24"
 		availability_zone = "us-west-2c"
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-redshift-cluster-not-publicly-accessible-foobar"
 		}
 	}
@@ -1243,13 +1243,13 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "foo" {
 		cidr_block = "10.1.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-redshift-cluster-upd-publicly-accessible"
 		}
 	}
 	resource "aws_internet_gateway" "foo" {
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			foo = "bar"
 		}
 	}
@@ -1257,7 +1257,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 		cidr_block = "10.1.1.0/24"
 		availability_zone = "us-west-2a"
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-redshift-cluster-upd-publicly-accessible-foo"
 		}
 	}
@@ -1265,7 +1265,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 		cidr_block = "10.1.2.0/24"
 		availability_zone = "us-west-2b"
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-redshift-cluster-upd-publicly-accessible-bar"
 		}
 	}
@@ -1273,7 +1273,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 		cidr_block = "10.1.3.0/24"
 		availability_zone = "us-west-2c"
 		vpc_id = "${aws_vpc.foo.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-redshift-cluster-upd-publicly-accessible-foobar"
 		}
 	}

--- a/aws/resource_aws_redshift_event_subscription_test.go
+++ b/aws/resource_aws_redshift_event_subscription_test.go
@@ -261,7 +261,7 @@ resource "aws_redshift_event_subscription" "bar" {
     "monitoring",
     "security",
   ]
-  tags {
+  tags = {
     Name = "name"
   }
 }`, rInt, rInt)
@@ -282,7 +282,7 @@ resource "aws_redshift_event_subscription" "bar" {
   event_categories = [
     "monitoring",
   ]
-  tags {
+  tags = {
     Name = "new-name"
   }
 }`, rInt, rInt)
@@ -309,7 +309,7 @@ resource "aws_redshift_event_subscription" "bar" {
   event_categories = [
     "configuration",
   ]
-  tags {
+  tags = {
     Name = "name"
   }
 }`, rInt, rInt, rInt)
@@ -342,7 +342,7 @@ func testAccAWSRedshiftEventSubscriptionConfigUpdateSourceIds(rInt int) string {
         event_categories = [
             "configuration",
         ]
-        tags {
+  tags = {
             Name = "name"
         }
     }`, rInt, rInt, rInt, rInt)
@@ -362,7 +362,7 @@ resource "aws_redshift_event_subscription" "bar" {
   event_categories = [
     "monitoring",
   ]
-  tags {
+  tags = {
     Name = "name"
   }
 }`, rInt, rInt)

--- a/aws/resource_aws_redshift_snapshot_copy_grant_test.go
+++ b/aws/resource_aws_redshift_snapshot_copy_grant_test.go
@@ -93,7 +93,7 @@ func testAccAWSRedshiftSnapshotCopyGrant_Basic(rName string) string {
 resource "aws_redshift_snapshot_copy_grant" "basic" {
   snapshot_copy_grant_name = "%s"
 
-  tags {
+  tags = {
     Name = "tf-redshift-snapshot-copy-grant-basic"
   }
 }

--- a/aws/resource_aws_redshift_subnet_group_test.go
+++ b/aws/resource_aws_redshift_subnet_group_test.go
@@ -254,7 +254,7 @@ func testAccRedshiftSubnetGroupConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-redshift-subnet-group"
 	}
 }
@@ -263,7 +263,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-foo"
 	}
 }
@@ -272,7 +272,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-bar"
 	}
 }
@@ -289,7 +289,7 @@ func testAccRedshiftSubnetGroup_updateDescription(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-redshift-subnet-group-upd-description"
 	}
 }
@@ -298,7 +298,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-upd-description-foo"
 	}
 }
@@ -307,7 +307,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-upd-description-bar"
 	}
 }
@@ -324,7 +324,7 @@ func testAccRedshiftSubnetGroupConfigWithTags(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-redshift-subnet-group-with-tags"
 	}
 }
@@ -333,7 +333,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-with-tags-foo"
 	}
 }
@@ -342,7 +342,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-with-tags-bar"
 	}
 }
@@ -350,7 +350,7 @@ resource "aws_subnet" "bar" {
 resource "aws_redshift_subnet_group" "foo" {
 	name = "foo-%d"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-redshift-subnetgroup"
 	}
 }
@@ -361,7 +361,7 @@ func testAccRedshiftSubnetGroupConfigWithTagsUpdated(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-redshift-subnet-group-with-tags"
 	}
 }
@@ -370,7 +370,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-with-tags-foo"
 	}
 }
@@ -379,7 +379,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-with-tags-bar"
 	}
 }
@@ -387,7 +387,7 @@ resource "aws_subnet" "bar" {
 resource "aws_redshift_subnet_group" "foo" {
 	name = "foo-%d"
 	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
-	tags {
+	tags = {
 		Name = "tf-redshift-subnetgroup"
 		environment = "production"
 		foo = "bar"
@@ -400,7 +400,7 @@ func testAccRedshiftSubnetGroupConfig_updateSubnetIds(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-redshift-subnet-group-upd-subnet-ids"
 	}
 }
@@ -409,7 +409,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-foo"
 	}
 }
@@ -418,7 +418,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-bar"
 	}
 }
@@ -427,7 +427,7 @@ resource "aws_subnet" "foobar" {
 	cidr_block = "10.1.3.0/24"
 	availability_zone = "us-west-2c"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-redshift-subnet-group-upd-subnet-ids-foobar"
 	}
 }

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -126,7 +126,7 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.6.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-route53-zone-association-foo"
 	}
 }
@@ -135,7 +135,7 @@ resource "aws_vpc" "bar" {
 	cidr_block = "10.7.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-route53-zone-association-bar"
 	}
 }
@@ -167,7 +167,7 @@ resource "aws_vpc" "foo" {
 	cidr_block = "10.6.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-route53-zone-association-region-foo"
 	}
 }
@@ -177,7 +177,7 @@ resource "aws_vpc" "bar" {
 	cidr_block = "10.7.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-route53-zone-association-region-bar"
 	}
 }

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -702,7 +702,7 @@ func testAccRoute53ZoneConfigTagsSingle(zoneName, tag1Key, tag1Value string) str
 resource "aws_route53_zone" "test" {
   name = "%s."
 
-  tags {
+  tags = {
     %q = %q
   }
 }
@@ -714,7 +714,7 @@ func testAccRoute53ZoneConfigTagsMultiple(zoneName, tag1Key, tag1Value, tag2Key,
 resource "aws_route53_zone" "test" {
   name = "%s."
 
-  tags {
+  tags = {
     %q = %q
     %q = %q
   }
@@ -727,7 +727,7 @@ func testAccRoute53ZoneConfigVPCID(zoneName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "172.29.0.0/24"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route53-zone-private"
   }
 }
@@ -756,7 +756,7 @@ resource "aws_vpc" "test" {
 
   cidr_block = "172.29.0.0/24"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route53-zone-private-region"
   }
 }
@@ -776,7 +776,7 @@ func testAccRoute53ZoneConfigVPCSingle(rName, zoneName string) string {
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -796,7 +796,7 @@ func testAccRoute53ZoneConfigVPCMultiple(rName, zoneName string) string {
 resource "aws_vpc" "test1" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -804,7 +804,7 @@ resource "aws_vpc" "test1" {
 resource "aws_vpc" "test2" {
   cidr_block = "10.2.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_route_table_association_test.go
+++ b/aws/resource_aws_route_table_association_test.go
@@ -108,7 +108,7 @@ func testAccCheckRouteTableAssociationExists(n string, v *ec2.RouteTable) resour
 const testAccRouteTableAssociationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-association"
 	}
 }
@@ -116,7 +116,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-route-table-association"
 	}
 }
@@ -124,7 +124,7 @@ resource "aws_subnet" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-association"
 	}
 }
@@ -146,7 +146,7 @@ resource "aws_route_table_association" "foo" {
 const testAccRouteTableAssociationConfigChange = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-association"
 	}
 }
@@ -154,7 +154,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 	cidr_block = "10.1.1.0/24"
-	tags {
+	tags = {
 		Name = "tf-acc-route-table-association"
 	}
 }
@@ -162,7 +162,7 @@ resource "aws_subnet" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-association"
 	}
 }

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -436,7 +436,7 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 const testAccRouteTableConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table"
 	}
 }
@@ -444,7 +444,7 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table"
 	}
 }
@@ -462,7 +462,7 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigChange = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table"
 	}
 }
@@ -470,7 +470,7 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table"
 	}
 }
@@ -494,7 +494,7 @@ const testAccRouteTableConfigIpv6 = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  tags {
+  tags = {
     Name = "terraform-testacc-route-table-ipv6"
   }
 }
@@ -516,7 +516,7 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigInstance = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-instance"
 	}
 }
@@ -524,7 +524,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-acc-route-table-instance"
 	}
 }
@@ -549,7 +549,7 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigTags = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-tags"
 	}
 }
@@ -557,7 +557,7 @@ resource "aws_vpc" "foo" {
 resource "aws_route_table" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		foo = "bar"
 	}
 }
@@ -566,7 +566,7 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-tags"
 	}
 }
@@ -574,7 +574,7 @@ resource "aws_vpc" "foo" {
 resource "aws_route_table" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		bar = "baz"
 	}
 }
@@ -584,7 +584,7 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableVpcPeeringConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-vpc-peering-foo"
 	}
 }
@@ -592,14 +592,14 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-vpc-peering-foo"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.3.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-vpc-peering-bar"
 	}
 }
@@ -607,7 +607,7 @@ resource "aws_vpc" "bar" {
 resource "aws_internet_gateway" "bar" {
 	vpc_id = "${aws_vpc.bar.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-vpc-peering-bar"
 	}
 }
@@ -615,7 +615,7 @@ resource "aws_internet_gateway" "bar" {
 resource "aws_vpc_peering_connection" "foo" {
 		vpc_id = "${aws_vpc.foo.id}"
 		peer_vpc_id = "${aws_vpc.bar.id}"
-		tags {
+	tags = {
 			foo = "bar"
 		}
 }
@@ -633,7 +633,7 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableVgwRoutePropagationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-vgw-route-propagation"
 	}
 }
@@ -653,7 +653,7 @@ resource "aws_route_table" "foo" {
 const testAccRouteTableConfigPanicEmptyRoute = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.2.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-table-panic-empty-route"
 	}
 }
@@ -671,7 +671,7 @@ func testAccAWSRouteTableConfigRouteTransitGatewayID() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-route-table-transit-gateway-id"
   }
 }
@@ -680,7 +680,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-route-table-transit-gateway-id"
   }
 }

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -481,7 +481,7 @@ func testAccAWSRouteImportStateIdFunc(resourceName string) resource.ImportStateI
 var testAccAWSRouteBasicConfig = fmt.Sprint(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-basic"
 	}
 }
@@ -489,7 +489,7 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-basic"
 	}
 }
@@ -509,7 +509,7 @@ var testAccAWSRouteConfigIpv6InternetGateway = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  tags {
+  tags = {
     Name = "terraform-testacc-route-ipv6-igw"
   }
 }
@@ -521,7 +521,7 @@ resource "aws_egress_only_internet_gateway" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-ipv6-igw"
 	}
 }
@@ -543,7 +543,7 @@ resource "aws_vpc" "examplevpc" {
   cidr_block = "10.100.0.0/16"
   enable_dns_hostnames = true
   assign_generated_ipv6_cidr_block = true
-  tags {
+  tags = {
     Name = "terraform-testacc-route-ipv6-network-interface"
   }
 }
@@ -553,7 +553,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_internet_gateway" "internet" {
   vpc_id = "${aws_vpc.examplevpc.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-ipv6-network-interface"
   }
 }
@@ -577,7 +577,7 @@ resource "aws_subnet" "router-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = true
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  tags {
+  tags = {
     Name = "tf-acc-route-ipv6-network-interface-router"
   }
 }
@@ -589,7 +589,7 @@ resource "aws_subnet" "client-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = false
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  tags {
+  tags = {
     Name = "tf-acc-route-ipv6-network-interface-client"
   }
 }
@@ -652,7 +652,7 @@ resource "aws_vpc" "examplevpc" {
   cidr_block = "10.100.0.0/16"
   enable_dns_hostnames = true
   assign_generated_ipv6_cidr_block = true
-  tags {
+  tags = {
     Name = "terraform-testacc-route-ipv6-instance"
   }
 }
@@ -662,7 +662,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_internet_gateway" "internet" {
   vpc_id = "${aws_vpc.examplevpc.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-ipv6-instance"
   }
 }
@@ -686,7 +686,7 @@ resource "aws_subnet" "router-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = true
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  tags {
+  tags = {
     Name = "tf-acc-route-ipv6-instance-router"
   }
 }
@@ -698,7 +698,7 @@ resource "aws_subnet" "client-network" {
   assign_ipv6_address_on_creation = true
   map_public_ip_on_launch = false
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  tags {
+  tags = {
     Name = "tf-acc-route-ipv6-instance-client"
   }
 }
@@ -749,7 +749,7 @@ var testAccAWSRouteConfigIpv6PeeringConnection = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.0.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-ipv6-peering-connection"
 	}
 }
@@ -781,7 +781,7 @@ var testAccAWSRouteConfigIpv6 = fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  tags {
+  tags = {
     Name = "terraform-testacc-route-ipv6"
   }
 }
@@ -806,7 +806,7 @@ resource "aws_route" "bar" {
 var testAccAWSRouteBasicConfigChangeCidr = fmt.Sprint(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-change-cidr"
 	}
 }
@@ -814,7 +814,7 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-change-cidr"
 	}
 }
@@ -833,7 +833,7 @@ resource "aws_route" "bar" {
 var testAccAWSRouteNoopChange = fmt.Sprint(`
 resource "aws_vpc" "test" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-route-noop-change"
   }
 }
@@ -845,7 +845,7 @@ resource "aws_route_table" "test" {
 resource "aws_subnet" "test" {
   vpc_id = "${aws_vpc.test.id}"
   cidr_block = "10.10.10.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-route-noop-change"
   }
 }
@@ -866,7 +866,7 @@ resource "aws_instance" "nat" {
 var testAccAWSRouteWithVPCEndpoint = fmt.Sprint(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-route-with-vpc-endpoint"
   }
 }
@@ -874,7 +874,7 @@ resource "aws_vpc" "foo" {
 resource "aws_internet_gateway" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-route-with-vpc-endpoint"
   }
 }
@@ -902,14 +902,14 @@ resource "aws_vpc_endpoint" "baz" {
 var testAccAWSRouteNewRouteTable = fmt.Sprint(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-basic"
 	}
 }
 
 resource "aws_vpc" "bar" {
 	cidr_block = "10.2.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-new-route-table"
 	}
 }
@@ -917,7 +917,7 @@ resource "aws_vpc" "bar" {
 resource "aws_internet_gateway" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-basic"
 	}
 }
@@ -925,7 +925,7 @@ resource "aws_internet_gateway" "foo" {
 resource "aws_internet_gateway" "bar" {
 	vpc_id = "${aws_vpc.bar.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-new-route-table"
 	}
 }
@@ -933,7 +933,7 @@ resource "aws_internet_gateway" "bar" {
 resource "aws_route_table" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-basic"
 	}
 }
@@ -941,7 +941,7 @@ resource "aws_route_table" "foo" {
 resource "aws_route_table" "bar" {
 	vpc_id = "${aws_vpc.bar.id}"
 
-	tags {
+	tags = {
 		Name = "terraform-testacc-route-new-route-table"
 	}
 }
@@ -958,7 +958,7 @@ func testAccAWSRouteConfigTransitGatewayIDDestinatationCidrBlock() string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-route-transit-gateway-id"
   }
 }
@@ -967,7 +967,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-route-transit-gateway-id"
   }
 }

--- a/aws/resource_aws_s3_bucket_metric_test.go
+++ b/aws/resource_aws_s3_bucket_metric_test.go
@@ -630,7 +630,7 @@ resource "aws_s3_bucket_metric" "test" {
   filter {
     prefix = "%s"
 
-    tags {
+  tags = {
       "tag1" = "%s"
       "tag2" = "%s"
     }
@@ -650,7 +650,7 @@ resource "aws_s3_bucket_metric" "test" {
   filter {
     prefix = "%s"
 
-    tags {
+  tags = {
       "tag1" = "%s"
     }
   }
@@ -667,7 +667,7 @@ resource "aws_s3_bucket_metric" "test" {
   name = "%s"
 
   filter {
-    tags {
+  tags = {
       "tag1" = "%s"
       "tag2" = "%s"
     }
@@ -685,7 +685,7 @@ resource "aws_s3_bucket_metric" "test" {
   name   = "%s"
 
   filter {
-    tags {
+  tags = {
       "tag1" = "%s"
     }
   }

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -761,7 +761,7 @@ resource "aws_s3_bucket_object" "object" {
 	bucket = "${aws_s3_bucket.object_bucket_2.bucket}"
 	key = "test-key"
 	content = "stuff"
-	tags {
+	tags = {
 		Key1 = "Value One"
 		Description = "Very interesting"
 	}

--- a/aws/resource_aws_s3_bucket_policy_test.go
+++ b/aws/resource_aws_s3_bucket_policy_test.go
@@ -143,7 +143,7 @@ func testAccAWSS3BucketPolicyConfig(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
 	bucket = "%s"
-	tags {
+	tags = {
 		TestName = "TestAccAWSS3BucketPolicy_basic"
 	}
 }
@@ -179,7 +179,7 @@ func testAccAWSS3BucketPolicyConfig_updated(bucketName string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
 	bucket = "%s"
-	tags {
+	tags = {
 		TestName = "TestAccAWSS3BucketPolicy_basic"
 	}
 }

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1914,7 +1914,7 @@ resource "aws_s3_bucket" "bucket1" {
 	bucket = "tf-test-bucket-1-{{.GUID}}"
 	acl = "private"
 	force_destroy = true
-	tags {
+	tags = {
 		Name = "tf-test-bucket-1-{{.GUID}}"
 		Environment = "{{.GUID}}"
 	}
@@ -1924,7 +1924,7 @@ resource "aws_s3_bucket" "bucket2" {
 	bucket = "tf-test-bucket-2-{{.GUID}}"
 	acl = "private"
 	force_destroy = true
-	tags {
+	tags = {
 		Name = "tf-test-bucket-2-{{.GUID}}"
 		Environment = "{{.GUID}}"
 	}
@@ -1934,7 +1934,7 @@ resource "aws_s3_bucket" "bucket3" {
 	bucket = "tf-test-bucket-3-{{.GUID}}"
 	acl = "private"
 	force_destroy = true
-	tags {
+	tags = {
 		Name = "tf-test-bucket-3-{{.GUID}}"
 		Environment = "{{.GUID}}"
 	}
@@ -1944,7 +1944,7 @@ resource "aws_s3_bucket" "bucket4" {
 	bucket = "tf-test-bucket-4-{{.GUID}}"
 	acl = "private"
 	force_destroy = true
-	tags {
+	tags = {
 		Name = "tf-test-bucket-4-{{.GUID}}"
 		Environment = "{{.GUID}}"
 	}
@@ -1954,7 +1954,7 @@ resource "aws_s3_bucket" "bucket5" {
 	bucket = "tf-test-bucket-5-{{.GUID}}"
 	acl = "private"
 	force_destroy = true
-	tags {
+	tags = {
 		Name = "tf-test-bucket-5-{{.GUID}}"
 		Environment = "{{.GUID}}"
 	}
@@ -1964,7 +1964,7 @@ resource "aws_s3_bucket" "bucket6" {
 	bucket = "tf-test-bucket-6-{{.GUID}}"
 	acl = "private"
 	force_destroy = true
-	tags {
+	tags = {
 		Name = "tf-test-bucket-6-{{.GUID}}"
 		Environment = "{{.GUID}}"
 	}
@@ -2340,7 +2340,7 @@ resource "aws_s3_bucket" "bucket" {
 		prefix = "path4/"
 		enabled = true
 
-		tags {
+	tags = {
 			"tagKey" = "tagValue"
 			"terraform" = "hashicorp"
 		}
@@ -2835,7 +2835,7 @@ resource "aws_s3_bucket" "bucket" {
             priority = 42
 
             filter {
-                tags {
+  tags = {
                     ReplicateMe = "Yes"
                 }
             }
@@ -2882,7 +2882,7 @@ resource "aws_s3_bucket" "bucket" {
             filter {
                 prefix = "foo"
 
-                tags {
+  tags = {
                     AnotherTag  = "OK"
                     ReplicateMe = "Yes"
                 }
@@ -2926,7 +2926,7 @@ resource "aws_s3_bucket" "bucket" {
             status = "Enabled"
 
             filter {
-                tags {
+  tags = {
                     AnotherTag  = "OK"
                     Foo         = "Bar"
                     ReplicateMe = "Yes"

--- a/aws/resource_aws_security_group_rule_test.go
+++ b/aws/resource_aws_security_group_rule_test.go
@@ -1376,7 +1376,7 @@ resource "aws_security_group" "web" {
     name = "terraform_test_%d"
     description = "Used in the terraform acceptance tests"
 
-    tags {
+  tags = {
       Name = "tf-acc-test"
     }
 }
@@ -1397,7 +1397,7 @@ const testAccAWSSecurityGroupRuleIngress_ipv6Config = `
 resource "aws_vpc" "tftest" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-rule-ingress-ipv6"
   }
 }
@@ -1405,7 +1405,7 @@ resource "aws_vpc" "tftest" {
 resource "aws_security_group" "web" {
   vpc_id = "${aws_vpc.tftest.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -1425,7 +1425,7 @@ const testAccAWSSecurityGroupRuleIngress_protocolConfig = `
 resource "aws_vpc" "tftest" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-rule-ingress-protocol"
   }
 }
@@ -1433,7 +1433,7 @@ resource "aws_vpc" "tftest" {
 resource "aws_security_group" "web" {
   vpc_id = "${aws_vpc.tftest.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -1472,7 +1472,7 @@ resource "aws_security_group" "web" {
     name = "terraform_test_%d"
     description = "Used in the terraform acceptance tests"
 
-    tags {
+  tags = {
         Name = "tf-acc-test"
     }
 }
@@ -1495,7 +1495,7 @@ resource "aws_security_group" "web" {
     name = "terraform_test_%d"
     description = "Used in the terraform acceptance tests"
 
-                tags {
+  tags = {
                                 Name = "tf-acc-test"
                 }
 }
@@ -1550,7 +1550,7 @@ func testAccAWSSecurityGroupRuleMultiDescription(rInt int, rType string) string 
 	b.WriteString(fmt.Sprintf(`
 resource "aws_vpc" "tf_sgrule_description_test" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-rule-multi-desc"
     }
 }
@@ -1564,14 +1564,14 @@ resource "aws_security_group" "worker" {
     name = "terraform_test_%[1]d"
     vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
     description = "Used in the terraform acceptance tests"
-    tags { Name = "tf-sg-rule-description" }
+  tags = { Name = "tf-sg-rule-description" }
 }
 
 resource "aws_security_group" "nat" {
     name = "terraform_test_%[1]d_nat"
     vpc_id = "${aws_vpc.tf_sgrule_description_test.id}"
     description = "Used in the terraform acceptance tests"
-    tags { Name = "tf-sg-rule-description" }
+  tags = { Name = "tf-sg-rule-description" }
 }
 
 resource "aws_security_group_rule" "%[2]s_rule_1" {
@@ -1626,7 +1626,7 @@ resource "aws_security_group_rule" "egress_rule_4" {
 const testAccAWSSecurityGroupRuleConfigSelfReference = `
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-rule-self-ref"
   }
 }
@@ -1634,7 +1634,7 @@ resource "aws_vpc" "main" {
 resource "aws_security_group" "web" {
   name = "main"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "sg-self-test"
   }
 }
@@ -1653,7 +1653,7 @@ func testAccAWSSecurityGroupRulePartialMatchingConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "default" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-rule-partial-match"
     }
 }
@@ -1661,7 +1661,7 @@ resource "aws_vpc" "default" {
 resource "aws_security_group" "web" {
         name = "tf-other-%d"
         vpc_id = "${aws_vpc.default.id}"
-        tags {
+  tags = {
                 Name        = "tf-other-sg"
         }
 }
@@ -1669,7 +1669,7 @@ resource "aws_security_group" "web" {
 resource "aws_security_group" "nat" {
         name = "tf-nat-%d"
         vpc_id = "${aws_vpc.default.id}"
-        tags {
+  tags = {
                 Name        = "tf-nat-sg"
         }
 }
@@ -1711,7 +1711,7 @@ func testAccAWSSecurityGroupRulePartialMatching_SourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "default" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-rule-partial-match"
     }
 }
@@ -1719,7 +1719,7 @@ resource "aws_vpc" "default" {
 resource "aws_security_group" "web" {
         name = "tf-other-%d"
         vpc_id = "${aws_vpc.default.id}"
-        tags {
+  tags = {
                 Name        = "tf-other-sg"
         }
 }
@@ -1727,7 +1727,7 @@ resource "aws_security_group" "web" {
 resource "aws_security_group" "nat" {
         name = "tf-nat-%d"
         vpc_id = "${aws_vpc.default.id}"
-        tags {
+  tags = {
                 Name        = "tf-nat-sg"
         }
 }
@@ -1758,7 +1758,7 @@ const testAccAWSSecurityGroupRulePrefixListEgressConfig = `
 
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-rule-prefix-list-egress"
     }
 }
@@ -1809,7 +1809,7 @@ resource "aws_security_group" "web" {
     name = "terraform_test_%d"
     description = "Used in the terraform acceptance tests"
 
-                tags {
+  tags = {
                                 Name = "tf-acc-test"
                 }
 }
@@ -1833,7 +1833,7 @@ resource "aws_security_group" "web" {
     name = "terraform_test_%d"
     description = "Used in the terraform acceptance tests"
 
-                tags {
+  tags = {
                                 Name = "tf-acc-test"
                 }
 }
@@ -1857,7 +1857,7 @@ resource "aws_security_group" "web" {
     name = "terraform_test_%d"
     description = "Used in the terraform acceptance tests"
 
-                tags {
+  tags = {
                                 Name = "tf-acc-test"
                 }
 }
@@ -1881,7 +1881,7 @@ resource "aws_security_group" "web" {
     name = "terraform_test_%d"
     description = "Used in the terraform acceptance tests"
 
-                tags {
+  tags = {
                                 Name = "tf-acc-test"
                 }
 }
@@ -1904,7 +1904,7 @@ func testAccAWSSecurityGroupRuleConfigDescriptionAllPorts(rName, description str
 resource "aws_security_group" "test" {
   name = %q
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-security-group-rule"
   }
 }
@@ -1926,7 +1926,7 @@ func testAccAWSSecurityGroupRuleConfigDescriptionAllPortsNonZeroPorts(rName, des
 resource "aws_security_group" "test" {
   name = %q
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-security-group-rule"
   }
 }
@@ -1948,7 +1948,7 @@ func testAccAWSSecurityGroupRuleConfigMultipleRuleSearchingAllProtocolCrash(rNam
 resource "aws_security_group" "test" {
   name = %q
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-security-group-rule"
   }
 }
@@ -1979,7 +1979,7 @@ var testAccAWSSecurityGroupRuleRace = func() string {
 	b.WriteString(fmt.Sprintf(`
 resource "aws_vpc" "default" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-rule-race"
     }
 }
@@ -2018,7 +2018,7 @@ func testAccAWSSecurityGroupRuleSelfInSource(rInt int) string {
 resource "aws_vpc" "foo" {
     cidr_block = "10.1.0.0/16"
 
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-rule-self-ingress"
     }
 }
@@ -2045,7 +2045,7 @@ func testAccAWSSecurityGroupRuleExpectInvalidType(rInt int) string {
 resource "aws_vpc" "foo" {
     cidr_block = "10.1.0.0/16"
 
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-rule-invalid-type"
     }
 }

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -2487,7 +2487,7 @@ func testAccAWSSecurityGroupConfigRuleLimit(egressStartIndex, egressRulesCount i
 	c := `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-rule-limit"
   }
 }
@@ -2497,7 +2497,7 @@ resource "aws_security_group" "test" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.test.id}"
 
-	tags {
+	tags = {
     Name = "tf-acc-test"
   }
 
@@ -2524,7 +2524,7 @@ func testAccAWSSecurityGroupConfigCidrBlockRuleLimit(egressStartIndex, egressRul
 	c := `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-rule-limit"
   }
 }
@@ -2534,7 +2534,7 @@ resource "aws_security_group" "test" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.test.id}"
 
-	tags {
+	tags = {
     Name = "tf-acc-test"
   }
 
@@ -2560,7 +2560,7 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfigEmptyRuleDescription = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-empty-rule-description"
   }
 }
@@ -2586,7 +2586,7 @@ resource "aws_security_group" "web" {
     description = ""
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`
@@ -2594,7 +2594,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigIpv6 = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-ipv6"
   }
 }
@@ -2618,7 +2618,7 @@ resource "aws_security_group" "web" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
-	tags {
+	tags = {
 		Name = "tf-acc-test"
 	}
 }
@@ -2627,7 +2627,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group"
 	}
 }
@@ -2644,7 +2644,7 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
-	tags {
+	tags = {
 		Name = "tf-acc-revoke-test"
 	}
 }
@@ -2653,7 +2653,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfig_revoke_base_removed = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-revoke"
 	}
 }
@@ -2661,7 +2661,7 @@ resource "aws_vpc" "sg-race-revoke" {
 const testAccAWSSecurityGroupConfig_revoke_base = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-revoke"
 	}
 }
@@ -2671,7 +2671,7 @@ resource "aws_security_group" "primary" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.sg-race-revoke.id}"
 
-	tags {
+	tags = {
 		Name = "tf-acc-revoke-test-primary"
 	}
 }
@@ -2681,7 +2681,7 @@ resource "aws_security_group" "secondary" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.sg-race-revoke.id}"
 
-	tags {
+	tags = {
 		Name = "tf-acc-revoke-test-secondary"
 	}
 }
@@ -2690,7 +2690,7 @@ resource "aws_security_group" "secondary" {
 const testAccAWSSecurityGroupConfig_revoke_false = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-revoke"
 	}
 }
@@ -2700,7 +2700,7 @@ resource "aws_security_group" "primary" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.sg-race-revoke.id}"
 
-	tags {
+	tags = {
 		Name = "tf-acc-revoke-test-primary"
 	}
 
@@ -2712,7 +2712,7 @@ resource "aws_security_group" "secondary" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.sg-race-revoke.id}"
 
-	tags {
+	tags = {
 		Name = "tf-acc-revoke-test-secondary"
 	}
 
@@ -2723,7 +2723,7 @@ resource "aws_security_group" "secondary" {
 const testAccAWSSecurityGroupConfig_revoke_true = `
 resource "aws_vpc" "sg-race-revoke" {
   cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-revoke"
 	}
 }
@@ -2733,7 +2733,7 @@ resource "aws_security_group" "primary" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.sg-race-revoke.id}"
 
-	tags {
+	tags = {
 		Name = "tf-acc-revoke-test-primary"
 	}
 
@@ -2745,7 +2745,7 @@ resource "aws_security_group" "secondary" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.sg-race-revoke.id}"
 
-	tags {
+	tags = {
 		Name = "tf-acc-revoke-test-secondary"
 	}
 
@@ -2756,7 +2756,7 @@ resource "aws_security_group" "secondary" {
 const testAccAWSSecurityGroupConfigChange = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-change"
   }
 }
@@ -2793,7 +2793,7 @@ func testAccAWSSecurityGroupConfigRuleDescription(egressDescription, ingressDesc
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-description"
   }
 }
@@ -2819,7 +2819,7 @@ resource "aws_security_group" "web" {
     description = "%s"
   }
 
-	tags {
+	tags = {
 		Name = "tf-acc-test"
 	}
 }
@@ -2829,7 +2829,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigSelf = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-self"
   }
 }
@@ -2858,7 +2858,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigVpc = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-vpc"
   }
 }
@@ -2887,7 +2887,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigVpcNegOneIngress = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-vpc-neg-one-ingress"
 	}
 }
@@ -2909,7 +2909,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigVpcProtoNumIngress = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-vpc-proto-num-ingress"
 	}
 }
@@ -2931,7 +2931,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigMultiIngress = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-multi-ingress"
 	}
 }
@@ -2994,7 +2994,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigTags = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-tags"
 	}
 }
@@ -3004,7 +3004,7 @@ resource "aws_security_group" "foo" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -3013,7 +3013,7 @@ resource "aws_security_group" "foo" {
 const testAccAWSSecurityGroupConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-tags"
 	}
 }
@@ -3023,7 +3023,7 @@ resource "aws_security_group" "foo" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     bar = "baz"
     env = "Production"
   }
@@ -3033,7 +3033,7 @@ resource "aws_security_group" "foo" {
 const testAccAWSSecurityGroupConfig_generatedName = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-generated-name"
 	}
 }
@@ -3041,7 +3041,7 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "web" {
   vpc_id = "${aws_vpc.foo.id}"
 
-	tags {
+	tags = {
 		Name = "tf-acc-test"
 	}
 }
@@ -3050,7 +3050,7 @@ resource "aws_security_group" "web" {
 const testAccAWSSecurityGroupConfigDefaultEgress = `
 resource "aws_vpc" "tf_sg_egress_test" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-default-egress"
     }
 }
@@ -3107,7 +3107,7 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["206.0.0.0/8"]
   }
 
-        tags {
+  tags = {
                 Name = "tf-acc-test"
         }
 }
@@ -3118,7 +3118,7 @@ func testAccAWSSecurityGroupConfig_drift_complex() string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-drift-complex"
 	}
 }
@@ -3176,7 +3176,7 @@ resource "aws_security_group" "web" {
     security_groups = ["${aws_security_group.otherweb.id}"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }`, acctest.RandInt(), acctest.RandInt())
@@ -3233,7 +3233,7 @@ resource "aws_security_group" "foo" {
 const testAccAWSSecurityGroupCombindCIDRandGroups = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-combine-rand-groups"
 	}
 }
@@ -3241,7 +3241,7 @@ resource "aws_vpc" "foo" {
 resource "aws_security_group" "two" {
 	name = "tf-test-1"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-test-1"
 	}
 }
@@ -3249,7 +3249,7 @@ resource "aws_security_group" "two" {
 resource "aws_security_group" "one" {
 	name = "tf-test-2"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-test-w"
 	}
 }
@@ -3257,7 +3257,7 @@ resource "aws_security_group" "one" {
 resource "aws_security_group" "three" {
 	name = "tf-test-3"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "tf-test-3"
 	}
 }
@@ -3279,7 +3279,7 @@ resource "aws_security_group" "mixed" {
     ]
   }
 
-  tags {
+  tags = {
     Name = "tf-mix-test"
   }
 }
@@ -3288,7 +3288,7 @@ resource "aws_security_group" "mixed" {
 const testAccAWSSecurityGroupConfig_ingressWithCidrAndSGs = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-security-group-ingress-w-cidr-and-sg"
 	}
 }
@@ -3298,7 +3298,7 @@ resource "aws_security_group" "other_web" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -3333,7 +3333,7 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -3344,7 +3344,7 @@ resource "aws_security_group" "other_web" {
   name        = "tf_other_acc_tests"
   description = "Used in the terraform acceptance tests"
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -3371,7 +3371,7 @@ resource "aws_security_group" "web" {
     security_groups = ["${aws_security_group.other_web.name}"]
   }
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 }
@@ -3383,7 +3383,7 @@ const testAccAWSSecurityGroupConfig_failWithDiffMismatch = `
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-fail-w-diff-mismatch"
   }
 }
@@ -3427,7 +3427,7 @@ const testAccAWSSecurityGroupConfig_importSelf = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-import-self"
   }
 }
@@ -3463,7 +3463,7 @@ const testAccAWSSecurityGroupConfig_importSourceSecurityGroup = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-import-source-sg"
   }
 }
@@ -3508,7 +3508,7 @@ const testAccAWSSecurityGroupConfig_importIPRangeAndSecurityGroupWithSameRules =
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-import-ip-range-and-sg"
   }
 }
@@ -3558,7 +3558,7 @@ const testAccAWSSecurityGroupConfig_importIPRangesWithSameRules = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-import-ip-ranges"
   }
 }
@@ -3593,7 +3593,7 @@ const testAccAWSSecurityGroupConfigIpv4andIpv6Egress = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  tags {
+  tags = {
       Name = "terraform-testacc-security-group-ipv4-and-ipv6-egress"
   }
 }
@@ -3622,7 +3622,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-prefix-list-egress"
     }
 }
@@ -3670,7 +3670,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc" "tf_sg_prefix_list_ingress_test" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-security-group-prefix-list-ingress"
     }
 }
@@ -3724,7 +3724,7 @@ data "aws_region" "current" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }
@@ -3841,7 +3841,7 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfig_rulesDropOnError_Init = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-drop-rules-test"
   }
 }
@@ -3861,7 +3861,7 @@ resource "aws_security_group" "test" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 
@@ -3880,7 +3880,7 @@ resource "aws_security_group" "test" {
 const testAccAWSSecurityGroupConfig_rulesDropOnError_AddBadRule = `
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-security-group-drop-rules-test"
   }
 }
@@ -3900,7 +3900,7 @@ resource "aws_security_group" "test" {
   description = "Used in the terraform acceptance tests"
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test"
   }
 

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -89,7 +89,7 @@ func testAccServiceDiscoveryPrivateDnsNamespaceConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-service-discovery-private-dns-ns"
   }
 }

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -148,7 +148,7 @@ func testAccServiceDiscoveryServiceConfig_private(rName string, th int) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-service-discovery-service-private"
   }
 }
@@ -179,7 +179,7 @@ func testAccServiceDiscoveryServiceConfig_private_update(rName string, th int) s
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-service-discovery-service-private"
   }
 }

--- a/aws/resource_aws_servicecatalog_portfolio_test.go
+++ b/aws/resource_aws_servicecatalog_portfolio_test.go
@@ -174,7 +174,7 @@ resource "aws_servicecatalog_portfolio" "test" {
   name = "%s"
   description = "test-2"
   provider_name = "test-3"
-  tags {
+  tags = {
     Key1 = "Value One"
   }
 }
@@ -187,7 +187,7 @@ resource "aws_servicecatalog_portfolio" "test" {
   name = "%s"
   description = "test-b"
   provider_name = "test-c"
-  tags {
+  tags = {
     Key1 = "Value 1"
     Key2 = "Value Two"
   }
@@ -201,7 +201,7 @@ resource "aws_servicecatalog_portfolio" "test" {
   name = "%s"
   description = "test-only-change-me"
   provider_name = "test-c"
-  tags {
+  tags = {
     Key3 = "Value Three"
   }
 }

--- a/aws/resource_aws_snapshot_create_volume_permission_test.go
+++ b/aws/resource_aws_snapshot_create_volume_permission_test.go
@@ -66,7 +66,7 @@ resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   size              = 40
 
-  tags {
+  tags = {
     Name = "ebs_snap_perm"
   }
 }

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1290,7 +1290,7 @@ EOF
 
 resource "aws_vpc" "foo" {
     cidr_block = "10.1.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-spot-fleet-request-w-subnet"
     }
 }
@@ -1299,7 +1299,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-spot-fleet-request-w-subnet-foo"
     }
 }
@@ -1308,7 +1308,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-spot-fleet-request-w-subnet-bar"
     }
 }
@@ -1403,7 +1403,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-spot-fleet-request-with-elb-foo"
     }
 }
@@ -1412,7 +1412,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-spot-fleet-request-with-elb-bar"
     }
 }
@@ -1515,7 +1515,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-spot-fleet-request-with-target-groups-foo"
     }
 }
@@ -1524,7 +1524,7 @@ resource "aws_subnet" "bar" {
     cidr_block = "10.1.20.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2b"
-    tags {
+  tags = {
         Name = "tf-acc-spot-fleet-request-with-target-groups-bar"
     }
 }
@@ -1714,7 +1714,7 @@ EOF
 
 resource "aws_vpc" "foo" {
     cidr_block = "10.1.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-spot-fleet-request-multi-instance-types"
     }
 }
@@ -1723,7 +1723,7 @@ resource "aws_subnet" "foo" {
     cidr_block = "10.1.1.0/24"
     vpc_id = "${aws_vpc.foo.id}"
     availability_zone = "us-west-2a"
-    tags {
+  tags = {
         Name = "tf-acc-spot-fleet-request-multi-instance-types"
     }
 }
@@ -2322,7 +2322,7 @@ resource "aws_spot_fleet_request" "foo" {
     launch_specification {
         instance_type = "m1.small"
         ami = "ami-516b9131"
-        tags {
+  tags = {
             First = "TfAccTest"
             Second = "Terraform"
         }

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -549,7 +549,7 @@ func testAccAWSSpotInstanceRequestConfig(rInt int) string {
 		// and verify termination behavior
 		wait_for_fulfillment = true
 
-		tags {
+	tags = {
 			Name = "terraform-test"
 		}
 	}`, rInt)
@@ -579,7 +579,7 @@ func testAccAWSSpotInstanceRequestConfigValidUntil(rInt int, validUntil string) 
 		// and verify termination behavior
 		wait_for_fulfillment = true
 
-		tags {
+	tags = {
 			Name = "terraform-test"
 		}
 	}`, rInt, validUntil)
@@ -603,7 +603,7 @@ func testAccAWSSpotInstanceRequestConfig_withoutSpotPrice(rInt int) string {
 		# and verify termination behavior
 		wait_for_fulfillment = true
 
-		tags {
+	tags = {
 			Name = "terraform-test"
 		}
 	}`, rInt)
@@ -631,7 +631,7 @@ func testAccAWSSpotInstanceRequestConfig_withLaunchGroup(rInt int) string {
 
 		launch_group = "terraform-test-group"
 
-		tags {
+	tags = {
 			Name = "terraform-test"
 		}
 	}`, rInt)
@@ -659,7 +659,7 @@ func testAccAWSSpotInstanceRequestConfig_withBlockDuration(rInt int) string {
 
 		block_duration_minutes = 60
 
-		tags {
+	tags = {
 			Name = "terraform-test"
 		}
 	}`, rInt)
@@ -669,7 +669,7 @@ func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "foo_VPC" {
 		cidr_block = "10.1.0.0/16"
-		tags {
+	tags = {
 			Name = "terraform-testacc-spot-instance-request-vpc"
 		}
 	}
@@ -677,7 +677,7 @@ func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
 	resource "aws_subnet" "foo_VPC" {
 		cidr_block = "10.1.1.0/24"
 		vpc_id = "${aws_vpc.foo_VPC.id}"
-		tags {
+	tags = {
 			Name = "tf-acc-spot-instance-request-vpc"
 		}
 	}
@@ -703,7 +703,7 @@ func testAccAWSSpotInstanceRequestConfigVPC(rInt int) string {
 		// and verify termination behavior
 		wait_for_fulfillment = true
 
-		tags {
+	tags = {
 			Name = "terraform-test-VPC"
 		}
 	}`, rInt)
@@ -725,7 +725,7 @@ func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int)
 		cidr_block           = "10.0.0.0/16"
 		enable_dns_hostnames = true
 
-		tags {
+	tags = {
 			Name = "terraform-testacc-spot-instance-request-subnet-and-sg-public-ip"
 		}
 	}
@@ -735,7 +735,7 @@ func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int)
 		cidr_block              = "10.0.0.0/24"
 		map_public_ip_on_launch = true
 
-		tags {
+	tags = {
 			Name = "tf-acc-spot-instance-request-subnet-and-sg-public-ip"
 		}
 	}
@@ -745,7 +745,7 @@ func testAccAWSSpotInstanceRequestConfig_SubnetAndSGAndPublicIpAddress(rInt int)
 		description = "tf_test_sg_ssh"
 		vpc_id      = "${aws_vpc.default.id}"
 
-		tags {
+	tags = {
 			Name = "tf_test_sg_ssh-%d"
 		}
 	}`, rInt, rInt)

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -695,7 +695,7 @@ func testAccAWSSQSConfigWithTags(r string) string {
 resource "aws_sqs_queue" "queue" {
   name = "%s"
 
-  tags {
+  tags = {
     Environment = "production"
     Usage = "original"
   }
@@ -708,7 +708,7 @@ func testAccAWSSQSConfigWithTagsChanged(r string) string {
 resource "aws_sqs_queue" "queue" {
   name = "%s"
 
-  tags {
+  tags = {
     Usage = "changed"
   }
 }

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -498,7 +498,7 @@ data "aws_ami" "amzn" {
 
 resource "aws_vpc" "main" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }
@@ -527,7 +527,7 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
   vpc_security_group_ids = ["${aws_security_group.tf_test_foo.id}"]
   subnet_id = "${aws_subnet.first.id}"
-  tags {
+  tags = {
     Name = "${var.name}"
   }
 }

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -721,7 +721,7 @@ resource "aws_ssm_document" "foo" {
     }
 DOC
 
-  tags {
+  tags = {
     %s = %q
   }
 }
@@ -754,7 +754,7 @@ resource "aws_ssm_document" "foo" {
     }
 DOC
 
-  tags {
+  tags = {
     %s = %q
     %s = %q
   }

--- a/aws/resource_aws_storagegateway_cache_test.go
+++ b/aws/resource_aws_storagegateway_cache_test.go
@@ -167,7 +167,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -198,7 +198,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
+++ b/aws/resource_aws_storagegateway_cached_iscsi_volume_test.go
@@ -248,7 +248,7 @@ resource "aws_ebs_volume" "test" {
   size              = 10
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -295,7 +295,7 @@ resource "aws_ebs_volume" "cachevolume" {
   size              = 10
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -331,7 +331,7 @@ resource "aws_ebs_volume" "snapvolume" {
   size              = 5
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -339,7 +339,7 @@ resource "aws_ebs_volume" "snapvolume" {
 resource "aws_ebs_snapshot" "test" {
   volume_id = "${aws_ebs_volume.snapvolume.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -380,7 +380,7 @@ resource "aws_ebs_volume" "test" {
   size              = 10
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -398,7 +398,7 @@ func testAccAWSStorageGateway_VPCBase(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -407,7 +407,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -415,7 +415,7 @@ resource "aws_subnet" "test" {
 resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -428,7 +428,7 @@ resource "aws_route_table" "test" {
     gateway_id = "${aws_internet_gateway.test.id}"
   }
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -455,7 +455,7 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -490,7 +490,7 @@ resource "aws_instance" "test" {
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   subnet_id                   = "${aws_subnet.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -525,7 +525,7 @@ resource "aws_instance" "test" {
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   subnet_id                   = "${aws_subnet.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -594,7 +594,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -606,7 +606,7 @@ resource "aws_subnet" "test" {
   cidr_block        = "10.0.${count.index}.0/24"
   vpc_id            = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -614,7 +614,7 @@ resource "aws_subnet" "test" {
 resource "aws_internet_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -627,7 +627,7 @@ resource "aws_route_table" "test" {
     gateway_id = "${aws_internet_gateway.test.id}"
   }
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -656,7 +656,7 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -671,7 +671,7 @@ resource "aws_directory_service_directory" "test" {
     vpc_id     = "${aws_vpc.test.id}"
   }
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -680,7 +680,7 @@ resource "aws_vpc_dhcp_options" "test" {
   domain_name         = "${aws_directory_service_directory.test.name}"
   domain_name_servers = ["${aws_directory_service_directory.test.dns_ip_addresses}"]
 
-  tags {
+  tags = {
     Name = %q
   }
 }
@@ -714,7 +714,7 @@ resource "aws_instance" "test" {
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]
   subnet_id                   = "${aws_subnet.test.*.id[0]}"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_storagegateway_upload_buffer_test.go
+++ b/aws/resource_aws_storagegateway_upload_buffer_test.go
@@ -140,7 +140,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_storagegateway_working_storage_test.go
+++ b/aws/resource_aws_storagegateway_working_storage_test.go
@@ -140,7 +140,7 @@ resource "aws_ebs_volume" "test" {
   size              = "10"
   type              = "gp2"
 
-  tags {
+  tags = {
     Name = %q
   }
 }

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -340,7 +340,7 @@ func testAccCheckSubnetExists(n string, v *ec2.Subnet) resource.TestCheckFunc {
 const testAccSubnetConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-subnet"
 	}
 }
@@ -349,7 +349,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
-	tags {
+	tags = {
 		Name = "tf-acc-subnet"
 	}
 }
@@ -359,7 +359,7 @@ const testAccSubnetConfigPreIpv6 = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-subnet-ipv6"
 	}
 }
@@ -368,7 +368,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.10.1.0/24"
 	vpc_id = "${aws_vpc.foo.id}"
 	map_public_ip_on_launch = true
-	tags {
+	tags = {
 		Name = "tf-acc-subnet-ipv6"
 	}
 }
@@ -378,7 +378,7 @@ const testAccSubnetConfigIpv6 = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-subnet-ipv6"
 	}
 }
@@ -389,7 +389,7 @@ resource "aws_subnet" "foo" {
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
 	map_public_ip_on_launch = true
 	assign_ipv6_address_on_creation = true
-	tags {
+	tags = {
 		Name = "tf-acc-subnet-ipv6"
 	}
 }
@@ -399,7 +399,7 @@ const testAccSubnetConfigIpv6UpdateAssignIpv6OnCreation = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-subnet-assign-ipv6-on-creation"
 	}
 }
@@ -410,7 +410,7 @@ resource "aws_subnet" "foo" {
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 1)}"
 	map_public_ip_on_launch = true
 	assign_ipv6_address_on_creation = false
-	tags {
+	tags = {
 		Name = "tf-acc-subnet-assign-ipv6-on-creation"
 	}
 }
@@ -420,7 +420,7 @@ const testAccSubnetConfigIpv6UpdateIpv6Cidr = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.10.0.0/16"
 	assign_generated_ipv6_cidr_block = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-subnet-ipv6-update-cidr"
 	}
 }
@@ -431,7 +431,7 @@ resource "aws_subnet" "foo" {
 	ipv6_cidr_block = "${cidrsubnet(aws_vpc.foo.ipv6_cidr_block, 8, 3)}"
 	map_public_ip_on_launch = true
 	assign_ipv6_address_on_creation = false
-	tags {
+	tags = {
 		Name = "tf-acc-subnet-ipv6-update-cidr"
 	}
 }
@@ -444,7 +444,7 @@ provider "aws" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-subnet"
   }
 }
@@ -453,7 +453,7 @@ resource "aws_subnet" "foo" {
   cidr_block = "10.1.1.0/24"
   vpc_id = "${aws_vpc.foo.id}"
   availability_zone_id = "usw2-az3"
-  tags {
+  tags = {
     Name = "tf-acc-subnet"
   }
 }

--- a/aws/resource_aws_volume_attachment_test.go
+++ b/aws/resource_aws_volume_attachment_test.go
@@ -190,7 +190,7 @@ resource "aws_instance" "web" {
   ami = "ami-21f78e11"
   availability_zone = "us-west-2a"
   instance_type = "t1.micro"
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }
@@ -201,7 +201,7 @@ resource "aws_instance" "web" {
   ami = "ami-21f78e11"
   availability_zone = "us-west-2a"
   instance_type = "t1.micro"
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }
@@ -223,7 +223,7 @@ resource "aws_instance" "web" {
   ami = "ami-21f78e11"
   availability_zone = "us-west-2a"
   instance_type = "t1.micro"
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }
@@ -231,7 +231,7 @@ resource "aws_instance" "web" {
 resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   size = 1
-  tags {
+  tags = {
     Name = "TestVolume"
   }
 }

--- a/aws/resource_aws_vpc_dhcp_options_association_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_association_test.go
@@ -78,7 +78,7 @@ func testAccCheckDHCPOptionsAssociationExist(n string, vpc *ec2.Vpc) resource.Te
 const testAccDHCPOptionsAssociationConfig = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-dhcp-options-association"
 	}
 }
@@ -90,7 +90,7 @@ resource "aws_vpc_dhcp_options" "foo" {
 	netbios_name_servers = ["127.0.0.1"]
 	netbios_node_type = 2
 
-	tags {
+	tags = {
 		Name = "foo"
 	}
 }

--- a/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_test.go
@@ -173,7 +173,7 @@ resource "aws_vpc_dhcp_options" "foo" {
 	netbios_name_servers = ["127.0.0.1"]
 	netbios_node_type = 2
 
-	tags {
+	tags = {
 		Name = "foo-name"
 	}
 }

--- a/aws/resource_aws_vpc_endpoint_connection_notification_test.go
+++ b/aws/resource_aws_vpc_endpoint_connection_notification_test.go
@@ -127,7 +127,7 @@ func testAccVpcEndpointConnectionNotificationBasicConfig(lbName string) string {
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-connection-notification"
   }
 }
@@ -145,7 +145,7 @@ resource "aws_lb" "nlb_test" {
   idle_timeout               = 60
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "testAccVpcEndpointConnectionNotificationBasicConfig_nlb"
   }
 }
@@ -155,7 +155,7 @@ resource "aws_subnet" "nlb_test_1" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-connection-notification-1"
   }
 }
@@ -165,7 +165,7 @@ resource "aws_subnet" "nlb_test_2" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-connection-notification-2"
   }
 }
@@ -216,7 +216,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 		resource "aws_vpc" "nlb_test" {
 			cidr_block = "10.0.0.0/16"
 
-			tags {
+	tags = {
 				Name = "terraform-testacc-vpc-endpoint-connection-notification"
 			}
 		}
@@ -234,7 +234,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 			idle_timeout               = 60
 			enable_deletion_protection = false
 
-			tags {
+	tags = {
 				Name = "testAccVpcEndpointConnectionNotificationBasicConfig_nlb"
 			}
 		}
@@ -244,7 +244,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 			cidr_block        = "10.0.1.0/24"
 			availability_zone = "us-west-2a"
 
-			tags {
+	tags = {
 				Name = "tf-acc-vpc-endpoint-connection-notification-1"
 			}
 		}
@@ -254,7 +254,7 @@ func testAccVpcEndpointConnectionNotificationModifiedConfig(lbName string) strin
 			cidr_block        = "10.0.2.0/24"
 			availability_zone = "us-west-2b"
 
-			tags {
+	tags = {
 				Name = "tf-acc-vpc-endpoint-connection-notification-2"
 			}
 		}

--- a/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -109,7 +109,7 @@ provider "aws" {
 
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
-    tags {
+  tags = {
         Name = "terraform-testacc-vpc-endpoint-route-table-association"
     }
 }
@@ -122,7 +122,7 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_route_table" "rt" {
     vpc_id = "${aws_vpc.foo.id}"
 
-    tags {
+  tags = {
         Name = "test"
     }
 }

--- a/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_allowed_principal_test.go
@@ -100,7 +100,7 @@ func testAccVpcEndpointServiceAllowedPrincipalBasicConfig(lbName string) string 
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-service-allowed-principal"
   }
 }
@@ -118,7 +118,7 @@ resource "aws_lb" "nlb_test_1" {
   idle_timeout               = 60
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "testAccVpcEndpointServiceBasicConfig_nlb1"
   }
 }
@@ -128,7 +128,7 @@ resource "aws_subnet" "nlb_test_1" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-allowed-principal-1"
   }
 }
@@ -138,7 +138,7 @@ resource "aws_subnet" "nlb_test_2" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-allowed-principal-2"
   }
 }

--- a/aws/resource_aws_vpc_endpoint_service_test.go
+++ b/aws/resource_aws_vpc_endpoint_service_test.go
@@ -164,7 +164,7 @@ func testAccVpcEndpointServiceBasicConfig(lb1Name string) string {
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-service"
   }
 }
@@ -182,7 +182,7 @@ resource "aws_lb" "nlb_test_1" {
   idle_timeout               = 60
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "testAccVpcEndpointServiceBasicConfig_nlb1"
   }
 }
@@ -192,7 +192,7 @@ resource "aws_subnet" "nlb_test_1" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-1"
   }
 }
@@ -202,7 +202,7 @@ resource "aws_subnet" "nlb_test_2" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-2"
   }
 }
@@ -229,7 +229,7 @@ func testAccVpcEndpointServiceModifiedConfig(lb1Name, lb2Name string) string {
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-service"
   }
 }
@@ -247,7 +247,7 @@ resource "aws_lb" "nlb_test_1" {
   idle_timeout               = 60
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "testAccVpcEndpointServiceBasicConfig_nlb1"
   }
 }
@@ -265,7 +265,7 @@ resource "aws_lb" "nlb_test_2" {
 	idle_timeout               = 60
 	enable_deletion_protection = false
 
-	tags {
+	tags = {
 	  Name = "testAccVpcEndpointServiceBasicConfig_nlb2"
 	}
   }
@@ -275,7 +275,7 @@ resource "aws_subnet" "nlb_test_1" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-1"
   }
 }
@@ -285,7 +285,7 @@ resource "aws_subnet" "nlb_test_2" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "us-west-2b"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-service-2"
   }
 }

--- a/aws/resource_aws_vpc_endpoint_subnet_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_subnet_association_test.go
@@ -128,7 +128,7 @@ func testAccCheckVpcEndpointSubnetAssociationExists(n string, vpce *ec2.VpcEndpo
 const testAccVpcEndpointSubnetAssociationConfig_basic = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-subnet-association"
   }
 }
@@ -154,7 +154,7 @@ resource "aws_subnet" "sn" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "10.0.0.0/17"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-subnet-association"
   }
 }
@@ -168,7 +168,7 @@ resource "aws_vpc_endpoint_subnet_association" "a" {
 const testAccVpcEndpointSubnetAssociationConfig_multiple = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-subnet-association"
   }
 }
@@ -196,7 +196,7 @@ resource "aws_subnet" "sn" {
   vpc_id            = "${aws_vpc.foo.id}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   cidr_block        = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, count.index)}"
-  tags {
+  tags = {
     Name = "${format("tf-acc-vpc-endpoint-subnet-association-%d", count.index + 1)}"
   }
 }

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -317,7 +317,7 @@ func testAccCheckVpcEndpointPrefixListAvailable(n string) resource.TestCheckFunc
 const testAccVpcEndpointConfig_gatewayWithRouteTableAndPolicy = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-gw-w-route-table-and-policy"
   }
 }
@@ -325,7 +325,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-gw-w-route-table-and-policy"
   }
 }
@@ -363,7 +363,7 @@ resource "aws_route_table_association" "main" {
 const testAccVpcEndpointConfig_gatewayWithRouteTableAndPolicyModified = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-gw-w-route-table-and-policy"
   }
 }
@@ -371,7 +371,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "10.0.1.0/24"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-gw-w-route-table-and-policy"
   }
 }
@@ -407,7 +407,7 @@ resource "aws_route_table_association" "main" {
 const testAccVpcEndpointConfig_gatewayWithoutRouteTableOrPolicy = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-gw-wout-route-table-or-policy"
   }
 }
@@ -423,7 +423,7 @@ resource "aws_vpc_endpoint" "s3" {
 const testAccVpcEndpointConfig_interfaceWithoutSubnet = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-iface-wout-subnet"
   }
 }
@@ -448,7 +448,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
   enable_dns_support = true
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
   }
 }
@@ -461,7 +461,7 @@ resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
   }
 }
@@ -470,7 +470,7 @@ resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
   }
 }
@@ -479,7 +479,7 @@ resource "aws_subnet" "sn3" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
   availability_zone = "${data.aws_availability_zones.available.names[2]}"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-3"
   }
 }
@@ -507,7 +507,7 @@ resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
   enable_dns_support = true
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-iface-w-subnet"
   }
 }
@@ -520,7 +520,7 @@ resource "aws_subnet" "sn1" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 0)}"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-1"
   }
 }
@@ -529,7 +529,7 @@ resource "aws_subnet" "sn2" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 1)}"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-2"
   }
 }
@@ -538,7 +538,7 @@ resource "aws_subnet" "sn3" {
   vpc_id = "${aws_vpc.foo.id}"
   cidr_block = "${cidrsubnet(aws_vpc.foo.cidr_block, 2, 2)}"
   availability_zone = "${data.aws_availability_zones.available.names[2]}"
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-w-subnet-3"
   }
 }
@@ -566,7 +566,7 @@ func testAccVpcEndpointConfig_interfaceNonAWSService(lbName string) string {
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-endpoint-iface-non-aws-svc"
   }
 }
@@ -584,7 +584,7 @@ resource "aws_lb" "nlb_test_1" {
   idle_timeout               = 60
   enable_deletion_protection = false
 
-  tags {
+  tags = {
     Name = "testAccVpcEndpointServiceBasicConfig_nlb1"
   }
 }
@@ -598,7 +598,7 @@ resource "aws_subnet" "nlb_test_1" {
   cidr_block        = "10.0.1.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[0]}"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-non-aws-svc-1"
   }
 }
@@ -608,7 +608,7 @@ resource "aws_subnet" "nlb_test_2" {
   cidr_block        = "10.0.2.0/24"
   availability_zone = "${data.aws_availability_zones.available.names[1]}"
 
-  tags {
+  tags = {
     Name = "tf-acc-vpc-endpoint-iface-non-aws-svc-2"
   }
 }

--- a/aws/resource_aws_vpc_ipv4_cidr_block_association_test.go
+++ b/aws/resource_aws_vpc_ipv4_cidr_block_association_test.go
@@ -134,7 +134,7 @@ func testAccCheckAwsVpcIpv4CidrBlockAssociationExists(n string, association *ec2
 const testAccAwsVpcIpv4CidrBlockAssociationConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-ipv4-cidr-block-association"
   }
 }

--- a/aws/resource_aws_vpc_peering_connection_accepter_test.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter_test.go
@@ -65,14 +65,14 @@ func testAccAwsVPCPeeringConnectionAccepterDestroy(s *terraform.State) error {
 const testAccAwsVPCPeeringConnectionAccepterSameRegion = `
 resource "aws_vpc" "main" {
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-peering-conn-accepter-same-region-main"
 	}
 }
 
 resource "aws_vpc" "peer" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-peering-conn-accepter-same-region-peer"
 	}
 }
@@ -105,7 +105,7 @@ provider "aws" {
 resource "aws_vpc" "main" {
 	provider = "aws.main"
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-peering-conn-accepter-diff-region-main"
 	}
 }
@@ -113,7 +113,7 @@ resource "aws_vpc" "main" {
 resource "aws_vpc" "peer" {
 	provider = "aws.peer"
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-peering-conn-accepter-diff-region-peer"
 	}
 }

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -90,7 +90,7 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 const testAccVpcPeeringConnectionOptionsConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-options-foo"
   }
 }
@@ -98,7 +98,7 @@ resource "aws_vpc" "foo" {
 resource "aws_vpc" "bar" {
   cidr_block = "10.1.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-options-bar"
   }
 }

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -382,14 +382,14 @@ func TestAccAWSVPCPeeringConnection_region(t *testing.T) {
 const testAccVpcPeeringConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-foo"
   }
 }
 
 resource "aws_vpc" "bar" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-bar"
   }
 }
@@ -404,14 +404,14 @@ resource "aws_vpc_peering_connection" "foo" {
 const testAccVpcPeeringConfigTags = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-tags-foo"
   }
 }
 
 resource "aws_vpc" "bar" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-tags-bar"
   }
 }
@@ -420,7 +420,7 @@ resource "aws_vpc_peering_connection" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   peer_vpc_id = "${aws_vpc.bar.id}"
   auto_accept = true
-  tags {
+  tags = {
     foo = "bar"
   }
 }
@@ -429,7 +429,7 @@ resource "aws_vpc_peering_connection" "foo" {
 const testAccVpcPeeringConfigOptions = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-options-foo"
   }
 }
@@ -437,7 +437,7 @@ resource "aws_vpc" "foo" {
 resource "aws_vpc" "bar" {
   cidr_block = "10.1.0.0/16"
   enable_dns_hostnames = true
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-options-bar"
   }
 }
@@ -461,14 +461,14 @@ resource "aws_vpc_peering_connection" "foo" {
 const testAccVpcPeeringConfigFailedState = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-failed-state-foo"
   }
 }
 
 resource "aws_vpc" "bar" {
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-failed-state-bar"
   }
 }
@@ -493,7 +493,7 @@ provider "aws" {
 resource "aws_vpc" "foo" {
   provider = "aws.main"
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-foo"
   }
 }
@@ -501,7 +501,7 @@ resource "aws_vpc" "foo" {
 resource "aws_vpc" "bar" {
   provider = "aws.peer"
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-bar"
   }
 }
@@ -529,7 +529,7 @@ provider "aws" {
 resource "aws_vpc" "foo" {
   provider = "aws.main"
   cidr_block = "10.0.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-region-foo"
   }
 }
@@ -537,7 +537,7 @@ resource "aws_vpc" "foo" {
 resource "aws_vpc" "bar" {
   provider = "aws.peer"
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-peering-conn-region-bar"
   }
 }

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -479,7 +479,7 @@ func TestAccAWSVpc_classiclinkDnsSupportOptionSet(t *testing.T) {
 const testAccVpcConfig = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc"
 	}
 }
@@ -491,7 +491,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = %t
   cidr_block                       = "10.1.0.0/16"
 
-  tags {
+  tags = {
     Name = "terraform-testacc-vpc-ipv6"
   }
 }
@@ -502,7 +502,7 @@ const testAccVpcConfigUpdate = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	enable_dns_hostnames = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc"
 	}
 }
@@ -512,7 +512,7 @@ const testAccVpcConfigTags = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 
-	tags {
+	tags = {
 		foo = "bar"
 		Name = "terraform-testacc-vpc-tags"
 	}
@@ -523,7 +523,7 @@ const testAccVpcConfigTagsUpdate = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 
-	tags {
+	tags = {
 		bar = "baz"
 		Name = "terraform-testacc-vpc-tags"
 	}
@@ -533,7 +533,7 @@ const testAccVpcDedicatedConfig = `
 resource "aws_vpc" "test" {
 	instance_tenancy = "dedicated"
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-dedicated"
 	}
 }
@@ -544,7 +544,7 @@ resource "aws_vpc" "test" {
 	cidr_block = "10.2.0.0/16"
 	enable_dns_hostnames = true
 	enable_dns_support = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-both-dns-opts"
 	}
 }
@@ -554,7 +554,7 @@ const testAccVpcConfig_DisabledDnsSupport = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.2.0.0/16"
 	enable_dns_support = false
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-disabled-dns-support"
 	}
 }
@@ -564,7 +564,7 @@ const testAccVpcConfig_ClassiclinkOption = `
 resource "aws_vpc" "test" {
 	cidr_block = "172.2.0.0/16"
 	enable_classiclink = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-classic-link"
 	}
 }
@@ -575,7 +575,7 @@ resource "aws_vpc" "test" {
 	cidr_block = "172.2.0.0/16"
 	enable_classiclink = true
 	enable_classiclink_dns_support = true
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpc-classic-link-support"
 	}
 }

--- a/aws/resource_aws_vpn_connection_route_test.go
+++ b/aws/resource_aws_vpn_connection_route_test.go
@@ -148,7 +148,7 @@ func testAccAwsVpnConnectionRoute(
 func testAccAwsVpnConnectionRouteConfig(rBgpAsn int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpn_gateway" "vpn_gateway" {
-		tags {
+	tags = {
 			Name = "vpn_gateway"
 		}
 	}
@@ -177,7 +177,7 @@ func testAccAwsVpnConnectionRouteConfig(rBgpAsn int) string {
 func testAccAwsVpnConnectionRouteConfigUpdate(rBgpAsn int) string {
 	return fmt.Sprintf(`
 	resource "aws_vpn_gateway" "vpn_gateway" {
-		tags {
+	tags = {
 			Name = "vpn_gateway"
 		}
 	}

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -378,7 +378,7 @@ func TestAWSVpnConnection_xmlconfig(t *testing.T) {
 func testAccAwsVpnConnectionConfig(rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "vpn_gateway" {
-  tags {
+  tags = {
     Name = "vpn_gateway"
   }
 }
@@ -387,7 +387,7 @@ resource "aws_customer_gateway" "customer_gateway" {
   bgp_asn = %d
   ip_address = "178.0.0.1"
   type = "ipsec.1"
-  tags {
+  tags = {
     Name = "main-customer-gateway"
   }
 }
@@ -405,7 +405,7 @@ resource "aws_vpn_connection" "foo" {
 func testAccAwsVpnConnectionConfigUpdate(rInt, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "vpn_gateway" {
-  tags {
+  tags = {
     Name = "vpn_gateway"
   }
 }
@@ -414,7 +414,7 @@ resource "aws_customer_gateway" "customer_gateway" {
   bgp_asn = %d
   ip_address = "178.0.0.1"
   type = "ipsec.1"
-  tags {
+  tags = {
     Name = "main-customer-gateway-%d"
   }
 }
@@ -431,7 +431,7 @@ resource "aws_vpn_connection" "foo" {
 func testAccAwsVpnConnectionConfigSingleTunnelOptions(rBgpAsn int, psk string, tunnelCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "vpn_gateway" {
-  tags {
+  tags = {
     Name = "vpn_gateway"
   }
 }
@@ -440,7 +440,7 @@ resource "aws_customer_gateway" "customer_gateway" {
   bgp_asn = %d
   ip_address = "178.0.0.1"
   type = "ipsec.1"
-  tags {
+  tags = {
     Name = "main-customer-gateway"
   }
 }
@@ -466,7 +466,7 @@ resource "aws_customer_gateway" "test" {
   ip_address = "178.0.0.1"
   type       = "ipsec.1"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ec2-vpn-connection-transit-gateway-id"
   }
 }
@@ -482,7 +482,7 @@ resource "aws_vpn_connection" "test" {
 func testAccAwsVpnConnectionConfigTunnelOptions(rBgpAsn int, psk string, tunnelCidr string, psk2 string, tunnelCidr2 string) string {
 	return fmt.Sprintf(`
 resource "aws_vpn_gateway" "vpn_gateway" {
-  tags {
+  tags = {
     Name = "vpn_gateway"
   }
 }
@@ -491,7 +491,7 @@ resource "aws_customer_gateway" "customer_gateway" {
   bgp_asn = %d
   ip_address = "178.0.0.1"
   type = "ipsec.1"
-  tags {
+  tags = {
     Name = "main-customer-gateway"
   }
 }

--- a/aws/resource_aws_vpn_gateway_attachment_test.go
+++ b/aws/resource_aws_vpn_gateway_attachment_test.go
@@ -144,7 +144,7 @@ func testAccCheckVpnGatewayAttachmentDestroy(s *terraform.State) error {
 const testAccNoVpnGatewayAttachmentConfig = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpn-gateway-attachment-basic"
 	}
 }
@@ -155,7 +155,7 @@ resource "aws_vpn_gateway" "test" { }
 const testAccVpnGatewayAttachmentConfig = `
 resource "aws_vpc" "test" {
 	cidr_block = "10.0.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpn-gateway-attachment-deleted"
 	}
 }

--- a/aws/resource_aws_vpn_gateway_route_propagation_test.go
+++ b/aws/resource_aws_vpn_gateway_route_propagation_test.go
@@ -73,7 +73,7 @@ func TestAccAWSVPNGatewayRoutePropagation_basic(t *testing.T) {
 const testAccAWSVPNGatewayRoutePropagation_basic = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-vpn-gateway-route-propagation"
 	}
 }

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -492,7 +492,7 @@ func testAccCheckVpnGatewayExists(n string, ig *ec2.VpnGateway) resource.TestChe
 const testAccNoVpnGatewayConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-removed"
   }
 }
@@ -501,14 +501,14 @@ resource "aws_vpc" "foo" {
 const testAccVpnGatewayConfig = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway"
   }
 }
 
 resource "aws_vpn_gateway" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-basic"
   }
 }
@@ -517,14 +517,14 @@ resource "aws_vpn_gateway" "foo" {
 const testAccVpnGatewayConfigChangeVPC = `
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-change-vpc"
   }
 }
 
 resource "aws_vpn_gateway" "foo" {
   vpc_id = "${aws_vpc.bar.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-basic"
   }
 }
@@ -533,14 +533,14 @@ resource "aws_vpn_gateway" "foo" {
 const testAccCheckVpnGatewayConfigTags = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-tags"
   }
 }
 
 resource "aws_vpn_gateway" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-tags"
   }
 }
@@ -549,14 +549,14 @@ resource "aws_vpn_gateway" "foo" {
 const testAccCheckVpnGatewayConfigTagsUpdate = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-tags"
   }
 }
 
 resource "aws_vpn_gateway" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-tags-updated"
   }
 }
@@ -565,28 +565,28 @@ resource "aws_vpn_gateway" "foo" {
 const testAccCheckVpnGatewayConfigReattach = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-foo"
   }
 }
 
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-bar"
   }
 }
 
 resource "aws_vpn_gateway" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
 }
 
 resource "aws_vpn_gateway" "bar" {
   vpc_id = "${aws_vpc.bar.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
 }
@@ -595,28 +595,28 @@ resource "aws_vpn_gateway" "bar" {
 const testAccCheckVpnGatewayConfigReattachChange = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-foo"
   }
 }
 
 resource "aws_vpc" "bar" {
   cidr_block = "10.2.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach-bar"
   }
 }
 
 resource "aws_vpn_gateway" "foo" {
   vpc_id = "${aws_vpc.bar.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
 }
 
 resource "aws_vpn_gateway" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-reattach"
   }
 }
@@ -625,7 +625,7 @@ resource "aws_vpn_gateway" "bar" {
 const testAccVpnGatewayConfigWithAZ = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-with-az"
   }
 }
@@ -633,7 +633,7 @@ resource "aws_vpc" "foo" {
 resource "aws_vpn_gateway" "foo" {
   vpc_id = "${aws_vpc.foo.id}"
   availability_zone = "us-west-2a"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-with-az"
   }
 }
@@ -642,7 +642,7 @@ resource "aws_vpn_gateway" "foo" {
 const testAccVpnGatewayConfigWithASN = `
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-vpn-gateway-with-asn"
   }
 }

--- a/website/docs/d/cloudformation_stack.html.markdown
+++ b/website/docs/d/cloudformation_stack.html.markdown
@@ -23,7 +23,7 @@ resource "aws_instance" "web" {
   instance_type = "t1.micro"
   subnet_id     = "${data.aws_cloudformation_stack.network.outputs["SubnetId"]}"
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -43,7 +43,7 @@ data "aws_eip" "by_public_ip" {
 
 ```hcl
 data "aws_eip" "by_tags" {
-  tags {
+  tags = {
     Name = "exampleNameTagValue"
   }
 }

--- a/website/docs/d/inspector_rules_packages.html.markdown
+++ b/website/docs/d/inspector_rules_packages.html.markdown
@@ -20,7 +20,7 @@ data "aws_inspector_rules_packages" "rules" {}
 
 # e.g. Use in aws_inspector_assessment_template
 resource "aws_inspector_resource_group" "group" {
-  tags {
+  tags = {
     test = "test"
   }
 }

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -29,7 +29,7 @@ resource "aws_security_group" "from_europe" {
     ipv6_cidr_blocks = ["${data.aws_ip_ranges.european_ec2.ipv6_cidr_blocks}"]
   }
 
-  tags {
+  tags = {
     CreateDate = "${data.aws_ip_ranges.european_ec2.create_date}"
     SyncToken  = "${data.aws_ip_ranges.european_ec2.sync_token}"
   }

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -26,7 +26,7 @@ Usage with tags:
 data "aws_nat_gateway" "default" {
   subnet_id = "${aws_subnet.public.id}"
 
-  tags {
+  tags = {
     Name = "gw NAT"
   }
 }

--- a/website/docs/d/network_acls.html.markdown
+++ b/website/docs/d/network_acls.html.markdown
@@ -29,7 +29,7 @@ tag of `Tier` set to a value of "Private".
 data "aws_network_acls" "example" {
   vpc_id = "${var.vpc_id}"
 
-  tags {
+  tags = {
     Tier = "Private"
   }
 }

--- a/website/docs/d/network_interfaces.html.markdown
+++ b/website/docs/d/network_interfaces.html.markdown
@@ -24,7 +24,7 @@ The following example retrieves a list of all network interface ids with a custo
 
 ```hcl
 data "aws_network_interfaces" "example" {
-  tags {
+  tags = {
     Name = "test"
   }
 }

--- a/website/docs/d/security_groups.html.markdown
+++ b/website/docs/d/security_groups.html.markdown
@@ -14,7 +14,7 @@ outside of Terraform.
 ## Example Usage
 ```hcl
 data "aws_security_groups" "test" {
-  tags {
+  tags = {
     Application = "k8s"
     Environment = "dev"
   }

--- a/website/docs/d/subnet_ids.html.markdown
+++ b/website/docs/d/subnet_ids.html.markdown
@@ -39,7 +39,7 @@ can loop through the subnets, putting instances across availability zones.
 data "aws_subnet_ids" "private" {
   vpc_id = "${var.vpc_id}"
 
-  tags {
+  tags = {
     Tier = "Private"
   }
 }

--- a/website/docs/d/vpcs.html.markdown
+++ b/website/docs/d/vpcs.html.markdown
@@ -18,7 +18,7 @@ The following shows outputing all VPC Ids.
 
 ```hcl
 data "aws_vpcs" "foo" {
-  tags {
+  tags = {
     service = "production"
   }
 }

--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -33,7 +33,7 @@ resource "aws_acm_certificate" "cert" {
   domain_name       = "example.com"
   validation_method = "DNS"
 
-  tags {
+  tags = {
     Environment = "test"
   }
 

--- a/website/docs/r/ami_copy.html.markdown
+++ b/website/docs/r/ami_copy.html.markdown
@@ -29,7 +29,7 @@ resource "aws_ami_copy" "example" {
   source_ami_id     = "ami-xxxxxxxx"
   source_ami_region = "us-west-1"
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -29,7 +29,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "mybucket"
   acl    = "private"
 
-  tags {
+  tags = {
     Name = "My bucket"
   }
 }
@@ -134,7 +134,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     }
   }
 
-  tags {
+  tags = {
     Environment = "production"
   }
 

--- a/website/docs/r/cloudhsm_v2_cluster.html.markdown
+++ b/website/docs/r/cloudhsm_v2_cluster.html.markdown
@@ -33,7 +33,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "cloudhsm2_vpc" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
   }
 }
@@ -45,7 +45,7 @@ resource "aws_subnet" "cloudhsm2_subnets" {
   map_public_ip_on_launch = false
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
   }
 }
@@ -54,7 +54,7 @@ resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
   hsm_type   = "hsm1.medium"
   subnet_ids = ["${aws_subnet.cloudhsm2_subnets.*.id}"]
 
-  tags {
+  tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
   }
 }

--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -16,7 +16,7 @@ Provides a CloudWatch Log Group resource.
 resource "aws_cloudwatch_log_group" "yada" {
   name = "Yada"
 
-  tags {
+  tags = {
     Environment = "production"
     Application = "serviceA"
   }

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -135,7 +135,7 @@ resource "aws_codebuild_project" "example" {
     ]
   }
 
-  tags {
+  tags = {
     "Environment" = "Test"
   }
 }

--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -20,7 +20,7 @@ resource "aws_customer_gateway" "main" {
   ip_address = "172.83.124.10"
   type       = "ipsec.1"
 
-  tags {
+  tags = {
     Name = "main-customer-gateway"
   }
 }

--- a/website/docs/r/db_subnet_group.html.markdown
+++ b/website/docs/r/db_subnet_group.html.markdown
@@ -17,7 +17,7 @@ resource "aws_db_subnet_group" "default" {
   name       = "main"
   subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
 
-  tags {
+  tags = {
     Name = "My DB subnet group"
   }
 }

--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -50,7 +50,7 @@ resource "aws_default_route_table" "r" {
     # ...
   }
 
-  tags {
+  tags = {
     Name = "default table"
   }
 }

--- a/website/docs/r/default_subnet.html.markdown
+++ b/website/docs/r/default_subnet.html.markdown
@@ -23,7 +23,7 @@ Basic usage with tags:
 resource "aws_default_subnet" "default_az1" {
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "Default subnet for us-west-2a"
   }
 }

--- a/website/docs/r/default_vpc.html.markdown
+++ b/website/docs/r/default_vpc.html.markdown
@@ -25,7 +25,7 @@ Basic usage with tags:
 
 ```hcl
 resource "aws_default_vpc" "default" {
-  tags {
+  tags = {
     Name = "Default VPC"
   }
 }

--- a/website/docs/r/default_vpc_dhcp_options.html.markdown
+++ b/website/docs/r/default_vpc_dhcp_options.html.markdown
@@ -25,7 +25,7 @@ Basic usage with tags:
 
 ```hcl
 resource "aws_default_vpc_dhcp_options" "default" {
-  tags {
+  tags = {
     Name = "Default DHCP Option Set"
   }
 }

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -28,7 +28,7 @@ resource "aws_directory_service_directory" "bar" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
   }
 
-  tags {
+  tags = {
     Project = "foo"
   }
 }
@@ -64,7 +64,7 @@ resource "aws_directory_service_directory" "bar" {
     subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
   }
 
-  tags {
+  tags = {
     Project = "foo"
   }
 }

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -30,7 +30,7 @@ resource "aws_dms_endpoint" "test" {
   server_name                 = "test"
   ssl_mode                    = "none"
 
-  tags {
+  tags = {
     Name = "test"
   }
 

--- a/website/docs/r/dms_replication_instance.html.markdown
+++ b/website/docs/r/dms_replication_instance.html.markdown
@@ -28,7 +28,7 @@ resource "aws_dms_replication_instance" "test" {
   replication_instance_id      = "test-dms-replication-instance-tf"
   replication_subnet_group_id  = "${aws_dms_replication_subnet_group.test-dms-replication-subnet-group-tf.id}"
 
-  tags {
+  tags = {
     Name = "test"
   }
 

--- a/website/docs/r/dms_replication_subnet_group.html.markdown
+++ b/website/docs/r/dms_replication_subnet_group.html.markdown
@@ -22,7 +22,7 @@ resource "aws_dms_replication_subnet_group" "test" {
     "subnet-12345678",
   ]
 
-  tags {
+  tags = {
     Name = "test"
   }
 }

--- a/website/docs/r/dms_replication_task.html.markdown
+++ b/website/docs/r/dms_replication_task.html.markdown
@@ -23,7 +23,7 @@ resource "aws_dms_replication_task" "test" {
   source_endpoint_arn       = "${aws_dms_endpoint.test-dms-source-endpoint-tf.endpoint_arn}"
   table_mappings            = "{\"rules\":[{\"rule-type\":\"selection\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"object-locator\":{\"schema-name\":\"%\",\"table-name\":\"%\"},\"rule-action\":\"include\"}]}"
 
-  tags {
+  tags = {
     Name = "test"
   }
 

--- a/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
@@ -49,7 +49,7 @@ resource "aws_dx_hosted_private_virtual_interface_accepter" "accepter" {
   virtual_interface_id = "${aws_dx_hosted_private_virtual_interface.creator.id}"
   vpn_gateway_id       = "${aws_vpn_gateway.vpn_gw.id}"
 
-  tags {
+  tags = {
     Side = "Accepter"
   }
 }

--- a/website/docs/r/dx_hosted_public_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_public_virtual_interface_accepter.html.markdown
@@ -52,7 +52,7 @@ resource "aws_dx_hosted_public_virtual_interface_accepter" "accepter" {
   provider             = "aws.accepter"
   virtual_interface_id = "${aws_dx_hosted_public_virtual_interface.creator.id}"
 
-  tags {
+  tags = {
     Side = "Accepter"
   }
 }

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -56,7 +56,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     non_key_attributes = ["UserId"]
   }
 
-  tags {
+  tags = {
     Name        = "dynamodb-table-1"
     Environment = "production"
   }

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -17,7 +17,7 @@ resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   size              = 40
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }
@@ -25,7 +25,7 @@ resource "aws_ebs_volume" "example" {
 resource "aws_ebs_snapshot" "example_snapshot" {
   volume_id = "${aws_ebs_volume.example.id}"
 
-  tags {
+  tags = {
     Name = "HelloWorld_snap"
   }
 }

--- a/website/docs/r/ebs_snapshot_copy.html.markdown
+++ b/website/docs/r/ebs_snapshot_copy.html.markdown
@@ -17,7 +17,7 @@ resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   size              = 40
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }
@@ -25,7 +25,7 @@ resource "aws_ebs_volume" "example" {
 resource "aws_ebs_snapshot" "example_snapshot" {
   volume_id = "${aws_ebs_volume.example.id}"
 
-  tags {
+  tags = {
     Name = "HelloWorld_snap"
   }
 }
@@ -34,7 +34,7 @@ resource "aws_ebs_snapshot_copy" "example_copy" {
   source_snapshot_id = "${aws_ebs_snapshot.example_snapshot.id}"
   source_region      = "us-west-2"
 
-  tags {
+  tags = {
     Name = "HelloWorld_copy_snap"
   }
 }

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -17,7 +17,7 @@ resource "aws_ebs_volume" "example" {
   availability_zone = "us-west-2a"
   size              = 40
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }

--- a/website/docs/r/efs_file_system.html.markdown
+++ b/website/docs/r/efs_file_system.html.markdown
@@ -16,7 +16,7 @@ Provides an Elastic File System (EFS) resource.
 resource "aws_efs_file_system" "foo" {
   creation_token = "my-product"
 
-  tags {
+  tags = {
     Name = "MyProduct"
   }
 }

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -29,7 +29,7 @@ resource "aws_instance" "web" {
   availability_zone = "us-west-2a"
   instance_type     = "t1.micro"
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }

--- a/website/docs/r/elasticache_subnet_group.html.markdown
+++ b/website/docs/r/elasticache_subnet_group.html.markdown
@@ -20,7 +20,7 @@ ElastiCache cluster **inside** of a VPC. If you are on EC2 Classic, see the
 resource "aws_vpc" "foo" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-test"
   }
 }
@@ -30,7 +30,7 @@ resource "aws_subnet" "foo" {
   cidr_block        = "10.0.0.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-test"
   }
 }

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -27,7 +27,7 @@ resource "aws_elasticsearch_domain" "example" {
     automated_snapshot_start_hour = 23
   }
 
-  tags {
+  tags = {
     Domain = "TestDomain"
   }
 }

--- a/website/docs/r/elb.html.markdown
+++ b/website/docs/r/elb.html.markdown
@@ -62,7 +62,7 @@ resource "aws_elb" "bar" {
   connection_draining         = true
   connection_draining_timeout = 400
 
-  tags {
+  tags = {
     Name = "foobar-terraform-elb"
   }
 }

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -88,7 +88,7 @@ EOF
   core_instance_type   = "m5.xlarge"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role = "rolename"
     env  = "env"
   }
@@ -349,7 +349,7 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   core_instance_type   = "m5.xlarge"
   core_instance_count  = 1
 
-  tags {
+  tags = {
     role     = "rolename"
     dns_zone = "env_zone"
     env      = "env"
@@ -419,7 +419,7 @@ resource "aws_security_group" "allow_all" {
     ignore_changes = ["ingress", "egress"]
   }
 
-  tags {
+  tags = {
     name = "emr_test"
   }
 }
@@ -428,7 +428,7 @@ resource "aws_vpc" "main" {
   cidr_block           = "168.31.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     name = "emr_test"
   }
 }
@@ -437,7 +437,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "168.31.0.0/20"
 
-  tags {
+  tags = {
     name = "emr_test"
   }
 }

--- a/website/docs/r/glacier_vault.html.markdown
+++ b/website/docs/r/glacier_vault.html.markdown
@@ -45,7 +45,7 @@ resource "aws_glacier_vault" "my_archive" {
 }
 EOF
 
-  tags {
+  tags = {
     Test = "MyArchive"
   }
 }

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -32,7 +32,7 @@ resource "aws_iam_role" "test_role" {
 }
 EOF
 
-  tags {
+  tags = {
       tag-key = "tag-value"
   }
 }

--- a/website/docs/r/inspector_assessment_target.html.markdown
+++ b/website/docs/r/inspector_assessment_target.html.markdown
@@ -14,7 +14,7 @@ Provides a Inspector assessment target
 
 ```hcl
 resource "aws_inspector_resource_group" "bar" {
-  tags {
+  tags = {
     Name = "foo"
     Env  = "bar"
   }

--- a/website/docs/r/inspector_resource_group.html.markdown
+++ b/website/docs/r/inspector_resource_group.html.markdown
@@ -14,7 +14,7 @@ Provides a Inspector resource group
 
 ```hcl
 resource "aws_inspector_resource_group" "bar" {
-  tags {
+  tags = {
     Name = "foo"
     Env  = "bar"
   }

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -40,7 +40,7 @@ resource "aws_instance" "web" {
   ami           = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }
@@ -205,7 +205,7 @@ The `credit_specification` block supports the following:
 resource "aws_vpc" "my_vpc" {
   cidr_block = "172.16.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-example"
   }
 }
@@ -215,7 +215,7 @@ resource "aws_subnet" "my_subnet" {
   cidr_block        = "172.16.10.0/24"
   availability_zone = "us-west-2a"
 
-  tags {
+  tags = {
     Name = "tf-example"
   }
 }
@@ -224,7 +224,7 @@ resource "aws_network_interface" "foo" {
   subnet_id   = "${aws_subnet.my_subnet.id}"
   private_ips = ["172.16.10.100"]
 
-  tags {
+  tags = {
     Name = "primary_network_interface"
   }
 }

--- a/website/docs/r/internet_gateway.html.markdown
+++ b/website/docs/r/internet_gateway.html.markdown
@@ -16,7 +16,7 @@ Provides a resource to create a VPC Internet Gateway.
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "main"
   }
 }

--- a/website/docs/r/kinesis_stream.html.markdown
+++ b/website/docs/r/kinesis_stream.html.markdown
@@ -26,7 +26,7 @@ resource "aws_kinesis_stream" "test_stream" {
     "OutgoingBytes",
   ]
 
-  tags {
+  tags = {
     Environment = "test"
   }
 }

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -77,7 +77,7 @@ resource "aws_launch_template" "foo" {
   tag_specifications {
     resource_type = "instance"
 
-    tags {
+  tags = {
       Name = "test"
     }
   }

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -32,7 +32,7 @@ resource "aws_lb" "test" {
     enabled = true
   }
 
-  tags {
+  tags = {
     Environment = "production"
   }
 }
@@ -49,7 +49,7 @@ resource "aws_lb" "test" {
 
   enable_deletion_protection = true
 
-  tags {
+  tags = {
     Environment = "production"
   }
 }

--- a/website/docs/r/load_balancer_backend_server_policy.html.markdown
+++ b/website/docs/r/load_balancer_backend_server_policy.html.markdown
@@ -26,7 +26,7 @@ resource "aws_elb" "wu-tang" {
     ssl_certificate_id = "arn:aws:iam::000000000000:server-certificate/wu-tang.net"
   }
 
-  tags {
+  tags = {
     Name = "wu-tang"
   }
 }

--- a/website/docs/r/load_balancer_listener_policy.html.markdown
+++ b/website/docs/r/load_balancer_listener_policy.html.markdown
@@ -26,7 +26,7 @@ resource "aws_elb" "wu-tang" {
     ssl_certificate_id = "arn:aws:iam::000000000000:server-certificate/wu-tang.net"
   }
 
-  tags {
+  tags = {
     Name = "wu-tang"
   }
 }

--- a/website/docs/r/load_balancer_policy.html.markdown
+++ b/website/docs/r/load_balancer_policy.html.markdown
@@ -25,7 +25,7 @@ resource "aws_elb" "wu-tang" {
     ssl_certificate_id = "arn:aws:iam::000000000000:server-certificate/wu-tang.net"
   }
 
-  tags {
+  tags = {
     Name = "wu-tang"
   }
 }

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -26,7 +26,7 @@ resource "aws_nat_gateway" "gw" {
   allocation_id = "${aws_eip.nat.id}"
   subnet_id     = "${aws_subnet.public.id}"
 
-  tags {
+  tags = {
     Name = "gw NAT"
   }
 }

--- a/website/docs/r/neptune_event_subscription.html.markdown
+++ b/website/docs/r/neptune_event_subscription.html.markdown
@@ -55,7 +55,7 @@ resource "aws_neptune_event_subscription" "default" {
     "read replica",
   ]
 
-  tags {
+  tags = {
     "env" = "test"
   }
 }

--- a/website/docs/r/neptune_subnet_group.html.markdown
+++ b/website/docs/r/neptune_subnet_group.html.markdown
@@ -17,7 +17,7 @@ resource "aws_neptune_subnet_group" "default" {
   name       = "main"
   subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
 
-  tags {
+  tags = {
     Name = "My neptune subnet group"
   }
 }

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -41,7 +41,7 @@ resource "aws_network_acl" "main" {
     to_port    = 80
   }
 
-  tags {
+  tags = {
     Name = "main"
   }
 }

--- a/website/docs/r/opsworks_stack.html.markdown
+++ b/website/docs/r/opsworks_stack.html.markdown
@@ -19,7 +19,7 @@ resource "aws_opsworks_stack" "main" {
   service_role_arn             = "${aws_iam_role.opsworks.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks.arn}"
 
-  tags {
+  tags = {
     Name = "foobar-terraform-stack"
   }
 

--- a/website/docs/r/redshift_event_subscription.html.markdown
+++ b/website/docs/r/redshift_event_subscription.html.markdown
@@ -40,7 +40,7 @@ resource "aws_redshift_event_subscription" "default" {
     "security",
   ]
 
-  tags {
+  tags = {
     Name = "default"
   }
 }

--- a/website/docs/r/redshift_subnet_group.html.markdown
+++ b/website/docs/r/redshift_subnet_group.html.markdown
@@ -22,7 +22,7 @@ resource "aws_subnet" "foo" {
   availability_zone = "us-west-2a"
   vpc_id            = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-dbsubnet-test-1"
   }
 }
@@ -32,7 +32,7 @@ resource "aws_subnet" "bar" {
   availability_zone = "us-west-2b"
   vpc_id            = "${aws_vpc.foo.id}"
 
-  tags {
+  tags = {
     Name = "tf-dbsubnet-test-2"
   }
 }
@@ -41,7 +41,7 @@ resource "aws_redshift_subnet_group" "foo" {
   name       = "foo"
   subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
 
-  tags {
+  tags = {
     environment = "Production"
   }
 }

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -34,7 +34,7 @@ resource "aws_route53_zone" "main" {
 resource "aws_route53_zone" "dev" {
   name = "dev.example.com"
 
-  tags {
+  tags = {
     Environment = "dev"
   }
 }

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -45,7 +45,7 @@ resource "aws_route_table" "r" {
     egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
   }
 
-  tags {
+  tags = {
     Name = "main"
   }
 }

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "b" {
   bucket = "my-tf-test-bucket"
   acl    = "private"
 
-  tags {
+  tags = {
     Name        = "My bucket"
     Environment = "Dev"
   }
@@ -114,7 +114,7 @@ resource "aws_s3_bucket" "bucket" {
 
     prefix = "log/"
 
-    tags {
+  tags = {
       "rule"      = "log"
       "autoclean" = "true"
     }

--- a/website/docs/r/s3_bucket_metric.html.markdown
+++ b/website/docs/r/s3_bucket_metric.html.markdown
@@ -39,7 +39,7 @@ resource "aws_s3_bucket_metric" "example-filtered" {
   filter {
     prefix = "documents/"
 
-    tags {
+  tags = {
       priority = "high"
       class    = "blue"
     }

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -60,7 +60,7 @@ resource "aws_security_group" "allow_all" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "allow_all"
   }
 }

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -45,7 +45,7 @@ resource "aws_spot_fleet_request" "cheap_compute" {
       volume_type = "gp2"
     }
 
-    tags {
+  tags = {
       Name = "spot-fleet-example"
     }
   }

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -41,7 +41,7 @@ resource "aws_spot_instance_request" "cheap_worker" {
   spot_price    = "0.03"
   instance_type = "c4.xlarge"
 
-  tags {
+  tags = {
     Name = "CheapWorker"
   }
 }

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -19,7 +19,7 @@ resource "aws_sqs_queue" "terraform_queue" {
   receive_wait_time_seconds = 10
   redrive_policy            = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.terraform_queue_deadletter.arn}\",\"maxReceiveCount\":4}"
 
-  tags {
+  tags = {
     Environment = "production"
   }
 }

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -44,7 +44,7 @@ resource "aws_ssm_parameter" "secret" {
   type        = "SecureString"
   value       = "${var.database_master_password}"
 
-  tags {
+  tags = {
     environment = "${var.environment}"
   }
 }

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -19,7 +19,7 @@ resource "aws_subnet" "main" {
   vpc_id     = "${aws_vpc.main.id}"
   cidr_block = "10.0.1.0/24"
 
-  tags {
+  tags = {
     Name = "Main"
   }
 }

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -27,7 +27,7 @@ resource "aws_instance" "web" {
   availability_zone = "us-west-2a"
   instance_type     = "t1.micro"
 
-  tags {
+  tags = {
     Name = "HelloWorld"
   }
 }

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -27,7 +27,7 @@ resource "aws_vpc" "main" {
   cidr_block       = "10.0.0.0/16"
   instance_tenancy = "dedicated"
 
-  tags {
+  tags = {
     Name = "main"
   }
 }

--- a/website/docs/r/vpc_dhcp_options.html.markdown
+++ b/website/docs/r/vpc_dhcp_options.html.markdown
@@ -30,7 +30,7 @@ resource "aws_vpc_dhcp_options" "foo" {
   netbios_name_servers = ["127.0.0.1"]
   netbios_node_type    = 2
 
-  tags {
+  tags = {
     Name = "foo-name"
   }
 }

--- a/website/docs/r/vpc_peering.html.markdown
+++ b/website/docs/r/vpc_peering.html.markdown
@@ -59,7 +59,7 @@ resource "aws_vpc_peering_connection" "foo" {
   vpc_id        = "${aws_vpc.foo.id}"
   auto_accept   = true
 
-  tags {
+  tags = {
     Name = "VPC Peering between foo and bar"
   }
 }

--- a/website/docs/r/vpc_peering_accepter.html.markdown
+++ b/website/docs/r/vpc_peering_accepter.html.markdown
@@ -54,7 +54,7 @@ resource "aws_vpc_peering_connection" "peer" {
   peer_region   = "us-west-2"
   auto_accept   = false
 
-  tags {
+  tags = {
     Side = "Requester"
   }
 }
@@ -65,7 +65,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
   auto_accept               = true
 
-  tags {
+  tags = {
     Side = "Accepter"
   }
 }

--- a/website/docs/r/vpc_peering_options.html.markdown
+++ b/website/docs/r/vpc_peering_options.html.markdown
@@ -95,7 +95,7 @@ resource "aws_vpc_peering_connection" "peer" {
   peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
   auto_accept   = false
 
-  tags {
+  tags = {
     Side = "Requester"
   }
 }
@@ -107,7 +107,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
   auto_accept               = true
 
-  tags {
+  tags = {
     Side = "Accepter"
   }
 }

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -16,7 +16,7 @@ Provides a resource to create a VPC VPN Gateway.
 resource "aws_vpn_gateway" "vpn_gw" {
   vpc_id = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "main"
   }
 }

--- a/website/docs/r/vpn_gateway_attachment.html.markdown
+++ b/website/docs/r/vpn_gateway_attachment.html.markdown
@@ -23,7 +23,7 @@ resource "aws_vpc" "network" {
 }
 
 resource "aws_vpn_gateway" "vpn" {
-  tags {
+  tags = {
     Name = "example-vpn-gateway"
   }
 }


### PR DESCRIPTION
In preparation for Terraform 0.12 larger scale testing and changes. Change is backwards compatible. There may be other `TypeMap` HCL references out there missing the `=`, but `tags` is definitely the biggest offender.

Changes proposed in this pull request:

* tests/provider: Use `TypeMap` syntax for `tags` arguments
* docs/provider: Use `TypeMap` syntax for `tags` arguments

Output from acceptance testing: We'll handle this via daily acceptance testing runs
