### PR TITLE
website/docs/r/lb_target_group: Drop "TLS" from health-check protocols

### DIFF
--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) The name of the target group. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
 * `port` - (Required) The port on which targets receive traffic, unless overridden when registering a specific target.
-* `protocol` - (Required) The protocol to use for routing traffic to the targets. Should be one of "TCP", "HTTP", "HTTPS" or "TLS".
+* `protocol` - (Required) The protocol to use for routing traffic to the targets. Should be one of "TCP", "HTTP", or "HTTPS".
 * `vpc_id` - (Required) The identifier of the VPC in which to create the target group.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.


### PR DESCRIPTION
It was added in 10532bac (#5246), which quotes an error message that includes `TLS`.  But neither the AWS docs ([here][1] and [here][2]) nor our internal validation (e.g. see d2e38fda, #5367) include a TLS protocol.

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html#API_CreateTargetGroup_RequestParameters
[2]: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html#health-check-settings