### PR TITLE
aws_kms_ciphertext into new resource keeping datasource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -523,6 +523,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kms_alias":                                    resourceAwsKmsAlias(),
 			"aws_kms_grant":                                    resourceAwsKmsGrant(),
 			"aws_kms_key":                                      resourceAwsKmsKey(),
+			"aws_kms_ciphertext":                               resourceAwsKmsCiphertext(),
 			"aws_lambda_function":                              resourceAwsLambdaFunction(),
 			"aws_lambda_event_source_mapping":                  resourceAwsLambdaEventSourceMapping(),
 			"aws_lambda_alias":                                 resourceAwsLambdaAlias(),

--- a/aws/resource_aws_kms_ciphertext.go
+++ b/aws/resource_aws_kms_ciphertext.go
@@ -19,9 +19,9 @@ func resourceAwsKmsCiphertext() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"plaintext": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
 				Sensitive: true,
 			},
 

--- a/aws/resource_aws_kms_ciphertext.go
+++ b/aws/resource_aws_kms_ciphertext.go
@@ -17,25 +17,24 @@ func resourceAwsKmsCiphertext() *schema.Resource {
 		Read:   resourceAwsKmsCiphertextRead,
 		Delete: resourceAwsKmsCiphertextDelete,
 
-
 		Schema: map[string]*schema.Schema{
 			"plaintext": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNext: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew: true,
 			},
 
 			"key_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNext: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew: true,
 			},
 
 			"context": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				ForceNext: true,
+				Type:      schema.TypeMap,
+				Optional:  true,
+				Elem:      &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
 			},
 
 			"ciphertext_blob": {

--- a/aws/resource_aws_kms_ciphertext.go
+++ b/aws/resource_aws_kms_ciphertext.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"encoding/base64"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsKmsCiphertext() *schema.Resource {
+
+	return &schema.Resource{
+		Create: resourceAwsKmsCiphertextCreate,
+		Read:   resourceAwsKmsCiphertextRead,
+		Delete: resourceAwsKmsCiphertextDelete,
+
+
+		Schema: map[string]*schema.Schema{
+			"plaintext": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNext: true,
+			},
+
+			"key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNext: true,
+			},
+
+			"context": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNext: true,
+			},
+
+			"ciphertext_blob": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resoruceAwsKmsCiphertextCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kmsconn
+
+	d.SetId(time.Now().UTC().String())
+
+	req := &kms.EncryptInput{
+		KeyId:     aws.String(d.Get("key_id").(string)),
+		Plaintext: []byte(d.Get("plaintext").(string)),
+	}
+
+	if ec := d.Get("context"); ec != nil {
+		req.EncryptionContext = stringMapToPointers(ec.(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] KMS encrypt for key: %s", d.Get("key_id").(string))
+	resp, err := conn.Encrypt(req)
+	if err != nil {
+		return err
+	}
+
+	d.Set("ciphertext_blob", base64.StdEncoding.EncodeToString(resp.CiphertextBlob))
+
+	return nil
+}
+
+func resourceAwsKmsCiphertextDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func resourceAwsKmsCiphertextRead(d *schema.ResourceData, meta interface{}) error {
+	// If the input has changed, generate a new ciphertext_blob
+	// This should never be the case since ForceNew set on all input.
+	if d.HasChange("plaintext") || d.HasChange("key_id") || d.HasChange("context") {
+		return resourceAwsKmsCiphertextCreate(d, meta)
+	}
+	return nil
+}

--- a/aws/resource_aws_kms_ciphertext.go
+++ b/aws/resource_aws_kms_ciphertext.go
@@ -22,6 +22,7 @@ func resourceAwsKmsCiphertext() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				Sensitive: true,
 			},
 
 			"key_id": {

--- a/aws/resource_aws_kms_ciphertext.go
+++ b/aws/resource_aws_kms_ciphertext.go
@@ -19,21 +19,21 @@ func resourceAwsKmsCiphertext() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"plaintext": {
-				Type:      schema.TypeString,
-				Required:  true,
+				Type:     schema.TypeString,
+				Required: true,
 				ForceNew: true,
 			},
 
 			"key_id": {
-				Type:      schema.TypeString,
-				Required:  true,
+				Type:     schema.TypeString,
+				Required: true,
 				ForceNew: true,
 			},
 
 			"context": {
-				Type:      schema.TypeMap,
-				Optional:  true,
-				Elem:      &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				ForceNew: true,
 			},
 
@@ -45,7 +45,7 @@ func resourceAwsKmsCiphertext() *schema.Resource {
 	}
 }
 
-func resoruceAwsKmsCiphertextCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsKmsCiphertextCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kmsconn
 
 	d.SetId(time.Now().UTC().String())

--- a/aws/resource_aws_kms_ciphertext_test.go
+++ b/aws/resource_aws_kms_ciphertext_test.go
@@ -1,0 +1,136 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccResourceAwsKmsCiphertext_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAwsKmsCiphertextConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"aws_kms_ciphertext.foo", "ciphertext_blob"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceAwsKmsCiphertext_validate(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAwsKmsCiphertextConfig_validate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"aws_kms_ciphertext.foo", "ciphertext_blob"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_kms_secret.foo", "plaintext"),
+					resource.TestCheckResourceAttr(
+						"data.aws_kms_secret.foo", "plaintext", "Super secret data"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceAwsKmsCiphertext_validate_withContext(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAwsKmsCiphertextConfig_validate_withContext,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"aws_kms_ciphertext.foo", "ciphertext_blob"),
+					resource.TestCheckResourceAttrSet(
+						"aws_kms_secret.foo", "plaintext"),
+					resource.TestCheckResourceAttr(
+						"aws_kms_secret.foo", "plaintext", "Super secret data"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceAwsKmsCiphertextConfig_basic = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_kms_key" "foo" {
+  description = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
+  is_enabled = true
+}
+
+data "aws_kms_ciphertext" "foo" {
+  key_id = "${aws_kms_key.foo.key_id}"
+
+  plaintext = "Super secret data"
+}
+`
+
+const testAccResourceAwsKmsCiphertextConfig_validate = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_kms_key" "foo" {
+  description = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
+  is_enabled = true
+}
+
+data "aws_kms_ciphertext" "foo" {
+  key_id = "${aws_kms_key.foo.key_id}"
+
+  plaintext = "Super secret data"
+}
+
+data "aws_kms_secret" "foo" {
+  secret {
+    name = "plaintext"
+    payload = "${aws_kms_ciphertext.foo.ciphertext_blob}"
+  }
+}
+`
+
+const testAccResourceAwsKmsCiphertextConfig_validate_withContext = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_kms_key" "foo" {
+  description = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
+  is_enabled = true
+}
+
+data "aws_kms_ciphertext" "foo" {
+  key_id = "${aws_kms_key.foo.key_id}"
+
+  plaintext = "Super secret data"
+
+  context {
+	name = "value"
+  }
+}
+
+data "aws_kms_secret" "foo" {
+  secret {
+    name = "plaintext"
+    payload = "${aws_kms_ciphertext.foo.ciphertext_blob}"
+
+    context {
+	  name = "value"
+    }
+  }
+}
+`

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1637,6 +1637,10 @@
                     <a href="/docs/providers/aws/r/kms_grant.html">aws_kms_grant</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-aws-resource-kms-ciphertext") %>>
+                      <a href="/docs/providers/aws/r/kms_ciphertext.html">aws_kms_ciphertext</a>
+                  </li>
+
                   <li<%= sidebar_current("docs-aws-resource-kms-key") %>>
                     <a href="/docs/providers/aws/r/kms_key.html">aws_kms_key</a>
                   </li>

--- a/website/docs/r/kms_ciphertext.html.markdown
+++ b/website/docs/r/kms_ciphertext.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "aws"
+page_title: "AWS: aws_kms_ciphertext"
+sidebar_current: "docs-aws-resource-kms-ciphertext"
+description: |-
+    Provides ciphertext encrypted using a KMS key
+---
+
+# Data Source: aws_kms_ciphertext
+
+The KMS ciphertext resource allows you to encrypt plaintext into ciphertext
+by using an AWS KMS customer master key.
+
+~> **Note:** All arguments including the plaintext be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+resource "aws_kms_key" "oauth_config" {
+  description = "oauth config"
+  is_enabled  = true
+}
+
+resource "aws_kms_ciphertext" "oauth" {
+  key_id = "${aws_kms_key.oauth_config.key_id}"
+
+  plaintext = <<EOF
+{
+  "client_id": "e587dbae22222f55da22",
+  "client_secret": "8289575d00000ace55e1815ec13673955721b8a5"
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `plaintext` - (Required) Data to be encrypted. Note that this may show up in logs, and it will be stored in the state file.
+* `key_id` - (Required) Globally unique key ID for the customer master key.
+* `context` - (Optional) An optional mapping that makes up the encryption context.
+
+## Attributes Reference
+
+All of the argument attributes are also exported as result attributes.
+
+* `ciphertext_blob` - Base64 encoded ciphertext

--- a/website/docs/r/kms_ciphertext.html.markdown
+++ b/website/docs/r/kms_ciphertext.html.markdown
@@ -6,7 +6,7 @@ description: |-
     Provides ciphertext encrypted using a KMS key
 ---
 
-# Data Source: aws_kms_ciphertext
+# Resource: aws_kms_ciphertext
 
 The KMS ciphertext resource allows you to encrypt plaintext into ciphertext
 by using an AWS KMS customer master key.


### PR DESCRIPTION
Fixes #960

As a resource, the encryption is performed on create only.

Changing any of the input forces a new resource.

Rework of PR#2568