### PR TITLE
tests/provider: Support AWS GovCloud (US) Acceptance Test Sweeping

### DIFF
--- a/aws/aws_sweeper_test.go
+++ b/aws/aws_sweeper_test.go
@@ -15,12 +15,8 @@ func TestMain(m *testing.M) {
 // sharedClientForRegion returns a common AWSClient setup needed for the sweeper
 // functions for a given region
 func sharedClientForRegion(region string) (interface{}, error) {
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		return nil, fmt.Errorf("empty AWS_ACCESS_KEY_ID")
-	}
-
-	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		return nil, fmt.Errorf("empty AWS_SECRET_ACCESS_KEY")
+	if os.Getenv("AWS_PROFILE") == "" && (os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "") {
+		return nil, fmt.Errorf("must provide environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or environment variable AWS_PROFILE")
 	}
 
 	conf := &Config{

--- a/aws/data_source_aws_api_gateway_vpc_link_test.go
+++ b/aws/data_source_aws_api_gateway_vpc_link_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceAwsApiGatewayVpcLink(t *testing.T) {
-	rName := acctest.RandString(8)
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(8))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccDataSourceAWSMqBroker_basic(t *testing.T) {
 	rString := acctest.RandString(7)
-	prefix := "tf-acctest-d-mq-broker"
+	prefix := "tf-acc-test-d-mq-broker"
 	brokerName := fmt.Sprintf("%s-%s", prefix, rString)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -314,5 +314,12 @@ func testSweepSkipSweepError(err error) bool {
 	if isAWSErr(err, "InvalidParameterValue", "not permitted in this API version for your account") {
 		return true
 	}
+	// GovCloud has endpoints that respond with (no message provided):
+	// AccessDeniedException:
+	// Since acceptance test sweepers are best effort and this response is very common,
+	// we allow bypassing this error globally instead of individual test sweeper fixes.
+	if isAWSErr(err, "AccessDeniedException", "") {
+		return true
+	}
 	return false
 }

--- a/aws/resource_aws_ec2_capacity_reservation_test.go
+++ b/aws/resource_aws_ec2_capacity_reservation_test.go
@@ -28,6 +28,11 @@ func testSweepEc2CapacityReservations(region string) error {
 
 	resp, err := conn.DescribeCapacityReservations(&ec2.DescribeCapacityReservationsInput{})
 
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping EC2 Capacity Reservation sweep for %s: %s", region, err)
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error retrieving EC2 Capacity Reservations: %s", err)
 	}

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -16,7 +16,10 @@ import (
 func init() {
 	resource.AddTestSweepers("aws_internet_gateway", &resource.Sweeper{
 		Name: "aws_internet_gateway",
-		F:    testSweepInternetGateways,
+		Dependencies: []string{
+			"aws_subnet",
+		},
+		F: testSweepInternetGateways,
 	})
 }
 

--- a/aws/resource_aws_security_group_test.go
+++ b/aws/resource_aws_security_group_test.go
@@ -23,7 +23,10 @@ import (
 func init() {
 	resource.AddTestSweepers("aws_security_group", &resource.Sweeper{
 		Name: "aws_security_group",
-		F:    testSweepSecurityGroups,
+		Dependencies: []string{
+			"aws_subnet",
+		},
+		F: testSweepSecurityGroups,
 	})
 }
 

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -53,6 +53,7 @@ func testSweepSubnets(region string) error {
 			{
 				Name: aws.String("tag-value"),
 				Values: []*string{
+					aws.String("terraform-testacc-*"),
 					aws.String("tf-acc-*"),
 				},
 			},


### PR DESCRIPTION
Changes proposed in this pull request (see commit messages for additional details):

* tests/provider: Add `AccessDeniedException` to `testSweepSkipSweepError()`
* tests/provider: Allow `AWS_PROFILE` environment variable for acceptance test sweepers
* tests/data-source/aws_api_gateway_vpc_link: Fix naming prefix to `tf-acc-test` for sweepers
* tests/data-source/aws_mq_broker: Fix naming prefix to `tf-acc-test` for sweepers
* tests/resource/aws_ec2_capacity_reservation: Add missing `testSweepSkipSweepError()` check for sweeper
* tests/resource/aws_internet_gateway: Ensure sweeper runs after `aws_subnet` sweeper
* tests/resource/aws_security_group: Ensure sweeper runs after `aws_subnet` sweeper
* tests/resource/aws_subnet: Add `terraform-testacc-*` naming prefix for sweeper

Output from acceptance testing (AWS Commercial):

```
--- PASS: TestAccDataSourceAwsApiGatewayVpcLink (703.18s)
--- PASS: TestAccDataSourceAWSMqBroker_basic (1343.38s)
```

Output from acceptance testing sweepers (AWS GovCloud (US)):

```
2019/01/05 20:56:44 Sweeper Tests ran:
	- aws_cloudfront_distribution
	- aws_beanstalk_environment
	- aws_lambda_function
	- aws_network_acl
	- aws_glue_crawler
	- aws_vpn_gateway
	- aws_datasync_agent
	- aws_acmpca_certificate_authority
	- aws_storagegateway_gateway
	- aws_elasticsearch_domain
	- aws_redshift_cluster
	- aws_subnet
	- aws_gamelift_fleet
	- aws_iam_service_linked_role
	- aws_wafregional_regex_match_set
	- aws_config_configuration_aggregator
	- aws_autoscaling_group
	- aws_spot_fleet_request
	- aws_vpc
	- aws_glue_security_configuration
	- aws_beanstalk_application
	- aws_eks_cluster
	- aws_elasticache_cluster
	- aws_internet_gateway
	- aws_route_table
	- aws_security_group
	- aws_datasync_location_nfs
	- aws_glue_connection
	- aws_wafregional_rule_group
	- aws_launch_configuration
	- aws_batch_compute_environment
	- aws_waf_rule_group
	- aws_secretsmanager_secret
	- aws_instance
	- aws_gamelift_build
	- aws_glue_job
	- aws_glue_trigger
	- aws_config_configuration_recorder
	- aws_datasync_location_efs
	- aws_gamelift_alias
	- aws_waf_regex_match_set
	- aws_licensemanager_license_configuration
	- aws_batch_job_queue
	- aws_elasticache_replication_group
	- aws_nat_gateway
	- aws_lightsail_static_ip
	- aws_dynamodb_table
	- aws_db_instance
	- aws_directory_service_directory
	- aws_cloudwatch_event_rule
	- aws_api_gateway_rest_api
	- aws_datasync_location_s3
	- aws_db_option_group
	- aws_lb_target_group
	- aws_kms_key
	- aws_cognito_user_pool
	- aws_elasticache_security_group
	- aws_datasync_task
	- aws_key_pair
	- aws_config_delivery_channel
	- aws_dax_cluster
	- aws_elb
	- aws_lb
	- aws_mq_broker
	- aws_cloudwatch_event_permission
	- aws_glue_classifier
	- aws_iam_server_certificate
	- aws_ec2_capacity_reservation
	- aws_gamelift_game_session_queue
	- aws_config_aggregate_authorization
ok  	github.com/terraform-providers/terraform-provider-aws/aws	568.224s
```
