### PR TITLE
resource/aws_appautoscaling_policy: Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_appautoscaling_policy.go
+++ b/aws/resource_aws_appautoscaling_policy.go
@@ -455,7 +455,7 @@ func expandAppautoscalingCustomizedMetricSpecification(configured []interface{})
 		}
 
 		if s, ok := data["dimensions"].(*schema.Set); ok && s.Len() > 0 {
-			dimensions := make([]*applicationautoscaling.MetricDimension, s.Len(), s.Len())
+			dimensions := make([]*applicationautoscaling.MetricDimension, s.Len())
 			for i, d := range s.List() {
 				dimension := d.(map[string]interface{})
 				dimensions[i] = &applicationautoscaling.MetricDimension{
@@ -635,7 +635,7 @@ func flattenStepScalingPolicyConfiguration(cfg *applicationautoscaling.StepScali
 		return []interface{}{}
 	}
 
-	m := make(map[string]interface{}, 0)
+	m := make(map[string]interface{})
 
 	if cfg.AdjustmentType != nil {
 		m["adjustment_type"] = *cfg.AdjustmentType
@@ -657,10 +657,10 @@ func flattenStepScalingPolicyConfiguration(cfg *applicationautoscaling.StepScali
 }
 
 func flattenAppautoscalingStepAdjustments(adjs []*applicationautoscaling.StepAdjustment) []interface{} {
-	out := make([]interface{}, len(adjs), len(adjs))
+	out := make([]interface{}, len(adjs))
 
 	for i, adj := range adjs {
-		m := make(map[string]interface{}, 0)
+		m := make(map[string]interface{})
 
 		m["scaling_adjustment"] = *adj.ScalingAdjustment
 
@@ -682,7 +682,7 @@ func flattenTargetTrackingScalingPolicyConfiguration(cfg *applicationautoscaling
 		return []interface{}{}
 	}
 
-	m := make(map[string]interface{}, 0)
+	m := make(map[string]interface{})
 	m["target_value"] = *cfg.TargetValue
 
 	if cfg.DisableScaleIn != nil {
@@ -726,7 +726,7 @@ func flattenCustomizedMetricSpecification(cfg *applicationautoscaling.Customized
 }
 
 func flattenMetricDimensions(ds []*applicationautoscaling.MetricDimension) []interface{} {
-	l := make([]interface{}, len(ds), len(ds))
+	l := make([]interface{}, len(ds))
 	for i, d := range ds {
 		l[i] = map[string]interface{}{
 			"name":  *d.Name,


### PR DESCRIPTION
Reference: #6343 

Previously:

```
aws/resource_aws_appautoscaling_policy.go:458:66:warning: should use make([]*applicationautoscaling.MetricDimension, s.Len()) instead (S1019) (gosimple)
aws/resource_aws_appautoscaling_policy.go:638:36:warning: should use make(map[string]interface{}) instead (S1019) (gosimple)
aws/resource_aws_appautoscaling_policy.go:660:29:warning: should use make([]interface{}, len(adjs)) instead (S1019) (gosimple)
aws/resource_aws_appautoscaling_policy.go:663:37:warning: should use make(map[string]interface{}) instead (S1019) (gosimple)
aws/resource_aws_appautoscaling_policy.go:685:36:warning: should use make(map[string]interface{}) instead (S1019) (gosimple)
aws/resource_aws_appautoscaling_policy.go:729:27:warning: should use make([]interface{}, len(ds)) instead (S1019) (gosimple)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAppautoScalingPolicy_basic (37.33s)
--- PASS: TestAccAWSAppautoScalingPolicy_nestedSchema (37.39s)
--- PASS: TestAccAWSAppautoScalingPolicy_scaleOutAndIn (38.26s)
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (70.42s)
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (112.74s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource (113.80s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName (114.53s)
```

