### PR TITLE
Add support docdb subnet group resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -407,6 +407,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dms_replication_subnet_group":                 resourceAwsDmsReplicationSubnetGroup(),
 			"aws_dms_replication_task":                         resourceAwsDmsReplicationTask(),
 			"aws_docdb_cluster_parameter_group":                resourceAwsDocDBClusterParameterGroup(),
+			"aws_docdb_subnet_group":                           resourceAwsDocDBSubnetGroup(),
 			"aws_dx_bgp_peer":                                  resourceAwsDxBgpPeer(),
 			"aws_dx_connection":                                resourceAwsDxConnection(),
 			"aws_dx_connection_association":                    resourceAwsDxConnectionAssociation(),

--- a/aws/resource_aws_docdb_subnet_group.go
+++ b/aws/resource_aws_docdb_subnet_group.go
@@ -89,7 +89,7 @@ func resourceAwsDocDBSubnetGroupCreate(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Create DocDB Subnet Group: %#v", createOpts)
 	_, err := conn.CreateDBSubnetGroup(&createOpts)
 	if err != nil {
-		return fmt.Errorf("Error creating DocDB Subnet Group: %s", err)
+		return fmt.Errorf("error creating DocDB Subnet Group: %s", err)
 	}
 
 	d.SetId(groupName)
@@ -119,7 +119,7 @@ func resourceAwsDocDBSubnetGroupRead(d *schema.ResourceData, meta interface{}) e
 
 	if len(subnetGroups) != 1 ||
 		*subnetGroups[0].DBSubnetGroupName != d.Id() {
-		return fmt.Errorf("Unable to find DocDB Subnet Group: %s, removing from state", d.Id())
+		return fmt.Errorf("unable to find DocDB Subnet Group: %s, removing from state", d.Id())
 	}
 
 	subnetGroup := subnetGroups[0]
@@ -140,11 +140,11 @@ func resourceAwsDocDBSubnetGroupRead(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if err != nil {
-		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", aws.StringValue(subnetGroup.DBSubnetGroupArn))
+		return fmt.Errorf("error retrieving tags for ARN: %s", aws.StringValue(subnetGroup.DBSubnetGroupArn))
 	}
 
 	if err := d.Set("tags", tagsToMapDocDB(resp.TagList)); err != nil {
-		return fmt.Errorf("Error setting DocDB Subnet Group tags: %s", err)
+		return fmt.Errorf("error setting DocDB Subnet Group tags: %s", err)
 	}
 	return nil
 }

--- a/aws/resource_aws_docdb_subnet_group.go
+++ b/aws/resource_aws_docdb_subnet_group.go
@@ -1,0 +1,230 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDocDBSubnetGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDocDBSubnetGroupCreate,
+		Read:   resourceAwsDocDBSubnetGroupRead,
+		Update: resourceAwsDocDBSubnetGroupUpdate,
+		Delete: resourceAwsDocDBSubnetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateDocDBSubnetGroupName,
+			},
+			"name_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validateDocDBSubnetGroupNamePrefix,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+			},
+
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsDocDBSubnetGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+	tags := tagsFromMapDocDB(d.Get("tags").(map[string]interface{}))
+
+	subnetIdsSet := d.Get("subnet_ids").(*schema.Set)
+	subnetIds := make([]*string, subnetIdsSet.Len())
+	for i, subnetID := range subnetIdsSet.List() {
+		subnetIds[i] = aws.String(subnetID.(string))
+	}
+
+	var groupName string
+	if v, ok := d.GetOk("name"); ok {
+		groupName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		groupName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		groupName = resource.UniqueId()
+	}
+
+	createOpts := docdb.CreateDBSubnetGroupInput{
+		DBSubnetGroupName:        aws.String(groupName),
+		DBSubnetGroupDescription: aws.String(d.Get("description").(string)),
+		SubnetIds:                subnetIds,
+		Tags:                     tags,
+	}
+
+	log.Printf("[DEBUG] Create DocDB Subnet Group: %#v", createOpts)
+	_, err := conn.CreateDBSubnetGroup(&createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating DocDB Subnet Group: %s", err)
+	}
+
+	d.SetId(groupName)
+
+	return resourceAwsDocDBSubnetGroupRead(d, meta)
+}
+
+func resourceAwsDocDBSubnetGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	describeOpts := docdb.DescribeDBSubnetGroupsInput{
+		DBSubnetGroupName: aws.String(d.Id()),
+	}
+
+	var subnetGroups []*docdb.DBSubnetGroup
+	if err := conn.DescribeDBSubnetGroupsPages(&describeOpts, func(resp *docdb.DescribeDBSubnetGroupsOutput, lastPage bool) bool {
+		for _, v := range resp.DBSubnetGroups {
+			subnetGroups = append(subnetGroups, v)
+		}
+		return !lastPage
+	}); err != nil {
+		if isAWSErr(err, docdb.ErrCodeDBSubnetGroupNotFoundFault, "") {
+			log.Printf("[WARN] DocDB Subnet Group (%s) not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading DocDB Subnet Group (%s) parameters: %s", d.Id(), err)
+	}
+
+	if len(subnetGroups) != 1 ||
+		*subnetGroups[0].DBSubnetGroupName != d.Id() {
+		return fmt.Errorf("Unable to find DocDB Subnet Group: %s, removing from state", d.Id())
+	}
+
+	subnetGroup := subnetGroups[0]
+	d.Set("name", subnetGroup.DBSubnetGroupName)
+	d.Set("description", subnetGroup.DBSubnetGroupDescription)
+	d.Set("arn", subnetGroup.DBSubnetGroupArn)
+
+	subnets := make([]string, 0, len(subnetGroup.Subnets))
+	for _, s := range subnetGroup.Subnets {
+		subnets = append(subnets, aws.StringValue(s.SubnetIdentifier))
+	}
+	if err := d.Set("subnet_ids", subnets); err != nil {
+		return fmt.Errorf("error setting subnet_ids: %s", err)
+	}
+
+	resp, err := conn.ListTagsForResource(&docdb.ListTagsForResourceInput{
+		ResourceName: subnetGroup.DBSubnetGroupArn,
+	})
+
+	if err != nil {
+		log.Printf("[DEBUG] Error retrieving tags for ARN: %s", aws.StringValue(subnetGroup.DBSubnetGroupArn))
+	}
+
+	if err := d.Set("tags", tagsToMapDocDB(resp.TagList)); err != nil {
+		return fmt.Errorf("Error setting DocDB Subnet Group tags: %s", err)
+	}
+	return nil
+}
+
+func resourceAwsDocDBSubnetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	if d.HasChange("subnet_ids") || d.HasChange("description") {
+		_, n := d.GetChange("subnet_ids")
+		if n == nil {
+			n = new(schema.Set)
+		}
+		ns := n.(*schema.Set)
+
+		var sIds []*string
+		for _, s := range ns.List() {
+			sIds = append(sIds, aws.String(s.(string)))
+		}
+
+		_, err := conn.ModifyDBSubnetGroup(&docdb.ModifyDBSubnetGroupInput{
+			DBSubnetGroupName:        aws.String(d.Id()),
+			DBSubnetGroupDescription: aws.String(d.Get("description").(string)),
+			SubnetIds:                sIds,
+		})
+
+		if err != nil {
+			return fmt.Errorf("error modify DocDB Subnet Group (%s) parameters: %s", d.Id(), err)
+		}
+	}
+
+	if err := setTagsDocDB(conn, d); err != nil {
+		return fmt.Errorf("error setting DocDB Subnet Group (%s) tags: %s", d.Id(), err)
+	}
+	d.SetPartial("tags")
+
+	return resourceAwsDocDBSubnetGroupRead(d, meta)
+}
+
+func resourceAwsDocDBSubnetGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	delOpts := docdb.DeleteDBSubnetGroupInput{
+		DBSubnetGroupName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting DocDB Subnet Group: %s", d.Id())
+
+	_, err := conn.DeleteDBSubnetGroup(&delOpts)
+	if err != nil {
+		if isAWSErr(err, docdb.ErrCodeDBSubnetGroupNotFoundFault, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting DocDB Subnet Group (%s): %s", d.Id(), err)
+	}
+
+	return waitForDocDBSubnetGroupDeletion(conn, d.Id())
+}
+
+func waitForDocDBSubnetGroupDeletion(conn *docdb.DocDB, name string) error {
+	params := &docdb.DescribeDBSubnetGroupsInput{
+		DBSubnetGroupName: aws.String(name),
+	}
+
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+		_, err := conn.DescribeDBSubnetGroups(params)
+
+		if isAWSErr(err, docdb.ErrCodeDBSubnetGroupNotFoundFault, "") {
+			return nil
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return resource.RetryableError(fmt.Errorf("DocDB Subnet Group (%s) still exists", name))
+	})
+}

--- a/aws/resource_aws_docdb_subnet_group_test.go
+++ b/aws/resource_aws_docdb_subnet_group_test.go
@@ -1,0 +1,365 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+)
+
+func TestAccAWSDocDBSubnetGroup_basic(t *testing.T) {
+	var v docdb.DBSubnetGroup
+
+	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBSubnetGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBSubnetGroupExists(
+						"aws_docdb_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_subnet_group.foo", "name", rName),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_subnet_group.foo", "description", "Managed by Terraform"),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_subnet_group.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBSubnetGroup_disappears(t *testing.T) {
+	var v docdb.DBSubnetGroup
+
+	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBSubnetGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBSubnetGroupExists(
+						"aws_docdb_subnet_group.foo", &v),
+					testAccCheckAWSDocDBSubnetGroupDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBSubnetGroup_namePrefix(t *testing.T) {
+	var v docdb.DBSubnetGroup
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBSubnetGroupConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBSubnetGroupExists(
+						"aws_docdb_subnet_group.test", &v),
+					resource.TestMatchResourceAttr(
+						"aws_docdb_subnet_group.test", "name", regexp.MustCompile("^tf_test-")),
+				),
+			},
+			{
+				ResourceName:            "aws_docdb_subnet_group.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name_prefix"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBSubnetGroup_generatedName(t *testing.T) {
+	var v docdb.DBSubnetGroup
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBSubnetGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBSubnetGroupExists(
+						"aws_docdb_subnet_group.test", &v),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_subnet_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBSubnetGroup_updateDescription(t *testing.T) {
+	var v docdb.DBSubnetGroup
+
+	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBSubnetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBSubnetGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBSubnetGroupExists(
+						"aws_docdb_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_subnet_group.foo", "description", "Managed by Terraform"),
+				),
+			},
+
+			{
+				Config: testAccDocDBSubnetGroupConfig_updatedDescription(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBSubnetGroupExists(
+						"aws_docdb_subnet_group.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_subnet_group.foo", "description", "foo description updated"),
+				),
+			},
+			{
+				ResourceName:      "aws_docdb_subnet_group.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDocDBSubnetGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_docdb_subnet_group" {
+			continue
+		}
+
+		// Try to find the resource
+		resp, err := conn.DescribeDBSubnetGroups(
+			&docdb.DescribeDBSubnetGroupsInput{DBSubnetGroupName: aws.String(rs.Primary.ID)})
+
+		if err == nil {
+			if len(resp.DBSubnetGroups) != 0 &&
+				aws.StringValue(resp.DBSubnetGroups[0].DBSubnetGroupName) == rs.Primary.ID {
+				return fmt.Errorf("DocDB Subnet Group %s still exists", rs.Primary.ID)
+			}
+		}
+
+		if err != nil {
+			if isAWSErr(err, docdb.ErrCodeDBSubnetGroupNotFoundFault, "") {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSDocDBSubnetGroupDisappears(group *docdb.DBSubnetGroup) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+		params := &docdb.DeleteDBSubnetGroupInput{
+			DBSubnetGroupName: group.DBSubnetGroupName,
+		}
+
+		_, err := conn.DeleteDBSubnetGroup(params)
+		if err != nil {
+			return err
+		}
+
+		return waitForDocDBSubnetGroupDeletion(conn, *group.DBSubnetGroupName)
+	}
+}
+
+func testAccCheckDocDBSubnetGroupExists(n string, v *docdb.DBSubnetGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).docdbconn
+		resp, err := conn.DescribeDBSubnetGroups(
+			&docdb.DescribeDBSubnetGroupsInput{DBSubnetGroupName: aws.String(rs.Primary.ID)})
+		if err != nil {
+			return err
+		}
+		if len(resp.DBSubnetGroups) == 0 {
+			return fmt.Errorf("DbSubnetGroup not found")
+		}
+
+		*v = *resp.DBSubnetGroups[0]
+
+		return nil
+	}
+}
+
+func testAccDocDBSubnetGroupConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+	tags = {
+		Name = "terraform-testacc-docdb-subnet-group"
+	}
+}
+
+resource "aws_subnet" "foo" {
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-1"
+	}
+}
+
+resource "aws_subnet" "bar" {
+	cidr_block = "10.1.2.0/24"
+	availability_zone = "us-west-2b"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-2"
+	}
+}
+
+resource "aws_docdb_subnet_group" "foo" {
+	name = "%s"
+	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+	tags = {
+		Name = "tf-docdb-subnet-group-test"
+	}
+}`, rName)
+}
+
+func testAccDocDBSubnetGroupConfig_updatedDescription(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+	tags = {
+		Name = "terraform-testacc-docdb-subnet-group"
+	}
+}
+
+resource "aws_subnet" "foo" {
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-1"
+	}
+}
+
+resource "aws_subnet" "bar" {
+	cidr_block = "10.1.2.0/24"
+	availability_zone = "us-west-2b"
+	vpc_id = "${aws_vpc.foo.id}"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-2"
+	}
+}
+	
+resource "aws_docdb_subnet_group" "foo" {
+	name = "%s"
+	description = "foo description updated"
+	subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+	tags = {
+		Name = "tf-docdb-subnet-group-test"
+	}
+}`, rName)
+}
+
+const testAccDocDBSubnetGroupConfig_namePrefix = `
+resource "aws_vpc" "test" {
+	cidr_block = "10.1.0.0/16"
+	tags = {
+		Name = "terraform-testacc-docdb-subnet-group-name-prefix"
+	}
+}
+
+resource "aws_subnet" "a" {
+	vpc_id = "${aws_vpc.test.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-name-prefix-a"
+	}
+}
+
+resource "aws_subnet" "b" {
+	vpc_id = "${aws_vpc.test.id}"
+	cidr_block = "10.1.2.0/24"
+	availability_zone = "us-west-2b"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-name-prefix-b"
+	}
+}
+
+resource "aws_docdb_subnet_group" "test" {
+	name_prefix = "tf_test-"
+	subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
+}`
+
+const testAccDocDBSubnetGroupConfig_generatedName = `
+resource "aws_vpc" "test" {
+	cidr_block = "10.1.0.0/16"
+	tags = {
+		Name = "terraform-testacc-docdb-subnet-group-generated-name"
+	}
+}
+
+resource "aws_subnet" "a" {
+	vpc_id = "${aws_vpc.test.id}"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-generated-name-a"
+	}
+}
+
+resource "aws_subnet" "b" {
+	vpc_id = "${aws_vpc.test.id}"
+	cidr_block = "10.1.2.0/24"
+	availability_zone = "us-west-2b"
+	tags = {
+		Name = "tf-acc-docdb-subnet-group-generated-name-a"
+	}
+}
+
+resource "aws_docdb_subnet_group" "test" {
+	subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
+}`

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1125,6 +1125,23 @@ func validateDbSubnetGroupName(v interface{}, k string) (ws []string, errors []e
 	return
 }
 
+func validateDocDBSubnetGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[ .0-9a-z-_]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 255 characters", k))
+	}
+	if value == "default" {
+		errors = append(errors, fmt.Errorf(
+			"%q is not allowed as %q", "Default", k))
+	}
+	return
+}
+
 func validateNeptuneSubnetGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[ .0-9a-z-_]+$`).MatchString(value) {
@@ -1151,6 +1168,20 @@ func validateDbSubnetGroupNamePrefix(v interface{}, k string) (ws []string, erro
 	if len(value) > 229 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 229 characters", k))
+	}
+	return
+}
+
+func validateDocDBSubnetGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[ .0-9a-z-_]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
+	}
+	prefixMaxLength := 255 - resource.UniqueIDSuffixLength
+	if len(value) > prefixMaxLength {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than %d characters", k, prefixMaxLength))
 	}
 	return
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -992,6 +992,10 @@
                             <a href="/docs/providers/aws/r/docdb_cluster_parameter_group.html">aws_docdb_cluster_parameter_group</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-docdb-subnet-group") %>>
+                            <a href="/docs/providers/aws/r/docdb_subnet_group.html">aws_docdb_subnet_group</a>
+                        </li>
+
                     </ul>
                 </li>
 

--- a/website/docs/r/docdb_subnet_group.html.markdown
+++ b/website/docs/r/docdb_subnet_group.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "aws"
+page_title: "AWS: aws_docdb_subnet_group"
+sidebar_current: "docs-aws-resource-docdb-subnet-group"
+description: |-
+  Provides an DocumentDB subnet group resource.
+---
+
+# aws_docdb_subnet_group
+
+Provides an DocumentDB subnet group resource.
+
+## Example Usage
+
+```hcl
+resource "aws_docdb_subnet_group" "default" {
+  name       = "main"
+  subnet_ids = ["${aws_subnet.frontend.id}", "${aws_subnet.backend.id}"]
+
+  tags = {
+    Name = "My docdb subnet group"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, Forces new resource) The name of the docDB subnet group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `description` - (Optional) The description of the docDB subnet group. Defaults to "Managed by Terraform".
+* `subnet_ids` - (Required) A list of VPC subnet IDs.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The docDB subnet group name.
+* `arn` - The ARN of the docDB subnet group.
+
+
+## Import
+
+DocumentDB Subnet groups can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_docdb_subnet_group.default production-subnet-group
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Reference #7077  

Changes proposed in this pull request:

* Add `aws_docdb_subnet_group` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDocDBSubnetGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDocDBSubnetGroup_ -timeout 120m
=== RUN   TestAccAWSDocDBSubnetGroup_basic
=== PAUSE TestAccAWSDocDBSubnetGroup_basic
=== RUN   TestAccAWSDocDBSubnetGroup_disappears
=== PAUSE TestAccAWSDocDBSubnetGroup_disappears
=== RUN   TestAccAWSDocDBSubnetGroup_namePrefix
=== PAUSE TestAccAWSDocDBSubnetGroup_namePrefix
=== RUN   TestAccAWSDocDBSubnetGroup_generatedName
=== PAUSE TestAccAWSDocDBSubnetGroup_generatedName
=== RUN   TestAccAWSDocDBSubnetGroup_updateDescription
=== PAUSE TestAccAWSDocDBSubnetGroup_updateDescription
=== CONT  TestAccAWSDocDBSubnetGroup_basic
=== CONT  TestAccAWSDocDBSubnetGroup_generatedName
=== CONT  TestAccAWSDocDBSubnetGroup_updateDescription
=== CONT  TestAccAWSDocDBSubnetGroup_namePrefix
=== CONT  TestAccAWSDocDBSubnetGroup_disappears
--- PASS: TestAccAWSDocDBSubnetGroup_disappears (47.81s)
--- PASS: TestAccAWSDocDBSubnetGroup_namePrefix (52.62s)
--- PASS: TestAccAWSDocDBSubnetGroup_generatedName (52.97s)
--- PASS: TestAccAWSDocDBSubnetGroup_basic (53.05s)
--- PASS: TestAccAWSDocDBSubnetGroup_updateDescription (80.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws    80.284s
```
