### PR TITLE
Update error wording to be clearer

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -632,20 +632,20 @@ func resourceAwsLbTargetGroupCustomizeDiff(diff *schema.ResourceDiff, v interfac
 		if protocol == "TCP" {
 			// Cannot set custom matcher on TCP health checks
 			if m := healthCheck["matcher"].(string); m != "" {
-				return fmt.Errorf("%s: custom matcher is not supported for target_groups with TCP protocol", diff.Id())
+				return fmt.Errorf("%s: health_check.matcher is not supported for target_groups with TCP protocol", diff.Id())
 			}
 			// Cannot set custom path on TCP health checks
 			if m := healthCheck["path"].(string); m != "" {
-				return fmt.Errorf("%s: custom path is not supported for target_groups with TCP protocol", diff.Id())
+				return fmt.Errorf("%s: health_check.path is not supported for target_groups with TCP protocol", diff.Id())
 			}
 			// Cannot set custom timeout on TCP health checks
 			if t := healthCheck["timeout"].(int); t != 0 && diff.Id() == "" {
 				// timeout has a default value, so only check this if this is a network
 				// LB and is a first run
-				return fmt.Errorf("%s: custom timeout is not supported for target_groups with TCP protocol", diff.Id())
+				return fmt.Errorf("%s: health_check.timeout is not supported for target_groups with TCP protocol", diff.Id())
 			}
 			if healthCheck["healthy_threshold"].(int) != healthCheck["unhealthy_threshold"].(int) {
-				return fmt.Errorf("%s: healthy_threshold %d and unhealthy_threshold %d must be the same for target_groups with TCP protocol", diff.Id(), healthCheck["healthy_threshold"].(int), healthCheck["unhealthy_threshold"].(int))
+				return fmt.Errorf("%s: health_check.healthy_threshold %d and health_check.unhealthy_threshold %d must be the same for target_groups with TCP protocol", diff.Id(), healthCheck["healthy_threshold"].(int), healthCheck["unhealthy_threshold"].(int))
 			}
 		}
 	}

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -189,7 +189,7 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 			},
 			{
 				Config:      testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(targetGroupName),
-				ExpectError: regexp.MustCompile("healthy_threshold [0-9]+ and unhealthy_threshold [0-9]+ must be the same for target_groups with TCP protocol"),
+				ExpectError: regexp.MustCompile("health_check\\.healthy_threshold [0-9]+ and health_check\\.unhealthy_threshold [0-9]+ must be the same for target_groups with TCP protocol"),
 			},
 			{
 				Config: testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(targetGroupName),
@@ -768,15 +768,15 @@ func TestAccAWSLBTargetGroup_defaults_network(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid1),
-				ExpectError: regexp.MustCompile("custom path is not supported for target_groups with TCP protocol"),
+				ExpectError: regexp.MustCompile("health_check.path is not supported for target_groups with TCP protocol"),
 			},
 			{
 				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid2),
-				ExpectError: regexp.MustCompile("custom matcher is not supported for target_groups with TCP protocol"),
+				ExpectError: regexp.MustCompile("health_check.matcher is not supported for target_groups with TCP protocol"),
 			},
 			{
 				Config:      testAccNLB_defaults(targetGroupName, healthCheckInvalid3),
-				ExpectError: regexp.MustCompile("custom timeout is not supported for target_groups with TCP protocol"),
+				ExpectError: regexp.MustCompile("health_check.timeout is not supported for target_groups with TCP protocol"),
 			},
 			{
 				Config: testAccNLB_defaults(targetGroupName, healthCheckValid),


### PR DESCRIPTION
I ran a terraform plan recently and got this error:

```
Error: Error refreshing state: 1 error(s) occurred:

* aws_alb_target_group.foo: 1 error(s) occurred:

* aws_alb_target_group.foo: : custom timeout is not supported for target_groups with TCP protocol
```

from a config like:

```hcl
resource "aws_alb_target_group" "foo" {
  vpc_id = "vpc-abc123"
  name = "foo"
  protocol = "TCP"
  port = 1234
  target_type = "ip"
  slow_start = "0"
  deregistration_delay = "70"

  health_check {
    protocol = "TCP"
    interval = 30
    healthy_threshold = 3
    unhealthy_threshold = 3
    timeout = 10
  }
}
```

I wasn't sure which custom timeout it was referring to.

It seems clearer to explicitly say that it's the health check timeout:

```
Error: Error refreshing state: 1 error(s) occurred:

* aws_alb_target_group.foo: 1 error(s) occurred:

* aws_alb_target_group.foo: : health_check.timeout is not supported for target_groups with TCP protocol
```