### PR TITLE
service/efs: Fix gosimple Linting Issues

### DIFF
--- a/aws/resource_aws_efs_file_system.go
+++ b/aws/resource_aws_efs_file_system.go
@@ -255,9 +255,7 @@ func resourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) erro
 				d.Id(), err.Error())
 		}
 
-		for _, tag := range tagsResp.Tags {
-			tags = append(tags, tag)
-		}
+		tags = append(tags, tagsResp.Tags...)
 
 		if tagsResp.NextMarker != nil {
 			marker = *tagsResp.NextMarker
@@ -301,9 +299,8 @@ func resourceAwsEfsFileSystemRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("throughput_mode", fs.ThroughputMode)
 
 	region := meta.(*AWSClient).region
-	err = d.Set("dns_name", resourceAwsEfsDnsName(*fs.FileSystemId, region))
-	if err != nil {
-		return err
+	if err := d.Set("dns_name", resourceAwsEfsDnsName(aws.StringValue(fs.FileSystemId), region)); err != nil {
+		return fmt.Errorf("error setting dns_name: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_efs_file_system_test.go
+++ b/aws/resource_aws_efs_file_system_test.go
@@ -37,9 +37,7 @@ func TestResourceAWSEFSFileSystem_hasEmptyFileSystems(t *testing.T) {
 		FileSystems: []*efs.FileSystemDescription{},
 	}
 
-	var actual bool
-
-	actual = hasEmptyFileSystems(fs)
+	actual := hasEmptyFileSystems(fs)
 	if !actual {
 		t.Fatalf("Expected return value to be true, got %t", actual)
 	}
@@ -178,7 +176,8 @@ func TestAccAWSEFSFileSystem_pagedTags(t *testing.T) {
 
 func TestAccAWSEFSFileSystem_kmsKey(t *testing.T) {
 	rInt := acctest.RandInt()
-	keyRegex := regexp.MustCompile("^arn:aws:([a-zA-Z0-9\\-])+:([a-z]{2}-[a-z]+-\\d{1})?:(\\d{12})?:(.*)$")
+	kmsKeyResourceName := "aws_kms_key.foo"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -187,7 +186,7 @@ func TestAccAWSEFSFileSystem_kmsKey(t *testing.T) {
 			{
 				Config: testAccAWSEFSFileSystemConfigWithKmsKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("aws_efs_file_system.foo-with-kms", "kms_key_id", keyRegex),
+					resource.TestCheckResourceAttrPair("aws_efs_file_system.foo-with-kms", "kms_key_id", kmsKeyResourceName, "arn"),
 					resource.TestCheckResourceAttr("aws_efs_file_system.foo-with-kms", "encrypted", "true"),
 				),
 			},
@@ -320,11 +319,7 @@ func testAccCheckEfsFileSystem(resourceID string) resource.TestCheckFunc {
 			FileSystemId: aws.String(rs.Primary.ID),
 		})
 
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }
 
@@ -350,11 +345,7 @@ func testAccCheckEfsCreationToken(resourceID string, expectedToken string) resou
 				expectedToken, *fs.CreationToken)
 		}
 
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }
 

--- a/aws/resource_aws_efs_mount_target.go
+++ b/aws/resource_aws_efs_mount_target.go
@@ -221,9 +221,8 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	region := meta.(*AWSClient).region
-	err = d.Set("dns_name", resourceAwsEfsMountTargetDnsName(*mt.FileSystemId, region))
-	if err != nil {
-		return err
+	if err := d.Set("dns_name", resourceAwsEfsMountTargetDnsName(aws.StringValue(mt.FileSystemId), region)); err != nil {
+		return fmt.Errorf("error setting dns_name: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_efs_mount_target_test.go
+++ b/aws/resource_aws_efs_mount_target_test.go
@@ -128,9 +128,7 @@ func TestResourceAWSEFSMountTarget_hasEmptyMountTargets(t *testing.T) {
 		MountTargets: []*efs.MountTargetDescription{},
 	}
 
-	var actual bool
-
-	actual = hasEmptyMountTargets(mto)
+	actual := hasEmptyMountTargets(mto)
 	if !actual {
 		t.Fatalf("Expected return value to be true, got %t", actual)
 	}


### PR DESCRIPTION
Reference: #6343

Previously:

```
aws/resource_aws_efs_file_system.go:258:3:warning: should replace loop with tags = append(tags, tagsResp.Tags...) (S1011) (gosimple)
aws/resource_aws_efs_file_system.go:305:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_efs_file_system_test.go:40:2:warning: should merge variable declaration with assignment on next line (S1021) (gosimple)
aws/resource_aws_efs_file_system_test.go:181:14:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_efs_file_system_test.go:323:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_efs_file_system_test.go:323:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_efs_mount_target.go:225:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_efs_mount_target_test.go:131:2:warning: should merge variable declaration with assignment on next line (S1021) (gosimple)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEFSFileSystem_kmsConfigurationWithoutEncryption (32.15s)
--- PASS: TestAccAWSEFSFileSystem_importBasic (36.42s)
--- PASS: TestAccAWSEFSFileSystem_pagedTags (36.92s)
--- PASS: TestAccAWSEFSFileSystem_ThroughputMode (45.20s)
--- PASS: TestAccAWSEFSFileSystem_kmsKey (47.32s)
--- PASS: TestAccAWSEFSFileSystem_ProvisionedThroughputInMibps (61.17s)
--- PASS: TestAccAWSEFSFileSystem_basic (69.98s)
--- PASS: TestAccAWSEFSMountTarget_disappears (210.36s)
--- PASS: TestAccAWSEFSMountTarget_importBasic (215.00s)
--- PASS: TestAccAWSEFSMountTarget_basic (396.94s)
```