### PR TITLE
service/dax: Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_dax_cluster.go
+++ b/aws/resource_aws_dax_cluster.go
@@ -290,9 +290,9 @@ func resourceAwsDaxClusterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("replication_factor", c.TotalNodes)
 
 	if c.ClusterDiscoveryEndpoint != nil {
-		d.Set("port", c.ClusterDiscoveryEndpoint.Port)
-		d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", *c.ClusterDiscoveryEndpoint.Address, *c.ClusterDiscoveryEndpoint.Port)))
-		d.Set("cluster_address", aws.String(fmt.Sprintf("%s", *c.ClusterDiscoveryEndpoint.Address)))
+		d.Set("port", aws.Int64Value(c.ClusterDiscoveryEndpoint.Port))
+		d.Set("configuration_endpoint", fmt.Sprintf("%s:%d", aws.StringValue(c.ClusterDiscoveryEndpoint.Address), aws.Int64Value(c.ClusterDiscoveryEndpoint.Port)))
+		d.Set("cluster_address", aws.StringValue(c.ClusterDiscoveryEndpoint.Address))
 	}
 
 	d.Set("subnet_group_name", c.SubnetGroup)

--- a/aws/resource_aws_dax_cluster_test.go
+++ b/aws/resource_aws_dax_cluster_test.go
@@ -88,6 +88,8 @@ func TestAccAWSDAXCluster_importBasic(t *testing.T) {
 func TestAccAWSDAXCluster_basic(t *testing.T) {
 	var dc dax.Cluster
 	rString := acctest.RandString(10)
+	iamRoleResourceName := "aws_iam_role.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -97,12 +99,10 @@ func TestAccAWSDAXCluster_basic(t *testing.T) {
 				Config: testAccAWSDAXClusterConfig(rString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDAXClusterExists("aws_dax_cluster.test", &dc),
+					testAccMatchResourceAttrRegionalARN("aws_dax_cluster.test", "arn", "dax", regexp.MustCompile("cache/.+")),
 					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "arn", regexp.MustCompile("^arn:aws:dax:[\\w-]+:\\d+:cache/")),
-					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "cluster_name", regexp.MustCompile("^tf-\\w+$")),
-					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "iam_role_arn", regexp.MustCompile("^arn:aws:iam::\\d+:role/")),
+						"aws_dax_cluster.test", "cluster_name", regexp.MustCompile(`^tf-\w+$`)),
+					resource.TestCheckResourceAttrPair("aws_dax_cluster.test", "iam_role_arn", iamRoleResourceName, "arn"),
 					resource.TestCheckResourceAttr(
 						"aws_dax_cluster.test", "node_type", "dax.t2.small"),
 					resource.TestCheckResourceAttr(
@@ -110,19 +110,19 @@ func TestAccAWSDAXCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_dax_cluster.test", "description", "test cluster"),
 					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "parameter_group_name", regexp.MustCompile("^default.dax")),
+						"aws_dax_cluster.test", "parameter_group_name", regexp.MustCompile(`^default.dax`)),
 					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "maintenance_window", regexp.MustCompile("^\\w{3}:\\d{2}:\\d{2}-\\w{3}:\\d{2}:\\d{2}$")),
+						"aws_dax_cluster.test", "maintenance_window", regexp.MustCompile(`^\w{3}:\d{2}:\d{2}-\w{3}:\d{2}:\d{2}$`)),
 					resource.TestCheckResourceAttr(
 						"aws_dax_cluster.test", "subnet_group_name", "default"),
 					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "nodes.0.id", regexp.MustCompile("^tf-[\\w-]+$")),
+						"aws_dax_cluster.test", "nodes.0.id", regexp.MustCompile(`^tf-[\w-]+$`)),
 					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "configuration_endpoint", regexp.MustCompile(":\\d+$")),
+						"aws_dax_cluster.test", "configuration_endpoint", regexp.MustCompile(`:\d+$`)),
 					resource.TestCheckResourceAttrSet(
 						"aws_dax_cluster.test", "cluster_address"),
 					resource.TestMatchResourceAttr(
-						"aws_dax_cluster.test", "port", regexp.MustCompile("^\\d+$")),
+						"aws_dax_cluster.test", "port", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(
 						"aws_dax_cluster.test", "server_side_encryption.#", "1"),
 					resource.TestCheckResourceAttr(

--- a/aws/resource_aws_dax_parameter_group_test.go
+++ b/aws/resource_aws_dax_parameter_group_test.go
@@ -91,11 +91,8 @@ func testAccCheckAwsDaxParameterGroupExists(name string) resource.TestCheckFunc 
 		_, err := conn.DescribeParameterGroups(&dax.DescribeParameterGroupsInput{
 			ParameterGroupNames: []*string{aws.String(rs.Primary.ID)},
 		})
-		if err != nil {
-			return err
-		}
 
-		return nil
+		return err
 	}
 }
 

--- a/aws/resource_aws_dax_subnet_group_test.go
+++ b/aws/resource_aws_dax_subnet_group_test.go
@@ -79,11 +79,8 @@ func testAccCheckAwsDaxSubnetGroupExists(name string) resource.TestCheckFunc {
 		_, err := conn.DescribeSubnetGroups(&dax.DescribeSubnetGroupsInput{
 			SubnetGroupNames: []*string{aws.String(rs.Primary.ID)},
 		})
-		if err != nil {
-			return err
-		}
 
-		return nil
+		return err
 	}
 }
 


### PR DESCRIPTION
Reference: #6343 

Previously:

```
aws/resource_aws_dax_cluster.go:295:39:warning: the argument is already a string, there's no need to use fmt.Sprintf (S1025) (gosimple)
aws/resource_aws_dax_cluster_test.go:101:38:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_dax_cluster_test.go:103:47:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_dax_cluster_test.go:105:47:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_dax_cluster_test.go:115:53:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_dax_cluster_test.go:119:45:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_dax_cluster_test.go:121:57:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_dax_cluster_test.go:125:39:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_dax_parameter_group_test.go:94:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_dax_parameter_group_test.go:94:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_dax_subnet_group_test.go:82:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_dax_subnet_group_test.go:82:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDAXCluster_encryption_disabled (665.00s)
--- PASS: TestAccAWSDAXCluster_encryption_enabled (717.82s)
--- PASS: TestAccAWSDAXCluster_importBasic (722.76s)
--- PASS: TestAccAWSDAXCluster_basic (868.47s)
--- PASS: TestAccAWSDAXCluster_resize (1410.34s)
--- PASS: TestAccAwsDaxParameterGroup_import (12.88s)
--- PASS: TestAccAwsDaxParameterGroup_basic (19.91s)
--- PASS: TestAccAwsDaxSubnetGroup_basic (45.40s)
```