### PR TITLE
Adds a missing port to security groups in the EKS Getting Started guide

### DIFF
--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -430,7 +430,17 @@ resource "aws_security_group_rule" "demo-node-ingress-self" {
   type                     = "ingress"
 }
 
-resource "aws_security_group_rule" "demo-node-ingress-cluster" {
+resource "aws_security_group_rule" "demo-node-ingress-cluster-https" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.demo-node.id}"
+  source_security_group_id = "${aws_security_group.demo-cluster.id}"
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "demo-node-ingress-cluster-others" {
   description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
   from_port                = 1025
   protocol                 = "tcp"


### PR DESCRIPTION
The control plane also needs access to the 443 port on nodes, especially for webhooks. This is documented on the EKS site, but was missing in the example here.

See https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html