### PR TITLE
service/cloudwatcheventrule: Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -100,7 +100,7 @@ func resourceAwsCloudWatchEventRuleCreate(d *schema.ResourceData, meta interface
 	err = resource.Retry(30*time.Second, func() *resource.RetryError {
 		var err error
 		out, err = conn.PutRule(input)
-		pattern := regexp.MustCompile("cannot be assumed by principal '[a-z]+\\.amazonaws\\.com'\\.$")
+		pattern := regexp.MustCompile(`cannot be assumed by principal '[a-z]+\.amazonaws\.com'\.$`)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if awsErr.Code() == "ValidationException" && pattern.MatchString(awsErr.Message()) {
@@ -190,7 +190,7 @@ func resourceAwsCloudWatchEventRuleUpdate(d *schema.ResourceData, meta interface
 	// IAM Roles take some time to propagate
 	err = resource.Retry(30*time.Second, func() *resource.RetryError {
 		_, err := conn.PutRule(input)
-		pattern := regexp.MustCompile("cannot be assumed by principal '[a-z]+\\.amazonaws\\.com'\\.$")
+		pattern := regexp.MustCompile(`cannot be assumed by principal '[a-z]+\.amazonaws\.com'\.$`)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if awsErr.Code() == "ValidationException" && pattern.MatchString(awsErr.Message()) {


### PR DESCRIPTION
Reference: #6343

Previously:
```
aws/resource_aws_cloudwatch_event_rule.go:103:14:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/resource_aws_cloudwatch_event_rule.go:193:14:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
```
Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSCloudWatchEventRule_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchEventRule_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchEventRule_basic
=== PAUSE TestAccAWSCloudWatchEventRule_basic
=== CONT  TestAccAWSCloudWatchEventRule_basic
--- PASS: TestAccAWSCloudWatchEventRule_basic (44.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       44.423s
```
