### PR TITLE
docs/resource/aws_elasticache_replication_group: Add note about apply_immediately

### DIFF
--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -12,6 +12,14 @@ Provides an ElastiCache Replication Group resource.
 For working with Memcached or single primary Redis instances (Cluster Mode Disabled), see the
 [`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html).
 
+~> **Note:** When you change an attribute, such as `engine_version`, by
+default the ElastiCache API applies it in the next maintenance window. Because
+of this, Terraform may report a difference in its planning phase because the
+actual modification has not yet taken place. You can use the
+`apply_immediately` flag to instruct the service to apply the change
+immediately. Using `apply_immediately` can result in a brief downtime as
+servers reboots.
+
 ## Example Usage
 
 ### Redis Cluster Mode Disabled


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/7010

Copied from `aws_elasticache_cluster` resource documentation.

Output from acceptance testing: N/A

