### PR TITLE
Add math metric alarm

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -59,15 +59,13 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 							Required: true,
 						},
 						"expression": {
-							Type:          schema.TypeString,
-							ConflictsWith: []string{"metric_query.metric"},
-							Optional:      true,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"metric": {
-							Type:          schema.TypeList,
-							MaxItems:      1,
-							Optional:      true,
-							ConflictsWith: []string{"metric_query.expression"},
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"dimensions": {

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -254,35 +254,21 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	if a.Metrics != nil && len(a.Metrics) > 0 {
 		metricQueries := make([]interface{}, len(a.Metrics))
 		for i, mq := range a.Metrics {
-			metricQuery := make(map[string]interface{})
-			metricQuery["id"] = *mq.Id
-			if mq.Expression != nil {
-				metricQuery["expression"] = *mq.Expression
-			}
-			if mq.Label != nil {
-				metricQuery["label"] = *mq.Label
-			}
-			if mq.ReturnData != nil {
-				metricQuery["return_data"] = *mq.ReturnData
+			metricQuery := map[string]interface{}{
+				"expression":  aws.StringValue(mq.Expression),
+				"id":          aws.StringValue(mq.Id),
+				"label":       aws.StringValue(mq.Label),
+				"return_data": aws.BoolValue(mq.ReturnData),
 			}
 			if mq.MetricStat != nil {
-				metric := make(map[string]interface{})
-				if mq.MetricStat.Metric.MetricName != nil {
-					metric["metric_name"] = *mq.MetricStat.Metric.MetricName
+				metric := map[string]interface{}{
+					"metric_name": aws.StringValue(mq.MetricStat.Metric.MetricName),
+					"namespace":   aws.StringValue(mq.MetricStat.Metric.Namespace),
+					"period":      int(aws.Int64Value(mq.MetricStat.Period)),
+					"stat":        aws.StringValue(mq.MetricStat.Stat),
+					"unit":        aws.StringValue(mq.MetricStat.Unit),
+					"dimensions":  flattenDimensions(mq.MetricStat.Metric.Dimensions),
 				}
-				if mq.MetricStat.Metric.Namespace != nil {
-					metric["namespace"] = *mq.MetricStat.Metric.Namespace
-				}
-				if mq.MetricStat.Period != nil {
-					metric["period"] = int(*mq.MetricStat.Period)
-				}
-				if mq.MetricStat.Stat != nil {
-					metric["stat"] = *mq.MetricStat.Stat
-				}
-				if mq.MetricStat.Unit != nil {
-					metric["unit"] = *mq.MetricStat.Unit
-				}
-				metric["dimensions"] = flattenDimensions(mq.MetricStat.Metric.Dimensions)
 				metricQuery["metric"] = []interface{}{metric}
 			}
 			metricQueries[i] = metricQuery

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -290,7 +290,7 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 			metricQueries[i] = metricQuery
 		}
 		if err := d.Set("metric_query", metricQueries); err != nil {
-			return err
+			return fmt.Errorf("error setting metric_query: %s", err)
 		}
 	}
 

--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -44,12 +44,14 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"metric_name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"metric_query"},
 			},
 			"metric_query": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ConflictsWith: []string{"metric_name"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -57,13 +59,15 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 							Required: true,
 						},
 						"expression": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:          schema.TypeString,
+							ConflictsWith: []string{"metric_query.metric"},
+							Optional:      true,
 						},
 						"metric": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
+							Type:          schema.TypeList,
+							MaxItems:      1,
+							Optional:      true,
+							ConflictsWith: []string{"metric_query.expression"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"dimensions": {
@@ -106,17 +110,19 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				},
 			},
 			"namespace": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"metric_query"},
 			},
 			"period": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ConflictsWith: []string{"metric_query"},
 			},
 			"statistic": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"extended_statistic"},
+				ConflictsWith: []string{"extended_statistic", "metric_query"},
 			},
 			"threshold": {
 				Type:     schema.TypeFloat,
@@ -149,8 +155,9 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"dimensions": {
-				Type:     schema.TypeMap,
-				Optional: true,
+				Type:          schema.TypeMap,
+				Optional:      true,
+				ConflictsWith: []string{"metric_query"},
 			},
 			"insufficient_data_actions": {
 				Type:     schema.TypeSet,
@@ -171,7 +178,7 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 			"extended_statistic": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"statistic"},
+				ConflictsWith: []string{"statistic", "metric_query"},
 			},
 			"treat_missing_data": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -506,6 +506,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 	metric_query {
 		id = "e1"
 		expression = "m1"
+		label = "cat"
 		return_data = "true"
 	}
 	metric_query {
@@ -515,6 +516,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 			namespace   = "AWS/EC2"
 			period      = "120"
 			stat        = "Average"
+			unit        = "Count"
 			dimensions {
 				InstanceId = "i-abc123"
 			}

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -252,6 +252,13 @@ func TestAccAWSCloudWatchMetricAlarm_expression(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_query.#", "2"),
 				),
 			},
+			{
+				Config: testAccAWSCloudWatchMetricAlarmConfigWithExpressionUpdated(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
+					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_query.#", "3"),
+				),
+			},
 		},
 	})
 }
@@ -507,6 +514,42 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 		id = "e1"
 		expression = "m1"
 		label = "cat"
+		return_data = "true"
+	}
+	metric_query {
+		id = "m1"
+		metric {
+			metric_name = "CPUUtilization"
+			namespace   = "AWS/EC2"
+			period      = "120"
+			stat        = "Average"
+			unit        = "Count"
+			dimensions {
+				InstanceId = "i-abc123"
+			}
+		}
+	}
+}`, rInt)
+}
+
+func testAccAWSCloudWatchMetricAlarmConfigWithExpressionUpdated(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "foobar" {
+  alarm_name                = "terraform-test-foobar%d"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+	threshold                 = "80"
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+	metric_query {
+		id = "e1"
+		expression = "m1"
+		label = "cat"
+	}
+	metric_query {
+		id = "e2"
+		expression = "e1"
+		label = "bug"
 		return_data = "true"
 	}
 	metric_query {

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -246,6 +246,10 @@ func TestAccAWSCloudWatchMetricAlarm_expression(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudWatchMetricAlarmDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config:      testAccAWSCloudWatchMetricAlarmConfigWithBadExpression(rInt),
+				ExpectError: regexp.MustCompile("No metric_query may have both `expression` and a `metric` specified"),
+			},
+			{
 				Config: testAccAWSCloudWatchMetricAlarmConfigWithExpression(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
@@ -559,6 +563,33 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 	}
 	metric_query {
 		id = "m1"
+		metric {
+			metric_name = "CPUUtilization"
+			namespace   = "AWS/EC2"
+			period      = "120"
+			stat        = "Average"
+			unit        = "Count"
+			dimensions {
+				InstanceId = "i-abc123"
+			}
+		}
+	}
+}`, rInt)
+}
+
+func testAccAWSCloudWatchMetricAlarmConfigWithBadExpression(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "foobar" {
+  alarm_name                = "terraform-test-foobar%d"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+	threshold                 = "80"
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+	metric_query {
+		id = "e1"
+		expression = "m1"
+		label = "cat"
 		metric {
 			metric_name = "CPUUtilization"
 			namespace   = "AWS/EC2"

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -249,7 +249,7 @@ func TestAccAWSCloudWatchMetricAlarm_expression(t *testing.T) {
 				Config: testAccAWSCloudWatchMetricAlarmConfigWithExpression(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
-					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metrics.#", "2"),
+					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_query.#", "2"),
 				),
 			},
 		},

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -259,6 +259,11 @@ func TestAccAWSCloudWatchMetricAlarm_expression(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_query.#", "3"),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_metric_alarm.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: cloudwatch_metric_alarm"
 sidebar_current: "docs-aws-resource-cloudwatch-metric-alarm"
 description: |-
-  Provides an AutoScaling Scaling Group resource.
+  Provides a CloudWatch Metric Alarm resource.
 ---
 
 # aws_cloudwatch_metric_alarm
@@ -57,6 +57,51 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
 }
 ```
 
+## Example with an Expression
+
+```hcl
+resource "aws_cloudwatch_metric_alarm" "foobar" {
+  alarm_name                = "terraform-test-foobar%d"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+	threshold                 = "0.1"
+  alarm_description         = "Request error rate has exceeded 10%"
+  insufficient_data_actions = []
+	metric_query {
+		id = "e1"
+		expression = "m2/m1*100"
+		label = "Error Rate"
+		return_data = "true"
+	}
+	metric_query {
+		id = "m1"
+		metric {
+			metric_name = "RequestCount"
+			namespace   = "AWS/ApplicationELB"
+			period      = "120"
+			stat        = "Sum"
+			unit        = "Count"
+			dimensions {
+				LoadBalancer = "app/web"
+			}
+		}
+	}
+	metric_query {
+		id = "m2"
+		metric {
+			metric_name = "HTTPCode_ELB_5XX_Count"
+			namespace   = "AWS/ApplicationELB"
+			period      = "120"
+			stat        = "Sum"
+			unit        = "Count"
+			dimensions {
+				LoadBalancer = "app/web"
+			}
+		}
+	}
+}
+```
+
 ~> **NOTE:**  You cannot create a metric alarm consisting of both `statistic` and `extended_statistic` parameters.
 You must choose one or the other
 
@@ -71,11 +116,11 @@ The following arguments are supported:
 * `arn` - The ARN of the cloudwatch metric alarm.
 * `comparison_operator` - (Required) The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: `GreaterThanOrEqualToThreshold`, `GreaterThanThreshold`, `LessThanThreshold`, `LessThanOrEqualToThreshold`.
 * `evaluation_periods` - (Required) The number of periods over which data is compared to the specified threshold.
-* `metric_name` - (Required) The name for the alarm's associated metric.
+* `metric_name` - (Optional) The name for the alarm's associated metric.
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
-* `namespace` - (Required) The namespace for the alarm's associated metric. See docs for the [list of namespaces](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html).
+* `namespace` - (Optional) The namespace for the alarm's associated metric. See docs for the [list of namespaces](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html).
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
-* `period` - (Required) The period in seconds over which the specified `statistic` is applied.
+* `period` - (Optional) The period in seconds over which the specified `statistic` is applied.
 * `statistic` - (Optional) The statistic to apply to the alarm's associated metric.
    Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`
 * `threshold` - (Required) The value against which the specified statistic is compared.
@@ -95,6 +140,34 @@ change during periods with too few data points to be statistically significant.
 If you specify `evaluate` or omit this parameter, the alarm will always be
 evaluated and possibly change state no matter how many data points are available.
 The following values are supported: `ignore`, and `evaluate`.
+* `metric_query` (Optional) Enables you to create an alarm based on a metric math expression. You may specify at most 20.
+
+~> **NOTE:**  If you specify at least one `metric_query`, you may not specify a `metric_name`, `namespace`, `period` or `statistic`. If you do not specify a `metric_query`, you must specify each of these (although you may use `extended_statistic` instead of `statistic`).
+
+### Nested fields
+
+#### `metric_query`
+
+* `id` - (Required) A short name used to tie this object to the results in the response. If you are performing math expressions on this set of data, this name represents that data and can serve as a variable in the mathematical expression. The valid characters are letters, numbers, and underscore. The first character must be a lowercase letter. 
+* `expression` - (Optional) The math expression to be performed on the returned data, if this object is performing a math expression. This expression can use the id of the other metrics to refer to those metrics, and can also use the id of other expressions to use the result of those expressions. For more information about metric math expressions, see Metric Math Syntax and Functions in the [Amazon CloudWatch User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax). 
+* `label` - (Optional) A human-readable label for this metric or expression. This is especially useful if this is an expression, so that you know what the value represents.
+* `return_data` (Optional) Specify exactly one `metric_query` to be `true` to use that `metric_query` result as the alarm.
+* `metric` (Optional) The metric to be returned, along with statistics, period, and units. Use this parameter only if this object is retrieving a metric and not performing a math expression on returned data.
+
+~> **NOTE:**  You must specify either `metric` or `expression`. Not both.
+
+#### `metric`
+
+* `dimensions` - (Optional) The dimensions for this metric.  For the list of available dimensions see the AWS documentation [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
+* `metric_name` - (Required) The name for this metric.
+  See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
+* `namespace` - (Required) The namespace for this metric. See docs for the [list of namespaces](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html).
+  See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
+* `period` - (Required) The period in seconds over which the specified `stat` is applied.
+* `stat` - (Required) The statistic to apply to this metric.
+   Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`
+* `unit` - (Optional) The unit for this metric.
+
 
 ## Attributes Reference
 

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 * `local_secondary_index` - (Optional, Forces new resource) Describe an LSI on the table;
   these can only be allocated *at creation* so you cannot change this
 definition after you have created the resource.
-* `global_secondary_index` - (Optional) Describe a GSO for the table;
+* `global_secondary_index` - (Optional) Describe a GSI for the table;
   subject to the normal limits on the number of GSIs, projected
 attributes, etc.
 * `stream_enabled` - (Optional) Indicates whether Streams are to be enabled (true) or disabled (false).


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6551

Changes proposed in this pull request:

* added `metric_query` to support adding [`MetricDataQuery`](https://docs.aws.amazon.com/sdk-for-go/api/service/cloudwatch/#MetricDataQuery)s to alarms via the `Metrics` property. An example follows.
```
resource "aws_cloudwatch_metric_alarm" "foobar" {
  alarm_name                = "terraform-test-foobar%d"
  comparison_operator       = "GreaterThanOrEqualToThreshold"
  evaluation_periods        = "2"
	threshold                 = "80"
  alarm_description         = "This metric monitors ec2 cpu utilization"
  insufficient_data_actions = []
	metric_query {
		id = "e1"
		expression = "m1"
		label = "cat"
		return_data = "true"
	}
	metric_query {
		id = "m1"
		metric {
			metric_name = "CPUUtilization"
			namespace   = "AWS/EC2"
			period      = "120"
			stat        = "Average"
			unit        = "Count"
			dimensions {
				InstanceId = "i-abc123"
			}
		}
	}
}
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudWatchMetricAlarm_expression'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchMetricAlarm_expression -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchMetricAlarm_expression
=== PAUSE TestAccAWSCloudWatchMetricAlarm_expression
=== CONT  TestAccAWSCloudWatchMetricAlarm_expression
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (20.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       20.063s

```

This is my first attempt at a PR to this repo, so apologies in advance for all the conventions I've violated 😉 