### PR TITLE
Fix IAM User Policy No Such Entity Exception Handling

### DIFF
--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -101,7 +100,7 @@ func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) erro
 
 	getResp, err := iamconn.GetUserPolicy(request)
 	if err != nil {
-		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" { // XXX test me
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 			d.SetId("")
 			return nil
 		}
@@ -139,6 +138,9 @@ func resourceAwsIamUserPolicyDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if _, err := iamconn.DeleteUserPolicy(request); err != nil {
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			return nil
+		}
 		return fmt.Errorf("Error deleting IAM user policy %s: %s", d.Id(), err)
 	}
 	return nil

--- a/aws/resource_aws_iam_user_policy.go
+++ b/aws/resource_aws_iam_user_policy.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 
@@ -101,6 +102,7 @@ func resourceAwsIamUserPolicyRead(d *schema.ResourceData, meta interface{}) erro
 	getResp, err := iamconn.GetUserPolicy(request)
 	if err != nil {
 		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			log.Printf("[WARN] IAM User Policy (%s) for %s not found, removing from state", name, user)
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_iam_user_policy_test.go
+++ b/aws/resource_aws_iam_user_policy_test.go
@@ -77,6 +77,28 @@ func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMUserPolicy_disappears(t *testing.T) {
+	var out iam.GetUserPolicyOutput
+	suffix := randomString(10)
+	resourceName := fmt.Sprintf("aws_iam_user_policy.foo_%s", suffix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsIamUserPolicyConfig(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMUserPolicyExists(resourceName, &out),
+					testAccCheckIAMUserPolicyDisappears(&out),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSIAMUserPolicy_namePrefix(t *testing.T) {
 	rInt := acctest.RandInt()
 	policy1 := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"*","Resource":"*"}}`
@@ -204,6 +226,38 @@ func TestAccAWSIAMUserPolicy_multiplePolicies(t *testing.T) {
 	})
 }
 
+func testAccCheckIAMUserPolicyExists(resource string, res *iam.GetUserPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resource)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Policy name is set")
+		}
+
+		user, name, err := resourceAwsIamUserPolicyParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		resp, err := iamconn.GetUserPolicy(&iam.GetUserPolicyInput{
+			PolicyName: aws.String(name),
+			UserName:   aws.String(user),
+		})
+		if err != nil {
+			return err
+		}
+
+		*res = *resp
+
+		return nil
+	}
+}
+
 func testAccCheckIAMUserPolicyDestroy(s *terraform.State) error {
 	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
 
@@ -237,6 +291,22 @@ func testAccCheckIAMUserPolicyDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckIAMUserPolicyDisappears(out *iam.GetUserPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		params := &iam.DeleteUserPolicyInput{
+			PolicyName: out.PolicyName,
+			UserName:   out.UserName,
+		}
+
+		if _, err := iamconn.DeleteUserPolicy(params); err != nil {
+			return err
+		}
+		return nil
+	}
 }
 
 func testAccCheckIAMUserPolicy(


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* `aws_iam_user_policy` skip error when `NoSuchEntity` error occured while deleting.
* Add test case

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMUserPolicy_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSIAMUserPolicy_disappears -timeout 120m
=== RUN   TestAccAWSIAMUserPolicy_disappears
=== PAUSE TestAccAWSIAMUserPolicy_disappears
=== CONT  TestAccAWSIAMUserPolicy_disappears
--- PASS: TestAccAWSIAMUserPolicy_disappears (23.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws    23.570s
```
