### PR TITLE
Fix name of session_timeout argument

### DIFF
--- a/website/docs/r/lb_listener_rule.html.markdown
+++ b/website/docs/r/lb_listener_rule.html.markdown
@@ -196,7 +196,7 @@ Authenticate Cognito Blocks (for `authenticate_cognito`) supports the following:
 * `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
 * `scope` - (Optional) The set of user claims to be requested from the IdP.
 * `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
-* `session_time_out` - (Optional) The maximum duration of the authentication session, in seconds.
+* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
 * `user_pool_arn` - (Required) The ARN of the Cognito user pool.
 * `user_pool_client_id` - (Required) The ID of the Cognito user pool client.
 * `user_pool_domain` - (Required) The domain prefix or fully-qualified domain name of the Cognito user pool.
@@ -211,7 +211,7 @@ Authenticate OIDC Blocks (for `authenticate_oidc`) supports the following:
 * `on_unauthenticated_request` - (Optional) The behavior if the user is not authenticated. Valid values: `deny`, `allow` and `authenticate`
 * `scope` - (Optional) The set of user claims to be requested from the IdP.
 * `session_cookie_name` - (Optional) The name of the cookie used to maintain session information.
-* `session_time_out` - (Optional) The maximum duration of the authentication session, in seconds.
+* `session_timeout` - (Optional) The maximum duration of the authentication session, in seconds.
 * `token_endpoint` - (Required) The token endpoint of the IdP.
 * `user_info_endpoint` - (Required) The user info endpoint of the IdP.
 


### PR DESCRIPTION
It was wrongly spelled as ```session_time_out```

https://github.com/terraform-providers/terraform-provider-aws/blob/02bde27419022568b5a6a9938c11f98495138fa7/aws/resource_aws_lb_listener_rule.go#L195

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
