### PR TITLE
tests/resource/aws_key_pair: Sweep additional EC2 key pairs

### DIFF
--- a/aws/resource_aws_key_pair_test.go
+++ b/aws/resource_aws_key_pair_test.go
@@ -17,7 +17,12 @@ import (
 func init() {
 	resource.AddTestSweepers("aws_key_pair", &resource.Sweeper{
 		Name: "aws_key_pair",
-		F:    testSweepKeyPairs,
+		Dependencies: []string{
+			"aws_elastic_beanstalk_environment",
+			"aws_instance",
+			"aws_spot_fleet_request",
+		},
+		F: testSweepKeyPairs,
 	})
 }
 
@@ -33,8 +38,12 @@ func testSweepKeyPairs(region string) error {
 	resp, err := ec2conn.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("key-name"),
-				Values: []*string{aws.String("tmp-key*")},
+				Name: aws.String("key-name"),
+				Values: []*string{
+					aws.String("tf-acctest*"),
+					aws.String("tf_acc*"),
+					aws.String("tmp-key*"),
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Output from test sweeper:

```
$ aws ec2 describe-key-pairs | jq '.KeyPairs | length'
69

$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_key_pair -timeout 10h
...
2019/01/09 23:08:03 Sweeper Tests ran:
  - aws_instance
  - aws_spot_fleet_request
  - aws_key_pair
ok    github.com/terraform-providers/terraform-provider-aws/aws 58.889s

$ aws ec2 describe-key-pairs | jq '.KeyPairs | length'
5
```
