### PR TITLE
update api_gateway_base_path_mapping typo

### DIFF
--- a/website/docs/r/api_gateway_base_path_mapping.html.markdown
+++ b/website/docs/r/api_gateway_base_path_mapping.html.markdown
@@ -16,7 +16,7 @@ custom domain name.
 
 ```hcl
 resource "aws_api_gateway_deployment" "example" {
-  # See aws_api_gateway_rest_api_docs for how to create this
+  # See aws_api_gateway_rest_api docs for how to create this
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   stage_name  = "live"
 }


### PR DESCRIPTION
Removes underscore typo in comment for
`api_gateway_base_path_mapping`

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* update typo in api_gateway_base_path_mapping.html.markdown

Output from acceptance testing:

No go files modified in commit

```
$ make testacc TESTARGS='-run=TEstAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./aws/resource_aws_kinesis_analytics_application.go
./aws/resource_aws_rds_cluster_parameter_group.go
./aws/resource_aws_rds_cluster_instance.go
./aws/resource_aws_lb_listener.go
./aws/resource_aws_glue_security_configuration.go
./aws/resource_aws_s3_bucket.go
./aws/resource_aws_security_group_migrate_test.go
./aws/resource_aws_sns_topic.go
./aws/provider.go
./aws/resource_aws_swf_domain.go
./aws/resource_aws_kinesis_firehose_delivery_stream.go
./aws/resource_aws_neptune_cluster_instance.go
./aws/resource_aws_vpc.go
./aws/resource_aws_guardduty_detector.go
./aws/resource_aws_lb_listener_rule.go
./aws/resource_aws_gamelift_fleet.go
./aws/resource_aws_codedeploy_deployment_group_test.go
./aws/resource_aws_cloudfront_origin_access_identity.go
./aws/resource_aws_spot_fleet_request.go
./aws/resource_aws_db_instance.go
./aws/resource_aws_s3_bucket_inventory.go
./aws/opsworks_layers.go
./aws/resource_aws_neptune_cluster_parameter_group.go
./aws/resource_aws_ec2_fleet.go
./aws/resource_aws_ssm_patch_baseline.go
./aws/resource_aws_route53_record.go
./aws/resource_aws_licensemanager_license_configuration.go
./aws/data_source_aws_cloudformation_export_test.go
./aws/resource_aws_s3_bucket_notification.go
./aws/resource_aws_redshift_cluster.go
./aws/resource_aws_ssm_maintenance_window.go
./aws/resource_aws_spot_instance_request.go
./aws/resource_aws_emr_security_configuration.go
./aws/resource_aws_dms_replication_instance.go
./aws/resource_aws_instance.go
./aws/resource_aws_organizations_test.go
./aws/resource_aws_api_gateway_integration.go
./aws/validators_test.go
./aws/resource_aws_acmpca_certificate_authority.go
./aws/resource_aws_instance_migrate_test.go
./aws/resource_aws_db_security_group.go
You can use the command: `make fmt` to reformat code.
make: *** [GNUmakefile:28: fmtcheck] Error 1

...
```
