### PR TITLE
can't destroy aws_cloudwatch_log_stream if group has been destroyed

### DIFF
--- a/aws/resource_aws_cloudwatch_log_stream.go
+++ b/aws/resource_aws_cloudwatch_log_stream.go
@@ -58,9 +58,17 @@ func resourceAwsCloudWatchLogStreamCreate(d *schema.ResourceData, meta interface
 func resourceAwsCloudWatchLogStreamRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).cloudwatchlogsconn
 
-	ls, exists, err := lookupCloudWatchLogStream(conn, d.Id(), d.Get("log_group_name").(string), nil)
+	group := d.Get("log_group_name").(string)
+
+	ls, exists, err := lookupCloudWatchLogStream(conn, d.Id(), group, nil)
 	if err != nil {
-		return err
+		_, err2 := lookupCloudWatchLogGroup(conn, group)
+		if err2 != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] container CloudWatch group %q Not Found.", group)
+		exists = false
 	}
 
 	if !exists {

--- a/aws/resource_aws_cloudwatch_log_stream.go
+++ b/aws/resource_aws_cloudwatch_log_stream.go
@@ -62,8 +62,7 @@ func resourceAwsCloudWatchLogStreamRead(d *schema.ResourceData, meta interface{}
 
 	ls, exists, err := lookupCloudWatchLogStream(conn, d.Id(), group, nil)
 	if err != nil {
-		_, err2 := lookupCloudWatchLogGroup(conn, group)
-		if err2 != nil {
+		if !isAWSErr(err, cloudwatchlogs.ErrCodeResourceNotFoundException, "") {
 			return err
 		}
 

--- a/aws/resource_aws_cloudwatch_log_stream_test.go
+++ b/aws/resource_aws_cloudwatch_log_stream_test.go
@@ -65,8 +65,9 @@ func testAccCheckCloudWatchLogStreamDisappears(ls *cloudwatchlogs.LogStream, lgn
 	}
 }
 
-func TestAccAWSCloudWatchLogStream_disappears2(t *testing.T) {
+func TestAccAWSCloudWatchLogStream_disappears_LogGroup(t *testing.T) {
 	var ls cloudwatchlogs.LogStream
+	var lg cloudwatchlogs.LogGroup
 	rName := acctest.RandString(15)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -78,25 +79,13 @@ func TestAccAWSCloudWatchLogStream_disappears2(t *testing.T) {
 				Config: testAccAWSCloudWatchLogStreamConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchLogStreamExists("aws_cloudwatch_log_stream.foobar", &ls),
-					testAccCheckCloudWatchLogStreamDisappears2(&ls, rName),
+					testAccCheckCloudWatchLogGroupExists("aws_cloudwatch_log_group.foobar", &lg),
+					testAccCheckCloudWatchLogGroupDisappears(&lg),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
-}
-
-func testAccCheckCloudWatchLogStreamDisappears2(ls *cloudwatchlogs.LogStream, lgn string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
-		opts := &cloudwatchlogs.DeleteLogGroupInput{
-			LogGroupName: aws.String(lgn),
-		}
-		if _, err := conn.DeleteLogGroup(opts); err != nil {
-			return err
-		}
-		return nil
-	}
 }
 
 func testAccCheckCloudWatchLogStreamExists(n string, ls *cloudwatchlogs.LogStream) resource.TestCheckFunc {


### PR DESCRIPTION
consider this config:
```
resource "aws_cloudwatch_log_group" "index-logs" {
  name = "/ahl/test"
}

resource "aws_cloudwatch_log_stream" "index-log-stream" {
  name           = "S3Delivery"
  log_group_name = "${aws_cloudwatch_log_group.index-logs.name}"
}
```

If you delete the log group it will implicitly delete the log stream. A subsequent `terraform plan` will result in an error:

```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_cloudwatch_log_group.index-logs: Refreshing state... (ID: /ahl/test)
aws_cloudwatch_log_stream.index-log-stream: Refreshing state... (ID: S3Delivery)

Error: Error refreshing state: 1 error(s) occurred:

* aws_cloudwatch_log_stream.index-log-stream: 1 error(s) occurred:

* aws_cloudwatch_log_stream.index-log-stream: aws_cloudwatch_log_stream.index-log-stream: ResourceNotFoundException: The specified log group does not exist.
	status code: 400, request id: b4d05427-fab0-11e8-a129-c9ad87f29baf
```

The problem is that `resourceAwsCloudWatchLogStreamRead` doesn't properly interpret an error looking up the log stream in the case that the log group doesn't exist.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchLogStream*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchLogStream* -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudWatchLogStream_basic
=== PAUSE TestAccAWSCloudWatchLogStream_basic
=== RUN   TestAccAWSCloudWatchLogStream_disappears
=== PAUSE TestAccAWSCloudWatchLogStream_disappears
=== RUN   TestAccAWSCloudWatchLogStream_disappears2
=== PAUSE TestAccAWSCloudWatchLogStream_disappears2
=== CONT  TestAccAWSCloudWatchLogStream_basic
=== CONT  TestAccAWSCloudWatchLogStream_disappears2
=== CONT  TestAccAWSCloudWatchLogStream_disappears
--- PASS: TestAccAWSCloudWatchLogStream_disappears2 (8.60s)
--- PASS: TestAccAWSCloudWatchLogStream_disappears (11.38s)
--- PASS: TestAccAWSCloudWatchLogStream_basic (11.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.569s
```


Added a new test that fails without the fix:
```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchLogStream_disappears2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchLogStream_disappears2 -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudWatchLogStream_disappears2
=== PAUSE TestAccAWSCloudWatchLogStream_disappears2
=== CONT  TestAccAWSCloudWatchLogStream_disappears2
--- FAIL: TestAccAWSCloudWatchLogStream_disappears2 (7.69s)
    testing.go:538: Step 0 error: Error on follow-up refresh: 1 error occurred:
        	* aws_cloudwatch_log_stream.foobar: 1 error occurred:
        	* aws_cloudwatch_log_stream.foobar: aws_cloudwatch_log_stream.foobar: ResourceNotFoundException: The specified log group does not exist.
        	status code: 400, request id: 512d5254-fab1-11e8-9764-fb75fda2d9b2
        
        
        
        
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	7.731s
make: *** [testacc] Error 1
```