### PR TITLE
Updated to live under `display_name`

### DIFF
--- a/website/docs/d/canonical_user_id.html.markdown
+++ b/website/docs/d/canonical_user_id.html.markdown
@@ -12,8 +12,6 @@ description: |-
 The Canonical User ID data source allows access to the [canonical user ID](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)
 for the effective account in which Terraform is working.  
 
-**NOTE:** [This value](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html) is only included in the response in the US East (N. Virginia), US West (N. California), US West (Oregon), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), EU (Ireland), and South America (São Paulo) regions.
-
 ## Example Usage
 
 ```hcl
@@ -34,4 +32,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The canonical user ID associated with the AWS account.
 
-* `display_name` - The human-friendly name linked to the canonical user ID. The bucket owner's display name.
+* `display_name` - The human-friendly name linked to the canonical user ID. The bucket owner's display name. **NOTE:** [This value](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html) is only included in the response in the US East (N. Virginia), US West (N. California), US West (Oregon), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), EU (Ireland), and South America (São Paulo) regions.


### PR DESCRIPTION
Updated as the canonical owner ID is still returned in other regions, it's just the display name that is missing. Change per @bflad .
