### PR TITLE
tests/resource/aws_instance: Skip sweeping already terminated instances

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -46,6 +46,11 @@ func testSweepInstances(region string) error {
 				var nameTag string
 				id := aws.StringValue(instance.InstanceId)
 
+				if instance.State != nil && aws.StringValue(instance.State.Name) == ec2.InstanceStateNameTerminated {
+					log.Printf("[INFO] Skipping terminated EC2 Instance: %s", id)
+					continue
+				}
+
 				for _, instanceTag := range instance.Tags {
 					if aws.StringValue(instanceTag.Key) == "Name" {
 						nameTag = aws.StringValue(instanceTag.Value)


### PR DESCRIPTION
Otherwise an extraneous `TerminateInstances` call with 10 second delay per matching instance was made.

Previously with 6 matching terminated instances:

```
...
2019/01/09 21:46:46 [DEBUG] Waiting for state to become: [terminated]
2019/01/09 21:46:58 [INFO] Terminating EC2 Instance: i-0953ac3d04f85cc9d
2019/01/09 21:46:58 [INFO] Terminating instance: i-0953ac3d04f85cc9d
2019/01/09 21:46:58 [DEBUG] Waiting for instance (i-0953ac3d04f85cc9d) to become terminated
2019/01/09 21:46:58 [DEBUG] Waiting for state to become: [terminated]
2019/01/09 21:47:09 Sweeper Tests ran:
	- aws_instance
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.043s
```

Output from test sweeper:

```
...
2019/01/09 21:52:07 [INFO] Skipping terminated EC2 Instance: i-098197aec3b20650e
2019/01/09 21:52:07 [INFO] Skipping terminated EC2 Instance: i-0953ac3d04f85cc9d
2019/01/09 21:52:07 Sweeper Tests ran:
	- aws_instance
ok  	github.com/terraform-providers/terraform-provider-aws/aws	3.934s
```
