### PR TITLE
resource/aws_s3_bucket: Skip MethodNotAllowed error for missing S3 Bucket Acceleration functionality (eu-north-1 support)

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -870,7 +870,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	// Amazon S3 Transfer Acceleration might not be supported in the region
-	if err != nil && !isAWSErr(err, "UnsupportedArgument", "") {
+	if err != nil && !isAWSErr(err, "MethodNotAllowed", "") && !isAWSErr(err, "UnsupportedArgument", "") {
 		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
 	}
 	if accelerate, ok := accelerateResponse.(*s3.GetBucketAccelerateConfigurationOutput); ok {


### PR DESCRIPTION
Closes #6853 

Previously (in eu-north-1 region):

```
--- FAIL: TestAccAWSS3Bucket_basic (12.73s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_s3_bucket.bucket: 1 error occurred:
        	* aws_s3_bucket.bucket: error getting S3 Bucket acceleration configuration: MethodNotAllowed: The specified method is not allowed against this resource.
        	status code: 405, request id: C4FF2A8370BED40B, host id: 7N8DyRUtrgpFbAJAzpbdG0DjGRVoESdOcy+T9Jf2yxiKlTDUUSydC1YpqxZXdqBlz6XaMgsUDA4=
```

Output from acceptance testing (in eu-north-1 region):

```
--- PASS: TestAccAWSS3Bucket_basic (29.97s)
```
