### PR TITLE
r/aws-securityhub: Add aws_securityhub_account resource

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -88,6 +88,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/securityhub"
 	"github.com/aws/aws-sdk-go/service/servicecatalog"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/aws/aws-sdk-go/service/ses"
@@ -197,6 +198,7 @@ type AWSClient struct {
 	autoscalingconn       *autoscaling.AutoScaling
 	s3conn                *s3.S3
 	secretsmanagerconn    *secretsmanager.SecretsManager
+	securityhubconn       *securityhub.SecurityHub
 	scconn                *servicecatalog.ServiceCatalog
 	sesConn               *ses.SES
 	simpledbconn          *simpledb.SimpleDB
@@ -567,6 +569,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.sdconn = servicediscovery.New(sess)
 	client.sesConn = ses.New(sess)
 	client.secretsmanagerconn = secretsmanager.New(sess)
+	client.securityhubconn = securityhub.New(sess)
 	client.sfnconn = sfn.New(sess)
 	client.snsconn = sns.New(awsSnsSess)
 	client.sqsconn = sqs.New(awsSqsSess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -623,6 +623,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_network_interface_sg_attachment":              resourceAwsNetworkInterfaceSGAttachment(),
 			"aws_default_security_group":                       resourceAwsDefaultSecurityGroup(),
 			"aws_security_group_rule":                          resourceAwsSecurityGroupRule(),
+			"aws_securityhub_account":                          resourceAwsSecurityHubAccount(),
 			"aws_servicecatalog_portfolio":                     resourceAwsServiceCatalogPortfolio(),
 			"aws_service_discovery_private_dns_namespace":      resourceAwsServiceDiscoveryPrivateDnsNamespace(),
 			"aws_service_discovery_public_dns_namespace":       resourceAwsServiceDiscoveryPublicDnsNamespace(),

--- a/aws/resource_aws_securityhub_account.go
+++ b/aws/resource_aws_securityhub_account.go
@@ -31,7 +31,7 @@ func resourceAwsSecurityHubAccountCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error enabling Security Hub for account: %s", err)
 	}
 
-	d.SetId("securityhub-account")
+	d.SetId(meta.(*AWSClient).accountid)
 
 	return resourceAwsSecurityHubAccountRead(d, meta)
 }

--- a/aws/resource_aws_securityhub_account.go
+++ b/aws/resource_aws_securityhub_account.go
@@ -1,0 +1,68 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSecurityHubAccount() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSecurityHubAccountCreate,
+		Read:   resourceAwsSecurityHubAccountRead,
+		Delete: resourceAwsSecurityHubAccountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{},
+	}
+}
+
+func resourceAwsSecurityHubAccountCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+	log.Print("[DEBUG] Enabling Security Hub for account")
+
+	_, err := conn.EnableSecurityHub(&securityhub.EnableSecurityHubInput{})
+
+	if err != nil {
+		return fmt.Errorf("Error enabling Security Hub for account: %s", err)
+	}
+
+	d.SetId("securityhub-account")
+
+	return resourceAwsSecurityHubAccountRead(d, meta)
+}
+
+func resourceAwsSecurityHubAccountRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+
+	log.Printf("[DEBUG] Checking if Security Hub is enabled")
+	_, err := conn.GetEnabledStandards(&securityhub.GetEnabledStandardsInput{})
+
+	if err != nil {
+		// Can only read enabled standards if Security Hub is enabled
+		if isAWSErr(err, "InvalidAccessException", "not subscribed to AWS Security Hub") {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error checking if Security Hub is enabled: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsSecurityHubAccountDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+	log.Print("[DEBUG] Disabling Security Hub for account")
+
+	_, err := conn.DisableSecurityHub(&securityhub.DisableSecurityHubInput{})
+
+	if err != nil {
+		return fmt.Errorf("Error disabling Security Hub for account: %s", err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_securityhub_account_test.go
+++ b/aws/resource_aws_securityhub_account_test.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSSecurityHubAccount_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityHubAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityHubAccountConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityHubAccountExists("aws_securityhub_account.example"),
+				),
+			},
+			{
+				ResourceName:      "aws_securityhub_account.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSecurityHubAccountExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).securityhubconn
+
+		_, err := conn.GetEnabledStandards(&securityhub.GetEnabledStandardsInput{})
+
+		if err != nil {
+			// Can only read enabled standards if Security Hub is enabled
+			if isAWSErr(err, "InvalidAccessException", "not subscribed to AWS Security Hub") {
+				return fmt.Errorf("Security Hub account not found")
+			}
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSecurityHubAccountDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).securityhubconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_securityhub_account" {
+			continue
+		}
+
+		_, err := conn.GetEnabledStandards(&securityhub.GetEnabledStandardsInput{})
+
+		if err != nil {
+			// Can only read enabled standards if Security Hub is enabled
+			if isAWSErr(err, "InvalidAccessException", "not subscribed to AWS Security Hub") {
+				return nil
+			}
+			return err
+		}
+
+		return fmt.Errorf("Security Hub account still exists")
+	}
+
+	return nil
+}
+
+func testAccAWSSecurityHubAccountConfig() string {
+	return `
+resource "aws_securityhub_account" "example" {}
+`
+}

--- a/aws/resource_aws_securityhub_account_test.go
+++ b/aws/resource_aws_securityhub_account_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSSecurityHubAccount_basic(t *testing.T) {
+func testAccAWSSecurityHubAccount_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/aws/resource_aws_securityhub_test.go
+++ b/aws/resource_aws_securityhub_test.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestAccAWSSecurityHub(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Account": {
+			"basic": testAccAWSSecurityHubAccount_basic,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2176,6 +2176,17 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-securityhub") %>>
+                    <a href="#">Security Hub Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-securityhub-account") %>>
+                            <a href="/docs/providers/aws/r/securityhub_account.html">aws_securityhub_account</a>
+                        </li>
+
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current("docs-aws-resource-ses") %>>
                     <a href="#">SES Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/securityhub_account.markdown
+++ b/website/docs/r/securityhub_account.markdown
@@ -3,19 +3,19 @@ layout: "aws"
 page_title: "AWS: aws_securityhub_account"
 sidebar_current: "docs-aws-resource-securityhub-account"
 description: |-
-  Enables Security Hub.
+  Enables Security Hub for an AWS account.
 ---
 
 # aws_securityhub_account
 
--> **Note:** Destroying this resource will disable Security Hub.
+-> **Note:** Destroying this resource will disable Security Hub for this AWS account.
 
-Enables Security Hub.
+Enables Security Hub for this AWS account.
 
 ## Example Usage
 
 ```hcl
-resource "aws_securityhub_member" "example" {}
+resource "aws_securityhub_account" "example" {}
 ```
 
 ## Argument Reference
@@ -26,12 +26,12 @@ The resource does not support any arguments.
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - Returns `securityhub-account`.
+* `id` - AWS Account ID.
 
 ## Import
 
-Security Hub account enablemenet can be imported using the word `securityhub-account`, e.g.
+An existing Security Hub enabled account can be imported using the AWS account ID, e.g.
 
 ```
-$ terraform import aws_securityhub_account.example securityhub-account
+$ terraform import aws_securityhub_account.example 123456789012
 ```

--- a/website/docs/r/securityhub_account.markdown
+++ b/website/docs/r/securityhub_account.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aws"
+page_title: "AWS: aws_securityhub_account"
+sidebar_current: "docs-aws-resource-securityhub-account"
+description: |-
+  Enables Security Hub.
+---
+
+# aws_securityhub_account
+
+-> **Note:** Destroying this resource will disable Security Hub.
+
+Enables Security Hub.
+
+## Example Usage
+
+```hcl
+resource "aws_securityhub_member" "example" {}
+```
+
+## Argument Reference
+
+The resource does not support any arguments.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - Returns `securityhub-account`.
+
+## Import
+
+Security Hub account enablemenet can be imported using the word `securityhub-account`, e.g.
+
+```
+$ terraform import aws_securityhub_account.example securityhub-account
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Partly addresses #6674 

Changes proposed in this pull request:

* **New Resource:** `aws_securityhub_account`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSecurityHub'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSSecurityHub -timeout 120m
=== RUN   TestAccAWSSecurityHub
=== RUN   TestAccAWSSecurityHub/Account
=== RUN   TestAccAWSSecurityHub/Account/basic
--- PASS: TestAccAWSSecurityHub (74.25s)
    --- PASS: TestAccAWSSecurityHub/Account (74.25s)
        --- PASS: TestAccAWSSecurityHub/Account/basic (74.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	74.287s
```
