### PR TITLE
resource/aws_eks_cluster: Support version update

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -65,6 +65,7 @@ In addition to all arguments above, the following attributes are exported:
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
 * `create` - (Default `15 minutes`) How long to wait for the EKS Cluster to be created.
+* `update` - (Default `60 minutes`) How long to wait for the EKS Cluster to be updated.
 * `delete` - (Default `15 minutes`) How long to wait for the EKS Cluster to be deleted.
 
 ## Import


### PR DESCRIPTION
Changes proposed in this pull request:

* On the tin

Output from acceptance testing:

```
--- PASS: TestAccAWSEksCluster_basic (1088.52s)
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (1142.70s)
--- PASS: TestAccAWSEksCluster_Version (2447.04s)
```
