### PR TITLE
tests/data-source/aws_instances: Adjustments for inconsistent acceptance testing

### DIFF
--- a/aws/data_source_aws_instances_test.go
+++ b/aws/data_source_aws_instances_test.go
@@ -18,7 +18,8 @@ func TestAccAWSInstancesDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_instances.test", "ids.#", "3"),
 					resource.TestCheckResourceAttr("data.aws_instances.test", "private_ips.#", "3"),
-					resource.TestCheckResourceAttr("data.aws_instances.test", "public_ips.#", "3"),
+					// Public IP values are flakey for new EC2 instances due to eventual consistency
+					resource.TestCheckResourceAttrSet("data.aws_instances.test", "public_ips.#"),
 				),
 			},
 		},
@@ -34,9 +35,7 @@ func TestAccAWSInstancesDataSource_tags(t *testing.T) {
 			{
 				Config: testAccInstancesDataSourceConfig_tags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_instances.test", "ids.#", "5"),
-					resource.TestCheckResourceAttr("data.aws_instances.test", "private_ips.#", "5"),
-					resource.TestCheckResourceAttr("data.aws_instances.test", "public_ips.#", "5"),
+					resource.TestCheckResourceAttr("data.aws_instances.test", "ids.#", "2"),
 				),
 			},
 		},
@@ -112,22 +111,22 @@ data "aws_ami" "ubuntu" {
 }
 
 resource "aws_instance" "test" {
-  count = 5
+  count = 2
   ami = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
   tags = {
-    Name = "TfAccTest-HelloWorld"
-    TestSeed = "%[1]d"
+    Name      = "tf-acc-test-ec2-instance-data-source-%d"
+    SecondTag = "tf-acc-test-ec2-instance-data-source-%d"
   }
 }
 
 data "aws_instances" "test" {
   instance_tags {
-    Name = "${aws_instance.test.0.tags["Name"]}"
-    TestSeed = "%[1]d"
+    Name      = "${aws_instance.test.0.tags["Name"]}"
+    SecondTag = "${aws_instance.test.1.tags["Name"]}"
   }
 }
-`, rInt)
+`, rInt, rInt)
 }
 
 func testAccInstancesDataSourceConfig_instance_state_names(rInt int) string {
@@ -153,8 +152,7 @@ resource "aws_instance" "test" {
   ami = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
   tags = {
-    Name = "TfAccTest-HelloWorld"
-    TestSeed = "%[1]d"
+    Name = "tf-acc-test-ec2-instance-data-source-%d"
   }
 }
 


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

These acceptance tests are very flakey:
* TestAccAWSInstancesDataSource_basic: Frequent test status changes: 19 changes out of 69 invocations
* TestAccAWSInstancesDataSource_tags: Frequent test status changes: 37 changes out of 69 invocations

Some reasons for this include:
* EC2 Instance public IP eventual consistency with new instances
* Lack of explicit references in the test configurations
* Overlap of tag naming across test configurations

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSInstancesDataSource_basic (196.98s)
    testing.go:538: Step 0 error: Check failed: Check 3/3 error: data.aws_instances.test: Attribute 'public_ips.#' expected "3", got "0"

--- FAIL: TestAccAWSInstancesDataSource_tags (206.73s)
    testing.go:538: Step 0 error: Check failed: Check 1/3 error: data.aws_instances.test: Attribute 'ids.#' expected "5", got "4"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSInstancesDataSource_tags (107.16s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (107.20s)
--- PASS: TestAccAWSInstancesDataSource_basic (213.35s)
```
