### PR TITLE
docs/resource/aws_codedeploy_deployment_group: Ensure Blue Green Deployments with ECS example includes aws_codedeploy_app resource with compute_platform set to ECS

### DIFF
--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -88,6 +88,11 @@ resource "aws_codedeploy_deployment_group" "example" {
 ### Blue Green Deployments with ECS
 
 ```hcl
+resource "aws_codedeploy_app" "example" {
+  compute_platform = "ECS"
+  name             = "example"
+}
+
 resource "aws_codedeploy_deployment_group" "example" {
   app_name               = "${aws_codedeploy_app.example.name}"
   deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"


### PR DESCRIPTION
Easy to overlook as `compute_platform` defaults to a server based deployment type and should be included in this example.

Closes #6802