### PR TITLE
resource/resource_aws_cloudwatch_log_group: Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_cloudwatch_log_group.go
+++ b/aws/resource_aws_cloudwatch_log_group.go
@@ -117,7 +117,7 @@ func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{})
 	d.Set("kms_key_id", lg.KmsKeyId)
 	d.Set("retention_in_days", lg.RetentionInDays)
 
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string)
 	tagsOutput, err := conn.ListTagsLogGroup(&cloudwatchlogs.ListTagsLogGroupInput{
 		LogGroupName: aws.String(d.Id()),
 	})


### PR DESCRIPTION
Reference: #6343

Previously:

```
aws/resource_aws_cloudwatch_log_group.go:120:34:warning: should use make(map[string]string) instead (S1019) (gosimple)
```
Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSCloudWatchLogGroup_basic'                    ✔  1999  21:29:40
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchLogGroup_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchLogGroup_basic
=== PAUSE TestAccAWSCloudWatchLogGroup_basic
=== CONT  TestAccAWSCloudWatchLogGroup_basic
--- PASS: TestAccAWSCloudWatchLogGroup_basic (25.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       25.910s
```
