### PR TITLE
tests: Switch acceptance test configurations from removed nodejs4.3 Lambda runtime to nodejs8.10

### DIFF
--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceAWSLambdaFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "qualifier", "$LATEST"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "handler", "exports.example"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "memory_size", "128"),
-					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "runtime", "nodejs4.3"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "runtime", "nodejs8.10"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "timeout", "3"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "version", "$LATEST"),
 					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "reserved_concurrent_executions", "0"),
@@ -240,7 +240,7 @@ resource "aws_lambda_function" "acctest_create" {
   filename = "test-fixtures/lambdatest.zip"
   role = "${aws_iam_role.lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
 }
 
 data "aws_lambda_function" "acctest" {
@@ -257,7 +257,7 @@ resource "aws_lambda_function" "acctest_create" {
   filename = "test-fixtures/lambdatest.zip"
   role = "${aws_iam_role.lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
   publish = true
 }
 
@@ -276,7 +276,7 @@ resource "aws_lambda_function" "acctest_create" {
   filename = "test-fixtures/lambdatest.zip"
   role = "${aws_iam_role.lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
   publish = true
 }
 
@@ -301,7 +301,7 @@ resource "aws_lambda_function" "acctest_create" {
   filename = "test-fixtures/lambdatest.zip"
   role = "${aws_iam_role.lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
 
   vpc_config = {
     subnet_ids = ["${aws_subnet.lambda.id}"]
@@ -323,7 +323,7 @@ resource "aws_lambda_function" "acctest_create" {
   filename = "test-fixtures/lambdatest.zip"
   role = "${aws_iam_role.lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
 
   environment {
     variables = {

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -404,7 +404,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name = "%s"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
 }
 `, apiGatewayName, apiGatewayName, apiGatewayName, lambdaName)
 }

--- a/aws/resource_aws_api_gateway_method_test.go
+++ b/aws/resource_aws_api_gateway_method_test.go
@@ -384,7 +384,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name = "tf_acc_api_gateway_authorizer_%d"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-	runtime = "nodejs4.3"
+	runtime = "nodejs8.10"
 }
 
 resource "aws_api_gateway_authorizer" "test" {

--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -1367,7 +1367,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "tf-test-trail-event-select-%d"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 `, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt, cloudTrailRandInt)
 }

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -798,7 +798,7 @@ resource "aws_lambda_function" "lambda" {
   source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-	runtime = "nodejs4.3"
+	runtime = "nodejs8.10"
 }
 
 resource "aws_cloudwatch_event_rule" "schedule" {

--- a/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -187,7 +187,7 @@ resource "aws_lambda_function" "test_lambdafunction" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "example_lambda_name_%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
   handler       = "exports.handler"
 }
 

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -954,7 +954,7 @@ resource "aws_lambda_function" "main" {
   function_name = "%[1]s"
   role          = "${aws_iam_role.main.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_cognito_user_pool" "main" {
@@ -1001,7 +1001,7 @@ resource "aws_lambda_function" "main" {
   function_name = "%[1]s"
   role          = "${aws_iam_role.main.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_lambda_function" "second" {
@@ -1009,7 +1009,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = "${aws_iam_role.main.arn}"
   handler       = "exports.example"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_cognito_user_pool" "main" {

--- a/aws/resource_aws_config_config_rule_test.go
+++ b/aws/resource_aws_config_config_rule_test.go
@@ -485,7 +485,7 @@ resource "aws_lambda_function" "f" {
   function_name = "tf_acc_lambda_awsconfig_%d"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_permission" "p" {

--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1085,7 +1085,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 `, funcName)
 }

--- a/aws/resource_aws_lambda_alias_test.go
+++ b/aws/resource_aws_lambda_alias_test.go
@@ -268,7 +268,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name    = "%s"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs4.3"
+  runtime          = "nodejs8.10"
   source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
   publish          = "true"
 }
@@ -335,7 +335,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name    = "%s"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
-  runtime          = "nodejs4.3"
+  runtime          = "nodejs8.10"
   source_code_hash = "${base64sha256(file("test-fixtures/lambdatest_modified.zip"))}"
   publish          = "true"
 }

--- a/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -541,7 +541,7 @@ resource "aws_lambda_function" "test" {
   function_name = %q
   handler       = "exports.example"
   role          = "${aws_iam_role.test.arn}"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 `, rName, rName, rName)
 }
@@ -626,7 +626,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -634,7 +634,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -714,7 +714,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
 	function_name = "%s"
 	role = "${aws_iam_role.iam_for_lambda.arn}"
 	handler = "exports.example"
-	runtime = "nodejs4.3"
+	runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -722,7 +722,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
 	function_name = "%s"
 	role = "${aws_iam_role.iam_for_lambda.arn}"
 	handler = "exports.example"
-	runtime = "nodejs4.3"
+	runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -802,7 +802,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -810,7 +810,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -880,7 +880,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -888,7 +888,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -958,7 +958,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -966,7 +966,7 @@ resource "aws_lambda_function" "lambda_function_test_update" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_lambda_event_source_mapping" "lambda_event_source_mapping_test" {
@@ -1034,7 +1034,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
     function_name = "%[5]s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -283,7 +283,7 @@ func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
 				Config: testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs4.3"),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs8.10"),
 				),
 			},
 			{
@@ -1051,15 +1051,15 @@ func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 	})
 }
 
-func TestAccAWSLambdaFunction_runtimeValidation_nodeJs43(t *testing.T) {
+func TestAccAWSLambdaFunction_runtimeValidation_NodeJs810(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
 	rString := acctest.RandString(8)
 
-	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_node43_%s", rString)
-	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_node43_%s", rString)
-	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_node43_%s", rString)
-	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_node43_%s", rString)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs810_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs810_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs810_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_nodejs810_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1067,10 +1067,10 @@ func TestAccAWSLambdaFunction_runtimeValidation_nodeJs43(t *testing.T) {
 		CheckDestroy: testAccCheckLambdaFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaConfigNodeJs43Runtime(funcName, policyName, roleName, sgName),
+				Config: testAccAWSLambdaConfigNodeJs810Runtime(funcName, policyName, roleName, sgName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
-					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeNodejs43),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeNodejs810),
 				),
 			},
 		},
@@ -1576,7 +1576,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 `, funcName)
 }
@@ -1588,7 +1588,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
     reserved_concurrent_executions = 111
 }
 `, funcName)
@@ -1601,7 +1601,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
     reserved_concurrent_executions = 222
 }
 `, funcName)
@@ -1625,7 +1625,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-		runtime = "nodejs4.3"
+		runtime = "nodejs8.10"
 }
 `, funcName)
 }
@@ -1637,7 +1637,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
     environment {
         variables = {
             foo = "bar"
@@ -1654,7 +1654,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
     environment {
         variables = {
             foo = "baz"
@@ -1672,7 +1672,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 `, funcName)
 }
@@ -1706,7 +1706,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     kms_key_arn = "${aws_kms_key.foo.arn}"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
     environment {
         variables = {
             foo = "bar"
@@ -1744,7 +1744,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
     environment {
         variables = {
             foo = "bar"
@@ -1762,7 +1762,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     publish = true
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 data "template_file" "function_version" {
@@ -1798,7 +1798,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 
     tracing_config {
         mode = "Active"
@@ -1815,7 +1815,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 
     tracing_config {
         mode = "PassThrough"
@@ -1832,7 +1832,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 
     dead_letter_config {
         target_arn = "${aws_sns_topic.lambda_function_test.arn}"
@@ -1854,7 +1854,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 
     dead_letter_config {
         target_arn = "${aws_sns_topic.lambda_function_test_2.arn}"
@@ -1879,7 +1879,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 
     dead_letter_config {
         target_arn = ""
@@ -1895,7 +1895,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 
     vpc_config = {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}"]
@@ -1911,7 +1911,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 
     vpc_config = {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}", "${aws_subnet.subnet_for_lambda_2.id}"]
@@ -1959,7 +1959,7 @@ resource "aws_lambda_function" "test" {
     function_name = "%s"
     role          = "${aws_iam_role.iam_for_lambda.arn}"
     handler       = "exports.example"
-    runtime       = "nodejs4.3"
+    runtime       = "nodejs8.10"
 
     vpc_config {
         subnet_ids         = []
@@ -2005,7 +2005,7 @@ resource "aws_lambda_function" "lambda_function_s3test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 `, bucketName, roleName, funcName)
 }
@@ -2021,14 +2021,14 @@ resource "aws_lambda_function" "lambda_function_test" {
 `, funcName)
 }
 
-func testAccAWSLambdaConfigNodeJs43Runtime(funcName, policyName, roleName, sgName string) string {
+func testAccAWSLambdaConfigNodeJs810Runtime(funcName, policyName, roleName, sgName string) string {
 	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
 resource "aws_lambda_function" "lambda_function_test" {
     filename = "test-fixtures/lambdatest.zip"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 `, funcName)
 }
@@ -2064,7 +2064,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
   tags = {
 		Key1 = "Value One"
 		Description = "Very interesting"
@@ -2080,7 +2080,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
   tags = {
 		Key1 = "Value One Changed"
 		Key2 = "Value Two"
@@ -2164,7 +2164,7 @@ resource "aws_lambda_function" "lambda_function_local" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 data "template_file" "last_modified" {
@@ -2207,7 +2207,7 @@ resource "aws_lambda_function" "lambda_function_local" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }`, roleName, filePath, funcName)
 }
 
@@ -2252,7 +2252,7 @@ resource "aws_lambda_function" "lambda_function_s3" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 `, bucketName, key, path, path, roleName, funcName)
 }
@@ -2294,6 +2294,6 @@ resource "aws_lambda_function" "lambda_function_s3" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }`, bucketName, key, path, path, roleName, funcName)
 }

--- a/aws/resource_aws_lambda_permission_test.go
+++ b/aws/resource_aws_lambda_permission_test.go
@@ -567,7 +567,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -604,7 +604,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -642,7 +642,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "lambda_function_name_perm"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -690,7 +690,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -735,7 +735,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -794,7 +794,7 @@ resource "aws_lambda_function" "my-func" {
     function_name = "%s"
     role = "${aws_iam_role.police.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "police" {
@@ -843,7 +843,7 @@ resource "aws_lambda_function" "my-func" {
     function_name = "%s"
     role = "${aws_iam_role.police.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "police" {
@@ -881,7 +881,7 @@ resource "aws_lambda_function" "my-func" {
     function_name = "%s"
     role = "${aws_iam_role.police.arn}"
     handler = "exports.handler"
-    runtime = "nodejs4.3"
+    runtime = "nodejs8.10"
 }
 
 resource "aws_iam_role" "police" {

--- a/aws/resource_aws_s3_bucket_notification_test.go
+++ b/aws/resource_aws_s3_bucket_notification_test.go
@@ -547,7 +547,7 @@ resource "aws_lambda_function" "func" {
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
-		runtime = "nodejs4.3"
+		runtime = "nodejs8.10"
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -582,7 +582,7 @@ resource "aws_lambda_function" "test1" {
   function_name = "%[1]s-1"
   handler       = "exports.example"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_lambda_permission" "test1" {
@@ -598,7 +598,7 @@ resource "aws_lambda_function" "test2" {
   function_name = "%[1]s-2"
   handler       = "exports.example"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_lambda_permission" "test2" {
@@ -625,7 +625,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s"
   handler       = "exports.example"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -188,7 +188,7 @@ resource "aws_lambda_function" "lambda_function_test" {
   function_name = "sfn-%s"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
-  runtime = "nodejs4.3"
+  runtime = "nodejs8.10"
 }
 
 resource "aws_sfn_state_machine" "foo" {


### PR DESCRIPTION
The runtime has been EOL for a few months now, but support was actually turned off today in our main acceptance testing account. See also: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html

Previously:

```
--- FAIL: TestAccAWSCloudwatchLogSubscriptionFilter_basic (8.09s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_lambda_function.test_lambdafunction: 1 error occurred:
          * aws_lambda_function.test_lambdafunction: Error creating Lambda function: InvalidParameterValueException: The runtime parameter of nodejs4.3 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs8.10) while creating or updating functions.
          status code: 400, request id: 741dec0d-025e-11e9-9361-b14433c1c821
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudTrail (80.44s)
    --- PASS: TestAccAWSCloudTrail/Trail (80.44s)
        --- PASS: TestAccAWSCloudTrail/Trail/eventSelector (80.44s)
--- PASS: TestAccAWSConfig (242.17s)
    --- PASS: TestAccAWSConfig/Config (242.17s)
        --- PASS: TestAccAWSConfig/Config/customlambda (115.58s)
        --- PASS: TestAccAWSConfig/Config/importLambda (126.59s)

--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (60.64s)
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (35.02s)
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (22.43s)
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_basic (28.00s)
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_disappears (25.22s)
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup (26.85s)
--- PASS: TestAccAWSCognitoUserPool_withLambdaConfig (41.68s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (1236.04s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (136.39s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (132.66s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (137.89s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (137.73s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (133.54s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (148.69s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (342.45s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (143.88s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (0.76s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (0.93s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (196.12s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (162.40s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (123.72s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (111.77s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (892.83s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (92.16s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (147.85s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (212.48s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (114.95s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (103.34s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (337.09s)
--- PASS: TestAccAWSLambdaAlias_basic (32.55s)
--- PASS: TestAccAWSLambdaAlias_nameupdate (40.09s)
--- PASS: TestAccAWSLambdaAlias_routingconfig (43.06s)
--- PASS: TestAccAWSLambdaEventSourceMapping_changesInEnabledAreDetected (110.32s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_basic (93.45s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_disappears (85.50s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_import (84.81s)
--- PASS: TestAccAWSLambdaEventSourceMapping_kinesis_removeBatchSize (91.32s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_basic (87.84s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqs_withFunctionName (30.70s)
--- PASS: TestAccAWSLambdaEventSourceMapping_sqsDisappears (108.43s)
--- PASS: TestAccAWSLambdaEventSourceMapping_StartingPositionTimestamp (78.94s)
--- PASS: TestAccAWSLambdaFunction_basic (38.11s)
--- PASS: TestAccAWSLambdaFunction_concurrency (48.19s)
--- PASS: TestAccAWSLambdaFunction_concurrencyCycle (59.80s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfig (47.10s)
--- PASS: TestAccAWSLambdaFunction_DeadLetterConfigUpdated (47.08s)
--- PASS: TestAccAWSLambdaFunction_EmptyVpcConfig (33.52s)
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (68.81s)
--- PASS: TestAccAWSLambdaFunction_envVariables (74.63s)
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (21.29s)
--- PASS: TestAccAWSLambdaFunction_importLocalFile (32.44s)
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (38.30s)
--- PASS: TestAccAWSLambdaFunction_importS3 (34.38s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (35.48s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (34.94s)
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (29.84s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (31.38s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs810 (38.78s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (1.23s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (30.95s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (31.67s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (31.52s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (31.12s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (30.73s)
--- PASS: TestAccAWSLambdaFunction_s3 (33.07s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (52.97s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (50.72s)
--- PASS: TestAccAWSLambdaFunction_tags (60.73s)
--- PASS: TestAccAWSLambdaFunction_tracingConfig (52.71s)
--- PASS: TestAccAWSLambdaFunction_updateRuntime (51.72s)
--- PASS: TestAccAWSLambdaFunction_versioned (30.58s)
--- PASS: TestAccAWSLambdaFunction_versionedUpdate (50.35s)
--- PASS: TestAccAWSLambdaFunction_VPC (49.61s)
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (51.38s)
--- PASS: TestAccAWSLambdaFunction_VPCRemoval (61.83s)
--- PASS: TestAccAWSLambdaFunction_VPCUpdate (69.99s)
--- PASS: TestAccAWSLambdaPermission_basic (23.44s)
--- PASS: TestAccAWSLambdaPermission_multiplePerms (37.87s)
--- PASS: TestAccAWSLambdaPermission_withIAMRole (31.24s)
--- PASS: TestAccAWSLambdaPermission_withQualifier (25.42s)
--- PASS: TestAccAWSLambdaPermission_withRawFunctionName (22.49s)
--- PASS: TestAccAWSLambdaPermission_withS3 (39.75s)
--- PASS: TestAccAWSLambdaPermission_withSNS (30.08s)
--- PASS: TestAccAWSLambdaPermission_withStatementIdPrefix (23.36s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (43.14s)
--- PASS: TestAccDataSourceAWSLambdaFunction_alias (31.84s)
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (33.62s)
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (31.38s)
--- PASS: TestAccDataSourceAWSLambdaFunction_version (28.52s)
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (37.59s)
```
