### PR TITLE
Add support docdb cluster parameter group resource

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -47,6 +47,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 	"github.com/aws/aws-sdk-go/service/dlm"
+	"github.com/aws/aws-sdk-go/service/docdb"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -265,6 +266,7 @@ type AWSClient struct {
 	workspacesconn        *workspaces.WorkSpaces
 	appmeshconn           *appmesh.AppMesh
 	transferconn          *transfer.Transfer
+	docdbconn             *docdb.DocDB
 }
 
 func (c *AWSClient) S3() *s3.S3 {
@@ -603,6 +605,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.workspacesconn = workspaces.New(sess)
 	client.appmeshconn = appmesh.New(sess)
 	client.transferconn = transfer.New(sess)
+	client.docdbconn = docdb.New(sess)
 
 	// Workaround for https://github.com/aws/aws-sdk-go/issues/1376
 	client.kinesisconn.Handlers.Retry.PushBack(func(r *request.Request) {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -406,6 +406,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dms_replication_instance":                     resourceAwsDmsReplicationInstance(),
 			"aws_dms_replication_subnet_group":                 resourceAwsDmsReplicationSubnetGroup(),
 			"aws_dms_replication_task":                         resourceAwsDmsReplicationTask(),
+			"aws_docdb_cluster_parameter_group":                resourceAwsDocDBClusterParameterGroup(),
 			"aws_dx_bgp_peer":                                  resourceAwsDxBgpPeer(),
 			"aws_dx_connection":                                resourceAwsDxConnection(),
 			"aws_dx_connection_association":                    resourceAwsDxConnectionAssociation(),

--- a/aws/resource_aws_docdb_cluster_parameter_group.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group.go
@@ -1,0 +1,282 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+const docdbClusterParameterGroupMaxParamsBulkEdit = 20
+
+func resourceAwsDocDBClusterParameterGroup() *schema.Resource {
+
+	return &schema.Resource{
+		Create: resourceAwsDocDBClusterParameterGroupCreate,
+		Read:   resourceAwsDocDBClusterParameterGroupRead,
+		Update: resourceAwsDocDBClusterParameterGroupUpdate,
+		Delete: resourceAwsDocDBClusterParameterGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateDocDBParamGroupName,
+			},
+			"name_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateDocDBParamGroupNamePrefix,
+			},
+			"family": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "Managed by Terraform",
+			},
+			"parameter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"apply_method": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  docdb.ApplyMethodPendingReboot,
+							ValidateFunc: validation.StringInSlice([]string{
+								docdb.ApplyMethodImmediate,
+								docdb.ApplyMethodPendingReboot,
+							}, false),
+						},
+					},
+				},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+
+}
+
+func resourceAwsDocDBClusterParameterGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+	tags := tagsFromMapDocDB(d.Get("tags").(map[string]interface{}))
+
+	var groupName string
+	if v, ok := d.GetOk("name"); ok {
+		groupName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		groupName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		groupName = resource.UniqueId()
+	}
+
+	createOpts := docdb.CreateDBClusterParameterGroupInput{
+		DBClusterParameterGroupName: aws.String(groupName),
+		DBParameterGroupFamily:      aws.String(d.Get("family").(string)),
+		Description:                 aws.String(d.Get("description").(string)),
+		Tags:                        tags,
+	}
+
+	log.Printf("[DEBUG] Create DocDB Cluster Parameter Group: %#v", createOpts)
+
+	resp, err := conn.CreateDBClusterParameterGroup(&createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating DocDB Cluster Parameter Group: %s", err)
+	}
+
+	d.SetId(aws.StringValue(createOpts.DBClusterParameterGroupName))
+
+	d.Set("arn", resp.DBClusterParameterGroup.DBClusterParameterGroupArn)
+
+	return resourceAwsDocDBClusterParameterGroupUpdate(d, meta)
+}
+
+func resourceAwsDocDBClusterParameterGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	describeOpts := &docdb.DescribeDBClusterParameterGroupsInput{
+		DBClusterParameterGroupName: aws.String(d.Id()),
+	}
+
+	describeResp, err := conn.DescribeDBClusterParameterGroups(describeOpts)
+	if err != nil {
+		if isAWSErr(err, docdb.ErrCodeDBParameterGroupNotFoundFault, "") {
+			log.Printf("[WARN] DocDB Cluster Parameter Group (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading DocDB Cluster Parameter Group (%s): %s", d.Id(), err)
+	}
+
+	if len(describeResp.DBClusterParameterGroups) != 1 ||
+		*describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName != d.Id() {
+		return fmt.Errorf("Unable to find Cluster Parameter Group: %#v", describeResp.DBClusterParameterGroups)
+	}
+
+	arn := aws.StringValue(describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupArn)
+	d.Set("arn", arn)
+	d.Set("description", describeResp.DBClusterParameterGroups[0].Description)
+	d.Set("family", describeResp.DBClusterParameterGroups[0].DBParameterGroupFamily)
+	d.Set("name", describeResp.DBClusterParameterGroups[0].DBClusterParameterGroupName)
+
+	describeParametersOpts := &docdb.DescribeDBClusterParametersInput{
+		DBClusterParameterGroupName: aws.String(d.Id()),
+		Source:                      aws.String("user"),
+	}
+
+	describeParametersResp, err := conn.DescribeDBClusterParameters(describeParametersOpts)
+	if err != nil {
+		return fmt.Errorf("error reading DocDB Cluster Parameter Group (%s) parameters: %s", d.Id(), err)
+	}
+
+	if err := d.Set("parameter", flattenDocDBParameters(describeParametersResp.Parameters)); err != nil {
+		return fmt.Errorf("error setting docdb cluster parameter: %s", err)
+	}
+
+	resp, err := conn.ListTagsForResource(&docdb.ListTagsForResourceInput{
+		ResourceName: aws.String(arn),
+	})
+
+	if err != nil {
+		return fmt.Errorf("error listing tags for DocDB Cluster Parameter Group (%s): %s", d.Id(), err)
+	}
+
+	if err := d.Set("tags", tagsToMapDocDB(resp.TagList)); err != nil {
+		return fmt.Errorf("Error setting docdb parameter group tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceAwsDocDBClusterParameterGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	d.Partial(true)
+
+	if d.HasChange("parameter") {
+		o, n := d.GetChange("parameter")
+		if o == nil {
+			o = new(schema.Set)
+		}
+		if n == nil {
+			n = new(schema.Set)
+		}
+
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		parameters, err := expandDocDBParameters(ns.Difference(os).List())
+		if err != nil {
+			return err
+		}
+		if len(parameters) > 0 {
+			// We can only modify 20 parameters at a time, so walk them until
+			// we've got them all.
+			for parameters != nil {
+				var paramsToModify []*docdb.Parameter
+				if len(parameters) <= docdbClusterParameterGroupMaxParamsBulkEdit {
+					paramsToModify, parameters = parameters[:], nil
+				} else {
+					paramsToModify, parameters = parameters[:docdbClusterParameterGroupMaxParamsBulkEdit], parameters[docdbClusterParameterGroupMaxParamsBulkEdit:]
+				}
+				parameterGroupName := d.Id()
+				modifyOpts := docdb.ModifyDBClusterParameterGroupInput{
+					DBClusterParameterGroupName: aws.String(parameterGroupName),
+					Parameters:                  paramsToModify,
+				}
+
+				log.Printf("[DEBUG] Modify DocDB Cluster Parameter Group: %#v", modifyOpts)
+				_, err := conn.ModifyDBClusterParameterGroup(&modifyOpts)
+				if err != nil {
+					if isAWSErr(err, docdb.ErrCodeDBParameterGroupNotFoundFault, "") {
+						log.Printf("[WARN] DocDB Cluster Parameter Group (%s) not found, removing from state", d.Id())
+						d.SetId("")
+						return nil
+					}
+					return fmt.Errorf("Error modifying DocDB Cluster Parameter Group: %s", err)
+				}
+			}
+			d.SetPartial("parameter")
+		}
+	}
+
+	if err := setTagsDocDB(conn, d); err != nil {
+		return err
+	}
+	d.SetPartial("tags")
+
+	d.Partial(false)
+
+	return resourceAwsDocDBClusterParameterGroupRead(d, meta)
+}
+
+func resourceAwsDocDBClusterParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	deleteOpts := &docdb.DeleteDBClusterParameterGroupInput{
+		DBClusterParameterGroupName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteDBClusterParameterGroup(deleteOpts)
+	if err != nil {
+		if isAWSErr(err, docdb.ErrCodeDBParameterGroupNotFoundFault, "") {
+			return nil
+		}
+		return err
+	}
+
+	return waitForDocDBClusterParameterGroupDeletion(conn, d.Id())
+}
+
+func waitForDocDBClusterParameterGroupDeletion(conn *docdb.DocDB, name string) error {
+	params := &docdb.DescribeDBClusterParameterGroupsInput{
+		DBClusterParameterGroupName: aws.String(name),
+	}
+
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.DescribeDBClusterParameterGroups(params)
+
+		if isAWSErr(err, docdb.ErrCodeDBParameterGroupNotFoundFault, "") {
+			return nil
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return resource.RetryableError(fmt.Errorf("DocDB Parameter Group (%s) still exists", name))
+	})
+}

--- a/aws/resource_aws_docdb_cluster_parameter_group_test.go
+++ b/aws/resource_aws_docdb_cluster_parameter_group_test.go
@@ -1,0 +1,387 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDocDBClusterParameterGroup_basic(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig(parameterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestMatchResourceAttr(
+						"aws_docdb_cluster_parameter_group.bar", "arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:rds:[^:]+:\\d{12}:cluster-pg:%s", parameterGroupName))),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster_parameter_group.bar", "name", parameterGroupName),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster_parameter_group.bar", "family", "docdb3.6"),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster_parameter_group.bar", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.#", "0"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBClusterParameterGroup_namePrefix(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.test", &v),
+					resource.TestMatchResourceAttr(
+						"aws_docdb_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+				),
+			},
+			{
+				ResourceName:            "aws_docdb_cluster_parameter_group.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBClusterParameterGroup_generatedName(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.test", &v),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_cluster_parameter_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBClusterParameterGroup_Description(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_Description(parameterGroupName, "custom description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "description", "custom description"),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBClusterParameterGroup_disappears(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-terraform-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig(parameterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBClusterParameterGroup_Parameter(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_Parameter(parameterGroupName, "tls", "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.#", "1"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.3297634353.apply_method", "pending-reboot"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.3297634353.name", "tls"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.3297634353.value", "disabled"),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_Parameter(parameterGroupName, "tls", "enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.#", "1"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.4005179180.apply_method", "pending-reboot"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.4005179180.name", "tls"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "parameter.4005179180.value", "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBClusterParameterGroup_Tags(t *testing.T) {
+	var v docdb.DBClusterParameterGroup
+
+	parameterGroupName := fmt.Sprintf("cluster-parameter-group-test-tf-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDocDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_cluster_parameter_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_Tags(parameterGroupName, "key1", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.key1", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSDocDBClusterParameterGroupConfig_Tags(parameterGroupName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDocDBClusterParameterGroupExists("aws_docdb_cluster_parameter_group.bar", &v),
+					testAccCheckAWSDocDBClusterParameterGroupAttributes(&v, parameterGroupName),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_docdb_cluster_parameter_group.bar", "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDocDBClusterParameterGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_docdb_cluster_parameter_group" {
+			continue
+		}
+
+		resp, err := conn.DescribeDBClusterParameterGroups(
+			&docdb.DescribeDBClusterParameterGroupsInput{
+				DBClusterParameterGroupName: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if len(resp.DBClusterParameterGroups) != 0 &&
+				aws.StringValue(resp.DBClusterParameterGroups[0].DBClusterParameterGroupName) == rs.Primary.ID {
+				return errors.New("DocDB Cluster Parameter Group still exists")
+			}
+		}
+
+		if err != nil {
+			if isAWSErr(err, docdb.ErrCodeDBParameterGroupNotFoundFault, "") {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDocDBClusterParameterGroupDisappears(group *docdb.DBClusterParameterGroup) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+		params := &docdb.DeleteDBClusterParameterGroupInput{
+			DBClusterParameterGroupName: group.DBClusterParameterGroupName,
+		}
+
+		_, err := conn.DeleteDBClusterParameterGroup(params)
+		if err != nil {
+			return err
+		}
+
+		return waitForDocDBClusterParameterGroupDeletion(conn, *group.DBClusterParameterGroupName)
+	}
+}
+
+func testAccCheckAWSDocDBClusterParameterGroupAttributes(v *docdb.DBClusterParameterGroup, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if *v.DBClusterParameterGroupName != name {
+			return fmt.Errorf("bad name: %#v expected: %v", *v.DBClusterParameterGroupName, name)
+		}
+
+		if *v.DBParameterGroupFamily != "docdb3.6" {
+			return fmt.Errorf("bad family: %#v", *v.DBParameterGroupFamily)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSDocDBClusterParameterGroupExists(n string, v *docdb.DBClusterParameterGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No DocDB Cluster Parameter Group ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+		opts := docdb.DescribeDBClusterParameterGroupsInput{
+			DBClusterParameterGroupName: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeDBClusterParameterGroups(&opts)
+
+		if err != nil {
+			return err
+		}
+
+		if len(resp.DBClusterParameterGroups) != 1 ||
+			aws.StringValue(resp.DBClusterParameterGroups[0].DBClusterParameterGroupName) != rs.Primary.ID {
+			return fmt.Errorf("DocDB Cluster Parameter Group not found: %s", rs.Primary.ID)
+		}
+
+		*v = *resp.DBClusterParameterGroups[0]
+
+		return nil
+	}
+}
+
+func testAccAWSDocDBClusterParameterGroupConfig(name string) string {
+	return fmt.Sprintf(`resource "aws_docdb_cluster_parameter_group" "bar" {
+	family = "docdb3.6"
+	name   = "%s"
+}`, name)
+}
+
+func testAccAWSDocDBClusterParameterGroupConfig_Description(name, description string) string {
+	return fmt.Sprintf(`resource "aws_docdb_cluster_parameter_group" "bar" {
+  family = "docdb3.6"
+  description = "%s"
+  name        = "%s"
+}`, description, name)
+}
+
+func testAccAWSDocDBClusterParameterGroupConfig_Parameter(name, pName, pValue string) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster_parameter_group" "bar" {
+  name   = "%s"
+  family = "docdb3.6"
+
+  parameter {
+    name  = "%s"
+    value = "%s"
+  }
+}
+`, name, pName, pValue)
+}
+
+func testAccAWSDocDBClusterParameterGroupConfig_Tags(name, tKey, tValue string) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster_parameter_group" "bar" {
+  name   = "%s"
+  family = "docdb3.6"
+
+  tags = {
+    %s = "%s"
+  }
+}
+`, name, tKey, tValue)
+}
+
+const testAccAWSDocDBClusterParameterGroupConfig_namePrefix = `
+resource "aws_docdb_cluster_parameter_group" "test" {
+  name_prefix = "tf-test-"
+  family = "docdb3.6"
+}
+`
+const testAccAWSDocDBClusterParameterGroupConfig_generatedName = `
+resource "aws_docdb_cluster_parameter_group" "test" {
+	family = "docdb3.6"
+}
+`

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dax"
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
+	"github.com/aws/aws-sdk-go/service/docdb"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -339,6 +340,28 @@ func expandRedshiftParameters(configured []interface{}) ([]*redshift.Parameter, 
 		}
 
 		p := &redshift.Parameter{
+			ParameterName:  aws.String(data["name"].(string)),
+			ParameterValue: aws.String(data["value"].(string)),
+		}
+
+		parameters = append(parameters, p)
+	}
+
+	return parameters, nil
+}
+
+// Takes the result of flatmap.Expand for an array of parameters and
+// returns Parameter API compatible objects
+func expandDocDBParameters(configured []interface{}) ([]*docdb.Parameter, error) {
+	parameters := make([]*docdb.Parameter, 0, len(configured))
+
+	// Loop over our configured parameters and create
+	// an array of aws-sdk-go compatible objects
+	for _, pRaw := range configured {
+		data := pRaw.(map[string]interface{})
+
+		p := &docdb.Parameter{
+			ApplyMethod:    aws.String(data["apply_method"].(string)),
 			ParameterName:  aws.String(data["name"].(string)),
 			ParameterValue: aws.String(data["value"].(string)),
 		}
@@ -829,6 +852,21 @@ func flattenElastiCacheParameters(list []*elasticache.Parameter) []map[string]in
 
 // Flattens an array of Parameters into a []map[string]interface{}
 func flattenNeptuneParameters(list []*neptune.Parameter) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		if i.ParameterValue != nil {
+			result = append(result, map[string]interface{}{
+				"apply_method": aws.StringValue(i.ApplyMethod),
+				"name":         aws.StringValue(i.ParameterName),
+				"value":        aws.StringValue(i.ParameterValue),
+			})
+		}
+	}
+	return result
+}
+
+// Flattens an array of Parameters into a []map[string]interface{}
+func flattenDocDBParameters(list []*docdb.Parameter) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
 		if i.ParameterValue != nil {

--- a/aws/tagsDocDB.go
+++ b/aws/tagsDocDB.go
@@ -1,0 +1,118 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsDocDB(conn *docdb.DocDB, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsDocDB(tagsFromMapDocDB(o), tagsFromMapDocDB(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove), len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.RemoveTagsFromResource(&docdb.RemoveTagsFromResourceInput{
+				ResourceName: aws.String(d.Get("arn").(string)),
+				TagKeys:      k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.AddTagsToResource(&docdb.AddTagsToResourceInput{
+				ResourceName: aws.String(d.Get("arn").(string)),
+				Tags:         create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsDocDB(oldTags, newTags []*docdb.Tag) ([]*docdb.Tag, []*docdb.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*docdb.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapDocDB(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapDocDB(m map[string]interface{}) []*docdb.Tag {
+	result := make([]*docdb.Tag, 0, len(m))
+	for k, v := range m {
+		t := &docdb.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredDocDB(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapDocDB(ts []*docdb.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredDocDB(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredDocDB(t *docdb.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		if r, _ := regexp.MatchString(v, aws.StringValue(t.Key)); r == true {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsDocDB_test.go
+++ b/aws/tagsDocDB_test.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+)
+
+// go test -v -run="TestDiffDocDBTags"
+func TestDiffDocDBTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsDocDB(tagsFromMapDocDB(tc.Old), tagsFromMapDocDB(tc.New))
+		cm := tagsToMapDocDB(c)
+		rm := tagsToMapDocDB(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsDocDB"
+func TestIgnoringTagsDocDB(t *testing.T) {
+	var ignoredTags []*docdb.Tag
+	ignoredTags = append(ignoredTags, &docdb.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &docdb.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredDocDB(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -293,6 +293,52 @@ func validateDbParamGroupNamePrefix(v interface{}, k string) (ws []string, error
 	return
 }
 
+func validateDocDBParamGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in parameter group %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of parameter group %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"parameter group %q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"parameter group %q cannot end with a hyphen", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"parameter group %q cannot be greater than 255 characters", k))
+	}
+	return
+}
+
+func validateDocDBParamGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in parameter group %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of parameter group %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"parameter group %q cannot contain two consecutive hyphens", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"parameter group %q cannot be greater than 226 characters", k))
+	}
+	return
+}
+
 func validateElbName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) == 0 {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -984,6 +984,16 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current("docs-aws-resource-docdb") %>>
+                    <a href="#">DocumentDB Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-docdb-cluster-parameter-group") %>>
+                            <a href="/docs/providers/aws/r/docdb_cluster_parameter_group.html">aws_docdb_cluster_parameter_group</a>
+                        </li>
+
+                    </ul>
+                </li>
 
                 <li<%= sidebar_current("docs-aws-resource-(ami|app|autoscaling|ebs|elb|elbv2|eip|instance|launch|lb|proxy|snapshot|spot|volume|placement|key-pair|elb_attachment|load-balancer)") %>>
                     <a href="#">EC2 Resources</a>

--- a/website/docs/r/docdb_cluster_parameter_group.html.markdown
+++ b/website/docs/r/docdb_cluster_parameter_group.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "aws"
+page_title: "AWS: aws_docdb_cluster_parameter_group"
+sidebar_current: "docs-aws-resource-docdb-cluster-parameter-group"
+description: |-
+  Manages a DocumentDB Cluster Parameter Group
+---
+
+# aws_docdb_cluster_parameter_group
+
+Manages a DocumentDB Cluster Parameter Group
+
+## Example Usage
+
+```hcl
+resource "aws_docdb_cluster_parameter_group" "example" {
+  family      = "docdb3.6"
+  name        = "example"
+  description = "docdb cluster parameter group"
+
+  parameter {
+    name  = "tls"
+    value = "enabled"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, Forces new resource) The name of the documentDB cluster parameter group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `family` - (Required, Forces new resource) The family of the documentDB cluster parameter group.
+* `description` - (Optional, Forces new resource) The description of the documentDB cluster parameter group. Defaults to "Managed by Terraform".
+* `parameter` - (Optional) A list of documentDB parameters to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+Parameter blocks support the following:
+
+* `name` - (Required) The name of the documentDB parameter.
+* `value` - (Required) The value of the documentDB parameter.
+* `apply_method` - (Optional) Valid values are `immediate` and `pending-reboot`. Defaults to `pending-reboot`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The documentDB cluster parameter group name.
+* `arn` - The ARN of the documentDB cluster parameter group.
+
+
+## Import
+
+DocumentDB Cluster Parameter Groups can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_docdb_cluster_parameter_group.cluster_pg production-pg-1
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Reference #7077 

Changes proposed in this pull request:

* Add docdb tag resource
* Add resource `aws_docdb_cluster_parameter_group` 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDocDBClusterParameterGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDocDBClusterParameterGroup_ -timeout 120m
=== RUN   TestAccAWSDocDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDocDBClusterParameterGroup_basic
=== RUN   TestAccAWSDocDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDocDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDocDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDocDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDocDBClusterParameterGroup_Description
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Description
=== RUN   TestAccAWSDocDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDocDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDocDBClusterParameterGroup_Parameter
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Parameter
=== RUN   TestAccAWSDocDBClusterParameterGroup_Tags
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Tags
=== CONT  TestAccAWSDocDBClusterParameterGroup_basic
=== CONT  TestAccAWSDocDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDocDBClusterParameterGroup_Tags
=== CONT  TestAccAWSDocDBClusterParameterGroup_Parameter
=== CONT  TestAccAWSDocDBClusterParameterGroup_generatedName
=== CONT  TestAccAWSDocDBClusterParameterGroup_Description
=== CONT  TestAccAWSDocDBClusterParameterGroup_namePrefix
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (23.16s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (33.17s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (33.18s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (33.30s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (33.41s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (51.23s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (69.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	69.561s
...
```
