### PR TITLE
service/redshiftcluster, taglicensemanger:  Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -893,7 +893,7 @@ func resourceAwsRedshiftClusterDelete(d *schema.ResourceData, meta interface{}) 
 	skipFinalSnapshot := d.Get("skip_final_snapshot").(bool)
 	deleteOpts.SkipFinalClusterSnapshot = aws.Bool(skipFinalSnapshot)
 
-	if skipFinalSnapshot == false {
+	if !skipFinalSnapshot {
 		if name, present := d.GetOk("final_snapshot_identifier"); present {
 			deleteOpts.FinalClusterSnapshotIdentifier = aws.String(name.(string))
 		} else {

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -173,7 +173,7 @@ func TestAccAWSRedshiftCluster_kmsKey(t *testing.T) {
 
 	ri := acctest.RandInt()
 	config := testAccAWSRedshiftClusterConfig_kmsKey(ri)
-	keyRegex := regexp.MustCompile("^arn:aws:([a-zA-Z0-9\\-])+:([a-z]{2}-[a-z]+-\\d{1})?:(\\d{12})?:(.*)$")
+	keyRegex := regexp.MustCompile(`^arn:aws:([a-zA-Z0-9\-])+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:(.*)$`)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/tagsLicenseManager.go
+++ b/aws/tagsLicenseManager.go
@@ -21,7 +21,7 @@ func setTagsLicenseManager(conn *licensemanager.LicenseManager, d *schema.Resour
 		// Set tags
 		if len(remove) > 0 {
 			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			k := make([]*string, len(remove), len(remove))
+			k := make([]*string, len(remove))
 			for i, t := range remove {
 				k[i] = t.Key
 			}
@@ -106,7 +106,7 @@ func tagIgnoredLicenseManager(t *licensemanager.Tag) bool {
 	filter := []string{"^aws:"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
-		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+		if r, _ := regexp.MatchString(v, *t.Key); r {
 			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
 			return true
 		}


### PR DESCRIPTION
References #6343

Previously:

```
resource_aws_redshift_cluster.go:896:5: should omit comparison to bool constant, can be simplified to !skipFinalSnapshot (S1002)
resource_aws_redshift_cluster_test.go:176:14: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)

tagsLicenseManager.go:24:25: should use make([]*string, len(remove)) instead (S1019)
tagsLicenseManager.go:109:45: should omit comparison to bool constant, can be simplified to r (S1002)
```
Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSRedshiftCluster_kmsKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftCluster_kmsKey -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftCluster_kmsKey
=== PAUSE TestAccAWSRedshiftCluster_kmsKey
=== CONT  TestAccAWSRedshiftCluster_kmsKey
--- PASS: TestAccAWSRedshiftCluster_kmsKey (834.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       834.103s
```
