### PR TITLE
Add support for tags for aws_sfn_state_machine and aws_sfn_activity

### DIFF
--- a/aws/resource_aws_sfn_activity.go
+++ b/aws/resource_aws_sfn_activity.go
@@ -55,7 +55,18 @@ func resourceAwsSfnActivityCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(*activity.ActivityArn)
 
-	return resourceAwsSfnActivityUpdate(d, meta)
+	if v, ok := d.GetOk("tags"); ok {
+		input := &sfn.TagResourceInput{
+			ResourceArn: aws.String(d.Id()),
+			Tags:        tagsFromMapSfn(v.(map[string]interface{})),
+		}
+		log.Printf("[DEBUG] Tagging SFN Activity: %s", input)
+		_, err := conn.TagResource(input)
+		if err != nil {
+			return fmt.Errorf("error tagging SFN Activity (%s): %s", d.Id(), input)
+		}
+	}
+	return resourceAwsSfnActivityRead(d, meta)
 }
 
 func resourceAwsSfnActivityUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_sfn_activity.go
+++ b/aws/resource_aws_sfn_activity.go
@@ -132,6 +132,20 @@ func resourceAwsSfnActivityRead(d *schema.ResourceData, meta interface{}) error 
 		log.Printf("[DEBUG] Error setting creation_date: %s", err)
 	}
 
+	tagsResp, err := conn.ListTagsForResource(
+		&sfn.ListTagsForResourceInput{
+			ResourceArn: aws.String(d.Id()),
+		},
+	)
+
+	if err != nil {
+		return fmt.Errorf("error listing SFN Activity (%s) tags: %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tagsToMapSfn(tagsResp.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
 	return nil
 }
 

--- a/aws/resource_aws_sfn_activity.go
+++ b/aws/resource_aws_sfn_activity.go
@@ -17,6 +17,7 @@ func resourceAwsSfnActivity() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsSfnActivityCreate,
 		Read:   resourceAwsSfnActivityRead,
+		Update: resourceAwsSfnActivityUpdate,
 		Delete: resourceAwsSfnActivityDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -34,6 +35,7 @@ func resourceAwsSfnActivity() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -52,6 +54,48 @@ func resourceAwsSfnActivityCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(*activity.ActivityArn)
+
+	return resourceAwsSfnActivityUpdate(d, meta)
+}
+
+func resourceAwsSfnActivityUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).sfnconn
+
+	if d.HasChange("tags") {
+		oldTagsRaw, newTagsRaw := d.GetChange("tags")
+		oldTagsMap := oldTagsRaw.(map[string]interface{})
+		newTagsMap := newTagsRaw.(map[string]interface{})
+		createTags, removeTags := diffTagsSfn(tagsFromMapSfn(oldTagsMap), tagsFromMapSfn(newTagsMap))
+
+		if len(removeTags) > 0 {
+			removeTagKeys := make([]*string, len(removeTags))
+			for i, removeTag := range removeTags {
+				removeTagKeys[i] = removeTag.Key
+			}
+
+			input := &sfn.UntagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				TagKeys:     removeTagKeys,
+			}
+
+			log.Printf("[DEBUG] Untagging State Function Activity: %s", input)
+			if _, err := conn.UntagResource(input); err != nil {
+				return fmt.Errorf("error untagging State Function Activity (%s): %s", d.Id(), err)
+			}
+		}
+
+		if len(createTags) > 0 {
+			input := &sfn.TagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				Tags:        createTags,
+			}
+
+			log.Printf("[DEBUG] Tagging State Function Activity: %s", input)
+			if _, err := conn.TagResource(input); err != nil {
+				return fmt.Errorf("error tagging State Function Activity (%s): %s", d.Id(), err)
+			}
+		}
+	}
 
 	return resourceAwsSfnActivityRead(d, meta)
 }

--- a/aws/resource_aws_sfn_activity_test.go
+++ b/aws/resource_aws_sfn_activity_test.go
@@ -55,6 +55,43 @@ func TestAccAWSSfnActivity_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSfnActivity_Tags(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSfnActivityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSfnActivityBasicConfigTags1(name, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnActivityExists("aws_sfn_activity.foo"),
+					resource.TestCheckResourceAttr("aws_sfn_activity.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_activity.foo", "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSSfnActivityBasicConfigTags2(name, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnActivityExists("aws_sfn_activity.foo"),
+					resource.TestCheckResourceAttr("aws_sfn_activity.foo", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_sfn_activity.foo", "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr("aws_sfn_activity.foo", "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSfnActivityBasicConfigTags1(name, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnActivityExists("aws_sfn_activity.foo"),
+					resource.TestCheckResourceAttr("aws_sfn_activity.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_activity.foo", "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSSfnActivityExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -125,4 +162,27 @@ resource "aws_sfn_activity" "foo" {
   name = "%s"
 }
 `, rName)
+}
+
+func testAccAWSSfnActivityBasicConfigTags1(rName, tag1Key, tag1Value string) string {
+	return fmt.Sprintf(`
+resource "aws_sfn_activity" "foo" {
+  name = "%s"
+  tags = {
+	%q = %q
+}
+}
+`, rName, tag1Key, tag1Value)
+}
+
+func testAccAWSSfnActivityBasicConfigTags2(rName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return fmt.Sprintf(`
+resource "aws_sfn_activity" "foo" {
+  name = "%s"
+  tags = {
+	%q = %q
+	%q = %q
+}
+}
+`, rName, tag1Key, tag1Value, tag2Key, tag2Value)
 }

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -139,9 +139,10 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 		},
 	)
 	if err != nil {
-		return err
-	} else {
-		d.Set("tags", tagsToMapSfn(tagsResp.Tags))
+		return fmt.Errorf("error listing SFN Activity (%s) tags: %s", d.Id(), err)
+	}
+	if err := d.Set("tags", tagsToMapSfn(tagsResp.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -52,6 +52,7 @@ func resourceAwsSfnStateMachine() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -92,7 +93,7 @@ func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(*activity.StateMachineArn)
 
-	return resourceAwsSfnStateMachineRead(d, meta)
+	return resourceAwsSfnStateMachineUpdate(d, meta)
 }
 
 func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) error {
@@ -121,6 +122,16 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 	if err := d.Set("creation_date", sm.CreationDate.Format(time.RFC3339)); err != nil {
 		log.Printf("[DEBUG] Error setting creation_date: %s", err)
 	}
+	tagsResp, err := conn.ListTagsForResource(
+		&sfn.ListTagsForResourceInput{
+			ResourceArn: aws.String(d.Id()),
+		},
+	)
+	if err != nil {
+		log.Printf("[DEBUG] Error retrieving tags for Step Function: %s. %s", aws.StringValue(sm.Name), err)
+	} else {
+		d.Set("tags", tagsToMapSfn(tagsResp.Tags))
+	}
 
 	return nil
 }
@@ -143,6 +154,42 @@ func resourceAwsSfnStateMachineUpdate(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("Error updating Step Function State Machine: %s", err)
 		}
 		return err
+	}
+
+	if d.HasChange("tags") {
+		oldTagsRaw, newTagsRaw := d.GetChange("tags")
+		oldTagsMap := oldTagsRaw.(map[string]interface{})
+		newTagsMap := newTagsRaw.(map[string]interface{})
+		createTags, removeTags := diffTagsSfn(tagsFromMapSfn(oldTagsMap), tagsFromMapSfn(newTagsMap))
+
+		if len(removeTags) > 0 {
+			removeTagKeys := make([]*string, len(removeTags))
+			for i, removeTag := range removeTags {
+				removeTagKeys[i] = removeTag.Key
+			}
+
+			input := &sfn.UntagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				TagKeys:     removeTagKeys,
+			}
+
+			log.Printf("[DEBUG] Untagging State Function: %s", input)
+			if _, err := conn.UntagResource(input); err != nil {
+				return fmt.Errorf("error untagging State Function (%s): %s", d.Id(), err)
+			}
+		}
+
+		if len(createTags) > 0 {
+			input := &sfn.TagResourceInput{
+				ResourceArn: aws.String(d.Id()),
+				Tags:        createTags,
+			}
+
+			log.Printf("[DEBUG] Tagging State Function: %s", input)
+			if _, err := conn.TagResource(input); err != nil {
+				return fmt.Errorf("error tagging State Function (%s): %s", d.Id(), err)
+			}
+		}
 	}
 
 	return resourceAwsSfnStateMachineRead(d, meta)

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -48,6 +48,43 @@ func TestAccAWSSfnStateMachine_createUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAWSSfnStateMachine_Tags(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSfnStateMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSfnStateMachineConfigTags1(name, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSSfnStateMachineConfigTags2(name, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSSfnStateMachineConfigTags1(name, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSfnExists("aws_sfn_state_machine.foo"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_sfn_state_machine.foo", "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSSfnExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -219,4 +256,247 @@ EOF
 }
 
 `, rName, rName, rName, rName, rName, rName, rMaxAttempts)
+}
+
+func testAccAWSSfnStateMachineConfigTags1(rName string, tag1Key, tag1Value string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {
+  current = true
+}
+
+resource "aws_iam_role_policy" "iam_policy_for_lambda" {
+  name = "iam_policy_for_lambda_%s"
+  role = "${aws_iam_role.iam_for_lambda.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ],
+    "Resource": "arn:aws:logs:*:*:*"
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "iam_policy_for_sfn" {
+  name = "iam_policy_for_sfn_%s"
+  role = "${aws_iam_role.iam_for_sfn.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+        "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_sfn" {
+  name = "iam_for_sfn_%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "states.${data.aws_region.current.name}.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "lambda_function_test" {
+  filename = "test-fixtures/lambdatest.zip"
+  function_name = "sfn-%s"
+  role = "${aws_iam_role.iam_for_lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs8.10"
+}
+
+resource "aws_sfn_state_machine" "foo" {
+  name     = "test_sfn_%s"
+  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Task",
+      "Resource": "${aws_lambda_function.lambda_function_test.arn}",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 5,
+          "BackoffRate": 8.0
+        }
+      ],
+      "End": true
+    }
+  }
+}
+EOF
+tags = {
+	%q = %q
+}
+}
+`, rName, rName, rName, rName, rName, rName, tag1Key, tag1Value)
+}
+
+func testAccAWSSfnStateMachineConfigTags2(rName string, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return fmt.Sprintf(`
+data "aws_region" "current" {
+  current = true
+}
+
+resource "aws_iam_role_policy" "iam_policy_for_lambda" {
+  name = "iam_policy_for_lambda_%s"
+  role = "${aws_iam_role.iam_for_lambda.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ],
+    "Resource": "arn:aws:logs:*:*:*"
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda_%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "iam_policy_for_sfn" {
+  name = "iam_policy_for_sfn_%s"
+  role = "${aws_iam_role.iam_for_sfn.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+        "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "iam_for_sfn" {
+  name = "iam_for_sfn_%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "states.${data.aws_region.current.name}.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "lambda_function_test" {
+  filename = "test-fixtures/lambdatest.zip"
+  function_name = "sfn-%s"
+  role = "${aws_iam_role.iam_for_lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs8.10"
+}
+
+resource "aws_sfn_state_machine" "foo" {
+  name     = "test_sfn_%s"
+  role_arn = "${aws_iam_role.iam_for_sfn.arn}"
+
+  definition = <<EOF
+{
+  "Comment": "A Hello World example of the Amazon States Language using an AWS Lambda Function",
+  "StartAt": "HelloWorld",
+  "States": {
+    "HelloWorld": {
+      "Type": "Task",
+      "Resource": "${aws_lambda_function.lambda_function_test.arn}",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 5,
+          "BackoffRate": 8.0
+        }
+      ],
+      "End": true
+    }
+  }
+}
+EOF
+tags = {
+	%q = %q
+	%q = %q
+}
+}
+`, rName, rName, rName, rName, rName, rName, tag1Key, tag1Value, tag2Key, tag2Value)
 }

--- a/aws/tagsSfn.go
+++ b/aws/tagsSfn.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+)
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsSfn(oldTags, newTags []*sfn.Tag) ([]*sfn.Tag, []*sfn.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*sfn.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapSfn(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapSfn(tagMap map[string]interface{}) []*sfn.Tag {
+	tags := make([]*sfn.Tag, 0, len(tagMap))
+	for tagKey, tagValueRaw := range tagMap {
+		tag := &sfn.Tag{
+			Key:   aws.String(tagKey),
+			Value: aws.String(tagValueRaw.(string)),
+		}
+		if !tagIgnoredSfn(tag) {
+			tags = append(tags, tag)
+		}
+	}
+
+	return tags
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapSfn(tags []*sfn.Tag) map[string]string {
+	tagMap := make(map[string]string)
+	for _, tag := range tags {
+		if !tagIgnoredSfn(tag) {
+			tagMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+		}
+	}
+
+	return tagMap
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredSfn(t *sfn.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		r, _ := regexp.MatchString(v, aws.StringValue(t.Key))
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsSfn_test.go
+++ b/aws/tagsSfn_test.go
@@ -1,0 +1,110 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sfn"
+)
+
+func TestDiffSfnTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Add
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsSfn(tagsFromMapSfn(tc.Old), tagsFromMapSfn(tc.New))
+		cm := tagsToMapSfn(c)
+		rm := tagsToMapSfn(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+func TestIgnoringTagsSfn(t *testing.T) {
+	ignoredTags := []*sfn.Tag{
+		{
+			Key:   aws.String("aws:cloudformation:logical-id"),
+			Value: aws.String("foo"),
+		},
+		{
+			Key:   aws.String("aws:foo:bar"),
+			Value: aws.String("baz"),
+		},
+	}
+	for _, tag := range ignoredTags {
+		if !tagIgnoredSfn(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/sfn_activity.html.markdown
+++ b/website/docs/r/sfn_activity.html.markdown
@@ -23,6 +23,7 @@ resource "aws_sfn_activity" "sfn_activity" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the activity to create.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the state machine.
 * `definition` - (Required) The Amazon States Language definition of the state machine.
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role to use for this state machine.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
As part of #6971

Changes proposed in this pull request:

* Tag support for `aws_sfn_state_machine` and `aws_sfn_activity`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSfnStateMachine_Tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSfnStateMachine_Tags -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSfnStateMachine_Tags
=== PAUSE TestAccAWSSfnStateMachine_Tags
=== CONT  TestAccAWSSfnStateMachine_Tags
--- PASS: TestAccAWSSfnStateMachine_Tags (95.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       95.384s...



make testacc TESTARGS='-run=TestAccAWSSfnActivity_Tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSfnActivity_Tags -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSfnActivity_Tags
=== PAUSE TestAccAWSSfnActivity_Tags
=== CONT  TestAccAWSSfnActivity_Tags
--- PASS: TestAccAWSSfnActivity_Tags (50.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.171s

```
