### PR TITLE
tests/resource/aws_instance: Simplify TestAccAWSInstance_volumeTagsComputed

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -1064,7 +1064,6 @@ func TestAccAWSInstance_volumeTagsComputed(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
 				),
-				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -2716,15 +2715,13 @@ data "aws_ami" "debian_jessie_latest" {
 }
 
 resource "aws_instance" "foo" {
-  ami                         = "${data.aws_ami.debian_jessie_latest.id}"
-  associate_public_ip_address = true
-  count                       = 1
-  instance_type               = "t2.medium"
+  ami           = "${data.aws_ami.debian_jessie_latest.id}"
+  instance_type = "t2.medium"
 
   root_block_device {
+    delete_on_termination = true
     volume_size           = "10"
     volume_type           = "standard"
-    delete_on_termination = true
   }
 
   tags = {
@@ -2733,10 +2730,9 @@ resource "aws_instance" "foo" {
 }
 
 resource "aws_ebs_volume" "test" {
-  depends_on        = ["aws_instance.foo"]
   availability_zone = "${aws_instance.foo.availability_zone}"
-  type       = "gp2"
   size              = "10"
+  type              = "gp2"
 
   tags = {
     Name = "test-terraform"
@@ -2744,7 +2740,6 @@ resource "aws_ebs_volume" "test" {
 }
 
 resource "aws_volume_attachment" "test" {
-  depends_on  = ["aws_ebs_volume.test"]
   device_name = "/dev/xvdg"
   volume_id   = "${aws_ebs_volume.test.id}"
   instance_id = "${aws_instance.foo.id}"


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

The `associate_public_ip_address` argument can be flakey: Frequent test status changes: 21 changes out of 69 invocations. Its not necessary for this test configuration, so removing it. Also cleans up other extraneous test configurations like `count` and explicit `depends_on`.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSInstance_volumeTagsComputed (128.66s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:
...
        DESTROY/CREATE: aws_instance.foo
...
          associate_public_ip_address:               "false" => "true" (forces new resource)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSInstance_volumeTagsComputed (145.77s)
```
