### PR TITLE
tests/data-source/aws_elasticache_cluster: Remove optional parameter_group_name argument from resource in test configuration

### DIFF
--- a/aws/data_source_aws_elasticache_cluster_test.go
+++ b/aws/data_source_aws_elasticache_cluster_test.go
@@ -60,7 +60,6 @@ resource "aws_elasticache_cluster" "bar" {
     node_type = "cache.m1.small"
     num_cache_nodes = 1
     port = 11211
-    parameter_group_name = "default.memcached1.4"
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
 }
 


### PR DESCRIPTION
memcached 1.5 support was released and Elasticache defaults to the newer engine version, however the resource was not setting the engine version so it would previously fail with:

```
--- FAIL: TestAccAWSDataElasticacheCluster_basic (8.77s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_elasticache_cluster.bar: 1 error occurred:
        	* aws_elasticache_cluster.bar: error creating Elasticache Cache Cluster: InvalidParameterCombination: Expected a parameter group of family memcached1.5 but found one of family memcached1.4
        	status code: 400, request id: e0f65211-fd45-11e8-8f41-7b9e77cae090
```

This change simply removes the optional `parameter_group_name` argument from the test configuration so it cannot be out of sync based on engine version.

Output from acceptance testing:

```
--- PASS: TestAccAWSDataElasticacheCluster_basic (712.89s)
```
