### PR TITLE
Make tags truly optional on the transfer sftp server resource

### DIFF
--- a/aws/resource_aws_transfer_server.go
+++ b/aws/resource_aws_transfer_server.go
@@ -70,9 +70,10 @@ func resourceAwsTransferServer() *schema.Resource {
 func resourceAwsTransferServerCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).transferconn
 	tags := tagsFromMapTransferServer(d.Get("tags").(map[string]interface{}))
+	createOpts := &transfer.CreateServerInput{}
 
-	createOpts := &transfer.CreateServerInput{
-		Tags: tags,
+	if len(tags) != 0 {
+		createOpts.Tags = tags
 	}
 
 	identityProviderDetails := &transfer.IdentityProviderDetails{}


### PR DESCRIPTION
The aws transfer sftp server resource was introduced in
https://github.com/terraform-providers/terraform-provider-aws/pull/6639
and it's wonderful.

*Changes proposed in this pull request:*
* make tags truly optional on `aws_transfer_server`

*Background:*
In using it, i noticed that the documentation says that the tags are
optional, but if they're not provided then the AWS API responds with an
error. I investigated and the tags are truly optional on AWS's side, but
the code (in its current form) sets the `Tags` attribute to `[]` if the
resource is not defined with tags. This results in an invalid API
request to AWS. Here's an example of the error output:

```
Error: Error applying plan:

1 error(s) occurred:

* aws_transfer_server.sftp_server: 1 error(s) occurred:

* aws_transfer_server.sftp_server: Error creating Transfer Server: InvalidParameter: 1 validation error(s) found.
- minimum field size of 1, CreateServerInput.Tags.
```

This changeset only sets the tags when they're not empty. Voila!

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAvailabilityZones -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
=== PAUSE TestAccAWSAvailabilityZones_basic
=== RUN   TestAccAWSAvailabilityZones_stateFilter
=== PAUSE TestAccAWSAvailabilityZones_stateFilter
=== CONT  TestAccAWSAvailabilityZones_basic
=== CONT  TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_basic (10.65s)
--- PASS: TestAccAWSAvailabilityZones_stateFilter (10.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       11.507s
```
