### PR TITLE
Fix gosimple sns issues

### DIFF
--- a/aws/resource_aws_sns_platform_application.go
+++ b/aws/resource_aws_sns_platform_application.go
@@ -240,10 +240,7 @@ func resourceAwsSnsPlatformApplicationDelete(d *schema.ResourceData, meta interf
 	_, err := snsconn.DeletePlatformApplication(&sns.DeletePlatformApplicationInput{
 		PlatformApplicationArn: aws.String(d.Id()),
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func decodeResourceAwsSnsPlatformApplicationID(input string) (arnS, name, platform string, err error) {

--- a/aws/resource_aws_sns_platform_application_test.go
+++ b/aws/resource_aws_sns_platform_application_test.go
@@ -378,11 +378,8 @@ func testAccCheckAwsSnsPlatformApplicationExists(name string) resource.TestCheck
 
 		log.Printf("[DEBUG] Reading SNS Platform Application attributes: %s", input)
 		_, err := conn.GetPlatformApplicationAttributes(input)
-		if err != nil {
-			return err
-		}
 
-		return nil
+		return err
 	}
 }
 

--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -241,10 +241,8 @@ func resourceAwsSnsTopicDelete(d *schema.ResourceData, meta interface{}) error {
 	_, err := snsconn.DeleteTopic(&sns.DeleteTopicInput{
 		TopicArn: aws.String(d.Id()),
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
 }
 
 func updateAwsSnsTopicAttribute(topicArn, name string, value interface{}, conn *sns.SNS) error {
@@ -267,8 +265,6 @@ func updateAwsSnsTopicAttribute(topicArn, name string, value interface{}, conn *
 	_, err := retryOnAwsCode(sns.ErrCodeInvalidParameterException, func() (interface{}, error) {
 		return conn.SetTopicAttributes(&req)
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
 }

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -197,10 +197,8 @@ func resourceAwsSnsTopicSubscriptionDelete(d *schema.ResourceData, meta interfac
 	_, err := snsconn.Unsubscribe(&sns.UnsubscribeInput{
 		SubscriptionArn: aws.String(d.Id()),
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
 }
 
 func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.SubscribeOutput, err error) {

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -354,11 +354,7 @@ func testAccCheckAWSSNSTopicSubscriptionExists(n string, attributes map[string]s
 			attributes[k] = aws.StringValue(v)
 		}
 
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }
 


### PR DESCRIPTION
Related to #6343 technical debt

Changes proposed in this pull request:
* Fix remaining gosimple sns issues

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSSNSTopic_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSNSTopic_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSNSTopic_importBasic
=== PAUSE TestAccAWSSNSTopic_importBasic
=== RUN   TestAccAWSSNSTopic_basic
=== PAUSE TestAccAWSSNSTopic_basic
=== RUN   TestAccAWSSNSTopic_name
=== PAUSE TestAccAWSSNSTopic_name
=== RUN   TestAccAWSSNSTopic_namePrefix
=== PAUSE TestAccAWSSNSTopic_namePrefix
=== RUN   TestAccAWSSNSTopic_policy
=== PAUSE TestAccAWSSNSTopic_policy
=== RUN   TestAccAWSSNSTopic_withIAMRole
=== PAUSE TestAccAWSSNSTopic_withIAMRole
=== RUN   TestAccAWSSNSTopic_withFakeIAMRole
=== PAUSE TestAccAWSSNSTopic_withFakeIAMRole
=== RUN   TestAccAWSSNSTopic_withDeliveryPolicy
=== PAUSE TestAccAWSSNSTopic_withDeliveryPolicy
=== RUN   TestAccAWSSNSTopic_deliveryStatus
=== PAUSE TestAccAWSSNSTopic_deliveryStatus
=== RUN   TestAccAWSSNSTopic_encryption
=== PAUSE TestAccAWSSNSTopic_encryption
=== CONT  TestAccAWSSNSTopic_importBasic
=== CONT  TestAccAWSSNSTopic_withFakeIAMRole
=== CONT  TestAccAWSSNSTopic_name
=== CONT  TestAccAWSSNSTopic_policy
=== CONT  TestAccAWSSNSTopic_deliveryStatus
=== CONT  TestAccAWSSNSTopic_basic
=== CONT  TestAccAWSSNSTopic_encryption
=== CONT  TestAccAWSSNSTopic_withIAMRole
=== CONT  TestAccAWSSNSTopic_namePrefix
=== CONT  TestAccAWSSNSTopic_withDeliveryPolicy
--- PASS: TestAccAWSSNSTopic_namePrefix (13.33s)
--- PASS: TestAccAWSSNSTopic_name (13.47s)
--- PASS: TestAccAWSSNSTopic_basic (13.65s)
--- PASS: TestAccAWSSNSTopic_policy (13.91s)
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (14.18s)
--- PASS: TestAccAWSSNSTopic_importBasic (14.50s)
--- PASS: TestAccAWSSNSTopic_encryption (21.57s)
--- PASS: TestAccAWSSNSTopic_withIAMRole (25.85s)
--- PASS: TestAccAWSSNSTopic_deliveryStatus (33.15s)
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (69.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.824s
$ make testacc TESTARGS='-run=TestAccAWSSNSTopicSubscription_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSNSTopicSubscription_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSNSTopicSubscription_basic
=== PAUSE TestAccAWSSNSTopicSubscription_basic
=== RUN   TestAccAWSSNSTopicSubscription_filterPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_filterPolicy
=== RUN   TestAccAWSSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_deliveryPolicy
=== RUN   TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_basic
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_deliveryPolicy
=== CONT  TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_filterPolicy
--- PASS: TestAccAWSSNSTopicSubscription_basic (31.19s)
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (71.53s)
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (77.85s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (80.87s)
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (101.23s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (130.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	130.303s
```