### PR TITLE
tests/resource/aws_elasticache_replication_group: Simplify and update TestAccAWSElasticacheReplicationGroup_updateParameterGroup for redis5.0

### DIFF
--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -250,28 +250,29 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 //This is a test to prove that we panic we get in https://github.com/hashicorp/terraform/issues/9097
 func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
 	var rg elasticache.ReplicationGroup
+	parameterGroupResourceName1 := "aws_elasticache_parameter_group.test.0"
+	parameterGroupResourceName2 := "aws_elasticache_parameter_group.test.1"
+	resourceName := "aws_elasticache_replication_group.test"
 	rName := acctest.RandString(10)
-	rInt := acctest.RandInt()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
+				Config: testAccAWSElasticacheReplicationGroupConfigParameterGroupName(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
-					resource.TestMatchResourceAttr(
-						"aws_elasticache_replication_group.bar", "parameter_group_name", regexp.MustCompile(`^default.redis.+`)),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", parameterGroupResourceName1, "name"),
 				),
 			},
 
 			{
-				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedParameterGroup(rName, rInt),
+				Config: testAccAWSElasticacheReplicationGroupConfigParameterGroupName(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
-					resource.TestCheckResourceAttr(
-						"aws_elasticache_replication_group.bar", "parameter_group_name", fmt.Sprintf("allkeys-lru-%d", rInt)),
+					testAccCheckAWSElasticacheReplicationGroupExists(resourceName, &rg),
+					resource.TestCheckResourceAttrPair(resourceName, "parameter_group_name", parameterGroupResourceName2, "name"),
 				),
 			},
 		},
@@ -870,50 +871,31 @@ resource "aws_elasticache_replication_group" "bar" {
 }`, rName, rName, rName)
 }
 
-func testAccAWSElasticacheReplicationGroupConfigUpdatedParameterGroup(rName string, rInt int) string {
+func testAccAWSElasticacheReplicationGroupConfigParameterGroupName(rName string, parameterGroupNameIndex int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-resource "aws_security_group" "bar" {
-    name = "tf-test-security-group-%s"
-    description = "tf-test-security-group-descr"
-    ingress {
-        from_port = -1
-        to_port = -1
-        protocol = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-}
+resource "aws_elasticache_parameter_group" "test" {
+  count = 2
 
-resource "aws_elasticache_security_group" "bar" {
-    name = "tf-test-security-group-%s"
-    description = "tf-test-security-group-descr"
-    security_group_names = ["${aws_security_group.bar.name}"]
+  # We do not have a data source for "latest" Elasticache family
+  # so unfortunately we must hardcode this for now
+  family = "redis5.0"
+  name   = "tf-%s-${count.index}"
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "allkeys-lru"
+  }
 }
 
-resource "aws_elasticache_parameter_group" "bar" {
-    name = "allkeys-lru-%d"
-    # We do not have a data source for "latest" Elasticache family
-    # so unfortunately we must hardcode this for now
-    family = "redis4.0"
-
-    parameter {
-        name = "maxmemory-policy"
-        value = "allkeys-lru"
-    }
+resource "aws_elasticache_replication_group" "test" {
+  apply_immediately             = true
+  node_type                     = "cache.m1.small"
+  number_cache_clusters         = 2
+  parameter_group_name          = "${aws_elasticache_parameter_group.test.*.name[%d]}"
+  replication_group_description = "test description"
+  replication_group_id          = "tf-%s"
 }
-
-resource "aws_elasticache_replication_group" "bar" {
-    replication_group_id = "tf-%s"
-    replication_group_description = "test description"
-    node_type = "cache.m1.small"
-    number_cache_clusters = 2
-    port = 6379
-    parameter_group_name = "${aws_elasticache_parameter_group.bar.name}"
-    security_group_names = ["${aws_elasticache_security_group.bar.name}"]
-    apply_immediately = true
-}`, rName, rName, rInt, rName)
+`, rName, parameterGroupNameIndex, rName)
 }
 
 func testAccAWSElasticacheReplicationGroupConfigUpdatedDescription(rName string) string {


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

Opting to just update the hardcoded family reference for now. Simplifies by removing unrelated test configuration including `port`, `security_group_names`, etc. attributes.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (967.77s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
        	* aws_elasticache_replication_group.bar: 1 error occurred:
        	* aws_elasticache_replication_group.bar: error updating Elasticache Replication Group (tf-fpcrlqpb3z): InvalidParameterValue: Incompatible cache parameter group. The cache has Parameter Group Family redis5.0. The requested cache parameter group has Parameter Group Family redis4.0.
        	status code: 400, request id: 784d4de6-fd60-11e8-90d5-0f82f22fed01
```

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticacheReplicationGroup_updateParameterGroup (954.92s)
```
