### PR TITLE
New Datasource: aws_api_gateway_vpc_link

### DIFF
--- a/aws/data_source_aws_api_gateway_vpc_link.go
+++ b/aws/data_source_aws_api_gateway_vpc_link.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsApiGatewayVpcLink() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsApiGatewayVpcLinkRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsApiGatewayVpcLinkRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).apigateway
+	params := &apigateway.GetVpcLinksInput{}
+
+	target := d.Get("name")
+	var matchedVpcLinks []*apigateway.UpdateVpcLinkOutput
+	log.Printf("[DEBUG] Reading API Gateway VPC links: %s", params)
+	err := conn.GetVpcLinksPages(params, func(page *apigateway.GetVpcLinksOutput, lastPage bool) bool {
+		for _, api := range page.Items {
+			if aws.StringValue(api.Name) == target {
+				matchedVpcLinks = append(matchedVpcLinks, api)
+			}
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("error describing API Gateway VPC links: %s", err)
+	}
+
+	if len(matchedVpcLinks) == 0 {
+		return fmt.Errorf("no API Gateway VPC link with name %q found in this region", target)
+	}
+	if len(matchedVpcLinks) > 1 {
+		return fmt.Errorf("multiple API Gateway VPC links with name %q found in this region", target)
+	}
+
+	match := matchedVpcLinks[0]
+
+	d.SetId(*match.Id)
+	d.Set("name", match.Name)
+
+	return nil
+}

--- a/aws/data_source_aws_api_gateway_vpc_link_test.go
+++ b/aws/data_source_aws_api_gateway_vpc_link_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceAwsApiGatewayVpcLink(t *testing.T) {
 				Config: testAccDataSourceAwsApiGatewayVpcLinkConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsApiGatewayVpcLinkCheck("data.aws_api_gateway_vpc_link.vpc_link"),
-					resource.TestCheckResourceAttrSet("data.aws_api_gateway_vpc_link.vpc_link", "id"),
+					resource.TestCheckResourceAttrSet("data.aws_api_gateway_vpc_link.vpc_link", "id", "aws_api_gateway_vpc_link.vpc_link", "id"),
 				),
 			},
 		},

--- a/aws/data_source_aws_api_gateway_vpc_link_test.go
+++ b/aws/data_source_aws_api_gateway_vpc_link_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceAwsApiGatewayVpcLink(t *testing.T) {
@@ -18,37 +17,12 @@ func TestAccDataSourceAwsApiGatewayVpcLink(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsApiGatewayVpcLinkConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsApiGatewayVpcLinkCheck("data.aws_api_gateway_vpc_link.vpc_link"),
-					resource.TestCheckResourceAttrSet("data.aws_api_gateway_vpc_link.vpc_link", "id", "aws_api_gateway_vpc_link.vpc_link", "id"),
+					resource.TestCheckResourceAttrPair("data.aws_api_gateway_vpc_link.vpc_link", "name", "aws_api_gateway_vpc_link.vpc_link", "name"),
+					resource.TestCheckResourceAttrPair("data.aws_api_gateway_vpc_link.vpc_link", "id", "aws_api_gateway_vpc_link.vpc_link", "id"),
 				),
 			},
 		},
 	})
-}
-
-func testAccDataSourceAwsApiGatewayVpcLinkCheck(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resources, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		apiGatewayVpcLinkResources, ok := s.RootModule().Resources["aws_api_gateway_vpc_link.vpc_link"]
-		if !ok {
-			return fmt.Errorf("can't find aws_api_gateway_vpc_link.vpc_link in state")
-		}
-
-		attr := resources.Primary.Attributes
-		if attr["name"] != apiGatewayVpcLinkResources.Primary.Attributes["name"] {
-			return fmt.Errorf(
-				"name is %s; want %s",
-				attr["name"],
-				apiGatewayVpcLinkResources.Primary.Attributes["name"],
-			)
-		}
-
-		return nil
-	}
 }
 
 func testAccDataSourceAwsApiGatewayVpcLinkConfig(r string) string {
@@ -100,8 +74,7 @@ func testAccDataSourceAwsApiGatewayVpcLinkConfig(r string) string {
 	  resource "aws_subnet" "apigateway_vpclink_test_subnet1" {
 		vpc_id            = "${aws_vpc.apigateway_vpclink_test.id}"
 		cidr_block        = "10.0.1.0/24"
-		availability_zone = "us-west-2a"
-	  
+
 		tags = {
 		  Name = "tf-acc-lb-apigateway-vpclink"
 		}

--- a/aws/data_source_aws_api_gateway_vpc_link_test.go
+++ b/aws/data_source_aws_api_gateway_vpc_link_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsApiGatewayVpcLink(t *testing.T) {
+	rName := acctest.RandString(8)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsApiGatewayVpcLinkConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsApiGatewayVpcLinkCheck("data.aws_api_gateway_vpc_link.vpc_link"),
+					resource.TestCheckResourceAttrSet("data.aws_api_gateway_vpc_link.vpc_link", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsApiGatewayVpcLinkCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resources, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		apiGatewayVpcLinkResources, ok := s.RootModule().Resources["aws_api_gateway_vpc_link.vpc_link"]
+		if !ok {
+			return fmt.Errorf("can't find aws_api_gateway_vpc_link.vpc_link in state")
+		}
+
+		attr := resources.Primary.Attributes
+		if attr["name"] != apiGatewayVpcLinkResources.Primary.Attributes["name"] {
+			return fmt.Errorf(
+				"name is %s; want %s",
+				attr["name"],
+				apiGatewayVpcLinkResources.Primary.Attributes["name"],
+			)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsApiGatewayVpcLinkConfig(r string) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "apigateway_vpclink_test" {
+		cidr_block = "10.0.0.0/16"
+	  
+		tags = {
+		  Name = "terraform-testacc-lb-apigateway-vpc-link"
+		}
+	  }
+	  
+	  resource "aws_lb" "apigateway_vpclink_test" {
+		name = "%s"
+	  
+		subnets = [
+		  "${aws_subnet.apigateway_vpclink_test_subnet1.id}"
+		]
+	  
+		load_balancer_type               = "network"
+		internal                         = true
+		idle_timeout                     = 60
+		enable_deletion_protection       = false
+		enable_cross_zone_load_balancing = false
+	  
+		tags = {
+		  Name = "testAccDataSourceAwsApiGatewayVpcLinkConfig_networkLoadbalancer"
+		}
+	  }
+
+	  resource "aws_lb" "apigateway_vpclink_test2" {
+		name = "%s-wrong"
+	  
+		subnets = [
+		  "${aws_subnet.apigateway_vpclink_test_subnet1.id}"
+		]
+	  
+		load_balancer_type               = "network"
+		internal                         = true
+		idle_timeout                     = 60
+		enable_deletion_protection       = false
+		enable_cross_zone_load_balancing = false
+	  
+		tags = {
+		  Name = "testAccDataSourceAwsApiGatewayVpcLinkConfig_networkLoadbalancer"
+		}
+	  }
+	  
+	  resource "aws_subnet" "apigateway_vpclink_test_subnet1" {
+		vpc_id            = "${aws_vpc.apigateway_vpclink_test.id}"
+		cidr_block        = "10.0.1.0/24"
+		availability_zone = "us-west-2a"
+	  
+		tags = {
+		  Name = "tf-acc-lb-apigateway-vpclink"
+		}
+	  }
+
+	  resource "aws_api_gateway_vpc_link" "vpc_link" {
+		name = "%s"
+		target_arns = ["${aws_lb.apigateway_vpclink_test.arn}"]
+	  
+	  }
+
+	  resource "aws_api_gateway_vpc_link" "vpc_link2" {
+		name = "%s-wrong"
+		target_arns = ["${aws_lb.apigateway_vpclink_test2.arn}"]
+	  
+	  }
+
+	  data "aws_api_gateway_vpc_link" "vpc_link" {
+		  name = "${aws_api_gateway_vpc_link.vpc_link.name}"
+	  }
+	
+`, r, r, r, r)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -167,6 +167,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_api_gateway_api_key":                dataSourceAwsApiGatewayApiKey(),
 			"aws_api_gateway_resource":               dataSourceAwsApiGatewayResource(),
 			"aws_api_gateway_rest_api":               dataSourceAwsApiGatewayRestApi(),
+			"aws_api_gateway_vpc_link":               dataSourceAwsApiGatewayVpcLink(),
 			"aws_arn":                                dataSourceAwsArn(),
 			"aws_autoscaling_groups":                 dataSourceAwsAutoscalingGroups(),
 			"aws_availability_zone":                  dataSourceAwsAvailabilityZone(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -67,6 +67,9 @@
                         <li<%= sidebar_current("docs-aws_api_gateway_rest_api") %>>
                             <a href="/docs/providers/aws/d/api_gateway_rest_api.html">aws_api_gateway_rest_api</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws_api_gateway_vpc_link") %>>
+                            <a href="/docs/providers/aws/d/api_gateway_vpc_link.html">aws_api_gateway_vpc_link</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-arn") %>>
                             <a href="/docs/providers/aws/d/arn.html">aws_arn</a>
                         </li>

--- a/website/docs/d/api_gateway_vpc_link.html.markdown
+++ b/website/docs/d/api_gateway_vpc_link.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "aws"
+page_title: "AWS: aws_api_gateway_vpc_link"
+sidebar_current: "docs-aws_api_gateway_vpc_link"
+description: |-
+  Get information on a API Gateway VPC Link
+---
+
+# Data Source: aws_api_gateway_vpc_link
+
+Use this data source to get the id and target arns of a VPC Link in
+API Gateway. To fetch the VPC Link you must provide a name to match against. 
+As there is no unique name constraint on API Gateway VPC Links this data source will 
+error if there is more than one match.
+
+## Example Usage
+
+```hcl
+data "aws_api_gateway_vpc_link" "my_api_gateway_vpc_link" {
+  name = "my-vpc-link"
+}
+```
+
+## Argument Reference
+
+ * `name` - (Required) The name of the API Gateway VPC Link to look up. If no API Gateway VPC Link is found with this name, an error will be returned. 
+ If multiple API Gateway VPC Links are found with this name, an error will be returned.
+
+## Attributes Reference
+
+ * `id` - Set to the ID of the found API Gateway VPC Link.

--- a/website/docs/d/api_gateway_vpc_link.html.markdown
+++ b/website/docs/d/api_gateway_vpc_link.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_api_gateway_vpc_link
 
-Use this data source to get the id and target arns of a VPC Link in
+Use this data source to get the id of a VPC Link in
 API Gateway. To fetch the VPC Link you must provide a name to match against. 
 As there is no unique name constraint on API Gateway VPC Links this data source will 
 error if there is more than one match.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Changes proposed in this pull request:

* Add a new data source for API Gateway VPC Links

Output from acceptance testing:

```
╰─$ make testacc TESTARGS='-run=TestAccDataSourceAwsApiGatewayVpcLink'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccDataSourceAwsApiGatewayVpcLink -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccDataSourceAwsApiGatewayVpcLink
=== PAUSE TestAccDataSourceAwsApiGatewayVpcLink
=== CONT  TestAccDataSourceAwsApiGatewayVpcLink
--- PASS: TestAccDataSourceAwsApiGatewayVpcLink (716.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       716.355s

...
```
