### PR TITLE
P emr cluster ingress

### DIFF
--- a/aws/data_source_aws_elasticache_cluster_test.go
+++ b/aws/data_source_aws_elasticache_cluster_test.go
@@ -44,7 +44,7 @@ resource "aws_security_group" "bar" {
         from_port = -1
         to_port = -1
         protocol = "icmp"
-        cidr_blocks = ["0.0.0.0/0"]
+        self = true
     }
 }
 

--- a/aws/data_source_aws_elb_test.go
+++ b/aws/data_source_aws_elb_test.go
@@ -93,7 +93,7 @@ resource "aws_security_group" "elb_test" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
   }
 
   egress {

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -576,7 +576,7 @@ resource "aws_security_group" "tf_test_foo" {
     protocol = "icmp"
     from_port = -1
     to_port = -1
-    cidr_blocks = ["0.0.0.0/0"]
+    self = true
   }
 }
 
@@ -618,7 +618,7 @@ resource "aws_security_group" "tf_test_foo" {
     protocol = "icmp"
     from_port = -1
     to_port = -1
-    cidr_blocks = ["0.0.0.0/0"]
+    self = true
   }
 }
 

--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -219,7 +219,7 @@ resource "aws_security_group" "lambda" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
   }
 
   egress {

--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -186,7 +186,7 @@ resource "aws_security_group" "alb_test" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
   }
 
   egress {
@@ -305,7 +305,7 @@ resource "aws_security_group" "alb_test" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
   }
 
   egress {
@@ -424,7 +424,7 @@ resource "aws_security_group" "alb_test" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
   }
 
   egress {

--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -260,7 +260,7 @@ resource "aws_security_group" "hoge" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self = true
   }
 
   egress {

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -354,7 +354,7 @@ resource "aws_security_group" "allow_all" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
   }
 
   egress {

--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -178,7 +178,7 @@ resource "aws_security_group" "allow_all" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
   }
 
   egress {

--- a/aws/resource_aws_resourcegroups_group_test.go
+++ b/aws/resource_aws_resourcegroups_group_test.go
@@ -60,9 +60,9 @@ func TestAccAWSResourceGroup_basic(t *testing.T) {
 				),
 			},
 			{
-				    ResourceName:      resourceName,
-				    ImportState:       true,
-				    ImportStateVerify: true,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSResourceGroupConfig_basic(n, desc2, query2),


### PR DESCRIPTION
This PR is closing quite a few security holes across our tests. 

```
=== RUN   TestAccAWSEMRInstanceGroup_basic
=== PAUSE TestAccAWSEMRInstanceGroup_basic
=== CONT  TestAccAWSEMRInstanceGroup_basic
--- PASS: TestAccAWSEMRInstanceGroup_basic (615.77s)
=== RUN   TestAccAWSEMRInstanceGroup_basic
=== PAUSE TestAccAWSEMRInstanceGroup_basic
=== RUN   TestAccAWSEMRInstanceGroup_zero_count
=== PAUSE TestAccAWSEMRInstanceGroup_zero_count
=== RUN   TestAccAWSEMRInstanceGroup_ebsBasic
=== PAUSE TestAccAWSEMRInstanceGroup_ebsBasic
=== CONT  TestAccAWSEMRInstanceGroup_basic
=== CONT  TestAccAWSEMRInstanceGroup_zero_count
=== CONT  TestAccAWSEMRInstanceGroup_ebsBasic
--- PASS: TestAccAWSEMRInstanceGroup_zero_count (656.45s)
--- PASS: TestAccAWSEMRInstanceGroup_basic (658.72s)
--- PASS: TestAccAWSEMRInstanceGroup_ebsBasic (697.33s)
=== RUN   TestAccAWSAppautoscalingScheduledAction_EMR
=== PAUSE TestAccAWSAppautoscalingScheduledAction_EMR
=== CONT  TestAccAWSAppautoscalingScheduledAction_EMR
--- PASS: TestAccAWSAppautoscalingScheduledAction_EMR (432.05s)
=== RUN   TestAccAWSAppautoScalingTarget_emrCluster
=== PAUSE TestAccAWSAppautoScalingTarget_emrCluster
=== CONT  TestAccAWSAppautoScalingTarget_emrCluster
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (466.89s)
=== RUN   TestAccAWSDataElasticacheCluster_basic
=== PAUSE TestAccAWSDataElasticacheCluster_basic
=== CONT  TestAccAWSDataElasticacheCluster_basic
--- PASS: TestAccAWSDataElasticacheCluster_basic (642.47s)
=== RUN   TestAccDataSourceAWSELB_basic
=== PAUSE TestAccDataSourceAWSELB_basic
=== CONT  TestAccDataSourceAWSELB_basic
--- PASS: TestAccDataSourceAWSELB_basic (39.59s)
=== RUN   TestAccAWSInstanceDataSource_VPCSecurityGroups
=== PAUSE TestAccAWSInstanceDataSource_VPCSecurityGroups
=== CONT  TestAccAWSInstanceDataSource_VPCSecurityGroups
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (120.34s)
=== RUN   TestAccAWSInstanceDataSource_SecurityGroups
=== PAUSE TestAccAWSInstanceDataSource_SecurityGroups
=== CONT  TestAccAWSInstanceDataSource_SecurityGroups
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (119.84s)
=== RUN   TestAccDataSourceAWSLambdaFunction_basic
=== PAUSE TestAccDataSourceAWSLambdaFunction_basic
=== RUN   TestAccDataSourceAWSLambdaFunction_version
=== PAUSE TestAccDataSourceAWSLambdaFunction_version
=== RUN   TestAccDataSourceAWSLambdaFunction_alias
=== PAUSE TestAccDataSourceAWSLambdaFunction_alias
=== RUN   TestAccDataSourceAWSLambdaFunction_vpc
=== PAUSE TestAccDataSourceAWSLambdaFunction_vpc
=== RUN   TestAccDataSourceAWSLambdaFunction_environment
=== PAUSE TestAccDataSourceAWSLambdaFunction_environment
=== CONT  TestAccDataSourceAWSLambdaFunction_basic
=== CONT  TestAccDataSourceAWSLambdaFunction_vpc
=== CONT  TestAccDataSourceAWSLambdaFunction_environment
=== CONT  TestAccDataSourceAWSLambdaFunction_version
=== CONT  TestAccDataSourceAWSLambdaFunction_alias
--- FAIL: TestAccDataSourceAWSLambdaFunction_basic (1.55s)
=== RUN   TestAccDataSourceAWSLambdaFunction_basic
=== PAUSE TestAccDataSourceAWSLambdaFunction_basic
=== RUN   TestAccDataSourceAWSLambdaFunction_version
=== PAUSE TestAccDataSourceAWSLambdaFunction_version
=== RUN   TestAccDataSourceAWSLambdaFunction_alias
=== PAUSE TestAccDataSourceAWSLambdaFunction_alias
=== RUN   TestAccDataSourceAWSLambdaFunction_vpc
=== PAUSE TestAccDataSourceAWSLambdaFunction_vpc
=== RUN   TestAccDataSourceAWSLambdaFunction_environment
=== PAUSE TestAccDataSourceAWSLambdaFunction_environment
=== CONT  TestAccDataSourceAWSLambdaFunction_basic
=== CONT  TestAccDataSourceAWSLambdaFunction_vpc
=== CONT  TestAccDataSourceAWSLambdaFunction_alias
=== CONT  TestAccDataSourceAWSLambdaFunction_version
=== CONT  TestAccDataSourceAWSLambdaFunction_environment
--- PASS: TestAccDataSourceAWSLambdaFunction_version (35.39s)
--- PASS: TestAccDataSourceAWSLambdaFunction_alias (37.44s)
--- PASS: TestAccDataSourceAWSLambdaFunction_environment (38.02s)
--- PASS: TestAccDataSourceAWSLambdaFunction_basic (38.65s)
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (41.50s)
=== RUN   TestAccDataSourceAWSLBListener_basic
=== PAUSE TestAccDataSourceAWSLBListener_basic
=== CONT  TestAccDataSourceAWSLBListener_basic
--- PASS: TestAccDataSourceAWSLBListener_basic (206.95s)
=== RUN   TestAccDataSourceAWSLBListener_basic
=== PAUSE TestAccDataSourceAWSLBListener_basic
=== RUN   TestAccDataSourceAWSLBListener_BackwardsCompatibility
=== PAUSE TestAccDataSourceAWSLBListener_BackwardsCompatibility
=== RUN   TestAccDataSourceAWSLBListener_https
=== PAUSE TestAccDataSourceAWSLBListener_https
=== CONT  TestAccDataSourceAWSLBListener_basic
=== CONT  TestAccDataSourceAWSLBListener_https
=== CONT  TestAccDataSourceAWSLBListener_BackwardsCompatibility
--- PASS: TestAccDataSourceAWSLBListener_https (204.59s)
--- PASS: TestAccDataSourceAWSLBListener_basic (226.02s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (226.70s)
```