### PR TITLE
data-source/aws_lb_listener: Add missing attributes from resource

### DIFF
--- a/aws/data_source_aws_lb_listener.go
+++ b/aws/data_source_aws_lb_listener.go
@@ -54,6 +54,155 @@ func dataSourceAwsLbListener() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"authenticate_cognito": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"authentication_request_extra_params": {
+										Type:     schema.TypeMap,
+										Computed: true,
+									},
+									"on_unauthenticated_request": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"scope": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"session_cookie_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"session_timeout": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"user_pool_arn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"user_pool_client_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"user_pool_domain": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"authenticate_oidc": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"authentication_request_extra_params": {
+										Type:     schema.TypeMap,
+										Computed: true,
+									},
+									"authorization_endpoint": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"client_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"client_secret": {
+										Type:      schema.TypeString,
+										Computed:  true,
+										Sensitive: true,
+									},
+									"issuer": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"on_unauthenticated_request": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"scope": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"session_cookie_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"session_timeout": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"token_endpoint": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"user_info_endpoint": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"fixed_response": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"content_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"message_body": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"status_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"order": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"redirect": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"host": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"port": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"query": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"status_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"target_group_arn": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -39,7 +39,7 @@ func TestAccDataSourceAWSLBListener_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAWSLBListenerBackwardsCompatibility(t *testing.T) {
+func TestAccDataSourceAWSLBListener_BackwardsCompatibility(t *testing.T) {
 	lbName := fmt.Sprintf("testlistener-basic-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -632,7 +632,9 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 
 		defaultActions[i] = defaultActionMap
 	}
-	d.Set("default_action", defaultActions)
+	if err := d.Set("default_action", defaultActions); err != nil {
+		return fmt.Errorf("error setting default_action: %s", err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -43,7 +43,7 @@ func TestAccAWSLBListener_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSLBListenerBackwardsCompatibility(t *testing.T) {
+func TestAccAWSLBListener_BackwardsCompatibility(t *testing.T) {
 	var conf elbv2.Listener
 	lbName := fmt.Sprintf("testlistener-basic-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))


### PR DESCRIPTION
Another pull request in the series to reduce flakey/failing tests before our next major version development.

Previously, the data source would silently fail setting "default_action" attributes.

```
--- FAIL: TestAccDataSourceAWSLBListener_basic (194.84s)
    testing.go:538: Step 0 error: Check failed: 6 errors occurred:
          * Check 3/14 error: data.aws_lb_listener.front_end: Attribute 'default_action.0.target_group_arn' expected to be set
          * Check 6/14 error: data.aws_lb_listener.front_end: Attribute 'default_action.#' not found
          * Check 7/14 error: data.aws_lb_listener.front_end: Attribute 'default_action.0.type' not found
          * Check 10/14 error: data.aws_lb_listener.from_lb_and_port: Attribute 'default_action.0.target_group_arn' expected to be set
          * Check 13/14 error: data.aws_lb_listener.from_lb_and_port: Attribute 'default_action.#' not found
          * Check 14/14 error: data.aws_lb_listener.from_lb_and_port: Attribute 'default_action.0.type' not found
```

With error handling enabled in the resource, we now receive proper errors to catch this problem:

```
--- FAIL: TestAccDataSourceAWSLBListener_basic (173.14s)
    testing.go:538: Step 0 error: Error applying: 2 errors occurred:
          * data.aws_lb_listener.from_lb_and_port: data.aws_lb_listener.from_lb_and_port: error setting default_action: Invalid address to set: []string{"default_action", "0", "order"}
          * data.aws_lb_listener.front_end: data.aws_lb_listener.front_end: error setting default_action: Invalid address to set: []string{"default_action", "0", "order"}
```

After adding the attributes to the data source and the error handling, all existing acceptance testing is now passing:

```
--- PASS: TestAccAWSLBListener_oidc (201.60s)
--- PASS: TestAccAWSLBListener_fixedResponse (212.49s)
--- PASS: TestAccAWSLBListener_BackwardsCompatibility (212.58s)
--- PASS: TestAccDataSourceAWSLBListener_basic (213.95s)
--- PASS: TestAccAWSLBListener_redirect (223.34s)
--- PASS: TestAccAWSLBListener_basic (223.43s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (224.11s)
--- PASS: TestAccDataSourceAWSLBListener_https (225.09s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (225.14s)
--- PASS: TestAccAWSLBListener_https (235.40s)
--- PASS: TestAccAWSLBListener_cognito (234.78s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (255.74s)
```
