### PR TITLE
service/ssm: Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -363,11 +363,10 @@ func resourceAwsSsmDocumentDelete(d *schema.ResourceData, meta interface{}) erro
 			return resource.NonRetryableError(err)
 		}
 
-		return resource.RetryableError(
-			fmt.Errorf("%q: Timeout while waiting for the document to be deleted", d.Id()))
+		return resource.RetryableError(fmt.Errorf("SSM Document (%s) still exists", d.Id()))
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error waiting for SSM Document (%s) deletion: %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -339,11 +339,8 @@ func testAccCheckAWSSSMDocumentExists(n string) resource.TestCheckFunc {
 		_, err := conn.DescribeDocument(&ssm.DescribeDocumentInput{
 			Name: aws.String(rs.Primary.ID),
 		})
-		if err != nil {
-			return err
-		}
 
-		return nil
+		return err
 	}
 }
 

--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -154,7 +155,7 @@ func resourceAwsSsmMaintenanceWindowDelete(d *schema.ResourceData, meta interfac
 
 	_, err := ssmconn.DeleteMaintenanceWindow(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting SSM Maintenance Window (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -140,7 +140,7 @@ func resourceAwsSsmMaintenanceWindowTargetUpdate(d *schema.ResourceData, meta in
 
 	_, err := ssmconn.UpdateMaintenanceWindowTarget(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating SSM Maintenance Window Target (%s): %s", d.Id(), err)
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func resourceAwsSsmMaintenanceWindowTargetDelete(d *schema.ResourceData, meta in
 
 	_, err := ssmconn.DeregisterTargetFromMaintenanceWindow(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("error deregistering SSM Maintenance Window Target (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -2,8 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/validation"
 	"log"
+
+	"github.com/hashicorp/terraform/helper/validation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -299,7 +300,7 @@ func resourceAwsSsmMaintenanceWindowTaskDelete(d *schema.ResourceData, meta inte
 
 	_, err := ssmconn.DeregisterTaskFromMaintenanceWindow(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("error deregistering SSM Maintenance Window Task (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -159,7 +159,7 @@ func resourceAwsSsmParameterDelete(d *schema.ResourceData, meta interface{}) err
 		Name: aws.String(d.Get("name").(string)),
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting SSM Parameter (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -308,11 +308,8 @@ func testAccCheckAWSSSMParameterDisappears(param *ssm.Parameter) resource.TestCh
 		}
 
 		_, err := conn.DeleteParameter(paramInput)
-		if err != nil {
-			return err
-		}
 
-		return nil
+		return err
 	}
 }
 

--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -274,7 +274,7 @@ func resourceAwsSsmPatchBaselineDelete(d *schema.ResourceData, meta interface{})
 
 	_, err := ssmconn.DeletePatchBaseline(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting SSM Patch Baseline (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_ssm_patch_group.go
+++ b/aws/resource_aws_ssm_patch_group.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -88,7 +89,7 @@ func resourceAwsSsmPatchGroupDelete(d *schema.ResourceData, meta interface{}) er
 
 	_, err := ssmconn.DeregisterPatchBaselineForPatchGroup(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("error deregistering SSM Patch Group (%s): %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
Reference: #6343 

Previously:

```
aws/resource_aws_ssm_document.go:369:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_document_test.go:342:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_document_test.go:342:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_maintenance_window.go:156:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_maintenance_window_target.go:142:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_maintenance_window_target.go:160:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_maintenance_window_task.go:301:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_parameter.go:161:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_parameter_test.go:311:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_parameter_test.go:311:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_patch_baseline.go:276:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_ssm_patch_group.go:90:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMDocument_params (12.71s)
--- PASS: TestAccAWSSSMDocument_basic (12.86s)
--- PASS: TestAccAWSSSMDocument_session (12.89s)
--- PASS: TestAccAWSSSMDocument_permission_public (15.48s)
--- PASS: TestAccAWSSSMDocument_permission_batching (15.89s)
--- PASS: TestAccAWSSSMDocument_permission_private (18.35s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (24.63s)
--- PASS: TestAccAWSSSMDocument_automation (28.73s)
--- PASS: TestAccAWSSSMDocument_update (20.98s)
--- PASS: TestAccAWSSSMDocument_Tags (35.72s)
--- PASS: TestAccAWSSSMDocument_permission_change (36.31s)
--- PASS: TestAccAWSSSMMaintenanceWindow_disappears (8.70s)
--- PASS: TestAccAWSSSMMaintenanceWindow_basic (17.49s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_basic (13.99s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_update (19.75s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (227.81s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (241.90s)
--- PASS: TestAccAWSSSMParameter_disappears (9.10s)
--- PASS: TestAccAWSSSMParameter_secure (13.40s)
--- PASS: TestAccAWSSSMParameter_fullPath (13.41s)
--- PASS: TestAccAWSSSMParameter_importBasic (16.20s)
--- PASS: TestAccAWSSSMParameter_basic (21.09s)
--- PASS: TestAccAWSSSMParameter_updateDescription (23.86s)
--- PASS: TestAccAWSSSMParameter_update (24.57s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (26.10s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (51.83s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (55.90s)
--- PASS: TestAccAWSSSMPatchBaseline_disappears (8.53s)
--- PASS: TestAccAWSSSMPatchBaseline_basic (17.21s)
--- PASS: TestAccAWSSSMPatchGroup_basic (12.45s)
```
