### PR TITLE
Add engine_version parameter to the Redis example

### DIFF
--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -43,6 +43,7 @@ resource "aws_elasticache_cluster" "example" {
   node_type            = "cache.m4.large"
   num_cache_nodes      = 1
   parameter_group_name = "default.redis3.2"
+  engine_version       = "3.2"
   port                 = 6379
 }
 ```


### PR DESCRIPTION
If you don't have this parameter and try to apply this example, you get an error:

```
* aws_elasticache_cluster.archivematica: 1 error(s) occurred:

* aws_elasticache_cluster.archivematica: error creating Elasticache Cache Cluster:
        InvalidParameterCombination: Expected a parameter group of family redis5.0 but found one of family redis3.2
	status code: 400, request id: 95e5e568-103a-11e9-9d09-854b4ad5a13d
```

The error occurs with the latest version of the provider (1.54.0).