### PR TITLE
Fix error handling of aws_iam_policy resouce

### DIFF
--- a/aws/resource_aws_iam_policy.go
+++ b/aws/resource_aws_iam_policy.go
@@ -243,13 +243,11 @@ func resourceAwsIamPolicyDelete(d *schema.ResourceData, meta interface{}) error 
 		PolicyArn: aws.String(d.Id()),
 	}
 
-	_, err := iamconn.DeletePolicy(request)
-	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("Error deleting IAM policy %s: %#v", d.Id(), err)
+	if _, err := iamconn.DeletePolicy(request); err != nil {
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting IAM policy %s: %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_iam_policy_test.go
+++ b/aws/resource_aws_iam_policy_test.go
@@ -68,6 +68,28 @@ func TestAccAWSIAMPolicy_description(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMPolicy_disappears(t *testing.T) {
+	var out iam.GetPolicyOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_iam_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIAMPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIAMPolicyConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIAMPolicyExists(resourceName, &out),
+					testAccCheckAWSIAMPolicyDisappears(&out),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSIAMPolicy_namePrefix(t *testing.T) {
 	var out iam.GetPolicyOutput
 	namePrefix := "tf-acc-test-"
@@ -210,6 +232,21 @@ func testAccCheckAWSIAMPolicyDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckAWSIAMPolicyDisappears(out *iam.GetPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		params := &iam.DeletePolicyInput{
+			PolicyArn: out.Policy.Arn,
+		}
+
+		if _, err := iamconn.DeletePolicy(params); err != nil {
+			return err
+		}
+		return nil
+	}
 }
 
 func testAccAWSIAMPolicyConfigDescription(rName, description string) string {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #35

Changes proposed in this pull request:

* Fix Error handling at delete 
* Add test function

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSIAMPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSIAMPolicy_ -timeout 120m
=== RUN   TestAccAWSIAMPolicy_basic
=== PAUSE TestAccAWSIAMPolicy_basic
=== RUN   TestAccAWSIAMPolicy_description
=== PAUSE TestAccAWSIAMPolicy_description
=== RUN   TestAccAWSIAMPolicy_disappears
=== PAUSE TestAccAWSIAMPolicy_disappears
=== RUN   TestAccAWSIAMPolicy_namePrefix
=== PAUSE TestAccAWSIAMPolicy_namePrefix
=== RUN   TestAccAWSIAMPolicy_path
=== PAUSE TestAccAWSIAMPolicy_path
=== RUN   TestAccAWSIAMPolicy_policy
=== PAUSE TestAccAWSIAMPolicy_policy
=== CONT  TestAccAWSIAMPolicy_basic
=== CONT  TestAccAWSIAMPolicy_path
=== CONT  TestAccAWSIAMPolicy_disappears
=== CONT  TestAccAWSIAMPolicy_namePrefix
=== CONT  TestAccAWSIAMPolicy_policy
=== CONT  TestAccAWSIAMPolicy_description
--- PASS: TestAccAWSIAMPolicy_disappears (21.67s)
--- PASS: TestAccAWSIAMPolicy_path (32.46s)
--- PASS: TestAccAWSIAMPolicy_namePrefix (32.50s)
--- PASS: TestAccAWSIAMPolicy_basic (32.52s)
--- PASS: TestAccAWSIAMPolicy_description (32.51s)
--- PASS: TestAccAWSIAMPolicy_policy (51.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.572s
```
