### PR TITLE
[#6785] `aws_opsworks_custom_layer` should support `encrypted` `ebs_volume` configurations

### DIFF
--- a/aws/opsworks_layers.go
+++ b/aws/opsworks_layers.go
@@ -195,6 +195,12 @@ func (lt *opsworksLayerType) SchemaResource() *schema.Resource {
 						Optional: true,
 						Default:  "standard",
 					},
+
+					"encrypted": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
 				},
 			},
 			Set: func(v interface{}) int {
@@ -593,7 +599,9 @@ func (lt *opsworksLayerType) VolumeConfigurations(d *schema.ResourceData) []*ops
 			NumberOfDisks: aws.Int64(int64(volumeData["number_of_disks"].(int))),
 			Size:          aws.Int64(int64(volumeData["size"].(int))),
 			VolumeType:    aws.String(volumeData["type"].(string)),
+			Encrypted:     aws.Bool(volumeData["encrypted"].(bool)),
 		}
+
 		iops := int64(volumeData["iops"].(int))
 		if iops != 0 {
 			result[i].Iops = aws.Int64(iops)
@@ -638,6 +646,9 @@ func (lt *opsworksLayerType) SetVolumeConfigurations(d *schema.ResourceData, v [
 		}
 		if config.VolumeType != nil {
 			data["type"] = *config.VolumeType
+		}
+		if config.Encrypted != nil {
+			data["encrypted"] = *config.Encrypted
 		}
 	}
 

--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -44,6 +44,7 @@ func TestAccAWSOpsworksCustomLayer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.number_of_disks", "2"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.mount_point", "/home"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.encrypted", "false"),
 				),
 			},
 			{
@@ -84,6 +85,7 @@ func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.number_of_disks", "2"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.mount_point", "/home"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.3575749636.encrypted", "false"),
 				),
 			},
 			{
@@ -108,6 +110,7 @@ func TestAccAWSOpsworksCustomLayer_noVPC(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.raid_level", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_volume.1266957920.encrypted", "true"),
 					resource.TestCheckResourceAttr(resourceName, "custom_json", `{"layer_key":"layer_value2"}`),
 				),
 			},
@@ -285,6 +288,7 @@ resource "aws_opsworks_custom_layer" "tf-acc" {
     mount_point = "/home"
     size = 100
     raid_level = 0
+    encrypted = false
   }
 }
 
@@ -366,6 +370,7 @@ resource "aws_opsworks_custom_layer" "tf-acc" {
     mount_point = "/home"
     size = 100
     raid_level = 0
+    encrypted = true
   }
   ebs_volume {
     type = "io1"
@@ -374,6 +379,7 @@ resource "aws_opsworks_custom_layer" "tf-acc" {
     size = 100
     raid_level = 1
     iops = 3000
+    encrypted = true
   }
   custom_json = "{\"layer_key\": \"layer_value2\"}"
 }

--- a/website/docs/r/opsworks_custom_layer.html.markdown
+++ b/website/docs/r/opsworks_custom_layer.html.markdown
@@ -59,6 +59,7 @@ An `ebs_volume` block supports the following arguments:
 * `raid_level` - (Required) The RAID level to use for the volume.
 * `type` - (Optional) The type of volume to create. This may be `standard` (the default), `io1` or `gp2`.
 * `iops` - (Optional) For PIOPS volumes, the IOPS per disk.
+* `encrypted` - (Optional) Encrypt the volume.
 
 ## Attributes Reference
 


### PR DESCRIPTION

Adds an encrypted boolean option to the aws_opsworks_custom_layer
default set to false and set as optional for backward compatibility and tests added.


Output from acceptance testing:

=== RUN   TestAccAWSOpsworksCustomLayer_importBasic
=== PAUSE TestAccAWSOpsworksCustomLayer_importBasic
=== RUN   TestAccAWSOpsworksCustomLayer_basic
=== PAUSE TestAccAWSOpsworksCustomLayer_basic
=== CONT  TestAccAWSOpsworksCustomLayer_importBasic
--- PASS: TestAccAWSOpsworksCustomLayer_importBasic (68.78s)
=== CONT  TestAccAWSOpsworksCustomLayer_basic
--- PASS: TestAccAWSOpsworksCustomLayer_basic (69.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	138.301s
