### PR TITLE
Add support aws_s3_bucket_policy data source

### DIFF
--- a/aws/data_source_aws_s3_bucket_policy.go
+++ b/aws/data_source_aws_s3_bucket_policy.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsS3BucketPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsS3BucketPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3conn
+
+	bucket := d.Get("bucket").(string)
+
+	params := &s3.GetBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	}
+
+	resp, err := conn.GetBucketPolicy(params)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(bucket)
+	if err := d.Set("policy", resp.Policy); err != nil {
+		return fmt.Errorf("[WARN] Error setting S3 Bucket (%s) Policy: %s", bucket, err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_s3_bucket_policy_test.go
+++ b/aws/data_source_aws_s3_bucket_policy_test.go
@@ -1,0 +1,110 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAWSS3BucketPolicy_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSourceS3BucketPolicyConfigBasic1(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+				),
+			},
+			{
+				Config: testAccAWSDataSourceS3BucketPolicyConfigBasic2(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("aws_s3_bucket.bucket"),
+					resource.TestCheckResourceAttrPair("aws_s3_bucket_policy.bucket", "policy", "data.aws_s3_bucket_policy.policy", "policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSDataSourceS3BucketPolicyConfigBasic1(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_s3_bucket" "bucket" {
+		bucket = "tf-test-bucket-%d"
+		tags = {
+			TestName = "TestAccAWSS3BucketPolicy_basic"
+		}
+	}
+	
+	resource "aws_s3_bucket_policy" "bucket" {
+		bucket = "${aws_s3_bucket.bucket.bucket}"
+		policy = "${data.aws_iam_policy_document.policy.json}"
+	}
+	
+	data "aws_iam_policy_document" "policy" {
+	  statement {
+		effect = "Allow"
+	
+		actions = [
+		  "s3:*",
+		]
+	
+		resources = [
+		  "${aws_s3_bucket.bucket.arn}",
+		  "${aws_s3_bucket.bucket.arn}/*",
+		]
+	
+		principals {
+		  type        = "AWS"
+		  identifiers = ["*"]
+		}
+	  }
+	}
+`, rInt)
+}
+
+func testAccAWSDataSourceS3BucketPolicyConfigBasic2(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_s3_bucket" "bucket" {
+		bucket = "tf-test-bucket-%d"
+		tags = {
+			TestName = "TestAccAWSS3BucketPolicy_basic"
+		}
+	}
+	
+	resource "aws_s3_bucket_policy" "bucket" {
+		bucket = "${aws_s3_bucket.bucket.bucket}"
+		policy = "${data.aws_iam_policy_document.policy.json}"
+	}
+	
+	data "aws_iam_policy_document" "policy" {
+	  statement {
+		effect = "Allow"
+	
+		actions = [
+		  "s3:*",
+		]
+	
+		resources = [
+		  "${aws_s3_bucket.bucket.arn}",
+		  "${aws_s3_bucket.bucket.arn}/*",
+		]
+	
+		principals {
+		  type        = "AWS"
+		  identifiers = ["*"]
+		}
+	  }
+	}
+
+	data "aws_s3_bucket_policy" "policy" {
+		bucket = "${aws_s3_bucket.bucket.bucket}"
+	}
+`, rInt)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -248,6 +248,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route53_zone":                              dataSourceAwsRoute53Zone(),
 			"aws_s3_bucket":                                 dataSourceAwsS3Bucket(),
 			"aws_s3_bucket_object":                          dataSourceAwsS3BucketObject(),
+			"aws_s3_bucket_policy":                          dataSourceAwsS3BucketPolicy(),
 			"aws_secretsmanager_secret":                     dataSourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_version":             dataSourceAwsSecretsManagerSecretVersion(),
 			"aws_sns_topic":                                 dataSourceAwsSnsTopic(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -379,6 +379,9 @@
                             <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
                         </li>
                         <li>
+                            <a href="/docs/providers/aws/d/s3_bucket_policy.html">aws_s3_bucket_policy</a>
+                        </li>
+                        <li>
                          <a href="/docs/providers/aws/d/secretsmanager_secret.html">aws_secretsmanager_secret</a>
                         </li>
                         <li>

--- a/website/docs/d/s3_bucket_policy.html.markdown
+++ b/website/docs/d/s3_bucket_policy.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_policy"
+sidebar_current: "docs-aws-datasource-s3-bucket-policy"
+description: |-
+    Provides policy document of an S3 bucket
+---
+
+# Data Source: aws_s3_bucket_policy
+
+The S3 policy data source allows access to the policy document of an object stored inside S3 bucket.
+
+
+## Example Usage
+
+```hcl
+data "aws_s3_bucket_object" "policy" {
+  bucket = "tf-test-bucket"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket to read the policy from
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `policy` - The text of the policy attached to the bucket.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6977 

Changes proposed in this pull request:

* Add support for data source of `aws_s3_bucket_policy`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSS3BucketPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAWSS3BucketPolicy_ -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketPolicy_basic
=== PAUSE TestAccDataSourceAWSS3BucketPolicy_basic
=== CONT  TestAccDataSourceAWSS3BucketPolicy_basic
--- PASS: TestAccDataSourceAWSS3BucketPolicy_basic (73.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	73.968s
...
```
