### PR TITLE
Fix IAM Group Policy No Such Entity Exception Handling

### DIFF
--- a/aws/resource_aws_iam_group_policy.go
+++ b/aws/resource_aws_iam_group_policy.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 
@@ -88,6 +89,7 @@ func resourceAwsIamGroupPolicyRead(d *schema.ResourceData, meta interface{}) err
 	getResp, err := iamconn.GetGroupPolicy(request)
 	if err != nil {
 		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			log.Printf("[WARN] IAM Group Policy (%s) for %s not found, removing from state", name, group)
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_iam_group_policy_test.go
+++ b/aws/resource_aws_iam_group_policy_test.go
@@ -46,6 +46,31 @@ func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMGroupPolicy_disappears(t *testing.T) {
+	var out iam.GetGroupPolicyOutput
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMGroupPolicyConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMGroupPolicyExists(
+						"aws_iam_group.group",
+						"aws_iam_group_policy.foo",
+						&out,
+					),
+					testAccCheckIAMGroupPolicyDisappears(&out),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSIAMGroupPolicy_namePrefix(t *testing.T) {
 	var groupPolicy1, groupPolicy2 iam.GetGroupPolicyOutput
 	rInt := acctest.RandInt()
@@ -142,6 +167,22 @@ func testAccCheckIAMGroupPolicyDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckIAMGroupPolicyDisappears(out *iam.GetGroupPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		params := &iam.DeleteGroupPolicyInput{
+			PolicyName: out.PolicyName,
+			GroupName:  out.GroupName,
+		}
+
+		if _, err := iamconn.DeleteGroupPolicy(params); err != nil {
+			return err
+		}
+		return nil
+	}
 }
 
 func testAccCheckIAMGroupPolicyExists(


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* `aws_iam_group_policy` skip error when `NoSuchEntity` error occured while deleting.
* Add test case

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMGroupPolicy_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSIAMGroupPolicy_disappears -timeout 120m
=== RUN   TestAccAWSIAMGroupPolicy_disappears
=== PAUSE TestAccAWSIAMGroupPolicy_disappears
=== CONT  TestAccAWSIAMGroupPolicy_disappears
--- PASS: TestAccAWSIAMGroupPolicy_disappears (26.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	26.300s
```
