### PR TITLE
Fix typo in documentation "exemple.com"

### DIFF
--- a/website/docs/r/cognito_user_pool_domain.markdown
+++ b/website/docs/r/cognito_user_pool_domain.markdown
@@ -26,7 +26,7 @@ resource "aws_cognito_user_pool" "example" {
 ### Custom Cognito domain
 ```hcl
 resource "aws_cognito_user_pool_domain" "main" {
-  domain          = "example-domain.exemple.com"
+  domain          = "example-domain.example.com"
   certificate_arn = "${aws_acm_certificate.cert.arn}"
   user_pool_id    = "${aws_cognito_user_pool.example.id}"
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
