### PR TITLE
d/aws_organizations_accounts: Adding new data source for listing AWS Organization member account IDs

### DIFF
--- a/aws/data_source_aws_organizations_accounts.go
+++ b/aws/data_source_aws_organizations_accounts.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsOrganizationsAccounts() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsOrganizationsAccountsRead,
+
+		Schema: map[string]*schema.Schema{
+			"account_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceAwsOrganizationsAccountsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).organizationsconn
+
+	accounts := make([]string, 0)
+	input := &organizations.ListAccountsInput{}
+	for {
+		output, err := conn.ListAccounts(input)
+		if err != nil {
+			return fmt.Errorf("error reading AWS Organization: %s", err)
+		}
+		for _, account := range output.Accounts {
+			accounts = append(accounts, aws.StringValue(account.Id))
+		}
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+
+	d.Set("account_ids", accounts)
+
+	return nil
+}

--- a/aws/data_source_aws_organizations_accounts_test.go
+++ b/aws/data_source_aws_organizations_accounts_test.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsOrganizationsAccounts_basic(t *testing.T) {
+	orgsEmailDomain, ok := os.LookupEnv("TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN")
+
+	if !ok {
+		t.Skip("'TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN' not set, skipping test.")
+	}
+
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("tf_acctest_%d", rInt)
+	email := fmt.Sprintf("tf-acctest+%d@%s", rInt, orgsEmailDomain)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsAccountsConfig(name, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsAccountIds("data.aws_organizations_accounts.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOrganizationsAccountIds(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Organizations resource: %s", n)
+		}
+
+		if len(rs.Primary.Attributes["account_ids"]) == 0 {
+			return fmt.Errorf("No account IDs found")
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsOrganizationsAccountsConfig(name, email string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_account" "test" {
+  name = "%s"
+  email = "%s"
+}
+
+data "aws_organizations_accounts" "current" { }
+`, name, email)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -243,6 +243,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_network_acls":                       dataSourceAwsNetworkAcls(),
 			"aws_network_interface":                  dataSourceAwsNetworkInterface(),
 			"aws_network_interfaces":                 dataSourceAwsNetworkInterfaces(),
+			"aws_organizations_accounts":             dataSourceAwsOrganizationsAccounts(),
 			"aws_partition":                          dataSourceAwsPartition(),
 			"aws_prefix_list":                        dataSourceAwsPrefixList(),
 			"aws_pricing_product":                    dataSourceAwsPricingProduct(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -299,6 +299,9 @@
                          <li<%= sidebar_current("docs-aws-datasource-network-interfaces") %>>
                             <a href="/docs/providers/aws/d/network_interfaces.html">aws_network_interfaces</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-organizations-accounts") %>>
+                          <a href="/docs/providers/aws/d/organizations_accounts.html">aws_organizations_accounts</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-partition") %>>
                             <a href="/docs/providers/aws/d/partition.html">aws_partition</a>
                         </li>

--- a/website/docs/d/organizations_accounts.html.markdown
+++ b/website/docs/d/organizations_accounts.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "aws"
+page_title: "AWS: aws_organizations_accounts"
+sidebar_current: "docs-aws-datasource-organizations-accounts"
+description: |-
+  Get account IDs associated with an AWS Organization account.
+---
+
+# Data Source: aws_organizations_accounts
+
+Use this data source to get the account IDs associated with a particular AWS Organization account.
+
+## Example Usage
+
+```hcl
+data "aws_organizations_accounts" "current" {}
+
+output "account_id_0" {
+  value = "${data.aws_caller_identity.current.account_id[0]}"
+}
+
+output "account_id_1" {
+  value = "${data.aws_caller_identity.current.account_id[1]}"
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+* `account_ids` - A list of account ID numbers from the account that manages the AWS Organization configuration.


### PR DESCRIPTION
Fixes #6842 

Changes proposed in this pull request:

* Adding a new data source for listing AWS Organization member account IDs: `aws_organizations_accounts`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsOrganizationsAccounts_basic'

...
```
