### PR TITLE
service/codebuild: Enable Github Enterprise Report Build Status

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -727,9 +727,9 @@ func expandProjectSourceData(data map[string]interface{}) codebuild.ProjectSourc
 		projectSource.Location = aws.String(data["location"].(string))
 	}
 
-	// Only valid for BITBUCKET and GITHUB source type, e.g.
-	// InvalidInputException: Source type GITHUB_ENTERPRISE does not support ReportBuildStatus
-	if sourceType == codebuild.SourceTypeBitbucket || sourceType == codebuild.SourceTypeGithub {
+	// Only valid for BITBUCKET, GITHUB, and GITHUB_ENTERPRISE source types, e.g.
+	// InvalidInputException: Source type NO_SOURCE does not support ReportBuildStatus
+	if sourceType == codebuild.SourceTypeBitbucket || sourceType == codebuild.SourceTypeGithub || sourceType == codebuild.SourceTypeGithubEnterprise {
 		projectSource.ReportBuildStatus = aws.Bool(data["report_build_status"].(bool))
 	}
 

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -460,6 +460,34 @@ func TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "source.2964899175.report_build_status", "true"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "source.553628638.report_build_status", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSCodeBuildProject_Source_Type_Bitbucket(t *testing.T) {
 	var project codebuild.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -1302,6 +1330,31 @@ resource "aws_codebuild_project" "test" {
 `, rName, reportBuildStatus)
 }
 
+func testAccAWSCodeBuildProjectConfig_Source_ReportBuildStatus_GitHubEnterprise(rName string, reportBuildStatus bool) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = %q
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    location            = "https://example.com/organization/repository.git"
+    report_build_status = %t
+    type                = "GITHUB_ENTERPRISE"
+  }
+}
+`, rName, reportBuildStatus)
+}
+
 func testAccAWSCodeBuildProjectConfig_Source_Type_Bitbucket(rName string) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
@@ -1438,8 +1491,8 @@ resource "aws_codebuild_project" "test" {
   }
 
   source {
-    type     	= "NO_SOURCE"
-    location	= "%s"
+    type      = "NO_SOURCE"
+    location  = "%s"
     buildspec = %q
   }
 }
@@ -1635,13 +1688,13 @@ resource "aws_codebuild_project" "test" {
   secondary_sources {
     location = "https://git-codecommit.region-id.amazonaws.com/v1/repos/second-repo-name"
     type     = "CODECOMMIT"
-	source_identifier = "secondarySource1"
+    source_identifier = "secondarySource1"
   }
 
   secondary_sources {
     location = "https://git-codecommit.region-id.amazonaws.com/v1/repos/third-repo-name"
     type     = "CODECOMMIT"
-	source_identifier = "secondarySource2"
+    source_identifier = "secondarySource2"
   }
 }
 `, rName)

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -232,7 +232,7 @@ The following arguments are supported:
 * `git_clone_depth` - (Optional) Truncate git history to this many commits.
 * `insecure_ssl` - (Optional) Ignore SSL warnings when connecting to source control.
 * `location` - (Optional) The location of the source code from git or s3.
-* `report_build_status` - (Optional) Set to `true` to report the status of a build's start and finish to your source provider. This option is only valid when your source provider is GitHub.
+* `report_build_status` - (Optional) Set to `true` to report the status of a build's start and finish to your source provider. This option is only valid when your source provider is `GITHUB`, `BITBUCKET`, or `GITHUB_ENTERPRISE`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Allow `GITHUB_ENTERPRISE` Codebuild sources to set `report_build_status`.  This is an extension of changes made in #6426, and is supported by the [Codebuild API](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectSource.html).

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub* -timeout 120m
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== RUN   TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== PAUSE TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub
=== CONT  TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (27.50s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (27.534s)
```
