### PR TITLE
Add force destroy support for Transfer Server

### DIFF
--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/transfer"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -36,9 +37,10 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "aws_transfer_server.foo",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "aws_transfer_server.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccAWSTransferServerConfig_basicUpdate(rName),
@@ -103,6 +105,40 @@ func TestAccAWSTransferServer_disappears(t *testing.T) {
 					testAccCheckAWSTransferServerDisappears(&conf),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSTransferServer_forcedestroy(t *testing.T) {
+	var conf transfer.DescribedServer
+	var roleConf iam.GetRoleOutput
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_transfer_server.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSTransferServerConfig_forcedestroy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSTransferServerExists("aws_transfer_server.foo", &conf),
+					testAccCheckAWSRoleExists("aws_iam_role.foo", &roleConf),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_server.foo", "identity_provider_type", "SERVICE_MANAGED"),
+					resource.TestCheckResourceAttr(
+						"aws_transfer_server.foo", "force_destroy", "true"),
+					testAccCheckAWSTransferCreateUser(&conf, &roleConf, rName),
+					testAccCheckAWSTransferCreateSshKey(&conf, rName),
+				),
+			},
+			{
+				ResourceName:            "aws_transfer_server.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -175,6 +211,42 @@ func testAccCheckAWSTransferServerDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckAWSTransferCreateUser(describedServer *transfer.DescribedServer, getRoleOutput *iam.GetRoleOutput, userName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).transferconn
+
+		input := &transfer.CreateUserInput{
+			ServerId: describedServer.ServerId,
+			UserName: aws.String(userName),
+			Role:     getRoleOutput.Role.Arn,
+		}
+
+		if _, err := conn.CreateUser(input); err != nil {
+			return fmt.Errorf("error creating Transfer User (%s) on Server (%s): %s", userName, aws.StringValue(describedServer.ServerId), err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSTransferCreateSshKey(describedServer *transfer.DescribedServer, userName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).transferconn
+
+		input := &transfer.ImportSshPublicKeyInput{
+			ServerId:         describedServer.ServerId,
+			UserName:         aws.String(userName),
+			SshPublicKeyBody: aws.String("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"),
+		}
+
+		if _, err := conn.ImportSshPublicKey(input); err != nil {
+			return fmt.Errorf("error creating Transfer SSH Public Key for  (%s/%s): %s", userName, aws.StringValue(describedServer.ServerId), err)
+		}
+
+		return nil
+	}
 }
 
 const testAccAWSTransferServerConfig_basic = `
@@ -347,4 +419,51 @@ resource "aws_transfer_server" "foo" {
 }
 `, rName, rName, rName, rName)
 
+}
+
+func testAccAWSTransferServerConfig_forcedestroy(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_transfer_server" "foo" {
+	force_destroy = true
+}
+
+resource "aws_iam_role" "foo" {
+	name = "tf-test-transfer-user-iam-role-%s"
+
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": "transfer.amazonaws.com"
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "foo" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.foo.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"s3:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+`, rName, rName)
 }

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -71,6 +71,7 @@ The following arguments are supported:
 * `url` - (Optional) - URL of the service endpoint used to authenticate users with an `identity_provider_type` of `API_GATEWAY`.
 * `identity_provider_type` - (Optional) The mode of authentication enabled for this service. The default value is `SERVICE_MANAGED`, which allows you to store and access SFTP user credentials within the service. `API_GATEWAY` indicates that user authentication requires a call to an API Gateway endpoint URL provided by you to integrate an identity provider of your choice.
 * `logging_role` - (Optional) Amazon Resource Name (ARN) of an IAM role that allows the service to write your SFTP users’ activity to your Amazon CloudWatch logs for monitoring and auditing purposes.
+* `force_destroy` - (Optional) A boolean that indicates all users associated with the server should be deleted so that the Server can be destroyed without error. The default value is `false`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
When destroy `aws_transfer_server` resource with users not managed by terraform, the apply would be failed.


Changes proposed in this pull request:

* Add `force_destroy` attribute to `aws_transfer_server` resource

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSTransferServer_forcedestroy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSTransferServer_forcedestroy -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSTransferServer_forcedestroy
=== PAUSE TestAccAWSTransferServer_forcedestroy
=== CONT  TestAccAWSTransferServer_forcedestroy
--- PASS: TestAccAWSTransferServer_forcedestroy (33.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.046s
...
```
