### PR TITLE
Added MediaPackage Channel resource

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -77,6 +77,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/licensemanager"
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/aws/aws-sdk-go/service/macie"
+	"github.com/aws/aws-sdk-go/service/mediapackage"
 	"github.com/aws/aws-sdk-go/service/mediastore"
 	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/aws/aws-sdk-go/service/neptune"
@@ -253,6 +254,7 @@ type AWSClient struct {
 	glueconn              *glue.Glue
 	athenaconn            *athena.Athena
 	dxconn                *directconnect.DirectConnect
+	mediapackageconn      *mediapackage.MediaPackage
 	mediastoreconn        *mediastore.MediaStore
 	appsyncconn           *appsync.AppSync
 	lexmodelconn          *lexmodelbuildingservice.LexModelBuildingService
@@ -592,6 +594,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.glueconn = glue.New(sess)
 	client.athenaconn = athena.New(sess)
 	client.dxconn = directconnect.New(sess)
+	client.mediapackageconn = mediapackage.New(sess)
 	client.mediastoreconn = mediastore.New(sess)
 	client.appsyncconn = appsync.New(sess)
 	client.neptuneconn = neptune.New(sess)

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -544,6 +544,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_main_route_table_association":                 resourceAwsMainRouteTableAssociation(),
 			"aws_mq_broker":                                    resourceAwsMqBroker(),
 			"aws_mq_configuration":                             resourceAwsMqConfiguration(),
+			"aws_media_package_channel":                        resourceAwsMediaPackageChannel(),
 			"aws_media_store_container":                        resourceAwsMediaStoreContainer(),
 			"aws_media_store_container_policy":                 resourceAwsMediaStoreContainerPolicy(),
 			"aws_nat_gateway":                                  resourceAwsNatGateway(),

--- a/aws/resource_aws_media_package_channel.go
+++ b/aws/resource_aws_media_package_channel.go
@@ -1,0 +1,156 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediapackage"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsMediaPackageChannel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsMediaPackageChannelCreate,
+		Read:   resourceAwsMediaPackageChannelRead,
+		Update: resourceAwsMediaPackageChannelUpdate,
+		Delete: resourceAwsMediaPackageChannelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"channel_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\w-]+$`), "must only contain alphanumeric characters, dashes or underscores"),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+			"ingest_endpoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"password": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsMediaPackageChannelCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediapackageconn
+
+	input := &mediapackage.CreateChannelInput{
+		Id:          aws.String(d.Get("channel_id").(string)),
+		Description: aws.String(d.Get("description").(string)),
+	}
+
+	_, err := conn.CreateChannel(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(d.Get("channel_id").(string))
+	return resourceAwsMediaPackageChannelRead(d, meta)
+}
+
+func resourceAwsMediaPackageChannelRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediapackageconn
+
+	input := &mediapackage.DescribeChannelInput{
+		Id: aws.String(d.Id()),
+	}
+	resp, err := conn.DescribeChannel(input)
+	if err != nil {
+		return err
+	}
+	d.Set("arn", resp.Arn)
+	d.Set("description", resp.Description)
+	d.Set("ingest_endpoints", convertIngestEndpoints(resp.HlsIngest.IngestEndpoints))
+
+	return nil
+}
+
+func resourceAwsMediaPackageChannelUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediapackageconn
+
+	input := &mediapackage.UpdateChannelInput{
+		Id:          aws.String(d.Id()),
+		Description: aws.String(d.Get("description").(string)),
+	}
+
+	_, err := conn.UpdateChannel(input)
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsMediaPackageChannelRead(d, meta)
+}
+
+func resourceAwsMediaPackageChannelDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).mediapackageconn
+
+	input := &mediapackage.DeleteChannelInput{
+		Id: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteChannel(input)
+	if err != nil {
+		if isAWSErr(err, mediapackage.ErrCodeNotFoundException, "") {
+			return nil
+		}
+		return err
+	}
+
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		dcinput := &mediapackage.DescribeChannelInput{
+			Id: aws.String(d.Id()),
+		}
+		_, err := conn.DescribeChannel(dcinput)
+		if err != nil {
+			if isAWSErr(err, mediapackage.ErrCodeNotFoundException, "") {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("Media Package Channel (%s) still exists", d.Id()))
+	})
+	if err != nil {
+		return fmt.Errorf("error waiting for Media Package Channel (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func convertIngestEndpoints(es []*mediapackage.IngestEndpoint) (ingestEndpoints []map[string]interface{}) {
+	for _, e := range es {
+		endpoint := map[string]interface{}{
+			"password": *e.Password,
+			"url":      *e.Url,
+			"username": *e.Username,
+		}
+
+		ingestEndpoints = append(ingestEndpoints, endpoint)
+	}
+
+	return
+}

--- a/aws/resource_aws_media_package_channel_test.go
+++ b/aws/resource_aws_media_package_channel_test.go
@@ -24,12 +24,50 @@ func TestAccAWSMediaPackageChannel_basic(t *testing.T) {
 				Config: testAccMediaPackageChannelConfig(acctest.RandString(5)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsMediaPackageChannelExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.0.password", regexp.MustCompile("^[0-9a-f]*$")),
-					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.0.url", regexp.MustCompile("^https://")),
-					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.0.username", regexp.MustCompile("^[0-9a-f]*$")),
-					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.1.password", regexp.MustCompile("^[0-9a-f]*$")),
-					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.1.url", regexp.MustCompile("^https://")),
-					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.1.username", regexp.MustCompile("^[0-9a-f]*$")),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "mediapackage", regexp.MustCompile(`channels/.+`)),
+					resource.TestMatchResourceAttr(resourceName, "hls_ingest.0.ingest_endpoints.0.password", regexp.MustCompile("^[0-9a-f]*$")),
+					resource.TestMatchResourceAttr(resourceName, "hls_ingest.0.ingest_endpoints.0.url", regexp.MustCompile("^https://")),
+					resource.TestMatchResourceAttr(resourceName, "hls_ingest.0.ingest_endpoints.0.username", regexp.MustCompile("^[0-9a-f]*$")),
+					resource.TestMatchResourceAttr(resourceName, "hls_ingest.0.ingest_endpoints.1.password", regexp.MustCompile("^[0-9a-f]*$")),
+					resource.TestMatchResourceAttr(resourceName, "hls_ingest.0.ingest_endpoints.1.url", regexp.MustCompile("^https://")),
+					resource.TestMatchResourceAttr(resourceName, "hls_ingest.0.ingest_endpoints.1.username", regexp.MustCompile("^[0-9a-f]*$")),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSMediaPackageChannel_description(t *testing.T) {
+	resourceName := "aws_media_package_channel.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaPackageChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaPackageChannelConfigDescription(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaPackageChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMediaPackageChannelConfigDescription(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaPackageChannelExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
 				),
 			},
 		},
@@ -85,4 +123,12 @@ func testAccMediaPackageChannelConfig(rName string) string {
 resource "aws_media_package_channel" "test" {
   channel_id = "tf_mediachannel_%s"
 }`, rName)
+}
+
+func testAccMediaPackageChannelConfigDescription(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_media_package_channel" "test" {
+  channel_id = %q
+  description = %q
+}`, rName, description)
 }

--- a/aws/resource_aws_media_package_channel_test.go
+++ b/aws/resource_aws_media_package_channel_test.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediapackage"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSMediaPackageChannel_basic(t *testing.T) {
+	resourceName := "aws_media_package_channel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMediaPackageChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMediaPackageChannelConfig(acctest.RandString(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMediaPackageChannelExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.0.password", regexp.MustCompile("^[0-9a-f]*$")),
+					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.0.url", regexp.MustCompile("^https://")),
+					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.0.username", regexp.MustCompile("^[0-9a-f]*$")),
+					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.1.password", regexp.MustCompile("^[0-9a-f]*$")),
+					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.1.url", regexp.MustCompile("^https://")),
+					resource.TestMatchResourceAttr(resourceName, "ingest_endpoints.1.username", regexp.MustCompile("^[0-9a-f]*$")),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsMediaPackageChannelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).mediapackageconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_media_package_channel" {
+			continue
+		}
+
+		input := &mediapackage.DescribeChannelInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeChannel(input)
+		if err == nil {
+			return fmt.Errorf("MediaPackage Channel (%s) not deleted", rs.Primary.ID)
+		}
+
+		if !isAWSErr(err, mediapackage.ErrCodeNotFoundException, "") {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsMediaPackageChannelExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).mediapackageconn
+
+		input := &mediapackage.DescribeChannelInput{
+			Id: aws.String(rs.Primary.ID),
+		}
+
+		_, err := conn.DescribeChannel(input)
+
+		return err
+	}
+}
+
+func testAccMediaPackageChannelConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_media_package_channel" "test" {
+  channel_id = "tf_mediachannel_%s"
+}`, rName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1725,6 +1725,17 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-media-package") %>>
+                    <a href="#">MediaPackage Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-media-package-channel") %>>
+                          <a href="/docs/providers/aws/r/media_package_channel.html">aws_media_package_channel</a>
+                        </li>
+
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current("docs-aws-resource-media-store") %>>
                     <a href="#">MediaStore Resources</a>
                     <ul class="nav nav-visible">

--- a/website/docs/r/media_package_channel.html.markdown
+++ b/website/docs/r/media_package_channel.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_media_package_channel"
+sidebar_current: "docs-aws-resource-media-package-channel"
+description: |-
+  Provides an AWS Elemental MediaPackage Channel.
+---
+
+# aws_media_package_channel
+
+Provides an AWS Elemental MediaPackage Channel.
+
+## Example Usage
+
+```hcl
+resource "aws_media_package_channel" "kittens" {
+  channel_id  = "kitten-channel"
+  description = "A channel dedicated to amusing videos of kittens."
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `channel_id` - (Required) A unique identifier describing the channel
+* `description` - (Optional) A description of the channel
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The same as `channel_id`
+* `arn` - The ARN of the channel
+* `ingest_endpoints` - A list of the ingest endpoints (see below)
+
+Ingest endpoints export the following attributes:
+
+* `password` - The password
+* `url` - The URL
+* `username` - The username

--- a/website/docs/r/media_package_channel.html.markdown
+++ b/website/docs/r/media_package_channel.html.markdown
@@ -39,3 +39,11 @@ Ingest endpoints export the following attributes:
 * `password` - The password
 * `url` - The URL
 * `username` - The username
+
+## Import
+
+Media Package Channels can be imported via the channel ID, e.g.
+
+```
+$ terraform import aws_media_package_channel.kittens kittens-channel
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6930 
Changes proposed in this pull request:

* New resource: AWS Elemental MediaPackage Channel

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSMediaPackageChannel_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run TestAccAWSMediaPackageChannel_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSMediaPackageChannel_basic
=== PAUSE TestAccAWSMediaPackageChannel_basic
=== CONT  TestAccAWSMediaPackageChannel_basic
--- PASS: TestAccAWSMediaPackageChannel_basic (14.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       14.427s
...
```
