### PR TITLE
d/aws_cloudfront_distribution: Adding a data source for specific Cloudfront distributions

### DIFF
--- a/aws/data_source_aws_cloudfront_distribution.go
+++ b/aws/data_source_aws_cloudfront_distribution.go
@@ -1,0 +1,82 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCloudFrontDistribution() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCloudfrontDistributionRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"in_progress_validation_batches": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"active_trusted_signers": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCloudfrontDistributionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cloudfrontconn
+	id := d.Get("id").(string)
+	input := &cloudfront.GetDistributionInput{
+		Id: aws.String(id),
+	}
+
+	log.Printf("[DEBUG] Reading CloudFront Distribution: %s", input)
+	out, err := conn.GetDistribution(input)
+	if err != nil {
+		return fmt.Errorf("Failed getting CloudFront distribution (%s): %s", id, err)
+	}
+	dist := out.Distribution
+	etag := out.ETag
+	d.SetId(*dist.Id)
+
+	d.Set("arn", dist.ARN)
+	d.Set("status", dist.Status)
+	d.Set("domain_name", dist.DomainName)
+	d.Set("last_modified_time", dist.LastModifiedTime)
+	d.Set("in_progress_validation_batches", dist.InProgressInvalidationBatches)
+	d.Set("etag", etag)
+
+	err = d.Set("active_trusted_signers", flattenActiveTrustedSigners(dist.ActiveTrustedSigners))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_cloudfront_distribution_test.go
+++ b/aws/data_source_aws_cloudfront_distribution_test.go
@@ -1,0 +1,109 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudfrontDistribution_dataSource_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionDsConfig, ri, distOriginBucket, distLogBucket, testAccAWSCloudFrontDistributionRetainConfig())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.aws_cloudfront_distribution.s3_distribution", "arn",
+						regexp.MustCompile(`^arn:aws:cloudfront::\d+:distribution\/[A-Z]\w+$`)),
+					resource.TestMatchResourceAttr("data.aws_cloudfront_distribution.s3_distribution", "status",
+						regexp.MustCompile(`^InProgress|Deployed$`)),
+					resource.TestMatchResourceAttr("data.aws_cloudfront_distribution.s3_distribution", "domain_name",
+						regexp.MustCompile(`^[a-z0-9]+\.cloudfront\.net$`)),
+					resource.TestMatchResourceAttr("data.aws_cloudfront_distribution.s3_distribution", "etag",
+						regexp.MustCompile(`^[A-Z0-9]+$`)),
+					resource.TestMatchResourceAttr("data.aws_cloudfront_distribution.s3_distribution", "in_progress_validation_batches",
+						regexp.MustCompile(`^\d+$`)),
+				),
+			},
+		},
+	})
+}
+
+var distOriginBucket = fmt.Sprintf(`
+resource "aws_s3_bucket" "s3_bucket_origin" {
+	bucket = "mybucket.${var.rand_id}"
+	acl = "public-read"
+}
+`)
+
+var distLogBucket = fmt.Sprintf(`
+resource "aws_s3_bucket" "s3_bucket_logs" {
+	bucket = "mylogs.${var.rand_id}"
+	acl = "public-read"
+}
+`)
+
+var testAccAWSCloudFrontDistributionDsConfig = `
+variable rand_id {
+	default = %d
+}
+
+# origin bucket
+%s
+
+# log bucket
+%s
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+	origin {
+		domain_name = "${aws_s3_bucket.s3_bucket_origin.id}.s3.amazonaws.com"
+		origin_id = "myS3Origin"
+	}
+	enabled = true
+	default_root_object = "index.html"
+	logging_config {
+		include_cookies = false
+		bucket = "${aws_s3_bucket.s3_bucket_logs.id}.s3.amazonaws.com"
+		prefix = "myprefix"
+	}
+	aliases = [ "mysite.${var.rand_id}.example.com", "yoursite.${var.rand_id}.example.com" ]
+	default_cache_behavior {
+		allowed_methods = [ "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT" ]
+		cached_methods = [ "GET", "HEAD" ]
+		target_origin_id = "myS3Origin"
+		forwarded_values {
+			query_string = false
+			cookies {
+				forward = "none"
+			}
+		}
+		viewer_protocol_policy = "allow-all"
+		min_ttl = 0
+		default_ttl = 3600
+		max_ttl = 86400
+	}
+	price_class = "PriceClass_200"
+	restrictions {
+		geo_restriction {
+			restriction_type = "whitelist"
+			locations = [ "US", "CA", "GB", "DE" ]
+		}
+	}
+	viewer_certificate {
+		cloudfront_default_certificate = true
+	}
+	%s
+}
+
+data "aws_cloudfront_distribution" "s3_distribution" {
+	id = "${aws_cloudfront_distribution.s3_distribution.id}"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -180,6 +180,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_canonical_user_id":                  dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_export":              dataSourceAwsCloudFormationExport(),
 			"aws_cloudformation_stack":               dataSourceAwsCloudFormationStack(),
+			"aws_cloudfront_distribution":            dataSourceAwsCloudFrontDistribution(),
 			"aws_cloudhsm_v2_cluster":                dataSourceCloudHsm2Cluster(),
 			"aws_cloudtrail_service_account":         dataSourceAwsCloudTrailServiceAccount(),
 			"aws_cloudwatch_log_group":               dataSourceAwsCloudwatchLogGroup(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -98,6 +98,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-cloudformation-stack") %>>
                             <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-cloudfront-distribution") %>>
+                            <a href="/docs/providers/aws/d/cloudfront_distribution.html">aws_cloudfront_distribution</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-cloudhsm-v2-cluster") %>>
                             <a href="/docs/providers/aws/d/cloudhsm_v2_cluster.html">aws_cloudhsm_v2_cluster</a>
                         </li>

--- a/website/docs/d/cloudfront_distribution.html.markdown
+++ b/website/docs/d/cloudfront_distribution.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "aws"
+page_title: "AWS: cloudfront_distribution"
+sidebar_current: "docs-aws-datasource-cloudfront-distribution"
+description: |-
+  Provides metadata for a CloudFront web distribution resource.
+---
+
+# aws_cloudfront_distribution
+
+This data source allows access to useful information related to a specific Cloudfront distribution.
+
+For information about CloudFront distributions, see the
+[Amazon CloudFront Developer Guide][1]. For specific information about reading
+CloudFront web distribution information, see the [GET Distribution][2] page in the Amazon
+CloudFront API Reference.
+
+## Example Usage
+
+The following example below reads data from a CloudFront distribution with an S3 origin.
+
+```hcl
+data "aws_cloudfront_distribution" "s3_distribution" {
+  id = "EDFDVBD632BHDS5"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Required) The ID of the distribution
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
+
+* `arn` - The ARN (Amazon Resource Name) for the distribution. For example: arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5, where 123456789012 is your AWS account ID.
+
+* `status` - The current status of the distribution. `Deployed` if the
+  distribution's information is fully propagated throughout the Amazon
+  CloudFront system.
+
+* `active_trusted_signers` - The key pair IDs that CloudFront is aware of for
+  each trusted signer, if the distribution is set up to serve private content
+  with signed URLs.
+
+* `domain_name` - The domain name corresponding to the distribution. For
+  example: `d604721fxaaqy9.cloudfront.net`.
+
+* `last_modified_time` - The date and time the distribution was last modified.
+
+* `in_progress_validation_batches` - The number of validation batches
+  currently in progress.
+
+* `etag` - The current version of the distribution's information. For example:
+  `E2QWRUHAPOMQZL`.
+
+[1]: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html
+[2]: https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetDistribution.html


### PR DESCRIPTION
Fixes #6985

Changes proposed in this pull request:

* Adds a new data source for specific Cloudfront distributions

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudfrontDistribution_dataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudfrontDistribution_dataSource_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudfrontDistribution_dataSource_basic
=== PAUSE TestAccAWSCloudfrontDistribution_dataSource_basic
=== CONT  TestAccAWSCloudfrontDistribution_dataSource_basic
--- PASS: TestAccAWSCloudfrontDistribution_dataSource_basic (1059.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1059.459s
```
