### PR TITLE
tests/data-source/aws_pricing_product: Add capacitystatus filter for EC2 test configuration

### DIFF
--- a/aws/data_source_aws_pricing_product_test.go
+++ b/aws/data_source_aws_pricing_product_test.go
@@ -77,6 +77,10 @@ func testAccDataSourceAwsPricingProductConfigEc2(dataName string, instanceType s
 			field = "tenancy"
 			value = "Shared"
 		  },
+		  {
+			field = "capacitystatus"
+			value = "Used"
+		  },
 		]
 }
 `, dataName, instanceType)


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

The Pricing API is now returning multiple product results without specifying a particular capacity filter. Seems related to the recently added EC2 Capacity Reservations.

Previous output from acceptance testing:

```
--- FAIL: TestAccDataSourceAwsPricingProduct_ec2 (2.10s)
    testing.go:538: Step 0 error: Error refreshing: 1 error occurred:
        	* data.aws_pricing_product.test: 1 error occurred:
        	* data.aws_pricing_product.test: data.aws_pricing_product.test: Pricing product query not precise enough. Returned more than one element: [{"product": ... big JSON blob ...
```

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsPricingProduct_redshift (6.80s)
--- PASS: TestAccDataSourceAwsPricingProduct_ec2 (6.84s)
```
