### PR TITLE
data-source/aws_ip_ranges: Add url argument

### DIFF
--- a/aws/data_source_aws_ip_ranges_test.go
+++ b/aws/data_source_aws_ip_ranges_test.go
@@ -13,13 +13,30 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIPRanges(t *testing.T) {
+func TestAccAWSIPRanges_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSIPRangesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSIPRangesCheckAttributes("data.aws_ip_ranges.some"),
+					testAccAWSIPRangesCheckCidrBlocksAttribute("data.aws_ip_ranges.some", "cidr_blocks"),
+					testAccAWSIPRangesCheckCidrBlocksAttribute("data.aws_ip_ranges.some", "ipv6_cidr_blocks"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIPRanges_Url(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIPRangesConfigUrl,
 				Check: resource.ComposeTestCheckFunc(
 					testAccAWSIPRangesCheckAttributes("data.aws_ip_ranges.some"),
 					testAccAWSIPRangesCheckCidrBlocksAttribute("data.aws_ip_ranges.some", "cidr_blocks"),
@@ -139,5 +156,13 @@ const testAccAWSIPRangesConfig = `
 data "aws_ip_ranges" "some" {
   regions = [ "eu-west-1", "eu-central-1" ]
   services = [ "ec2" ]
+}
+`
+
+const testAccAWSIPRangesConfigUrl = `
+data "aws_ip_ranges" "some" {
+  regions  = [ "eu-west-1", "eu-central-1" ]
+  services = [ "ec2" ]
+  url      = "https://ip-ranges.amazonaws.com/ip-ranges.json"
 }
 `

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_ip_ranges
 
-Use this data source to get the [IP ranges][1] of various AWS products and services.
+Use this data source to get the IP ranges of various AWS products and services. For more information about the contents of this data source and required JSON syntax if referencing a custom URL, see the [AWS IP Address Ranges documention][1].
 
 ## Example Usage
 
@@ -48,6 +48,8 @@ omitted). Valid items are `global` (for `cloudfront`) as well as all AWS regions
 ~> **NOTE:** If the specified combination of regions and services does not yield any
 CIDR blocks, Terraform will fail.
 
+* `url` - (Optional) Custom URL for source JSON file. Syntax must match [AWS IP Address Ranges documention][1]. Defaults to `https://ip-ranges.amazonaws.com/ip-ranges.json`.
+
 ## Attributes Reference
 
 * `cidr_blocks` - The lexically ordered list of CIDR blocks.
@@ -56,4 +58,4 @@ CIDR blocks, Terraform will fail.
 * `sync_token` - The publication time of the IP ranges, in Unix epoch time format
   (e.g. `1470267965`).
 
-[1]: http://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html
+[1]: https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html


### PR DESCRIPTION
The original hardcoded URL (https://ip-ranges.amazonaws.com/ip-ranges.json) is only for the AWS Commercial partition. Other AWS partitions have privately available IP Range JSON files at known URLs.

Output from acceptance testing:

```
--- PASS: TestAccAWSIPRanges_basic (9.89s)
--- PASS: TestAccAWSIPRanges_Url (10.13s)
```
