### PR TITLE
 DocumentDB: added aws_docdb_cluster resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -411,6 +411,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dms_replication_task":                         resourceAwsDmsReplicationTask(),
 			"aws_docdb_cluster_parameter_group":                resourceAwsDocDBClusterParameterGroup(),
 			"aws_docdb_subnet_group":                           resourceAwsDocDBSubnetGroup(),
+			"aws_docdb_cluster":                                resourceAwsDocDBCluster(),
 			"aws_dx_bgp_peer":                                  resourceAwsDxBgpPeer(),
 			"aws_dx_connection":                                resourceAwsDxConnection(),
 			"aws_dx_connection_association":                    resourceAwsDxConnectionAssociation(),

--- a/aws/resource_aws_docdb_cluster.go
+++ b/aws/resource_aws_docdb_cluster.go
@@ -1,0 +1,796 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsDocDBCluster() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDocDBClusterCreate,
+		Read:   resourceAwsDocDBClusterRead,
+		Update: resourceAwsDocDBClusterUpdate,
+		Delete: resourceAwsDocDBClusterDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsDocDBClusterImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(120 * time.Minute),
+			Update: schema.DefaultTimeout(120 * time.Minute),
+			Delete: schema.DefaultTimeout(120 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"availability_zones": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"cluster_identifier": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"cluster_identifier_prefix"},
+				ValidateFunc:  validateDocDBIdentifier,
+			},
+			"cluster_identifier_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"cluster_identifier"},
+				ValidateFunc:  validateDocDBIdentifierPrefix,
+			},
+
+			"cluster_members": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"db_subnet_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"db_cluster_parameter_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"reader_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"hosted_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"engine": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "docdb",
+				ForceNew:     true,
+				ValidateFunc: validateDocDBEngine(),
+			},
+
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"final_snapshot_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"only alphanumeric characters and hyphens allowed in %q", k))
+					}
+					if regexp.MustCompile(`--`).MatchString(value) {
+						es = append(es, fmt.Errorf("%q cannot contain two consecutive hyphens", k))
+					}
+					if regexp.MustCompile(`-$`).MatchString(value) {
+						es = append(es, fmt.Errorf("%q cannot end in a hyphen", k))
+					}
+					return
+				},
+			},
+
+			"skip_final_snapshot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"master_username": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"master_password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+
+			"snapshot_identifier": {
+				Type:     schema.TypeString,
+				Computed: false,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"apply_immediately": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"vpc_security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"preferred_backup_window": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateOnceADayWindowFormat,
+			},
+
+			"preferred_maintenance_window": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				StateFunc: func(val interface{}) string {
+					if val == nil {
+						return ""
+					}
+					return strings.ToLower(val.(string))
+				},
+				ValidateFunc: validateOnceAWeekWindowFormat,
+			},
+
+			"backup_retention_period": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntAtMost(35),
+			},
+
+			"kms_key_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"cluster_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"enabled_cloudwatch_logs_exports": {
+				Type:     schema.TypeList,
+				Computed: false,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"audit",
+						"error",
+						"general",
+						"slowquery",
+					}, false),
+				},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsDocDBClusterImport(
+	d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Neither skip_final_snapshot nor final_snapshot_identifier can be fetched
+	// from any API call, so we need to default skip_final_snapshot to true so
+	// that final_snapshot_identifier is not required
+	d.Set("skip_final_snapshot", true)
+	return []*schema.ResourceData{d}, nil
+}
+
+func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+	tags := tagsFromMapDocDB(d.Get("tags").(map[string]interface{}))
+
+	// Some API calls (e.g. RestoreDBClusterFromSnapshot do not support all
+	// parameters to correctly apply all settings in one pass. For missing
+	// parameters or unsupported configurations, we may need to call
+	// ModifyDBInstance afterwadocdb to prevent Terraform operators from API
+	// errors or needing to double apply.
+	var requiresModifyDbCluster bool
+	modifyDbClusterInput := &docdb.ModifyDBClusterInput{
+		ApplyImmediately: aws.Bool(true),
+	}
+
+	var identifier string
+	if v, ok := d.GetOk("cluster_identifier"); ok {
+		identifier = v.(string)
+	} else if v, ok := d.GetOk("cluster_identifier_prefix"); ok {
+		identifier = resource.PrefixedUniqueId(v.(string))
+	} else {
+		identifier = resource.PrefixedUniqueId("tf-")
+	}
+
+	if _, ok := d.GetOk("snapshot_identifier"); ok {
+		opts := docdb.RestoreDBClusterFromSnapshotInput{
+			DBClusterIdentifier: aws.String(identifier),
+			Engine:              aws.String(d.Get("engine").(string)),
+			SnapshotIdentifier:  aws.String(d.Get("snapshot_identifier").(string)),
+			Tags:                tags,
+		}
+
+		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
+			opts.AvailabilityZones = expandStringList(attr.List())
+		}
+
+		if attr, ok := d.GetOk("backup_retention_period"); ok {
+			modifyDbClusterInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
+			requiresModifyDbCluster = true
+		}
+
+		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+			opts.DBSubnetGroupName = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			opts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
+		}
+
+		if attr, ok := d.GetOk("engine_version"); ok {
+			opts.EngineVersion = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("kms_key_id"); ok {
+			opts.KmsKeyId = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("port"); ok {
+			opts.Port = aws.Int64(int64(attr.(int)))
+		}
+
+		if attr, ok := d.GetOk("preferred_backup_window"); ok {
+			modifyDbClusterInput.PreferredBackupWindow = aws.String(attr.(string))
+			requiresModifyDbCluster = true
+		}
+
+		if attr, ok := d.GetOk("preferred_maintenance_window"); ok {
+			modifyDbClusterInput.PreferredMaintenanceWindow = aws.String(attr.(string))
+			requiresModifyDbCluster = true
+		}
+
+		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			opts.VpcSecurityGroupIds = expandStringList(attr.List())
+		}
+
+		log.Printf("[DEBUG] DocDB Cluster restore from snapshot configuration: %s", opts)
+		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+			_, err := conn.RestoreDBClusterFromSnapshot(&opts)
+			if err != nil {
+				if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("Error creating DocDB Cluster: %s", err)
+		}
+	} else {
+		if _, ok := d.GetOk("master_password"); !ok {
+			return fmt.Errorf(`provider.aws: aws_docdb_cluster: %s: "master_password": required field is not set`, identifier)
+		}
+
+		if _, ok := d.GetOk("master_username"); !ok {
+			return fmt.Errorf(`provider.aws: aws_docdb_cluster: %s: "master_username": required field is not set`, identifier)
+		}
+
+		createOpts := &docdb.CreateDBClusterInput{
+			DBClusterIdentifier: aws.String(identifier),
+			Engine:              aws.String(d.Get("engine").(string)),
+			MasterUserPassword:  aws.String(d.Get("master_password").(string)),
+			MasterUsername:      aws.String(d.Get("master_username").(string)),
+			Tags:                tags,
+		}
+
+		if attr, ok := d.GetOk("port"); ok {
+			createOpts.Port = aws.Int64(int64(attr.(int)))
+		}
+
+		if attr, ok := d.GetOk("db_subnet_group_name"); ok {
+			createOpts.DBSubnetGroupName = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
+			createOpts.DBClusterParameterGroupName = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("engine_version"); ok {
+			createOpts.EngineVersion = aws.String(attr.(string))
+		}
+
+		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			createOpts.VpcSecurityGroupIds = expandStringList(attr.List())
+		}
+
+		if attr := d.Get("availability_zones").(*schema.Set); attr.Len() > 0 {
+			createOpts.AvailabilityZones = expandStringList(attr.List())
+		}
+
+		if v, ok := d.GetOk("backup_retention_period"); ok {
+			createOpts.BackupRetentionPeriod = aws.Int64(int64(v.(int)))
+		}
+
+		if v, ok := d.GetOk("preferred_backup_window"); ok {
+			createOpts.PreferredBackupWindow = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("preferred_maintenance_window"); ok {
+			createOpts.PreferredMaintenanceWindow = aws.String(v.(string))
+		}
+
+		if attr, ok := d.GetOk("kms_key_id"); ok {
+			createOpts.KmsKeyId = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && len(attr.([]interface{})) > 0 {
+			createOpts.EnableCloudwatchLogsExports = expandStringList(attr.([]interface{}))
+		}
+
+		if attr, ok := d.GetOkExists("storage_encrypted"); ok {
+			createOpts.StorageEncrypted = aws.Bool(attr.(bool))
+		}
+
+		log.Printf("[DEBUG] DocDB Cluster create options: %s", createOpts)
+		var resp *docdb.CreateDBClusterOutput
+		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+			var err error
+			resp, err = conn.CreateDBCluster(createOpts)
+			if err != nil {
+				if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("error creating DocDB cluster: %s", err)
+		}
+
+		log.Printf("[DEBUG]: DocDB Cluster create response: %s", resp)
+	}
+
+	d.SetId(identifier)
+
+	log.Printf("[INFO] DocDB Cluster ID: %s", d.Id())
+
+	log.Println(
+		"[INFO] Waiting for DocDB Cluster to be available")
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    resourceAwsDocDBClusterCreatePendingStates,
+		Target:     []string{"available"},
+		Refresh:    resourceAwsDocDBClusterStateRefreshFunc(conn, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	// Wait, catching any errors
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for DocDB Cluster state to be \"available\": %s", err)
+	}
+
+	if requiresModifyDbCluster {
+		modifyDbClusterInput.DBClusterIdentifier = aws.String(d.Id())
+
+		log.Printf("[INFO] DocDB Cluster (%s) configuration requires ModifyDBCluster: %s", d.Id(), modifyDbClusterInput)
+		_, err := conn.ModifyDBCluster(modifyDbClusterInput)
+		if err != nil {
+			return fmt.Errorf("error modifying DocDB Cluster (%s): %s", d.Id(), err)
+		}
+
+		log.Printf("[INFO] Waiting for DocDB Cluster (%s) to be available", d.Id())
+		err = waitForDocDBClusterUpdate(conn, d.Id(), d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return fmt.Errorf("error waiting for DocDB Cluster (%s) to be available: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsDocDBClusterRead(d, meta)
+}
+
+func resourceAwsDocDBClusterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	input := &docdb.DescribeDBClustersInput{
+		DBClusterIdentifier: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Describing DocDB Cluster: %s", input)
+	resp, err := conn.DescribeDBClusters(input)
+
+	if isAWSErr(err, docdb.ErrCodeDBClusterNotFoundFault, "") {
+		log.Printf("[WARN] DocDB Cluster (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing DocDB Cluster (%s): %s", d.Id(), err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("Error retrieving DocDB cluster: empty response for: %s", input)
+	}
+
+	var dbc *docdb.DBCluster
+	for _, c := range resp.DBClusters {
+		if aws.StringValue(c.DBClusterIdentifier) == d.Id() {
+			dbc = c
+			break
+		}
+	}
+
+	if dbc == nil {
+		log.Printf("[WARN] DocDB Cluster (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("availability_zones", aws.StringValueSlice(dbc.AvailabilityZones)); err != nil {
+		return fmt.Errorf("error setting availability_zones: %s", err)
+	}
+
+	d.Set("arn", dbc.DBClusterArn)
+	d.Set("backup_retention_period", dbc.BackupRetentionPeriod)
+	d.Set("cluster_identifier", dbc.DBClusterIdentifier)
+
+	var cm []string
+	for _, m := range dbc.DBClusterMembers {
+		cm = append(cm, aws.StringValue(m.DBInstanceIdentifier))
+	}
+	if err := d.Set("cluster_members", cm); err != nil {
+		return fmt.Errorf("error setting cluster_members: %s", err)
+	}
+
+	d.Set("cluster_resource_id", dbc.DbClusterResourceId)
+
+	d.Set("db_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
+	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
+
+	if err := d.Set("enabled_cloudwatch_logs_exports", aws.StringValueSlice(dbc.EnabledCloudwatchLogsExports)); err != nil {
+		return fmt.Errorf("error setting enabled_cloudwatch_logs_exports: %s", err)
+	}
+
+	d.Set("endpoint", dbc.Endpoint)
+	d.Set("engine_version", dbc.EngineVersion)
+	d.Set("engine", dbc.Engine)
+	d.Set("hosted_zone_id", dbc.HostedZoneId)
+
+	d.Set("kms_key_id", dbc.KmsKeyId)
+	d.Set("master_username", dbc.MasterUsername)
+	d.Set("port", dbc.Port)
+	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
+	d.Set("preferred_maintenance_window", dbc.PreferredMaintenanceWindow)
+	d.Set("reader_endpoint", dbc.ReaderEndpoint)
+	d.Set("storage_encrypted", dbc.StorageEncrypted)
+
+	var vpcg []string
+	for _, g := range dbc.VpcSecurityGroups {
+		vpcg = append(vpcg, aws.StringValue(g.VpcSecurityGroupId))
+	}
+	if err := d.Set("vpc_security_group_ids", vpcg); err != nil {
+		return fmt.Errorf("error setting vpc_security_group_ids: %s", err)
+	}
+
+	// Fetch and save tags
+	if err := saveTagsDocDB(conn, d, aws.StringValue(dbc.DBClusterArn)); err != nil {
+		log.Printf("[WARN] Failed to save tags for DocDB Cluster (%s): %s", aws.StringValue(dbc.DBClusterIdentifier), err)
+	}
+
+	return nil
+}
+
+func resourceAwsDocDBClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+	requestUpdate := false
+
+	req := &docdb.ModifyDBClusterInput{
+		ApplyImmediately:    aws.Bool(d.Get("apply_immediately").(bool)),
+		DBClusterIdentifier: aws.String(d.Id()),
+	}
+
+	if d.HasChange("master_password") {
+		req.MasterUserPassword = aws.String(d.Get("master_password").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("engine_version") {
+		req.EngineVersion = aws.String(d.Get("engine_version").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("vpc_security_group_ids") {
+		if attr := d.Get("vpc_security_group_ids").(*schema.Set); attr.Len() > 0 {
+			req.VpcSecurityGroupIds = expandStringList(attr.List())
+		} else {
+			req.VpcSecurityGroupIds = []*string{}
+		}
+		requestUpdate = true
+	}
+
+	if d.HasChange("preferred_backup_window") {
+		req.PreferredBackupWindow = aws.String(d.Get("preferred_backup_window").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("preferred_maintenance_window") {
+		req.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintenance_window").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("backup_retention_period") {
+		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_period").(int)))
+		requestUpdate = true
+	}
+
+	if d.HasChange("db_cluster_parameter_group_name") {
+		d.SetPartial("db_cluster_parameter_group_name")
+		req.DBClusterParameterGroupName = aws.String(d.Get("db_cluster_parameter_group_name").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("enabled_cloudwatch_logs_exports") {
+		d.SetPartial("enabled_cloudwatch_logs_exports")
+		req.CloudwatchLogsExportConfiguration = buildDocDBCloudwatchLogsExportConfiguration(d)
+		requestUpdate = true
+	}
+
+	if requestUpdate {
+		err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+			_, err := conn.ModifyDBCluster(req)
+			if err != nil {
+				if isAWSErr(err, "InvalidParameterValue", "IAM role ARN value is invalid or does not include the required permissions") {
+					return resource.RetryableError(err)
+				}
+
+				if isAWSErr(err, docdb.ErrCodeInvalidDBClusterStateFault, "Cannot modify engine version without a primary instance in DB cluster") {
+					return resource.NonRetryableError(err)
+				}
+
+				if isAWSErr(err, docdb.ErrCodeInvalidDBClusterStateFault, "") {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("Failed to modify DocDB Cluster (%s): %s", d.Id(), err)
+		}
+
+		log.Printf("[INFO] Waiting for DocDB Cluster (%s) to be available", d.Id())
+		err = waitForDocDBClusterUpdate(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("error waiting for DocDB Cluster (%s) to be available: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		if err := setTagsDocDB(conn, d); err != nil {
+			return err
+		} else {
+			d.SetPartial("tags")
+		}
+	}
+
+	return resourceAwsDocDBClusterRead(d, meta)
+}
+
+func resourceAwsDocDBClusterDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+	log.Printf("[DEBUG] Destroying DocDB Cluster (%s)", d.Id())
+
+	deleteOpts := docdb.DeleteDBClusterInput{
+		DBClusterIdentifier: aws.String(d.Id()),
+	}
+
+	skipFinalSnapshot := d.Get("skip_final_snapshot").(bool)
+	deleteOpts.SkipFinalSnapshot = aws.Bool(skipFinalSnapshot)
+
+	if skipFinalSnapshot == false {
+		if name, present := d.GetOk("final_snapshot_identifier"); present {
+			deleteOpts.FinalDBSnapshotIdentifier = aws.String(name.(string))
+		} else {
+			return fmt.Errorf("DocDB Cluster FinalSnapshotIdentifier is required when a final snapshot is required")
+		}
+	}
+
+	log.Printf("[DEBUG] DocDB Cluster delete options: %s", deleteOpts)
+
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteDBCluster(&deleteOpts)
+		if err != nil {
+			if isAWSErr(err, docdb.ErrCodeInvalidDBClusterStateFault, "is not currently in the available state") {
+				return resource.RetryableError(err)
+			}
+			if isAWSErr(err, docdb.ErrCodeDBClusterNotFoundFault, "") {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("DocDB Cluster cannot be deleted: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    resourceAwsDocDBClusterDeletePendingStates,
+		Target:     []string{"destroyed"},
+		Refresh:    resourceAwsDocDBClusterStateRefreshFunc(conn, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second,
+	}
+
+	// Wait, catching any errors
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error deleting DocDB Cluster (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsDocDBClusterStateRefreshFunc(conn *docdb.DocDB, dbClusterIdentifier string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := conn.DescribeDBClusters(&docdb.DescribeDBClustersInput{
+			DBClusterIdentifier: aws.String(dbClusterIdentifier),
+		})
+
+		if isAWSErr(err, docdb.ErrCodeDBClusterNotFoundFault, "") {
+			return 42, "destroyed", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		var dbc *docdb.DBCluster
+
+		for _, c := range resp.DBClusters {
+			if *c.DBClusterIdentifier == dbClusterIdentifier {
+				dbc = c
+			}
+		}
+
+		if dbc == nil {
+			return 42, "destroyed", nil
+		}
+
+		if dbc.Status != nil {
+			log.Printf("[DEBUG] DB Cluster status (%s): %s", dbClusterIdentifier, *dbc.Status)
+		}
+
+		return dbc, aws.StringValue(dbc.Status), nil
+	}
+}
+
+var resourceAwsDocDBClusterCreatePendingStates = []string{
+	"creating",
+	"backing-up",
+	"modifying",
+	"preparing-data-migration",
+	"migrating",
+	"resetting-master-credentials",
+}
+
+var resourceAwsDocDBClusterDeletePendingStates = []string{
+	"available",
+	"deleting",
+	"backing-up",
+	"modifying",
+}
+
+var resourceAwsDocDBClusterUpdatePendingStates = []string{
+	"backing-up",
+	"modifying",
+	"resetting-master-credentials",
+	"upgrading",
+}
+
+func waitForDocDBClusterUpdate(conn *docdb.DocDB, id string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    resourceAwsDocDBClusterUpdatePendingStates,
+		Target:     []string{"available"},
+		Refresh:    resourceAwsDocDBClusterStateRefreshFunc(conn, id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+		Delay:      30 * time.Second, // Wait 30 secs before starting
+	}
+	_, err := stateConf.WaitForState()
+	return err
+}
+
+func buildDocDBCloudwatchLogsExportConfiguration(d *schema.ResourceData) *docdb.CloudwatchLogsExportConfiguration {
+
+	oraw, nraw := d.GetChange("enabled_cloudwatch_logs_exports")
+	o := oraw.([]interface{})
+	n := nraw.([]interface{})
+
+	create, disable := diffCloudwatchLogsExportConfiguration(o, n)
+
+	return &docdb.CloudwatchLogsExportConfiguration{
+		EnableLogTypes:  expandStringList(create),
+		DisableLogTypes: expandStringList(disable),
+	}
+}

--- a/aws/resource_aws_docdb_cluster_test.go
+++ b/aws/resource_aws_docdb_cluster_test.go
@@ -1,0 +1,635 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/docdb"
+)
+
+func TestAccAWSDocDBCluster_importBasic(t *testing.T) {
+	resourceName := "aws_docdb_cluster.default"
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig(ri),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"master_password", "skip_final_snapshot"},
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_basic(t *testing.T) {
+	var dbCluster docdb.DBCluster
+	rInt := acctest.RandInt()
+	resourceName := "aws_docdb_cluster.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists(resourceName, &dbCluster),
+					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:(rds|docdb):[^:]+:\d{12}:cluster:.+`)),
+					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "db_cluster_parameter_group_name", "default.docdb3.6"),
+					resource.TestCheckResourceAttrSet(resourceName, "reader_endpoint"),
+					resource.TestCheckResourceAttrSet(resourceName, "cluster_resource_id"),
+					resource.TestCheckResourceAttr(resourceName, "engine", "docdb"),
+					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone_id"),
+					resource.TestCheckResourceAttr(resourceName,
+						"enabled_cloudwatch_logs_exports.0", "audit"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_namePrefix(t *testing.T) {
+	var v docdb.DBCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig_namePrefix(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.test", &v),
+					resource.TestMatchResourceAttr(
+						"aws_docdb_cluster.test", "cluster_identifier", regexp.MustCompile("^tf-test-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_generatedName(t *testing.T) {
+	var v docdb.DBCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig_generatedName(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.test", &v),
+					resource.TestMatchResourceAttr(
+						"aws_docdb_cluster.test", "cluster_identifier", regexp.MustCompile("^tf-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_takeFinalSnapshot(t *testing.T) {
+	var v docdb.DBCluster
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterSnapshot(rInt),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfigWithFinalSnapshot(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+				),
+			},
+		},
+	})
+}
+
+/// This is a regression test to make sure that we always cover the scenario as hightlighted in
+/// https://github.com/hashicorp/terraform/issues/11568
+func TestAccAWSDocDBCluster_missingUserNameCausesError(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDocDBClusterConfigWithoutUserNameAndPassword(acctest.RandInt()),
+				ExpectError: regexp.MustCompile(`required field is not set`),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_updateTags(t *testing.T) {
+	var v docdb.DBCluster
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "tags.%", "1"),
+				),
+			},
+			{
+				Config: testAccDocDBClusterConfigUpdatedTags(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_updateCloudwatchLogsExports(t *testing.T) {
+	var v docdb.DBCluster
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterNoCloudwatchLogsConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+				),
+			},
+			{
+				Config: testAccDocDBClusterConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+					resource.TestCheckResourceAttr("aws_docdb_cluster.default",
+						"enabled_cloudwatch_logs_exports.0", "audit"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_kmsKey(t *testing.T) {
+	var v docdb.DBCluster
+	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig_kmsKey(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+					resource.TestMatchResourceAttr(
+						"aws_docdb_cluster.default", "kms_key_id", keyRegex),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_encrypted(t *testing.T) {
+	var v docdb.DBCluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig_encrypted(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "storage_encrypted", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "db_cluster_parameter_group_name", "default.docdb3.6"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_backupsUpdate(t *testing.T) {
+	var v docdb.DBCluster
+
+	ri := acctest.RandInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig_backups(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "preferred_backup_window", "07:00-09:00"),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "backup_retention_period", "5"),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "preferred_maintenance_window", "tue:04:00-tue:04:30"),
+				),
+			},
+
+			{
+				Config: testAccDocDBClusterConfig_backupsUpdate(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists("aws_docdb_cluster.default", &v),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "preferred_backup_window", "03:00-09:00"),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "backup_retention_period", "10"),
+					resource.TestCheckResourceAttr(
+						"aws_docdb_cluster.default", "preferred_maintenance_window", "wed:01:00-wed:01:30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDocDBCluster_Port(t *testing.T) {
+	var dbCluster1, dbCluster2 docdb.DBCluster
+	rInt := acctest.RandInt()
+	resourceName := "aws_docdb_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocDBClusterConfig_Port(rInt, 5432),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists(resourceName, &dbCluster1),
+					resource.TestCheckResourceAttr(resourceName, "port", "5432"),
+				),
+			},
+			{
+				Config: testAccDocDBClusterConfig_Port(rInt, 2345),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterExists(resourceName, &dbCluster2),
+					testAccCheckDocDBClusterRecreated(&dbCluster1, &dbCluster2),
+					resource.TestCheckResourceAttr(resourceName, "port", "2345"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDocDBClusterDestroy(s *terraform.State) error {
+	return testAccCheckDocDBClusterDestroyWithProvider(s, testAccProvider)
+}
+
+func testAccCheckDocDBClusterDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
+	conn := provider.Meta().(*AWSClient).docdbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_docdb_cluster" {
+			continue
+		}
+
+		// Try to find the Group
+		var err error
+		resp, err := conn.DescribeDBClusters(
+			&docdb.DescribeDBClustersInput{
+				DBClusterIdentifier: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if len(resp.DBClusters) != 0 &&
+				*resp.DBClusters[0].DBClusterIdentifier == rs.Primary.ID {
+				return fmt.Errorf("DB Cluster %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the cluster is already destroyed
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "DBClusterNotFoundFault" {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckDocDBClusterExists(n string, v *docdb.DBCluster) resource.TestCheckFunc {
+	return testAccCheckDocDBClusterExistsWithProvider(n, v, func() *schema.Provider { return testAccProvider })
+}
+
+func testAccCheckDocDBClusterExistsWithProvider(n string, v *docdb.DBCluster, providerF func() *schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DB Instance ID is set")
+		}
+
+		provider := providerF()
+		conn := provider.Meta().(*AWSClient).docdbconn
+		resp, err := conn.DescribeDBClusters(&docdb.DescribeDBClustersInput{
+			DBClusterIdentifier: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		for _, c := range resp.DBClusters {
+			if *c.DBClusterIdentifier == rs.Primary.ID {
+				*v = *c
+				return nil
+			}
+		}
+
+		return fmt.Errorf("DB Cluster (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckDocDBClusterRecreated(i, j *docdb.DBCluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.ClusterCreateTime) == aws.TimeValue(j.ClusterCreateTime) {
+			return errors.New("DocDB Cluster was not recreated")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDocDBClusterSnapshot(rInt int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_docdb_cluster" {
+				continue
+			}
+
+			// Try and delete the snapshot before we check for the cluster not found
+			snapshot_identifier := fmt.Sprintf("tf-acctest-docdbcluster-snapshot-%d", rInt)
+
+			awsClient := testAccProvider.Meta().(*AWSClient)
+			conn := awsClient.docdbconn
+
+			log.Printf("[INFO] Deleting the Snapshot %s", snapshot_identifier)
+			_, snapDeleteErr := conn.DeleteDBClusterSnapshot(
+				&docdb.DeleteDBClusterSnapshotInput{
+					DBClusterSnapshotIdentifier: aws.String(snapshot_identifier),
+				})
+			if snapDeleteErr != nil {
+				return snapDeleteErr
+			}
+
+			// Try to find the Group
+			var err error
+			resp, err := conn.DescribeDBClusters(
+				&docdb.DescribeDBClustersInput{
+					DBClusterIdentifier: aws.String(rs.Primary.ID),
+				})
+
+			if err == nil {
+				if len(resp.DBClusters) != 0 &&
+					*resp.DBClusters[0].DBClusterIdentifier == rs.Primary.ID {
+					return fmt.Errorf("DB Cluster %s still exists", rs.Primary.ID)
+				}
+			}
+
+			// Return nil if the cluster is already destroyed
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == "DBClusterNotFoundFault" {
+					return nil
+				}
+			}
+
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccDocDBClusterConfig(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.docdb3.6"
+  skip_final_snapshot = true
+  tags = {
+    Environment = "production"
+  }
+  enabled_cloudwatch_logs_exports = [
+	"audit",
+  ]
+}`, n)
+}
+
+func testAccDocDBClusterConfig_namePrefix() string {
+	return `
+resource "aws_docdb_cluster" "test" {
+  cluster_identifier_prefix = "tf-test-"
+  master_username = "root"
+  master_password = "password"
+  skip_final_snapshot = true
+}
+`
+}
+
+func testAccDocDBClusterConfig_generatedName() string {
+	return `
+resource "aws_docdb_cluster" "test" {
+  master_username = "root"
+  master_password = "password"
+  skip_final_snapshot = true
+}
+`
+}
+
+func testAccDocDBClusterConfigWithFinalSnapshot(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.docdb3.6"
+  final_snapshot_identifier = "tf-acctest-docdbcluster-snapshot-%d"
+  tags = {
+    Environment = "production"
+  }
+}`, n, n)
+}
+
+func testAccDocDBClusterConfigWithoutUserNameAndPassword(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  skip_final_snapshot = true
+}`, n)
+}
+
+func testAccDocDBClusterConfigUpdatedTags(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.docdb3.6"
+  skip_final_snapshot = true
+  tags = {
+    Environment = "production"
+    AnotherTag = "test"
+  }
+}`, n)
+}
+
+func testAccDocDBClusterNoCloudwatchLogsConfig(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  db_cluster_parameter_group_name = "default.docdb3.6"
+  skip_final_snapshot = true
+  tags = {
+    Environment = "production"
+  }
+}`, n)
+}
+
+func testAccDocDBClusterConfig_kmsKey(n int) string {
+	return fmt.Sprintf(`
+
+ resource "aws_kms_key" "foo" {
+     description = "Terraform acc test %d"
+     policy = <<POLICY
+ {
+   "Version": "2012-10-17",
+   "Id": "kms-tf-1",
+   "Statement": [
+     {
+       "Sid": "Enable IAM User Permissions",
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "*"
+       },
+       "Action": "kms:*",
+       "Resource": "*"
+     }
+   ]
+ }
+ POLICY
+ }
+
+ resource "aws_docdb_cluster" "default" {
+   cluster_identifier = "tf-docdb-cluster-%d"
+   availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+   master_username = "foo"
+   master_password = "mustbeeightcharaters"
+   db_cluster_parameter_group_name = "default.docdb3.6"
+   storage_encrypted = true
+   kms_key_id = "${aws_kms_key.foo.arn}"
+   skip_final_snapshot = true
+ }`, n, n)
+}
+
+func testAccDocDBClusterConfig_encrypted(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  storage_encrypted = true
+  skip_final_snapshot = true
+}`, n)
+}
+
+func testAccDocDBClusterConfig_backups(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  preferred_maintenance_window = "tue:04:00-tue:04:30"
+  skip_final_snapshot = true
+}`, n)
+}
+
+func testAccDocDBClusterConfig_backupsUpdate(n int) string {
+	return fmt.Sprintf(`
+resource "aws_docdb_cluster" "default" {
+  cluster_identifier = "tf-docdb-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  master_username = "foo"
+  master_password = "mustbeeightcharaters"
+  backup_retention_period = 10
+  preferred_backup_window = "03:00-09:00"
+  preferred_maintenance_window = "wed:01:00-wed:01:30"
+  apply_immediately = true
+  skip_final_snapshot = true
+}`, n)
+}
+
+func testAccDocDBClusterConfig_Port(rInt, port int) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_docdb_cluster" "test" {
+  availability_zones              = ["${data.aws_availability_zones.available.names}"]
+  cluster_identifier              = "tf-acc-test-%d"
+  db_cluster_parameter_group_name = "default.docdb3.6"
+  engine                          = "docdb"
+  master_password                 = "mustbeeightcharaters"
+  master_username                 = "foo"
+  port                            = %d
+  skip_final_snapshot             = true
+}`, rInt, port)
+}

--- a/aws/tagsDocDB.go
+++ b/aws/tagsDocDB.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"regexp"
 
@@ -73,6 +74,23 @@ func diffTagsDocDB(oldTags, newTags []*docdb.Tag) ([]*docdb.Tag, []*docdb.Tag) {
 	}
 
 	return tagsFromMapDocDB(create), remove
+}
+
+func saveTagsDocDB(conn *docdb.DocDB, d *schema.ResourceData, arn string) error {
+	resp, err := conn.ListTagsForResource(&docdb.ListTagsForResourceInput{
+		ResourceName: aws.String(arn),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retreiving tags for ARN: %s", arn)
+	}
+
+	var dt []*docdb.Tag
+	if len(resp.TagList) > 0 {
+		dt = resp.TagList
+	}
+
+	return d.Set("tags", tagsToMapDocDB(dt))
 }
 
 // tagsFromMap returns the tags for the given map of data.

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -293,6 +293,50 @@ func validateDbParamGroupNamePrefix(v interface{}, k string) (ws []string, error
 	return
 }
 
+func validateDocDBIdentifier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	return
+}
+
+func validateDocDBIdentifierPrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	return
+}
+
+func validateDocDBEngine() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"docdb",
+	}, false)
+}
+
 func validateDocDBParamGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1003,6 +1003,10 @@
                     <a href="#">DocumentDB Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-docdb-cluster") %>>
+                            <a href="/docs/providers/aws/r/docdb_cluster.html">aws_docdb_cluster</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-docdb-cluster-parameter-group") %>>
                             <a href="/docs/providers/aws/r/docdb_cluster_parameter_group.html">aws_docdb_cluster_parameter_group</a>
                         </li>

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -27,11 +27,11 @@ phase because a modification has not yet taken place. You can use the
 resource "aws_docdb_cluster" "docdb" {
   cluster_identifier      = "my-docdb-cluster"
   engine                  = "docdb"
-  availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
   master_username         = "foo"
   master_password         = "mustbeeightchars"
   backup_retention_period = 5
   preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
 }
 ```
 
@@ -42,59 +42,50 @@ the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/referenc
 
 The following arguments are supported:
 
-* `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
-* `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifer`.
-* `master_password` - (Required unless a `snapshot_identifier` is provided) Password for the master DB user. Note that this may
-    show up in logs, and it will be stored in the state file. Please refer to the DocDB Naming Constraints.
-* `master_username` - (Required unless a `snapshot_identifier` is provided) Username for the master DB user. * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
-    when this DB cluster is deleted. If omitted, no final snapshot will be
-    made.
-* `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created. If false is specified, a DB snapshot is created before the DB cluster is deleted, using the value from `final_snapshot_identifier`. Default is `false`.
-* `availability_zones` - (Optional) A list of EC2 Availability Zones that
-  instances in the DB cluster can be created in
-* `backup_retention_period` - (Optional) The days to retain backups for. Default `1`
-* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC
-Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
-* `preferred_maintenance_window` - (Optional) The weekly time range during which system maintenance can occur, in (UTC) e.g. wed:04:00-wed:04:30
-* `port` - (Optional) The port on which the DB accepts connections
-* `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
-  with the Cluster
-* `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot.
-* `storage_encrypted` - (Optional) Specifies whether the DB cluster is encrypted. The default is `false` for `provisioned` `engine_mode` and `true` for `serverless` `engine_mode`.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications
      are applied immediately, or during the next maintenance window. Default is
      `false`.
+* `availability_zones` - (Optional) A list of EC2 Availability Zones that
+  instances in the DB cluster can be created in.
+* `backup_retention_period` - (Optional) The days to retain backups for. Default `1`
+* `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifer`.
+* `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance.* `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
-* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true.
-* `engine` - (Optional) The name of the database engine to be used for this DB cluster. Defaults to `docdb`. Valid Values: `docdb`
-* `engine_version` - (Optional) The database engine version. Updating this argument results in an outage.
 * `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
    The following log types are supported: `audit`.
+* `engine_version` - (Optional) The database engine version. Updating this argument results in an outage.
+* `engine` - (Optional) The name of the database engine to be used for this DB cluster. Defaults to `docdb`. Valid Values: `docdb`
+* `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
+    when this DB cluster is deleted. If omitted, no final snapshot will be
+    made.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true.
+* `master_password` - (Required unless a `snapshot_identifier` is provided) Password for the master DB user. Note that this may
+    show up in logs, and it will be stored in the state file. Please refer to the DocDB Naming Constraints.
+* `master_username` - (Required unless a `snapshot_identifier` is provided) Username for the master DB user. 
+* `port` - (Optional) The port on which the DB accepts connections
+* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
+* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC
+Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
+* `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created. If false is specified, a DB snapshot is created before the DB cluster is deleted, using the value from `final_snapshot_identifier`. Default is `false`.
+* `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot.
+* `storage_encrypted` - (Optional) Specifies whether the DB cluster is encrypted. The default is `false`.
 * `tags` - (Optional) A mapping of tags to assign to the DB cluster.
+* `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
+  with the Cluster
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of cluster
-* `id` - The DocDB Cluster Identifier
-* `cluster_identifier` - The DocDB Cluster Identifier
-* `cluster_resource_id` - The DocDB Cluster Resource ID
 * `cluster_members` – List of DocDB Instances that are a part of this cluster
-* `availability_zones` - The availability zone of the instance
-* `backup_retention_period` - The backup retention period
-* `preferred_backup_window` - The daily time range during which the backups happen
-* `preferred_maintenance_window` - The maintenance window
+* `cluster_resource_id` - The DocDB Cluster Resource ID
 * `endpoint` - The DNS address of the DocDB instance
-* `reader_endpoint` - A read-only endpoint for the DocDB cluster, automatically load-balanced across replicas
-* `engine` - The database engine
-* `engine_version` - The database engine version
-* `maintenance_window` - The instance maintenance window
-* `port` - The database port
-* `status` - The DocDB instance status
-* `master_username` - The master username for the database
-* `storage_encrypted` - Specifies whether the DB cluster is encrypted
 * `hosted_zone_id` - The Route53 Hosted Zone ID of the endpoint
+* `id` - The DocDB Cluster Identifier
+* `maintenance_window` - The instance maintenance window
+* `reader_endpoint` - A read-only endpoint for the DocDB cluster, automatically load-balanced across replicas
+* `status` - The DocDB instance status
 
 ## Timeouts
 

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -1,0 +1,115 @@
+---
+layout: "aws"
+page_title: "AWS: aws_docdb"
+sidebar_current: "docs-aws-resource-docdb-cluster"
+description: |-
+  Manages a DocDB Aurora Cluster
+---
+
+# aws_docdb_cluster
+
+Manages a DocDB Cluster.
+
+Changes to a DocDB Cluster can occur when you manually change a
+parameter, such as `port`, and are reflected in the next maintenance
+window. Because of this, Terraform may report a difference in its planning
+phase because a modification has not yet taken place. You can use the
+`apply_immediately` flag to instruct the service to apply the change immediately
+(see documentation below).
+
+~> **Note:** using `apply_immediately` can result in a brief downtime as the server reboots.
+~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+resource "aws_docdb_cluster" "docdb" {
+  cluster_identifier      = "my-docdb-cluster"
+  engine                  = "docdb"
+  availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  master_username         = "foo"
+  master_password         = "mustbeeightchars"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+}
+```
+
+## Argument Reference
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-cluster.html).
+
+The following arguments are supported:
+
+* `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
+* `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifer`.
+* `master_password` - (Required unless a `snapshot_identifier` is provided) Password for the master DB user. Note that this may
+    show up in logs, and it will be stored in the state file. Please refer to the DocDB Naming Constraints.
+* `master_username` - (Required unless a `snapshot_identifier` is provided) Username for the master DB user. * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
+    when this DB cluster is deleted. If omitted, no final snapshot will be
+    made.
+* `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created. If false is specified, a DB snapshot is created before the DB cluster is deleted, using the value from `final_snapshot_identifier`. Default is `false`.
+* `availability_zones` - (Optional) A list of EC2 Availability Zones that
+  instances in the DB cluster can be created in
+* `backup_retention_period` - (Optional) The days to retain backups for. Default `1`
+* `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.Time in UTC
+Default: A 30-minute window selected at random from an 8-hour block of time per region. e.g. 04:00-09:00
+* `preferred_maintenance_window` - (Optional) The weekly time range during which system maintenance can occur, in (UTC) e.g. wed:04:00-wed:04:30
+* `port` - (Optional) The port on which the DB accepts connections
+* `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
+  with the Cluster
+* `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot.
+* `storage_encrypted` - (Optional) Specifies whether the DB cluster is encrypted. The default is `false` for `provisioned` `engine_mode` and `true` for `serverless` `engine_mode`.
+* `apply_immediately` - (Optional) Specifies whether any cluster modifications
+     are applied immediately, or during the next maintenance window. Default is
+     `false`.
+* `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance.* `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true.
+* `engine` - (Optional) The name of the database engine to be used for this DB cluster. Defaults to `docdb`. Valid Values: `docdb`
+* `engine_version` - (Optional) The database engine version. Updating this argument results in an outage.
+* `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
+   The following log types are supported: `audit`.
+* `tags` - (Optional) A mapping of tags to assign to the DB cluster.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of cluster
+* `id` - The DocDB Cluster Identifier
+* `cluster_identifier` - The DocDB Cluster Identifier
+* `cluster_resource_id` - The DocDB Cluster Resource ID
+* `cluster_members` – List of DocDB Instances that are a part of this cluster
+* `availability_zones` - The availability zone of the instance
+* `backup_retention_period` - The backup retention period
+* `preferred_backup_window` - The daily time range during which the backups happen
+* `preferred_maintenance_window` - The maintenance window
+* `endpoint` - The DNS address of the DocDB instance
+* `reader_endpoint` - A read-only endpoint for the DocDB cluster, automatically load-balanced across replicas
+* `engine` - The database engine
+* `engine_version` - The database engine version
+* `maintenance_window` - The instance maintenance window
+* `port` - The database port
+* `status` - The DocDB instance status
+* `master_username` - The master username for the database
+* `storage_encrypted` - Specifies whether the DB cluster is encrypted
+* `hosted_zone_id` - The Route53 Hosted Zone ID of the endpoint
+
+## Timeouts
+
+`aws_docdb_cluster` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `120 minutes`) Used for Cluster creation
+- `update` - (Default `120 minutes`) Used for Cluster modifications
+- `delete` - (Default `120 minutes`) Used for destroying cluster. This includes
+any cleanup task during the destroying process.
+
+## Import
+
+DocDB Clusters can be imported using the `cluster_identifier`, e.g.
+
+```
+$ terraform import aws_docdb_cluster.docdb_cluster docdb-prod-cluster
+```


### PR DESCRIPTION
This PR forms part of #7077.

Adds the aws_docdb_cluster resource.

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSDocDBCluster_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDocDBCluster_ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDocDBCluster_importBasic
=== PAUSE TestAccAWSDocDBCluster_importBasic
=== RUN   TestAccAWSDocDBCluster_basic
=== PAUSE TestAccAWSDocDBCluster_basic
=== RUN   TestAccAWSDocDBCluster_namePrefix
=== PAUSE TestAccAWSDocDBCluster_namePrefix
=== RUN   TestAccAWSDocDBCluster_generatedName
=== PAUSE TestAccAWSDocDBCluster_generatedName
=== RUN   TestAccAWSDocDBCluster_takeFinalSnapshot
=== PAUSE TestAccAWSDocDBCluster_takeFinalSnapshot
=== RUN   TestAccAWSDocDBCluster_missingUserNameCausesError
=== PAUSE TestAccAWSDocDBCluster_missingUserNameCausesError
=== RUN   TestAccAWSDocDBCluster_updateTags
=== PAUSE TestAccAWSDocDBCluster_updateTags
=== RUN   TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== PAUSE TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== RUN   TestAccAWSDocDBCluster_kmsKey
=== PAUSE TestAccAWSDocDBCluster_kmsKey
=== RUN   TestAccAWSDocDBCluster_encrypted
=== PAUSE TestAccAWSDocDBCluster_encrypted
=== RUN   TestAccAWSDocDBCluster_backupsUpdate
=== PAUSE TestAccAWSDocDBCluster_backupsUpdate
=== RUN   TestAccAWSDocDBCluster_Port
=== PAUSE TestAccAWSDocDBCluster_Port
=== CONT  TestAccAWSDocDBCluster_generatedName
=== CONT  TestAccAWSDocDBCluster_kmsKey
=== CONT  TestAccAWSDocDBCluster_missingUserNameCausesError
=== CONT  TestAccAWSDocDBCluster_updateTags
=== CONT  TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== CONT  TestAccAWSDocDBCluster_namePrefix
=== CONT  TestAccAWSDocDBCluster_basic
=== CONT  TestAccAWSDocDBCluster_importBasic
=== CONT  TestAccAWSDocDBCluster_Port
=== CONT  TestAccAWSDocDBCluster_backupsUpdate
=== CONT  TestAccAWSDocDBCluster_encrypted
=== CONT  TestAccAWSDocDBCluster_takeFinalSnapshot
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (5.87s)
--- PASS: TestAccAWSDocDBCluster_generatedName (115.99s)
--- PASS: TestAccAWSDocDBCluster_encrypted (137.66s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (138.01s)
--- PASS: TestAccAWSDocDBCluster_importBasic (150.86s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (162.21s)
--- PASS: TestAccAWSDocDBCluster_updateTags (163.11s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (176.17s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (181.46s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (183.95s)
--- PASS: TestAccAWSDocDBCluster_basic (191.73s)
--- PASS: TestAccAWSDocDBCluster_Port (235.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       235.586s
```
