### PR TITLE
Added the missing id attribute in aws_iam_role doc

### DIFF
--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -63,9 +63,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) specifying the role.
 * `create_date` - The creation date of the IAM role.
-* `unique_id` - The stable and unique string identifying the role.
-* `name` - The name of the role.
 * `description` - The description of the role.
+* `id` - The name of the role.
+* `name` - The name of the role.
+* `unique_id` - The stable and unique string identifying the role.
 
 ## Example of Using Data Source for Assume Role Policy
 


### PR DESCRIPTION
Also re-ordered the attributes by alpha.  The `id` was missing and is the same as the `name` [line 183](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_iam_role.go#L183), see #7015

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7015

Changes proposed in this pull request:

* Add missing attribute `id` from `aws_iam_role`'s documentation, this provides clarity when this resource is viewed in other documents that show `.id` and this doc does not.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
