### PR TITLE
Add a note on blue/green deployments and COPY_AUTO_SCALING_GROUP.

### DIFF
--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a CodeDeploy Deployment Group for a CodeDeploy Application
 
+~> **NOTE on blue/green deployments:** When using `green_fleet_provisioning_option` with the `COPY_AUTO_SCALING_GROUP` action, CodeDeploy will create a new ASG with a different name. This ASG is _not_ managed by terraform and will conflict with existing configuration and state. You may want to use a different approach to managing deployments that involve multiple ASG, such as `DISCOVER_EXISTING` with separate blue and green ASG.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #4678 

Changes proposed in this pull request:

* Add a note to the CodeDeploy Deployment Group documentation on issues using `green_fleet_provisioning_option` with the `COPY_AUTO_SCALING_GROUP` action.

@bflad 
How does this look?