### PR TITLE
New resource: service discovery http namespace

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -626,6 +626,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_security_group_rule":                          resourceAwsSecurityGroupRule(),
 			"aws_securityhub_account":                          resourceAwsSecurityHubAccount(),
 			"aws_servicecatalog_portfolio":                     resourceAwsServiceCatalogPortfolio(),
+			"aws_service_discovery_http_namespace":             resourceAwsServiceDiscoveryHttpNamespace(),
 			"aws_service_discovery_private_dns_namespace":      resourceAwsServiceDiscoveryPrivateDnsNamespace(),
 			"aws_service_discovery_public_dns_namespace":       resourceAwsServiceDiscoveryPublicDnsNamespace(),
 			"aws_service_discovery_service":                    resourceAwsServiceDiscoveryService(),

--- a/aws/resource_aws_service_discovery_http_namespace.go
+++ b/aws/resource_aws_service_discovery_http_namespace.go
@@ -1,0 +1,132 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsServiceDiscoveryHttpNamespace() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceDiscoveryHttpNamespaceCreate,
+		Read:   resourceAwsServiceDiscoveryHttpNamespaceRead,
+		Delete: resourceAwsServiceDiscoveryHttpNamespaceDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateServiceDiscoveryHttpNamespaceName,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsServiceDiscoveryHttpNamespaceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	name := d.Get("name").(string)
+	// The CreatorRequestId has a limit of 64 bytes
+	var requestId string
+	if len(name) > (64 - resource.UniqueIDSuffixLength) {
+		requestId = resource.PrefixedUniqueId(name[0:(64 - resource.UniqueIDSuffixLength - 1)])
+	} else {
+		requestId = resource.PrefixedUniqueId(name)
+	}
+
+	input := &servicediscovery.CreateHttpNamespaceInput{
+		Name:             aws.String(name),
+		CreatorRequestId: aws.String(requestId),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	resp, err := conn.CreateHttpNamespace(input)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
+		Target:  []string{servicediscovery.OperationStatusSuccess},
+		Refresh: servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
+		Timeout: 5 * time.Minute,
+	}
+
+	opresp, err := stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*opresp.(*servicediscovery.GetOperationOutput).Operation.Targets["NAMESPACE"])
+	return resourceAwsServiceDiscoveryHttpNamespaceRead(d, meta)
+}
+
+func resourceAwsServiceDiscoveryHttpNamespaceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	input := &servicediscovery.GetNamespaceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetNamespace(input)
+	if err != nil {
+		if isAWSErr(err, servicediscovery.ErrCodeNamespaceNotFound, "") {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", resp.Namespace.Name)
+	d.Set("description", resp.Namespace.Description)
+	d.Set("arn", resp.Namespace.Arn)
+
+	return nil
+}
+
+func resourceAwsServiceDiscoveryHttpNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sdconn
+
+	input := &servicediscovery.DeleteNamespaceInput{
+		Id: aws.String(d.Id()),
+	}
+
+	resp, err := conn.DeleteNamespace(input)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{servicediscovery.OperationStatusSubmitted, servicediscovery.OperationStatusPending},
+		Target:  []string{servicediscovery.OperationStatusSuccess},
+		Refresh: servicediscoveryOperationRefreshStatusFunc(conn, *resp.OperationId),
+		Timeout: 5 * time.Minute,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/resource_aws_service_discovery_http_namespace.go
+++ b/aws/resource_aws_service_discovery_http_namespace.go
@@ -1,8 +1,8 @@
 package aws
 
 import (
-	"time"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
@@ -107,6 +107,10 @@ func resourceAwsServiceDiscoveryHttpNamespaceDelete(d *schema.ResourceData, meta
 
 	resp, err := conn.DeleteNamespace(input)
 	if err != nil {
+		if isAWSErr(err, servicediscovery.ErrCodeNamespaceNotFound, "") {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("error deleting Service Discovery HTTP Namespace (%s): %s", d.Id(), err)
 	}
 

--- a/aws/resource_aws_service_discovery_http_namespace_test.go
+++ b/aws/resource_aws_service_discovery_http_namespace_test.go
@@ -1,0 +1,92 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSServiceDiscoveryHttpNamespace_basic(t *testing.T) {
+	resourceName := "aws_service_discovery_http_namespace.test"
+	rName := "terraformtesting"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryHttpNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryHttpNamespaceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryHttpNamespaceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsServiceDiscoveryHttpNamespaceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sdconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_service_discovery_http_namespace" {
+			continue
+		}
+
+		input := &servicediscovery.GetNamespaceInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetNamespace(input)
+		if err != nil {
+			if isAWSErr(err, servicediscovery.ErrCodeNamespaceNotFound, "") {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsServiceDiscoveryHttpNamespaceExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).sdconn
+
+		input := &servicediscovery.GetNamespaceInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.GetNamespace(input)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccServiceDiscoveryHttpNamespaceConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_http_namespace" "test" {
+  name = %q
+  description = "test"
+}
+`, rName)
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2015,6 +2015,27 @@ func validateCloudFrontPublicKeyNamePrefix(v interface{}, k string) (ws []string
 	return
 }
 
+func validateServiceDiscoveryHttpNamespaceName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z_-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters, underscores and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-zA-Z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if !regexp.MustCompile(`[a-zA-Z]$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"last character of %q must be a letter", k))
+	}
+	if len(value) > 1024 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 1024 characters", k))
+	}
+	return
+}
+
 func validateLbTargetGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 32 {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2260,6 +2260,10 @@
                     <a href="#">Service Discovery Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-service-discovery-http-namespace") %>>
+                            <a href="/docs/providers/aws/r/service_discovery_http_namespace.html">aws_service_discovery_http_namespace</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-service-discovery-private-dns-namespace") %>>
                             <a href="/docs/providers/aws/r/service_discovery_private_dns_namespace.html">aws_service_discovery_private_dns_namespace</a>
                         </li>

--- a/website/docs/r/service_discovery_http_namespace.html.markdown
+++ b/website/docs/r/service_discovery_http_namespace.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_service_discovery_http_namespace"
+sidebar_current: "docs-aws-resource-service-discovery-http-namespace"
+description: |-
+  Provides a Service Discovery HTTP Namespace resource.
+---
+
+# aws_service_discovery_http_namespace
+
+
+## Example Usage
+
+```hcl
+resource "aws_service_discovery_http_namespace" "example" {
+  name        = "development"
+  description = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the http namespace.
+* `description` - (Optional) The description that you specify for the namespace when you create it.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of a namespace.
+* `arn` - The ARN that Amazon Route 53 assigns to the namespace when you create it.
+
+## Import
+
+Service Discovery HTTP Namespace can be imported using the namespace ID, e.g.
+
+```
+$ terraform import aws_service_discovery_http_namespace.example ns-1234567890
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6783 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSServiceDiscoveryHttpNamespace_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSServiceDiscoveryHttpNamespace_basic -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryHttpNamespace_basic
=== PAUSE TestAccAWSServiceDiscoveryHttpNamespace_basic
=== CONT  TestAccAWSServiceDiscoveryHttpNamespace_basic
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_basic (120.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws
...
```
