### PR TITLE
r/aws_flow_log: Add workaround for destination type API bug

### DIFF
--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -174,7 +174,12 @@ func resourceAwsLogFlowRead(d *schema.ResourceData, meta interface{}) error {
 	fl := resp.FlowLogs[0]
 	d.Set("traffic_type", fl.TrafficType)
 	d.Set("log_destination", fl.LogDestination)
-	d.Set("log_destination_type", fl.LogDestinationType)
+	if fl.LogDestinationType == nil {
+		log.Printf("[WARN] AWS EC2 API bug, not returning destination type (%v)", fl.LogDestinationType)
+		d.Set("log_destination_type", ec2.LogDestinationTypeCloudWatchLogs)
+	} else {
+		d.Set("log_destination_type", fl.LogDestinationType)
+	}
 	d.Set("log_group_name", fl.LogGroupName)
 	d.Set("iam_role_arn", fl.DeliverLogsPermissionArn)
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6631

Changes proposed in this pull request:

* resource/aws_flow_log: Add check for `nil` return in `LogDestinationType` AWS responses. This allows flow logs to work without `apply` cycling even in regions that don't return that parameter.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSFlowLog_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSFlowLog_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSFlowLog_VPCID
=== PAUSE TestAccAWSFlowLog_VPCID
=== RUN   TestAccAWSFlowLog_SubnetID
=== PAUSE TestAccAWSFlowLog_SubnetID
=== RUN   TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs
=== PAUSE TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs
=== RUN   TestAccAWSFlowLog_LogDestinationType_S3
=== PAUSE TestAccAWSFlowLog_LogDestinationType_S3
=== CONT  TestAccAWSFlowLog_VPCID
=== CONT  TestAccAWSFlowLog_LogDestinationType_S3
=== CONT  TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs
=== CONT  TestAccAWSFlowLog_SubnetID
--- PASS: TestAccAWSFlowLog_LogDestinationType_CloudWatchLogs (27.98s)
--- PASS: TestAccAWSFlowLog_LogDestinationType_S3 (30.79s)
--- PASS: TestAccAWSFlowLog_SubnetID (32.16s)
--- PASS: TestAccAWSFlowLog_VPCID (43.47s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	43.518s
```