### PR TITLE
Add complex table definition for kinesis parquet integration

### DIFF
--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -12,10 +12,69 @@ Provides a Glue Catalog Table Resource. You can refer to the [Glue Developer Gui
 
 ## Example Usage
 
+### Basic Table
+
 ```hcl
 resource "aws_glue_catalog_table" "aws_glue_catalog_table" {
   name          = "MyCatalogTable"
   database_name = "MyCatalogDatabase"
+}
+```
+
+### Parquet Table for Athena
+
+```hcl
+resource "aws_glue_catalog_table" "aws_glue_catalog_table" {
+  name          = "MyCatalogTable"
+  database_name = "MyCatalogDatabase"
+
+  table_type  = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL            = "TRUE"
+    parquet.compression = "SNAPPY"
+  }
+
+  storage_descriptor {
+    location      = "s3://my-bucket/event-streams/my-stream"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      name                  = "my-stream"
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+
+      parameters {
+        serialization.format = 1
+      }
+    }
+
+    columns = [
+      {
+        name    = "my_string"
+        type    = "string"
+      },
+      {
+        name    = "my_double"
+        type    = "double"
+      },
+      {
+        name    = "my_date"
+        type    = "date"
+        comment = ""
+      },
+      {
+        name    = "my_bigint"
+        type    = "bigint"
+        comment = ""
+      },
+      {
+        name    = "my_struct"
+        type    = "struct<my_nested_string:string>"
+        comment = ""
+      },
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
It took me quite a bit of trial and error to figure out the right format to configure a more complex example like this (a glue table which is used as the schema for kinesis firehose -> s3 conversion and athena queries).

Felt like it would probably save others trying to do something similar a bunch of time so here's a PR to add it to the docs.

Let me know if you have any changes or suggestions you'd like.