### PR TITLE
resource/aws_batch_job_queue: Properly read compute_environments into Terraform state

### DIFF
--- a/aws/resource_aws_batch_job_queue.go
+++ b/aws/resource_aws_batch_job_queue.go
@@ -95,11 +95,21 @@ func resourceAwsBatchJobQueueRead(d *schema.ResourceData, meta interface{}) erro
 		d.SetId("")
 		return nil
 	}
+
 	d.Set("arn", jq.JobQueueArn)
-	d.Set("compute_environments", jq.ComputeEnvironmentOrder)
+
+	computeEnvironments := make([]string, len(jq.ComputeEnvironmentOrder))
+	for _, computeEnvironmentOrder := range jq.ComputeEnvironmentOrder {
+		computeEnvironments[aws.Int64Value(computeEnvironmentOrder.Order)] = aws.StringValue(computeEnvironmentOrder.ComputeEnvironment)
+	}
+	if err := d.Set("compute_environments", computeEnvironments); err != nil {
+		return fmt.Errorf("error setting compute_environments: %s", err)
+	}
+
 	d.Set("name", jq.JobQueueName)
 	d.Set("priority", jq.Priority)
 	d.Set("state", jq.State)
+
 	return nil
 }
 


### PR DESCRIPTION
Previously with `TF_SCHEMA_PANIC_ON_ERROR=1`:

```
panic: compute_environments.0: '' expected type 'string', got unconvertible type '*batch.ComputeEnvironmentOrder'

goroutine 709 [running]:
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc000c7b7a0, 0x3c93d6e, 0x14, 0x30d5460, 0xc00075cb40, 0x0, 0x0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x334
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsBatchJobQueueRead(0xc000c7b7a0, 0x36595a0, 0xc00090a380, 0x1, 0x1)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_batch_job_queue.go:99 +0x23c
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsBatchJobQueueCreate(0xc000c7b7a0, 0x36595a0, 0xc00090a380, 0x24, 0x73fb6c0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_batch_job_queue.go:83 +0x742
```

Output from acceptance testing:

```
--- PASS: TestAccAWSBatchJobQueue_disappears (120.15s)
--- PASS: TestAccAWSBatchJobQueue_basic (145.61s)
--- PASS: TestAccAWSBatchJobQueue_update (168.76s)
```
