### PR TITLE
resource/aws_ssm_maintenance_window: Add end_date, schedule_timezone, and start_date attributes

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window.go
+++ b/aws/resource_aws_ssm_maintenance_window.go
@@ -51,6 +51,21 @@ func resourceAwsSsmMaintenanceWindow() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+
+			"end_date": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"schedule_timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"start_date": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -59,50 +74,74 @@ func resourceAwsSsmMaintenanceWindowCreate(d *schema.ResourceData, meta interfac
 	ssmconn := meta.(*AWSClient).ssmconn
 
 	params := &ssm.CreateMaintenanceWindowInput{
+		AllowUnassociatedTargets: aws.Bool(d.Get("allow_unassociated_targets").(bool)),
+		Cutoff:                   aws.Int64(int64(d.Get("cutoff").(int))),
+		Duration:                 aws.Int64(int64(d.Get("duration").(int))),
 		Name:                     aws.String(d.Get("name").(string)),
 		Schedule:                 aws.String(d.Get("schedule").(string)),
-		Duration:                 aws.Int64(int64(d.Get("duration").(int))),
-		Cutoff:                   aws.Int64(int64(d.Get("cutoff").(int))),
-		AllowUnassociatedTargets: aws.Bool(d.Get("allow_unassociated_targets").(bool)),
+	}
+
+	if v, ok := d.GetOk("end_date"); ok {
+		params.EndDate = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("schedule_timezone"); ok {
+		params.ScheduleTimezone = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("start_date"); ok {
+		params.StartDate = aws.String(v.(string))
 	}
 
 	resp, err := ssmconn.CreateMaintenanceWindow(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating SSM Maintenance Window: %s", err)
 	}
 
 	d.SetId(*resp.WindowId)
-	return resourceAwsSsmMaintenanceWindowUpdate(d, meta)
+
+	if !d.Get("enabled").(bool) {
+		input := &ssm.UpdateMaintenanceWindowInput{
+			Enabled:  aws.Bool(false),
+			WindowId: aws.String(d.Id()),
+		}
+
+		_, err := ssmconn.UpdateMaintenanceWindow(input)
+		if err != nil {
+			return fmt.Errorf("error disabling SSM Maintenance Window (%s): %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsSsmMaintenanceWindowRead(d, meta)
 }
 
 func resourceAwsSsmMaintenanceWindowUpdate(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
+	// Replace must be set otherwise its not possible to remove optional attributes, e.g.
+	// ValidationException: 1 validation error detected: Value '' at 'startDate' failed to satisfy constraint: Member must have length greater than or equal to 1
 	params := &ssm.UpdateMaintenanceWindowInput{
-		WindowId: aws.String(d.Id()),
+		AllowUnassociatedTargets: aws.Bool(d.Get("allow_unassociated_targets").(bool)),
+		Cutoff:                   aws.Int64(int64(d.Get("cutoff").(int))),
+		Duration:                 aws.Int64(int64(d.Get("duration").(int))),
+		Enabled:                  aws.Bool(d.Get("enabled").(bool)),
+		Name:                     aws.String(d.Get("name").(string)),
+		Replace:                  aws.Bool(true),
+		Schedule:                 aws.String(d.Get("schedule").(string)),
+		WindowId:                 aws.String(d.Id()),
 	}
 
-	if d.HasChange("name") {
-		params.Name = aws.String(d.Get("name").(string))
+	if v, ok := d.GetOk("end_date"); ok {
+		params.EndDate = aws.String(v.(string))
 	}
 
-	if d.HasChange("schedule") {
-		params.Schedule = aws.String(d.Get("schedule").(string))
+	if v, ok := d.GetOk("schedule_timezone"); ok {
+		params.ScheduleTimezone = aws.String(v.(string))
 	}
 
-	if d.HasChange("duration") {
-		params.Duration = aws.Int64(int64(d.Get("duration").(int)))
+	if v, ok := d.GetOk("start_date"); ok {
+		params.StartDate = aws.String(v.(string))
 	}
-
-	if d.HasChange("cutoff") {
-		params.Cutoff = aws.Int64(int64(d.Get("cutoff").(int)))
-	}
-
-	if d.HasChange("allow_unassociated_targets") {
-		params.AllowUnassociatedTargets = aws.Bool(d.Get("allow_unassociated_targets").(bool))
-	}
-
-	params.Enabled = aws.Bool(d.Get("enabled").(bool))
 
 	_, err := ssmconn.UpdateMaintenanceWindow(params)
 	if err != nil {
@@ -111,7 +150,7 @@ func resourceAwsSsmMaintenanceWindowUpdate(d *schema.ResourceData, meta interfac
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error updating SSM Maintenance Window (%s): %s", d.Id(), err)
 	}
 
 	return resourceAwsSsmMaintenanceWindowRead(d, meta)
@@ -131,15 +170,18 @@ func resourceAwsSsmMaintenanceWindowRead(d *schema.ResourceData, meta interface{
 			d.SetId("")
 			return nil
 		}
-		return err
+		return fmt.Errorf("error reading SSM Maintenance Window (%s): %s", d.Id(), err)
 	}
 
-	d.Set("name", resp.Name)
+	d.Set("allow_unassociated_targets", resp.AllowUnassociatedTargets)
 	d.Set("cutoff", resp.Cutoff)
 	d.Set("duration", resp.Duration)
 	d.Set("enabled", resp.Enabled)
-	d.Set("allow_unassociated_targets", resp.AllowUnassociatedTargets)
+	d.Set("end_date", resp.EndDate)
+	d.Set("name", resp.Name)
+	d.Set("schedule_timezone", resp.ScheduleTimezone)
 	d.Set("schedule", resp.Schedule)
+	d.Set("start_date", resp.StartDate)
 
 	return nil
 }

--- a/aws/resource_aws_ssm_maintenance_window_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -13,7 +14,8 @@ import (
 
 func TestAccAWSSSMMaintenanceWindow_basic(t *testing.T) {
 	var winId ssm.MaintenanceWindowIdentity
-	name := acctest.RandString(10)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,36 +23,23 @@ func TestAccAWSSSMMaintenanceWindow_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowBasicConfig(name),
+				Config: testAccAWSSSMMaintenanceWindowConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowExists("aws_ssm_maintenance_window.foo", &winId),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "schedule", "cron(0 16 ? * TUE *)"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "duration", "3"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "cutoff", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "name", fmt.Sprintf("maintenance-window-%s", name)),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "enabled", "false"),
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &winId),
+					resource.TestCheckResourceAttr(resourceName, "cutoff", "1"),
+					resource.TestCheckResourceAttr(resourceName, "duration", "3"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "end_date", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "schedule_timezone", ""),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(0 16 ? * TUE *)"),
+					resource.TestCheckResourceAttr(resourceName, "start_date", ""),
 				),
 			},
 			{
-				Config: testAccAWSSSMMaintenanceWindowBasicConfigUpdated(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMMaintenanceWindowExists("aws_ssm_maintenance_window.foo", &winId),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "schedule", "cron(0 16 ? * WED *)"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "duration", "10"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "cutoff", "8"),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "name", fmt.Sprintf("updated-maintenance-window-%s", name)),
-					resource.TestCheckResourceAttr(
-						"aws_ssm_maintenance_window.foo", "enabled", "true"),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -59,7 +48,7 @@ func TestAccAWSSSMMaintenanceWindow_basic(t *testing.T) {
 func TestAccAWSSSMMaintenanceWindow_disappears(t *testing.T) {
 	var winId ssm.MaintenanceWindowIdentity
 	name := acctest.RandString(10)
-	resourceName := "aws_ssm_maintenance_window.foo"
+	resourceName := "aws_ssm_maintenance_window.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,12 +56,305 @@ func TestAccAWSSSMMaintenanceWindow_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMMaintenanceWindowBasicConfig(name),
+				Config: testAccAWSSSMMaintenanceWindowConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &winId),
 					testAccCheckAWSSSMMaintenanceWindowDisappears(&winId),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_multipleUpdates(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2 ssm.MaintenanceWindowIdentity
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfig(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "cutoff", "1"),
+					resource.TestCheckResourceAttr(resourceName, "duration", "3"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(0 16 ? * TUE *)"),
+				),
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigMultipleUpdates(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "cutoff", "8"),
+					resource.TestCheckResourceAttr(resourceName, "duration", "10"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(0 16 ? * WED *)"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_Cutoff(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2 ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigCutoff(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "cutoff", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigCutoff(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "cutoff", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_Duration(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2 ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigDuration(rName, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "duration", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigDuration(rName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "duration", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_Enabled(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2 ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_EndDate(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2, maintenanceWindow3 ssm.MaintenanceWindowIdentity
+	endDate1 := time.Now().UTC().Add(365 * 24 * time.Hour).Format(time.RFC3339)
+	endDate2 := time.Now().UTC().Add(730 * 24 * time.Hour).Format(time.RFC3339)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigEndDate(rName, endDate1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "end_date", endDate1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigEndDate(rName, endDate2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "end_date", endDate2),
+				),
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow3),
+					resource.TestCheckResourceAttr(resourceName, "end_date", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_Schedule(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2 ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigSchedule(rName, "cron(0 16 ? * TUE *)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(0 16 ? * TUE *)"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigSchedule(rName, "cron(0 16 ? * WED *)"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(0 16 ? * WED *)"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_ScheduleTimezone(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2, maintenanceWindow3 ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigScheduleTimezone(rName, "America/Los_Angeles"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "schedule_timezone", "America/Los_Angeles"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigScheduleTimezone(rName, "America/New_York"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "schedule_timezone", "America/New_York"),
+				),
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow3),
+					resource.TestCheckResourceAttr(resourceName, "schedule_timezone", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_StartDate(t *testing.T) {
+	var maintenanceWindow1, maintenanceWindow2, maintenanceWindow3 ssm.MaintenanceWindowIdentity
+	startDate1 := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+	startDate2 := time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigStartDate(rName, startDate1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow1),
+					resource.TestCheckResourceAttr(resourceName, "start_date", startDate1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigStartDate(rName, startDate2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow2),
+					resource.TestCheckResourceAttr(resourceName, "start_date", startDate2),
+				),
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &maintenanceWindow3),
+					resource.TestCheckResourceAttr(resourceName, "start_date", ""),
+				),
 			},
 		},
 	})
@@ -160,28 +442,106 @@ func testAccCheckAWSSSMMaintenanceWindowDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSSSMMaintenanceWindowBasicConfig(rName string) string {
+func testAccAWSSSMMaintenanceWindowConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_maintenance_window" "foo" {
-  name = "maintenance-window-%s"
-  schedule = "cron(0 16 ? * TUE *)"
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 1
   duration = 3
-  cutoff = 1
-  enabled = false
+  name     = %q
+  schedule = "cron(0 16 ? * TUE *)"
 }
-
 `, rName)
 }
 
-func testAccAWSSSMMaintenanceWindowBasicConfigUpdated(rName string) string {
+func testAccAWSSSMMaintenanceWindowConfigCutoff(rName string, cutoff int) string {
 	return fmt.Sprintf(`
-resource "aws_ssm_maintenance_window" "foo" {
-  name = "updated-maintenance-window-%s"
-  schedule = "cron(0 16 ? * WED *)"
-  duration = 10
-  cutoff = 8
-  enabled = true
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = %d
+  duration = 3
+  name     = %q
+  schedule = "cron(0 16 ? * TUE *)"
+}
+`, cutoff, rName)
 }
 
+func testAccAWSSSMMaintenanceWindowConfigDuration(rName string, duration int) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 1
+  duration = %d
+  name     = %q
+  schedule = "cron(0 16 ? * TUE *)"
+}
+`, duration, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigEnabled(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 1
+  duration = 3
+  enabled  = %t
+  name     = %q
+  schedule = "cron(0 16 ? * TUE *)"
+}
+`, enabled, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigEndDate(rName, endDate string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 1
+  duration = 3
+  end_date = %q
+  name     = %q
+  schedule = "cron(0 16 ? * TUE *)"
+}
+`, endDate, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigMultipleUpdates(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 8
+  duration = 10
+  enabled  = false
+  name     = %q
+  schedule = "cron(0 16 ? * WED *)"
+}
 `, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigSchedule(rName, schedule string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 1
+  duration = 3
+  name     = %q
+  schedule = %q
+}
+`, rName, schedule)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigScheduleTimezone(rName, scheduleTimezone string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff            = 1
+  duration          = 3
+  name              = %q
+  schedule          = "cron(0 16 ? * TUE *)"
+  schedule_timezone = %q
+}
+`, rName, scheduleTimezone)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigStartDate(rName, startDate string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff     = 1
+  duration   = 3
+  name       = %q
+  schedule   = "cron(0 16 ? * TUE *)"
+  start_date = %q
+}
+`, rName, startDate)
 }

--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -30,6 +30,10 @@ The following arguments are supported:
 * `cutoff` - (Required) The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution.
 * `duration` - (Required) The duration of the Maintenance Window in hours.
 * `allow_unassociated_targets` - (Optional) Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.
+* `enabled` - (Optional) Whether the maintenance window is enabled. Default: `true`.
+* `end_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to no longer run the maintenance window.
+* `schedule_timezone` - (Optional) Timezone for schedule in [Internet Assigned Numbers Authority (IANA) Time Zone Database format](https://www.iana.org/time-zones). For example: `America/Los_Angeles`, `etc/UTC`, or `Asia/Seoul`.
+* `start_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to begin the maintenance window.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Closes #6962
Closes #6980 

Changes:
* resource/aws_ssm_maintenance_window: Add `end_date`, `schedule_timezone`, and `start_date` attributes
* resource/aws_ssm_maintenance_window: Refactor to call Read after Create
* tests/resource/aws_ssm_maintenance_window: Refactor acceptance testing to test all attributes

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMMaintenanceWindow_disappears (8.55s)
--- PASS: TestAccAWSSSMMaintenanceWindow_basic (14.14s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Enabled (18.78s)
--- PASS: TestAccAWSSSMMaintenanceWindow_multipleUpdates (20.36s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Cutoff (20.94s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Duration (21.10s)
--- PASS: TestAccAWSSSMMaintenanceWindow_EndDate (28.64s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Schedule (30.68s)
--- PASS: TestAccAWSSSMMaintenanceWindow_ScheduleTimezone (31.00s)
--- PASS: TestAccAWSSSMMaintenanceWindow_StartDate (32.63s)
```
