### PR TITLE
tests/resource/aws_ami_copy: Simplify basic test and add description test

### DIFF
--- a/aws/resource_aws_ami_copy_test.go
+++ b/aws/resource_aws_ami_copy_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccAWSAMICopy_basic(t *testing.T) {
 	var image ec2.Image
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ami_copy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,10 +22,38 @@ func TestAccAWSAMICopy_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAMICopyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAMICopyConfig,
+				Config: testAccAWSAMICopyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAMICopyExists(resourceName, &image),
-					testAccCheckAWSAMICopyAttributes(&image),
+					testAccCheckAWSAMICopyAttributes(&image, rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAMICopy_Description(t *testing.T) {
+	var image ec2.Image
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ami_copy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAMICopyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAMICopyConfigDescription(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAMICopyExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				Config: testAccAWSAMICopyConfigDescription(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAMICopyExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
 				),
 			},
 		},
@@ -42,7 +71,7 @@ func TestAccAWSAMICopy_EnaSupport(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAMICopyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAMICopyConfig_ENASupport(rName),
+				Config: testAccAWSAMICopyConfigENASupport(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAMICopyExists(resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "ena_support", "true"),
@@ -108,7 +137,7 @@ func testAccCheckAWSAMICopyDestroy(s *terraform.State) error {
 	return testAccCheckAWSEbsSnapshotDestroy(s)
 }
 
-func testAccCheckAWSAMICopyAttributes(image *ec2.Image) resource.TestCheckFunc {
+func testAccCheckAWSAMICopyAttributes(image *ec2.Image, expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if expected := "available"; aws.StringValue(image.State) != expected {
 			return fmt.Errorf("invalid image state; expected %s, got %s", expected, aws.StringValue(image.State))
@@ -116,7 +145,7 @@ func testAccCheckAWSAMICopyAttributes(image *ec2.Image) resource.TestCheckFunc {
 		if expected := "machine"; aws.StringValue(image.ImageType) != expected {
 			return fmt.Errorf("wrong image type; expected %s, got %s", expected, aws.StringValue(image.ImageType))
 		}
-		if expected := "terraform-acc-ami-copy"; aws.StringValue(image.Name) != expected {
+		if expected := expectedName; aws.StringValue(image.Name) != expected {
 			return fmt.Errorf("wrong name; expected %s, got %s", expected, aws.StringValue(image.Name))
 		}
 
@@ -138,70 +167,7 @@ func testAccCheckAWSAMICopyAttributes(image *ec2.Image) resource.TestCheckFunc {
 	}
 }
 
-var testAccAWSAMICopyConfig = `
-provider "aws" {
-	region = "us-east-1"
-}
-
-// An AMI can't be directly copied from one account to another, and
-// we can't rely on any particular AMI being available since anyone
-// can run this test in whatever account they like.
-// Therefore we jump through some hoops here:
-//  - Spin up an EC2 instance based on a public AMI
-//  - Create an AMI by snapshotting that EC2 instance, using
-//    aws_ami_from_instance .
-//  - Copy the new AMI using aws_ami_copy .
-//
-// Thus this test can only succeed if the aws_ami_from_instance resource
-// is working. If it's misbehaving it will likely cause this test to fail too.
-
-// Since we're booting a t2.micro HVM instance we need a VPC for it to boot
-// up into.
-
-resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-ami-copy"
-	}
-}
-
-resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
-	tags = {
-		Name = "tf-acc-ami-copy"
-	}
-}
-
-resource "aws_instance" "test" {
-    // This AMI has one block device mapping, so we expect to have
-    // one snapshot in our created AMI.
-    // This is an Ubuntu Linux HVM AMI. A public HVM AMI is required
-    // because paravirtual images cannot be copied between accounts.
-    ami = "ami-0f8bce65"
-    instance_type = "t2.micro"
-  tags = {
-        Name = "terraform-acc-ami-copy-victim"
-    }
-
-    subnet_id = "${aws_subnet.foo.id}"
-}
-
-resource "aws_ami_from_instance" "test" {
-    name = "terraform-acc-ami-copy-victim"
-    description = "Testing Terraform aws_ami_from_instance resource"
-    source_instance_id = "${aws_instance.test.id}"
-}
-
-resource "aws_ami_copy" "test" {
-    name = "terraform-acc-ami-copy"
-    description = "Testing Terraform aws_ami_copy resource"
-    source_ami_id = "${aws_ami_from_instance.test.id}"
-    source_ami_region = "us-east-1"
-}
-`
-
-func testAccAWSAMICopyConfig_ENASupport(rName string) string {
+func testAccAWSAMICopyConfigBase() string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 data "aws_region" "current" {}
@@ -211,7 +177,7 @@ resource "aws_ebs_volume" "test" {
   size              = 1
 
   tags = {
-    Name = %q
+    Name = "tf-acc-test-ami-copy"
   }
 }
 
@@ -219,10 +185,57 @@ resource "aws_ebs_snapshot" "test" {
   volume_id = "${aws_ebs_volume.test.id}"
 
   tags = {
-    Name = %q
+    Name = "tf-acc-test-ami-copy"
+  }
+}
+`)
+}
+
+func testAccAWSAMICopyConfig(rName string) string {
+	return testAccAWSAMICopyConfigBase() + fmt.Sprintf(`
+resource "aws_ami" "test" {
+  name                = "%s-source"
+  virtualization_type = "hvm"
+  root_device_name    = "/dev/sda1"
+
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    snapshot_id = "${aws_ebs_snapshot.test.id}"
   }
 }
 
+resource "aws_ami_copy" "test" {
+  name              = %q
+  source_ami_id     = "${aws_ami.test.id}"
+  source_ami_region = "${data.aws_region.current.name}"
+}
+`, rName, rName)
+}
+
+func testAccAWSAMICopyConfigDescription(rName, description string) string {
+	return testAccAWSAMICopyConfigBase() + fmt.Sprintf(`
+resource "aws_ami" "test" {
+  name                = "%s-source"
+  virtualization_type = "hvm"
+  root_device_name    = "/dev/sda1"
+
+  ebs_block_device {
+    device_name = "/dev/sda1"
+    snapshot_id = "${aws_ebs_snapshot.test.id}"
+  }
+}
+
+resource "aws_ami_copy" "test" {
+  description       = %q
+  name              = %q
+  source_ami_id     = "${aws_ami.test.id}"
+  source_ami_region = "${data.aws_region.current.name}"
+}
+`, rName, description, rName)
+}
+
+func testAccAWSAMICopyConfigENASupport(rName string) string {
+	return testAccAWSAMICopyConfigBase() + fmt.Sprintf(`
 resource "aws_ami" "test" {
   ena_support         = true
   name                = "%s-source"
@@ -240,5 +253,5 @@ resource "aws_ami_copy" "test" {
     source_ami_id     = "${aws_ami.test.id}"
     source_ami_region = "${data.aws_region.current.name}"
 }
-`, rName, rName, rName, rName)
+`, rName, rName)
 }


### PR DESCRIPTION
The PR is the first in a series to reduce the daily acceptance test failures/flakey tests in preparation for switching development to the next major version of the provider.

The usage of the `aws_ami_from_instance` resource was flakey at best and highlighted an issue that needs to be addressed in a separate bug fix. Daily acceptance testing is reporting this currently with `TestAccAWSAMICopy_basic`: Frequent test status changes: 9 changes out of 66 invocations

With the following error:

```
--- FAIL: TestAccAWSAMICopy_basic (58.68s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_ami_from_instance.test: 1 error occurred:
          * aws_ami_from_instance.test: Error waiting for AMI (ami-07772720b881c21d9) to be ready: unexpected state 'failed', wanted target 'available'. last error: %!s(<nil>)
```

As an added bonus, this reduces the runtime of `TestAccAWSAMICopy_basic` by a minute or two.

Changes:
* tests/resource/aws_ami_copy: Switch `TestAccAWSAMICopy_basic` from `aws_ami_from_instance` resource usage to directly using `aws_ebs_volume`, `aws_ebs_snapshot`, and `aws_ami` resources
* tests/resource/aws_ami_copy: Add `TestAccAWSAMICopy_Description` acceptance test for verifying `description` attribute on creation and updates

Output from acceptance testing:

```
--- PASS: TestAccAWSAMICopy_EnaSupport (368.45s)
--- PASS: TestAccAWSAMICopy_basic (394.48s)
--- PASS: TestAccAWSAMICopy_Description (405.82s)
```