### PR TITLE
Add Transfer User Resource Support

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -666,6 +666,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_subnet":                                       resourceAwsSubnet(),
 			"aws_swf_domain":                                   resourceAwsSwfDomain(),
 			"aws_transfer_server":                              resourceAwsTransferServer(),
+			"aws_transfer_user":                                resourceAwsTransferUser(),
 			"aws_volume_attachment":                            resourceAwsVolumeAttachment(),
 			"aws_vpc_dhcp_options_association":                 resourceAwsVpcDhcpOptionsAssociation(),
 			"aws_default_vpc_dhcp_options":                     resourceAwsDefaultVpcDhcpOptions(),

--- a/aws/resource_aws_transfer_server.go
+++ b/aws/resource_aws_transfer_server.go
@@ -69,7 +69,7 @@ func resourceAwsTransferServer() *schema.Resource {
 
 func resourceAwsTransferServerCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).transferconn
-	tags := tagsFromMapTransferServer(d.Get("tags").(map[string]interface{}))
+	tags := tagsFromMapTransfer(d.Get("tags").(map[string]interface{}))
 	createOpts := &transfer.CreateServerInput{}
 
 	if len(tags) != 0 {
@@ -141,7 +141,7 @@ func resourceAwsTransferServerRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("identity_provider_type", resp.Server.IdentityProviderType)
 	d.Set("logging_role", resp.Server.LoggingRole)
 
-	if err := d.Set("tags", tagsToMapTransferServer(resp.Server.Tags)); err != nil {
+	if err := d.Set("tags", tagsToMapTransfer(resp.Server.Tags)); err != nil {
 		return fmt.Errorf("Error setting tags: %s", err)
 	}
 	return nil
@@ -184,7 +184,7 @@ func resourceAwsTransferServerUpdate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if err := setTagsTransferServer(conn, d); err != nil {
+	if err := setTagsTransfer(conn, d); err != nil {
 		return fmt.Errorf("Error update tags: %s", err)
 	}
 

--- a/aws/resource_aws_transfer_user.go
+++ b/aws/resource_aws_transfer_user.go
@@ -1,0 +1,239 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/transfer"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsTransferUser() *schema.Resource {
+
+	return &schema.Resource{
+		Create: resourceAwsTransferUserCreate,
+		Read:   resourceAwsTransferUserRead,
+		Update: resourceAwsTransferUserUpdate,
+		Delete: resourceAwsTransferUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsTransferUserImport,
+		},
+		Schema: map[string]*schema.Schema{
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"home_directory": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"role": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"tags": tagsSchema(),
+
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsTransferUserCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).transferconn
+	userName := d.Get("user_name").(string)
+	serverID := d.Get("server_id").(string)
+
+	createOpts := &transfer.CreateUserInput{
+		ServerId: aws.String(serverID),
+		UserName: aws.String(userName),
+		Role:     aws.String(d.Get("role").(string)),
+	}
+
+	if attr, ok := d.GetOk("home_directory"); ok {
+		createOpts.HomeDirectory = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("policy"); ok {
+		createOpts.Policy = aws.String(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("tags"); ok {
+		createOpts.Tags = tagsFromMapTransferServer(attr.(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] Create Transfer User Option: %#v", createOpts)
+
+	_, err := conn.CreateUser(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating Transfer User: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s-%s", userName, serverID))
+
+	return resourceAwsTransferUserRead(d, meta)
+}
+
+func resourceAwsTransferUserRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).transferconn
+	userName := d.Get("user_name").(string)
+	serverID := d.Get("server_id").(string)
+
+	descOpts := &transfer.DescribeUserInput{
+		UserName: aws.String(userName),
+		ServerId: aws.String(serverID),
+	}
+
+	log.Printf("[DEBUG] Describe Transfer User Option: %#v", descOpts)
+
+	resp, err := conn.DescribeUser(descOpts)
+	if err != nil {
+		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] Transfer User (%s) for Server (%s) not found, removing from state", userName, serverID)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("arn", resp.User.Arn)
+	d.Set("home_directory", resp.User.HomeDirectory)
+	d.Set("policy", resp.User.Policy)
+	d.Set("role", resp.User.Role)
+
+	if err := d.Set("tags", tagsToMapTransferServer(resp.User.Tags)); err != nil {
+		return fmt.Errorf("Error setting tags: %s", err)
+	}
+	return nil
+}
+
+func resourceAwsTransferUserUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).transferconn
+	updateFlag := false
+	userName := d.Get("user_name").(string)
+	serverID := d.Get("server_id").(string)
+
+	updateOpts := &transfer.UpdateUserInput{
+		UserName: aws.String(userName),
+		ServerId: aws.String(serverID),
+	}
+
+	if d.HasChange("home_directory") {
+		updateOpts.HomeDirectory = aws.String(d.Get("home_directory").(string))
+		updateFlag = true
+	}
+
+	if d.HasChange("policy") {
+		updateOpts.Policy = aws.String(d.Get("policy").(string))
+		updateFlag = true
+	}
+
+	if d.HasChange("role") {
+		updateOpts.Role = aws.String(d.Get("role").(string))
+		updateFlag = true
+	}
+
+	if updateFlag {
+		_, err := conn.UpdateUser(updateOpts)
+		if err != nil {
+			if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+				log.Printf("[WARN] Transfer User (%s) for Server (%s) not found, removing from state", userName, serverID)
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
+	}
+
+	if err := setTagsTransferServer(conn, d); err != nil {
+		return fmt.Errorf("Error update tags: %s", err)
+	}
+
+	return resourceAwsTransferUserRead(d, meta)
+}
+
+func resourceAwsTransferUserDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).transferconn
+	userName := d.Get("user_name").(string)
+	serverID := d.Get("server_id").(string)
+
+	delOpts := &transfer.DeleteUserInput{
+		UserName: aws.String(userName),
+		ServerId: aws.String(serverID),
+	}
+
+	log.Printf("[DEBUG] Delete Transfer User Option: %#v", delOpts)
+
+	_, err := conn.DeleteUser(delOpts)
+	if err != nil {
+		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting Transfer User (%s) for Server(%s): %s", userName, serverID, err)
+	}
+
+	if err := waitForTransferUserDeletion(conn, serverID, userName); err != nil {
+		return fmt.Errorf("error waiting for Transfer User (%s) for Server (%s): %s", userName, serverID, err)
+	}
+
+	return nil
+}
+
+func resourceAwsTransferUserImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <user_name>/<server_id>", d.Id())
+	}
+	userName := idParts[0]
+	serverID := idParts[1]
+	d.Set("user_name", userName)
+	d.Set("server_id", serverID)
+	d.SetId(fmt.Sprintf("%s-%s", userName, serverID))
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func waitForTransferUserDeletion(conn *transfer.Transfer, serverID, userName string) error {
+	params := &transfer.DescribeUserInput{
+		ServerId: aws.String(serverID),
+		UserName: aws.String(userName),
+	}
+
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.DescribeUser(params)
+
+		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return resource.RetryableError(fmt.Errorf("Transfer User (%s) for Server (%s) still exists", userName, serverID))
+	})
+}

--- a/aws/resource_aws_transfer_user.go
+++ b/aws/resource_aws_transfer_user.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsTransferUser() *schema.Resource {
@@ -31,13 +32,16 @@ func resourceAwsTransferUser() *schema.Resource {
 			},
 
 			"home_directory": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
 
 			"policy": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validateIAMPolicyJson,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
 
 			"role": {
@@ -47,17 +51,19 @@ func resourceAwsTransferUser() *schema.Resource {
 			},
 
 			"server_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateTransferServerID,
 			},
 
 			"tags": tagsSchema(),
 
 			"user_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateTransferUserName,
 			},
 		},
 	}

--- a/aws/resource_aws_transfer_user.go
+++ b/aws/resource_aws_transfer_user.go
@@ -83,7 +83,7 @@ func resourceAwsTransferUserCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if attr, ok := d.GetOk("tags"); ok {
-		createOpts.Tags = tagsFromMapTransferServer(attr.(map[string]interface{}))
+		createOpts.Tags = tagsFromMapTransfer(attr.(map[string]interface{}))
 	}
 
 	log.Printf("[DEBUG] Create Transfer User Option: %#v", createOpts)
@@ -125,7 +125,7 @@ func resourceAwsTransferUserRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("policy", resp.User.Policy)
 	d.Set("role", resp.User.Role)
 
-	if err := d.Set("tags", tagsToMapTransferServer(resp.User.Tags)); err != nil {
+	if err := d.Set("tags", tagsToMapTransfer(resp.User.Tags)); err != nil {
 		return fmt.Errorf("Error setting tags: %s", err)
 	}
 	return nil
@@ -169,7 +169,7 @@ func resourceAwsTransferUserUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	if err := setTagsTransferServer(conn, d); err != nil {
+	if err := setTagsTransfer(conn, d); err != nil {
 		return fmt.Errorf("Error update tags: %s", err)
 	}
 

--- a/aws/resource_aws_transfer_user.go
+++ b/aws/resource_aws_transfer_user.go
@@ -90,7 +90,7 @@ func resourceAwsTransferUserCreate(d *schema.ResourceData, meta interface{}) err
 
 	_, err := conn.CreateUser(createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating Transfer User: %s", err)
+		return fmt.Errorf("error creating Transfer User: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", serverID, userName))
@@ -119,7 +119,7 @@ func resourceAwsTransferUserRead(d *schema.ResourceData, meta interface{}) error
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading Transfer User (%s): %s", d.Id(), err)
 	}
 
 	d.Set("server_id", resp.ServerId)
@@ -171,7 +171,7 @@ func resourceAwsTransferUserUpdate(d *schema.ResourceData, meta interface{}) err
 				d.SetId("")
 				return nil
 			}
-			return err
+			return fmt.Errorf("error updating Transfer User (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -155,17 +155,6 @@ func testAccCheckAWSTransferUserExists(n string, res *transfer.DescribedUser) re
 	}
 }
 
-func testAccAWSTransferUserImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["user_name"], rs.Primary.Attributes["server_id"]), nil
-	}
-}
-
 func testAccCheckAWSTransferUserDisappears(serverConf *transfer.DescribedServer, userConf *transfer.DescribedUser) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {

--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -1,0 +1,370 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/transfer"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSTransferUser_basic(t *testing.T) {
+	var conf transfer.DescribedUser
+	rName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_transfer_user.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTransferUserConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &conf),
+					testAccMatchResourceAttrRegionalARN("aws_transfer_user.foo", "arn", "transfer", regexp.MustCompile(`user/.+`)),
+					resource.TestCheckResourceAttrPair(
+						"aws_transfer_user.foo", "server_id", "aws_transfer_server.foo", "id"),
+					resource.TestCheckResourceAttrPair(
+						"aws_transfer_user.foo", "role", "aws_iam_role.foo", "arn"),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_user.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_user.foo", "tags.NAME", "tftestuser"),
+				),
+			},
+			{
+				ResourceName:      "aws_transfer_user.foo",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSTransferUserImportStateIdFunc("aws_transfer_user.foo"),
+				// We do not have a way to align IDs since the Create function uses resource.PrefixedUniqueId()
+				// Failed state verification, resource with ID USER-POLICYARN not found
+				// ImportStateVerify: true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %#v", s)
+					}
+
+					rs := s[0]
+
+					if !strings.HasPrefix(rs.Attributes["server_id"], "s-") {
+						return fmt.Errorf("expected server_id attribute to be set and begin with s-, received: %s", rs.Attributes["server_id"])
+					}
+
+					if !strings.HasPrefix(rs.Attributes["arn"], "arn:") {
+						return fmt.Errorf("expected arn attribute to be set and begin with arn:, received: %s", rs.Attributes["arn"])
+					}
+
+					return nil
+				},
+			},
+			{
+				Config: testAccAWSTransferUserConfig_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_user.foo", "home_directory", "/home/tftestuser"),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_user.foo", "tags.%", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_user.foo", "tags.ENV", "test"),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_user.foo", "tags.ADMIN", "test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSTransferUser_disappears(t *testing.T) {
+	var serverConf transfer.DescribedServer
+	var userConf transfer.DescribedUser
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSTransferUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTransferUserConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &serverConf),
+					testAccCheckAWSTransferUserExists("aws_transfer_user.foo", &userConf),
+					testAccCheckAWSTransferUserDisappears(&serverConf, &userConf),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSTransferUserExists(n string, res *transfer.DescribedUser) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Transfer User ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).transferconn
+		userName := rs.Primary.Attributes["user_name"]
+		serverID := rs.Primary.Attributes["server_id"]
+
+		describe, err := conn.DescribeUser(&transfer.DescribeUserInput{
+			ServerId: aws.String(serverID),
+			UserName: aws.String(userName),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		*res = *describe.User
+
+		return nil
+	}
+}
+
+func testAccAWSTransferUserImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["user_name"], rs.Primary.Attributes["server_id"]), nil
+	}
+}
+
+func testAccCheckAWSTransferUserDisappears(serverConf *transfer.DescribedServer, userConf *transfer.DescribedUser) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).transferconn
+
+		params := &transfer.DeleteUserInput{
+			ServerId: serverConf.ServerId,
+			UserName: userConf.UserName,
+		}
+
+		_, err := conn.DeleteUser(params)
+		if err != nil {
+			return err
+		}
+
+		return waitForTransferUserDeletion(conn, *serverConf.ServerId, *userConf.UserName)
+	}
+}
+
+func testAccCheckAWSTransferUserDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).transferconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_transfer_user" {
+			continue
+		}
+
+		userName := rs.Primary.Attributes["user_name"]
+		serverID := rs.Primary.Attributes["server_id"]
+
+		_, err := conn.DescribeUser(&transfer.DescribeUserInput{
+			UserName: aws.String(userName),
+			ServerId: aws.String(serverID),
+		})
+
+		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccAWSTransferUserConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_transfer_server" "foo" {
+	identity_provider_type = "SERVICE_MANAGED"
+	
+	tags {
+		NAME     = "tf-acc-test-transfer-server"
+	}
+}
+
+
+resource "aws_iam_role" "foo" {
+	name = "tf-test-transfer-user-iam-role-%s"
+  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Effect": "Allow",
+		"Principal": {
+			"Service": "transfer.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "foo" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.foo.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"s3:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+
+resource "aws_transfer_user" "foo" {
+	server_id      = "${aws_transfer_server.foo.id}"
+	user_name      = "tftestuser"
+	role           = "${aws_iam_role.foo.arn}"
+
+	tags {
+		NAME = "tftestuser"
+	}
+}
+
+
+	`, rName, rName)
+}
+
+func testAccAWSTransferUserConfig_update(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_transfer_server" "foo" {
+	identity_provider_type = "SERVICE_MANAGED"
+	
+	tags {
+		NAME     = "tf-acc-test-transfer-server"
+	}
+}
+
+
+resource "aws_iam_role" "foo" {
+	name = "tf-test-transfer-user-iam-role-%s"
+  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Effect": "Allow",
+		"Principal": {
+			"Service": "transfer.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "foo" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.foo.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Sid": "AllowFullAccesstoS3",
+		"Effect": "Allow",
+		"Action": [
+			"s3:*"
+		],
+		"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+data "aws_iam_policy_document" "foo" {
+	statement {
+	  sid = "ListHomeDir"
+  
+	  actions = [
+		"s3:ListBucket",
+	  ]
+  
+	  resources = [
+		"arn:aws:s3:::&{transfer:HomeBucket}",
+	  ]
+	}
+
+	statement {
+		sid = "AWSTransferRequirements"
+	
+		actions = [
+		  "s3:ListAllMyBuckets",
+		  "s3:GetBucketLocation",
+		]
+	
+		resources = [
+		  "*",
+		]
+	}
+
+	statement {
+		sid = "HomeDirObjectAccess"
+	
+		actions = [
+		  "s3:PutObject",
+		  "s3:GetObject",
+		  "s3:DeleteObjectVersion",
+		  "s3:DeleteObject",
+		  "s3:GetObjectVersion",
+		]
+	
+		resources = [
+		  "arn:aws:s3:::&{transfer:HomeDirectory}*",
+		]
+	}
+}
+
+
+resource "aws_transfer_user" "foo" {
+	server_id      = "${aws_transfer_server.foo.id}"
+	user_name      = "tftestuser"
+	role           = "${aws_iam_role.foo.arn}"
+	policy         = "${data.aws_iam_policy_document.foo.json}"
+	home_directory = "/home/tftestuser"
+
+	tags {
+		ENV = "test"
+		ADMIN = "test"
+	}
+}
+
+
+	`, rName, rName)
+}

--- a/aws/tagsTransfer.go
+++ b/aws/tagsTransfer.go
@@ -11,12 +11,12 @@ import (
 
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags"
-func setTagsTransferServer(conn *transfer.Transfer, d *schema.ResourceData) error {
+func setTagsTransfer(conn *transfer.Transfer, d *schema.ResourceData) error {
 	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})
 		n := nraw.(map[string]interface{})
-		create, remove := diffTagsTransferServer(tagsFromMapTransferServer(o), tagsFromMapTransferServer(n))
+		create, remove := diffTagsTransfer(tagsFromMapTransfer(o), tagsFromMapTransfer(n))
 
 		// Set tags
 		if len(remove) > 0 {
@@ -52,7 +52,7 @@ func setTagsTransferServer(conn *transfer.Transfer, d *schema.ResourceData) erro
 // diffTags takes our tags locally and the ones remotely and returns
 // the set of tags that must be created, and the set of tags that must
 // be destroyed.
-func diffTagsTransferServer(oldTags, newTags []*transfer.Tag) ([]*transfer.Tag, []*transfer.Tag) {
+func diffTagsTransfer(oldTags, newTags []*transfer.Tag) ([]*transfer.Tag, []*transfer.Tag) {
 	// First, we're creating everything we have
 	create := make(map[string]interface{})
 	for _, t := range newTags {
@@ -72,18 +72,18 @@ func diffTagsTransferServer(oldTags, newTags []*transfer.Tag) ([]*transfer.Tag, 
 		}
 	}
 
-	return tagsFromMapTransferServer(create), remove
+	return tagsFromMapTransfer(create), remove
 }
 
 // tagsFromMap returns the tags for the given map of data.
-func tagsFromMapTransferServer(m map[string]interface{}) []*transfer.Tag {
+func tagsFromMapTransfer(m map[string]interface{}) []*transfer.Tag {
 	result := make([]*transfer.Tag, 0, len(m))
 	for k, v := range m {
 		t := &transfer.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v.(string)),
 		}
-		if !tagIgnoredTransferServer(t) {
+		if !tagIgnoredTransfer(t) {
 			result = append(result, t)
 		}
 	}
@@ -92,10 +92,10 @@ func tagsFromMapTransferServer(m map[string]interface{}) []*transfer.Tag {
 }
 
 // tagsToMap turns the list of tags into a map.
-func tagsToMapTransferServer(ts []*transfer.Tag) map[string]string {
+func tagsToMapTransfer(ts []*transfer.Tag) map[string]string {
 	result := make(map[string]string)
 	for _, t := range ts {
-		if !tagIgnoredTransferServer(t) {
+		if !tagIgnoredTransfer(t) {
 			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
 		}
 	}
@@ -105,7 +105,7 @@ func tagsToMapTransferServer(ts []*transfer.Tag) map[string]string {
 
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
-func tagIgnoredTransferServer(t *transfer.Tag) bool {
+func tagIgnoredTransfer(t *transfer.Tag) bool {
 	filter := []string{"^aws:"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))

--- a/aws/tagsTransfer_test.go
+++ b/aws/tagsTransfer_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/transfer"
 )
 
-// go test -v -run="TestDiffTransferServerTags"
-func TestDiffTransferServerTags(t *testing.T) {
+// go test -v -run="TestDiffTransferTags"
+func TestDiffTransferTags(t *testing.T) {
 	cases := []struct {
 		Old, New       map[string]interface{}
 		Create, Remove map[string]string
@@ -81,9 +81,9 @@ func TestDiffTransferServerTags(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		c, r := diffTagsTransferServer(tagsFromMapTransferServer(tc.Old), tagsFromMapTransferServer(tc.New))
-		cm := tagsToMapTransferServer(c)
-		rm := tagsToMapTransferServer(r)
+		c, r := diffTagsTransfer(tagsFromMapTransfer(tc.Old), tagsFromMapTransfer(tc.New))
+		cm := tagsToMapTransfer(c)
+		rm := tagsToMapTransfer(r)
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}
@@ -93,8 +93,8 @@ func TestDiffTransferServerTags(t *testing.T) {
 	}
 }
 
-// go test -v -run="TestIgnoringTagsTransferServer"
-func TestIgnoringTagsTransferServer(t *testing.T) {
+// go test -v -run="TestIgnoringTagsTransfer"
+func TestIgnoringTagsTransfer(t *testing.T) {
 	var ignoredTags []*transfer.Tag
 	ignoredTags = append(ignoredTags, &transfer.Tag{
 		Key:   aws.String("aws:cloudformation:logical-id"),
@@ -105,7 +105,7 @@ func TestIgnoringTagsTransferServer(t *testing.T) {
 		Value: aws.String("baz"),
 	})
 	for _, tag := range ignoredTags {
-		if !tagIgnoredTransferServer(tag) {
+		if !tagIgnoredTransfer(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
 		}
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -82,6 +82,34 @@ func validateTypeStringNullableFloat(v interface{}, k string) (ws []string, es [
 	return
 }
 
+func validateTransferServerID(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	// https://docs.aws.amazon.com/transfer/latest/userguide/API_CreateUser.html
+	pattern := `^s-([0-9a-f]{17})$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q isn't a valid transfer server id (only lowercase alphanumeric characters are allowed): %q",
+			k, value))
+	}
+
+	return
+}
+
+func validateTransferUserName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	// https://docs.aws.amazon.com/transfer/latest/userguide/API_CreateUser.html
+	pattern := `^[a-z0-9]{3,32}$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q isn't a valid transfer user name (only lowercase alphanumeric characters are allowed): %q",
+			k, value))
+	}
+
+	return
+}
+
 func validateRdsIdentifier(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2452,6 +2452,9 @@
                             <a href="/docs/providers/aws/r/transfer_server.html">aws_transfer_server</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-transfer-user") %>>
+                            <a href="/docs/providers/aws/r/transfer_user.html">aws_transfer_user</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -20,9 +20,8 @@ resource "aws_transfer_server" "foo" {
 	}
 }
 
-
 resource "aws_iam_role" "foo" {
-	name = "tf-test-transfer-user-iam-role-%s"
+	name = "tf-test-transfer-user-iam-role"
 
 	assume_role_policy = <<EOF
 {
@@ -41,7 +40,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foo" {
-	name = "tf-test-transfer-user-iam-policy-%s"
+	name = "tf-test-transfer-user-iam-policy"
 	role = "${aws_iam_role.foo.id}"
 	policy = <<POLICY
 {
@@ -60,15 +59,10 @@ resource "aws_iam_role_policy" "foo" {
 POLICY
 }
 
-
 resource "aws_transfer_user" "foo" {
 	server_id      = "${aws_transfer_server.foo.id}"
 	user_name      = "tftestuser"
 	role           = "${aws_iam_role.foo.arn}"
-
-	tags {
-		NAME = "tftestuser"
-	}
 }
 
 ```
@@ -80,8 +74,8 @@ The following arguments are supported:
 * `server_id` - (Requirement) The Server ID of the Transfer Server (e.g. `s-12345678`)
 * `user_name` - (Requirement) The name used for log in to your SFTP server.
 * `home_directory` - (Optional) The landing directory (folder) for a user when they log in to the server using their SFTP client.
-* `policy` - (Optional) The policy scopes down user access to portions of their Amazon S3 bucket. Variables you can use inside this policy include ${Transfer:UserName}, ${Transfer:HomeDirectory}, and ${Transfer:HomeBucket}.
-* `role` - (Optional) Amazon Resource Name (ARN) of an IAM role that allows the service to controls your user’s access to your Amazon S3 bucket.
+* `policy` - (Optional) An IAM JSON policy document that scopes down user access to portions of their Amazon S3 bucket. IAM variables you can use inside this policy include `${Transfer:UserName}`, `${Transfer:HomeDirectory}`, and `${Transfer:HomeBucket}`. Since the IAM variable syntax matches Terraform's interpolation syntax, they must be escaped inside Terraform configuration strings (`$${Transfer:UserName}`).
+* `role` - (Requirement) Amazon Resource Name (ARN) of an IAM role that allows the service to controls your user’s access to your Amazon S3 bucket.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
@@ -91,8 +85,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Transfer user can be imported using the `user_name` and `server_id` separated by `/`.
+Transfer Users can be imported using the `server_id` and `user_name` separated by `/`.
 
 ```
-$ terraform import aws_transfer_user.bar test-username/s-12345678
+$ terraform import aws_transfer_user.bar s-12345678/test-username
 ```

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -1,0 +1,98 @@
+---
+layout: "aws"
+page_title: "AWS: aws_transfer_user"
+sidebar_current: "docs-aws-resource-transfer-user"
+description: |-
+  Provides a AWS Transfer User resource.
+---
+
+# aws_transfer_server
+
+Provides a AWS Transfer User resource.
+
+
+```hcl
+resource "aws_transfer_server" "foo" {
+	identity_provider_type = "SERVICE_MANAGED"
+
+	tags {
+		NAME     = "tf-acc-test-transfer-server"
+	}
+}
+
+
+resource "aws_iam_role" "foo" {
+	name = "tf-test-transfer-user-iam-role-%s"
+
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Effect": "Allow",
+		"Principal": {
+			"Service": "transfer.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "foo" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.foo.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"s3:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+
+resource "aws_transfer_user" "foo" {
+	server_id      = "${aws_transfer_server.foo.id}"
+	user_name      = "tftestuser"
+	role           = "${aws_iam_role.foo.arn}"
+
+	tags {
+		NAME = "tftestuser"
+	}
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `server_id` - (Requirement) The Server ID of the Transfer Server (e.g. `s-12345678`)
+* `user_name` - (Requirement) The name used for log in to your SFTP server.
+* `home_directory` - (Optional) The landing directory (folder) for a user when they log in to the server using their SFTP client.
+* `policy` - (Optional) The policy scopes down user access to portions of their Amazon S3 bucket. Variables you can use inside this policy include ${Transfer:UserName}, ${Transfer:HomeDirectory}, and ${Transfer:HomeBucket}.
+* `role` - (Optional) Amazon Resource Name (ARN) of an IAM role that allows the service to controls your user’s access to your Amazon S3 bucket.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of Transfer User
+
+## Import
+
+Transfer user can be imported using the `user_name` and `server_id` separated by `/`.
+
+```
+$ terraform import aws_transfer_user.bar test-username/s-12345678
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Reference: #6584 

Changes proposed in this pull request:

* Add `aws_transfer_user` reource support

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSTransferUser_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSTransferUser_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSTransferUser_basic
=== PAUSE TestAccAWSTransferUser_basic
=== RUN   TestAccAWSTransferUser_disappears
=== PAUSE TestAccAWSTransferUser_disappears
=== CONT  TestAccAWSTransferUser_basic
=== CONT  TestAccAWSTransferUser_disappears
--- PASS: TestAccAWSTransferUser_disappears (26.83s)
--- PASS: TestAccAWSTransferUser_basic (46.93s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	46.987s
...
```

TODO
- [x] Add tests for `aws_transfer_user`
- [x] Add documents for `aws_transfer_user`