### PR TITLE
r/aws_licensemanager: Add aws_licensemanager_license_configuration resource

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -74,6 +74,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lexmodelbuildingservice"
+	"github.com/aws/aws-sdk-go/service/licensemanager"
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/aws/aws-sdk-go/service/macie"
 	"github.com/aws/aws-sdk-go/service/mediastore"
@@ -222,6 +223,7 @@ type AWSClient struct {
 	elasticbeanstalkconn  *elasticbeanstalk.ElasticBeanstalk
 	elastictranscoderconn *elastictranscoder.ElasticTranscoder
 	lambdaconn            *lambda.Lambda
+	licensemanagerconn    *licensemanager.LicenseManager
 	lightsailconn         *lightsail.Lightsail
 	macieconn             *macie.Macie
 	mqconn                *mq.MQ
@@ -552,6 +554,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.kmsconn = kms.New(awsKmsSess)
 	client.lambdaconn = lambda.New(awsLambdaSess)
 	client.lexmodelconn = lexmodelbuildingservice.New(sess)
+	client.licensemanagerconn = licensemanager.New(sess)
 	client.lightsailconn = lightsail.New(sess)
 	client.macieconn = macie.New(sess)
 	client.mqconn = mq.New(sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -527,6 +527,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lambda_permission":                            resourceAwsLambdaPermission(),
 			"aws_launch_configuration":                         resourceAwsLaunchConfiguration(),
 			"aws_launch_template":                              resourceAwsLaunchTemplate(),
+			"aws_licensemanager_license_configuration":         resourceAwsLicenseManagerLicenseConfiguration(),
 			"aws_lightsail_domain":                             resourceAwsLightsailDomain(),
 			"aws_lightsail_instance":                           resourceAwsLightsailInstance(),
 			"aws_lightsail_key_pair":                           resourceAwsLightsailKeyPair(),

--- a/aws/resource_aws_licensemanager_license_configuration.go
+++ b/aws/resource_aws_licensemanager_license_configuration.go
@@ -1,0 +1,189 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/licensemanager"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsLicenseManagerLicenseConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLicenseManagerLicenseConfigurationCreate,
+		Read:   resourceAwsLicenseManagerLicenseConfigurationRead,
+		Update: resourceAwsLicenseManagerLicenseConfigurationUpdate,
+		Delete: resourceAwsLicenseManagerLicenseConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"license_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"license_count_hard_limit": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"license_counting_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					licensemanager.LicenseCountingTypeVCpu,
+					licensemanager.LicenseCountingTypeInstance,
+					licensemanager.LicenseCountingTypeCore,
+					licensemanager.LicenseCountingTypeSocket,
+				}, false),
+			},
+			"license_rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsLicenseManagerLicenseConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).licensemanagerconn
+
+	opts := &licensemanager.CreateLicenseConfigurationInput{
+		LicenseCountingType: aws.String(d.Get("license_counting_type").(string)),
+		Name:                aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		opts.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("license_count"); ok {
+		opts.LicenseCount = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("license_count_hard_limit"); ok {
+		opts.LicenseCountHardLimit = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("license_rules"); ok {
+		opts.LicenseRules = expandStringList(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("tags"); ok && len(v.(map[string]interface{})) > 0 {
+		opts.Tags = tagsFromMapLicenseManager(v.(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] License Manager license configuration: %s", opts)
+
+	resp, err := conn.CreateLicenseConfiguration(opts)
+	if err != nil {
+		return fmt.Errorf("Error creating License Manager license configuration: %s", err)
+	}
+	d.SetId(*resp.LicenseConfigurationArn)
+	return resourceAwsLicenseManagerLicenseConfigurationRead(d, meta)
+}
+
+func resourceAwsLicenseManagerLicenseConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).licensemanagerconn
+
+	resp, err := conn.GetLicenseConfiguration(&licensemanager.GetLicenseConfigurationInput{
+		LicenseConfigurationArn: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		if isAWSErr(err, licensemanager.ErrCodeInvalidParameterValueException, "") {
+			log.Printf("[WARN] License Manager license configuration (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading License Manager license configuration: %s", err)
+	}
+
+	d.Set("description", resp.Description)
+	d.Set("license_count", resp.LicenseCount)
+	d.Set("license_count_hard_limit", resp.LicenseCountHardLimit)
+	d.Set("license_counting_type", resp.LicenseCountingType)
+	d.Set("license_rules", flattenStringList(resp.LicenseRules))
+	d.Set("name", resp.Name)
+
+	if err := d.Set("tags", tagsToMapLicenseManager(resp.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsLicenseManagerLicenseConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).licensemanagerconn
+
+	d.Partial(true)
+
+	if d.HasChange("tags") {
+		if err := setTagsLicenseManager(conn, d); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
+	}
+
+	d.Partial(false)
+
+	opts := &licensemanager.UpdateLicenseConfigurationInput{
+		LicenseConfigurationArn: aws.String(d.Id()),
+		Name:                    aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		opts.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("license_count"); ok {
+		opts.LicenseCount = aws.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("license_count_hard_limit"); ok {
+		opts.LicenseCountHardLimit = aws.Bool(v.(bool))
+	}
+
+	log.Printf("[DEBUG] License Manager license configuration: %s", opts)
+
+	_, err := conn.UpdateLicenseConfiguration(opts)
+	if err != nil {
+		return fmt.Errorf("Error updating License Manager license configuration: %s", err)
+	}
+	return resourceAwsLicenseManagerLicenseConfigurationRead(d, meta)
+}
+
+func resourceAwsLicenseManagerLicenseConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).licensemanagerconn
+
+	opts := &licensemanager.DeleteLicenseConfigurationInput{
+		LicenseConfigurationArn: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteLicenseConfiguration(opts)
+	if err != nil {
+		if isAWSErr(err, licensemanager.ErrCodeInvalidParameterValueException, "") {
+			log.Printf("[WARN] License Manager license configuration (%s) not found", d.Id())
+			return nil
+		}
+		return fmt.Errorf("Error deleting License Manager license configuration: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_licensemanager_license_configuration.go
+++ b/aws/resource_aws_licensemanager_license_configuration.go
@@ -151,18 +151,12 @@ func resourceAwsLicenseManagerLicenseConfigurationUpdate(d *schema.ResourceData,
 	opts := &licensemanager.UpdateLicenseConfigurationInput{
 		LicenseConfigurationArn: aws.String(d.Id()),
 		Name:                    aws.String(d.Get("name").(string)),
-	}
-
-	if v, ok := d.GetOk("description"); ok {
-		opts.Description = aws.String(v.(string))
+		Description:             aws.String(d.Get("description").(string)),
+		LicenseCountHardLimit:   aws.Bool(d.Get("license_count_hard_limit").(bool)),
 	}
 
 	if v, ok := d.GetOk("license_count"); ok {
 		opts.LicenseCount = aws.Int64(int64(v.(int)))
-	}
-
-	if v, ok := d.GetOk("license_count_hard_limit"); ok {
-		opts.LicenseCountHardLimit = aws.Bool(v.(bool))
 	}
 
 	log.Printf("[DEBUG] License Manager license configuration: %s", opts)

--- a/aws/resource_aws_licensemanager_license_configuration_test.go
+++ b/aws/resource_aws_licensemanager_license_configuration_test.go
@@ -1,0 +1,161 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/licensemanager"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func init() {
+	resource.AddTestSweepers("aws_licensemanager_license_configuration", &resource.Sweeper{
+		Name: "aws_licensemanager_license_configuration",
+		F:    testSweepLicenseManagerLicenseConfigurations,
+	})
+}
+
+func testSweepLicenseManagerLicenseConfigurations(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).licensemanagerconn
+
+	resp, err := conn.ListLicenseConfigurations(&licensemanager.ListLicenseConfigurationsInput{})
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving License Manager license configurations: %s", err)
+	}
+
+	if len(resp.LicenseConfigurations) == 0 {
+		log.Print("[DEBUG] No License Manager license configurations to sweep")
+		return nil
+	}
+
+	for _, lc := range resp.LicenseConfigurations {
+		id := aws.StringValue(lc.LicenseConfigurationArn)
+
+		log.Printf("[INFO] Deleting License Manager license configuration: %s", id)
+
+		opts := &licensemanager.DeleteLicenseConfigurationInput{
+			LicenseConfigurationArn: aws.String(id),
+		}
+
+		_, err := conn.DeleteLicenseConfiguration(opts)
+
+		if err != nil {
+			log.Printf("[ERROR] Error deleting License Manager license configuration (%s): %s", id, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAWSLicenseManagerLicenseConfiguration_basic(t *testing.T) {
+	var licenseConfiguration licensemanager.LicenseConfiguration
+	resourceName := "aws_licensemanager_license_configuration.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLicenseManagerLicenseConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLicenseManagerLicenseConfigurationConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLicenseManagerLicenseConfigurationExists(resourceName, &licenseConfiguration),
+					resource.TestCheckResourceAttr(resourceName, "name", "Example"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Example"),
+					resource.TestCheckResourceAttr(resourceName, "license_count", "10"),
+					resource.TestCheckResourceAttr(resourceName, "license_count_hard_limit", "true"),
+					resource.TestCheckResourceAttr(resourceName, "license_counting_type", "Socket"),
+					resource.TestCheckResourceAttr(resourceName, "license_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "license_rules.0", "#minimumSockets=3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "barr"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckLicenseManagerLicenseConfigurationExists(resourceName string, licenseConfiguration *licensemanager.LicenseConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).licensemanagerconn
+		resp, err := conn.ListLicenseConfigurations(&licensemanager.ListLicenseConfigurationsInput{
+			LicenseConfigurationArns: [](*string){aws.String(rs.Primary.ID)},
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving License Manager license configuration (%s): %s", rs.Primary.ID, err)
+		}
+
+		if len(resp.LicenseConfigurations) == 0 {
+			return fmt.Errorf("Error retrieving License Manager license configuration (%s): Not found", rs.Primary.ID)
+		}
+
+		*licenseConfiguration = *resp.LicenseConfigurations[0]
+		return nil
+	}
+}
+
+func testAccCheckLicenseManagerLicenseConfigurationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).licensemanagerconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_licensemanager_license_configuration" {
+			continue
+		}
+
+		// Try to find the resource
+		_, err := conn.GetLicenseConfiguration(&licensemanager.GetLicenseConfigurationInput{
+			LicenseConfigurationArn: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			if isAWSErr(err, licensemanager.ErrCodeInvalidParameterValueException, "") {
+				continue
+			}
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+const testAccLicenseManagerLicenseConfigurationConfig_basic = `
+resource "aws_licensemanager_license_configuration" "example" {
+  name                     = "Example"
+  description              = "Example"
+  license_count            = 10
+  license_count_hard_limit = true
+  license_counting_type    = "Socket"
+
+  license_rules = [
+    "#minimumSockets=3"
+  ]
+
+  tags {
+    foo = "barr"
+  }
+}
+`

--- a/aws/resource_aws_licensemanager_license_configuration_test.go
+++ b/aws/resource_aws_licensemanager_license_configuration_test.go
@@ -112,8 +112,8 @@ func TestAccAWSLicenseManagerLicenseConfiguration_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLicenseManagerLicenseConfigurationExists(resourceName, &licenseConfiguration),
 					resource.TestCheckResourceAttr(resourceName, "name", "NewName"),
-					resource.TestCheckResourceAttr(resourceName, "description", "NewDescription"),
-					resource.TestCheckResourceAttr(resourceName, "license_count", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "license_count", "123"),
 					resource.TestCheckResourceAttr(resourceName, "license_count_hard_limit", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.test", "test"),
@@ -204,9 +204,7 @@ resource "aws_licensemanager_license_configuration" "example" {
 const testAccLicenseManagerLicenseConfigurationConfig_update = `
 resource "aws_licensemanager_license_configuration" "example" {
   name                     = "NewName"
-  description              = "NewDescription"
-  # license_count            = 99
-  license_count_hard_limit = false
+  license_count            = 123
   license_counting_type    = "Socket"
 
   license_rules = [

--- a/aws/tagsLicenseManager.go
+++ b/aws/tagsLicenseManager.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/licensemanager"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsLicenseManager(conn *licensemanager.LicenseManager, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsLicenseManager(tagsFromMapLicenseManager(o), tagsFromMapLicenseManager(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove), len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&licensemanager.UntagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&licensemanager.TagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsLicenseManager(oldTags, newTags []*licensemanager.Tag) ([]*licensemanager.Tag, []*licensemanager.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*licensemanager.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapLicenseManager(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapLicenseManager(m map[string]interface{}) []*licensemanager.Tag {
+	result := make([]*licensemanager.Tag, 0, len(m))
+	for k, v := range m {
+		t := &licensemanager.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredLicenseManager(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapLicenseManager(ts []*licensemanager.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredLicenseManager(t) {
+			result[*t.Key] = *t.Value
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredLicenseManager(t *licensemanager.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1664,6 +1664,17 @@
                   </ul>
               </li>
 
+                <li<%= sidebar_current("docs-aws-resource-licensemanager") %>>
+                    <a href="#">License Manager Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-licensemanager-license-configuration") %>>
+                            <a href="/docs/providers/aws/r/licensemanager_license_configuration.html">aws_licensemanager_license_configuration</a>
+                        </li>
+
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current("docs-aws-resource-lightsail") %>>
                     <a href="#">Lightsail Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/licensemanager_license_configuration.markdown
+++ b/website/docs/r/licensemanager_license_configuration.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a License Manager license configuration resource.
 
+~> **Note:** Removing the `license_count` attribute is not supported by the License Manager API - use `terraform taint aws_licensemanager_license_configuration.<id>` to recreate the resource instead.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/licensemanager_license_configuration.markdown
+++ b/website/docs/r/licensemanager_license_configuration.markdown
@@ -42,6 +42,18 @@ The following arguments are supported:
 * `license_rules` - (Optional) Array of configured License Manager rules.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+## Rules
+
+License rules should be in the format of `#RuleType=RuleValue`. Supported rule types:
+
+* `minimumVcpus` - Resource must have minimum vCPU count in order to use the license. Default: 1
+* `maximumVcpus` - Resource must have maximum vCPU count in order to use the license. Default: unbounded, limit: 10000
+* `minimumCores` - Resource must have minimum core count in order to use the license. Default: 1
+* `maximumCores` - Resource must have maximum core count in order to use the license. Default: unbounded, limit: 10000
+* `minimumSockets` - Resource must have minimum socket count in order to use the license. Default: 1
+* `maximumSockets` - Resource must have maximum socket count in order to use the license. Default: unbounded, limit: 10000
+* `allowedTenancy` - Defines where the license can be used. If set, restricts license usage to selected tenancies. Specify a comma delimited list of `EC2-Default`, `EC2-DedicatedHost`, `EC2-DedicatedInstance`
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/website/docs/r/licensemanager_license_configuration.markdown
+++ b/website/docs/r/licensemanager_license_configuration.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: aws_licensemanager_license_configuration"
+sidebar_current: "docs-aws-resource-licensemanager-license-configuration"
+description: |-
+  Provides a License Manager license configuration resource.
+---
+
+# aws_licensemanager_license_configuration
+
+Provides a License Manager license configuration resource.
+
+## Example Usage
+
+```hcl
+resource "aws_licensemanager_license_configuration" "example" {
+  name                     = "Example"
+  description              = "Example"
+  license_count            = 10
+  license_count_hard_limit = true
+  license_counting_type    = "Socket"
+
+  license_rules = [
+    "#minimumSockets=2"
+  ]
+
+  tags {
+    foo = "barr"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the license configuration.
+* `description` - (Optional) Description of the license configuration.
+* `license_count` - (Optional) Number of licenses managed by the license configuration.
+* `license_count_hard_limit` - (Optional) Sets the number of available licenses as a hard limit.
+* `license_counting_type` - (Required) Dimension to use to track license inventory. Specify either `vCPU`, `Instance`, `Core` or `Socket`.
+* `license_rules` - (Optional) Array of configured License Manager rules.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The license configuration ARN.
+
+## Import
+
+License configurations can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_licensemanager_license_configuration.example arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef
+```


### PR DESCRIPTION
Reference: #6654

Changes proposed in this pull request:

* **New Resource:** `aws_licensemanager_license_configuration`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLicenseManagerLicenseConfiguration'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLicenseManagerLicenseConfiguration -timeout 120m
=== RUN   TestAccAWSLicenseManagerLicenseConfiguration_basic
=== PAUSE TestAccAWSLicenseManagerLicenseConfiguration_basic
=== CONT  TestAccAWSLicenseManagerLicenseConfiguration_basic
--- PASS: TestAccAWSLicenseManagerLicenseConfiguration_basic (10.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.172s
```
