### PR TITLE
tests: Ensure Amazon Linux 2 AMI matching includes expected architecture

### DIFF
--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -314,7 +314,7 @@ data "aws_ami" "amzn" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*"]
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
   }
 }
 

--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -492,7 +492,7 @@ data "aws_ami" "amzn" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*-gp2"]
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
   }
 }
 


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

Amazon started releasing `arm64` architecture AMIs that matched the previous name wildcard.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSSSMAssociation_basic (7.26s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_instance.foo: 1 error occurred:
        	* aws_instance.foo: Error launching source instance: Unsupported: The requested configuration is currently not supported. Please check the documentation for supported configurations.
        	status code: 400, request id: 7becdb98-c6b8-4b56-a877-bbf3f09db612
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoscalingPolicy_zerovalue (41.49s)
--- PASS: TestAccAWSAutoscalingPolicy_disappears (43.43s)
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (44.44s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (49.59s)
--- PASS: TestAccAWSAutoscalingPolicy_upgrade (80.77s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (80.87s)
--- PASS: TestAccAWSAutoscalingPolicy_basic (81.92s)

--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (16.10s)
--- PASS: TestAccAWSSSMAssociation_withParameters (26.30s)
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (28.41s)
--- PASS: TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression (32.45s)
--- PASS: TestAccAWSSSMAssociation_withTargets (37.09s)
--- PASS: TestAccAWSSSMAssociation_withAssociationName (38.50s)
--- PASS: TestAccAWSSSMAssociation_withOutputLocation (66.50s)
--- PASS: TestAccAWSSSMAssociation_basic (150.99s)
```
