### PR TITLE
Updated docs to include regions

### DIFF
--- a/website/docs/d/canonical_user_id.html.markdown
+++ b/website/docs/d/canonical_user_id.html.markdown
@@ -10,7 +10,9 @@ description: |-
 # Data Source: aws_canonical_user_id
 
 The Canonical User ID data source allows access to the [canonical user ID](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)
-for the effective account in which Terraform is working.
+for the effective account in which Terraform is working.  
+
+**NOTE:** [This value](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html) is only included in the response in the US East (N. Virginia), US West (N. California), US West (Oregon), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), EU (Ireland), and South America (São Paulo) regions.
 
 ## Example Usage
 
@@ -32,4 +34,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The canonical user ID associated with the AWS account.
 
-* `display_name` - The human-friendly name linked to the canonical user ID.
+* `display_name` - The human-friendly name linked to the canonical user ID. The bucket owner's display name.


### PR DESCRIPTION
Resolves #6762 

User(s) receiving empty string for `display_name` depending on which region. Added verbiage to TF documentation to clarify which regions will/should actually show `display_name`.