### PR TITLE
resource/aws_iam_role: Implement test sweeper

### DIFF
--- a/aws/resource_aws_iam_role.go
+++ b/aws/resource_aws_iam_role.go
@@ -341,81 +341,19 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
 	// Roles cannot be destroyed when attached to an existing Instance Profile
-	resp, err := iamconn.ListInstanceProfilesForRole(&iam.ListInstanceProfilesForRoleInput{
-		RoleName: aws.String(d.Id()),
-	})
-	if err != nil {
-		return fmt.Errorf("Error listing Profiles for IAM Role (%s) when trying to delete: %s", d.Id(), err)
-	}
-
-	// Loop and remove this Role from any Profiles
-	if len(resp.InstanceProfiles) > 0 {
-		for _, i := range resp.InstanceProfiles {
-			_, err := iamconn.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
-				InstanceProfileName: i.InstanceProfileName,
-				RoleName:            aws.String(d.Id()),
-			})
-			if err != nil {
-				return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
-			}
-		}
+	if err := deleteAwsIamRoleInstanceProfiles(iamconn, d.Id()); err != nil {
+		return fmt.Errorf("error deleting IAM Role (%s) instance profiles: %s", d.Id(), err)
 	}
 
 	if d.Get("force_detach_policies").(bool) {
 		// For managed policies
-		managedPolicies := make([]*string, 0)
-		err = iamconn.ListAttachedRolePoliciesPages(&iam.ListAttachedRolePoliciesInput{
-			RoleName: aws.String(d.Id()),
-		}, func(page *iam.ListAttachedRolePoliciesOutput, lastPage bool) bool {
-			for _, v := range page.AttachedPolicies {
-				managedPolicies = append(managedPolicies, v.PolicyArn)
-			}
-			return len(page.AttachedPolicies) > 0
-		})
-		if err != nil {
-			return fmt.Errorf("Error listing Policies for IAM Role (%s) when trying to delete: %s", d.Id(), err)
-		}
-		if len(managedPolicies) > 0 {
-			for _, parn := range managedPolicies {
-				_, err = iamconn.DetachRolePolicy(&iam.DetachRolePolicyInput{
-					PolicyArn: parn,
-					RoleName:  aws.String(d.Id()),
-				})
-				if err != nil {
-					if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
-						log.Printf("[WARN] Role policy attachment (%s) was already removed from role (%s)", aws.StringValue(parn), d.Id())
-					} else {
-						return fmt.Errorf("Error deleting IAM Role %s: %s", d.Id(), err)
-					}
-				}
-			}
+		if err := deleteAwsIamRolePolicyAttachments(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error deleting IAM Role (%s) policy attachments: %s", d.Id(), err)
 		}
 
 		// For inline policies
-		inlinePolicies := make([]*string, 0)
-		err = iamconn.ListRolePoliciesPages(&iam.ListRolePoliciesInput{
-			RoleName: aws.String(d.Id()),
-		}, func(page *iam.ListRolePoliciesOutput, lastPage bool) bool {
-			inlinePolicies = append(inlinePolicies, page.PolicyNames...)
-			return len(page.PolicyNames) > 0
-		})
-		if err != nil {
-			return fmt.Errorf("Error listing inline Policies for IAM Role (%s) when trying to delete: %s", d.Id(), err)
-		}
-		if len(inlinePolicies) > 0 {
-			for _, pname := range inlinePolicies {
-				_, err := iamconn.DeleteRolePolicy(&iam.DeleteRolePolicyInput{
-					PolicyName: pname,
-					RoleName:   aws.String(d.Id()),
-				})
-				if err != nil {
-					if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
-						log.Printf("[WARN] Inline role policy (%s) was already removed from role (%s)", aws.StringValue(pname), d.Id())
-					} else {
-						return fmt.Errorf("Error deleting inline policy of IAM Role %s: %s", d.Id(), err)
-					}
-				}
-			}
+		if err := deleteAwsIamRolePolicies(iamconn, d.Id()); err != nil {
+			return fmt.Errorf("error deleting IAM Role (%s) policies: %s", d.Id(), err)
 		}
 	}
 
@@ -435,4 +373,99 @@ func resourceAwsIamRoleDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 		return nil
 	})
+}
+
+func deleteAwsIamRoleInstanceProfiles(conn *iam.IAM, rolename string) error {
+	resp, err := conn.ListInstanceProfilesForRole(&iam.ListInstanceProfilesForRoleInput{
+		RoleName: aws.String(rolename),
+	})
+	if err != nil {
+		return fmt.Errorf("Error listing Profiles for IAM Role (%s) when trying to delete: %s", rolename, err)
+	}
+
+	// Loop and remove this Role from any Profiles
+	for _, i := range resp.InstanceProfiles {
+		input := &iam.RemoveRoleFromInstanceProfileInput{
+			InstanceProfileName: i.InstanceProfileName,
+			RoleName:            aws.String(rolename),
+		}
+
+		_, err := conn.RemoveRoleFromInstanceProfile(input)
+
+		if err != nil {
+			return fmt.Errorf("Error deleting IAM Role %s: %s", rolename, err)
+		}
+	}
+
+	return nil
+}
+
+func deleteAwsIamRolePolicyAttachments(conn *iam.IAM, rolename string) error {
+	managedPolicies := make([]*string, 0)
+	input := &iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(rolename),
+	}
+
+	err := conn.ListAttachedRolePoliciesPages(input, func(page *iam.ListAttachedRolePoliciesOutput, lastPage bool) bool {
+		for _, v := range page.AttachedPolicies {
+			managedPolicies = append(managedPolicies, v.PolicyArn)
+		}
+		return !lastPage
+	})
+	if err != nil {
+		return fmt.Errorf("Error listing Policies for IAM Role (%s) when trying to delete: %s", rolename, err)
+	}
+	for _, parn := range managedPolicies {
+		input := &iam.DetachRolePolicyInput{
+			PolicyArn: parn,
+			RoleName:  aws.String(rolename),
+		}
+
+		_, err = conn.DetachRolePolicy(input)
+
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error deleting IAM Role %s: %s", rolename, err)
+		}
+	}
+
+	return nil
+}
+
+func deleteAwsIamRolePolicies(conn *iam.IAM, rolename string) error {
+	inlinePolicies := make([]*string, 0)
+	input := &iam.ListRolePoliciesInput{
+		RoleName: aws.String(rolename),
+	}
+
+	err := conn.ListRolePoliciesPages(input, func(page *iam.ListRolePoliciesOutput, lastPage bool) bool {
+		inlinePolicies = append(inlinePolicies, page.PolicyNames...)
+		return !lastPage
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error listing inline Policies for IAM Role (%s) when trying to delete: %s", rolename, err)
+	}
+
+	for _, pname := range inlinePolicies {
+		input := &iam.DeleteRolePolicyInput{
+			PolicyName: pname,
+			RoleName:   aws.String(rolename),
+		}
+
+		_, err := conn.DeleteRolePolicy(input)
+
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			continue
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error deleting inline policy of IAM Role %s: %s", rolename, err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Output from sweeper:

```
$ aws iam list-roles | jq '.Roles | length'
996
$ go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_iam_role -timeout 10h
...
2019/01/07 22:50:48 [DEBUG] Deleting IAM Role: tf_acc_test_batch_inst_role_9177302013105991460
2019/01/07 22:50:50 [DEBUG] Deleting IAM Role: tf_acc_test_batch_inst_role_9194852063673357596
2019/01/07 22:50:52 Sweeper Tests ran:
  - aws_config_configuration_aggregator
  - aws_datasync_location_s3
  - aws_db_instance
  - aws_autoscaling_group
  - aws_batch_compute_environment
  - aws_cognito_user_pool
  - aws_eks_cluster
  - aws_elasticsearch_domain
  - aws_glue_crawler
  - aws_glue_job
  - aws_instance
  - aws_lambda_function
  - aws_launch_configuration
  - aws_redshift_cluster
  - aws_iam_role
  - aws_batch_job_queue
  - aws_config_configuration_recorder
  - aws_dax_cluster
  - aws_db_option_group
  - aws_spot_fleet_request
ok    github.com/terraform-providers/terraform-provider-aws/aws 1952.805s
$ aws iam list-roles | jq '.Roles | length'
17
```

Output from acceptance testing:

```
--- PASS: TestAccAWSIAMRole_badJSON (1.69s)
--- PASS: TestAccAWSIAMRole_disappears (6.97s)
--- PASS: TestAccAWSIAMRole_basic (8.72s)
--- PASS: TestAccAWSIAMRole_namePrefix (8.74s)
--- PASS: TestAccAWSIAMRole_importBasic (9.67s)
--- PASS: TestAccAWSIAMRole_force_detach_policies (10.49s)
--- PASS: TestAccAWSIAMRole_tags (14.54s)
--- PASS: TestAccAWSIAMRole_MaxSessionDuration (15.31s)
--- PASS: TestAccAWSIAMRole_testNameChange (17.54s)
--- PASS: TestAccAWSIAMRole_basicWithDescription (18.81s)
--- PASS: TestAccAWSIAMRole_PermissionsBoundary (32.33s)
```
