### PR TITLE
Fix typo: 'type = string' => 'types = list'

### DIFF
--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -92,7 +92,7 @@ resource "aws_api_gateway_domain_name" "example" {
   regional_certificate_arn = "${aws_acm_certificate_validation.example.certificate_arn}"
 
   endpoint_configuration {
-    type = "REGIONAL"
+    types = ["REGIONAL"]
   }
 }
 
@@ -122,7 +122,7 @@ resource "aws_api_gateway_domain_name" "example" {
   regional_certificate_name = "example-api"
 
   endpoint_configuration {
-    type = "REGIONAL"
+    types = ["REGIONAL"]
   }
 }
 


### PR DESCRIPTION
The documentation for the module already uses `types` instead of `type`
(and using a list instead of just a string), this is only to fix the
example code.