### PR TITLE
Bump AWS SDK to v1.16.7

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/user_agent.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/user_agent.go
@@ -17,7 +17,7 @@ var SDKVersionUserAgentHandler = request.NamedHandler{
 }
 
 const execEnvVar = `AWS_EXECUTION_ENV`
-const execEnvUAKey = `exec_env`
+const execEnvUAKey = `exec-env`
 
 // AddHostExecEnvUserAgentHander is a request handler appending the SDK's
 // execution environment to the user agent.

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -1669,6 +1669,12 @@ var awsPartition = partition{
 		"neptune": service{
 
 			Endpoints: endpoints{
+				"ap-southeast-1": endpoint{
+					Hostname: "rds.ap-southeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-southeast-1",
+					},
+				},
 				"eu-central-1": endpoint{
 					Hostname: "rds.eu-central-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -2308,7 +2314,7 @@ var awsPartition = partition{
 		"shield": service{
 			IsRegionalized: boxedFalse,
 			Defaults: endpoint{
-				SSLCommonName: "Shield.us-east-1.amazonaws.com",
+				SSLCommonName: "shield.us-east-1.amazonaws.com",
 				Protocols:     []string{"https"},
 			},
 			Endpoints: endpoints{
@@ -2461,6 +2467,8 @@ var awsPartition = partition{
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.16.5"
+const SDKVersion = "1.16.7"

--- a/vendor/github.com/aws/aws-sdk-go/service/athena/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/athena/api.go
@@ -1561,9 +1561,7 @@ type DeleteNamedQueryInput struct {
 	_ struct{} `type:"structure"`
 
 	// The unique ID of the query to delete.
-	//
-	// NamedQueryId is a required field
-	NamedQueryId *string `type:"string" required:"true" idempotencyToken:"true"`
+	NamedQueryId *string `type:"string" idempotencyToken:"true"`
 }
 
 // String returns the string representation
@@ -1574,19 +1572,6 @@ func (s DeleteNamedQueryInput) String() string {
 // GoString returns the string representation
 func (s DeleteNamedQueryInput) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *DeleteNamedQueryInput) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "DeleteNamedQueryInput"}
-	if s.NamedQueryId == nil {
-		invalidParams.Add(request.NewErrParamRequired("NamedQueryId"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetNamedQueryId sets the NamedQueryId field's value.
@@ -2550,9 +2535,7 @@ type StopQueryExecutionInput struct {
 	_ struct{} `type:"structure"`
 
 	// The unique ID of the query execution to stop.
-	//
-	// QueryExecutionId is a required field
-	QueryExecutionId *string `type:"string" required:"true" idempotencyToken:"true"`
+	QueryExecutionId *string `type:"string" idempotencyToken:"true"`
 }
 
 // String returns the string representation
@@ -2563,19 +2546,6 @@ func (s StopQueryExecutionInput) String() string {
 // GoString returns the string representation
 func (s StopQueryExecutionInput) GoString() string {
 	return s.String()
-}
-
-// Validate inspects the fields of the type to determine if they are valid.
-func (s *StopQueryExecutionInput) Validate() error {
-	invalidParams := request.ErrInvalidParams{Context: "StopQueryExecutionInput"}
-	if s.QueryExecutionId == nil {
-		invalidParams.Add(request.NewErrParamRequired("QueryExecutionId"))
-	}
-
-	if invalidParams.Len() > 0 {
-		return invalidParams
-	}
-	return nil
 }
 
 // SetQueryExecutionId sets the QueryExecutionId field's value.

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
@@ -4706,30 +4706,71 @@ func (s ContinueUpdateRollbackOutput) GoString() string {
 type CreateChangeSetInput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of values that you must specify before AWS CloudFormation can update
-	// certain stacks. Some stack templates might include resources that can affect
-	// permissions in your AWS account, for example, by creating new AWS Identity
-	// and Access Management (IAM) users. For those stacks, you must explicitly
-	// acknowledge their capabilities by specifying this parameter.
+	// In some cases, you must explicity acknowledge that your stack template contains
+	// certain capabilities in order for AWS CloudFormation to create the stack.
 	//
-	// The only valid values are CAPABILITY_IAM and CAPABILITY_NAMED_IAM. The following
-	// resources require you to specify this parameter:  AWS::IAM::AccessKey (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html),
-	//  AWS::IAM::Group (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html),
-	//  AWS::IAM::InstanceProfile (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html),
-	//  AWS::IAM::Policy (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html),
-	//  AWS::IAM::Role (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html),
-	//  AWS::IAM::User (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html),
-	// and  AWS::IAM::UserToGroupAddition (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html).
+	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM
+	//
+	// Some stack templates might include resources that can affect permissions
+	//    in your AWS account; for example, by creating new AWS Identity and Access
+	//    Management (IAM) users. For those stacks, you must explicitly acknowledge
+	//    this by specifying one of these capabilities.
+	//
+	// The following IAM resources require you to specify either the CAPABILITY_IAM
+	//    or CAPABILITY_NAMED_IAM capability.
+	//
+	// If you have IAM resources, you can specify either capability.
+	//
+	// If you have IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM.
+	//
+	//
+	// If you don't specify either of these capabilities, AWS CloudFormation returns
+	//    an InsufficientCapabilities error.
+	//
 	// If your stack template contains these resources, we recommend that you review
-	// all permissions associated with them and edit their permissions if necessary.
+	//    all permissions associated with them and edit their permissions if necessary.
 	//
-	// If you have IAM resources, you can specify either capability. If you have
-	// IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM. If
-	// you don't specify this parameter, this action returns an InsufficientCapabilities
-	// error.
+	//  AWS::IAM::AccessKey (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
+	//
+	//  AWS::IAM::Group (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html)
+	//
+	//  AWS::IAM::InstanceProfile (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html)
+	//
+	//  AWS::IAM::Policy (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html)
+	//
+	//  AWS::IAM::Role (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html)
+	//
+	//  AWS::IAM::User (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html)
+	//
+	//  AWS::IAM::UserToGroupAddition (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html)
 	//
 	// For more information, see Acknowledging IAM Resources in AWS CloudFormation
-	// Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
+	//    Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
+	//
+	//    * CAPABILITY_AUTO_EXPAND
+	//
+	// Some template contain macros. Macros perform custom processing on templates;
+	//    this can include simple actions like find-and-replace operations, all
+	//    the way to extensive transformations of entire templates. Because of this,
+	//    users typically create a change set from the processed template, so that
+	//    they can review the changes resulting from the macros before actually
+	//    creating the stack. If your stack template contains one or more macros,
+	//    and you choose to create a stack directly from the processed template,
+	//    without first reviewing the resulting changes in a change set, you must
+	//    acknowledge this capability. This includes the AWS::Include (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)
+	//    and AWS::Serverless (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html)
+	//    transforms, which are macros hosted by AWS CloudFormation.
+	//
+	// This capacity does not apply to creating change sets, and specifying it when
+	//    creating change sets has no effect.
+	//
+	// Also, change sets do not currently support nested stacks. If you want to
+	//    create a stack from a stack template that contains macros and nested stacks,
+	//    you must create or update the stack directly from the template using the
+	//    CreateStack or UpdateStack action, and specifying this capability.
+	//
+	// For more information on macros, see Using AWS CloudFormation Macros to Perform
+	//    Custom Processing on Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
 	Capabilities []*string `type:"list"`
 
 	// The name of the change set. The name must be unique among all change sets
@@ -5064,7 +5105,7 @@ type CreateStackInput struct {
 	//  AWS::IAM::UserToGroupAddition (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html)
 	//
 	// For more information, see Acknowledging IAM Resources in AWS CloudFormation
-	//    Templates (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
+	//    Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
 	//
 	//    * CAPABILITY_AUTO_EXPAND
 	//
@@ -5076,8 +5117,8 @@ type CreateStackInput struct {
 	//    creating the stack. If your stack template contains one or more macros,
 	//    and you choose to create a stack directly from the processed template,
 	//    without first reviewing the resulting changes in a change set, you must
-	//    acknowledge this capability. This includes the AWS::Include (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)
-	//    and AWS::Serverless (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html)
+	//    acknowledge this capability. This includes the AWS::Include (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)
+	//    and AWS::Serverless (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html)
 	//    transforms, which are macros hosted by AWS CloudFormation.
 	//
 	// Change sets do not currently support nested stacks. If you want to create
@@ -5092,7 +5133,7 @@ type CreateStackInput struct {
 	//    function operation without AWS CloudFormation being notified.
 	//
 	// For more information, see Using AWS CloudFormation Macros to Perform Custom
-	//    Processing on Templates (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
+	//    Processing on Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
 	Capabilities []*string `type:"list"`
 
 	// A unique identifier for this CreateStack request. Specify this token if you
@@ -5596,40 +5637,62 @@ type CreateStackSetInput struct {
 	// in the AWS CloudFormation User Guide.
 	AdministrationRoleARN *string `min:"20" type:"string"`
 
-	// A list of values that you must specify before AWS CloudFormation can create
-	// certain stack sets. Some stack set templates might include resources that
-	// can affect permissions in your AWS account—for example, by creating new AWS
-	// Identity and Access Management (IAM) users. For those stack sets, you must
-	// explicitly acknowledge their capabilities by specifying this parameter.
+	// In some cases, you must explicity acknowledge that your stack set template
+	// contains certain capabilities in order for AWS CloudFormation to create the
+	// stack set and related stack instances.
 	//
-	// The only valid values are CAPABILITY_IAM and CAPABILITY_NAMED_IAM. The following
-	// resources require you to specify this parameter:
+	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM
 	//
-	//    * AWS::IAM::AccessKey
+	// Some stack templates might include resources that can affect permissions
+	//    in your AWS account; for example, by creating new AWS Identity and Access
+	//    Management (IAM) users. For those stack sets, you must explicitly acknowledge
+	//    this by specifying one of these capabilities.
 	//
-	//    * AWS::IAM::Group
+	// The following IAM resources require you to specify either the CAPABILITY_IAM
+	//    or CAPABILITY_NAMED_IAM capability.
 	//
-	//    * AWS::IAM::InstanceProfile
+	// If you have IAM resources, you can specify either capability.
 	//
-	//    * AWS::IAM::Policy
+	// If you have IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM.
 	//
-	//    * AWS::IAM::Role
 	//
-	//    * AWS::IAM::User
-	//
-	//    * AWS::IAM::UserToGroupAddition
+	// If you don't specify either of these capabilities, AWS CloudFormation returns
+	//    an InsufficientCapabilities error.
 	//
 	// If your stack template contains these resources, we recommend that you review
-	// all permissions that are associated with them and edit their permissions
-	// if necessary.
+	//    all permissions associated with them and edit their permissions if necessary.
 	//
-	// If you have IAM resources, you can specify either capability. If you have
-	// IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM. If
-	// you don't specify this parameter, this action returns an InsufficientCapabilities
-	// error.
+	//  AWS::IAM::AccessKey (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
+	//
+	//  AWS::IAM::Group (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html)
+	//
+	//  AWS::IAM::InstanceProfile (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html)
+	//
+	//  AWS::IAM::Policy (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html)
+	//
+	//  AWS::IAM::Role (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html)
+	//
+	//  AWS::IAM::User (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html)
+	//
+	//  AWS::IAM::UserToGroupAddition (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html)
 	//
 	// For more information, see Acknowledging IAM Resources in AWS CloudFormation
-	// Templates. (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities)
+	//    Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
+	//
+	//    * CAPABILITY_AUTO_EXPAND
+	//
+	// Some templates contain macros. If your stack template contains one or more
+	//    macros, and you choose to create a stack directly from the processed template,
+	//    without first reviewing the resulting changes in a change set, you must
+	//    acknowledge this capability. For more information, see Using AWS CloudFormation
+	//    Macros to Perform Custom Processing on Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
+	//
+	// Stack sets do not currently support macros in stack templates. (This includes
+	//    the AWS::Include (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)
+	//    and AWS::Serverless (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html)
+	//    transforms, which are macros hosted by AWS CloudFormation.) Even if you
+	//    specify this capability, if you include a macro in your template the stack
+	//    set operation will fail.
 	Capabilities []*string `type:"list"`
 
 	// A unique identifier for this CreateStackSet request. Specify this token if
@@ -9975,7 +10038,7 @@ type Stack struct {
 	// Information on whether a stack's actual configuration differs, or has drifted,
 	// from it's expected configuration, as defined in the stack template and any
 	// values specified as template parameters. For more information, see Detecting
-	// Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
+	// Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
 	DriftInformation *StackDriftInformation `type:"structure"`
 
 	// Whether termination protection is enabled for the stack.
@@ -10630,7 +10693,7 @@ type StackResource struct {
 	// Information about whether the resource's actual configuration differs, or
 	// has drifted, from its expected configuration, as defined in the stack template
 	// and any values specified as template parameters. For more information, see
-	// Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
+	// Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
 	DriftInformation *StackResourceDriftInformation `type:"structure"`
 
 	// The logical name of the resource specified in the template.
@@ -10749,7 +10812,7 @@ type StackResourceDetail struct {
 	// Information about whether the resource's actual configuration differs, or
 	// has drifted, from its expected configuration, as defined in the stack template
 	// and any values specified as template parameters. For more information, see
-	// Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
+	// Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
 	DriftInformation *StackResourceDriftInformation `type:"structure"`
 
 	// Time the status was updated.
@@ -10877,7 +10940,7 @@ func (s *StackResourceDetail) SetStackName(v string) *StackResourceDetail {
 //
 // Resources that do not currently support drift detection cannot be checked.
 // For a list of resources that support drift detection, see Resources that
-// Support Drift Detection (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html).
+// Support Drift Detection (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html).
 //
 // Use DetectStackResourceDrift to detect drift on individual resources, or
 // DetectStackDrift to detect drift on all resources in a given stack that support
@@ -11137,7 +11200,7 @@ type StackResourceSummary struct {
 	// Information about whether the resource's actual configuration differs, or
 	// has drifted, from its expected configuration, as defined in the stack template
 	// and any values specified as template parameters. For more information, see
-	// Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
+	// Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
 	DriftInformation *StackResourceDriftInformationSummary `type:"structure"`
 
 	// Time the status was updated.
@@ -11853,7 +11916,7 @@ type StackSummary struct {
 	// Summarizes information on whether a stack's actual configuration differs,
 	// or has drifted, from it's expected configuration, as defined in the stack
 	// template and any values specified as template parameters. For more information,
-	// see Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
+	// see Detecting Unregulated Configuration Changes to Stacks and Resources (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html).
 	DriftInformation *StackDriftInformationSummary `type:"structure"`
 
 	// The time the stack was last updated. This field will only be returned if
@@ -12199,7 +12262,7 @@ type UpdateStackInput struct {
 	//  AWS::IAM::UserToGroupAddition (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html)
 	//
 	// For more information, see Acknowledging IAM Resources in AWS CloudFormation
-	//    Templates (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
+	//    Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
 	//
 	//    * CAPABILITY_AUTO_EXPAND
 	//
@@ -12211,8 +12274,8 @@ type UpdateStackInput struct {
 	//    updating the stack. If your stack template contains one or more macros,
 	//    and you choose to update a stack directly from the processed template,
 	//    without first reviewing the resulting changes in a change set, you must
-	//    acknowledge this capability. This includes the AWS::Include (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)
-	//    and AWS::Serverless (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html)
+	//    acknowledge this capability. This includes the AWS::Include (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)
+	//    and AWS::Serverless (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html)
 	//    transforms, which are macros hosted by AWS CloudFormation.
 	//
 	// Change sets do not currently support nested stacks. If you want to update
@@ -12227,7 +12290,7 @@ type UpdateStackInput struct {
 	//    function operation without AWS CloudFormation being notified.
 	//
 	// For more information, see Using AWS CloudFormation Macros to Perform Custom
-	//    Processing on Templates (http://docs.aws.amazon.com/http:/docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
+	//    Processing on Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
 	Capabilities []*string `type:"list"`
 
 	// A unique identifier for this UpdateStack request. Specify this token if you
@@ -12750,40 +12813,62 @@ type UpdateStackSetInput struct {
 	// on the stack set.
 	AdministrationRoleARN *string `min:"20" type:"string"`
 
-	// A list of values that you must specify before AWS CloudFormation can create
-	// certain stack sets. Some stack set templates might include resources that
-	// can affect permissions in your AWS account—for example, by creating new AWS
-	// Identity and Access Management (IAM) users. For those stack sets, you must
-	// explicitly acknowledge their capabilities by specifying this parameter.
+	// In some cases, you must explicity acknowledge that your stack template contains
+	// certain capabilities in order for AWS CloudFormation to update the stack
+	// set and its associated stack instances.
 	//
-	// The only valid values are CAPABILITY_IAM and CAPABILITY_NAMED_IAM. The following
-	// resources require you to specify this parameter:
+	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM
 	//
-	//    * AWS::IAM::AccessKey
+	// Some stack templates might include resources that can affect permissions
+	//    in your AWS account; for example, by creating new AWS Identity and Access
+	//    Management (IAM) users. For those stacks sets, you must explicitly acknowledge
+	//    this by specifying one of these capabilities.
 	//
-	//    * AWS::IAM::Group
+	// The following IAM resources require you to specify either the CAPABILITY_IAM
+	//    or CAPABILITY_NAMED_IAM capability.
 	//
-	//    * AWS::IAM::InstanceProfile
+	// If you have IAM resources, you can specify either capability.
 	//
-	//    * AWS::IAM::Policy
+	// If you have IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM.
 	//
-	//    * AWS::IAM::Role
 	//
-	//    * AWS::IAM::User
-	//
-	//    * AWS::IAM::UserToGroupAddition
+	// If you don't specify either of these capabilities, AWS CloudFormation returns
+	//    an InsufficientCapabilities error.
 	//
 	// If your stack template contains these resources, we recommend that you review
-	// all permissions that are associated with them and edit their permissions
-	// if necessary.
+	//    all permissions associated with them and edit their permissions if necessary.
 	//
-	// If you have IAM resources, you can specify either capability. If you have
-	// IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM. If
-	// you don't specify this parameter, this action returns an InsufficientCapabilities
-	// error.
+	//  AWS::IAM::AccessKey (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
+	//
+	//  AWS::IAM::Group (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html)
+	//
+	//  AWS::IAM::InstanceProfile (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html)
+	//
+	//  AWS::IAM::Policy (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html)
+	//
+	//  AWS::IAM::Role (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html)
+	//
+	//  AWS::IAM::User (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html)
+	//
+	//  AWS::IAM::UserToGroupAddition (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html)
 	//
 	// For more information, see Acknowledging IAM Resources in AWS CloudFormation
-	// Templates. (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities)
+	//    Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
+	//
+	//    * CAPABILITY_AUTO_EXPAND
+	//
+	// Some templates contain macros. If your stack template contains one or more
+	//    macros, and you choose to update a stack directly from the processed template,
+	//    without first reviewing the resulting changes in a change set, you must
+	//    acknowledge this capability. For more information, see Using AWS CloudFormation
+	//    Macros to Perform Custom Processing on Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
+	//
+	// Stack sets do not currently support macros in stack templates. (This includes
+	//    the AWS::Include (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html)
+	//    and AWS::Serverless (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html)
+	//    transforms, which are macros hosted by AWS CloudFormation.) Even if you
+	//    specify this capability, if you include a macro in your template the stack
+	//    set operation will fail.
 	Capabilities []*string `type:"list"`
 
 	// A brief description of updates that you are making.

--- a/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecr/api.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol"
+	"github.com/aws/aws-sdk-go/private/protocol/jsonrpc"
 )
 
 const opBatchCheckLayerAvailability = "BatchCheckLayerAvailability"
@@ -455,6 +457,15 @@ func (c *ECR) CreateRepositoryRequest(input *CreateRepositoryInput) (req *reques
 //   * ErrCodeInvalidParameterException "InvalidParameterException"
 //   The specified parameter is invalid. Review the available parameters for the
 //   API request.
+//
+//   * ErrCodeInvalidTagParameterException "InvalidTagParameterException"
+//   An invalid parameter has been specified. Tag keys can have a maximum character
+//   length of 128 characters, and tag values can have a maximum length of 256
+//   characters.
+//
+//   * ErrCodeTooManyTagsException "TooManyTagsException"
+//   The list of tags on the repository is over the limit. The maximum number
+//   of tags that can be applied to a repository is 50.
 //
 //   * ErrCodeRepositoryAlreadyExistsException "RepositoryAlreadyExistsException"
 //   The specified repository already exists in the specified registry.
@@ -1756,6 +1767,93 @@ func (c *ECR) ListImagesPagesWithContext(ctx aws.Context, input *ListImagesInput
 	return p.Err()
 }
 
+const opListTagsForResource = "ListTagsForResource"
+
+// ListTagsForResourceRequest generates a "aws/request.Request" representing the
+// client's request for the ListTagsForResource operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListTagsForResource for more information on using the ListTagsForResource
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListTagsForResourceRequest method.
+//    req, resp := client.ListTagsForResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/ListTagsForResource
+func (c *ECR) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
+	op := &request.Operation{
+		Name:       opListTagsForResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListTagsForResourceInput{}
+	}
+
+	output = &ListTagsForResourceOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListTagsForResource API operation for Amazon EC2 Container Registry.
+//
+// List the tags for an Amazon ECR resource.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation ListTagsForResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * ErrCodeRepositoryNotFoundException "RepositoryNotFoundException"
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+//   * ErrCodeServerException "ServerException"
+//   These errors are usually caused by a server-side issue.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/ListTagsForResource
+func (c *ECR) ListTagsForResource(input *ListTagsForResourceInput) (*ListTagsForResourceOutput, error) {
+	req, out := c.ListTagsForResourceRequest(input)
+	return out, req.Send()
+}
+
+// ListTagsForResourceWithContext is the same as ListTagsForResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListTagsForResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) ListTagsForResourceWithContext(ctx aws.Context, input *ListTagsForResourceInput, opts ...request.Option) (*ListTagsForResourceOutput, error) {
+	req, out := c.ListTagsForResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opPutImage = "PutImage"
 
 // PutImageRequest generates a "aws/request.Request" representing the
@@ -2126,6 +2224,201 @@ func (c *ECR) StartLifecyclePolicyPreview(input *StartLifecyclePolicyPreviewInpu
 // for more information on using Contexts.
 func (c *ECR) StartLifecyclePolicyPreviewWithContext(ctx aws.Context, input *StartLifecyclePolicyPreviewInput, opts ...request.Option) (*StartLifecyclePolicyPreviewOutput, error) {
 	req, out := c.StartLifecyclePolicyPreviewRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opTagResource = "TagResource"
+
+// TagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the TagResource operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See TagResource for more information on using the TagResource
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the TagResourceRequest method.
+//    req, resp := client.TagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/TagResource
+func (c *ECR) TagResourceRequest(input *TagResourceInput) (req *request.Request, output *TagResourceOutput) {
+	op := &request.Operation{
+		Name:       opTagResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &TagResourceInput{}
+	}
+
+	output = &TagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// TagResource API operation for Amazon EC2 Container Registry.
+//
+// Adds specified tags to a resource with the specified ARN. Existing tags on
+// a resource are not changed if they are not specified in the request parameters.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation TagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * ErrCodeInvalidTagParameterException "InvalidTagParameterException"
+//   An invalid parameter has been specified. Tag keys can have a maximum character
+//   length of 128 characters, and tag values can have a maximum length of 256
+//   characters.
+//
+//   * ErrCodeTooManyTagsException "TooManyTagsException"
+//   The list of tags on the repository is over the limit. The maximum number
+//   of tags that can be applied to a repository is 50.
+//
+//   * ErrCodeRepositoryNotFoundException "RepositoryNotFoundException"
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+//   * ErrCodeServerException "ServerException"
+//   These errors are usually caused by a server-side issue.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/TagResource
+func (c *ECR) TagResource(input *TagResourceInput) (*TagResourceOutput, error) {
+	req, out := c.TagResourceRequest(input)
+	return out, req.Send()
+}
+
+// TagResourceWithContext is the same as TagResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See TagResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) TagResourceWithContext(ctx aws.Context, input *TagResourceInput, opts ...request.Option) (*TagResourceOutput, error) {
+	req, out := c.TagResourceRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUntagResource = "UntagResource"
+
+// UntagResourceRequest generates a "aws/request.Request" representing the
+// client's request for the UntagResource operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UntagResource for more information on using the UntagResource
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UntagResourceRequest method.
+//    req, resp := client.UntagResourceRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/UntagResource
+func (c *ECR) UntagResourceRequest(input *UntagResourceInput) (req *request.Request, output *UntagResourceOutput) {
+	op := &request.Operation{
+		Name:       opUntagResource,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UntagResourceInput{}
+	}
+
+	output = &UntagResourceOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// UntagResource API operation for Amazon EC2 Container Registry.
+//
+// Deletes specified tags from a resource.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EC2 Container Registry's
+// API operation UntagResource for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInvalidParameterException "InvalidParameterException"
+//   The specified parameter is invalid. Review the available parameters for the
+//   API request.
+//
+//   * ErrCodeInvalidTagParameterException "InvalidTagParameterException"
+//   An invalid parameter has been specified. Tag keys can have a maximum character
+//   length of 128 characters, and tag values can have a maximum length of 256
+//   characters.
+//
+//   * ErrCodeTooManyTagsException "TooManyTagsException"
+//   The list of tags on the repository is over the limit. The maximum number
+//   of tags that can be applied to a repository is 50.
+//
+//   * ErrCodeRepositoryNotFoundException "RepositoryNotFoundException"
+//   The specified repository could not be found. Check the spelling of the specified
+//   repository and ensure that you are performing operations on the correct registry.
+//
+//   * ErrCodeServerException "ServerException"
+//   These errors are usually caused by a server-side issue.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/ecr-2015-09-21/UntagResource
+func (c *ECR) UntagResource(input *UntagResourceInput) (*UntagResourceOutput, error) {
+	req, out := c.UntagResourceRequest(input)
+	return out, req.Send()
+}
+
+// UntagResourceWithContext is the same as UntagResource with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UntagResource for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ECR) UntagResourceWithContext(ctx aws.Context, input *UntagResourceInput, opts ...request.Option) (*UntagResourceOutput, error) {
+	req, out := c.UntagResourceRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2745,6 +3038,8 @@ type CreateRepositoryInput struct {
 	//
 	// RepositoryName is a required field
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
+
+	Tags []*Tag `locationName:"tags" type:"list"`
 }
 
 // String returns the string representation
@@ -2776,6 +3071,12 @@ func (s *CreateRepositoryInput) Validate() error {
 // SetRepositoryName sets the RepositoryName field's value.
 func (s *CreateRepositoryInput) SetRepositoryName(v string) *CreateRepositoryInput {
 	s.RepositoryName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateRepositoryInput) SetTags(v []*Tag) *CreateRepositoryInput {
+	s.Tags = v
 	return s
 }
 
@@ -3119,7 +3420,7 @@ type DescribeImagesInput struct {
 	// results in a single page along with a nextToken response element. The remaining
 	// results of the initial request can be seen by sending another DescribeImages
 	// request with the returned nextToken value. This value can be between 1 and
-	// 100. If this parameter is not used, then DescribeImages returns up to 100
+	// 1000. If this parameter is not used, then DescribeImages returns up to 100
 	// results and a nextToken value, if applicable. This option cannot be used
 	// when you specify images with imageIds.
 	MaxResults *int64 `locationName:"maxResults" min:"1" type:"integer"`
@@ -3136,8 +3437,7 @@ type DescribeImagesInput struct {
 	// registry is assumed.
 	RegistryId *string `locationName:"registryId" type:"string"`
 
-	// A list of repositories to describe. If this parameter is omitted, then all
-	// repositories in a registry are described.
+	// A list of repositories to describe.
 	//
 	// RepositoryName is a required field
 	RepositoryName *string `locationName:"repositoryName" min:"2" type:"string" required:"true"`
@@ -3254,7 +3554,7 @@ type DescribeRepositoriesInput struct {
 	// returns maxResults results in a single page along with a nextToken response
 	// element. The remaining results of the initial request can be seen by sending
 	// another DescribeRepositories request with the returned nextToken value. This
-	// value can be between 1 and 100. If this parameter is not used, then DescribeRepositories
+	// value can be between 1 and 1000. If this parameter is not used, then DescribeRepositories
 	// returns up to 100 results and a nextToken value, if applicable. This option
 	// cannot be used when you specify repositories with repositoryNames.
 	MaxResults *int64 `locationName:"maxResults" min:"1" type:"integer"`
@@ -3640,7 +3940,7 @@ type GetLifecyclePolicyPreviewInput struct {
 	// only returns  maxResults results in a single page along with a nextToken
 	// response element. The remaining results of the initial request can be seen
 	// by sending  another GetLifecyclePolicyPreviewRequest request with the returned
-	// nextToken  value. This value can be between 1 and 100. If this  parameter
+	// nextToken  value. This value can be between 1 and 1000. If this  parameter
 	// is not used, then GetLifecyclePolicyPreviewRequest returns up to  100 results
 	// and a nextToken value, if  applicable. This option cannot be used when you
 	// specify images with imageIds.
@@ -4452,9 +4752,9 @@ type ListImagesInput struct {
 	// When this parameter is used, ListImages only returns maxResults results in
 	// a single page along with a nextToken response element. The remaining results
 	// of the initial request can be seen by sending another ListImages request
-	// with the returned nextToken value. This value can be between 1 and 100. If
-	// this parameter is not used, then ListImages returns up to 100 results and
-	// a nextToken value, if applicable.
+	// with the returned nextToken value. This value can be between 1 and 1000.
+	// If this parameter is not used, then ListImages returns up to 100 results
+	// and a nextToken value, if applicable.
 	MaxResults *int64 `locationName:"maxResults" min:"1" type:"integer"`
 
 	// The nextToken value returned from a previous paginated ListImages request
@@ -4568,6 +4868,68 @@ func (s *ListImagesOutput) SetImageIds(v []*ImageIdentifier) *ListImagesOutput {
 // SetNextToken sets the NextToken field's value.
 func (s *ListImagesOutput) SetNextToken(v string) *ListImagesOutput {
 	s.NextToken = &v
+	return s
+}
+
+type ListTagsForResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) that identifies the resource for which to
+	// list the tags. Currently, the only supported resource is an Amazon ECR repository.
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListTagsForResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListTagsForResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *ListTagsForResourceInput) SetResourceArn(v string) *ListTagsForResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+type ListTagsForResourceOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The tags for the resource.
+	Tags []*Tag `locationName:"tags" type:"list"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceOutput) GoString() string {
+	return s.String()
+}
+
+// SetTags sets the Tags field's value.
+func (s *ListTagsForResourceOutput) SetTags(v []*Tag) *ListTagsForResourceOutput {
+	s.Tags = v
 	return s
 }
 
@@ -5074,6 +5436,180 @@ func (s *StartLifecyclePolicyPreviewOutput) SetStatus(v string) *StartLifecycleP
 	return s
 }
 
+// The metadata that you apply to a resource to help you categorize and organize
+// them. Each tag consists of a key and an optional value, both of which you
+// define. Tag keys can have a maximum character length of 128 characters, and
+// tag values can have a maximum length of 256 characters.
+type Tag struct {
+	_ struct{} `type:"structure"`
+
+	// One part of a key-value pair that make up a tag. A key is a general label
+	// that acts like a category for more specific tag values.
+	Key *string `type:"string"`
+
+	// The optional part of a key-value pair that make up a tag. A value acts as
+	// a descriptor within a tag category (key).
+	Value *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
+// SetKey sets the Key field's value.
+func (s *Tag) SetKey(v string) *Tag {
+	s.Key = &v
+	return s
+}
+
+// SetValue sets the Value field's value.
+func (s *Tag) SetValue(v string) *Tag {
+	s.Value = &v
+	return s
+}
+
+type TagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the the resource to which to add tags.
+	// Currently, the only supported resource is an Amazon ECR repository.
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
+
+	// The tags to add to the resource. A tag is an array of key-value pairs. Tag
+	// keys can have a maximum character length of 128 characters, and tag values
+	// can have a maximum length of 256 characters.
+	//
+	// Tags is a required field
+	Tags []*Tag `locationName:"tags" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s TagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *TagResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "TagResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.Tags == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tags"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *TagResourceInput) SetResourceArn(v string) *TagResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *TagResourceInput) SetTags(v []*Tag) *TagResourceInput {
+	s.Tags = v
+	return s
+}
+
+type TagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s TagResourceOutput) GoString() string {
+	return s.String()
+}
+
+type UntagResourceInput struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon Resource Name (ARN) of the resource from which to remove tags.
+	// Currently, the only supported resource is an Amazon ECR repository.
+	//
+	// ResourceArn is a required field
+	ResourceArn *string `locationName:"resourceArn" type:"string" required:"true"`
+
+	// The keys of the tags to be removed.
+	//
+	// TagKeys is a required field
+	TagKeys []*string `locationName:"tagKeys" type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s UntagResourceInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UntagResourceInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UntagResourceInput"}
+	if s.ResourceArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("ResourceArn"))
+	}
+	if s.TagKeys == nil {
+		invalidParams.Add(request.NewErrParamRequired("TagKeys"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetResourceArn sets the ResourceArn field's value.
+func (s *UntagResourceInput) SetResourceArn(v string) *UntagResourceInput {
+	s.ResourceArn = &v
+	return s
+}
+
+// SetTagKeys sets the TagKeys field's value.
+func (s *UntagResourceInput) SetTagKeys(v []*string) *UntagResourceInput {
+	s.TagKeys = v
+	return s
+}
+
+type UntagResourceOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UntagResourceOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UntagResourceOutput) GoString() string {
+	return s.String()
+}
+
 type UploadLayerPartInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5292,4 +5828,7 @@ const (
 
 	// TagStatusUntagged is a TagStatus enum value
 	TagStatusUntagged = "UNTAGGED"
+
+	// TagStatusAny is a TagStatus enum value
+	TagStatusAny = "ANY"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/ecr/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecr/errors.go
@@ -44,6 +44,14 @@ const (
 	// API request.
 	ErrCodeInvalidParameterException = "InvalidParameterException"
 
+	// ErrCodeInvalidTagParameterException for service response error code
+	// "InvalidTagParameterException".
+	//
+	// An invalid parameter has been specified. Tag keys can have a maximum character
+	// length of 128 characters, and tag values can have a maximum length of 256
+	// characters.
+	ErrCodeInvalidTagParameterException = "InvalidTagParameterException"
+
 	// ErrCodeLayerAlreadyExistsException for service response error code
 	// "LayerAlreadyExistsException".
 	//
@@ -130,6 +138,13 @@ const (
 	//
 	// These errors are usually caused by a server-side issue.
 	ErrCodeServerException = "ServerException"
+
+	// ErrCodeTooManyTagsException for service response error code
+	// "TooManyTagsException".
+	//
+	// The list of tags on the repository is over the limit. The maximum number
+	// of tags that can be applied to a repository is 50.
+	ErrCodeTooManyTagsException = "TooManyTagsException"
 
 	// ErrCodeUploadNotFoundException for service response error code
 	// "UploadNotFoundException".

--- a/vendor/github.com/aws/aws-sdk-go/service/redshift/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/redshift/api.go
@@ -13575,8 +13575,19 @@ type DescribeClusterSnapshotsInput struct {
 
 	// A value that indicates whether to return snapshots only for an existing cluster.
 	// Table-level restore can be performed only using a snapshot of an existing
-	// cluster, that is, a cluster that has not been deleted. If ClusterExists is
-	// set to true, ClusterIdentifier is required.
+	// cluster, that is, a cluster that has not been deleted.
+	//
+	//    * If ClusterExists is set to true, ClusterIdentifier is required.
+	//
+	//    * If ClusterExists is set to false and ClusterIdentifier is not specified,
+	//    all snapshots associated with deleted clusters (orphaned snapshots) are
+	//    returned.
+	//
+	//    * If ClusterExists is set to false and ClusterIdentifier is specified
+	//    for a deleted cluster, snapshots associated with that cluster are returned.
+	//
+	//    * If ClusterExists is set to false and ClusterIdentifier is specified
+	//    for an existing cluster, no snapshots are returned.
 	ClusterExists *bool `type:"boolean"`
 
 	// The identifier of the cluster for which information about snapshots is requested.

--- a/vendor/github.com/aws/aws-sdk-go/service/servicecatalog/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/servicecatalog/api.go
@@ -8242,9 +8242,7 @@ type CopyProductInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The Amazon Resource Name (ARN) of the source product.
 	//
@@ -8275,9 +8273,6 @@ func (s CopyProductInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CopyProductInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CopyProductInput"}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
-	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
 	}
@@ -8380,9 +8375,7 @@ type CreateConstraintInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The constraint parameters, in JSON format. The syntax depends on the constraint
 	// type as follows:
@@ -8454,9 +8447,6 @@ func (s CreateConstraintInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CreateConstraintInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateConstraintInput"}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
-	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
 	}
@@ -8594,9 +8584,7 @@ type CreatePortfolioInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The name of the portfolio provider.
 	//
@@ -8625,9 +8613,6 @@ func (s *CreatePortfolioInput) Validate() error {
 	}
 	if s.DisplayName != nil && len(*s.DisplayName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("DisplayName", 1))
-	}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
 	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
@@ -8846,9 +8831,7 @@ type CreateProductInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The name of the product.
 	//
@@ -8896,9 +8879,6 @@ func (s CreateProductInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CreateProductInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateProductInput"}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
-	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
 	}
@@ -9064,9 +9044,7 @@ type CreateProvisionedProductPlanInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// Passed to CloudFormation. The SNS topic ARNs to which to publish stack-related
 	// events.
@@ -9124,9 +9102,6 @@ func (s CreateProvisionedProductPlanInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CreateProvisionedProductPlanInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateProvisionedProductPlanInput"}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
-	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
 	}
@@ -9324,9 +9299,7 @@ type CreateProvisioningArtifactInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The configuration for the provisioning artifact.
 	//
@@ -9352,9 +9325,6 @@ func (s CreateProvisioningArtifactInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *CreateProvisioningArtifactInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "CreateProvisioningArtifactInput"}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
-	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
 	}
@@ -9486,9 +9456,7 @@ type CreateServiceActionInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The self-service action name.
 	//
@@ -9517,9 +9485,6 @@ func (s *CreateServiceActionInput) Validate() error {
 	}
 	if s.DefinitionType == nil {
 		invalidParams.Add(request.NewErrParamRequired("DefinitionType"))
-	}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
 	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
@@ -12107,9 +12072,7 @@ type ExecuteProvisionedProductPlanInput struct {
 	// A unique identifier that you provide to ensure idempotency. If multiple requests
 	// differ only by the idempotency token, the same response is returned for each
 	// repeated request.
-	//
-	// IdempotencyToken is a required field
-	IdempotencyToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	IdempotencyToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The plan identifier.
 	//
@@ -12130,9 +12093,6 @@ func (s ExecuteProvisionedProductPlanInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *ExecuteProvisionedProductPlanInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ExecuteProvisionedProductPlanInput"}
-	if s.IdempotencyToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("IdempotencyToken"))
-	}
 	if s.IdempotencyToken != nil && len(*s.IdempotencyToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("IdempotencyToken", 1))
 	}
@@ -12203,9 +12163,7 @@ type ExecuteProvisionedProductServiceActionInput struct {
 	AcceptLanguage *string `type:"string"`
 
 	// An idempotency token that uniquely identifies the execute request.
-	//
-	// ExecuteToken is a required field
-	ExecuteToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	ExecuteToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// The identifier of the provisioned product.
 	//
@@ -12231,9 +12189,6 @@ func (s ExecuteProvisionedProductServiceActionInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *ExecuteProvisionedProductServiceActionInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ExecuteProvisionedProductServiceActionInput"}
-	if s.ExecuteToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("ExecuteToken"))
-	}
 	if s.ExecuteToken != nil && len(*s.ExecuteToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ExecuteToken", 1))
 	}
@@ -14602,9 +14557,7 @@ type ProvisionProductInput struct {
 	ProductId *string `min:"1" type:"string" required:"true"`
 
 	// An idempotency token that uniquely identifies the provisioning request.
-	//
-	// ProvisionToken is a required field
-	ProvisionToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	ProvisionToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// A user-friendly name for the provisioned product. This value must be unique
 	// for the AWS account and cannot be updated after the product is provisioned.
@@ -14650,9 +14603,6 @@ func (s *ProvisionProductInput) Validate() error {
 	}
 	if s.ProductId != nil && len(*s.ProductId) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ProductId", 1))
-	}
-	if s.ProvisionToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("ProvisionToken"))
 	}
 	if s.ProvisionToken != nil && len(*s.ProvisionToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ProvisionToken", 1))
@@ -17394,9 +17344,7 @@ type TerminateProvisionedProductInput struct {
 	// token is only valid during the termination process. After the provisioned
 	// product is terminated, subsequent requests to terminate the same provisioned
 	// product always return ResourceNotFound.
-	//
-	// TerminateToken is a required field
-	TerminateToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	TerminateToken *string `min:"1" type:"string" idempotencyToken:"true"`
 }
 
 // String returns the string representation
@@ -17417,9 +17365,6 @@ func (s *TerminateProvisionedProductInput) Validate() error {
 	}
 	if s.ProvisionedProductName != nil && len(*s.ProvisionedProductName) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ProvisionedProductName", 1))
-	}
-	if s.TerminateToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("TerminateToken"))
 	}
 	if s.TerminateToken != nil && len(*s.TerminateToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("TerminateToken", 1))
@@ -17956,9 +17901,7 @@ type UpdateProvisionedProductInput struct {
 	ProvisioningPreferences *UpdateProvisioningPreferences `type:"structure"`
 
 	// The idempotency token that uniquely identifies the provisioning update request.
-	//
-	// UpdateToken is a required field
-	UpdateToken *string `min:"1" type:"string" required:"true" idempotencyToken:"true"`
+	UpdateToken *string `min:"1" type:"string" idempotencyToken:"true"`
 }
 
 // String returns the string representation
@@ -17988,9 +17931,6 @@ func (s *UpdateProvisionedProductInput) Validate() error {
 	}
 	if s.ProvisioningArtifactId != nil && len(*s.ProvisioningArtifactId) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("ProvisioningArtifactId", 1))
-	}
-	if s.UpdateToken == nil {
-		invalidParams.Add(request.NewErrParamRequired("UpdateToken"))
 	}
 	if s.UpdateToken != nil && len(*s.UpdateToken) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("UpdateToken", 1))

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -47,1148 +47,1148 @@
 			"versionExact": "v1.0.0"
 		},
 		{
-			"checksumSHA1": "gGnQxkEuru/VdxMqLiomDes7tg0=",
+			"checksumSHA1": "R6j0+FjEyphjx3Y6lxrtZr6N9oY=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "DtuTqKH29YnLjrIJkRYX0HQtXY0=",
 			"path": "github.com/aws/aws-sdk-go/aws/arn",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "PEDqMAEPxlh9Y8/dIbHlE6A7LEA=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "EwL79Cq6euk+EV/t/n2E+jzPNmU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
-			"checksumSHA1": "b/UdBwIe3u1L1L5i34laH/NunDI=",
+			"checksumSHA1": "GvmthjOyNZGOKmXK4XVrbT5+K9I=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "21pBkDFjY5sDY1rAW+f8dDPcWhk=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "JTilCBYWVAfhbKSnrxCNhE8IFns=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "1pENtl2K9hG7qoB7R6J7dAHa82g=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "sPtOSV32SZr2xN7vZlF4FXo43/o=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/processcreds",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "KeiwYyPDCfoCtuskGS5t1ieqh90=",
 			"path": "github.com/aws/aws-sdk-go/aws/crr",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "BCjWH3AilHcgiTJUKpRCWsS5Vnc=",
 			"path": "github.com/aws/aws-sdk-go/aws/csm",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "7AmyyJXVkMdmy8dphC3Nalx5XkI=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "mYqgKOMSGvLmrt0CoBNbqdcTM3c=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
-			"checksumSHA1": "xY0p/3c8TuwtBb65rf2Yf9WkLB8=",
+			"checksumSHA1": "zAp5PEXucy9nY0EYfz0YJNttid4=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "MNKn210bYCRn/q16hyQcBa4Lm5I=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "rfEGeim4zz2FVqTxFvf6HUuqOZc=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "IfIlsdOjFX8FAdTB/+woaJ8Lswg=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "3A0q2ZxyOnQN77dQV0AEpVv9HPY=",
 			"path": "github.com/aws/aws-sdk-go/internal/ini",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "QvKGojx+wCHTDfXQ1aoOYzH3Y88=",
 			"path": "github.com/aws/aws-sdk-go/internal/s3err",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "tQVg7Sz2zv+KkhbiXxPH0mh9spg=",
 			"path": "github.com/aws/aws-sdk-go/internal/sdkuri",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "LjfJ5ydXdiSuQixC+HrmSZjW3NU=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "NtXXi501Kou3laVAsJfcbKSkNI8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "0cZnOaE1EcFUuiu4bdHV2k7slQg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "stsUCJVnZ5yMrmzSExbjbYp5tZ8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "bOQjEfKXaTqe7dZhDDER/wZUzQc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "tXRIRarT7qepHconxydtO7mXod4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "v2c4B7IgTyjl7ShytqbTOqhCIoM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "lj56XJFI2OSp+hEOrFZ+eiEi/yM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "+O6A945eTP9plLpkEMZB0lwBAcg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "uRvmEPKcEdv7qc0Ep2zn0E3Xumc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "S7NJNuKPbT+a9/zk9qC1/zZAHLM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "ZZgzuZoMphxAf8wwz9QqpSQdBGc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "B8unEuOlpQfnig4cMyZtXLZVVOs=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "EE1kEl6LrogKK1fyTchinNmwnHk=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "ZQl13fSMGMnU0pih5C8GCSvPtaM=",
 			"path": "github.com/aws/aws-sdk-go/service/acmpca",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "ZXwC0Lo87x2YDgsrWIl2oonqpcQ=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "MFpZ8rFizG3ym2b4mpivxbexEns=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "YXT9X//qW2ptEQkgbfIuDOOnR/k=",
 			"path": "github.com/aws/aws-sdk-go/service/appmesh",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "MeaVtRxOCtSYe4MGZBWr5gimwOw=",
 			"path": "github.com/aws/aws-sdk-go/service/appsync",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
-			"checksumSHA1": "UqNgliSgoWSsyvOdEQHr3/IHJhE=",
+			"checksumSHA1": "/MFYWR9eiI01kNrcg1bO1WLPh/o=",
 			"path": "github.com/aws/aws-sdk-go/service/athena",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "+PRoDkvCYkbIuodNbbBrW5NvyY4=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "r8SWN+8OAODmG/ZBGBDbLxVee9U=",
 			"path": "github.com/aws/aws-sdk-go/service/batch",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "Mn96BtYLLRhcnw0I6eVlSQMzom4=",
 			"path": "github.com/aws/aws-sdk-go/service/budgets",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "K/laFSydDPMkq0Yfb53s1O+JEF0=",
 			"path": "github.com/aws/aws-sdk-go/service/cloud9",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
-			"checksumSHA1": "WA1qwbL0lPnGn33FaW+3WEHNv4Y=",
+			"checksumSHA1": "ojYNV1ZiGYtnbNnjTLdPKHWRZKc=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "yh/gLMPTHczESU9/C3Z3PeM4oV4=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "pIdeT4ULrOz9wnsNwehC1mbFIkI=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudhsmv2",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "tOw80eNTNpvIpMRVBr9oRjLcQ58=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudsearch",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "DbTn6rrsnWixIU3GQ9JFngD7MJk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "wbEFJ+KCAOO3yzyyCS3kLmnkh18=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "fwE/DPNQQASAHUs0WrChhbMpcJQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "GTzGu0LXjYNIhXM30Igd6DovyKk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "9EKK11PN6JFTxektilB8nJatcC0=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "LFsmeBlP/E2/MV+dcUbQH33eWAg=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "u2WGBUgooeNlPM9eJ/qTf8q6kl8=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "fa8kzvG2yVR8PzcbtLfR4GLzw4Q=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "llEU4jCzUfKKMzVV9MJRuP93XoY=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "7eRPVOoXvfzOeYKt423Br6xQdQE=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentityprovider",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "gx2kjZO474xii5KKH0qjAiLMevA=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "qI+cyLFj+bHPEhk+womeZsx9pX4=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "e6ftIB/fgCtM3QpVeofgCPbywVE=",
 			"path": "github.com/aws/aws-sdk-go/service/datapipeline",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "0TEIdGlzTUmtcfuhxI662lcux14=",
 			"path": "github.com/aws/aws-sdk-go/service/datasync",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "E2PzR2gdjvKrUoxFlf5Recjd604=",
 			"path": "github.com/aws/aws-sdk-go/service/dax",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "KNGztezNRoGAH6fzY553cSqo16g=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "/8dc5YeHiEY9PwRQA/HZsa5MsSQ=",
 			"path": "github.com/aws/aws-sdk-go/service/directconnect",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "y42YYmqcpM7mCszR+IDHnqp79PU=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "h6aDi4GHX51Rb8a5CQ3gU+XYjZ0=",
 			"path": "github.com/aws/aws-sdk-go/service/dlm",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "g0orEerUpOz9BShqSXbvWQv8jFY=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "DBhYoePuzGNoyokf8Azxg4sK+F8=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
-			"checksumSHA1": "Ib0Plp1+0bdv4RlTvyTjJY38drE=",
+			"checksumSHA1": "OGQBdfb7lW0pVVfYTr+6AKIQenA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "A99tHN1jinsqu68vXj1B+y3CNO0=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "rcHmPVmc6fqsOTCkUMu1CiQEg+M=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "VmA4DmhV4Apj1J4BF+Z755FhrFI=",
 			"path": "github.com/aws/aws-sdk-go/service/eks",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "WpRlOFso5wQh4rG4M0wD8eUH74c=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "wsGmTTTQccJ5jixDKWiPPeN7FQg=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "MiPz9txADnTA8PnULYrQkDSXMDw=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "+qjiJR1LWyVQjCihataCLbhzg6g=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "7Xdct5YMsJUhQhbtxFCn5An5hdk=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "i8M1Xk5KkckvrZwXelh/s649Kd8=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "0GmwOGXaoWOZOUlr6CyiSkofBwo=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "KQL2dGfnBoJ9ghpo3QBYjKT03Tc=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "SxBpkzMABX12XMH49BL7r+EGqBQ=",
 			"path": "github.com/aws/aws-sdk-go/service/fms",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "KsG0neNZIAzag1mNBUvEOzZwtLs=",
 			"path": "github.com/aws/aws-sdk-go/service/fsx",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "5FD+is50VLWra7buR8W/z5Ifuh4=",
 			"path": "github.com/aws/aws-sdk-go/service/gamelift",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "+Hr7ndW/ERg8M0mlSeQF9pYDQz0=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "GmrZQswb/hr643tOiFmNasocVJ4=",
 			"path": "github.com/aws/aws-sdk-go/service/glue",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "7Fovq9CiMwWn4UpWoKH2nT1dpnw=",
 			"path": "github.com/aws/aws-sdk-go/service/guardduty",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "D2EX6UbE+d1LY6M4faM63iBhthU=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "PN/Y8KyrqNLhJDk11TjpzBMCo2M=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "UYnvOJ1+ejXPng+8LLGPDElASXk=",
 			"path": "github.com/aws/aws-sdk-go/service/iot",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "rTnVWHb+GKYm5wmBnkaggHn5rDk=",
 			"path": "github.com/aws/aws-sdk-go/service/kafka",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "9kDpq3AlsrXLSABP4Z6+MV2su7E=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "Zsl0LKaQf9Lt9e6cwUUD7YOq6oE=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesisanalytics",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "Kvm9mT9uvo51OK+Wgea9vKHUZbM=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "HqBkX7WPAPkzCxah7ucfxKaV4Zw=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "R6YRm7OQMapLnyrDSgvC1K5fOmM=",
 			"path": "github.com/aws/aws-sdk-go/service/lexmodelbuildingservice",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "T8dhQqdm4Wf8DLVBJXN5DsaCZv4=",
 			"path": "github.com/aws/aws-sdk-go/service/licensemanager",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "CNuSI6Ik9u7l9XG9rehlD/70LO8=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "TcBHzaPQxQmHWWVDtRVmsAvXRr8=",
 			"path": "github.com/aws/aws-sdk-go/service/macie",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "RTIBPvZdgj3xVFNDh9G5BYajubk=",
 			"path": "github.com/aws/aws-sdk-go/service/mediaconvert",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "uyyf2nm0BWdMNCrsfGWj6PZAFHY=",
 			"path": "github.com/aws/aws-sdk-go/service/medialive",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "RBcnvBUpQ/84zmzgB/ppfEz/BsM=",
 			"path": "github.com/aws/aws-sdk-go/service/mediapackage",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "KeGSzO4SDcTNeflXObJ2tZ2BbAU=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastore",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "nMNqEcQ/y15xElZvt/BT7uSiEt0=",
 			"path": "github.com/aws/aws-sdk-go/service/mediastoredata",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "P5yr/06QBpcxEu5jpgv+EuxQa/Y=",
 			"path": "github.com/aws/aws-sdk-go/service/mq",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "BgTcTNx4iCteBI+CgicqyYWGT3k=",
 			"path": "github.com/aws/aws-sdk-go/service/neptune",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "zApKqBqgQmGYTlOuOVIF01h9vOU=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "jNgMW47WT5ylqdfMMzSoQpymW1U=",
 			"path": "github.com/aws/aws-sdk-go/service/organizations",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "0tkM+hh0nqbF1h+fi8bM+7ervTw=",
 			"path": "github.com/aws/aws-sdk-go/service/pinpoint",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "xKY1N27xgmGIfx4qRKsuPRzhY4Q=",
 			"path": "github.com/aws/aws-sdk-go/service/pricing",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "j5X6U9plgQylA93Idq9bqw6eVfM=",
 			"path": "github.com/aws/aws-sdk-go/service/ram",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "T1h31bS20H/5NC3FclZQ5G/u+Ns=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
-			"checksumSHA1": "n7ujIEXX0sl3/RmG25Hd0R9Rl7c=",
+			"checksumSHA1": "thEma7g62V8g7KmaMUdzLxqxsrQ=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "Xw+FQNNThXt51ctmHF7jvJ4KMPE=",
 			"path": "github.com/aws/aws-sdk-go/service/resourcegroups",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "5pj0bVxCT6szBmKclTv7SfK1WJQ=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "vlLn1uDLfJ0yUKH5k5uoFL/YhV0=",
 			"path": "github.com/aws/aws-sdk-go/service/route53resolver",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "yM7+8aIDvclU8Kd94iZlWLFL77Y=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "rCCjRj7ky6VPqpZ3yVgcTs9tEck=",
 			"path": "github.com/aws/aws-sdk-go/service/s3control",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "g0+y6BHf4z9rGtXYFAOJO3NKxVk=",
 			"path": "github.com/aws/aws-sdk-go/service/sagemaker",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "1E6f63scIIeQIplEYGKCphMyi4w=",
 			"path": "github.com/aws/aws-sdk-go/service/secretsmanager",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "o02DnzX/lAzrHC2T+QUJ8WF/pkM=",
 			"path": "github.com/aws/aws-sdk-go/service/securityhub",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "IW02fAz0WeeLqymuIGNzMwV85u0=",
 			"path": "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
-			"checksumSHA1": "X0wAJiohcQRuetlkg3Nh0tfGbJI=",
+			"checksumSHA1": "YbIHAsjve6UaM9xb/Xsj2jjhsXI=",
 			"path": "github.com/aws/aws-sdk-go/service/servicecatalog",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "3rfA3IMRtktnSQc/nczj/UZ5FxY=",
 			"path": "github.com/aws/aws-sdk-go/service/servicediscovery",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "E/qsyDZ9522LxbHcq8o9dEKIlh8=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "M/NoZOoY+lUdoh2jvsxtl/JfEw8=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "sjrhEmnfLjgjrD7AB/6qvWWykxM=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "rvv2y74/0pzlfS8WWUm+4SAEeJg=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "y8TMGgL596MV0u5DS4GU4zdMla4=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "owQhl1SbU5RpHT+ILkvfdSA1s0Y=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "SpMuPA0iLaKQkbrFBSyX6dxuAsk=",
 			"path": "github.com/aws/aws-sdk-go/service/storagegateway",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "35a/vm5R/P68l/hQD55GqviO6bg=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "KSsXRBmEITb8l3UbNGqC1nFG/8M=",
 			"path": "github.com/aws/aws-sdk-go/service/swf",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "wXp+g2bRcR7J/NZTtEYRMKAsfhw=",
 			"path": "github.com/aws/aws-sdk-go/service/transfer",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "jgbbh/UOIxrqUdYa5Vil/qrytBg=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "wn23MKD7cDb2xXZMr6Gb0ncL+ok=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "Nlc+Yw4Raq2WRCa0wIoyObgrEOA=",
 			"path": "github.com/aws/aws-sdk-go/service/workspaces",
-			"revision": "056aa960bc0fb3918d8b2101e2a9c92675327ea3",
-			"revisionTime": "2018-12-13T22:28:27Z",
-			"version": "v1.16.5",
-			"versionExact": "v1.16.5"
+			"revision": "a21788f1964e28dc1e3932e595db6707ce8070cf",
+			"revisionTime": "2018-12-17T23:14:06Z",
+			"version": "v1.16.7",
+			"versionExact": "v1.16.7"
 		},
 		{
 			"checksumSHA1": "yBBHqv7DvZNsZdF00SO8PbEQAKU=",


### PR DESCRIPTION
[AWS SDK v1.16.7](https://github.com/aws/aws-sdk-go/releases/tag/v1.16.7) required for:
* https://github.com/terraform-providers/terraform-provider-aws/issues/6896

```console
$ govendor fetch github.com/aws/aws-sdk-go/...@v1.16.7
```
