### PR TITLE
r/aws_securityhub: Add aws_securityhub_product_subscription resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -626,6 +626,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_default_security_group":                       resourceAwsDefaultSecurityGroup(),
 			"aws_security_group_rule":                          resourceAwsSecurityGroupRule(),
 			"aws_securityhub_account":                          resourceAwsSecurityHubAccount(),
+			"aws_securityhub_product_subscription":             resourceAwsSecurityHubProductSubscription(),
 			"aws_securityhub_standards_subscription":           resourceAwsSecurityHubStandardsSubscription(),
 			"aws_servicecatalog_portfolio":                     resourceAwsServiceCatalogPortfolio(),
 			"aws_service_discovery_private_dns_namespace":      resourceAwsServiceDiscoveryPrivateDnsNamespace(),

--- a/aws/resource_aws_securityhub_product_subscription.go
+++ b/aws/resource_aws_securityhub_product_subscription.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSecurityHubProductSubscription() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSecurityHubProductSubscriptionCreate,
+		Read:   resourceAwsSecurityHubProductSubscriptionRead,
+		Delete: resourceAwsSecurityHubProductSubscriptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"product_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+		},
+	}
+}
+
+func resourceAwsSecurityHubProductSubscriptionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+	log.Printf("[DEBUG] Enabling Security Hub product subscription for product %s", d.Get("product_arn"))
+
+	resp, err := conn.EnableImportFindingsForProduct(&securityhub.EnableImportFindingsForProductInput{
+		ProductArn: aws.String(d.Get("product_arn").(string)),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error enabling Security Hub product subscription for product %s: %s", d.Get("product_arn"), err)
+	}
+
+	d.SetId(*resp.ProductSubscriptionArn)
+
+	return resourceAwsSecurityHubProductSubscriptionRead(d, meta)
+}
+
+func resourceAwsSecurityHubProductSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+
+	log.Printf("[DEBUG] Reading Security Hub product subscriptions to find %s", d.Id())
+	resp, err := conn.ListEnabledProductsForImport(&securityhub.ListEnabledProductsForImportInput{})
+
+	if err != nil {
+		return fmt.Errorf("Error reading Security Hub product subscriptions to find %s: %s", d.Id(), err)
+	}
+
+	productSubscriptions := make([]interface{}, len(resp.ProductSubscriptions))
+	for i := range resp.ProductSubscriptions {
+		productSubscriptions[i] = *resp.ProductSubscriptions[i]
+	}
+
+	if _, contains := sliceContainsString(productSubscriptions, d.Id()); !contains {
+		log.Printf("[WARN] Security Hub product subscriptions (%s) not found, removing from state", d.Id())
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceAwsSecurityHubProductSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+	log.Printf("[DEBUG] Disabling Security Hub product subscription %s", d.Id())
+
+	_, err := conn.DisableImportFindingsForProduct(&securityhub.DisableImportFindingsForProductInput{
+		ProductSubscriptionArn: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error disabling Security Hub product subscription %s: %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_securityhub_product_subscription_test.go
+++ b/aws/resource_aws_securityhub_product_subscription_test.go
@@ -21,10 +21,9 @@ func testAccAWSSecurityHubProductSubscription_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_securityhub_product_subscription.example",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"product_arn"},
+				ResourceName:      "aws_securityhub_product_subscription.example",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				// Check Destroy - but only target the specific resource (otherwise Security Hub
@@ -45,7 +44,13 @@ func testAccCheckAWSSecurityHubProductSubscriptionExists(n string) resource.Test
 
 		conn := testAccProvider.Meta().(*AWSClient).securityhubconn
 
-		exists, err := resourceAwsSecurityHubProductSubscriptionCheckExists(conn, rs.Primary.ID)
+		_, productSubscriptionArn, err := resourceAwsSecurityHubProductSubscriptionParseId(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		exists, err := resourceAwsSecurityHubProductSubscriptionCheckExists(conn, productSubscriptionArn)
 
 		if err != nil {
 			return err
@@ -67,7 +72,13 @@ func testAccCheckAWSSecurityHubProductSubscriptionDestroy(s *terraform.State) er
 			continue
 		}
 
-		exists, err := resourceAwsSecurityHubProductSubscriptionCheckExists(conn, rs.Primary.ID)
+		_, productSubscriptionArn, err := resourceAwsSecurityHubProductSubscriptionParseId(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		exists, err := resourceAwsSecurityHubProductSubscriptionCheckExists(conn, productSubscriptionArn)
 
 		if err != nil {
 			return err

--- a/aws/resource_aws_securityhub_product_subscription_test.go
+++ b/aws/resource_aws_securityhub_product_subscription_test.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testAccAWSSecurityHubProductSubscription_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityHubAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityHubProductSubscriptionConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSecurityHubProductSubscriptionExists("aws_securityhub_product_subscription.example"),
+				),
+			},
+			// Import is not supported, since the API to lookup product_arn from a product
+			// subscription is currrently private
+			{
+				// Check Destroy - but only target the specific resource (otherwise Security Hub
+				// will be disabled and the destroy check will fail)
+				Config: testAccAWSSecurityHubProductSubscriptionConfig_empty,
+				Check:  testAccCheckAWSSecurityHubProductSubscriptionDestroy,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSecurityHubProductSubscriptionExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).securityhubconn
+
+		resp, err := conn.ListEnabledProductsForImport(&securityhub.ListEnabledProductsForImportInput{})
+
+		if err != nil {
+			return err
+		}
+
+		productSubscriptions := make([]interface{}, len(resp.ProductSubscriptions))
+		for i := range resp.ProductSubscriptions {
+			productSubscriptions[i] = *resp.ProductSubscriptions[i]
+		}
+
+		if _, contains := sliceContainsString(productSubscriptions, rs.Primary.ID); !contains {
+			return fmt.Errorf("Security Hub product subscription %s not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSecurityHubProductSubscriptionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).securityhubconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_securityhub_product_subscription" {
+			continue
+		}
+
+		resp, err := conn.ListEnabledProductsForImport(&securityhub.ListEnabledProductsForImportInput{})
+
+		if err != nil {
+			return err
+		}
+
+		productSubscriptions := make([]interface{}, len(resp.ProductSubscriptions))
+		for i := range resp.ProductSubscriptions {
+			productSubscriptions[i] = *resp.ProductSubscriptions[i]
+		}
+
+		if _, contains := sliceContainsString(productSubscriptions, rs.Primary.ID); contains {
+			return fmt.Errorf("Security Hub product subscription %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+const testAccAWSSecurityHubProductSubscriptionConfig_empty = `
+resource "aws_securityhub_account" "example" {}
+`
+
+const testAccAWSSecurityHubProductSubscriptionConfig_basic = `
+resource "aws_securityhub_account" "example" {}
+
+data "aws_region" "current" {}
+
+resource "aws_securityhub_product_subscription" "example" {
+  depends_on  = ["aws_securityhub_account.example"]
+  product_arn = "arn:aws:securityhub:${data.aws_region.current.name}:733251395267:product/alertlogic/althreatmanagement"
+}
+`

--- a/aws/resource_aws_securityhub_test.go
+++ b/aws/resource_aws_securityhub_test.go
@@ -9,6 +9,9 @@ func TestAccAWSSecurityHub(t *testing.T) {
 		"Account": {
 			"basic": testAccAWSSecurityHubAccount_basic,
 		},
+		"ProductSubscription": {
+			"basic": testAccAWSSecurityHubProductSubscription_basic,
+		},
 		"StandardsSubscription": {
 			"basic": testAccAWSSecurityHubStandardsSubscription_basic,
 		},

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2190,6 +2190,10 @@
                             <a href="/docs/providers/aws/r/securityhub_account.html">aws_securityhub_account</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-securityhub-product-subscription") %>>
+                            <a href="/docs/providers/aws/r/securityhub_product_subscription.html">aws_securityhub_product_subscription</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-securityhub-standards-subscription") %>>
                             <a href="/docs/providers/aws/r/securityhub_standards_subscription.html">aws_securityhub_standards_subscription</a>
                         </li>

--- a/website/docs/r/securityhub_product_subscription.markdown
+++ b/website/docs/r/securityhub_product_subscription.markdown
@@ -68,3 +68,11 @@ Currently available products (remember to replace `${var.region}` as appropriate
 The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The ARN of a resource that represents your subscription to the product that generates the findings that you want to import into Security Hub.
+
+## Import
+
+Security Hub Product Subscriptions can be imported via the product subscription ARN, e.g.
+
+```sh
+$ terraform import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:123456789012:product-subscription/armordefense/armoranywhere
+```

--- a/website/docs/r/securityhub_product_subscription.markdown
+++ b/website/docs/r/securityhub_product_subscription.markdown
@@ -67,12 +67,12 @@ Currently available products (remember to replace `${var.region}` as appropriate
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The ARN of a resource that represents your subscription to the product that generates the findings that you want to import into Security Hub.
+* `arn` - The ARN of a resource that represents your subscription to the product that generates the findings that you want to import into Security Hub.
 
 ## Import
 
-Security Hub Product Subscriptions can be imported via the product subscription ARN, e.g.
+Security Hub product subscriptions can be imported in the form `product_arn,arn`, e.g.
 
 ```sh
-$ terraform import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:123456789012:product-subscription/armordefense/armoranywhere
+$ terraform import aws_securityhub_product_subscription.example arn:aws:securityhub:eu-west-1:733251395267:product/alertlogic/althreatmanagement,arn:aws:securityhub:eu-west-1:123456789012:product-subscription/alertlogic/althreatmanagement
 ```

--- a/website/docs/r/securityhub_product_subscription.markdown
+++ b/website/docs/r/securityhub_product_subscription.markdown
@@ -1,0 +1,70 @@
+---
+layout: "aws"
+page_title: "AWS: aws_securityhub_product_subscription"
+sidebar_current: "docs-aws-resource-securityhub-product-subscription"
+description: |-
+  Subscribes to a Security Hub product.
+---
+
+# aws_securityhub_product_subscription
+
+Subscribes to a Security Hub product.
+
+## Example Usage
+
+```hcl
+resource "aws_securityhub_account" "example" {}
+
+data "aws_region" "current" {}
+
+resource "aws_securityhub_product_subscription" "example" {
+  depends_on  = ["aws_securityhub_account.example"]
+  product_arn = "arn:aws:securityhub:${data.aws_region.current.name}:733251395267:product/alertlogic/althreatmanagement"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `product_arn` - (Required) The ARN of the product that generates findings that you want to import into Security Hub - see below.
+
+Currently available products (remember to replace `${var.region}` as appropriate):
+
+* `arn:aws:securityhub:${var.region}::product/aws/guardduty`
+* `arn:aws:securityhub:${var.region}::product/aws/inspector`
+* `arn:aws:securityhub:${var.region}::product/aws/macie`
+* `arn:aws:securityhub:${var.region}:733251395267:product/alertlogic/althreatmanagement`
+* `arn:aws:securityhub:${var.region}:679703615338:product/armordefense/armoranywhere`
+* `arn:aws:securityhub:${var.region}:151784055945:product/barracuda/cloudsecurityguardian`
+* `arn:aws:securityhub:${var.region}:758245563457:product/checkpoint/cloudguard-iaas`
+* `arn:aws:securityhub:${var.region}:634729597623:product/checkpoint/dome9-arc`
+* `arn:aws:securityhub:${var.region}:517716713836:product/crowdstrike/crowdstrike-falcon`
+* `arn:aws:securityhub:${var.region}:749430749651:product/cyberark/cyberark-pta`
+* `arn:aws:securityhub:${var.region}:250871914685:product/f5networks/f5-advanced-waf`
+* `arn:aws:securityhub:${var.region}:123073262904:product/fortinet/fortigate`
+* `arn:aws:securityhub:${var.region}:324264561773:product/guardicore/aws-infection-monkey`
+* `arn:aws:securityhub:${var.region}:324264561773:product/guardicore/guardicore`
+* `arn:aws:securityhub:${var.region}:949680696695:product/ibm/qradar-siem`
+* `arn:aws:securityhub:${var.region}:955745153808:product/imperva/imperva-attack-analytics`
+* `arn:aws:securityhub:${var.region}:297986523463:product/mcafee-skyhigh/mcafee-mvision-cloud-aws`
+* `arn:aws:securityhub:${var.region}:188619942792:product/paloaltonetworks/redlock`
+* `arn:aws:securityhub:${var.region}:122442690527:product/paloaltonetworks/vm-series`
+* `arn:aws:securityhub:${var.region}:805950163170:product/qualys/qualys-pc`
+* `arn:aws:securityhub:${var.region}:805950163170:product/qualys/qualys-vm`
+* `arn:aws:securityhub:${var.region}:336818582268:product/rapid7/insightvm`
+* `arn:aws:securityhub:${var.region}:062897671886:product/sophos/sophos-server-protection`
+* `arn:aws:securityhub:${var.region}:112543817624:product/splunk/splunk-enterprise`
+* `arn:aws:securityhub:${var.region}:112543817624:product/splunk/splunk-phantom`
+* `arn:aws:securityhub:${var.region}:956882708938:product/sumologicinc/sumologic-mda`
+* `arn:aws:securityhub:${var.region}:754237914691:product/symantec-corp/symantec-cwp`
+* `arn:aws:securityhub:${var.region}:422820575223:product/tenable/tenable-io`
+* `arn:aws:securityhub:${var.region}:679593333241:product/trend-micro/deep-security`
+* `arn:aws:securityhub:${var.region}:453761072151:product/turbot/turbot`
+* `arn:aws:securityhub:${var.region}:496947949261:product/twistlock/twistlock-enterprise`
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The ARN of a resource that represents your subscription to the product that generates the findings that you want to import into Security Hub.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Partly addresses #6674 

Changes proposed in this pull request:

* **New Resource:** `aws_securityhub_product_subscription`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSecurityHub/ProductSubscription'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSSecurityHub/ProductSubscription -timeout 120m
=== RUN   TestAccAWSSecurityHub
=== RUN   TestAccAWSSecurityHub/ProductSubscription
=== RUN   TestAccAWSSecurityHub/ProductSubscription/basic
--- PASS: TestAccAWSSecurityHub (46.97s)
    --- PASS: TestAccAWSSecurityHub/ProductSubscription (46.97s)
        --- PASS: TestAccAWSSecurityHub/ProductSubscription/basic (46.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	47.021s
```