### PR TITLE
Amazon ECR Repository tags

### DIFF
--- a/aws/data_source_aws_ecr_repository.go
+++ b/aws/data_source_aws_ecr_repository.go
@@ -1,10 +1,10 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -31,6 +31,7 @@ func dataSourceAwsEcrRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -38,30 +39,33 @@ func dataSourceAwsEcrRepository() *schema.Resource {
 func dataSourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecrconn
 
-	repositoryName := d.Get("name").(string)
 	params := &ecr.DescribeRepositoriesInput{
-		RepositoryNames: []*string{aws.String(repositoryName)},
+		RepositoryNames: aws.StringSlice([]string{d.Get("name").(string)}),
 	}
 	log.Printf("[DEBUG] Reading ECR repository: %s", params)
 	out, err := conn.DescribeRepositories(params)
 	if err != nil {
-		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+		if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
 			log.Printf("[WARN] ECR Repository %s not found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading ECR repository: %s", err)
 	}
 
 	repository := out.Repositories[0]
 
 	log.Printf("[DEBUG] Received ECR repository %s", out)
 
-	d.SetId(*repository.RepositoryName)
+	d.SetId(aws.StringValue(repository.RepositoryName))
 	d.Set("arn", repository.RepositoryArn)
 	d.Set("registry_id", repository.RegistryId)
 	d.Set("name", repository.RepositoryName)
 	d.Set("repository_url", repository.RepositoryUri)
+
+	if err := getTagsECR(conn, d); err != nil {
+		return fmt.Errorf("error getting ECR repository tags: %s", err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_ecr_repository_test.go
+++ b/aws/data_source_aws_ecr_repository_test.go
@@ -10,28 +10,40 @@ import (
 )
 
 func TestAccAWSEcrDataSource_ecrRepository(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "data.aws_ecr_repository.default"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckAwsEcrRepositoryDataSourceConfig,
+				Config: testAccCheckAwsEcrRepositoryDataSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.aws_ecr_repository.default", "arn", regexp.MustCompile(`^arn:aws:ecr:[a-zA-Z]+-[a-zA-Z]+-\d+:\d+:repository/foo-repository-terraform-\d+$`)),
-					resource.TestCheckResourceAttrSet("data.aws_ecr_repository.default", "registry_id"),
-					resource.TestMatchResourceAttr("data.aws_ecr_repository.default", "repository_url", regexp.MustCompile(`^\d+\.dkr\.ecr\.[a-zA-Z]+-[a-zA-Z]+-\d+\.amazonaws\.com/foo-repository-terraform-\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:aws:ecr:[a-zA-Z]+-[a-zA-Z]+-\d+:\d+:repository/tf-acc-test-\d+$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "registry_id"),
+					resource.TestMatchResourceAttr(resourceName, "repository_url", regexp.MustCompile(`^\d+\.dkr\.ecr\.[a-zA-Z]+-[a-zA-Z]+-\d+\.amazonaws\.com/tf-acc-test-\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
 				),
 			},
 		},
 	})
 }
 
-var testAccCheckAwsEcrRepositoryDataSourceConfig = fmt.Sprintf(`
+func testAccCheckAwsEcrRepositoryDataSourceConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_ecr_repository" "default" {
-  name = "foo-repository-terraform-%d"
+  name = %q
+
+  tags = {
+    Environment = "production"
+    Usage = "original"
+  }
 }
 
 data "aws_ecr_repository" "default" {
   name = "${aws_ecr_repository.default.name}"
 }
-`, acctest.RandInt())
+`, rName)
+}

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -69,7 +69,12 @@ func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	d.SetId(aws.StringValue(repository.RepositoryName))
 	// ARN required for setting any tags.
 	d.Set("arn", repository.RepositoryArn)
-	return resourceAwsEcrRepositoryUpdate(d, meta)
+
+	if err := setTagsECR(conn, d); err != nil {
+		return fmt.Errorf("error setting ECR repository tags: %s", err)
+	}
+
+	return resourceAwsEcrRepositoryRead(d, meta)
 }
 
 func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -17,6 +16,7 @@ func resourceAwsEcrRepository() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsEcrRepositoryCreate,
 		Read:   resourceAwsEcrRepositoryRead,
+		Update: resourceAwsEcrRepositoryUpdate,
 		Delete: resourceAwsEcrRepositoryDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -32,6 +32,7 @@ func resourceAwsEcrRepository() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"tags": tagsSchema(),
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -55,30 +56,29 @@ func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 		RepositoryName: aws.String(d.Get("name").(string)),
 	}
 
-	log.Printf("[DEBUG] Creating ECR resository: %s", input)
+	log.Printf("[DEBUG] Creating ECR repository: %#v", input)
 	out, err := conn.CreateRepository(&input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating ECR repository: %s", err)
 	}
 
 	repository := *out.Repository
 
 	log.Printf("[DEBUG] ECR repository created: %q", *repository.RepositoryArn)
 
-	d.SetId(*repository.RepositoryName)
+	d.SetId(aws.StringValue(repository.RepositoryName))
+	// ARN required for setting any tags.
 	d.Set("arn", repository.RepositoryArn)
-	d.Set("registry_id", repository.RegistryId)
-
-	return resourceAwsEcrRepositoryRead(d, meta)
+	return resourceAwsEcrRepositoryUpdate(d, meta)
 }
 
 func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ecrconn
 
-	log.Printf("[DEBUG] Reading repository %s", d.Id())
+	log.Printf("[DEBUG] Reading ECR repository %s", d.Id())
 	var out *ecr.DescribeRepositoriesOutput
 	input := &ecr.DescribeRepositoriesInput{
-		RepositoryNames: []*string{aws.String(d.Id())},
+		RepositoryNames: aws.StringSlice([]string{d.Id()}),
 	}
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
@@ -100,7 +100,7 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading ECR repository: %s", err)
 	}
 
 	repository := out.Repositories[0]
@@ -110,7 +110,21 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("registry_id", repository.RegistryId)
 	d.Set("repository_url", repository.RepositoryUri)
 
+	if err := getTagsECR(conn, d); err != nil {
+		return fmt.Errorf("error getting ECR repository tags: %s", err)
+	}
+
 	return nil
+}
+
+func resourceAwsEcrRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+
+	if err := setTagsECR(conn, d); err != nil {
+		return fmt.Errorf("error setting ECR repository tags: %s", err)
+	}
+
+	return resourceAwsEcrRepositoryRead(d, meta)
 }
 
 func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
@@ -122,28 +136,21 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 		Force:          aws.Bool(true),
 	})
 	if err != nil {
-		if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+		if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
 			return nil
 		}
-		return err
+		return fmt.Errorf("error deleting ECR repository: %s", err)
 	}
 
 	log.Printf("[DEBUG] Waiting for ECR Repository %q to be deleted", d.Id())
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := conn.DescribeRepositories(&ecr.DescribeRepositoriesInput{
-			RepositoryNames: []*string{aws.String(d.Id())},
+			RepositoryNames: aws.StringSlice([]string{d.Id()}),
 		})
-
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if !ok {
-				return resource.NonRetryableError(err)
-			}
-
-			if awsErr.Code() == "RepositoryNotFoundException" {
+			if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
 				return nil
 			}
-
 			return resource.NonRetryableError(err)
 		}
 
@@ -151,7 +158,7 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 			fmt.Errorf("%q: Timeout while waiting for the ECR Repository to be deleted", d.Id()))
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting ECR repository: %s", err)
 	}
 
 	log.Printf("[DEBUG] repository %q deleted.", d.Get("name").(string))

--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -39,6 +39,37 @@ func TestAccAWSEcrRepository_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcrRepository_tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ecr_repository.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcrRepositoryConfig_tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
+				),
+			},
+			{
+				Config: testAccAWSEcrRepositoryConfig_tagsChanged(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEcrRepositoryDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ecrconn
 
@@ -99,7 +130,32 @@ func testAccCheckAWSEcrRepositoryRepositoryURL(resourceName, repositoryName stri
 func testAccAWSEcrRepositoryConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecr_repository" "default" {
-	name = %q
+  name = %q
+}
+`, rName)
+}
+
+func testAccAWSEcrRepositoryConfig_tags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "default" {
+  name = %q
+
+  tags = {
+    Environment = "production"
+    Usage = "original"
+  }
+}
+`, rName)
+}
+
+func testAccAWSEcrRepositoryConfig_tagsChanged(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecr_repository" "default" {
+  name = %q
+
+  tags = {
+    Usage = "changed"
+  }
 }
 `, rName)
 }

--- a/aws/tagsECR.go
+++ b/aws/tagsECR.go
@@ -81,8 +81,10 @@ func diffTagsECR(oldTags, newTags []*ecr.Tag) ([]*ecr.Tag, []*ecr.Tag) {
 	for _, t := range oldTags {
 		old, ok := create[aws.StringValue(t.Key)]
 		if !ok || old != aws.StringValue(t.Value) {
-			// Delete it!
 			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
 		}
 	}
 

--- a/aws/tagsECR.go
+++ b/aws/tagsECR.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// getTags is a helper to get the tags for a resource. It expects the
+// tags field to be named "tags" and the ARN field to be named "arn".
+func getTagsECR(conn *ecr.ECR, d *schema.ResourceData) error {
+	resp, err := conn.ListTagsForResource(&ecr.ListTagsForResourceInput{
+		ResourceArn: aws.String(d.Get("arn").(string)),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("tags", tagsToMapECR(resp.Tags)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags" and the ARN field to be named "arn".
+func setTagsECR(conn *ecr.ECR, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsECR(tagsFromMapECR(o), tagsFromMapECR(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&ecr.UntagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&ecr.TagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsECR(oldTags, newTags []*ecr.Tag) ([]*ecr.Tag, []*ecr.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*ecr.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapECR(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapECR(m map[string]interface{}) []*ecr.Tag {
+	result := make([]*ecr.Tag, 0, len(m))
+	for k, v := range m {
+		t := &ecr.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredECR(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapECR(ts []*ecr.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredECR(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredECR(t *ecr.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		r, _ := regexp.MatchString(v, *t.Key)
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsECR_test.go
+++ b/aws/tagsECR_test.go
@@ -14,20 +14,19 @@ func TestDiffECRTags(t *testing.T) {
 		Old, New       map[string]interface{}
 		Create, Remove map[string]string
 	}{
-		// Basic add/remove
+		// Add
 		{
 			Old: map[string]interface{}{
 				"foo": "bar",
 			},
 			New: map[string]interface{}{
+				"foo": "bar",
 				"bar": "baz",
 			},
 			Create: map[string]string{
 				"bar": "baz",
 			},
-			Remove: map[string]string{
-				"foo": "bar",
-			},
+			Remove: map[string]string{},
 		},
 
 		// Modify
@@ -43,6 +42,39 @@ func TestDiffECRTags(t *testing.T) {
 			},
 			Remove: map[string]string{
 				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
 			},
 		},
 	}

--- a/aws/tagsECR_test.go
+++ b/aws/tagsECR_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+)
+
+// go test -v -run="TestDiffECRTags"
+func TestDiffECRTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsECR(tagsFromMapECR(tc.Old), tagsFromMapECR(tc.New))
+		cm := tagsToMapECR(c)
+		rm := tagsToMapECR(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsECR"
+func TestIgnoringTagsECR(t *testing.T) {
+	var ignoredTags []*ecr.Tag
+	ignoredTags = append(ignoredTags, &ecr.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &ecr.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredECR(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/d/ecr_repository.html.markdown
+++ b/website/docs/d/ecr_repository.html.markdown
@@ -31,3 +31,4 @@ In addition to all arguments above, the following attributes are exported:
 * `arn` - Full ARN of the repository.
 * `registry_id` - The registry ID where the repository was created.
 * `repository_url` - The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`).
+* `tags` - A mapping of tags assigned to the resource.

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -27,6 +27,7 @@ resource "aws_ecr_repository" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the repository.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6896.

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEcrDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSEcrDataSource_ -timeout 120m
=== RUN   TestAccAWSEcrDataSource_ecrRepository
=== PAUSE TestAccAWSEcrDataSource_ecrRepository
=== CONT  TestAccAWSEcrDataSource_ecrRepository
--- PASS: TestAccAWSEcrDataSource_ecrRepository (25.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	44.473s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEcrRepository_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSEcrRepository_ -timeout 120m
=== RUN   TestAccAWSEcrRepository_basic
=== PAUSE TestAccAWSEcrRepository_basic
=== RUN   TestAccAWSEcrRepository_tags
=== PAUSE TestAccAWSEcrRepository_tags
=== CONT  TestAccAWSEcrRepository_basic
=== CONT  TestAccAWSEcrRepository_tags
--- PASS: TestAccAWSEcrRepository_basic (20.98s)
--- PASS: TestAccAWSEcrRepository_tags (33.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	54.343s
```
