### PR TITLE
enable changing encryption without creating new resource for redshift cluster

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -154,7 +154,6 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			"enhanced_vpc_routing": {

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -153,7 +153,7 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			"encrypted": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
+				Default:  false,
 			},
 
 			"enhanced_vpc_routing": {
@@ -166,7 +166,6 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},
 
@@ -709,6 +708,16 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if d.HasChange("enhanced_vpc_routing") {
 		req.EnhancedVpcRouting = aws.Bool(d.Get("enhanced_vpc_routing").(bool))
+		requestUpdate = true
+	}
+
+	if d.HasChange("encrypted") {
+		req.Encrypted = aws.Bool(d.Get("encrypted").(bool))
+		requestUpdate = true
+	}
+
+	if d.Get("encrypted").(bool) && d.HasChange("kms_key_id") {
+		req.KmsKeyId = aws.String(d.Get("kms_key_id").(string))
 		requestUpdate = true
 	}
 

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -1001,7 +1001,7 @@ resource "aws_redshift_cluster" "default" {
 }
 
 func testAccAWSRedshiftClusterConfig_unencrypted(rInt int) string {
-	// This is used along with the terraform config created testAccAWSRedshiftClusterConfig_encrypted, to test removal of encryption. 
+	// This is used along with the terraform config created testAccAWSRedshiftClusterConfig_encrypted, to test removal of encryption.
 	//Removing the kms key here causes the key to be deleted before the redshift cluster is unencrypted, resulting in an unstable cluster. This is to be kept for the time-being unti we find a better way to handle this.
 	return fmt.Sprintf(`
 resource "aws_kms_key" "foo" {

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -560,8 +561,8 @@ func TestAccAWSRedshiftCluster_changeAvailabilityZone(t *testing.T) {
 	})
 }
 
-func TestAccAWSRedshiftCluster_changeEncryption(t *testing.T) {
-	var v redshift.Cluster
+func TestAccAWSRedshiftCluster_changeEncryption1(t *testing.T) {
+	var cluster1, cluster2 redshift.Cluster
 
 	ri := acctest.RandInt()
 	preConfig := testAccAWSRedshiftClusterConfig_basic(ri)
@@ -575,7 +576,7 @@ func TestAccAWSRedshiftCluster_changeEncryption(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &cluster1),
 					resource.TestCheckResourceAttr("aws_redshift_cluster.default", "encrypted", "false"),
 				),
 			},
@@ -583,8 +584,40 @@ func TestAccAWSRedshiftCluster_changeEncryption(t *testing.T) {
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &cluster2),
+					testAccCheckAWSRedshiftClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr("aws_redshift_cluster.default", "encrypted", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRedshiftCluster_changeEncryption2(t *testing.T) {
+	var cluster1, cluster2 redshift.Cluster
+
+	ri := acctest.RandInt()
+	preConfig := testAccAWSRedshiftClusterConfig_encrypted(ri)
+	postConfig := testAccAWSRedshiftClusterConfig_unencrypted(ri)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &cluster1),
+					resource.TestCheckResourceAttr("aws_redshift_cluster.default", "encrypted", "true"),
+				),
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &cluster2),
+					testAccCheckAWSRedshiftClusterNotRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr("aws_redshift_cluster.default", "encrypted", "false"),
 				),
 			},
 		},
@@ -865,6 +898,21 @@ func TestResourceAWSRedshiftClusterMasterPasswordValidation(t *testing.T) {
 	}
 }
 
+func testAccCheckAWSRedshiftClusterNotRecreated(i, j *redshift.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// In lieu of some other uniquely identifying attribute from the API that always changes
+		// when a cluster is destroyed and recreated with the same identifier, we use the SSH key
+		// as it will get regenerated when a cluster is destroyed.
+		// Certain update operations (e.g KMS encrypting a cluster) will change ClusterCreateTime.
+		// Clusters with the same identifier can/will have an overlapping Endpoint.Address.
+		if aws.StringValue(i.ClusterPublicKey) != aws.StringValue(j.ClusterPublicKey) {
+			return errors.New("Redshift Cluster was recreated")
+		}
+
+		return nil
+	}
+}
+
 func testAccAWSRedshiftClusterConfig_updateNodeCount(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "default" {
@@ -951,6 +999,45 @@ resource "aws_redshift_cluster" "default" {
   kms_key_id = "${aws_kms_key.foo.arn}"
 }`, rInt, rInt)
 }
+
+func testAccAWSRedshiftClusterConfig_unencrypted(rInt int) string {
+	// This is used along with the terraform config created testAccAWSRedshiftClusterConfig_encrypted, to test removal of encryption. 
+	//Removing the kms key here causes the key to be deleted before the redshift cluster is unencrypted, resulting in an unstable cluster. This is to be kept for the time-being unti we find a better way to handle this.
+	return fmt.Sprintf(`
+resource "aws_kms_key" "foo" {
+	description = "Terraform acc test %d"
+	policy = <<POLICY
+	{
+	"Version": "2012-10-17",
+	"Id": "kms-tf-1",
+	"Statement": [
+		{
+		"Sid": "Enable IAM User Permissions",
+		"Effect": "Allow",
+		"Principal": {
+			"AWS": "*"
+		},
+		"Action": "kms:*",
+		"Resource": "*"
+		}
+	]
+	}
+	POLICY
+	}
+	  
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  availability_zone = "us-west-2a"
+  database_name = "mydb"
+  master_username = "foo_test"
+  master_password = "Mustbe8characters"
+  node_type = "dc1.large"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade = false
+  skip_final_snapshot = true
+}`, rInt, rInt)
+}
+
 func testAccAWSRedshiftClusterConfigWithFinalSnapshot(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "default" {


### PR DESCRIPTION
Fixes #6857

Changes proposed in this pull request:

* Change Encryption without forcing for new resource

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSRedshiftCluster_changeEncryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftCluster_changeEncryption -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftCluster_changeEncryption
=== PAUSE TestAccAWSRedshiftCluster_changeEncryption
=== CONT  TestAccAWSRedshiftCluster_changeEncryption
--- PASS: TestAccAWSRedshiftCluster_changeEncryption (1555.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1555.623s
```
