### PR TITLE
service/servicediscovery: Return operation ErrorCode and ErrorMessage when Status is FAIL

### DIFF
--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,6 +47,26 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "arn"),
 					resource.TestCheckResourceAttrSet("aws_service_discovery_private_dns_namespace.test", "hosted_zone"),
 				),
+			},
+		},
+	})
+}
+
+// This acceptance test ensures we properly send back error messaging. References:
+//  * https://github.com/terraform-providers/terraform-provider-aws/issues/2830
+//  * https://github.com/terraform-providers/terraform-provider-aws/issues/5532
+func TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap(t *testing.T) {
+	rName := acctest.RandString(5) + ".example.com"
+	subDomain := acctest.RandString(5) + "." + rName
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(rName, subDomain),
+				ExpectError: regexp.MustCompile(`overlapping name space`),
 			},
 		},
 	})
@@ -100,4 +121,26 @@ resource "aws_service_discovery_private_dns_namespace" "test" {
   vpc = "${aws_vpc.test.id}"
 }
 `, rName)
+}
+
+func testAccServiceDiscoveryPrivateDnsNamespaceConfigOverlapping(topDomain, subDomain string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "terraform-testacc-service-discovery-private-dns-ns"
+  }
+}
+
+resource "aws_service_discovery_private_dns_namespace" "top" {
+  name = %q
+  vpc  = "${aws_vpc.test.id}"
+}
+
+# Ensure ordering after first namespace
+resource "aws_service_discovery_private_dns_namespace" "subdomain" {
+  name = %q
+  vpc  = "${aws_service_discovery_private_dns_namespace.top.vpc}"
+}
+`, topDomain, subDomain)
 }

--- a/aws/resource_aws_service_discovery_public_dns_namespace.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -138,9 +139,20 @@ func servicediscoveryOperationRefreshStatusFunc(conn *servicediscovery.ServiceDi
 			OperationId: aws.String(oid),
 		}
 		resp, err := conn.GetOperation(input)
+
 		if err != nil {
-			return nil, "failed", err
+			return nil, servicediscovery.OperationStatusFail, err
 		}
-		return resp, *resp.Operation.Status, nil
+
+		// Error messages can also be contained in the response with FAIL status
+		//   "ErrorCode":"CANNOT_CREATE_HOSTED_ZONE",
+		//   "ErrorMessage":"The VPC that you chose, vpc-xxx in region xxx, is already associated with another private hosted zone that has an overlapping name space, xxx.. (Service: AmazonRoute53; Status Code: 400; Error Code: ConflictingDomainExists; Request ID: xxx)"
+		//   "Status":"FAIL",
+
+		if aws.StringValue(resp.Operation.Status) == servicediscovery.OperationStatusFail {
+			return resp, servicediscovery.OperationStatusFail, fmt.Errorf("%s: %s", aws.StringValue(resp.Operation.ErrorCode), aws.StringValue(resp.Operation.ErrorMessage))
+		}
+
+		return resp, aws.StringValue(resp.Operation.Status), nil
 	}
 }


### PR DESCRIPTION
Fixes #2830 
Fixes #5532

Previously, the full error messaging from the API response was not present when an operation failed:

```
aws_service_discovery_private_dns_namespace.subdomain: unexpected state 'FAIL', wanted target 'SUCCESS'. last error: %!s(<nil>)
```

This change returns the ErrorCode and ErrorMessage fields from the API response:

```
aws_service_discovery_private_dns_namespace.subdomain: CANNOT_CREATE_HOSTED_ZONE: The VPC that you chose, vpc-0c04acdb2f40a49d6 in region us-west-2, is already associated with another private hosted zone that has an overlapping name space, wavsx.example.com.. (Service: AmazonRoute53; Status Code: 400; Error Code: ConflictingDomainExists; Request ID: 600b3096-15c4-11e9-97af-ade1478492a8)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_basic (96.16s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname (105.49s)
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_basic (105.77s)
--- PASS: TestAccAWSServiceDiscoveryHttpNamespace_Description (105.87s)
--- PASS: TestAccAWSServiceDiscoveryPublicDnsNamespace_longname (105.92s)
--- PASS: TestAccAWSServiceDiscoveryService_import (108.32s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (116.13s)
--- PASS: TestAccAWSServiceDiscoveryService_private (122.87s)
--- PASS: TestAccAWSServiceDiscoveryService_public (133.85s)
--- PASS: TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap (188.37s)
```
