### PR TITLE
resource/aws_app_cookie_stickiness_policy: Properly read lb_port into Terraform state and support resource import

### DIFF
--- a/aws/resource_aws_app_cookie_stickiness_policy.go
+++ b/aws/resource_aws_app_cookie_stickiness_policy.go
@@ -20,6 +20,9 @@ func resourceAwsAppCookieStickinessPolicy() *schema.Resource {
 		Create: resourceAwsAppCookieStickinessPolicyCreate,
 		Read:   resourceAwsAppCookieStickinessPolicyRead,
 		Delete: resourceAwsAppCookieStickinessPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -136,7 +139,9 @@ func resourceAwsAppCookieStickinessPolicyRead(d *schema.ResourceData, meta inter
 	d.Set("cookie_name", cookieAttr.AttributeValue)
 	d.Set("name", policyName)
 	d.Set("load_balancer", lbName)
-	d.Set("lb_port", lbPort)
+
+	lbPortInt, _ := strconv.Atoi(lbPort)
+	d.Set("lb_port", lbPortInt)
 
 	return nil
 }

--- a/aws/resource_aws_app_cookie_stickiness_policy_test.go
+++ b/aws/resource_aws_app_cookie_stickiness_policy_test.go
@@ -31,6 +31,11 @@ func TestAccAWSAppCookieStickinessPolicy_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_app_cookie_stickiness_policy.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAppCookieStickinessPolicyConfigUpdate(lbName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppCookieStickinessPolicy(

--- a/website/docs/r/app_cookie_stickiness_policy.html.markdown
+++ b/website/docs/r/app_cookie_stickiness_policy.html.markdown
@@ -54,3 +54,11 @@ In addition to all arguments above, the following attributes are exported:
 * `load_balancer` - The name of load balancer to which the policy is attached.
 * `lb_port` - The load balancer port to which the policy is applied.
 * `cookie_name` - The application cookie whose lifetime the ELB's cookie should follow.
+
+## Import
+
+Application cookie stickiness policies can be imported using the ELB name, port, and policy name separated by colons (`:`), e.g.
+
+```sh
+$ terraform import aws_app_cookie_stickiness_policy.example my-elb:80:my-policy
+```


### PR DESCRIPTION
Previously with `TF_SCHEMA_PANIC_ON_ERROR=1`:

```
panic: lb_port: '' expected type 'int', got unconvertible type 'string'

goroutine 636 [running]:
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc00022f030, 0x3c65264, 0x7, 0x3152440, 0xc00004cf60, 0x0, 0x0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x334
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsAppCookieStickinessPolicyRead(0xc00022f030, 0x36595a0, 0xc000a68a80, 0xc00022f030, 0x0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_app_cookie_stickiness_policy.go:139 +0x4de
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAppCookieStickinessPolicy_drift (32.27s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_missingLB (32.81s)
--- PASS: TestAccAWSAppCookieStickinessPolicy_basic (34.11s)
```
