### PR TITLE
Add DataPipeline Resource Support

### DIFF
--- a/aws/datapipeline_helpers.go
+++ b/aws/datapipeline_helpers.go
@@ -1,0 +1,800 @@
+package aws
+
+import (
+	"strconv"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+)
+
+func buildDefaultPipelineObject(rawDefault map[string]interface{}) (*datapipeline.PipelineObject, error) {
+	pipelineObject := &datapipeline.PipelineObject{}
+	fieldList := []*datapipeline.Field{}
+
+	pipelineObject.Id = aws.String("Default")
+	pipelineObject.Name = aws.String("Default")
+
+	typeField := &datapipeline.Field{
+		Key:         aws.String("type"),
+		StringValue: aws.String("Default"),
+	}
+	fieldList = append(fieldList, typeField)
+
+	if val, ok := rawDefault["schedule_type"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("scheduleType"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawDefault["failure_and_rerun_mode"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("failureAndRerunMode"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawDefault["pipeline_log_uri"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("pipelineLogUri"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawDefault["role"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("role"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawDefault["resource_role"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("resourceRole"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawDefault["schedule"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("schedule"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	pipelineObject.Fields = fieldList
+
+	err := pipelineObject.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return pipelineObject, nil
+}
+
+func buildCommonPipelineObject(pipelineObjectType string, rawPipelineObject map[string]interface{}) (*datapipeline.PipelineObject, error) {
+	pipelineObject := &datapipeline.PipelineObject{}
+	fieldList := []*datapipeline.Field{}
+
+	if val, ok := rawPipelineObject["id"].(string); ok && val != "" {
+		pipelineObject.Id = aws.String(val)
+	}
+
+	if val, ok := rawPipelineObject["name"].(string); ok && val != "" {
+		pipelineObject.Name = aws.String(val)
+	}
+
+	typeField := &datapipeline.Field{
+		Key:         aws.String("type"),
+		StringValue: aws.String(pipelineObjectType),
+	}
+	fieldList = append(fieldList, typeField)
+
+	if val, ok := rawPipelineObject["associate_public_ip_address"].(bool); ok && val {
+		f := &datapipeline.Field{
+			Key:         aws.String("associatePublicIpAddress"),
+			StringValue: aws.String(strconv.FormatBool(val)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["username"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("username"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["password"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("*password"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["rds_instance_id"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("rdsInstanceId"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["database_name"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("databaseName"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["jdbc_driver_jar_uri"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("jdbcDriverJarUri"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["jdbc_properties"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("jdbcProperties"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["schedule"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("schedule"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["runs_on"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("runsOn"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["worker_group"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("workerGroup"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["attempt_status"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("attemptStatus"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["attempt_timeout"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("attemptTimeout"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["create_table_sql"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("createTableSql"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["database"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("database"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["compression"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("compression"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["data_format"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("dataFormat"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["depends_on"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("dependsOn"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["directory_path"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("directoryPath"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["failure_and_rerun_mode"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("failureAndRerunMode"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["insert_query"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("insertQuery"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["availability_zone"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("availabilityZone"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["http_proxy"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("httpProxy"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["image_id"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("imageId"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["instance_type"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("instanceType"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["key_pair"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("keyPair"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["input"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("input"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["file_path"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("filePath"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["late_after_timeout"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("lateAfterTimeout"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["manifest_file_path"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("manifestFilePath"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["max_active_instances"].(int); ok && val != 0 {
+		f := &datapipeline.Field{
+			Key:         aws.String("maxActiveInstances"),
+			StringValue: aws.String(strconv.Itoa(val)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["maximum_retries"].(int); ok && val != 0 {
+		f := &datapipeline.Field{
+			Key:         aws.String("maximumRetries"),
+			StringValue: aws.String(strconv.Itoa(val)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["on_fail"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("onFail"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["on_late_action"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("onLateAction"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["on_success"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("onSuccess"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["output"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("output"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["period"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("period"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["start_at"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("startAt"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["start_date_time"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("startDateTime"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["end_date_time"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("endDateTime"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["occurrences"].(int); ok && val != 0 {
+		f := &datapipeline.Field{
+			Key:         aws.String("occurrences"),
+			StringValue: aws.String(strconv.Itoa(val)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["parent"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("parent"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["pipeline_log_uri"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("pipelineLogUri"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["precondition"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:      aws.String("precondition"),
+			RefValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["report_progress_timeout"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("reportProgressTimeout"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["retry_delay"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("retryDelay"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["region"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("region"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["s3_encryption_type"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("s3EncryptionType"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["schedule_type"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("scheduleType"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["table"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("table"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["schema_name"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("schemaName"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["select_query"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("selectQuery"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["security_group_ids"].([]string); ok && len(val) != 0 {
+		for _, v := range val {
+			f := &datapipeline.Field{
+				Key:         aws.String("securityGroupIds"),
+				StringValue: aws.String(v),
+			}
+			fieldList = append(fieldList, f)
+		}
+	}
+
+	if val, ok := rawPipelineObject["security_groups"].([]string); ok && len(val) != 0 {
+		for _, v := range val {
+			f := &datapipeline.Field{
+				Key:         aws.String("securityGroups"),
+				StringValue: aws.String(v),
+			}
+			fieldList = append(fieldList, f)
+		}
+	}
+
+	if val, ok := rawPipelineObject["spot_bid_price"].(float64); ok && val > 0 && val < 20 {
+		f := &datapipeline.Field{
+			Key:         aws.String("spotBidPrice"),
+			StringValue: aws.String(strconv.FormatFloat(val, 'f', -1, 64)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["subnet_id"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("subnetId"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["terminate_after"].(string); ok && val != "" {
+		f := &datapipeline.Field{
+			Key:         aws.String("terminateAfter"),
+			StringValue: aws.String(val),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	if val, ok := rawPipelineObject["use_on_demand_on_last_attempt"].(bool); ok {
+		f := &datapipeline.Field{
+			Key:         aws.String("useOnDemandOnLastAttempt"),
+			StringValue: aws.String(strconv.FormatBool(val)),
+		}
+		fieldList = append(fieldList, f)
+	}
+
+	pipelineObject.Fields = fieldList
+	err := pipelineObject.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return pipelineObject, nil
+}
+
+func buildParameterObject(rawParameterObject map[string]interface{}) (*datapipeline.ParameterObject, error) {
+	parameterObject := &datapipeline.ParameterObject{}
+	parameterAttributeList := []*datapipeline.ParameterAttribute{}
+
+	if val, ok := rawParameterObject["id"].(string); ok && val != "" {
+		parameterObject.Id = aws.String(val)
+	}
+
+	if val, ok := rawParameterObject["description"].(string); ok && val != "" {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("description"),
+			StringValue: aws.String(val),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["type"].(string); ok && val != "" {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("type"),
+			StringValue: aws.String(val),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["optional"].(bool); ok {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("optional"),
+			StringValue: aws.String(strconv.FormatBool(val)),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["allowed_values"].([]string); ok && len(val) != 0 {
+		for _, v := range val {
+			p := &datapipeline.ParameterAttribute{
+				Key:         aws.String("allowedValues"),
+				StringValue: aws.String(v),
+			}
+			parameterAttributeList = append(parameterAttributeList, p)
+		}
+	}
+
+	if val, ok := rawParameterObject["default"].(string); ok && val != "" {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("default"),
+			StringValue: aws.String(val),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	if val, ok := rawParameterObject["is_array"].(bool); ok {
+		p := &datapipeline.ParameterAttribute{
+			Key:         aws.String("isArray"),
+			StringValue: aws.String(strconv.FormatBool(val)),
+		}
+		parameterAttributeList = append(parameterAttributeList, p)
+	}
+
+	parameterObject.Attributes = parameterAttributeList
+	err := parameterObject.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return parameterObject, nil
+}
+
+func flattenDefaultPipelineObject(object *datapipeline.PipelineObject) (map[string]interface{}, error) {
+	pipelineObject := make(map[string]interface{})
+	for _, field := range object.Fields {
+		switch *field.Key {
+		case "scheduleType":
+			pipelineObject["schedule_type"] = *field.StringValue
+		case "failureAndRerunMode":
+			pipelineObject["failure_and_rerun_mode"] = *field.StringValue
+		case "pipelineLogUri":
+			pipelineObject["pipeline_log_uri"] = *field.StringValue
+		case "role":
+			pipelineObject["role"] = *field.StringValue
+		case "resourceRole":
+			pipelineObject["resource_role"] = *field.StringValue
+		case "schedule":
+			pipelineObject["schedule"] = *field.RefValue
+		}
+	}
+	return pipelineObject, nil
+}
+
+func flattenCommonPipelineObject(object *datapipeline.PipelineObject) (map[string]interface{}, error) {
+	pipelineObject := make(map[string]interface{})
+	var securityGroupIDObjects []string
+	var securityGroupObjects []string
+
+	pipelineObject["id"] = *object.Id
+	pipelineObject["name"] = *object.Name
+
+	for _, field := range object.Fields {
+		switch *field.Key {
+		case "attemptStatus":
+			pipelineObject["attempt_status"] = *field.StringValue
+		case "attemptTimeout":
+			pipelineObject["attempt_timeout"] = *field.StringValue
+		case "associatePublicIpAddress":
+			val, _ := strconv.ParseBool(*field.StringValue)
+			pipelineObject["associate_public_ip_address"] = val
+		case "username":
+			pipelineObject["username"] = *field.StringValue
+		case "*password":
+			pipelineObject["password"] = *field.StringValue
+		case "rdsInstanceId":
+			pipelineObject["rds_instance_id"] = *field.StringValue
+		case "databaseName":
+			pipelineObject["database_name"] = *field.StringValue
+		case "jdbcProperties":
+			pipelineObject["jdbc_properties"] = *field.StringValue
+		case "jdbcDriverJarUri":
+			pipelineObject["jdbc_driver_jar_uri"] = *field.StringValue
+		case "createTableSql":
+			pipelineObject["create_table_sql"] = *field.StringValue
+		case "database":
+			pipelineObject["database"] = *field.RefValue
+		case "insertQuery":
+			pipelineObject["insert_query"] = *field.StringValue
+		case "schemaName":
+			pipelineObject["schema_name"] = *field.StringValue
+		case "selectQuery":
+			pipelineObject["select_query"] = *field.StringValue
+		case "availabilityZone":
+			pipelineObject["availability_zone"] = *field.StringValue
+		case "httpProxy":
+			pipelineObject["http_proxy"] = *field.RefValue
+		case "imageId":
+			pipelineObject["image_id"] = *field.StringValue
+		case "instanceType":
+			pipelineObject["instance_type"] = *field.StringValue
+		case "keyPair":
+			pipelineObject["key_pair"] = *field.StringValue
+		case "maxActiveInstances":
+			val, _ := strconv.Atoi(*field.StringValue)
+			pipelineObject["max_active_instances"] = val
+		case "maximumRetries":
+			val, _ := strconv.Atoi(*field.StringValue)
+			pipelineObject["maximum_retries"] = val
+		case "onSuccess":
+			pipelineObject["on_success"] = *field.RefValue
+		case "onFail":
+			pipelineObject["on_fail"] = *field.RefValue
+		case "onLateAction":
+			pipelineObject["on_late_action"] = *field.RefValue
+		case "pipelineLogUri":
+			pipelineObject["pipeline_log_uri"] = *field.StringValue
+		case "region":
+			pipelineObject["region"] = *field.StringValue
+		case "scheduleType":
+			pipelineObject["schedule_type"] = *field.StringValue
+		case "schedule":
+			pipelineObject["schedule"] = *field.RefValue
+		case "securityGroupIds":
+			securityGroupIDObjects = append(securityGroupIDObjects, *field.StringValue)
+		case "securityGroups":
+			securityGroupObjects = append(securityGroupObjects, *field.StringValue)
+		case "subnetId":
+			pipelineObject["subnet_id"] = *field.StringValue
+		case "table":
+			pipelineObject["table"] = *field.StringValue
+		case "terminateAfter":
+			pipelineObject["terminate_after"] = *field.StringValue
+		case "useOnDemandOnLastAttempt":
+			val, _ := strconv.ParseBool(*field.StringValue)
+			pipelineObject["use_on_demand_on_last_attempt"] = val
+		case "compression":
+			pipelineObject["compression"] = *field.StringValue
+		case "dataFormat":
+			pipelineObject["data_format"] = *field.RefValue
+		case "dependsOn":
+			pipelineObject["depends_on"] = *field.RefValue
+		case "directoryPath":
+			pipelineObject["directory_path"] = *field.StringValue
+		case "failureAndRerunMode":
+			pipelineObject["failure_and_rerun_mode"] = *field.StringValue
+		case "input":
+			pipelineObject["input"] = *field.RefValue
+		case "filePath":
+			pipelineObject["file_path"] = *field.StringValue
+		case "output":
+			pipelineObject["output"] = *field.RefValue
+		case "parent":
+			pipelineObject["parent"] = *field.RefValue
+		case "lateAfterTimeout":
+			pipelineObject["late_after_timeout"] = *field.StringValue
+		case "manifestFilePath":
+			pipelineObject["manifest_file_path"] = *field.StringValue
+		case "precondition":
+			pipelineObject["precondition"] = *field.RefValue
+		case "reportProgressTimeout":
+			pipelineObject["report_progress_timeout"] = *field.StringValue
+		case "retryDelay":
+			pipelineObject["retry_delay"] = *field.StringValue
+		case "runsOn":
+			pipelineObject["runs_on"] = *field.RefValue
+		case "s3EncryptionType":
+			pipelineObject["s3_encryption_type"] = *field.StringValue
+		case "workerGroup":
+			pipelineObject["worker_group"] = *field.StringValue
+		case "period":
+			pipelineObject["period"] = *field.StringValue
+		case "spotBidPrice":
+			val, _ := strconv.ParseFloat(*field.StringValue, 64)
+			pipelineObject["spot_bid_price"] = val
+		case "startAt":
+			pipelineObject["start_at"] = *field.StringValue
+		case "startDateTime":
+			pipelineObject["start_date_time"] = *field.StringValue
+		case "endDateTime":
+			pipelineObject["end_date_time"] = *field.StringValue
+		case "occurrences":
+			val, err := strconv.Atoi(*field.StringValue)
+			if err != nil {
+				return nil, err
+			}
+			pipelineObject["occurrences"] = val
+		}
+	}
+	if len(securityGroupIDObjects) != 0 {
+		pipelineObject["security_group_ids"] = make([]string, 0, len(securityGroupIDObjects))
+		pipelineObject["security_group_ids"] = securityGroupIDObjects
+	}
+	if len(securityGroupObjects) != 0 {
+		pipelineObject["security_groups"] = make([]string, 0, len(securityGroupObjects))
+		pipelineObject["security_groups"] = securityGroupObjects
+	}
+
+	return pipelineObject, nil
+}

--- a/aws/datapipeline_helpers.go
+++ b/aws/datapipeline_helpers.go
@@ -634,19 +634,19 @@ func buildParameterObject(rawParameterObject map[string]interface{}) (*datapipel
 func flattenDefaultPipelineObject(object *datapipeline.PipelineObject) (map[string]interface{}, error) {
 	pipelineObject := make(map[string]interface{})
 	for _, field := range object.Fields {
-		switch *field.Key {
+		switch aws.StringValue(field.Key) {
 		case "scheduleType":
-			pipelineObject["schedule_type"] = *field.StringValue
+			pipelineObject["schedule_type"] = aws.StringValue(field.StringValue)
 		case "failureAndRerunMode":
-			pipelineObject["failure_and_rerun_mode"] = *field.StringValue
+			pipelineObject["failure_and_rerun_mode"] = aws.StringValue(field.StringValue)
 		case "pipelineLogUri":
-			pipelineObject["pipeline_log_uri"] = *field.StringValue
+			pipelineObject["pipeline_log_uri"] = aws.StringValue(field.StringValue)
 		case "role":
-			pipelineObject["role"] = *field.StringValue
+			pipelineObject["role"] = aws.StringValue(field.StringValue)
 		case "resourceRole":
-			pipelineObject["resource_role"] = *field.StringValue
+			pipelineObject["resource_role"] = aws.StringValue(field.StringValue)
 		case "schedule":
-			pipelineObject["schedule"] = *field.RefValue
+			pipelineObject["schedule"] = aws.StringValue(field.RefValue)
 		}
 	}
 	return pipelineObject, nil
@@ -661,126 +661,126 @@ func flattenCommonPipelineObject(object *datapipeline.PipelineObject) (map[strin
 	pipelineObject["name"] = *object.Name
 
 	for _, field := range object.Fields {
-		switch *field.Key {
+		switch aws.StringValue(field.Key) {
 		case "attemptStatus":
-			pipelineObject["attempt_status"] = *field.StringValue
+			pipelineObject["attempt_status"] = aws.StringValue(field.StringValue)
 		case "attemptTimeout":
-			pipelineObject["attempt_timeout"] = *field.StringValue
+			pipelineObject["attempt_timeout"] = aws.StringValue(field.StringValue)
 		case "associatePublicIpAddress":
-			val, _ := strconv.ParseBool(*field.StringValue)
+			val, _ := strconv.ParseBool(aws.StringValue(field.StringValue))
 			pipelineObject["associate_public_ip_address"] = val
 		case "username":
-			pipelineObject["username"] = *field.StringValue
+			pipelineObject["username"] = aws.StringValue(field.StringValue)
 		case "*password":
-			pipelineObject["password"] = *field.StringValue
+			pipelineObject["password"] = aws.StringValue(field.StringValue)
 		case "rdsInstanceId":
-			pipelineObject["rds_instance_id"] = *field.StringValue
+			pipelineObject["rds_instance_id"] = aws.StringValue(field.StringValue)
 		case "databaseName":
-			pipelineObject["database_name"] = *field.StringValue
+			pipelineObject["database_name"] = aws.StringValue(field.StringValue)
 		case "jdbcProperties":
-			pipelineObject["jdbc_properties"] = *field.StringValue
+			pipelineObject["jdbc_properties"] = aws.StringValue(field.StringValue)
 		case "jdbcDriverJarUri":
-			pipelineObject["jdbc_driver_jar_uri"] = *field.StringValue
+			pipelineObject["jdbc_driver_jar_uri"] = aws.StringValue(field.StringValue)
 		case "createTableSql":
-			pipelineObject["create_table_sql"] = *field.StringValue
+			pipelineObject["create_table_sql"] = aws.StringValue(field.StringValue)
 		case "database":
-			pipelineObject["database"] = *field.RefValue
+			pipelineObject["database"] = aws.StringValue(field.RefValue)
 		case "insertQuery":
-			pipelineObject["insert_query"] = *field.StringValue
+			pipelineObject["insert_query"] = aws.StringValue(field.StringValue)
 		case "schemaName":
-			pipelineObject["schema_name"] = *field.StringValue
+			pipelineObject["schema_name"] = aws.StringValue(field.StringValue)
 		case "selectQuery":
-			pipelineObject["select_query"] = *field.StringValue
+			pipelineObject["select_query"] = aws.StringValue(field.StringValue)
 		case "availabilityZone":
-			pipelineObject["availability_zone"] = *field.StringValue
+			pipelineObject["availability_zone"] = aws.StringValue(field.StringValue)
 		case "httpProxy":
-			pipelineObject["http_proxy"] = *field.RefValue
+			pipelineObject["http_proxy"] = aws.StringValue(field.RefValue)
 		case "imageId":
-			pipelineObject["image_id"] = *field.StringValue
+			pipelineObject["image_id"] = aws.StringValue(field.StringValue)
 		case "instanceType":
-			pipelineObject["instance_type"] = *field.StringValue
+			pipelineObject["instance_type"] = aws.StringValue(field.StringValue)
 		case "keyPair":
-			pipelineObject["key_pair"] = *field.StringValue
+			pipelineObject["key_pair"] = aws.StringValue(field.StringValue)
 		case "maxActiveInstances":
-			val, _ := strconv.Atoi(*field.StringValue)
+			val, _ := strconv.Atoi(aws.StringValue(field.StringValue))
 			pipelineObject["max_active_instances"] = val
 		case "maximumRetries":
-			val, _ := strconv.Atoi(*field.StringValue)
+			val, _ := strconv.Atoi(aws.StringValue(field.StringValue))
 			pipelineObject["maximum_retries"] = val
 		case "onSuccess":
-			pipelineObject["on_success"] = *field.RefValue
+			pipelineObject["on_success"] = aws.StringValue(field.RefValue)
 		case "onFail":
-			pipelineObject["on_fail"] = *field.RefValue
+			pipelineObject["on_fail"] = aws.StringValue(field.RefValue)
 		case "onLateAction":
-			pipelineObject["on_late_action"] = *field.RefValue
+			pipelineObject["on_late_action"] = aws.StringValue(field.RefValue)
 		case "pipelineLogUri":
-			pipelineObject["pipeline_log_uri"] = *field.StringValue
+			pipelineObject["pipeline_log_uri"] = aws.StringValue(field.StringValue)
 		case "region":
-			pipelineObject["region"] = *field.StringValue
+			pipelineObject["region"] = aws.StringValue(field.StringValue)
 		case "scheduleType":
-			pipelineObject["schedule_type"] = *field.StringValue
+			pipelineObject["schedule_type"] = aws.StringValue(field.StringValue)
 		case "schedule":
-			pipelineObject["schedule"] = *field.RefValue
+			pipelineObject["schedule"] = aws.StringValue(field.RefValue)
 		case "securityGroupIds":
-			securityGroupIDObjects = append(securityGroupIDObjects, *field.StringValue)
+			securityGroupIDObjects = append(securityGroupIDObjects, aws.StringValue(field.StringValue))
 		case "securityGroups":
-			securityGroupObjects = append(securityGroupObjects, *field.StringValue)
+			securityGroupObjects = append(securityGroupObjects, aws.StringValue(field.StringValue))
 		case "subnetId":
-			pipelineObject["subnet_id"] = *field.StringValue
+			pipelineObject["subnet_id"] = aws.StringValue(field.StringValue)
 		case "table":
-			pipelineObject["table"] = *field.StringValue
+			pipelineObject["table"] = aws.StringValue(field.StringValue)
 		case "terminateAfter":
-			pipelineObject["terminate_after"] = *field.StringValue
+			pipelineObject["terminate_after"] = aws.StringValue(field.StringValue)
 		case "useOnDemandOnLastAttempt":
-			val, _ := strconv.ParseBool(*field.StringValue)
+			val, _ := strconv.ParseBool(aws.StringValue(field.StringValue))
 			pipelineObject["use_on_demand_on_last_attempt"] = val
 		case "compression":
-			pipelineObject["compression"] = *field.StringValue
+			pipelineObject["compression"] = aws.StringValue(field.StringValue)
 		case "dataFormat":
-			pipelineObject["data_format"] = *field.RefValue
+			pipelineObject["data_format"] = aws.StringValue(field.RefValue)
 		case "dependsOn":
-			pipelineObject["depends_on"] = *field.RefValue
+			pipelineObject["depends_on"] = aws.StringValue(field.RefValue)
 		case "directoryPath":
-			pipelineObject["directory_path"] = *field.StringValue
+			pipelineObject["directory_path"] = aws.StringValue(field.StringValue)
 		case "failureAndRerunMode":
-			pipelineObject["failure_and_rerun_mode"] = *field.StringValue
+			pipelineObject["failure_and_rerun_mode"] = aws.StringValue(field.StringValue)
 		case "input":
-			pipelineObject["input"] = *field.RefValue
+			pipelineObject["input"] = aws.StringValue(field.RefValue)
 		case "filePath":
-			pipelineObject["file_path"] = *field.StringValue
+			pipelineObject["file_path"] = aws.StringValue(field.StringValue)
 		case "output":
-			pipelineObject["output"] = *field.RefValue
+			pipelineObject["output"] = aws.StringValue(field.RefValue)
 		case "parent":
-			pipelineObject["parent"] = *field.RefValue
+			pipelineObject["parent"] = aws.StringValue(field.RefValue)
 		case "lateAfterTimeout":
-			pipelineObject["late_after_timeout"] = *field.StringValue
+			pipelineObject["late_after_timeout"] = aws.StringValue(field.StringValue)
 		case "manifestFilePath":
-			pipelineObject["manifest_file_path"] = *field.StringValue
+			pipelineObject["manifest_file_path"] = aws.StringValue(field.StringValue)
 		case "precondition":
-			pipelineObject["precondition"] = *field.RefValue
+			pipelineObject["precondition"] = aws.StringValue(field.RefValue)
 		case "reportProgressTimeout":
-			pipelineObject["report_progress_timeout"] = *field.StringValue
+			pipelineObject["report_progress_timeout"] = aws.StringValue(field.StringValue)
 		case "retryDelay":
-			pipelineObject["retry_delay"] = *field.StringValue
+			pipelineObject["retry_delay"] = aws.StringValue(field.StringValue)
 		case "runsOn":
-			pipelineObject["runs_on"] = *field.RefValue
+			pipelineObject["runs_on"] = aws.StringValue(field.RefValue)
 		case "s3EncryptionType":
-			pipelineObject["s3_encryption_type"] = *field.StringValue
+			pipelineObject["s3_encryption_type"] = aws.StringValue(field.StringValue)
 		case "workerGroup":
-			pipelineObject["worker_group"] = *field.StringValue
+			pipelineObject["worker_group"] = aws.StringValue(field.StringValue)
 		case "period":
-			pipelineObject["period"] = *field.StringValue
+			pipelineObject["period"] = aws.StringValue(field.StringValue)
 		case "spotBidPrice":
-			val, _ := strconv.ParseFloat(*field.StringValue, 64)
+			val, _ := strconv.ParseFloat(aws.StringValue(field.StringValue), 64)
 			pipelineObject["spot_bid_price"] = val
 		case "startAt":
-			pipelineObject["start_at"] = *field.StringValue
+			pipelineObject["start_at"] = aws.StringValue(field.StringValue)
 		case "startDateTime":
-			pipelineObject["start_date_time"] = *field.StringValue
+			pipelineObject["start_date_time"] = aws.StringValue(field.StringValue)
 		case "endDateTime":
-			pipelineObject["end_date_time"] = *field.StringValue
+			pipelineObject["end_date_time"] = aws.StringValue(field.StringValue)
 		case "occurrences":
-			val, err := strconv.Atoi(*field.StringValue)
+			val, err := strconv.Atoi(aws.StringValue(field.StringValue))
 			if err != nil {
 				return nil, err
 			}

--- a/aws/datapipeline_helpers_test.go
+++ b/aws/datapipeline_helpers_test.go
@@ -1,0 +1,796 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+)
+
+type pipelineObjectTestCase struct {
+	Attrs    map[string]interface{}
+	Expected *datapipeline.PipelineObject
+}
+
+func TestBuildDefaultPipelineObject(t *testing.T) {
+	testCases := []pipelineObjectTestCase{
+		{
+			map[string]interface{}{
+				"schedule_type":          "cron",
+				"failure_and_rerun_mode": "CASCADE",
+				"pipeline_log_uri":       "s3://bucket-name/key-name-prefix/",
+				"role":                   "DataPipelineDefaultRole",
+				"resource_role":          "DataPipelineDefaultResourceRole",
+				"schedule":               "myDefaultSchedule",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("Default"),
+				Name: aws.String("Default"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("Default"),
+					},
+					{
+						Key:         aws.String("scheduleType"),
+						StringValue: aws.String("cron"),
+					},
+					{
+						Key:         aws.String("failureAndRerunMode"),
+						StringValue: aws.String("CASCADE"),
+					},
+					{
+						Key:         aws.String("pipelineLogUri"),
+						StringValue: aws.String("s3://bucket-name/key-name-prefix/"),
+					},
+					{
+						Key:         aws.String("role"),
+						StringValue: aws.String("DataPipelineDefaultRole"),
+					},
+					{
+						Key:         aws.String("resourceRole"),
+						StringValue: aws.String("DataPipelineDefaultResourceRole"),
+					},
+					{
+						Key:      aws.String("schedule"),
+						RefValue: aws.String("myDefaultSchedule"),
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		result, err := buildDefaultPipelineObject(testCase.Attrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(result, testCase.Expected) {
+			t.Errorf(
+				"test case %d: got %#v, but want %#v",
+				i, result, testCase.Expected,
+			)
+		}
+	}
+}
+
+func TestBuildEc2ResourcePipelineObject(t *testing.T) {
+	testCases := []pipelineObjectTestCase{
+		{
+			map[string]interface{}{
+				"id":                          "bar",
+				"name":                        "boo",
+				"associate_public_ip_address": true,
+				"image_id":                    "i-xxxxxxxxxxxxxx",
+				"instance_type":               "t2.micro",
+				"max_active_instances":        10,
+				"maximum_retries":             5,
+				"security_group_ids": []string{
+					"sg-12345678",
+					"sg-23456789",
+				},
+				"subnet_id": "subnet-12345678",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("Ec2Resource"),
+					},
+					{
+						Key:         aws.String("associatePublicIpAddress"),
+						StringValue: aws.String("true"),
+					},
+					{
+						Key:         aws.String("imageId"),
+						StringValue: aws.String("i-xxxxxxxxxxxxxx"),
+					},
+					{
+						Key:         aws.String("instanceType"),
+						StringValue: aws.String("t2.micro"),
+					},
+					{
+						Key:         aws.String("maxActiveInstances"),
+						StringValue: aws.String("10"),
+					},
+					{
+						Key:         aws.String("maximumRetries"),
+						StringValue: aws.String("5"),
+					},
+					{
+						Key:         aws.String("securityGroupIds"),
+						StringValue: aws.String("sg-12345678"),
+					},
+					{
+						Key:         aws.String("securityGroupIds"),
+						StringValue: aws.String("sg-23456789"),
+					},
+					{
+						Key:         aws.String("subnetId"),
+						StringValue: aws.String("subnet-12345678"),
+					},
+				},
+			},
+		},
+		{
+			map[string]interface{}{
+				"id":                          "bar",
+				"name":                        "boo",
+				"associate_public_ip_address": true,
+				"availability_zone":           "ap-northeast-1a",
+				"image_id":                    "i-xxxxxxxxxxxxxx",
+				"instance_type":               "m4.large",
+				"max_active_instances":        10,
+				"maximum_retries":             5,
+				"security_groups": []string{
+					"default",
+					"test-group",
+				},
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("Ec2Resource"),
+					},
+					{
+						Key:         aws.String("associatePublicIpAddress"),
+						StringValue: aws.String("true"),
+					},
+					{
+						Key:         aws.String("availabilityZone"),
+						StringValue: aws.String("ap-northeast-1a"),
+					},
+					{
+						Key:         aws.String("imageId"),
+						StringValue: aws.String("i-xxxxxxxxxxxxxx"),
+					},
+					{
+						Key:         aws.String("instanceType"),
+						StringValue: aws.String("m4.large"),
+					},
+					{
+						Key:         aws.String("maxActiveInstances"),
+						StringValue: aws.String("10"),
+					},
+					{
+						Key:         aws.String("maximumRetries"),
+						StringValue: aws.String("5"),
+					},
+					{
+						Key:         aws.String("securityGroups"),
+						StringValue: aws.String("default"),
+					},
+					{
+						Key:         aws.String("securityGroups"),
+						StringValue: aws.String("test-group"),
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		result, err := buildCommonPipelineObject("Ec2Resource", testCase.Attrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(result, testCase.Expected) {
+			t.Errorf(
+				"test case %d: got %#v, but want %#v",
+				i, result, testCase.Expected,
+			)
+		}
+	}
+}
+
+func TestBuildSchedulePipelineObject(t *testing.T) {
+	testCases := []pipelineObjectTestCase{
+		{
+			map[string]interface{}{
+				"id":              "bar",
+				"name":            "boo",
+				"period":          "1 hour",
+				"start_date_time": "2019-01-01T00:00:00",
+				"end_date_time":   "2019-09-01T00:00:00",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("Schedule"),
+					},
+					{
+						Key:         aws.String("period"),
+						StringValue: aws.String("1 hour"),
+					},
+					{
+						Key:         aws.String("startDateTime"),
+						StringValue: aws.String("2019-01-01T00:00:00"),
+					},
+					{
+						Key:         aws.String("endDateTime"),
+						StringValue: aws.String("2019-09-01T00:00:00"),
+					},
+				},
+			},
+		},
+		{
+			map[string]interface{}{
+				"id":          "bar",
+				"name":        "boo",
+				"occurrences": 1,
+				"period":      "1 Day",
+				"start_at":    "FIRST_ACTIVATION_DATE_TIME",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("Schedule"),
+					},
+					{
+						Key:         aws.String("period"),
+						StringValue: aws.String("1 Day"),
+					},
+					{
+						Key:         aws.String("startAt"),
+						StringValue: aws.String("FIRST_ACTIVATION_DATE_TIME"),
+					},
+					{
+						Key:         aws.String("occurrences"),
+						StringValue: aws.String("1"),
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		result, err := buildCommonPipelineObject("Schedule", testCase.Attrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(result, testCase.Expected) {
+			t.Errorf(
+				"test case %d: got %#v, but want %#v",
+				i, result, testCase.Expected,
+			)
+		}
+	}
+}
+
+func TestBuildS3DataNodePipelineObject(t *testing.T) {
+	testCases := []pipelineObjectTestCase{
+		{
+			map[string]interface{}{
+				"id":             "bar",
+				"name":           "boo",
+				"compression":    "none",
+				"directory_path": "hogehoge",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("S3DataNode"),
+					},
+					{
+						Key:         aws.String("compression"),
+						StringValue: aws.String("none"),
+					},
+					{
+						Key:         aws.String("directoryPath"),
+						StringValue: aws.String("hogehoge"),
+					},
+				},
+			},
+		},
+		{
+			map[string]interface{}{
+				"id":             "bar",
+				"name":           "boo",
+				"compression":    "gzip",
+				"directory_path": "hogehoge",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("S3DataNode"),
+					},
+					{
+						Key:         aws.String("compression"),
+						StringValue: aws.String("gzip"),
+					},
+					{
+						Key:         aws.String("directoryPath"),
+						StringValue: aws.String("hogehoge"),
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		result, err := buildCommonPipelineObject("S3DataNode", testCase.Attrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(result, testCase.Expected) {
+			t.Errorf(
+				"test case %d: got %#v, but want %#v",
+				i, result, testCase.Expected,
+			)
+		}
+	}
+}
+
+func TestBuildSqlDataNodePipelineObject(t *testing.T) {
+	testCases := []pipelineObjectTestCase{
+		{
+			map[string]interface{}{
+				"id":    "bar",
+				"name":  "boo",
+				"table": "test_table",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("SqlDataNode"),
+					},
+					{
+						Key:         aws.String("table"),
+						StringValue: aws.String("test_table"),
+					},
+				},
+			},
+		},
+		{
+			map[string]interface{}{
+				"id":           "bar",
+				"name":         "boo",
+				"table":        "test_table",
+				"database":     "hogehoge",
+				"select_query": "select * from #{table} where eventTime >= '#{@scheduledStartTime.format('YYYY-MM-dd HH:mm:ss')}' and eventTime < '#{@scheduledEndTime.format('YYYY-MM-dd HH:mm:ss')}'",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("bar"),
+				Name: aws.String("boo"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("SqlDataNode"),
+					},
+					{
+						Key:      aws.String("database"),
+						RefValue: aws.String("hogehoge"),
+					},
+					{
+						Key:         aws.String("table"),
+						StringValue: aws.String("test_table"),
+					},
+					{
+						Key:         aws.String("selectQuery"),
+						StringValue: aws.String("select * from #{table} where eventTime >= '#{@scheduledStartTime.format('YYYY-MM-dd HH:mm:ss')}' and eventTime < '#{@scheduledEndTime.format('YYYY-MM-dd HH:mm:ss')}'"),
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		result, err := buildCommonPipelineObject("SqlDataNode", testCase.Attrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(result, testCase.Expected) {
+			t.Errorf(
+				"test case %d: got %#v, but want %#v",
+				i, result, testCase.Expected,
+			)
+		}
+	}
+}
+
+func TestBuildRdsDatabasePipelineObject(t *testing.T) {
+	testCases := []pipelineObjectTestCase{
+		{
+			map[string]interface{}{
+				"id":              "MyRdsDatabase",
+				"name":            "MyRdsDatabase",
+				"username":        "user_name",
+				"password":        "my_password",
+				"rds_instance_id": "my_db_instance_identifier",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("MyRdsDatabase"),
+				Name: aws.String("MyRdsDatabase"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("RdsDatabase"),
+					},
+					{
+						Key:         aws.String("username"),
+						StringValue: aws.String("user_name"),
+					},
+					{
+						Key:         aws.String("*password"),
+						StringValue: aws.String("my_password"),
+					},
+					{
+						Key:         aws.String("rdsInstanceId"),
+						StringValue: aws.String("my_db_instance_identifier"),
+					},
+				},
+			},
+		},
+		{
+			map[string]interface{}{
+				"id":                  "MyRdsDatabase",
+				"name":                "MyRdsDatabase",
+				"username":            "user_name",
+				"password":            "my_password",
+				"rds_instance_id":     "my_db_instance_identifier",
+				"jdbc_driver_jar_uri": "s3://example.com/test/jdbc.driver",
+				"jdbc_properties":     "useUnicode=yes&characterEncoding=UTF-8",
+			},
+			&datapipeline.PipelineObject{
+				Id:   aws.String("MyRdsDatabase"),
+				Name: aws.String("MyRdsDatabase"),
+				Fields: []*datapipeline.Field{
+					{
+						Key:         aws.String("type"),
+						StringValue: aws.String("RdsDatabase"),
+					},
+					{
+						Key:         aws.String("username"),
+						StringValue: aws.String("user_name"),
+					},
+					{
+						Key:         aws.String("*password"),
+						StringValue: aws.String("my_password"),
+					},
+					{
+						Key:         aws.String("rdsInstanceId"),
+						StringValue: aws.String("my_db_instance_identifier"),
+					},
+					{
+						Key:         aws.String("jdbcDriverJarUri"),
+						StringValue: aws.String("s3://example.com/test/jdbc.driver"),
+					},
+					{
+						Key:         aws.String("jdbcProperties"),
+						StringValue: aws.String("useUnicode=yes&characterEncoding=UTF-8"),
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		result, err := buildCommonPipelineObject("RdsDatabase", testCase.Attrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(result, testCase.Expected) {
+			t.Errorf(
+				"test case %d: got %#v, but want %#v",
+				i, result, testCase.Expected,
+			)
+		}
+	}
+}
+
+func TestFlattenDefaultPipelineObject(t *testing.T) {
+	in := defaultPipelineObjectConf()
+	dpo, err := buildDefaultPipelineObject(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := flattenDefaultPipelineObject(dpo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestFlattenCommonPipelineObject_copyActivity(t *testing.T) {
+	in := copyActivityPipelineObjectConf()
+	epo, err := buildCommonPipelineObject("CopyActivity", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := flattenCommonPipelineObject(epo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestFlattenCommonPipelineObject_ec2Resource(t *testing.T) {
+	in := ec2ResourcePipelineObjectConf()
+	epo, err := buildCommonPipelineObject("Ec2Resource", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := flattenCommonPipelineObject(epo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Expected out to be %+v, got %+v", in, out)
+	}
+}
+
+func TestFlattenCommonPipelineObject_rdsDatabase(t *testing.T) {
+	in := rdsDatabasePipelineObjectConf()
+	epo, err := buildCommonPipelineObject("RdsDatabase", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := flattenCommonPipelineObject(epo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestFlattenCommonPipelineObject_s3DataNode(t *testing.T) {
+	in := s3DataNodePipelineObjectConf()
+	epo, err := buildCommonPipelineObject("S3DataNode", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := flattenCommonPipelineObject(epo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestFlattenCommonPipelineObject_sqlDataNode(t *testing.T) {
+	in := sqlDataNodePipelineObjectConf()
+	epo, err := buildCommonPipelineObject("SqlDataNode", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := flattenCommonPipelineObject(epo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Expected out to be %v, got %v", in, out)
+	}
+}
+
+func TestFlattenCommonPipelineObject_schedule(t *testing.T) {
+	in := schedulePipelineObjectConf()
+	epo, err := buildCommonPipelineObject("Schedule", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := flattenCommonPipelineObject(epo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("Expected out to be %+v, got %+v", in, out)
+	}
+}
+
+func defaultPipelineObjectConf() map[string]interface{} {
+	return map[string]interface{}{
+		"schedule_type":          "cron",
+		"failure_and_rerun_mode": "CASCADE",
+		"pipeline_log_uri":       "s3://example.com/test/",
+		"role":                   "arn:aws:iam::123456789012:role/test-role",
+		"resource_role":          "arn:aws:iam::123456789012:role/test-resource-role",
+		"schedule":               "DefaultSchedule",
+	}
+}
+
+func copyActivityPipelineObjectConf() map[string]interface{} {
+	return map[string]interface{}{
+		"id":                      "DefaultCopyActivity",
+		"name":                    "DefaultCopyActivity",
+		"schedule":                "DefaultSchedule",
+		"runs_on":                 "DefaultEc2Resource",
+		"attempt_timeout":         "1 hour",
+		"depends_on":              "DefaultEc2Resource",
+		"failure_and_rerun_mode":  "CASCADE",
+		"input":                   "S3InputDataNode",
+		"late_after_timeout":      "2 hours",
+		"max_active_instances":    1,
+		"maximum_retries":         5,
+		"on_fail":                 "DefaultSnsAlarm",
+		"on_late_action":          "DefaultSnsAlarm",
+		"on_success":              "DefaultSnsAlarm",
+		"output":                  "S3OutputDataNode",
+		"parent":                  "DefaultEc2Resource",
+		"pipeline_log_uri":        "s3://BucketName/Key/",
+		"precondition":            "DefaultS3KeyExists",
+		"report_progress_timeout": "10 minutes",
+		"retry_delay":             "20 minutes",
+		"schedule_type":           "cron",
+	}
+}
+
+func ec2ResourcePipelineObjectConf() map[string]interface{} {
+	return map[string]interface{}{
+		"id":                          "DefaultEc2Resource",
+		"name":                        "DefaultEc2Resource",
+		"associate_public_ip_address": true,
+		"attempt_timeout":             "1 hour",
+		"availability_zone":           "ap-northeast-1a",
+		"http_proxy":                  "DefaultHttpProxy",
+		"image_id":                    "ami-012345678",
+		"instance_type":               "t2.micro",
+		"key_pair":                    "test-ssh-key",
+		"max_active_instances":        5,
+		"maximum_retries":             10,
+		"on_fail":                     "DefaultSnsAlarm",
+		"on_late_action":              "DefaultSnsAlarm",
+		"on_success":                  "DefaultSnsAlarm",
+		"pipeline_log_uri":            "s3://BucketName/Key/",
+		"region":                      "ap-northeast-1",
+		"schedule_type":               "ondemand",
+		"security_group_ids": []string{
+			"sg-0123456",
+			"sg-1234567",
+		},
+
+		"security_groups": []string{
+			"default",
+			"test-sg",
+		},
+		"subnet_id":                     "subnet-01234567",
+		"spot_bid_price":                0.05,
+		"terminate_after":               "15 minutes",
+		"use_on_demand_on_last_attempt": true,
+	}
+}
+
+func rdsDatabasePipelineObjectConf() map[string]interface{} {
+	return map[string]interface{}{
+		"id":                  "MyRdsDatabase",
+		"name":                "MyRdsDatabase",
+		"username":            "user_name",
+		"password":            "my_password",
+		"rds_instance_id":     "my_db_instance_identifier",
+		"database_name":       "database_name",
+		"jdbc_properties":     "useUnicode=yes&characterEncoding=UTF-8",
+		"region":              "us-east-1",
+		"parent":              "DefaultEc2Resource",
+		"jdbc_driver_jar_uri": "s3://BucketName/Key/",
+	}
+}
+
+func s3DataNodePipelineObjectConf() map[string]interface{} {
+	return map[string]interface{}{
+		"id":                      "DefaultS3DataNode",
+		"name":                    "DefaultS3DataNode",
+		"compression":             "gzip",
+		"data_format":             "DefaultCsvDataFormat",
+		"depends_on":              "DefaultEc2Resource",
+		"directory_path":          "s3://my-bucket/my-key-for-directory",
+		"failure_and_rerun_mode":  "CASCADE",
+		"file_path":               "s3://my-bucket/my-key-for-file",
+		"late_after_timeout":      "2 hours",
+		"manifest_file_path":      "s3://my-bucket/my-key-for-directory",
+		"max_active_instances":    5,
+		"maximum_retries":         10,
+		"on_fail":                 "DefaultSnsAlarm",
+		"on_late_action":          "DefaultSnsAlarm",
+		"on_success":              "DefaultSnsAlarm",
+		"parent":                  "DefaultEc2Resource",
+		"pipeline_log_uri":        "s3://BucketName/Key/",
+		"precondition":            "DefaultS3KeyExists",
+		"report_progress_timeout": "10 minutes",
+		"retry_delay":             "20 minutes",
+		"runs_on":                 "DefaultEc2Resource",
+		"s3_encryption_type":      "SERVER_SIDE_ENCRYPTION",
+		"schedule_type":           "cron",
+		"worker_group":            "test",
+	}
+}
+
+func sqlDataNodePipelineObjectConf() map[string]interface{} {
+	return map[string]interface{}{
+		"id":                     "DefaultSqlDataNode",
+		"name":                   "DefaultSqlDataNode",
+		"table":                  "test",
+		"create_table_sql":       "CREATE TABLE #{table}",
+		"database":               "DefaultRdsDatabase",
+		"depends_on":             "DefaultEc2Resource",
+		"failure_and_rerun_mode": "none",
+		"insert_query": `INSERT INTO #{table} (col_name1, col_name2)
+		VALUES ("value1", "value2")`,
+		"maximum_retries":  10,
+		"on_fail":          "DefaultSnsAlarm",
+		"on_late_action":   "DefaultSnsAlarm",
+		"on_success":       "DefaultSnsAlarm",
+		"parent":           "DefaultEc2Resource",
+		"pipeline_log_uri": "s3://BucketName/Key/",
+		"precondition":     "DefaultS3KeyExists",
+		"retry_delay":      "20 minutes",
+		"select_query":     "SELECT * FROM #{table}",
+	}
+}
+
+func schedulePipelineObjectConf() map[string]interface{} {
+	return map[string]interface{}{
+		"id":              "DefaultSchedule",
+		"name":            "DefaultSchedule",
+		"period":          "1 hour",
+		"start_at":        "FIRST_ACTIVATION_DATE_TIME",
+		"start_date_time": "2019-01-01T00:00:00",
+		"end_date_time":   "2019-09-01T00:00:00",
+		"occurrences":     1,
+		"parent":          "DefaultEc2Resource",
+	}
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -380,6 +380,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_datasync_location_nfs":                               resourceAwsDataSyncLocationNfs(),
 			"aws_datasync_location_s3":                                resourceAwsDataSyncLocationS3(),
 			"aws_datasync_task":                                       resourceAwsDataSyncTask(),
+			"aws_datapipeline":                                        resourceAwsDataPipeline(),
 			"aws_dax_cluster":                                         resourceAwsDaxCluster(),
 			"aws_dax_parameter_group":                                 resourceAwsDaxParameterGroup(),
 			"aws_dax_subnet_group":                                    resourceAwsDaxSubnetGroup(),

--- a/aws/resource_aws_datapipeline.go
+++ b/aws/resource_aws_datapipeline.go
@@ -1,0 +1,1292 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+var dataPipelineScheduleTypeList = []string{
+	"cron",
+	"ondemand",
+	"timeseries",
+}
+
+var dataPipelineActionOnResourceFailureList = []string{
+	"retryall",
+	"retrynone",
+}
+
+var dataPipelineActionOnTaskFailureList = []string{
+	"continue",
+	"terminate",
+}
+
+var dataPipelineParameterObjectTypeList = []string{
+	"String",
+	"Integer",
+	"Double",
+	"AWS::S3::ObjectKey",
+}
+
+var dataPipelineFailureAndRerunModeList = []string{
+	"cascade",
+	"none",
+}
+
+var dataPipelineS3EncryptionTypeList = []string{
+	"NONE",
+	"SERVER_SIDE_ENCRYPTION",
+}
+
+var dataPipelineS3CompressionTypeList = []string{
+	"none",
+	"gzip",
+}
+
+func resourceAwsDataPipeline() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDataPipelineCreate,
+		Read:   resourceAwsDataPipelineRead,
+		Update: resourceAwsDataPipelineUpdate,
+		Delete: resourceAwsDataPipelineDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Default
+			"default": {
+				Type:     schema.TypeMap,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"schedule_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineScheduleTypeList, false),
+						},
+
+						"failure_and_rerun_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineFailureAndRerunModeList, false),
+							Default:      "none",
+						},
+
+						"pipeline_log_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"role": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"resource_role": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"schedule": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			// Activity
+			"copy_activity": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"schedule": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"runs_on": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"worker_group": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"attempt_status": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"attempt_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"depends_on": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"failure_and_rerun_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineFailureAndRerunModeList, false),
+							Default:      "none",
+						},
+
+						"input": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"late_after_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"max_active_instances": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"maximum_retries": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"on_fail": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_late_action": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_success": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"output": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"parent": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"pipeline_log_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"precondition": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"report_progress_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"retry_delay": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"schedule_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineScheduleTypeList, false),
+						},
+					},
+				},
+			},
+
+			// Resources
+			"ec2_resource": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"action_on_resource_failure": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineActionOnResourceFailureList, false),
+						},
+
+						"action_on_task_failure": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineActionOnTaskFailureList, false),
+						},
+
+						"associate_public_ip_address": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
+						"attempt_status": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"attempt_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"image_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"init_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"instance_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"key_pair": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"late_after_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"max_active_instances": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"maximum_retries": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"on_fail": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_late_action": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_success": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"pipeline_log_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"region": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"schedule_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineScheduleTypeList, false),
+						},
+
+						"security_group_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
+						"security_groups": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
+						"spot_bid_price": {
+							Type:         schema.TypeFloat,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 20),
+						},
+
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"terminate_after": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"use_on_demand_on_last_attempt": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+
+			// Databases
+			"rds_database": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"username": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"password": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+						},
+
+						"rds_instance_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"database_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"jdbc_driver_jar_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"jdbc_properties": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"parent": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"region": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			// Data Node
+			"s3_data_node": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"attempt_status": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"attempt_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"compression": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineS3CompressionTypeList, false),
+							Default:      "none",
+						},
+
+						"data_format": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"depends_on": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"directory_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"failure_and_rerun_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineFailureAndRerunModeList, false),
+							Default:      "none",
+						},
+
+						"file_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"late_after_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"manifest_file_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"max_active_instances": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"maximum_retries": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"on_fail": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_late_action": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_success": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"parent": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"pipeline_log_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"precondition": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"report_progress_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"retry_delay": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"runs_on": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"s3_encryption_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineS3EncryptionTypeList, false),
+						},
+
+						"schedule_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineScheduleTypeList, false),
+						},
+
+						"worker_group": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"sql_data_node": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"table": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"attempt_status": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"attempt_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"create_table_sql": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"database": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"depends_on": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"failure_and_rerun_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineFailureAndRerunModeList, false),
+							Default:      "none",
+						},
+
+						"insert_query": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"late_after_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"max_active_instances": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"maximum_retries": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+
+						"on_fail": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_late_action": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"on_success": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"parent": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"pipeline_log_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"precondition": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"report_progress_timeout": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"retry_delay": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"runs_on": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"schedule_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(dataPipelineScheduleTypeList, false),
+						},
+
+						"schema_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"select_query": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"worker_group": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"schedule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"period": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"start_at": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"schedule.start_date_time"},
+						},
+
+						"start_date_time": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"schedule.start_at"},
+						},
+
+						"end_date_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"occurrences": {
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ConflictsWith: []string{"schedule.end_date_time"},
+						},
+
+						"parent": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"parameter_object": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "String",
+							ValidateFunc: validation.StringInSlice(dataPipelineParameterObjectTypeList, false),
+						},
+						"optional": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"allowed_values": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"default": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"is_array": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"parameter_value": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"string_value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsDataPipelineCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	name := d.Get("name").(string)
+	uniqueID := resource.PrefixedUniqueId(name)
+
+	input := datapipeline.CreatePipelineInput{
+		Name:     aws.String(name),
+		UniqueId: aws.String(uniqueID),
+	}
+
+	if v, ok := d.GetOk("description"); ok && v != nil {
+		input.Description = aws.String(v.(string))
+	}
+
+	tags := tagsFromMapDataPipeline(d.Get("tags").(map[string]interface{}))
+	if len(tags) != 0 && tags != nil {
+		input.Tags = tags
+	}
+
+	resp, err := conn.CreatePipeline(&input)
+
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] DataPipeline received: %s", resp)
+	d.SetId(*resp.PipelineId)
+	d.Set("tags", tagsToMapDataPipeline(tags))
+
+	return resourceAwsDataPipelineUpdate(d, meta)
+}
+
+func resourceAwsDataPipelineUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+	pipelineID := d.Id()
+
+	parameterObjects := d.Get("parameter_object").([]interface{})
+	parameterObjectConfigs := make([]*datapipeline.ParameterObject, 0, len(parameterObjects))
+	for _, p := range parameterObjects {
+		p := p.(map[string]interface{})
+		po, err := buildParameterObject(p)
+		if err != nil {
+			return err
+		}
+		parameterObjectConfigs = append(parameterObjectConfigs, po)
+	}
+
+	parameterValues := d.Get("parameter_value").([]interface{})
+	parameterValuesConfigs := make([]*datapipeline.ParameterValue, 0, len(parameterValues))
+	for _, c := range parameterValues {
+		pv := &datapipeline.ParameterValue{}
+		c := c.(map[string]interface{})
+		if val, ok := c["id"].(string); ok && val != "" {
+			pv.SetId(val)
+		}
+		if val, ok := c["string_value"].(string); ok && val != "" {
+			pv.SetStringValue(val)
+		}
+		parameterValuesConfigs = append(parameterValuesConfigs, pv)
+	}
+
+	pipelineObjectsConfigs := []*datapipeline.PipelineObject{}
+
+	if v, ok := d.GetOk("default"); ok && v != nil {
+		v := v.(map[string]interface{})
+		po, err := buildDefaultPipelineObject(v)
+		if err != nil {
+			return err
+		}
+		pipelineObjectsConfigs = append(pipelineObjectsConfigs, po)
+	} else {
+		log.Printf("[DEBUG] Not setting default pipeline object for %q", d.Id())
+	}
+
+	if v, ok := d.GetOk("copy_activity"); ok && v != nil {
+		for _, c := range v.([]interface{}) {
+			c := c.(map[string]interface{})
+			po, err := buildCommonPipelineObject("CopyActivity", c)
+			if err != nil {
+				return err
+			}
+			pipelineObjectsConfigs = append(pipelineObjectsConfigs, po)
+		}
+	}
+
+	if v, ok := d.GetOk("ec2_resource"); ok && v != nil {
+		for _, e := range v.([]interface{}) {
+			e := e.(map[string]interface{})
+			po, err := buildCommonPipelineObject("Ec2Resource", e)
+			if err != nil {
+				return err
+			}
+			pipelineObjectsConfigs = append(pipelineObjectsConfigs, po)
+		}
+	}
+
+	if v, ok := d.GetOk("rds_database"); ok && v != nil {
+		for _, r := range v.([]interface{}) {
+			r := r.(map[string]interface{})
+			po, err := buildCommonPipelineObject("RdsDatabase", r)
+			if err != nil {
+				return err
+			}
+			pipelineObjectsConfigs = append(pipelineObjectsConfigs, po)
+		}
+	}
+
+	if v, ok := d.GetOk("s3_data_node"); ok && v != nil {
+		for _, s := range v.([]interface{}) {
+			s := s.(map[string]interface{})
+			po, err := buildCommonPipelineObject("S3DataNode", s)
+			if err != nil {
+				return err
+			}
+			pipelineObjectsConfigs = append(pipelineObjectsConfigs, po)
+		}
+	}
+
+	if v, ok := d.GetOk("sql_data_node"); ok && v != nil {
+		for _, s := range v.([]interface{}) {
+			s := s.(map[string]interface{})
+			po, err := buildCommonPipelineObject("SqlDataNode", s)
+			if err != nil {
+				return err
+			}
+			pipelineObjectsConfigs = append(pipelineObjectsConfigs, po)
+		}
+	}
+
+	if v, ok := d.GetOk("schedule"); ok && v != nil {
+		for _, s := range v.([]interface{}) {
+			s := s.(map[string]interface{})
+			po, err := buildCommonPipelineObject("Schedule", s)
+			if err != nil {
+				return err
+			}
+			pipelineObjectsConfigs = append(pipelineObjectsConfigs, po)
+		}
+	}
+
+	input := &datapipeline.PutPipelineDefinitionInput{
+		PipelineId: aws.String(pipelineID),
+	}
+	if len(parameterObjectConfigs) > 0 {
+		input.ParameterObjects = parameterObjectConfigs
+	}
+
+	if len(parameterValuesConfigs) > 0 {
+		input.ParameterValues = parameterValuesConfigs
+	}
+
+	if len(pipelineObjectsConfigs) > 0 {
+		input.PipelineObjects = pipelineObjectsConfigs
+	}
+
+	err := input.Validate()
+	if err != nil {
+		return err
+	}
+
+	resp, err := conn.PutPipelineDefinition(input)
+
+	if err != nil {
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			log.Printf("[WARN] DataPipeline (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error updating DataPipeline (%s): %s", d.Id(), err)
+	}
+
+	for _, validationWarn := range resp.ValidationWarnings {
+		for _, warn := range validationWarn.Warnings {
+			log.Printf("[WARN] %s:  %s", *validationWarn.Id, *warn)
+		}
+	}
+
+	for _, validationError := range resp.ValidationErrors {
+		for _, err := range validationError.Errors {
+			log.Printf("[ERROR] %s:  %s", *validationError.Id, *err)
+		}
+	}
+
+	if err := setTagsDataPipeline(conn, d); err != nil {
+		return fmt.Errorf("Error update tags: %s", err)
+	}
+
+	return resourceAwsDataPipelineRead(d, meta)
+}
+
+func resourceAwsDataPipelineRead(d *schema.ResourceData, meta interface{}) error {
+
+	v, err := resourceAwsDataPipelineRetrieve(d.Id(), meta.(*AWSClient).datapipelineconn)
+
+	if err != nil {
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			log.Printf("[WARN] DataPipeline (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	if v == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(*v.PipelineId)
+	d.Set("name", v.Name)
+	d.Set("description", v.Description)
+	d.Set("tags", tagsToMapDataPipeline(v.Tags))
+
+	r, err := resourceAwsDataPipelineDefinitionRetrieve(d.Id(), meta.(*AWSClient).datapipelineconn)
+	if err != nil {
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			log.Printf("[WARN] DataPipeline (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	// Parameter Objects
+	if err := d.Set("parameter_object", flattenParameterObjects(r.ParameterObjects)); err != nil {
+		return fmt.Errorf("error reading DataPipeline \"%s\" parameter objects: %s", d.Id(), err.Error())
+	}
+
+	// Parameter Values
+	if err := d.Set("parameter_value", flattenParameterValues(r.ParameterValues)); err != nil {
+		return fmt.Errorf("error reading DataPipeline \"%s\" parameter values: %s", d.Id(), err.Error())
+	}
+
+	if err := flattenPipelineObjects(d, r.PipelineObjects); err != nil {
+		return fmt.Errorf("error reading DataPipeline \"%s\" pipeline object: %s", d.Id(), err.Error())
+	}
+
+	return nil
+}
+
+func resourceAwsDataPipelineDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).datapipelineconn
+
+	log.Printf("[DEBUG] DataPipeline  destroy: %s", d.Id())
+
+	opts := datapipeline.DeletePipelineInput{
+		PipelineId: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] DataPipeline destroy configuration: %v", opts)
+	_, err := conn.DeletePipeline(&opts)
+	if err != nil {
+		return fmt.Errorf("Error deleting Data Pipeline %s: %s", d.Id(), err.Error())
+	}
+
+	return waitForDataPipelineDeletion(conn, d.Id())
+}
+
+func resourceAwsDataPipelineRetrieve(id string, conn *datapipeline.DataPipeline) (*datapipeline.PipelineDescription, error) {
+	opts := datapipeline.DescribePipelinesInput{
+		PipelineIds: []*string{aws.String(id)},
+	}
+
+	log.Printf("[DEBUG] Data Pipeline describe configuration: %#v", opts)
+
+	resp, err := conn.DescribePipelines(&opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.PipelineDescriptionList) != 1 ||
+		*resp.PipelineDescriptionList[0].PipelineId != id {
+		if err != nil {
+			return nil, nil
+		}
+	}
+
+	return resp.PipelineDescriptionList[0], nil
+}
+
+func resourceAwsDataPipelineDefinitionRetrieve(id string, conn *datapipeline.DataPipeline) (*datapipeline.GetPipelineDefinitionOutput, error) {
+	opts := datapipeline.GetPipelineDefinitionInput{
+		PipelineId: aws.String(id),
+	}
+	log.Printf("[DEBUG] Data Pipeline describe configuration: %#v", opts)
+
+	resp, err := conn.GetPipelineDefinition(&opts)
+	if err != nil {
+		return nil, nil
+	}
+
+	return resp, nil
+}
+
+func flattenParameterObjects(objects []*datapipeline.ParameterObject) []map[string]interface{} {
+	parameterObjects := make([]map[string]interface{}, 0, len(objects))
+	for _, object := range objects {
+		var obj map[string]interface{}
+
+		obj["id"] = *object.Id
+		for _, attribute := range object.Attributes {
+			if *attribute.Key == "description" {
+				obj["description"] = *attribute.StringValue
+			}
+			if *attribute.Key == "optional" {
+				obj["optional"] = *attribute.StringValue
+			}
+			if *attribute.Key == "allowed_values" {
+				obj["type"] = *attribute.StringValue
+			}
+			if *attribute.Key == "default" {
+				obj["default"] = *attribute.StringValue
+			}
+			if *attribute.Key == "is_array" {
+				obj["is_array"] = *attribute.StringValue
+			}
+		}
+		parameterObjects = append(parameterObjects, obj)
+	}
+
+	return parameterObjects
+}
+
+func flattenParameterValues(objects []*datapipeline.ParameterValue) []map[string]interface{} {
+	parameterValues := make([]map[string]interface{}, 0, len(objects))
+
+	for _, object := range objects {
+		var obj map[string]interface{}
+		obj["id"] = *object.Id
+		obj["string_value"] = *object.StringValue
+
+		parameterValues = append(parameterValues, obj)
+	}
+	return parameterValues
+}
+
+func flattenPipelineObjects(d *schema.ResourceData, pipelineObjects []*datapipeline.PipelineObject) error {
+	var copyActivities, ec2Resources, rdsDatabases, s3DataNodes, sqlDataNodes, schedules []map[string]interface{}
+
+	for _, pipelineObject := range pipelineObjects {
+		for _, field := range pipelineObject.Fields {
+			if *field.Key == "type" {
+				switch *field.StringValue {
+				case "Default":
+					object, err := flattenDefaultPipelineObject(pipelineObject)
+					if err != nil {
+						return err
+					}
+					d.Set("default", object)
+				case "CopyActivity":
+					object, err := flattenCommonPipelineObject(pipelineObject)
+					if err != nil {
+						return err
+					}
+					copyActivities = append(copyActivities, object)
+				case "Ec2Resource":
+					object, err := flattenCommonPipelineObject(pipelineObject)
+					if err != nil {
+						return err
+					}
+					ec2Resources = append(ec2Resources, object)
+				case "RdsDatabase":
+					object, err := flattenCommonPipelineObject(pipelineObject)
+					if err != nil {
+						return err
+					}
+					rdsDatabases = append(rdsDatabases, object)
+				case "S3DataNode":
+					object, err := flattenCommonPipelineObject(pipelineObject)
+					if err != nil {
+						return err
+					}
+					s3DataNodes = append(s3DataNodes, object)
+				case "SqlDataNode":
+					object, err := flattenCommonPipelineObject(pipelineObject)
+					if err != nil {
+						return err
+					}
+					sqlDataNodes = append(sqlDataNodes, object)
+				case "Schedule":
+					object, err := flattenCommonPipelineObject(pipelineObject)
+					if err != nil {
+						return err
+					}
+					schedules = append(schedules, object)
+				}
+			}
+		}
+	}
+
+	if len(copyActivities) != 0 {
+		d.Set("copy_activity", copyActivities)
+	}
+
+	if len(ec2Resources) != 0 {
+		d.Set("ec2_resource", ec2Resources)
+	}
+
+	if len(rdsDatabases) != 0 {
+		d.Set("rds_database", rdsDatabases)
+	}
+
+	if len(s3DataNodes) != 0 {
+		d.Set("s3_data_node", s3DataNodes)
+	}
+
+	if len(sqlDataNodes) != 0 {
+		d.Set("sql_data_node", sqlDataNodes)
+	}
+
+	if len(schedules) != 0 {
+		d.Set("schedule", schedules)
+	}
+
+	return nil
+}
+
+func waitForDataPipelineDeletion(conn *datapipeline.DataPipeline, pipelineID string) error {
+	params := &datapipeline.DescribePipelinesInput{
+		PipelineIds: []*string{aws.String(pipelineID)},
+	}
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.DescribePipelines(params)
+		if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") || isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+			return nil
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("DataPipeline (%s) still exists", pipelineID))
+	})
+}

--- a/aws/resource_aws_datapipeline.go
+++ b/aws/resource_aws_datapipeline.go
@@ -1130,9 +1130,7 @@ func resourceAwsDataPipelineRetrieve(id string, conn *datapipeline.DataPipeline)
 
 	if len(resp.PipelineDescriptionList) != 1 ||
 		*resp.PipelineDescriptionList[0].PipelineId != id {
-		if err != nil {
-			return nil, nil
-		}
+		return nil, nil
 	}
 
 	return resp.PipelineDescriptionList[0], nil

--- a/aws/resource_aws_datapipeline.go
+++ b/aws/resource_aws_datapipeline.go
@@ -1153,7 +1153,7 @@ func resourceAwsDataPipelineDefinitionRetrieve(id string, conn *datapipeline.Dat
 func flattenParameterObjects(objects []*datapipeline.ParameterObject) []map[string]interface{} {
 	parameterObjects := make([]map[string]interface{}, 0, len(objects))
 	for _, object := range objects {
-		var obj map[string]interface{}
+		obj := make(map[string]interface{})
 
 		obj["id"] = *object.Id
 		for _, attribute := range object.Attributes {
@@ -1184,7 +1184,7 @@ func flattenParameterValues(objects []*datapipeline.ParameterValue) []map[string
 	parameterValues := make([]map[string]interface{}, 0, len(objects))
 
 	for _, object := range objects {
-		var obj map[string]interface{}
+		obj := make(map[string]interface{})
 		obj["id"] = aws.StringValue(object.Id)
 		obj["string_value"] = aws.StringValue(object.StringValue)
 

--- a/aws/resource_aws_datapipeline.go
+++ b/aws/resource_aws_datapipeline.go
@@ -1157,20 +1157,21 @@ func flattenParameterObjects(objects []*datapipeline.ParameterObject) []map[stri
 
 		obj["id"] = *object.Id
 		for _, attribute := range object.Attributes {
-			if *attribute.Key == "description" {
-				obj["description"] = *attribute.StringValue
+			attributeKey := aws.StringValue(attribute.Key)
+			if attributeKey == "description" {
+				obj["description"] = aws.StringValue(attribute.StringValue)
 			}
-			if *attribute.Key == "optional" {
-				obj["optional"] = *attribute.StringValue
+			if attributeKey == "optional" {
+				obj["optional"] = aws.StringValue(attribute.StringValue)
 			}
-			if *attribute.Key == "allowed_values" {
-				obj["type"] = *attribute.StringValue
+			if attributeKey == "allowed_values" {
+				obj["allowed_values"] = aws.StringValue(attribute.StringValue)
 			}
-			if *attribute.Key == "default" {
-				obj["default"] = *attribute.StringValue
+			if attributeKey == "default" {
+				obj["default"] = aws.StringValue(attribute.StringValue)
 			}
-			if *attribute.Key == "is_array" {
-				obj["is_array"] = *attribute.StringValue
+			if attributeKey == "is_array" {
+				obj["is_array"] = aws.StringValue(attribute.StringValue)
 			}
 		}
 		parameterObjects = append(parameterObjects, obj)
@@ -1184,8 +1185,8 @@ func flattenParameterValues(objects []*datapipeline.ParameterValue) []map[string
 
 	for _, object := range objects {
 		var obj map[string]interface{}
-		obj["id"] = *object.Id
-		obj["string_value"] = *object.StringValue
+		obj["id"] = aws.StringValue(object.Id)
+		obj["string_value"] = aws.StringValue(object.StringValue)
 
 		parameterValues = append(parameterValues, obj)
 	}
@@ -1197,8 +1198,8 @@ func flattenPipelineObjects(d *schema.ResourceData, pipelineObjects []*datapipel
 
 	for _, pipelineObject := range pipelineObjects {
 		for _, field := range pipelineObject.Fields {
-			if *field.Key == "type" {
-				switch *field.StringValue {
+			if aws.StringValue(field.Key) == "type" {
+				switch aws.StringValue(field.StringValue) {
 				case "Default":
 					object, err := flattenDefaultPipelineObject(pipelineObject)
 					if err != nil {

--- a/aws/resource_aws_datapipeline_test.go
+++ b/aws/resource_aws_datapipeline_test.go
@@ -1,0 +1,609 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+)
+
+func TestAccAWSDataPipeline_basic(t *testing.T) {
+	var conf datapipeline.PipelineDescription
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineExists("aws_datapipeline.foo", &conf),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "default.role", "aws_iam_role.role", "arn"),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "default.resource_role", "aws_iam_instance_profile.resource_role", "arn"),
+				),
+			},
+			{
+				ResourceName:      "aws_datapipeline.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipeline_copyActivity(t *testing.T) {
+	var conf datapipeline.PipelineDescription
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineConfig_copyActivity(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineExists("aws_datapipeline.foo", &conf),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "default.role", "aws_iam_role.role", "arn"),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "default.resource_role", "aws_iam_instance_profile.resource_role", "arn"),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "copy_activity.0.runs_on", "aws_datapipeline.foo", "ec2_resource.0.id"),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "rds_database.0.id", "aws_datapipeline.foo", "sql_data_node.0.database"),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "copy_activity.0.input", "aws_datapipeline.foo", "sql_data_node.0.id"),
+					resource.TestCheckResourceAttrPair(
+						"aws_datapipeline.foo", "copy_activity.0.output", "aws_datapipeline.foo", "s3_data_node.0.id"),
+					resource.TestCheckResourceAttr("aws_datapipeline.foo", "tags.%", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_datapipeline.foo", "tags.NAME", "tf-datapipeline-test"),
+					resource.TestCheckResourceAttr(
+						"aws_datapipeline.foo", "tags.ENV", "test"),
+				),
+			},
+			{
+				ResourceName:      "aws_datapipeline.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDataPipeline_disappears(t *testing.T) {
+	var conf datapipeline.PipelineDescription
+	rName := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDataPipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataPipelineConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDataPipelineExists("aws_datapipeline.foo", &conf),
+					testAccCheckAWSDataPipelineDisappears(&conf),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDataPipelineDisappears(conf *datapipeline.PipelineDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+		params := &datapipeline.DeletePipelineInput{
+			PipelineId: conf.PipelineId,
+		}
+
+		_, err := conn.DeletePipeline(params)
+		if err != nil {
+			return err
+		}
+		return waitForDataPipelineDeletion(conn, *conf.PipelineId)
+	}
+}
+
+func testAccCheckAWSDataPipelineDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_datapipeline" {
+			continue
+		}
+		// Try to find the Pipeline
+		var err error
+		resp, err := conn.DescribePipelines(
+			&datapipeline.DescribePipelinesInput{
+				PipelineIds: []*string{aws.String(rs.Primary.ID)},
+			})
+
+		if err != nil {
+			if isAWSErr(err, datapipeline.ErrCodePipelineNotFoundException, "") {
+				continue
+			} else if isAWSErr(err, datapipeline.ErrCodePipelineDeletedException, "") {
+				continue
+			}
+			return err
+		}
+		if len(resp.PipelineDescriptionList) != 0 &&
+			*resp.PipelineDescriptionList[0].PipelineId == rs.Primary.ID {
+			return fmt.Errorf("Pipeline still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDataPipelineExists(n string, v *datapipeline.PipelineDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DataPipeline ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).datapipelineconn
+
+		opts := &datapipeline.DescribePipelinesInput{
+			PipelineIds: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		resp, err := conn.DescribePipelines(opts)
+		if err != nil {
+			return err
+		}
+		if len(resp.PipelineDescriptionList) != 1 ||
+			*resp.PipelineDescriptionList[0].PipelineId != rs.Primary.ID {
+			return fmt.Errorf("DataPipeline not found")
+		}
+
+		*v = *resp.PipelineDescriptionList[0]
+		return nil
+	}
+}
+
+func testAccAWSDataPipelineConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+	name = "tf-test-datapipeline-role-%s"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"elasticmapreduce.amazonaws.com",
+					"datapipeline.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "role" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:DescribeObjects",
+				"datapipeline:EvaluateExpression",
+				"dynamodb:BatchGetItem",
+				"dynamodb:DescribeTable",
+				"dynamodb:GetItem",
+				"dynamodb:Query",
+				"dynamodb:Scan",
+				"dynamodb:UpdateTable",
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:CancelSpotInstanceRequests",
+				"ec2:CreateSecurityGroup",
+				"ec2:CreateTags",
+				"ec2:DeleteTags",
+				"ec2:Describe*",
+				"ec2:ModifyImageAttribute",
+				"ec2:ModifyInstanceAttribute",
+				"ec2:RequestSpotInstances",
+				"ec2:RunInstances",
+				"ec2:StartInstances",
+				"ec2:StopInstances",
+				"ec2:TerminateInstances",
+				"ec2:AuthorizeSecurityGroupEgress", 
+				"ec2:DeleteSecurityGroup", 
+				"ec2:RevokeSecurityGroupEgress", 
+				"ec2:DescribeNetworkInterfaces", 
+				"ec2:CreateNetworkInterface", 
+				"ec2:DeleteNetworkInterface", 
+				"ec2:DetachNetworkInterface",
+				"elasticmapreduce:*",
+				"iam:GetInstanceProfile",
+				"iam:GetRole",
+				"iam:GetRolePolicy",
+				"iam:ListAttachedRolePolicies",
+				"iam:ListRolePolicies",
+				"iam:ListInstanceProfiles",
+				"iam:PassRole",
+				"rds:DescribeDBInstances",
+				"rds:DescribeDBSecurityGroups",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:CreateBucket",
+				"s3:DeleteObject",
+				"s3:Get*",
+				"s3:List*",
+				"s3:Put*",
+				"sdb:BatchPutAttributes",
+				"sdb:Select*",
+				"sns:GetTopicAttributes",
+				"sns:ListTopics",
+				"sns:Publish",
+				"sns:Subscribe",
+				"sns:Unsubscribe",
+				"sqs:CreateQueue", 
+				"sqs:Delete*", 
+				"sqs:GetQueue*", 
+				"sqs:PurgeQueue", 
+				"sqs:ReceiveMessage" 
+			],
+			"Resource": "*"
+		},
+		{
+			"Effect": "Allow",
+			"Action": "iam:CreateServiceLinkedRole",
+			"Resource": "*",
+			"Condition": {
+			  "StringLike": {
+				  "iam:AWSServiceName": ["elasticmapreduce.amazonaws.com","spot.amazonaws.com"]
+			  }
+			}
+		}
+	]
+}
+POLICY
+}
+
+
+
+resource "aws_iam_role" "resource_role" {
+	name = "tf-test-datapipeline-resource-role-%s"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"ec2.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "resource_role" {
+	name = "tf-test-datapipeline-resource-role-profile-%s"
+	role = "${aws_iam_role.resource_role.name}"
+}
+
+resource "aws_iam_role_policy" "resource_role" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.resource_role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:*",
+				"dynamodb:*",
+				"ec2:Describe*",
+				"elasticmapreduce:AddJobFlowSteps",
+				"elasticmapreduce:Describe*",
+				"elasticmapreduce:ListInstance*",
+				"rds:Describe*",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:*",
+				"sdb:*",
+				"sns:*",
+				"sqs:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+
+resource "aws_datapipeline" "foo" {
+	name      = "tf-datapipeline-%s"
+
+	default {
+		schedule_type          = "ondemand"
+		failure_and_rerun_mode = "cascade"
+		role                   = "${aws_iam_role.role.arn}"
+		resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+	}
+}`, rName, rName, rName, rName, rName, rName)
+
+}
+
+func testAccAWSDataPipelineConfig_copyActivity(rName string) string {
+	return fmt.Sprintf(`
+
+resource "aws_iam_role" "role" {
+	name = "tf-test-datapipeline-role-%s"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service":[
+					"elasticmapreduce.amazonaws.com",
+					"datapipeline.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "role" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:DescribeObjects",
+				"datapipeline:EvaluateExpression",
+				"dynamodb:BatchGetItem",
+				"dynamodb:DescribeTable",
+				"dynamodb:GetItem",
+				"dynamodb:Query",
+				"dynamodb:Scan",
+				"dynamodb:UpdateTable",
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:CancelSpotInstanceRequests",
+				"ec2:CreateSecurityGroup",
+				"ec2:CreateTags",
+				"ec2:DeleteTags",
+				"ec2:Describe*",
+				"ec2:ModifyImageAttribute",
+				"ec2:ModifyInstanceAttribute",
+				"ec2:RequestSpotInstances",
+				"ec2:RunInstances",
+				"ec2:StartInstances",
+				"ec2:StopInstances",
+				"ec2:TerminateInstances",
+				"ec2:AuthorizeSecurityGroupEgress", 
+				"ec2:DeleteSecurityGroup", 
+				"ec2:RevokeSecurityGroupEgress", 
+				"ec2:DescribeNetworkInterfaces", 
+				"ec2:CreateNetworkInterface", 
+				"ec2:DeleteNetworkInterface", 
+				"ec2:DetachNetworkInterface",
+				"elasticmapreduce:*",
+				"iam:GetInstanceProfile",
+				"iam:GetRole",
+				"iam:GetRolePolicy",
+				"iam:ListAttachedRolePolicies",
+				"iam:ListRolePolicies",
+				"iam:ListInstanceProfiles",
+				"iam:PassRole",
+				"rds:DescribeDBInstances",
+				"rds:DescribeDBSecurityGroups",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:CreateBucket",
+				"s3:DeleteObject",
+				"s3:Get*",
+				"s3:List*",
+				"s3:Put*",
+				"sdb:BatchPutAttributes",
+				"sdb:Select*",
+				"sns:GetTopicAttributes",
+				"sns:ListTopics",
+				"sns:Publish",
+				"sns:Subscribe",
+				"sns:Unsubscribe",
+				"sqs:CreateQueue", 
+				"sqs:Delete*", 
+				"sqs:GetQueue*", 
+				"sqs:PurgeQueue", 
+				"sqs:ReceiveMessage" 
+			],
+			"Resource": "*"
+		},
+		{
+			"Effect": "Allow",
+			"Action": "iam:CreateServiceLinkedRole",
+			"Resource": "*",
+			"Condition": {
+			  "StringLike": {
+				  "iam:AWSServiceName": ["elasticmapreduce.amazonaws.com","spot.amazonaws.com"]
+			  }
+			}
+		}
+	]
+}
+POLICY
+}
+
+
+
+resource "aws_iam_role" "resource_role" {
+	name = "tf-test-datapipeline-resource-role-%s"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"ec2.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "resource_role" {
+	name = "tf-test-datapipeline-resource-role-profile-%s"
+	role = "${aws_iam_role.resource_role.name}"
+}
+
+resource "aws_iam_role_policy" "resource_role" {
+	name = "tf-test-transfer-user-iam-policy-%s"
+	role = "${aws_iam_role.resource_role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:*",
+				"dynamodb:*",
+				"ec2:Describe*",
+				"elasticmapreduce:AddJobFlowSteps",
+				"elasticmapreduce:Describe*",
+				"elasticmapreduce:ListInstance*",
+				"rds:Describe*",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:*",
+				"sdb:*",
+				"sns:*",
+				"sqs:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+
+resource "aws_datapipeline" "foo" {
+	name      = "tf-datapipeline-%s"
+
+	default {
+		schedule_type          = "cron"
+		schedule			   = "TestHourlySchedule"
+		failure_and_rerun_mode = "cascade"
+		role                   = "${aws_iam_role.role.arn}"
+		resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+	}
+
+	copy_activity {
+		id = "TestCopyActivity"
+		name = "TestCopyActivity"
+		schedule = "TestDailySchedule"
+		runs_on = "TestEC2Resource"
+		depends_on = "TestEC2Resource"
+		input = "TestInputSqlDataNode"
+		output = "TestOutputS3DataNode"
+	}
+
+	ec2_resource {
+		id            = "TestEC2Resource"
+		name          = "TestEC2Resource"
+		instance_type = "t1.small"
+
+		associate_public_ip_address = true
+	}
+
+	rds_database {
+		id = "TestInputRdsDatabase"
+		name = "TestInputRdsDatabase"
+		rds_instance_id = "my_db_instance_identifier"
+		username = "test"
+		password = "test"
+		database_name = "test"
+	}
+
+	sql_data_node {
+		id = "TestInputSqlDataNode"
+		name = "TestInputSqlDataNode"
+		database = "TestInputRdsDatabase"
+		table = "test"
+		select_query = "SELECT * FROM #{table}"
+	}
+
+	s3_data_node {
+		id = "TestOutputS3DataNode"
+		name = "TestOutputS3DataNode"
+		compression = "gzip"
+		file_path = "s3://my-bucket/output/my-key-for-file"
+	}
+
+	schedule {
+		id 				= "TestDailySchedule"
+		name			= "TestDailySchedule"
+		period			= "1 Day"
+		start_date_time = "2019-01-01T00:00:00"
+		end_date_time 	= "2019-09-01T00:00:00"
+	}
+
+	tags {
+		NAME = "tf-datapipeline-test"
+		ENV  = "test"
+	}
+}
+	`, rName, rName, rName, rName, rName, rName)
+}

--- a/aws/tagsDataPipeline.go
+++ b/aws/tagsDataPipeline.go
@@ -20,7 +20,7 @@ func setTagsDataPipeline(conn *datapipeline.DataPipeline, d *schema.ResourceData
 		// Set tags
 		if len(remove) > 0 {
 			log.Printf("[DEBUG] Removing tags: %#v", remove)
-			k := make([]*string, len(remove), len(remove))
+			k := make([]*string, len(remove))
 			for i, t := range remove {
 				k[i] = t.Key
 			}
@@ -102,7 +102,7 @@ func tagIgnoredDataPipeline(t *datapipeline.Tag) bool {
 	filter := []string{"^aws:"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
-		if r, _ := regexp.MatchString(v, aws.StringValue(t.Key)); r == true {
+		if r, _ := regexp.MatchString(v, aws.StringValue(t.Key)); r {
 			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
 			return true
 		}

--- a/aws/tagsDataPipeline.go
+++ b/aws/tagsDataPipeline.go
@@ -1,0 +1,111 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsDataPipeline(conn *datapipeline.DataPipeline, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsDataPipeline(tagsFromMapDataPipeline(o), tagsFromMapDataPipeline(n))
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove), len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+			_, err := conn.RemoveTags(&datapipeline.RemoveTagsInput{
+				PipelineId: aws.String(d.Id()),
+				TagKeys:    k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.AddTags(&datapipeline.AddTagsInput{
+				PipelineId: aws.String(d.Id()),
+				Tags:       create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsDataPipeline(oldTags, newTags []*datapipeline.Tag) ([]*datapipeline.Tag, []*datapipeline.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+	// Build the list of what to remove
+	var remove []*datapipeline.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+	return tagsFromMapDataPipeline(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapDataPipeline(m map[string]interface{}) []*datapipeline.Tag {
+	var result []*datapipeline.Tag
+	for k, v := range m {
+		t := &datapipeline.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredDataPipeline(t) {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapDataPipeline(ts []*datapipeline.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredDataPipeline(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredDataPipeline(t *datapipeline.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		if r, _ := regexp.MatchString(v, aws.StringValue(t.Key)); r == true {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsDataPipeline_test.go
+++ b/aws/tagsDataPipeline_test.go
@@ -1,0 +1,108 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/datapipeline"
+)
+
+func TestDiffTagsDataPipeline(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+	for i, tc := range cases {
+		c, r := diffTagsDataPipeline(tagsFromMapDataPipeline(tc.Old), tagsFromMapDataPipeline(tc.New))
+		cm := tagsToMapDataPipeline(c)
+		rm := tagsToMapDataPipeline(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+func TestIgnoringTagsDataPipeline(t *testing.T) {
+	var ignoredTags []*datapipeline.Tag
+	ignoredTags = append(ignoredTags, &datapipeline.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &datapipeline.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredDataPipeline(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -938,6 +938,17 @@
                 </li>
 
                 <li>
+                    <a href="#">DataPipeline Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/datapipeline.html">aws_datapipeline</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
                     <a href="#">DataSync Resources</a>
                     <ul class="nav">
 

--- a/website/docs/r/datapipeline.html.markdown
+++ b/website/docs/r/datapipeline.html.markdown
@@ -1,0 +1,624 @@
+---
+layout: "aws"
+page_title: "AWS: aws_datapipeline"
+sidebar_current: "docs-aws-resource-datapipeline"
+description: |-
+  Provides a AWS DataPipeline.
+---
+
+# aws_datapipeline
+
+Provides a Data Pipeline resource.
+
+## Example Usage
+
+### Create Pipeline Only
+
+```hcl
+resource "aws_iam_role" "role" {
+	name = "tf-test-datapipeline-role"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"elasticmapreduce.amazonaws.com",
+					"datapipeline.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "role" {
+	name = "tf-test-transfer-user-iam-policy"
+	role = "${aws_iam_role.role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:DescribeObjects",
+				"datapipeline:EvaluateExpression",
+				"dynamodb:BatchGetItem",
+				"dynamodb:DescribeTable",
+				"dynamodb:GetItem",
+				"dynamodb:Query",
+				"dynamodb:Scan",
+				"dynamodb:UpdateTable",
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:CancelSpotInstanceRequests",
+				"ec2:CreateSecurityGroup",
+				"ec2:CreateTags",
+				"ec2:DeleteTags",
+				"ec2:Describe*",
+				"ec2:ModifyImageAttribute",
+				"ec2:ModifyInstanceAttribute",
+				"ec2:RequestSpotInstances",
+				"ec2:RunInstances",
+				"ec2:StartInstances",
+				"ec2:StopInstances",
+				"ec2:TerminateInstances",
+				"ec2:AuthorizeSecurityGroupEgress", 
+				"ec2:DeleteSecurityGroup", 
+				"ec2:RevokeSecurityGroupEgress", 
+				"ec2:DescribeNetworkInterfaces", 
+				"ec2:CreateNetworkInterface", 
+				"ec2:DeleteNetworkInterface", 
+				"ec2:DetachNetworkInterface",
+				"elasticmapreduce:*",
+				"iam:GetInstanceProfile",
+				"iam:GetRole",
+				"iam:GetRolePolicy",
+				"iam:ListAttachedRolePolicies",
+				"iam:ListRolePolicies",
+				"iam:ListInstanceProfiles",
+				"iam:PassRole",
+				"rds:DescribeDBInstances",
+				"rds:DescribeDBSecurityGroups",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:CreateBucket",
+				"s3:DeleteObject",
+				"s3:Get*",
+				"s3:List*",
+				"s3:Put*",
+				"sdb:BatchPutAttributes",
+				"sdb:Select*",
+				"sns:GetTopicAttributes",
+				"sns:ListTopics",
+				"sns:Publish",
+				"sns:Subscribe",
+				"sns:Unsubscribe",
+				"sqs:CreateQueue", 
+				"sqs:Delete*", 
+				"sqs:GetQueue*", 
+				"sqs:PurgeQueue", 
+				"sqs:ReceiveMessage" 
+			],
+			"Resource": "*"
+		},
+		{
+			"Effect": "Allow",
+			"Action": "iam:CreateServiceLinkedRole",
+			"Resource": "*",
+			"Condition": {
+			  "StringLike": {
+				  "iam:AWSServiceName": ["elasticmapreduce.amazonaws.com","spot.amazonaws.com"]
+			  }
+			}
+		}
+	]
+}
+POLICY
+}
+
+
+
+resource "aws_iam_role" "resource_role" {
+	name = "tf-test-datapipeline-resource-role"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"ec2.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "resource_role" {
+	name = "tf-test-datapipeline-resource-role-profile"
+	role = "${aws_iam_role.resource_role.name}"
+}
+
+resource "aws_iam_role_policy" "resource_role" {
+	name = "tf-test-transfer-user-iam-policy"
+	role = "${aws_iam_role.resource_role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:*",
+				"dynamodb:*",
+				"ec2:Describe*",
+				"elasticmapreduce:AddJobFlowSteps",
+				"elasticmapreduce:Describe*",
+				"elasticmapreduce:ListInstance*",
+				"rds:Describe*",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:*",
+				"sdb:*",
+				"sns:*",
+				"sqs:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+
+resource "aws_datapipeline" "foo" {
+	name      = "tf-datapipeline-%s"
+
+	default {
+		schedule_type          = "ondemand"
+		failure_and_rerun_mode = "cascade"
+		role                   = "${aws_iam_role.role.arn}"
+		resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+	}
+}
+```
+
+### Create Copy Activity Pipeline
+
+```hcl
+resource "aws_iam_role" "role" {
+	name = "tf-test-datapipeline-role"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service":[
+					"elasticmapreduce.amazonaws.com",
+					"datapipeline.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "role" {
+	name = "tf-test-transfer-user-iam-policy"
+	role = "${aws_iam_role.role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:DescribeObjects",
+				"datapipeline:EvaluateExpression",
+				"dynamodb:BatchGetItem",
+				"dynamodb:DescribeTable",
+				"dynamodb:GetItem",
+				"dynamodb:Query",
+				"dynamodb:Scan",
+				"dynamodb:UpdateTable",
+				"ec2:AuthorizeSecurityGroupIngress",
+				"ec2:CancelSpotInstanceRequests",
+				"ec2:CreateSecurityGroup",
+				"ec2:CreateTags",
+				"ec2:DeleteTags",
+				"ec2:Describe*",
+				"ec2:ModifyImageAttribute",
+				"ec2:ModifyInstanceAttribute",
+				"ec2:RequestSpotInstances",
+				"ec2:RunInstances",
+				"ec2:StartInstances",
+				"ec2:StopInstances",
+				"ec2:TerminateInstances",
+				"ec2:AuthorizeSecurityGroupEgress", 
+				"ec2:DeleteSecurityGroup", 
+				"ec2:RevokeSecurityGroupEgress", 
+				"ec2:DescribeNetworkInterfaces", 
+				"ec2:CreateNetworkInterface", 
+				"ec2:DeleteNetworkInterface", 
+				"ec2:DetachNetworkInterface",
+				"elasticmapreduce:*",
+				"iam:GetInstanceProfile",
+				"iam:GetRole",
+				"iam:GetRolePolicy",
+				"iam:ListAttachedRolePolicies",
+				"iam:ListRolePolicies",
+				"iam:ListInstanceProfiles",
+				"iam:PassRole",
+				"rds:DescribeDBInstances",
+				"rds:DescribeDBSecurityGroups",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:CreateBucket",
+				"s3:DeleteObject",
+				"s3:Get*",
+				"s3:List*",
+				"s3:Put*",
+				"sdb:BatchPutAttributes",
+				"sdb:Select*",
+				"sns:GetTopicAttributes",
+				"sns:ListTopics",
+				"sns:Publish",
+				"sns:Subscribe",
+				"sns:Unsubscribe",
+				"sqs:CreateQueue", 
+				"sqs:Delete*", 
+				"sqs:GetQueue*", 
+				"sqs:PurgeQueue", 
+				"sqs:ReceiveMessage" 
+			],
+			"Resource": "*"
+		},
+		{
+			"Effect": "Allow",
+			"Action": "iam:CreateServiceLinkedRole",
+			"Resource": "*",
+			"Condition": {
+			  "StringLike": {
+				  "iam:AWSServiceName": ["elasticmapreduce.amazonaws.com","spot.amazonaws.com"]
+			  }
+			}
+		}
+	]
+}
+POLICY
+}
+
+
+
+resource "aws_iam_role" "resource_role" {
+	name = "tf-test-datapipeline-resource-role"
+	  
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Service": [
+					"ec2.amazonaws.com"
+				]
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "resource_role" {
+	name = "tf-test-datapipeline-resource-role-profile"
+	role = "${aws_iam_role.resource_role.name}"
+}
+
+resource "aws_iam_role_policy" "resource_role" {
+	name = "tf-test-transfer-user-iam-policy"
+	role = "${aws_iam_role.resource_role.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowFullAccesstoS3",
+			"Effect": "Allow",
+			"Action": [
+				"cloudwatch:*",
+				"datapipeline:*",
+				"dynamodb:*",
+				"ec2:Describe*",
+				"elasticmapreduce:AddJobFlowSteps",
+				"elasticmapreduce:Describe*",
+				"elasticmapreduce:ListInstance*",
+				"rds:Describe*",
+				"redshift:DescribeClusters",
+				"redshift:DescribeClusterSecurityGroups",
+				"s3:*",
+				"sdb:*",
+				"sns:*",
+				"sqs:*"
+			],
+			"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+
+resource "aws_datapipeline" "foo" {
+	name      = "tf-datapipeline"
+
+	default {
+		schedule_type          = "cron"
+		schedule			   = "TestHourlySchedule"
+		failure_and_rerun_mode = "cascade"
+		role                   = "${aws_iam_role.role.arn}"
+		resource_role          = "${aws_iam_instance_profile.resource_role.arn}"
+	}
+
+	copy_activity {
+		id = "TestCopyActivity"
+		name = "TestCopyActivity"
+		schedule = "TestDailySchedule"
+		runs_on = "TestEC2Resource"
+		depends_on = "TestEC2Resource"
+		input = "TestInputSqlDataNode"
+		output = "TestOutputS3DataNode"
+	}
+
+	ec2_resource {
+		id            = "TestEC2Resource"
+		name          = "TestEC2Resource"
+		instance_type = "t1.small"
+
+		associate_public_ip_address = true
+	}
+
+	rds_database {
+		id = "TestInputRdsDatabase"
+		name = "TestInputRdsDatabase"
+		rds_instance_id = "my_db_instance_identifier"
+		username = "test"
+		password = "test"
+		database_name = "test"
+	}
+
+	sql_data_node {
+		id = "TestInputSqlDataNode"
+		name = "TestInputSqlDataNode"
+		database = "TestInputRdsDatabase"
+		table = "test"
+		select_query = "SELECT * FROM #{table}"
+	}
+
+	s3_data_node {
+		id = "TestOutputS3DataNode"
+		name = "TestOutputS3DataNode"
+		compression = "gzip"
+		file_path = "s3://my-bucket/output/my-key-for-file"
+	}
+
+	schedule {
+		id 				= "TestDailySchedule"
+		name			= "TestDailySchedule"
+		period			= "1 Day"
+		start_date_time = "2019-01-01T00:00:00"
+		end_date_time 	= "2019-09-01T00:00:00"
+	}
+
+	tags {
+		NAME = "tf-datapipeline-test"
+		ENV  = "test"
+	}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of Pipeline.
+* `description` - (Optional) The description of Pipeline.
+* `default` - (Required) The default configuration (documented below).
+* `copy_activity` - (Optional) The activity configuration to CopyActivity (documented below).
+* `ec2_resource` - (Optional) The resource configuration to EC2 (documented below).
+* `rds_database` - (Optional) The database configuration to RDS (documented below).
+* `s3_data_node` - (Optional) The data node configuration to S3 (documented below).
+* `sql_data_node` - (Optional) The data node configuration to SQL (documented below).
+* `schedule` - (Optional) The schedule configuration (documented below).
+* `parameter_object` - (Optional) The Parameter Object configuration (documented below).
+* `parameter_value` - (Optional) The Parameter Value configuration (documented below).
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `default` resource configuration supports the following:
+
+* `schedule_type` - (Required) The string of schedule type. Supported values are `cron`, `ondemand` and `timeseries`.
+* `failure_and_rerun_mode` - (Optional) Describes consumer node behavior when dependencies fail or are rerun. Supported values are `cascade` and `none`. Default value is `none`.
+* `pipeline_log_uri` - (Optional) The s3 URI for uploading logs for the pipeline.  (such as `s3://BucketName/Key/`) 
+* `role` - (Required) The IAM role that AWS Data Pipeline uses to create the EC2 instance.
+* `resource_role` - (Required) The IAM role that controls the resources that the Amazon EC2 instance can access.	
+* `schedule` - (Optional) This object is invoked within the execution of a schedule interval.
+
+The `copy_activity` activity configuration supports the following:
+For more information, see the [AWS Data Pipeline CopyActivity Guide](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-copyactivity.html).
+
+* `id` - (Required) Specifies unique identifier for each Pipeline Object.
+* `name` - (Required) The name of pipeline object.
+* `schedule` - (Optional) This object is invoked within the execution of a schedule interval.
+* `runs_on` - (Required) The computational resource to run the activity or command. For example, an Amazon EC2 instance or Amazon EMR cluster.
+* `worker_group` - (Optional) The worker group. This is used for routing tasks. If you provide a `runs_on` value and `worker_group` exists, `worker_group` is ignored.
+* `attempt_status` - (Optional) Most recently reported status from the remote activity.
+* `attempt_timeout` - (Optional) Timeout for remote work completion. If set then a remote activity that does not complete within the set time of starting may be retried.
+* `depends_on` - (Optional) Specify dependency on another runnable object.	
+* `failure_and_rerun_mode` - (Optional) Describes consumer node behavior when dependencies fail or are rerun.
+* `input` - (Optional) The input data source.
+* `late_after_timeout` - (Optional) The elapsed time after pipeline start within which the object must start. It is triggered only when the schedule type is not set to `ondemand`.
+* `max_active_instances` - (Optional) The maximum number of concurrent active instances of a component. Re-runs do not count toward the number of active instances.
+* `maximum_retries` - (Optional) Maximum number attempt retries on failure.
+* `on_fail` - (Optional) An action to run when current object fails.
+* `on_late_action` - (Optional) Actions that should be triggered if an object has not yet been scheduled or still not completed.
+* `on_success` - (Optional) An action to run when current object succeeds.
+* `output` - (Optional) The output data source.
+* `parent` - (Optional) Parent of the current object from which slots will be inherited.
+* `pipeline_log_uri` - (Optional) The s3 URI for uploading logs for the pipeline.  (such as `s3://BucketName/Key/`) 
+* `precondition` - (Optional) A data node is not marked `READY` until all preconditions have been met.
+* `report_progress_timeout` - (Optional) Timeout for remote work successive calls to reportProgress. If set, then remote activities that do not report progress for the specified period may be considered stalled and so retried.
+* `retry_delay` - (Optional) The timeout duration between two retry attempts.
+* `schedule_type` - (Optional) The string of schedule type. Supported values are `cron`, `ondemand` and `timeseries`.
+
+The `ec2_resource` resource configuration supports the following:
+For more information, see the [AWS Data Pipeline Ec2Resource Guide](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-ec2resource.html).
+
+* `id` - (Required) Specifies unique identifier for each Pipeline Object.
+* `name` - (Required) The name of pipeline object.
+* `action_on_resource_failure` - (Optional) The action taken after a resource failure for this resource. Valid values are `retryall` and `retrynone`.
+* `action_on_task_failure` - (Optional) The action taken after a task failure for this resource. Valid values are `continue` or `terminate`.	
+* `associate_public_ip_address` - (Optional) ndicates whether to assign a public IP address to the instance. If the instance is in Amazon EC2 or Amazon VPC, the default value is `true`. Otherwise, the default value is `false`.
+* `attempt_status` - (Optional) Most recently reported status from the remote activity.
+* `attempt_timeout` - (Optional) Timeout for remote work completion. If set then a remote activity that does not complete within the set time of starting may be retried.
+* `availability_zone` - (Optional) The Availability Zone in which to launch the Amazon EC2 instance.
+* `image_id` - (Optional) The ID of the AMI to use for the instance. By default, AWS Data Pipeline uses the HVM AMI virtualization type. [The specific AMI IDs used are based on a Region.](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-ec2resource.html)
+* `init_timeout` - (Optional) The amount of time to wait for the resource to start.	
+* `instance_type` - (Optional)  For more information, see the [Supported Instance Types for Pipeline Work Activities](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-supported-instance-types.html) 
+* `key_pair` - (Optional) The name of the key pair. If you launch an Amazon EC2 instance without specifying a key pair, you cannot log on to it.	
+* `late_after_timeout` - (Optional) The elapsed time after pipeline start within which the object must start. It is triggered only when the schedule type is not set to `ondemand`.	
+* `max_active_instances` - (Optional) The maximum number of concurrent active instances of a component. Re-runs do not count toward the number of active instances.
+* `maximum_retries` - (Optional) The maximum number of attempt retries on failure.	
+* `on_fail` - (Optional) An action to run when current object fails.
+* `on_late_action` - (Optional) Actions that should be triggered if an object has not yet been scheduled or still not completed.
+* `on_success` - (Optional) An action to run when current object succeeds.
+* `pipeline_log_uri` - (Optional) The s3 URI for uploading logs for the pipeline.  (such as `s3://BucketName/Key/`) 
+* `region` - (Optional) The code for the Region in which the Amazon EC2 instance should run. By default, the instance runs in the same Region as the pipeline.
+* `schedule_type` - (Optional) The string of schedule type. Supported values are `cron`, `ondemand` and `timeseries`.
+* `security_group_ids` - (Optional) The IDs of one or more Amazon EC2 security groups to use for the instances in the resource pool.
+* `security_groups` - (Optional) One or more Amazon EC2 security groups to use for the instances in the resource pool.
+* `spot_bid_price` - (Optional) The maximum amount per hour for your Spot Instance in dollars, which is a decimal value between `0` and `20.00`, exclusive.
+* `subnet_id` - (Optional) The ID of the Amazon EC2 subnet in which to start the instance.	
+* `terminate_after` - (Optional) The number of hours after which to terminate the resource.
+* `use_on_demand_on_last_attempt` - (Optional) On the last attempt to request a Spot Instance, make a request for On-Demand Instances rather than a Spot Instance.
+
+The `rds_database` resource configuration supports the following:
+For more information, see the [AWS Data Pipeline RdsDatabase Guide](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-rdsdatabase.html).
+
+* `id` - (Required) Specifies unique identifier for each Pipeline Object.
+* `name` - (Required) The name of pipeline object.
+* `username` - (Required) The name of database user to access.
+* `password` - (Required) The password of database user to access.
+* `rds_instance_id` - (Required) The identifier of the DB instance.
+* `database_name` - (Optional) The name of logical database to attach.
+* `jdbc_driver_jar_uri` - (Optional) The location in Amazon S3 of the JDBC driver JAR file used to connect to the database. For the `MySQL` and `PostgreSQL` engines, the default driver is used if this field is not specified, but you can override the default using this field. For the `Oracle` and `SQL Server` engines, this field is required.
+* `jdbc_properties` - (Optional) Pairs of the form A=B that will be set as properties on JDBC connections for this database.
+* `parent` - (Optional) Parent of the current object from which slots will be inherited.
+* `region` - (Optional) The code for the region where the database exists. 
+
+The `s3_data_node` data node configuration supports the following:
+For more information, see the [AWS Data Pipeline S3DataNode Guide](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-s3datanode.html).
+
+* `id` - (Required) Specifies unique identifier for each Pipeline Object.
+* `name` - (Required) The name of pipeline object.
+* `compression` - (Optional) The type of compression for the data described by the S3DataNode. `none` is no compression and `gzip` is compressed with the gzip algorithm. This field is only supported for use with Amazon Redshift and when you use S3DataNode with CopyActivity.
+* `data_format` - (Optional) DataFormat for the data described by this S3DataNode.
+* `depends_on` - (Optional) Specify dependency on another runnable object.
+* `directory_path` - (Optional) Amazon S3 directory path as a URI: s3://my-bucket/my-key-for-directory. You must provide either a filePath or directoryPath value.
+* `failure_and_rerun_mode` - (Optional) Describes consumer node behavior when dependencies fail or are rerun. Supported values are `cascade` and `none`. Default value is `none`.
+* `file_path` - (Optional) The path to the object in Amazon S3 as a URI, for example: s3://my-bucket/my-key-for-file. You must provide either a filePath or directoryPath value. These represent a folder and a file name. Use the directoryPath value to accommodate multiple files in a directory.
+* `late_after_timeout` - (Optional) The elapsed time after pipeline start within which the object must start. It is triggered only when the schedule type is not set to `ondemand`.
+* `manifest_file_path` - (Optional) The Amazon S3 path to a manifest file in the format supported by Amazon Redshift. AWS Data Pipeline uses the manifest file to copy the specified Amazon S3 files into the table. This field is valid only when a RedShiftCopyActivity references the S3DataNode.
+* `max_active_instances` - (Optional) The maximum number of concurrent active instances of a component. Re-runs do not count toward the number of active instances.
+* `maximum_retries` - (Optional) Maximum number attempt retries on failure.
+* `on_fail` - (Optional) An action to run when current object fails.
+* `on_late_action` - (Optional) Actions that should be triggered if an object has not yet been scheduled or still not completed.
+* `on_success` - (Optional) An action to run when current object succeeds.
+* `parent` - (Optional) Parent of the current object from which slots will be inherited.
+* `pipeline_log_uri` - (Optional) The s3 URI for uploading logs for the pipeline.  (such as `s3://BucketName/Key/`) 
+* `precondition` - (Optional) A data node is not marked `READY` until all preconditions have been met.
+* `report_progress_timeout` - (Optional) Timeout for remote work successive calls to reportProgress. If set, then remote activities that do not report progress for the specified period may be considered stalled and so retried.
+* `retry_delay` - (Optional) The timeout duration between two retry attempts.
+* `runs_on` - (Required) The computational resource to run the activity or command. For example, an Amazon EC2 instance or Amazon EMR cluster.
+* `s3_encryption_type` - (Optional) Overrides the Amazon S3 encryption type. Values are `SERVER_SIDE_ENCRYPTION` or `NONE`. Server-side encryption is enabled by default.
+* `schedule_type` - (Optional) The string of schedule type. Supported values are `cron`, `ondemand` and `timeseries`.
+* `worker_group` - (Optional) The worker group. This is used for routing tasks. If you provide a `runs_on` value and `worker_group` exists, `worker_group` is ignored.
+
+The `sql_data_node` data node configuration supports the following:
+For more information, see the [AWS Data Pipeline SqlDataNode Guide](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-sqldatanode.html).
+
+* `id` - (Required) Specifies unique identifier for each Pipeline Object.
+* `name` - (Required) The name of pipeline object.
+* `table` - (Required) The name of the table in the SQL database.
+* `create_table_sql` - (Optional) An SQL create table expression that creates the table.
+* `database` - (Optional) The name of the database.
+* `depends_on` - (Optional) Specify dependency on another runnable object.
+* `failure_and_rerun_mode` - (Optional) Describes consumer node behavior when dependencies fail or are rerun. Supported values are `cascade` and `none`. Default value is `none`.
+* `insert_query` - (Optional) An SQL statement to insert data into the table.
+* `late_after_timeout` - (Optional) The elapsed time after pipeline start within which the object must start. It is triggered only when the schedule type is not set to `ondemand`.
+* `max_active_instances` - (Optional) The maximum number of concurrent active instances of a component. Re-runs do not count toward the number of active instances.
+* `maximum_retries` - (Optional) Maximum number attempt retries on failure.
+* `on_fail` - (Optional) An action to run when current object fails.
+* `on_late_action` - (Optional) Actions that should be triggered if an object has not yet been scheduled or still not completed.
+* `on_success` - (Optional) An action to run when current object succeeds.
+* `parent` - (Optional) Parent of the current object from which slots will be inherited.
+* `pipeline_log_uri` - (Optional) The s3 URI for uploading logs for the pipeline.  (such as `s3://BucketName/Key/`) 
+* `precondition` - (Optional) A data node is not marked `READY` until all preconditions have been met.
+* `report_progress_timeout` - (Optional) Timeout for remote work successive calls to reportProgress. If set, then remote activities that do not report progress for the specified period may be considered stalled and so retried.
+* `retry_delay` - (Optional) The timeout duration between two retry attempts.
+* `runs_on` - (Required) The computational resource to run the activity or command. For example, an Amazon EC2 instance or Amazon EMR cluster.
+* `schedule_type` - (Optional) The string of schedule type. Supported values are `cron`, `ondemand` and `timeseries`.
+* `schema_name` - (Optional) The name of the schema holding the table.
+* `select_query` - (Optional) A SQL statement to fetch data from the table.
+* `worker_group` - (Optional) The worker group. This is used for routing tasks. If you provide a `runs_on` value and `worker_group` exists, `worker_group` is ignored.
+
+The `schedule` configuration supports the following:
+For more information, see the [AWS Data Pipeline Schedule Guide](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-schedule.html).
+
+* `id` - (Required) Specifies unique identifier for each Pipeline Object.
+* `name` - (Required) The name of schedule pipeline object.
+* `period` - (Required) Specifies how often the pipeline should run. The format is `N [minutes|hours|days|weeks|months]` The minimum period is 15 minutes and the maximum period is 3 years.
+* `start_at` - (Optional) The date and time at which to start the scheduled pipeline runs. Valid value is FIRST_ACTIVATION_DATE_TIME, which is deprecated in favor of creating an on-demand pipeline.
+* `start_date_time` - (Optional) The date and time to start the scheduled runs. You must use either startDateTime or startAt but not both.
+* `end_date_time` - (Optional) The date and time to end the scheduled runs. Must be a date and time later than the value of startDateTime or startAt. The default behavior is to schedule runs until the pipeline is shut down.
+* `occurrences` - (Optional) The number of times to execute the pipeline after it's activated. You can't use occurrences with endDateTime.
+* `parent` - (Optional) Parent of the current object from which slots will be inherited.
+
+The `parameter_object` configuration supports the following:
+For more information, see the [AWS Data Pipeline Pipeline ParameterObjects](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datapipeline-pipeline-parameterobjects.html).
+
+* `id` - (Required) The identifier of the parameter object.
+* `description` - (Optional) A description of the parameter.
+* `type` - (Optional) The parameter type that defines the allowed range of input values and validation rules. The default is `String`.
+* `optional` - (Optional) Indicates whether the parameter is optional or required. The default is `false`.
+* `allowed_values` - (Optional) Enumerates all permitted values for the parameter.
+* `default` - (Optional) The default value for the parameter. If you specify a value for this parameter using parameter values, it overrides the default value.
+* `is_array` - (Optional) Indicates whether the parameter is an array.
+
+The `parameter_value` configuration supports the following:
+For more information, see the [AWS Data Pipeline User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-datapipeline-pipeline-parametervalues.html).
+
+* `id` - (Required) The ID of a parameter object.
+* `string_value` - (Required) A value to associate with the parameter object.

--- a/website/docs/r/datapipeline.html.markdown
+++ b/website/docs/r/datapipeline.html.markdown
@@ -189,7 +189,7 @@ POLICY
 resource "aws_datapipeline" "foo" {
 	name      = "tf-datapipeline-%s"
 
-	default {
+	default = {
 		schedule_type          = "ondemand"
 		failure_and_rerun_mode = "cascade"
 		role                   = "${aws_iam_role.role.arn}"
@@ -375,7 +375,7 @@ POLICY
 resource "aws_datapipeline" "foo" {
 	name      = "tf-datapipeline"
 
-	default {
+	default = {
 		schedule_type          = "cron"
 		schedule			   = "TestHourlySchedule"
 		failure_and_rerun_mode = "cascade"
@@ -433,7 +433,7 @@ resource "aws_datapipeline" "foo" {
 		end_date_time 	= "2019-09-01T00:00:00"
 	}
 
-	tags {
+	tags = {
 		NAME = "tf-datapipeline-test"
 		ENV  = "test"
 	}
@@ -622,3 +622,11 @@ For more information, see the [AWS Data Pipeline User Guide](https://docs.aws.am
 
 * `id` - (Required) The ID of a parameter object.
 * `string_value` - (Required) A value to associate with the parameter object.
+
+## Import
+
+`aws_datapipeline` can be imported by using the id (Pipeline ID), e.g.
+
+```
+$ terraform import aws_datapipeline.example df-1234567890
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #1538 

Changes proposed in this pull request:

* Add DataPipeline Resource
  * Support Pipeline Objects
    * default
    * [copy activity](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-copyactivity.html)
    * Resources
      * [ec2 resource](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-ec2resource.html)
    * Databases
      - [x] [Rds Database](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-rdsdatabase.html)
    * Data nodes
      * [s3 data node](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-s3datanode.html)
      * [sql data node](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-sqldatanode.html)
    * [schedule](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-schedule.html)

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataPipeline_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDataPipeline_ -timeout 120m
=== RUN   TestAccAWSDataPipeline_basic
=== PAUSE TestAccAWSDataPipeline_basic
=== RUN   TestAccAWSDataPipeline_copyActivity
=== PAUSE TestAccAWSDataPipeline_copyActivity
=== RUN   TestAccAWSDataPipeline_disappears
=== PAUSE TestAccAWSDataPipeline_disappears
=== CONT  TestAccAWSDataPipeline_basic
=== CONT  TestAccAWSDataPipeline_disappears
=== CONT  TestAccAWSDataPipeline_copyActivity
--- PASS: TestAccAWSDataPipeline_disappears (31.63s)
--- PASS: TestAccAWSDataPipeline_basic (36.01s)
--- PASS: TestAccAWSDataPipeline_copyActivity (37.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	37.557s
```

TODO
- [x] Add support serveral resources
- [x] Add documentation