### PR TITLE
resource/aws_api_gateway_deployment: Handle new AWS Go SDK parameter validation for GetStage during deletion

### DIFF
--- a/aws/resource_aws_api_gateway_deployment_test.go
+++ b/aws/resource_aws_api_gateway_deployment_test.go
@@ -2,17 +2,21 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSAPIGatewayDeployment_basic(t *testing.T) {
-	var conf apigateway.Deployment
+	var deployment apigateway.Deployment
+	resourceName := "aws_api_gateway_deployment.test"
+	restApiResourceName := "aws_api_gateway_rest_api.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test-deployment")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,17 +24,17 @@ func TestAccAWSAPIGatewayDeployment_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayDeploymentConfig,
+				Config: testAccAWSAPIGatewayDeploymentConfigStageName(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "stage_name", "test"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "description", "This is a test"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "variables.a", "2"),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_deployment.test", "created_date"),
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					resource.TestCheckResourceAttrSet(resourceName, "created_date"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					testAccMatchResourceAttrRegionalARN(resourceName, "execution_arn", "execute-api", regexp.MustCompile(fmt.Sprintf(".+/%s", rName))),
+					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexp.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", testAccGetRegion(), rName))),
+					resource.TestCheckResourceAttrPair(resourceName, "rest_api_id", restApiResourceName, "id"),
+					resource.TestCheckNoResourceAttr(resourceName, "stage_description"),
+					resource.TestCheckResourceAttr(resourceName, "stage_name", rName),
+					resource.TestCheckNoResourceAttr(resourceName, "variables.%"),
 				),
 			},
 		},
@@ -38,8 +42,9 @@ func TestAccAWSAPIGatewayDeployment_basic(t *testing.T) {
 }
 
 func TestAccAWSAPIGatewayDeployment_createBeforeDestoryUpdate(t *testing.T) {
-	var conf apigateway.Deployment
+	var deployment apigateway.Deployment
 	var stage apigateway.Stage
+	resourceName := "aws_api_gateway_deployment.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -47,33 +52,109 @@ func TestAccAWSAPIGatewayDeployment_createBeforeDestoryUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayDeploymentCreateBeforeDestroyConfig("description1", "https://www.google.com"),
+				Config: testAccAWSAPIGatewayDeploymentConfigCreateBeforeDestroy("description1", "https://example.com"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "stage_name", "test"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "description", "description1"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "variables.a", "2"),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_deployment.test", "created_date"),
-					testAccCheckAWSAPIGatewayDeploymentStageExists("aws_api_gateway_deployment.test", &stage),
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					testAccCheckAWSAPIGatewayDeploymentStageExists(resourceName, &stage),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+					resource.TestCheckResourceAttr(resourceName, "stage_description", "description1"),
 				),
 			},
 			{
-				Config: testAccAWSAPIGatewayDeploymentCreateBeforeDestroyConfig("description2", "https://www.google.de"),
+				Config: testAccAWSAPIGatewayDeploymentConfigCreateBeforeDestroy("description2", "https://example.org"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayDeploymentExists("aws_api_gateway_deployment.test", &conf),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "stage_name", "test"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "description", "description2"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_deployment.test", "variables.a", "2"),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_deployment.test", "created_date"),
-					testAccCheckAWSAPIGatewayDeploymentStageExists("aws_api_gateway_deployment.test", &stage),
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					testAccCheckAWSAPIGatewayDeploymentStageExists(resourceName, &stage),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+					resource.TestCheckResourceAttr(resourceName, "stage_description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDeployment_Description(t *testing.T) {
+	var deployment apigateway.Deployment
+	resourceName := "aws_api_gateway_deployment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayDeploymentConfigDescription("description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayDeploymentConfigDescription("description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDeployment_StageDescription(t *testing.T) {
+	var deployment apigateway.Deployment
+	resourceName := "aws_api_gateway_deployment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayDeploymentConfigStageDescription("description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					resource.TestCheckResourceAttr(resourceName, "stage_description", "description1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDeployment_StageName_Empty(t *testing.T) {
+	var deployment apigateway.Deployment
+	resourceName := "aws_api_gateway_deployment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayDeploymentConfigStageName(""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					resource.TestCheckNoResourceAttr(resourceName, "stage_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayDeployment_Variables(t *testing.T) {
+	var deployment apigateway.Deployment
+	resourceName := "aws_api_gateway_deployment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayDeploymentConfigVariables("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDeploymentExists(resourceName, &deployment),
+					resource.TestCheckResourceAttr(resourceName, "variables.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "variables.key1", "value1"),
 				),
 			},
 		},
@@ -140,40 +221,39 @@ func testAccCheckAWSAPIGatewayDeploymentDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).apigateway
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "aws_api_gateway_resource" {
+		if rs.Type != "aws_api_gateway_deployment" {
 			continue
 		}
 
 		req := &apigateway.GetDeploymentsInput{
-			RestApiId: aws.String(s.RootModule().Resources["aws_api_gateway_rest_api.test"].Primary.ID),
+			RestApiId: aws.String(rs.Primary.Attributes["rest_api_id"]),
 		}
 		describe, err := conn.GetDeployments(req)
 
-		if err == nil {
-			if len(describe.Items) != 0 &&
-				*describe.Items[0].Id == rs.Primary.ID {
-				return fmt.Errorf("API Gateway Deployment still exists")
+		if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if describe != nil {
+			for _, deployment := range describe.Items {
+				if aws.StringValue(deployment.Id) == rs.Primary.ID {
+					return fmt.Errorf("API Gateway Deployment still exists")
+				}
 			}
 		}
-
-		aws2err, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if aws2err.Code() != "NotFoundException" {
-			return err
-		}
-
-		return nil
 	}
 
 	return nil
 }
 
-func buildAPIGatewayDeploymentConfig(description, url, extras string) string {
+func testAccAWSAPIGatewayDeploymentConfigBase(uri string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "test"
+  name = "tf-acc-test-deployment"
 }
 
 resource "aws_api_gateway_resource" "test" {
@@ -212,30 +292,72 @@ resource "aws_api_gateway_integration_response" "test" {
   http_method = "${aws_api_gateway_integration.test.http_method}"
   status_code = "${aws_api_gateway_method_response.error.status_code}"
 }
+`, uri)
+}
 
+func testAccAWSAPIGatewayDeploymentConfigCreateBeforeDestroy(description string, url string) string {
+	return testAccAWSAPIGatewayDeploymentConfigBase(url) + fmt.Sprintf(`
+resource "aws_api_gateway_deployment" "test" {
+  depends_on = ["aws_api_gateway_integration.test"]
+
+  description       = %q
+  rest_api_id       = "${aws_api_gateway_rest_api.test.id}"
+  stage_description = %q
+  stage_name        = "tf-acc-test"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`, description, description)
+}
+
+func testAccAWSAPIGatewayDeploymentConfigDescription(description string) string {
+	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
+resource "aws_api_gateway_deployment" "test" {
+  depends_on = ["aws_api_gateway_integration.test"]
+
+  description = %q
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "tf-acc-test"
+}
+`, description)
+}
+
+func testAccAWSAPIGatewayDeploymentConfigStageDescription(stageDescription string) string {
+	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
+resource "aws_api_gateway_deployment" "test" {
+  depends_on = ["aws_api_gateway_integration.test"]
+
+  rest_api_id       = "${aws_api_gateway_rest_api.test.id}"
+  stage_description = %q
+  stage_name        = "tf-acc-test"
+}
+`, stageDescription)
+}
+
+func testAccAWSAPIGatewayDeploymentConfigStageName(stageName string) string {
+	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
 resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
 
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "test"
-	description = "%s"
-	stage_description = "%s"
+  stage_name  = %q
+}
+`, stageName)
+}
 
-	%s
+func testAccAWSAPIGatewayDeploymentConfigVariables(key1, value1 string) string {
+	return testAccAWSAPIGatewayDeploymentConfigBase("http://example.com") + fmt.Sprintf(`
+resource "aws_api_gateway_deployment" "test" {
+  depends_on = ["aws_api_gateway_integration.test"]
+
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "tf-acc-test"
 
   variables = {
-    "a" = "2"
+    %q = %q
   }
 }
-`, url, description, description, extras)
-}
-
-var testAccAWSAPIGatewayDeploymentConfig = buildAPIGatewayDeploymentConfig("This is a test", "https://www.google.de", "")
-
-func testAccAWSAPIGatewayDeploymentCreateBeforeDestroyConfig(description string, url string) string {
-	return buildAPIGatewayDeploymentConfig(description, url, `
-		lifecycle {
-			create_before_destroy = true
-		}
-	`)
+`, key1, value1)
 }


### PR DESCRIPTION
Fixes #6806 (this issue highlights a regression which would have been released since it did not have a covering acceptance test)

Changes:
* tests/resource/aws_api_gateway_deployment: Add acceptance test for empty stage_name
* resource/aws_api_gateway_deployment: Handle new AWS Go SDK parameter validation for GetStage during deletion
* tests/resource/aws_api_gateway_deployment: Fix CheckDestroy function to check for aws_api_gateway_deployment resources
* tests/resource/aws_api_gateway_deployment: Enhance testing for check every attribute

Output from acceptance testing before change:

```
--- FAIL: TestAccAWSAPIGatewayDeployment_StageName_Empty (13.21s)
    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Error applying: 1 error occurred:
        	* aws_api_gateway_deployment.test (destroy): 1 error occurred:
        	* aws_api_gateway_deployment.test: error getting referenced stage: InvalidParameter: 1 validation error(s) found.
        - minimum field size of 1, GetStageInput.StageName.
```

Output from acceptance testing after change:

```
--- PASS: TestAccAWSAPIGatewayDeployment_StageDescription (16.37s)
--- PASS: TestAccAWSAPIGatewayDeployment_Variables (17.63s)
--- PASS: TestAccAWSAPIGatewayDeployment_Description (81.95s)
--- PASS: TestAccAWSAPIGatewayDeployment_StageName_Empty (135.55s)
--- PASS: TestAccAWSAPIGatewayDeployment_basic (138.77s)
--- PASS: TestAccAWSAPIGatewayDeployment_createBeforeDestoryUpdate (138.78s)
```
