### PR TITLE
Add import support for aws_iam_user_group_membership resource

### DIFF
--- a/website/docs/r/iam_user_group_membership.html.markdown
+++ b/website/docs/r/iam_user_group_membership.html.markdown
@@ -68,3 +68,11 @@ The following arguments are supported:
 [1]: /docs/providers/aws/r/iam_group.html
 [2]: /docs/providers/aws/r/iam_user.html
 [3]: /docs/providers/aws/r/iam_group_membership.html
+
+## Import
+
+IAM user group membership can be imported using the user name and group names separated by `/`.
+
+```
+$ terraform import aws_iam_user_group_membership.example1 user1/group1/group2
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6698 

Changes proposed in this pull request:

* Add import support for `aws_iam_user_group_membership`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSUserGroupMembership_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSUserGroupMembership_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSUserGroupMembership_basic
=== PAUSE TestAccAWSUserGroupMembership_basic
=== CONT  TestAccAWSUserGroupMembership_basic
--- PASS: TestAccAWSUserGroupMembership_basic (108.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	(cached)
...
```
