### PR TITLE
r/aws_guardduty: Add argument finding_publishing_frequency to aws_guardduty_detector

### DIFF
--- a/aws/resource_aws_guardduty_detector.go
+++ b/aws/resource_aws_guardduty_detector.go
@@ -30,6 +30,11 @@ func resourceAwsGuardDutyDetector() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"finding_publishing_frequency": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "SIX_HOURS",
+			},
 		},
 	}
 }
@@ -38,7 +43,8 @@ func resourceAwsGuardDutyDetectorCreate(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).guarddutyconn
 
 	input := guardduty.CreateDetectorInput{
-		Enable: aws.Bool(d.Get("enable").(bool)),
+		Enable:                     aws.Bool(d.Get("enable").(bool)),
+		FindingPublishingFrequency: aws.String(d.Get("finding_publishing_frequency").(string)),
 	}
 
 	log.Printf("[DEBUG] Creating GuardDuty Detector: %s", input)
@@ -70,6 +76,7 @@ func resourceAwsGuardDutyDetectorRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("account_id", meta.(*AWSClient).accountid)
 	d.Set("enable", *gdo.Status == guardduty.DetectorStatusEnabled)
+	d.Set("finding_publishing_frequency", gdo.FindingPublishingFrequency)
 
 	return nil
 }
@@ -78,8 +85,9 @@ func resourceAwsGuardDutyDetectorUpdate(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).guarddutyconn
 
 	input := guardduty.UpdateDetectorInput{
-		DetectorId: aws.String(d.Id()),
-		Enable:     aws.Bool(d.Get("enable").(bool)),
+		DetectorId:                 aws.String(d.Id()),
+		Enable:                     aws.Bool(d.Get("enable").(bool)),
+		FindingPublishingFrequency: aws.String(d.Get("finding_publishing_frequency").(string)),
 	}
 
 	log.Printf("[DEBUG] Update GuardDuty Detector: %s", input)

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -24,6 +24,7 @@ func testAccAwsGuardDutyDetector_basic(t *testing.T) {
 					testAccCheckAwsGuardDutyDetectorExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "account_id"),
 					resource.TestCheckResourceAttr(resourceName, "enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "finding_publishing_frequency", "SIX_HOURS"),
 				),
 			},
 			{

--- a/aws/resource_aws_guardduty_detector_test.go
+++ b/aws/resource_aws_guardduty_detector_test.go
@@ -40,6 +40,13 @@ func testAccAwsGuardDutyDetector_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enable", "true"),
 				),
 			},
+			{
+				Config: testAccGuardDutyDetectorConfig_basic4,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsGuardDutyDetectorExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "finding_publishing_frequency", "FIFTEEN_MINUTES"),
+				),
+			},
 		},
 	})
 }
@@ -113,4 +120,9 @@ resource "aws_guardduty_detector" "test" {
 const testAccGuardDutyDetectorConfig_basic3 = `
 resource "aws_guardduty_detector" "test" {
   enable = true
+}`
+
+const testAccGuardDutyDetectorConfig_basic4 = `
+resource "aws_guardduty_detector" "test" {
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
 }`

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -26,7 +26,7 @@ resource "aws_guardduty_detector" "MyDetector" {
 The following arguments are supported:
 
 * `enable` - (Optional) Enable monitoring and feedback reporting. Setting to `false` is equivalent to "suspending" GuardDuty. Defaults to `true`.
-* `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent about the subsequent finding occurrences. Defaults to `SIX_HOURS`.
+* `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. Valid values: `FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS`. Default: `SIX_HOURS`. See [AWS Documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency) for more information.
 
 ## Attributes Reference
 

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -17,6 +17,7 @@ Provides a resource to manage a GuardDuty detector.
 ```hcl
 resource "aws_guardduty_detector" "MyDetector" {
   enable = true
+  finding_publishing_frequency = "SIX_HOURS"
 }
 ```
 
@@ -25,6 +26,7 @@ resource "aws_guardduty_detector" "MyDetector" {
 The following arguments are supported:
 
 * `enable` - (Optional) Enable monitoring and feedback reporting. Setting to `false` is equivalent to "suspending" GuardDuty. Defaults to `true`.
+* `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent about the subsequent finding occurrences. Defaults to `SIX_HOURS`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Add argument `finding_publishing_frequency` to aws_guardduty_detector
https://docs.aws.amazon.com/guardduty/latest/ug/create-detector.html

Output from acceptance testing:
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGuardDuty'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSGuardDuty -timeout 120m
=== RUN   TestAccAWSGuardDuty
=== RUN   TestAccAWSGuardDuty/Detector
=== RUN   TestAccAWSGuardDuty/Detector/import
=== RUN   TestAccAWSGuardDuty/Detector/basic
=== RUN   TestAccAWSGuardDuty/IPSet
=== RUN   TestAccAWSGuardDuty/IPSet/basic
=== RUN   TestAccAWSGuardDuty/IPSet/import
=== RUN   TestAccAWSGuardDuty/ThreatIntelSet
=== RUN   TestAccAWSGuardDuty/ThreatIntelSet/basic
=== RUN   TestAccAWSGuardDuty/ThreatIntelSet/import
=== RUN   TestAccAWSGuardDuty/Member
=== RUN   TestAccAWSGuardDuty/Member/basic
=== RUN   TestAccAWSGuardDuty/Member/inviteOnUpdate
=== RUN   TestAccAWSGuardDuty/Member/inviteDisassociate
=== RUN   TestAccAWSGuardDuty/Member/invitationMessage
--- PASS: TestAccAWSGuardDuty (290.22s)
    --- PASS: TestAccAWSGuardDuty/Detector (64.55s)
        --- PASS: TestAccAWSGuardDuty/Detector/import (16.73s)
        --- PASS: TestAccAWSGuardDuty/Detector/basic (47.83s)
    --- PASS: TestAccAWSGuardDuty/IPSet (104.54s)
        --- PASS: TestAccAWSGuardDuty/IPSet/basic (63.51s)
        --- PASS: TestAccAWSGuardDuty/IPSet/import (41.04s)
    --- PASS: TestAccAWSGuardDuty/ThreatIntelSet (101.92s)
        --- PASS: TestAccAWSGuardDuty/ThreatIntelSet/basic (63.08s)
        --- PASS: TestAccAWSGuardDuty/ThreatIntelSet/import (38.83s)
    --- PASS: TestAccAWSGuardDuty/Member (19.20s)
        --- PASS: TestAccAWSGuardDuty/Member/basic (19.20s)
        --- SKIP: TestAccAWSGuardDuty/Member/inviteOnUpdate (0.00s)
            resource_aws_guardduty_test.go:46: Environment variable AWS_GUARDDUTY_MEMBER_ACCOUNT_ID is not set. To properly test inviting GuardDuty member accounts, a valid AWS account ID must be provided.
        --- SKIP: TestAccAWSGuardDuty/Member/inviteDisassociate (0.00s)
            resource_aws_guardduty_test.go:46: Environment variable AWS_GUARDDUTY_MEMBER_ACCOUNT_ID is not set. To properly test inviting GuardDuty member accounts, a valid AWS account ID must be provided.
        --- SKIP: TestAccAWSGuardDuty/Member/invitationMessage (0.00s)
            resource_aws_guardduty_test.go:46: Environment variable AWS_GUARDDUTY_MEMBER_ACCOUNT_ID is not set. To properly test inviting GuardDuty member accounts, a valid AWS account ID must be provided.
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	290.233s
```