### PR TITLE
resource/aws_iam_user: Implement test sweeper

### DIFF
--- a/aws/resource_aws_iam_user.go
+++ b/aws/resource_aws_iam_user.go
@@ -219,49 +219,26 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
 	// IAM Users must be removed from all groups before they can be deleted
-	var groups []string
-	listGroups := &iam.ListGroupsForUserInput{
-		UserName: aws.String(d.Id()),
-	}
-	pageOfGroups := func(page *iam.ListGroupsForUserOutput, lastPage bool) (shouldContinue bool) {
-		for _, g := range page.Groups {
-			groups = append(groups, *g.GroupName)
-		}
-		return !lastPage
-	}
-	err := iamconn.ListGroupsForUserPages(listGroups, pageOfGroups)
-	if err != nil {
-		return fmt.Errorf("Error removing user %q from all groups: %s", d.Id(), err)
-	}
-	for _, g := range groups {
-		// use iam group membership func to remove user from all groups
-		log.Printf("[DEBUG] Removing IAM User %s from IAM Group %s", d.Id(), g)
-		if err := removeUsersFromGroup(iamconn, []*string{aws.String(d.Id())}, g); err != nil {
-			return err
-		}
+	if err := deleteAwsIamUserGroupMemberships(iamconn, d.Id()); err != nil {
+		return fmt.Errorf("error removing IAM User (%s) group memberships: %s", d.Id(), err)
 	}
 
 	// All access keys, MFA devices and login profile for the user must be removed
 	if d.Get("force_destroy").(bool) {
-
-		err = deleteAwsIamUserAccessKeys(iamconn, d.Id())
-		if err != nil {
-			return err
+		if err := deleteAwsIamUserAccessKeys(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error removing IAM User (%s) access keys: %s", d.Id(), err)
 		}
 
-		err = deleteAwsIamUserSSHKeys(iamconn, d.Id())
-		if err != nil {
-			return err
+		if err := deleteAwsIamUserSSHKeys(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error removing IAM User (%s) SSH keys: %s", d.Id(), err)
 		}
 
-		err = deleteAwsIamUserMFADevices(iamconn, d.Id())
-		if err != nil {
-			return err
+		if err := deleteAwsIamUserMFADevices(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error removing IAM User (%s) MFA devices: %s", d.Id(), err)
 		}
 
-		err = deleteAwsIamUserLoginProfile(iamconn, d.Id())
-		if err != nil {
-			return err
+		if err := deleteAwsIamUserLoginProfile(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error removing IAM User (%s) login profile: %s", d.Id(), err)
 		}
 	}
 
@@ -270,11 +247,13 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Println("[DEBUG] Delete IAM User request:", deleteUserInput)
-	_, err = iamconn.DeleteUser(deleteUserInput)
+	_, err := iamconn.DeleteUser(deleteUserInput)
+
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
-			return nil
-		}
 		return fmt.Errorf("Error deleting IAM User %s: %s", d.Id(), err)
 	}
 
@@ -289,6 +268,32 @@ func validateAwsIamUserName(v interface{}, k string) (ws []string, errors []erro
 			k, value))
 	}
 	return
+}
+
+func deleteAwsIamUserGroupMemberships(conn *iam.IAM, username string) error {
+	var groups []string
+	listGroups := &iam.ListGroupsForUserInput{
+		UserName: aws.String(username),
+	}
+	pageOfGroups := func(page *iam.ListGroupsForUserOutput, lastPage bool) (shouldContinue bool) {
+		for _, g := range page.Groups {
+			groups = append(groups, *g.GroupName)
+		}
+		return !lastPage
+	}
+	err := conn.ListGroupsForUserPages(listGroups, pageOfGroups)
+	if err != nil {
+		return fmt.Errorf("Error removing user %q from all groups: %s", username, err)
+	}
+	for _, g := range groups {
+		// use iam group membership func to remove user from all groups
+		log.Printf("[DEBUG] Removing IAM User %s from IAM Group %s", username, g)
+		if err := removeUsersFromGroup(conn, []*string{aws.String(username)}, g); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func deleteAwsIamUserSSHKeys(svc *iam.IAM, username string) error {


### PR DESCRIPTION
Output from sweeper:

```
$ aws iam list-users | jq '.Users | length'
411
$ go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_iam_user -timeout 10h
...
2019/01/07 21:52:10 [DEBUG] Deleting IAM User: tf-acc-test-928472207137643810
2019/01/07 21:52:11 [DEBUG] Waiting for state to become: [success]
2019/01/07 21:52:12 [DEBUG] Deleting IAM User: tf-acc-test-97130337766957049
2019/01/07 21:52:14 [DEBUG] Waiting for state to become: [success]
2019/01/07 21:52:14 Sweeper Tests ran:
  - aws_iam_user
ok    github.com/terraform-providers/terraform-provider-aws/aws 778.753s
$ aws iam list-users | jq '.Users | length'
77
```

Output from acceptance testing:

```
--- PASS: TestAccAWSUser_disappears (7.00s)
--- PASS: TestAccAWSUser_ForceDestroy_SSHKey (9.15s)
--- PASS: TestAccAWSUser_ForceDestroy_AccessKey (9.16s)
--- PASS: TestAccAWSUser_ForceDestroy_LoginProfile (9.27s)
--- PASS: TestAccAWSUser_ForceDestroy_MFADevice (9.62s)
--- PASS: TestAccAWSUser_importBasic (9.65s)
--- PASS: TestAccAWSUser_pathChange (13.78s)
--- PASS: TestAccAWSUser_basic (13.81s)
--- PASS: TestAccAWSUser_nameChange (13.93s)
--- PASS: TestAccAWSUser_tags (14.03s)
--- PASS: TestAccAWSUser_permissionsBoundary (31.74s)
```
