### PR TITLE
private - (Optional; AWS services and AWS Marketplace partner services only)

### DIFF
--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 * `route_table_ids` - (Optional) One or more route table IDs. Applicable for endpoints of type `Gateway`.
 * `subnet_ids` - (Optional) The ID of one or more subnets in which to create a network interface for the endpoint. Applicable for endpoints of type `Interface`.
 * `security_group_ids` - (Optional) The ID of one or more security groups to associate with the network interface. Required for endpoints of type `Interface`.
-* `private_dns_enabled` - (Optional) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.
+* `private_dns_enabled` - (Optional; AWS services and AWS Marketplace partner services only) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.
 Defaults to `false`.
 
 ### Timeouts


### PR DESCRIPTION
Documentation change for VPC endpoint

Changes proposed in this pull request:

Added **bold** section below (not bold in committed code!)

* `private_dns_enabled` - (Optional; **AWS services and AWS Marketplace partner services only**) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.

As per [point 4 of AWS docs](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html) This setting is only valid for OEM & Partner services. Plan will fail if this is set with terraform generated resources.

