### PR TITLE
[WIP] db_instance: allow_major_version_upgrade conflicts replicate_source_db

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -342,9 +342,10 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"allow_major_version_upgrade": {
-				Type:     schema.TypeBool,
-				Computed: false,
-				Optional: true,
+				Type:          schema.TypeBool,
+				Computed:      false,
+				Optional:      true,
+				ConflictsWith: []string{"replicate_source_db"},
 			},
 
 			"monitoring_role_arn": {


### PR DESCRIPTION
**Changes proposed in this pull request:**

* Mark `allow_major_version_upgrade` as conflicting with `replicate_source_db`

[This is at least true for PostgeSQL RDS read replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion). The following error is reported when `allow_major_version_upgrade=true` on a PostgreSQL read replica when attempting to modify `engine_version`.

```
Error: Error applying plan:

1 error(s) occurred:

* aws_db_instance.backend-upgrade-test-readreplica: 1 error(s) occurred:

* aws_db_instance.test-readreplica: Error modifying DB Instance test-readreplica: InvalidParameterValue: Major Version Upgrade not supported for Postgres Read Replica DB Instances
```

I'm unsure of behavior with MySQL, MariaDB, MSSQL or Oracle engines, or how to limit the `ConflictsWith` scope to a conditional on `engine`.

Alternatively, setting `allow_major_version_upgrade` could set the `ForceNew` flag for the PostgreSQL engine and `replicate_source_db`, but I'm unsure how to express that logic.

**TODO: Check and update acceptance tests.**

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=testAccCheckAWSDBInstanceReplicaAttributes'

...
```

**Enhancement/Bugfix to a Resource**
- [ ] Acceptance test coverage of new behavior
- [ ] Documentation updates: https://github.com/hashicorp/terraform/tree/master/website
- [ ] Well-formed Code
- [ ] ~~Vendor additions~~