### PR TITLE
tests/resource/aws_acmpca_certificate_authority: Allow DELETED status in CheckDestroy

### DIFF
--- a/aws/resource_aws_acmpca_certificate_authority_test.go
+++ b/aws/resource_aws_acmpca_certificate_authority_test.go
@@ -414,8 +414,8 @@ func testAccCheckAwsAcmpcaCertificateAuthorityDestroy(s *terraform.State) error 
 			return err
 		}
 
-		if output != nil {
-			return fmt.Errorf("ACMPCA Certificate Authority %q still exists", rs.Primary.ID)
+		if output != nil && output.CertificateAuthority != nil && aws.StringValue(output.CertificateAuthority.Arn) == rs.Primary.ID && aws.StringValue(output.CertificateAuthority.Status) != acmpca.CertificateAuthorityStatusDeleted {
+			return fmt.Errorf("ACMPCA Certificate Authority %q still exists in non-DELETED state: %s", rs.Primary.ID, aws.StringValue(output.CertificateAuthority.Status))
 		}
 	}
 


### PR DESCRIPTION
Previous output from acceptance testing:

```
--- FAIL: TestAccAwsAcmpcaCertificateAuthority_Basic (12.51s)
    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Check failed: ACMPCA Certificate Authority "arn:aws:acm-pca:us-west-2:*******:certificate-authority/d32bf6e7-bce0-4687-82d2-0b19335f467a" still exists

        State: <no state>
```

Output from acceptance testing:

```
--- PASS: TestAccAwsAcmpcaCertificateAuthority_Basic (21.43s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_CustomCname (107.04s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_Enabled (86.07s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_ExpirationInDays (68.28s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_Tags (52.84s)
```
