### PR TITLE
Vpc Peering auto accept

### DIFF
--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -85,7 +85,6 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 		if _, ok := d.GetOk("auto_accept"); ok {
 			log.Printf("[DEBUG] VPC Peering Auto Accept")
 			createOpts.PeerRegion = aws.String(v.(string))
-			// return fmt.Errorf("peer_region cannot be set whilst auto_accept is true when creating a vpc peering connection")
 			resp, err := conn.CreateVpcPeeringConnection(createOpts)
 			if err != nil {
 				return fmt.Errorf("Error creating VPC Peering Connection: %s", err)
@@ -96,21 +95,17 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 			if err != nil {
 				return fmt.Errorf("Error waiting for VPC Peering Connection to become available: %s", err)
 			}
-			// // Test if we can change AUTH Param and change the region
+			// Initialize a new session in order to change the region
 			sess, err := session.NewSession(&aws.Config{Region: aws.String(v.(string))})
 			if err != nil {
 				return fmt.Errorf("Error New Session Creation: %s", err)
 			}
 			svc := ec2.New(sess, aws.NewConfig().WithRegion(v.(string)))
 			_, err = resourceVPCPeeringConnectionAccept(svc, d.Id())
-
-			// Ori
-			// _, err = resourceVPCPeeringConnectionAccept(conn, d.Id())
 			if err != nil {
 				return fmt.Errorf("Error Peering Acceptation: %s", err)
 			}
 			return nil
-			// return resourceAwsVPCPeeringUpdate(d, meta)
 		}
 		createOpts.PeerRegion = aws.String(v.(string))
 	}

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -107,7 +107,7 @@ func resourceAwsVPCPeeringCreate(d *schema.ResourceData, meta interface{}) error
 			// Ori
 			// _, err = resourceVPCPeeringConnectionAccept(conn, d.Id())
 			if err != nil {
-				return fmt.Errorf("Error Peering Acceptation: %s %s", err, svc)
+				return fmt.Errorf("Error Peering Acceptation: %s", err)
 			}
 			return nil
 			// return resourceAwsVPCPeeringUpdate(d, meta)


### PR DESCRIPTION
Changes proposed in this pull request:

* Be able to auto-accept connexion on same account form to different region

Example of tf for this feature:
```
provider "aws" {
  alias   = "that"
  version = ">=2.0.4"
  region  = "eu-central-1"
}

resource "aws_vpc" "that_vpc" {
  cidr_block = "10.1.0.0/16"
  provider = "aws.that"
}

provider "aws" {
  alias   = "this"
  version = ">=2.0.4"
  region  = "eu-west-3"
}

resource "aws_vpc" "this_vpc" {
  cidr_block = "10.0.0.0/16"
  provider = "aws.this"
}

resource "aws_vpc_peering_connection" "test" {
  provider = "aws.that"
  vpc_id        = "${aws_vpc.that_vpc.id}"
  peer_vpc_id   = "${aws_vpc.this_vpc.id}"
  peer_region   = "eu-west-3"
  auto_accept   = "true"
}
```