### PR TITLE
tests/resource/aws_ssm_activation: Fix ExpectError in TestAccAWSSSMActivation_expirationDate

### DIFF
--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -44,7 +44,7 @@ func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSSSMActivationConfig_expirationDate(rName, "2018-03-01"),
-				ExpectError: regexp.MustCompile(`cannot parse`),
+				ExpectError: regexp.MustCompile(`invalid RFC3339 timestamp`),
 			},
 			{
 				Config: testAccAWSSSMActivationConfig_expirationDate(rName, expirationDateS),


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

Looks like this was an oversight from #6156 (technical debt PR to use upstream validation function)

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSSSMActivation_expirationDate (0.48s)
    testing.go:531: Step 0, expected error:

        config is invalid: aws_ssm_activation.foo: "expiration_date": invalid RFC3339 timestamp

        To match:

        cannot parse
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMActivation_expirationDate (30.55s)
```
