### PR TITLE
Fix gosimple lb issues

### DIFF
--- a/aws/resource_aws_lb.go
+++ b/aws/resource_aws_lb.go
@@ -557,11 +557,8 @@ func cleanupLBNetworkInterfaces(conn *ec2.EC2, lbArn string) error {
 	}
 
 	err = deleteNetworkInterfaces(conn, out.NetworkInterfaces)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 func waitForNLBNetworkInterfacesToDetach(conn *ec2.EC2, lbArn string) error {
@@ -631,7 +628,7 @@ func flattenSubnetMappingsFromAvailabilityZones(availabilityZones []*elbv2.Avail
 	l := make([]map[string]interface{}, 0)
 	for _, availabilityZone := range availabilityZones {
 		for _, loadBalancerAddress := range availabilityZone.LoadBalancerAddresses {
-			m := make(map[string]interface{}, 0)
+			m := make(map[string]interface{})
 			m["subnet_id"] = aws.StringValue(availabilityZone.SubnetId)
 
 			if loadBalancerAddress.AllocationId != nil {

--- a/aws/resource_aws_lb_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_lb_cookie_stickiness_policy_test.go
@@ -94,11 +94,7 @@ func testAccCheckLBCookieStickinessPolicy(elbResource string, policyResource str
 			PolicyNames:      []*string{aws.String(policyName)},
 		})
 
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 }
 

--- a/aws/resource_aws_lb_target_group_attachment_test.go
+++ b/aws/resource_aws_lb_target_group_attachment_test.go
@@ -122,12 +122,12 @@ func testAccCheckAWSLBTargetGroupAttachmentExists(n string) resource.TestCheckFu
 		conn := testAccProvider.Meta().(*AWSClient).elbv2conn
 
 		_, hasPort := rs.Primary.Attributes["port"]
-		targetGroupArn, _ := rs.Primary.Attributes["target_group_arn"]
+		targetGroupArn := rs.Primary.Attributes["target_group_arn"]
 
 		target := &elbv2.TargetDescription{
 			Id: aws.String(rs.Primary.Attributes["target_id"]),
 		}
-		if hasPort == true {
+		if hasPort {
 			port, _ := strconv.Atoi(rs.Primary.Attributes["port"])
 			target.Port = aws.Int64(int64(port))
 		}
@@ -158,12 +158,12 @@ func testAccCheckAWSLBTargetGroupAttachmentDestroy(s *terraform.State) error {
 		}
 
 		_, hasPort := rs.Primary.Attributes["port"]
-		targetGroupArn, _ := rs.Primary.Attributes["target_group_arn"]
+		targetGroupArn := rs.Primary.Attributes["target_group_arn"]
 
 		target := &elbv2.TargetDescription{
 			Id: aws.String(rs.Primary.Attributes["target_id"]),
 		}
-		if hasPort == true {
+		if hasPort {
 			port, _ := strconv.Atoi(rs.Primary.Attributes["port"])
 			target.Port = aws.Int64(int64(port))
 		}

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -189,7 +189,7 @@ func TestAccAWSLBTargetGroup_networkLB_TargetGroup(t *testing.T) {
 			},
 			{
 				Config:      testAccAWSLBTargetGroupConfig_typeTCPInvalidThreshold(targetGroupName),
-				ExpectError: regexp.MustCompile("health_check\\.healthy_threshold [0-9]+ and health_check\\.unhealthy_threshold [0-9]+ must be the same for target_groups with TCP protocol"),
+				ExpectError: regexp.MustCompile(`health_check\.healthy_threshold [0-9]+ and health_check\.unhealthy_threshold [0-9]+ must be the same for target_groups with TCP protocol`),
 			},
 			{
 				Config: testAccAWSLBTargetGroupConfig_typeTCPThresholdUpdated(targetGroupName),


### PR DESCRIPTION
Related to #6343 technical debt

Changes proposed in this pull request:

* Fix gosimple lb issues

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSLBTargetGroup_networkLB_TargetGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLBTargetGroup_networkLB_TargetGroup -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== RUN   TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== PAUSE TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroup
=== CONT  TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroupWithProxy (79.86s)
--- PASS: TestAccAWSLBTargetGroup_networkLB_TargetGroup (120.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	120.153s
$ make testacc TESTARGS='-run=TestAccAWSLBTargetGroupAttachment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLBTargetGroupAttachment_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLBTargetGroupAttachment_basic
=== PAUSE TestAccAWSLBTargetGroupAttachment_basic
=== RUN   TestAccAWSLBTargetGroupAttachment_withoutPort
=== PAUSE TestAccAWSLBTargetGroupAttachment_withoutPort
=== CONT  TestAccAWSLBTargetGroupAttachment_basic
=== CONT  TestAccAWSLBTargetGroupAttachment_withoutPort
--- PASS: TestAccAWSLBTargetGroupAttachment_withoutPort (140.03s)
--- PASS: TestAccAWSLBTargetGroupAttachment_basic (210.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	210.736s
$ make testacc TESTARGS='-run=TestAccAWSLBCookieStickinessPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLBCookieStickinessPolicy_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLBCookieStickinessPolicy_basic
=== PAUSE TestAccAWSLBCookieStickinessPolicy_basic
=== CONT  TestAccAWSLBCookieStickinessPolicy_basic
--- PASS: TestAccAWSLBCookieStickinessPolicy_basic (68.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.356s
$ make testacc TESTARGS='-run=TestAccAWSLB_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLB_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLB_basic
=== PAUSE TestAccAWSLB_basic
=== CONT  TestAccAWSLB_basic
--- PASS: TestAccAWSLB_basic (243.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	243.535s
```