### PR TITLE
r/aws_route: Make bad import fail on import not refresh

### DIFF
--- a/aws/resource_aws_route.go
+++ b/aws/resource_aws_route.go
@@ -43,6 +43,15 @@ func resourceAwsRoute() *schema.Resource {
 					d.Set("destination_cidr_block", destination)
 				}
 				d.SetId(fmt.Sprintf("r-%s%d", routeTableID, hashcode.String(destination)))
+				_, err := resourceAwsRouteFindRoute(
+					meta.(*AWSClient).ec2conn,
+					d.Get("route_table_id").(string),
+					d.Get("destination_cidr_block").(string),
+					d.Get("destination_ipv6_cidr_block").(string))
+				if err != nil {
+					d.SetId("")
+					return nil, err
+				}
 				return []*schema.ResourceData{d}, nil
 			},
 		},


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6404

Changes proposed in this pull request:

* r/aws_route: check for route existence, without doing a full `Read()`, as part of the import so that it will fail if the route does not exist at the import stage instead of the refresh stage

We ran into this problem going through the logs of large systems. It's not as clear as it should be what actually went wrong because it says "Import complete!"

Prior to this change:

```console
$ terraform import aws_route.test rtb-0b8835dc7eb1e3168_12.22.48.96/0
aws_route.test: Importing from ID "rtb-0b8835dc7eb1e3168_12.22.48.96/0"...
aws_route.test: Import complete!
  Imported aws_route (ID: r-rtb-0b8835dc7eb1e3168715786107)
aws_route.test: Refreshing state... (ID: r-rtb-0b8835dc7eb1e3168715786107)

Error: aws_route.test (import id: rtb-0b8835dc7eb1e3168_12.22.48.96/0): 1 error(s) occurred:

* import aws_route.test result: r-rtb-0b8835dc7eb1e3168715786107: import aws_route.test (id: r-rtb-0b8835dc7eb1e3168715786107): Terraform detected a resource with this ID doesn't
exist. Please verify the ID is correct. You cannot import non-existent
resources using Terraform import.
```

After this change:

```console
$ terraform import aws_route.test rtb-0aa2e1d85e940842_0.0.0.0/0
aws_route.test: Importing from ID "rtb-0aa2e1d85e940842_0.0.0.0/0"...

Error: aws_route.test (import id: rtb-0aa2e1d85e940842_0.0.0.0/0): import aws_route.test (id: rtb-0aa2e1d85e940842_0.0.0.0/0): InvalidRouteTableID.NotFound: The routeTable ID 'rtb-0aa2e1d85e940842' does not exist
	status code: 400, request id: 61615e87-6911-4cb2-86d8-acd0511806dc
```

Output from acceptance testing:

```
$ TF_ACC=1 go test ./... -v -parallel 1 -run=TestAccAWSRoute_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRoute_basic
=== PAUSE TestAccAWSRoute_basic
=== RUN   TestAccAWSRoute_ipv6Support
=== PAUSE TestAccAWSRoute_ipv6Support
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
=== PAUSE TestAccAWSRoute_ipv6ToInternetGateway
=== RUN   TestAccAWSRoute_ipv6ToInstance
=== PAUSE TestAccAWSRoute_ipv6ToInstance
=== RUN   TestAccAWSRoute_ipv6ToNetworkInterface
=== PAUSE TestAccAWSRoute_ipv6ToNetworkInterface
=== RUN   TestAccAWSRoute_ipv6ToPeeringConnection
=== PAUSE TestAccAWSRoute_ipv6ToPeeringConnection
=== RUN   TestAccAWSRoute_changeRouteTable
=== PAUSE TestAccAWSRoute_changeRouteTable
=== RUN   TestAccAWSRoute_changeCidr
=== PAUSE TestAccAWSRoute_changeCidr
=== RUN   TestAccAWSRoute_noopdiff
=== PAUSE TestAccAWSRoute_noopdiff
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
=== PAUSE TestAccAWSRoute_doesNotCrashWithVPCEndpoint
=== RUN   TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
=== PAUSE TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
=== CONT  TestAccAWSRoute_basic
=== CONT  TestAccAWSRoute_changeRouteTable
--- PASS: TestAccAWSRoute_basic (45.63s)
--- PASS: TestAccAWSRoute_changeRouteTable (71.03s)
=== CONT  TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
--- PASS: TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock (321.25s)
=== CONT  TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (53.88s)
=== CONT  TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (155.37s)
=== CONT  TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (71.51s)
=== CONT  TestAccAWSRoute_ipv6ToInstance
--- PASS: TestAccAWSRoute_ipv6ToInstance (159.94s)
=== CONT  TestAccAWSRoute_ipv6ToPeeringConnection
--- PASS: TestAccAWSRoute_ipv6ToPeeringConnection (36.37s)
=== CONT  TestAccAWSRoute_ipv6ToNetworkInterface
--- PASS: TestAccAWSRoute_ipv6ToNetworkInterface (235.14s)
=== CONT  TestAccAWSRoute_ipv6ToInternetGateway
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (46.88s)
=== CONT  TestAccAWSRoute_ipv6Support
--- PASS: TestAccAWSRoute_ipv6Support (34.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1231.105s
```