### PR TITLE
Fix example usage

### DIFF
--- a/website/docs/r/iam_role_policy.html.markdown
+++ b/website/docs/r/iam_role_policy.html.markdown
@@ -15,7 +15,7 @@ Provides an IAM role policy.
 ```hcl
 resource "aws_iam_role_policy" "test_policy" {
   name = "test_policy"
-  role = "${aws_iam_role.test_role.id}"
+  role = "${aws_iam_role.test_role.unique_id}"
 
   policy = <<EOF
 {


### PR DESCRIPTION
The `aws_iam_role.test_role.id` reference is not correct, the `id` attribute is only from a data source, it is a `unique_id` from a resource.  

https://www.terraform.io/docs/providers/aws/r/iam_role.html

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->


Changes proposed in this pull request:

* Fix an incorrect attribute reference for an IAM Role resource

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
I did not run acceptance tests, this is a markdown only change.