### PR TITLE
data-source/aws_cloudtrail_service_account: Support us-gov-east-1 and us-gov-west-1 regions

### DIFF
--- a/aws/data_source_aws_cloudtrail_service_account.go
+++ b/aws/data_source_aws_cloudtrail_service_account.go
@@ -8,6 +8,8 @@ import (
 )
 
 // See http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-supported-regions.html
+// See https://docs.aws.amazon.com/govcloud-us/latest/ug-east/verifying-cloudtrail.html
+// See https://docs.aws.amazon.com/govcloud-us/latest/ug-west/verifying-cloudtrail.html
 var cloudTrailServiceAccountPerRegionMap = map[string]string{
 	"ap-northeast-1": "216624486486",
 	"ap-northeast-2": "492519147666",
@@ -25,6 +27,8 @@ var cloudTrailServiceAccountPerRegionMap = map[string]string{
 	"sa-east-1":      "814480443879",
 	"us-east-1":      "086441151436",
 	"us-east-2":      "475085895292",
+	"us-gov-east-1":  "608710470296",
+	"us-gov-west-1":  "608710470296",
 	"us-west-1":      "388731089494",
 	"us-west-2":      "113285607260",
 }

--- a/aws/data_source_aws_cloudtrail_service_account_test.go
+++ b/aws/data_source_aws_cloudtrail_service_account_test.go
@@ -1,12 +1,15 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSCloudTrailServiceAccount_basic(t *testing.T) {
+	expectedAccountID := cloudTrailServiceAccountPerRegionMap[testAccGetRegion()]
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -14,15 +17,26 @@ func TestAccAWSCloudTrailServiceAccount_basic(t *testing.T) {
 			{
 				Config: testAccCheckAwsCloudTrailServiceAccountConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.main", "id", "113285607260"),
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.main", "arn", "arn:aws:iam::113285607260:root"),
+					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.main", "id", expectedAccountID),
+					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.main", "arn", fmt.Sprintf("arn:%s:iam::%s:root", testAccGetPartition(), expectedAccountID)),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSCloudTrailServiceAccount_Region(t *testing.T) {
+	expectedAccountID := cloudTrailServiceAccountPerRegionMap[testAccGetRegion()]
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsCloudTrailServiceAccountExplicitRegionConfig,
+				Config: testAccCheckAwsCloudTrailServiceAccountConfigRegion,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.regional", "id", "282025262664"),
-					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.regional", "arn", "arn:aws:iam::282025262664:root"),
+					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.regional", "id", expectedAccountID),
+					resource.TestCheckResourceAttr("data.aws_cloudtrail_service_account.regional", "arn", fmt.Sprintf("arn:%s:iam::%s:root", testAccGetPartition(), expectedAccountID)),
 				),
 			},
 		},
@@ -33,8 +47,10 @@ const testAccCheckAwsCloudTrailServiceAccountConfig = `
 data "aws_cloudtrail_service_account" "main" { }
 `
 
-const testAccCheckAwsCloudTrailServiceAccountExplicitRegionConfig = `
+const testAccCheckAwsCloudTrailServiceAccountConfigRegion = `
+data "aws_region" "current" {}
+
 data "aws_cloudtrail_service_account" "regional" {
-	region = "eu-west-2"
+  region = "${data.aws_region.current.name}"
 }
 `


### PR DESCRIPTION
Previously (AWS GovCloud (US)):

```
--- FAIL: TestAccAWSCloudTrailServiceAccount_basic (0.32s)
    testing.go:538: Step 0 error: Error refreshing: 1 error occurred:
        	* data.aws_cloudtrail_service_account.main: 1 error occurred:
        	* data.aws_cloudtrail_service_account.main: data.aws_cloudtrail_service_account.main: Unknown region ("us-gov-west-1")
```

Output from acceptance testing (AWS GovCloud (US)):

```
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (11.42s)
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (12.11s)
```

Output from acceptance testing (AWS Commercial):

```
--- PASS: TestAccAWSCloudTrailServiceAccount_basic (9.07s)
--- PASS: TestAccAWSCloudTrailServiceAccount_Region (9.07s)
```