### PR TITLE
Allow forced replacement of route table associated with subnet

### DIFF
--- a/aws/resource_aws_route_table_association.go
+++ b/aws/resource_aws_route_table_association.go
@@ -51,7 +51,7 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 	}
 
 	var associationID string
-	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, err := conn.AssociateRouteTable(&associationOpts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
@@ -60,9 +60,8 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 				}
 			}
 			return resource.NonRetryableError(err)
-		} else {
-			associationID = *resp.AssociationId
 		}
+		associationID = *resp.AssociationId
 		return nil
 	})
 	if err != nil {
@@ -188,8 +187,8 @@ func resourceAwsRouteTableAssociationImport(d *schema.ResourceData, meta interfa
 
 	var associationID string
 	for _, a := range rt.Associations {
-		if *a.SubnetId == subnetID {
-			associationID = *a.RouteTableAssociationId
+		if aws.StringValue(a.SubnetId) == subnetID {
+			associationID = aws.StringValue(a.RouteTableAssociationId)
 			break
 		}
 	}

--- a/aws/resource_aws_route_table_association.go
+++ b/aws/resource_aws_route_table_association.go
@@ -30,6 +30,12 @@ func resourceAwsRouteTableAssociation() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
+			"force_replace": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -47,17 +53,40 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 		SubnetId:     aws.String(d.Get("subnet_id").(string)),
 	}
 
-	var resp *ec2.AssociateRouteTableOutput
+	var associationID string
 	var err error
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		resp, err = conn.AssociateRouteTable(&associationOpts)
+	err = resource.Retry(30*time.Second, func() *resource.RetryError {
+		resp, err := conn.AssociateRouteTable(&associationOpts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if awsErr.Code() == "InvalidRouteTableID.NotFound" {
 					return resource.RetryableError(awsErr)
 				}
+				if awsErr.Code() == "Resource.AlreadyAssociated" && d.Get(
+					"force_replace").(bool) {
+
+					associationID, err = findExistingSubnetAssociationID(
+						conn,
+						d.Get("subnet_id").(string),
+					)
+					if err != nil {
+						return resource.NonRetryableError(err)
+					}
+
+					log.Print("[INFO] Replacing route table association")
+					input := &ec2.ReplaceRouteTableAssociationInput{
+						AssociationId: aws.String(associationID),
+						RouteTableId:  aws.String(d.Get("route_table_id").(string)),
+					}
+					_, err = conn.ReplaceRouteTableAssociation(input)
+					if err == nil {
+						return nil
+					}
+				}
 			}
 			return resource.NonRetryableError(err)
+		} else {
+			associationID = *resp.AssociationId
 		}
 		return nil
 	})
@@ -66,7 +95,7 @@ func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interfa
 	}
 
 	// Set the ID and return
-	d.SetId(*resp.AssociationId)
+	d.SetId(associationID)
 	log.Printf("[INFO] Association ID: %s", d.Id())
 
 	return nil
@@ -152,4 +181,35 @@ func resourceAwsRouteTableAssociationDelete(d *schema.ResourceData, meta interfa
 	}
 
 	return nil
+}
+
+func findExistingSubnetAssociationID(conn *ec2.EC2, subnetID string) (string, error) {
+	// only way to get association id is through the route table
+
+	input := &ec2.DescribeRouteTablesInput{}
+	input.Filters = buildEC2AttributeFilterList(
+		map[string]string{
+			"association.subnet-id": subnetID,
+		},
+	)
+
+	output, err := conn.DescribeRouteTables(input)
+	if err != nil || len(output.RouteTables) == 0 {
+		return "", fmt.Errorf("Error finding route table: %v", err)
+	}
+
+	rt := output.RouteTables[0]
+
+	var associationID string
+	for _, a := range rt.Associations {
+		if *a.SubnetId == subnetID {
+			associationID = *a.RouteTableAssociationId
+			break
+		}
+	}
+	if associationID == "" {
+		return "", fmt.Errorf("Error finding route table, ID: %v", *rt.RouteTableId)
+	}
+
+	return associationID, nil
 }

--- a/aws/resource_aws_route_table_association_test.go
+++ b/aws/resource_aws_route_table_association_test.go
@@ -14,6 +14,8 @@ import (
 func TestAccAWSRouteTableAssociation_basic(t *testing.T) {
 	var v, v2 ec2.RouteTable
 
+	resourceName := "aws_route_table_association.foo"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -23,16 +25,21 @@ func TestAccAWSRouteTableAssociation_basic(t *testing.T) {
 				Config: testAccRouteTableAssociationConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(
-						"aws_route_table_association.foo", &v),
+						resourceName, &v),
 				),
 			},
-
 			{
 				Config: testAccRouteTableAssociationConfigChange,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(
-						"aws_route_table_association.foo", &v2),
+						resourceName, &v2),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSRouteTabAssocImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -19,12 +19,25 @@ resource "aws_route_table_association" "a" {
 }
 ```
 
+## Example Replacement Usage
+
+If the subnet already has an associated route table, normally an error will be thrown if attempting to associate another route table. However, using `force_replace`, no error will be thrown and the subnet will become associated with the new route table instead.
+
+```hcl
+resource "aws_route_table_association" "a" {
+  subnet_id      = "${aws_subnet.foo.id}"
+  route_table_id = "${aws_route_table.bar.id}"
+  force_replace  = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `subnet_id` - (Required) The subnet ID to create an association.
 * `route_table_id` - (Required) The ID of the routing table to associate with.
+* `force_replace` - (Optional) Boolean indicating whether to replace an existing association or not.
 
 ## Attributes Reference
 

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -19,25 +19,12 @@ resource "aws_route_table_association" "a" {
 }
 ```
 
-## Example Replacement Usage
-
-If the subnet already has an associated route table, normally an error will be thrown if attempting to associate another route table. However, using `force_replace`, no error will be thrown and the subnet will become associated with the new route table instead.
-
-```hcl
-resource "aws_route_table_association" "a" {
-  subnet_id      = "${aws_subnet.foo.id}"
-  route_table_id = "${aws_route_table.bar.id}"
-  force_replace  = true
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
 
 * `subnet_id` - (Required) The subnet ID to create an association.
 * `route_table_id` - (Required) The ID of the routing table to associate with.
-* `force_replace` - (Optional) Boolean indicating whether to replace an existing association or not.
 
 ## Attributes Reference
 
@@ -45,3 +32,17 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the association
 
+## Import
+
+~> **NOTE:** Attempting to associate a route table with a subnet, where either
+is already associated, will result in an error (e.g.,
+`Resource.AlreadyAssociated: the specified association for route table
+rtb-4176657279 conflicts with an existing association`) unless you first
+import the original association.
+
+Route table associations can be imported using the subnet and route table IDs.
+For example, use this command:
+
+```
+$ terraform import aws_route_table_association.assoc subnet-6777656e646f6c796e/rtb-656c65616e6f72
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #73 

**UPDATE 7/19/19:** Rather than force replacement, allow the import of route table associations allows the associations to be updated. See [below](https://github.com/terraform-providers/terraform-provider-aws/pull/6999#issuecomment-513407131).

Changes proposed in this pull request:

* ~~`r/aws_route_table_association`: Add new argument `force_replace` allowing a route table to be associated with a subnet even if another route table is already associated.~~ Add corresponding docs & tests.
* `r/aws_route_table_association`: Implement import so that associations can be updated after they are imported.


Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSRouteTableAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRouteTableAssociation_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRouteTableAssociation_basic
=== PAUSE TestAccAWSRouteTableAssociation_basic
=== RUN   TestAccAWSRouteTableAssociation_replace
=== PAUSE TestAccAWSRouteTableAssociation_replace
=== CONT  TestAccAWSRouteTableAssociation_basic
=== CONT  TestAccAWSRouteTableAssociation_replace
--- PASS: TestAccAWSRouteTableAssociation_replace (63.32s)
--- PASS: TestAccAWSRouteTableAssociation_basic (63.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	63.696s
```