### PR TITLE
r/aws_glue_crawler: add a security_configuration argument

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -165,6 +165,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				},
 				ValidateFunc: validation.ValidateJsonString,
 			},
+			"security_configuration": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -238,6 +242,10 @@ func createCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.Creat
 			return nil, fmt.Errorf("Configuration contains an invalid JSON: %v", err)
 		}
 		crawlerInput.Configuration = aws.String(configuration)
+	}
+
+	if securityConfiguration, ok := d.GetOk("security_configuration"); ok {
+		crawlerInput.CrawlerSecurityConfiguration = aws.String(securityConfiguration.(string))
 	}
 
 	return crawlerInput, nil
@@ -412,6 +420,7 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("role", crawlerOutput.Crawler.Role)
 	d.Set("configuration", crawlerOutput.Crawler.Configuration)
 	d.Set("description", crawlerOutput.Crawler.Description)
+	d.Set("security_configuration", crawlerOutput.Crawler.CrawlerSecurityConfiguration)
 	d.Set("schedule", "")
 	if crawlerOutput.Crawler.Schedule != nil {
 		d.Set("schedule", crawlerOutput.Crawler.Schedule.ScheduleExpression)

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -775,17 +775,17 @@ func TestAccAWSGlueCrawler_SecurityConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGlueCrawlerConfig_SecurityConfiguration(rName, "security_configuration_name1"),
+				Config: testAccGlueCrawlerConfig_SecurityConfiguration(rName, "security_configuration1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
-					resource.TestCheckResourceAttr(resourceName, "security_configuration", "security_configuration_name1"),
+					resource.TestCheckResourceAttr(resourceName, "security_configuration", "security_configuration1"),
 				),
 			},
 			{
-				Config: testAccGlueCrawlerConfig_TablePrefix(rName, "security_configuration_name2"),
+				Config: testAccGlueCrawlerConfig_SecurityConfiguration(rName, "security_configuration2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
-					resource.TestCheckResourceAttr(resourceName, "security_configuration", "security_configuration_name2"),
+					resource.TestCheckResourceAttr(resourceName, "security_configuration", "security_configuration2"),
 				),
 			},
 			{
@@ -1393,17 +1393,35 @@ resource "aws_glue_catalog_database" "test" {
   name = %q
 }
 
+resource "aws_glue_security_configuration" "test" {
+  name = %q
+
+  encryption_configuration {
+    cloudwatch_encryption {
+      cloudwatch_encryption_mode = "DISABLED"
+    }
+
+    job_bookmarks_encryption {
+      job_bookmarks_encryption_mode = "DISABLED"
+    }
+
+    s3_encryption {
+      s3_encryption_mode = "DISABLED"
+    }
+  }
+}
+
 resource "aws_glue_crawler" "test" {
   depends_on = ["aws_iam_role_policy_attachment.test-AWSGlueServiceRole"]
 
   database_name          = "${aws_glue_catalog_database.test.name}"
   name                   = %q
   role                   = "${aws_iam_role.test.name}"
-  security_configuration = %q
+  security_configuration = "${aws_glue_security_configuration.test.name}"
 
   s3_target {
     path = "s3://bucket-name"
   }
 }
-`, rName, rName, securityConfiguration)
+`, rName, securityConfiguration, rName)
 }

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -764,6 +764,39 @@ func TestAccAWSGlueCrawler_TablePrefix(t *testing.T) {
 	})
 }
 
+func TestAccAWSGlueCrawler_SecurityConfiguration(t *testing.T) {
+	var crawler glue.Crawler
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_glue_crawler.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSGlueCrawlerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCrawlerConfig_SecurityConfiguration(rName, "security_configuration_name1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "security_configuration", "security_configuration_name1"),
+				),
+			},
+			{
+				Config: testAccGlueCrawlerConfig_TablePrefix(rName, "security_configuration_name2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					resource.TestCheckResourceAttr(resourceName, "security_configuration", "security_configuration_name2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSGlueCrawlerExists(resourceName string, crawler *glue.Crawler) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -1352,4 +1385,25 @@ resource "aws_glue_crawler" "test" {
   }
 }
 `, rName, rName, tablePrefix)
+}
+
+func testAccGlueCrawlerConfig_SecurityConfiguration(rName, securityConfiguration string) string {
+	return testAccGlueCrawlerConfig_Base(rName) + fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %q
+}
+
+resource "aws_glue_crawler" "test" {
+  depends_on = ["aws_iam_role_policy_attachment.test-AWSGlueServiceRole"]
+
+  database_name          = "${aws_glue_catalog_database.test.name}"
+  name                   = %q
+  role                   = "${aws_iam_role.test.name}"
+  security_configuration = %q
+
+  s3_target {
+    path = "s3://bucket-name"
+  }
+}
+`, rName, rName, securityConfiguration)
 }

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -73,6 +73,7 @@ The following arguments are supported:
 * `schedule` (Optional) A cron expression used to specify the schedule. For more information, see [Time-Based Schedules for Jobs and Crawlers](https://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html). For example, to run something every day at 12:15 UTC, you would specify: `cron(15 12 * * ? *)`.
 * `schema_change_policy` (Optional) Policy for the crawler's update and deletion behavior.
 * `table_prefix` (Optional) The table prefix used for catalog tables that are created.
+* `security_configuration` (Optional) The name of Security Configuration to be used by the crawler
 
 ### dynamodb_target Argument Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6714

Changes proposed in this pull request:

* Add new `security_configuration` argument to `aws_glue_crawler` resource


Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSGlueCrawler_SecurityConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGlueCrawler_SecurityConfiguration -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSGlueCrawler_SecurityConfiguration
=== PAUSE TestAccAWSGlueCrawler_SecurityConfiguration
=== CONT  TestAccAWSGlueCrawler_SecurityConfiguration
--- PASS: TestAccAWSGlueCrawler_SecurityConfiguration (82.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	82.661s

...
```
