### PR TITLE
tests/resource/aws_route53_query_log: Use lowercase naming, add ImportState testing to basic test

### DIFF
--- a/aws/resource_aws_route53_query_log_test.go
+++ b/aws/resource_aws_route53_query_log_test.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"fmt"
 	"os"
-	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -21,8 +21,10 @@ func TestAccAWSRoute53QueryLog_Basic(t *testing.T) {
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
 	defer os.Setenv("AWS_DEFAULT_REGION", oldRegion)
 
+	cloudwatchLogGroupResourceName := "aws_cloudwatch_log_group.test"
 	resourceName := "aws_route53_query_log.test"
-	rName := fmt.Sprintf("%s-%s", t.Name(), acctest.RandString(5))
+	route53ZoneResourceName := "aws_route53_zone.test"
+	rName := strings.ToLower(fmt.Sprintf("%s-%s", t.Name(), acctest.RandString(5)))
 
 	var queryLoggingConfig route53.QueryLoggingConfig
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,34 +36,10 @@ func TestAccAWSRoute53QueryLog_Basic(t *testing.T) {
 				Config: testAccCheckAWSRoute53QueryLogResourceConfigBasic1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53QueryLogExists(resourceName, &queryLoggingConfig),
-					resource.TestMatchResourceAttr(resourceName, "cloudwatch_log_group_arn",
-						regexp.MustCompile(fmt.Sprintf(`^arn:aws:logs:[^:]+:[0-9]{12}:log-group:/aws/route53/%s.com:\*$`, rName))),
-					resource.TestCheckResourceAttrSet(resourceName, "zone_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_log_group_arn", cloudwatchLogGroupResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "zone_id", route53ZoneResourceName, "zone_id"),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSRoute53QueryLog_Import(t *testing.T) {
-	// The underlying resources are sensitive to where they are located
-	// Use us-east-1 for testing
-	oldRegion := os.Getenv("AWS_DEFAULT_REGION")
-	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-	defer os.Setenv("AWS_DEFAULT_REGION", oldRegion)
-
-	resourceName := "aws_route53_query_log.test"
-	rName := fmt.Sprintf("%s-%s", t.Name(), acctest.RandString(5))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRoute53QueryLogDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckAWSRoute53QueryLogResourceConfigBasic1(rName),
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSRoute53QueryLog_Basic (49.42s)
    testing.go:538: Step 0 error: Check failed: Check 2/3 error: aws_route53_query_log.test: Attribute 'cloudwatch_log_group_arn' didn't match "^arn:aws:logs:[^:]+:[0-9]{12}:log-group:/aws/route53/TestAccAWSRoute53QueryLog_Basic-hs1i8.com:\\*$", got "arn:aws:logs:us-east-1:*******:log-group:/aws/route53/testaccawsroute53querylog_basic-hs1i8.com.:*"

--- FAIL: TestAccAWSRoute53QueryLog_Import (44.85s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:
...
        DESTROY/CREATE: aws_route53_zone.test
...
          name:           "testaccawsroute53querylog_import-4sibf.com." => "TestAccAWSRoute53QueryLog_Import-4sibf.com" (forces new resource)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53QueryLog_Basic (43.72s)
```
