### PR TITLE
resource/resource_aws_cloudwatch_log_subscription_filter: Fix gosimple linting issues

### DIFF
--- a/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -107,8 +107,8 @@ func testAccCheckCloudwatchLogSubscriptionFilterDestroy(s *terraform.State) erro
 			continue
 		}
 
-		logGroupName, _ := rs.Primary.Attributes["log_group_name"]
-		filterNamePrefix, _ := rs.Primary.Attributes["name"]
+		logGroupName := rs.Primary.Attributes["log_group_name"]
+		filterNamePrefix := rs.Primary.Attributes["name"]
 
 		input := cloudwatchlogs.DescribeSubscriptionFiltersInput{
 			LogGroupName:     aws.String(logGroupName),
@@ -140,8 +140,8 @@ func testAccCheckAwsCloudwatchLogSubscriptionFilterExists(n string, filter *clou
 
 		conn := testAccProvider.Meta().(*AWSClient).cloudwatchlogsconn
 
-		logGroupName, _ := rs.Primary.Attributes["log_group_name"]
-		filterNamePrefix, _ := rs.Primary.Attributes["name"]
+		logGroupName := rs.Primary.Attributes["log_group_name"]
+		filterNamePrefix := rs.Primary.Attributes["name"]
 
 		input := cloudwatchlogs.DescribeSubscriptionFiltersInput{
 			LogGroupName:     aws.String(logGroupName),
@@ -187,7 +187,7 @@ resource "aws_lambda_function" "test_lambdafunction" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "example_lambda_name_%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
-  runtime       = "nodejs4.3"
+  runtime       = "nodejs8.10"
   handler       = "exports.handler"
 }
 


### PR DESCRIPTION
Reference: #6343

Previously
```
aws/resource_aws_cloudwatch_log_subscription_filter_test.go:110:3:warning: should write logGroupName := rs.Primary.Attributes["log_group_name"] instead of logGroupName, _ := rs.Primary.Attributes["log_group_name"] (S1005) (gosimple)
aws/resource_aws_cloudwatch_log_subscription_filter_test.go:111:3:warning: should write filterNamePrefix := rs.Primary.Attributes["name"] instead of filterNamePrefix, _ :=rs.Primary.Attributes["name"] (S1005) (gosimple)
aws/resource_aws_cloudwatch_log_subscription_filter_test.go:143:3:warning: should write logGroupName := rs.Primary.Attributes["log_group_name"] instead of logGroupName, _ := rs.Primary.Attributes["log_group_name"] (S1005) (gosimple)
aws/resource_aws_cloudwatch_log_subscription_filter_test.go:144:3:warning: should write filterNamePrefix := rs.Primary.Attributes["name"] instead of filterNamePrefix, _ :=rs.Primary.Attributes["name"] (S1005) (gosimple)
```
Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSCloudwatchLogSubscriptionFilter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudwatchLogSubscriptionFilter_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== PAUSE TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== CONT  TestAccAWSCloudwatchLogSubscriptionFilter_basic
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_basic (48.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       48.627s
```
