### PR TITLE
r/lambda_layer_version: Add lambda_layer_version resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -529,6 +529,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lambda_event_source_mapping":                  resourceAwsLambdaEventSourceMapping(),
 			"aws_lambda_alias":                                 resourceAwsLambdaAlias(),
 			"aws_lambda_permission":                            resourceAwsLambdaPermission(),
+			"aws_lambda_layer_version":                         resourceAwsLambdaLayerVersion(),
 			"aws_launch_configuration":                         resourceAwsLaunchConfiguration(),
 			"aws_launch_template":                              resourceAwsLaunchTemplate(),
 			"aws_licensemanager_association":                   resourceAwsLicenseManagerAssociation(),

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -21,6 +21,24 @@ import (
 
 const awsMutexLambdaKey = `aws_lambda_function`
 
+var validLambdaRuntimes = []string{
+	// lambda.RuntimeNodejs has reached end of life since October 2016 so not included here
+	lambda.RuntimeDotnetcore10,
+	lambda.RuntimeDotnetcore20,
+	lambda.RuntimeDotnetcore21,
+	lambda.RuntimeGo1X,
+	lambda.RuntimeJava8,
+	lambda.RuntimeNodejs43,
+	lambda.RuntimeNodejs43Edge,
+	lambda.RuntimeNodejs610,
+	lambda.RuntimeNodejs810,
+	lambda.RuntimeProvided,
+	lambda.RuntimePython27,
+	lambda.RuntimePython36,
+	lambda.RuntimePython37,
+	lambda.RuntimeRuby25,
+}
+
 func resourceAwsLambdaFunction() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsLambdaFunctionCreate,
@@ -101,25 +119,9 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Required: true,
 			},
 			"runtime": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					// lambda.RuntimeNodejs has reached end of life since October 2016 so not included here
-					lambda.RuntimeDotnetcore10,
-					lambda.RuntimeDotnetcore20,
-					lambda.RuntimeDotnetcore21,
-					lambda.RuntimeGo1X,
-					lambda.RuntimeJava8,
-					lambda.RuntimeNodejs43,
-					lambda.RuntimeNodejs43Edge,
-					lambda.RuntimeNodejs610,
-					lambda.RuntimeNodejs810,
-					lambda.RuntimeProvided,
-					lambda.RuntimePython27,
-					lambda.RuntimePython36,
-					lambda.RuntimePython37,
-					lambda.RuntimeRuby25,
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(validLambdaRuntimes, false),
 			},
 			"timeout": {
 				Type:     schema.TypeInt,

--- a/aws/resource_aws_lambda_layer_version.go
+++ b/aws/resource_aws_lambda_layer_version.go
@@ -1,0 +1,261 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	arn2 "github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+const awsMutexLambdaLayerKey = `aws_lambda_layer_version`
+
+func resourceAwsLambdaLayerVersion() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLambdaLayerVersionPublish,
+		Read:   resourceAwsLambdaLayerVersionRead,
+		Delete: resourceAwsLambdaLayerVersionDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"layer_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"filename": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"s3_bucket", "s3_key", "s3_object_version"},
+			},
+			"s3_bucket": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"filename"},
+			},
+			"s3_key": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"filename"},
+			},
+			"s3_object_version": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"filename"},
+			},
+			"compatible_runtimes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				MinItems: 0,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(validLambdaRuntimes, false),
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"license_info": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(0, 512),
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"layer_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_code_hash": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"source_code_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsLambdaLayerVersionPublish(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	layerName := d.Get("layer_name").(string)
+	filename, hasFilename := d.GetOk("filename")
+	s3Bucket, bucketOk := d.GetOk("s3_bucket")
+	s3Key, keyOk := d.GetOk("s3_key")
+	s3ObjectVersion, versionOk := d.GetOk("s3_object_version")
+
+	if !hasFilename && !bucketOk && !keyOk && !versionOk {
+		return errors.New("filename or s3_* attributes must be set")
+	}
+
+	var layerContent *lambda.LayerVersionContentInput
+	if hasFilename {
+		awsMutexKV.Lock(awsMutexLambdaLayerKey)
+		defer awsMutexKV.Unlock(awsMutexLambdaLayerKey)
+		file, err := loadFileContent(filename.(string))
+		if err != nil {
+			return fmt.Errorf("Unable to load %q: %s", filename.(string), err)
+		}
+		layerContent = &lambda.LayerVersionContentInput{
+			ZipFile: file,
+		}
+	} else {
+		if !bucketOk || !keyOk {
+			return errors.New("s3_bucket and s3_key must all be set while using s3 code source")
+		}
+		layerContent = &lambda.LayerVersionContentInput{
+			S3Bucket: aws.String(s3Bucket.(string)),
+			S3Key:    aws.String(s3Key.(string)),
+		}
+		if versionOk {
+			layerContent.S3ObjectVersion = aws.String(s3ObjectVersion.(string))
+		}
+	}
+
+	params := &lambda.PublishLayerVersionInput{
+		Content:     layerContent,
+		Description: aws.String(d.Get("description").(string)),
+		LayerName:   aws.String(layerName),
+		LicenseInfo: aws.String(d.Get("license_info").(string)),
+	}
+
+	if v, ok := d.GetOk("compatible_runtimes"); ok && v.(*schema.Set).Len() > 0 {
+		params.CompatibleRuntimes = expandStringList(v.(*schema.Set).List())
+	}
+
+	log.Printf("[DEBUG] Publishing Lambda layer: %s", params)
+	result, err := conn.PublishLayerVersion(params)
+	if err != nil {
+		return fmt.Errorf("Error creating lambda layer: %s", err)
+	}
+
+	d.SetId(aws.StringValue(result.LayerVersionArn))
+	return resourceAwsLambdaLayerVersionRead(d, meta)
+}
+
+func resourceAwsLambdaLayerVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	layerName, version, err := resourceAwsLambdaLayerVersionParseId(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error parsing lambda layer ID: %s", err)
+	}
+
+	layerVersion, err := conn.GetLayerVersion(&lambda.GetLayerVersionInput{
+		LayerName:     aws.String(layerName),
+		VersionNumber: aws.Int64(version),
+	})
+
+	if isAWSErr(err, lambda.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Lambda Layer Version (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading Lambda Layer version (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("layer_name", layerName); err != nil {
+		return fmt.Errorf("Error setting lambda layer name: %s", err)
+	}
+	if err := d.Set("version", strconv.FormatInt(version, 10)); err != nil {
+		return fmt.Errorf("Error setting lambda layer version: %s", err)
+	}
+	if err := d.Set("arn", layerVersion.LayerArn); err != nil {
+		return fmt.Errorf("Error setting lambda layer arn: %s", err)
+	}
+	if err := d.Set("layer_arn", layerVersion.LayerVersionArn); err != nil {
+		return fmt.Errorf("Error setting lambda layer qualified arn: %s", err)
+	}
+	if err := d.Set("description", layerVersion.Description); err != nil {
+		return fmt.Errorf("Error setting lambda layer description: %s", err)
+	}
+	if err := d.Set("license_info", layerVersion.LicenseInfo); err != nil {
+		return fmt.Errorf("Error setting lambda layer license info: %s", err)
+	}
+	if err := d.Set("created_date", layerVersion.CreatedDate); err != nil {
+		return fmt.Errorf("Error setting lambda layer created date: %s", err)
+	}
+	if err := d.Set("source_code_hash", layerVersion.Content.CodeSha256); err != nil {
+		return fmt.Errorf("Error setting lambda layer source code hash: %s", err)
+	}
+	if err := d.Set("source_code_size", layerVersion.Content.CodeSize); err != nil {
+		return fmt.Errorf("Error setting lambda layer source code size: %s", err)
+	}
+	if err := d.Set("compatible_runtimes", flattenStringList(layerVersion.CompatibleRuntimes)); err != nil {
+		return fmt.Errorf("Error setting lambda layer compatible runtimes: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsLambdaLayerVersionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+
+	version, err := strconv.ParseInt(d.Get("version").(string), 10, 64)
+	if err != nil {
+		return fmt.Errorf("Error parsing lambda layer version: %s", err)
+	}
+
+	_, err = conn.DeleteLayerVersion(&lambda.DeleteLayerVersionInput{
+		LayerName:     aws.String(d.Get("layer_name").(string)),
+		VersionNumber: aws.Int64(version),
+	})
+	if err != nil {
+		return fmt.Errorf("error deleting Lambda Layer Version (%s): %s", d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Lambda layer %q deleted", d.Get("arn").(string))
+	return nil
+}
+
+func resourceAwsLambdaLayerVersionParseId(id string) (layerName string, version int64, err error) {
+	arn, err := arn2.Parse(id)
+	if err != nil {
+		return
+	}
+	parts := strings.Split(arn.Resource, ":")
+	if len(parts) != 3 || parts[0] != "layer" {
+		err = fmt.Errorf("lambda_layer ID must be a valid Layer ARN")
+		return
+	}
+
+	layerName = parts[1]
+	version, err = strconv.ParseInt(parts[2], 10, 64)
+	return
+}

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -1,0 +1,369 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_lambda_layer", &resource.Sweeper{
+		Name: "aws_lambda_layer",
+		F:    testSweepLambdaLayerVersions,
+	})
+}
+
+func testSweepLambdaLayerVersions(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	lambdaconn := client.(*AWSClient).lambdaconn
+	resp, err := lambdaconn.ListLayers(&lambda.ListLayersInput{})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lambda Layer sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("Error retrieving Lambda layers: %s", err)
+	}
+
+	if len(resp.Layers) == 0 {
+		log.Print("[DEBUG] No aws lambda layers to sweep")
+		return nil
+	}
+
+	for _, l := range resp.Layers {
+		if !strings.HasPrefix(*l.LayerName, "tf_acc_") {
+			continue
+		}
+
+		versionResp, err := lambdaconn.ListLayerVersions(&lambda.ListLayerVersionsInput{
+			LayerName: l.LayerName,
+		})
+		if err != nil {
+			return fmt.Errorf("Error retrieving versions for lambda layer: %s", err)
+		}
+
+		for _, v := range versionResp.LayerVersions {
+			_, err := lambdaconn.DeleteLayerVersion(&lambda.DeleteLayerVersionInput{
+				LayerName:     l.LayerName,
+				VersionNumber: v.Version,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccAWSLambdaLayerVersion_basic(t *testing.T) {
+	resourceName := "aws_lambda_layer_version.lambda_layer_test"
+	layerName := fmt.Sprintf("tf_acc_lambda_layer_basic_%s", acctest.RandString(8))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaLayerVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaLayerVersionBasic(layerName),
+				Check:  testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaLayerVersion_update(t *testing.T) {
+	resourceName := "aws_lambda_layer_version.lambda_layer_test"
+	layerName := fmt.Sprintf("tf_acc_lambda_layer_basic_%s", acctest.RandString(8))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaLayerVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaLayerVersionCreateBeforeDestroy(layerName, "test-fixtures/lambdatest.zip"),
+				Check:  testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "source_code_hash"},
+			},
+
+			{
+				Config: testAccAWSLambdaLayerVersionCreateBeforeDestroy(layerName, "test-fixtures/lambdatest_modified.zip"),
+				Check:  testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaLayerVersion_s3(t *testing.T) {
+	resourceName := "aws_lambda_layer_version.lambda_layer_test"
+	rString := acctest.RandString(8)
+	layerName := fmt.Sprintf("tf_acc_lambda_layer_s3_%s", rString)
+	bucketName := fmt.Sprintf("tf-acc-bucket-lambda-layer-s3-%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaLayerVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaLayerVersionS3(bucketName, layerName),
+				Check:  testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"s3_bucket", "s3_key"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaLayerVersion_compatibleRuntimes(t *testing.T) {
+	resourceName := "aws_lambda_layer_version.lambda_layer_test"
+	rString := acctest.RandString(8)
+	layerName := fmt.Sprintf("tf_acc_lambda_layer_runtimes_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaLayerVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaLayerVersionCompatibleRuntimes(layerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+					resource.TestCheckResourceAttr(resourceName, "compatible_runtimes.#", "2"),
+				),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaLayerVersion_description(t *testing.T) {
+	resourceName := "aws_lambda_layer_version.lambda_layer_test"
+	rString := acctest.RandString(8)
+	layerName := fmt.Sprintf("tf_acc_lambda_layer_description_%s", rString)
+	testDescription := "test description"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaLayerVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaLayerVersionDescription(layerName, testDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+					resource.TestCheckResourceAttr(resourceName, "description", testDescription),
+				),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename"},
+			},
+		},
+	})
+}
+
+func TestAccAWSLambdaLayerVersion_licenseInfo(t *testing.T) {
+	resourceName := "aws_lambda_layer_version.lambda_layer_test"
+	rString := acctest.RandString(8)
+	layerName := fmt.Sprintf("tf_acc_lambda_layer_license_info_%s", rString)
+	testLicenseInfo := "MIT"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaLayerVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaLayerVersionLicenseInfo(layerName, testLicenseInfo),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+					resource.TestCheckResourceAttr(resourceName, "license_info", testLicenseInfo),
+				),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename"},
+			},
+		},
+	})
+}
+
+func testAccCheckLambdaLayerVersionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).lambdaconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lambda_layer" {
+			continue
+		}
+
+		layerName, version, err := resourceAwsLambdaLayerVersionParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = conn.GetLayerVersion(&lambda.GetLayerVersionInput{
+			LayerName:     aws.String(layerName),
+			VersionNumber: aws.Int64(version),
+		})
+		if isAWSErr(err, lambda.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Lambda Layer Version (%s) still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckAwsLambdaLayerVersionExists(res, layerName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[res]
+		if !ok {
+			return fmt.Errorf("Lambda Layer version not found: %s", res)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Lambda Layer ID not set")
+		}
+
+		if rs.Primary.Attributes["version"] == "" {
+			return fmt.Errorf("Lambda Layer Version not set")
+		}
+
+		version, err := strconv.Atoi(rs.Primary.Attributes["version"])
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lambdaconn
+		_, err = conn.GetLayerVersion(&lambda.GetLayerVersionInput{
+			LayerName:     aws.String(layerName),
+			VersionNumber: aws.Int64(int64(version)),
+		})
+		return err
+	}
+}
+
+func testAccAWSLambdaLayerVersionBasic(layerName string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "lambda_layer_test" {
+	filename = "test-fixtures/lambdatest.zip"
+	layer_name = "%s"
+}
+`, layerName)
+}
+
+func testAccAWSLambdaLayerVersionS3(bucketName, layerName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "lambda_bucket" {
+	bucket = "%s"
+}
+
+resource "aws_s3_bucket_object" "lambda_code" {
+	bucket = "${aws_s3_bucket.lambda_bucket.id}"
+	key = "lambdatest.zip"
+	source = "test-fixtures/lambdatest.zip"
+}
+
+resource "aws_lambda_layer_version" "lambda_layer_test" {
+	s3_bucket = "${aws_s3_bucket.lambda_bucket.id}"
+	s3_key = "${aws_s3_bucket_object.lambda_code.id}"
+	layer_name = "%s"
+}
+`, bucketName, layerName)
+}
+
+func testAccAWSLambdaLayerVersionCreateBeforeDestroy(layerName string, filename string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "lambda_layer_test" {
+  filename         = "%s"
+  layer_name       = "%s"
+  source_code_hash = "${base64sha256(file("%s"))}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`, filename, layerName, filename)
+}
+
+func testAccAWSLambdaLayerVersionCompatibleRuntimes(layerName string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "lambda_layer_test" {
+	filename = "test-fixtures/lambdatest.zip"
+	layer_name = "%s"
+
+	compatible_runtimes = ["nodejs8.10", "nodejs6.10"]
+}
+`, layerName)
+}
+
+func testAccAWSLambdaLayerVersionDescription(layerName string, description string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "lambda_layer_test" {
+	filename = "test-fixtures/lambdatest.zip"
+	layer_name = "%s"
+
+	description = "%s"
+}
+`, layerName, description)
+}
+
+func testAccAWSLambdaLayerVersionLicenseInfo(layerName string, licenseInfo string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "lambda_layer_test" {
+	filename = "test-fixtures/lambdatest.zip"
+	layer_name = "%s"
+
+	license_info = "%s"
+}
+`, layerName, licenseInfo)
+}

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -237,7 +237,7 @@ func testAccCheckLambdaLayerVersionDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).lambdaconn
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_lambda_layer" {
+		if rs.Type != "aws_lambda_layer_version" {
 			continue
 		}
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1670,6 +1670,9 @@
                       <li<%= sidebar_current("docs-aws-resource-lambda-function") %>>
                           <a href="/docs/providers/aws/r/lambda_function.html">aws_lambda_function</a>
                       </li>
+                      <li<%= sidebar_current("docs-aws-resource-lambda-layer-version") %>>
+                          <a href="/docs/providers/aws/r/lambda_layer_version.html">aws_lambda_layer_version</a>
+                      </li>
                       <li<%= sidebar_current("docs-aws-resource-lambda-permission") %>>
                           <a href="/docs/providers/aws/r/lambda_permission.html">aws_lambda_permission</a>
                       </li>

--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -1,0 +1,68 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lambda_layer_version"
+sidebar_current: "docs-aws-resource-lambda-layer-version"
+description: |-
+  Provides a Lambda Layer Version resource. Lambda Layers allow you to reuse shared bits of code across multiple lambda functions.
+---
+
+# aws_lambda_layer_version
+
+Provides a Lambda Layer Version resource. Lambda Layers allow you to reuse shared bits of code across multiple lambda functions.
+
+For information about Lambda Layers and how to use them, see [AWS Lambda Layers][1]
+
+## Example Usage
+
+```hcl
+resource "aws_lambda_layer_version" "lambda_layer" {
+  filename = "lambda_layer_payload.zip"
+  layer_name = "lambda_layer_name"
+  
+  compatible_runtimes = ["nodejs8.10", nodejs6.10"]
+}
+```
+
+## Specifying the Deployment Package
+
+AWS Lambda Layers expect source code to be provided as a deployment package whose structure varies depending on which `compatible_runtimes` this layer specifies.
+See [Runtimes][2] for the valid values of `compatible_runtimes`.
+
+Once you have created your deployment package you can specify it either directly as a local file (using the `filename` argument) or
+indirectly via Amazon S3 (using the `s3_bucket`, `s3_key` and `s3_object_version` arguments). When providing the deployment
+package via S3 it may be useful to use [the `aws_s3_bucket_object` resource](s3_bucket_object.html) to upload it.
+
+For larger deployment packages it is recommended by Amazon to upload via S3, since the S3 API has better support for uploading
+large files efficiently.
+
+## Argument Reference
+
+* `layer_name` (Required) A unique name for your Lambda Layer
+* `filename` (Optional) The path to the function's deployment package within the local filesystem. If defined, The `s3_`-prefixed options cannot be used.
+* `s3_bucket` - (Optional) The S3 bucket location containing the function's deployment package. Conflicts with `filename`. This bucket must reside in the same AWS region where you are creating the Lambda function.
+* `s3_key` - (Optional) The S3 key of an object containing the function's deployment package. Conflicts with `filename`.
+* `s3_object_version` - (Optional) The object version containing the function's deployment package. Conflicts with `filename`.
+* `compatible_runtimes` - (Optional) A list of [Runtimes][2] this layer is compatible with. Up to 5 runtimes can be specified.
+* `description` - (Optional) Description of what your Lambda Layer does.
+* `license_info` - (Optional) License info for your Lambda Layer. See [License Info][3].
+* `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `${base64sha256(file("file.zip"))}`, where "file.zip" is the local filename of the lambda layer source archive.
+
+## Attributes Reference
+
+* `arn` - The Amazon Resource Name (ARN) identifying your Lambda Layer.
+* `layer_arn` - The Amazon Resource Name (ARN) identifying your specific Lambda Layer version.
+* `created_date` - The date this resource was created.
+* `source_code_size` - The size in bytes of the function .zip file.
+* `version` - This Lamba Layer version.
+
+[1]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
+[2]: https://docs.aws.amazon.com/lambda/latest/dg/API_PublishLayerVersion.html#SSS-PublishLayerVersion-request-CompatibleRuntimes
+[3]: https://docs.aws.amazon.com/lambda/latest/dg/API_PublishLayerVersion.html#SSS-PublishLayerVersion-request-LicenseInfo
+
+## Import
+
+Lambda Layers can be imported using `layer_name` and `version` together.
+
+```
+$ terraform import aws_lambda_layer_version.test_layer layer-name:1
+```


### PR DESCRIPTION
refs #6651 

Changes proposed in this pull request:

* Add `aws_lambda_layer` resource

TODO:
- [x] add docs for resource
- [x] finish adding remainder of tests

Output from acceptance testing (so far):

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaLayer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run TestAccAWSLambdaLayer -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLambdaLayer_basic
=== PAUSE TestAccAWSLambdaLayer_basic
=== RUN   TestAccAWSLambdaLayer_s3
=== PAUSE TestAccAWSLambdaLayer_s3
=== CONT  TestAccAWSLambdaLayer_basic
=== CONT  TestAccAWSLambdaLayer_s3
--- PASS: TestAccAWSLambdaLayer_basic (17.40s)
--- PASS: TestAccAWSLambdaLayer_s3 (25.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.018s
```