### PR TITLE
service/mediastore: Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_media_store_container.go
+++ b/aws/resource_aws_media_store_container.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/mediastore"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsMediaStoreContainer() *schema.Resource {
@@ -21,16 +22,10 @@ func resourceAwsMediaStoreContainer() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if !regexp.MustCompile("^\\w+$").MatchString(value) {
-						errors = append(errors, fmt.Errorf("%q must contain alphanumeric characters or underscores", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w+$`), "must contain alphanumeric characters or underscores"),
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -114,10 +109,10 @@ func resourceAwsMediaStoreContainerDelete(d *schema.ResourceData, meta interface
 			}
 			return resource.NonRetryableError(err)
 		}
-		return resource.RetryableError(nil)
+		return resource.RetryableError(fmt.Errorf("Media Store Container (%s) still exists", d.Id()))
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error waiting for Media Store Container (%s) deletion: %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_media_store_container_policy_test.go
+++ b/aws/resource_aws_media_store_container_policy_test.go
@@ -104,11 +104,8 @@ func testAccCheckAwsMediaStoreContainerPolicyExists(name string) resource.TestCh
 		}
 
 		_, err := conn.GetContainerPolicy(input)
-		if err != nil {
-			return err
-		}
 
-		return nil
+		return err
 	}
 }
 

--- a/aws/resource_aws_media_store_container_test.go
+++ b/aws/resource_aws_media_store_container_test.go
@@ -88,11 +88,8 @@ func testAccCheckAwsMediaStoreContainerExists(name string) resource.TestCheckFun
 		}
 
 		_, err := conn.DescribeContainer(input)
-		if err != nil {
-			return err
-		}
 
-		return nil
+		return err
 	}
 }
 


### PR DESCRIPTION
Reference: #6343 

Previously:

```
aws/resource_aws_media_store_container.go:29:10:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_media_store_container.go:119:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_media_store_container_policy_test.go:107:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_media_store_container_policy_test.go:107:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_media_store_container_test.go:91:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
aws/resource_aws_media_store_container_test.go:91:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (gosimple)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSMediaStoreContainer_basic (92.05s)
--- PASS: TestAccAWSMediaStoreContainer_import (93.59s)
--- PASS: TestAccAWSMediaStoreContainerPolicy_import (95.61s)
--- PASS: TestAccAWSMediaStoreContainerPolicy_basic (103.77s)
```
