### PR TITLE
tests/resource/aws_db_instance: Ensure TestAccAWSDBInstance_MSSQL_Domain aws_directory_service_directory are swept

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -1450,7 +1450,7 @@ func TestAccAWSDBInstance_MSSQL_Domain(t *testing.T) {
 				Config: testAccAWSDBMSSQLDomain(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &vBefore),
-					testAccCheckAWSDBInstanceDomainAttributes("foo.somedomain.com", &vBefore),
+					testAccCheckAWSDBInstanceDomainAttributes("terraformtesting.com", &vBefore),
 					resource.TestCheckResourceAttrSet(
 						"aws_db_instance.mssql", "domain"),
 					resource.TestCheckResourceAttrSet(
@@ -1461,7 +1461,7 @@ func TestAccAWSDBInstance_MSSQL_Domain(t *testing.T) {
 				Config: testAccAWSDBMSSQLUpdateDomain(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &vAfter),
-					testAccCheckAWSDBInstanceDomainAttributes("bar.somedomain.com", &vAfter),
+					testAccCheckAWSDBInstanceDomainAttributes("corp.notexample.com", &vAfter),
 					resource.TestCheckResourceAttrSet(
 						"aws_db_instance.mssql", "domain"),
 					resource.TestCheckResourceAttrSet(
@@ -1486,7 +1486,7 @@ func TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql_restore", &vRestoredInstance),
 					testAccCheckAWSDBInstanceExists("aws_db_instance.mssql", &v),
-					testAccCheckAWSDBInstanceDomainAttributes("foo.somedomain.com", &vRestoredInstance),
+					testAccCheckAWSDBInstanceDomainAttributes("terraformtesting.com", &vRestoredInstance),
 					resource.TestCheckResourceAttrSet(
 						"aws_db_instance.mssql_restore", "domain"),
 					resource.TestCheckResourceAttrSet(
@@ -2791,7 +2791,7 @@ resource "aws_security_group_rule" "rds-mssql-1" {
 }
 
 resource "aws_directory_service_directory" "foo" {
-  name     = "foo.somedomain.com"
+  name     = "terraformtesting.com"
   password = "SuperSecretPassw0rd"
   type     = "MicrosoftAD"
   edition  = "Standard"
@@ -2803,7 +2803,7 @@ resource "aws_directory_service_directory" "foo" {
 }
 
 resource "aws_directory_service_directory" "bar" {
-  name     = "bar.somedomain.com"
+  name     = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   type     = "MicrosoftAD"
   edition  = "Standard"
@@ -2914,7 +2914,7 @@ resource "aws_security_group_rule" "rds-mssql-1" {
 }
 
 resource "aws_directory_service_directory" "foo" {
-  name     = "foo.somedomain.com"
+  name     = "terraformtesting.com"
   password = "SuperSecretPassw0rd"
   type     = "MicrosoftAD"
   edition  = "Standard"
@@ -2926,7 +2926,7 @@ resource "aws_directory_service_directory" "foo" {
 }
 
 resource "aws_directory_service_directory" "bar" {
-  name     = "bar.somedomain.com"
+  name     = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   type     = "MicrosoftAD"
   edition  = "Standard"
@@ -3053,7 +3053,7 @@ resource "aws_security_group_rule" "rds-mssql-1" {
 }
 
 resource "aws_directory_service_directory" "foo" {
-  name     = "foo.somedomain.com"
+  name     = "terraformtesting.com"
   password = "SuperSecretPassw0rd"
   type     = "MicrosoftAD"
   edition  = "Standard"


### PR DESCRIPTION
References: 
* #7057 

https://github.com/terraform-providers/terraform-provider-aws/blob/7b1ae96e913e4a46927986bb5bc7f2d3dfef9db8/aws/resource_aws_directory_service_directory_test.go#L49

If the `TestAccAWSDBInstance_MSSQL_Domain` or `TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore` testing previously failed and left the directories dangling, it would prevent the `aws_subnet` sweeper from completing and require manual intervention:

```
[00:37:19][Step 2/4] 2019/01/08 00:37:19 [ERR] error running (aws_security_group): Error deleting Subnet (subnet-1f91a97a): DependencyViolation: The subnet 'subnet-1f91a97a' has dependencies and cannot be deleted.
[00:37:19][Step 2/4] 	status code: 400, request id: 205c6eac-1683-4456-87c0-5bfa2d89eba3
```

This is a quick update so the directories are at least cleaned up automatically by the `aws_directory_service_directory` test sweeper.
