### PR TITLE
DocumentDB: aws_docdb_cluster_snapshot resource added

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -410,6 +410,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dms_replication_subnet_group":                 resourceAwsDmsReplicationSubnetGroup(),
 			"aws_dms_replication_task":                         resourceAwsDmsReplicationTask(),
 			"aws_docdb_cluster_parameter_group":                resourceAwsDocDBClusterParameterGroup(),
+			"aws_docdb_cluster_snapshot":                       resourceAwsDocDBClusterSnapshot(),
 			"aws_docdb_subnet_group":                           resourceAwsDocDBSubnetGroup(),
 			"aws_dx_bgp_peer":                                  resourceAwsDxBgpPeer(),
 			"aws_dx_connection":                                resourceAwsDxConnection(),

--- a/aws/resource_aws_docdb_cluster_snapshot.go
+++ b/aws/resource_aws_docdb_cluster_snapshot.go
@@ -1,0 +1,206 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDocDBClusterSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDocDBClusterSnapshotCreate,
+		Read:   resourceAwsDocDBClusterSnapshotRead,
+		Delete: resourceAwsDocDBClusterSnapshotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"db_cluster_snapshot_identifier": {
+				Type:         schema.TypeString,
+				ValidateFunc: validateDocDBClusterSnapshotIdentifier,
+				Required:     true,
+				ForceNew:     true,
+			},
+			"db_cluster_identifier": {
+				Type:         schema.TypeString,
+				ValidateFunc: validateDocDBClusterIdentifier,
+				Required:     true,
+				ForceNew:     true,
+			},
+
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"db_cluster_snapshot_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"source_db_cluster_snapshot_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"snapshot_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDocDBClusterSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	params := &docdb.CreateDBClusterSnapshotInput{
+		DBClusterIdentifier:         aws.String(d.Get("db_cluster_identifier").(string)),
+		DBClusterSnapshotIdentifier: aws.String(d.Get("db_cluster_snapshot_identifier").(string)),
+	}
+
+	_, err := conn.CreateDBClusterSnapshot(params)
+	if err != nil {
+		return fmt.Errorf("error creating DocDB Cluster Snapshot: %s", err)
+	}
+	d.SetId(d.Get("db_cluster_snapshot_identifier").(string))
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"available"},
+		Refresh:    resourceAwsDocDBClusterSnapshotStateRefreshFunc(d.Id(), conn),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		MinTimeout: 10 * time.Second,
+		Delay:      5 * time.Second,
+	}
+
+	// Wait, catching any errors
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for DocDB Cluster Snapshot %q to create: %s", d.Id(), err)
+	}
+
+	return resourceAwsDocDBClusterSnapshotRead(d, meta)
+}
+
+func resourceAwsDocDBClusterSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	params := &docdb.DescribeDBClusterSnapshotsInput{
+		DBClusterSnapshotIdentifier: aws.String(d.Id()),
+	}
+	resp, err := conn.DescribeDBClusterSnapshots(params)
+	if err != nil {
+		if isAWSErr(err, docdb.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+			log.Printf("[WARN] DocDB Cluster Snapshot %q not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading DocDB Cluster Snapshot %q: %s", d.Id(), err)
+	}
+
+	if resp == nil || len(resp.DBClusterSnapshots) == 0 || resp.DBClusterSnapshots[0] == nil || aws.StringValue(resp.DBClusterSnapshots[0].DBClusterSnapshotIdentifier) != d.Id() {
+		log.Printf("[WARN] DocDB Cluster Snapshot %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	snapshot := resp.DBClusterSnapshots[0]
+
+	if err := d.Set("availability_zones", flattenStringList(snapshot.AvailabilityZones)); err != nil {
+		return fmt.Errorf("error setting availability_zones: %s", err)
+	}
+	d.Set("db_cluster_identifier", snapshot.DBClusterIdentifier)
+	d.Set("db_cluster_snapshot_arn", snapshot.DBClusterSnapshotArn)
+	d.Set("db_cluster_snapshot_identifier", snapshot.DBClusterSnapshotIdentifier)
+	d.Set("engine_version", snapshot.EngineVersion)
+	d.Set("engine", snapshot.Engine)
+	d.Set("kms_key_id", snapshot.KmsKeyId)
+	d.Set("port", snapshot.Port)
+	d.Set("snapshot_type", snapshot.SnapshotType)
+	d.Set("source_db_cluster_snapshot_arn", snapshot.SourceDBClusterSnapshotArn)
+	d.Set("status", snapshot.Status)
+	d.Set("storage_encrypted", snapshot.StorageEncrypted)
+	d.Set("vpc_id", snapshot.VpcId)
+
+	return nil
+}
+
+func resourceAwsDocDBClusterSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).docdbconn
+
+	params := &docdb.DeleteDBClusterSnapshotInput{
+		DBClusterSnapshotIdentifier: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteDBClusterSnapshot(params)
+	if err != nil {
+		if isAWSErr(err, docdb.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+			return nil
+		}
+		return fmt.Errorf("error deleting DocDB Cluster Snapshot %q: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsDocDBClusterSnapshotStateRefreshFunc(dbClusterSnapshotIdentifier string, conn *docdb.DocDB) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		opts := &docdb.DescribeDBClusterSnapshotsInput{
+			DBClusterSnapshotIdentifier: aws.String(dbClusterSnapshotIdentifier),
+		}
+
+		log.Printf("[DEBUG] DocDB Cluster Snapshot describe configuration: %#v", opts)
+
+		resp, err := conn.DescribeDBClusterSnapshots(opts)
+		if err != nil {
+			if isAWSErr(err, docdb.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+				return nil, "", nil
+			}
+			return nil, "", fmt.Errorf("Error retrieving DocDB Cluster Snapshots: %s", err)
+		}
+
+		if resp == nil || len(resp.DBClusterSnapshots) == 0 || resp.DBClusterSnapshots[0] == nil {
+			return nil, "", fmt.Errorf("No snapshots returned for %s", dbClusterSnapshotIdentifier)
+		}
+
+		snapshot := resp.DBClusterSnapshots[0]
+
+		return resp, aws.StringValue(snapshot.Status), nil
+	}
+}

--- a/aws/resource_aws_docdb_cluster_snapshot_test.go
+++ b/aws/resource_aws_docdb_cluster_snapshot_test.go
@@ -27,7 +27,7 @@ func TestAccAWSDocDBClusterSnapshot_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDocDBClusterSnapshotExists(resourceName, &dbClusterSnapshot),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zones.#"),
-					resource.TestMatchResourceAttr(resourceName, "db_cluster_snapshot_arn", regexp.MustCompile(`^arn:[^:]+:(rds|docdb):[^:]+:\d{12}:cluster-snapshot:.+`)),
+					testAccMatchResourceAttrRegionalARN(resourceName, "db_cluster_snapshot_arn", "rds", regexp.MustCompile(`cluster-snapshot:.+`)),
 					resource.TestCheckResourceAttrSet(resourceName, "engine"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
@@ -36,7 +36,7 @@ func TestAccAWSDocDBClusterSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source_db_cluster_snapshot_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
-					resource.TestMatchResourceAttr(resourceName, "vpc_id", regexp.MustCompile(`^vpc-.+`)),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "aws_vpc.test", "id"),
 				),
 			},
 			{

--- a/aws/resource_aws_docdb_cluster_snapshot_test.go
+++ b/aws/resource_aws_docdb_cluster_snapshot_test.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/docdb"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDocDBClusterSnapshot_basic(t *testing.T) {
+	var dbClusterSnapshot docdb.DBClusterSnapshot
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_docdb_cluster_snapshot.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDocDBClusterSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDocDBClusterSnapshotConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDocDBClusterSnapshotExists(resourceName, &dbClusterSnapshot),
+					resource.TestCheckResourceAttrSet(resourceName, "availability_zones.#"),
+					resource.TestMatchResourceAttr(resourceName, "db_cluster_snapshot_arn", regexp.MustCompile(`^arn:[^:]+:(rds|docdb):[^:]+:\d{12}:cluster-snapshot:.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, "engine"),
+					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot_type", "manual"),
+					resource.TestCheckResourceAttr(resourceName, "source_db_cluster_snapshot_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
+					resource.TestMatchResourceAttr(resourceName, "vpc_id", regexp.MustCompile(`^vpc-.+`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDocDBClusterSnapshotDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_docdb_cluster_snapshot" {
+			continue
+		}
+
+		input := &docdb.DescribeDBClusterSnapshotsInput{
+			DBClusterSnapshotIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeDBClusterSnapshots(input)
+		if err != nil {
+			if isAWSErr(err, docdb.ErrCodeDBClusterSnapshotNotFoundFault, "") {
+				continue
+			}
+			return err
+		}
+
+		if output != nil && len(output.DBClusterSnapshots) > 0 && output.DBClusterSnapshots[0] != nil && aws.StringValue(output.DBClusterSnapshots[0].DBClusterSnapshotIdentifier) == rs.Primary.ID {
+			return fmt.Errorf("DocDB Cluster Snapshot %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDocDBClusterSnapshotExists(resourceName string, dbClusterSnapshot *docdb.DBClusterSnapshot) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set for %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).docdbconn
+
+		request := &docdb.DescribeDBClusterSnapshotsInput{
+			DBClusterSnapshotIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		response, err := conn.DescribeDBClusterSnapshots(request)
+		if err != nil {
+			return err
+		}
+
+		if response == nil || len(response.DBClusterSnapshots) == 0 || response.DBClusterSnapshots[0] == nil || aws.StringValue(response.DBClusterSnapshots[0].DBClusterSnapshotIdentifier) != rs.Primary.ID {
+			return fmt.Errorf("DocDB Cluster Snapshot %q not found", rs.Primary.ID)
+		}
+
+		*dbClusterSnapshot = *response.DBClusterSnapshots[0]
+
+		return nil
+	}
+}
+
+func testAccAwsDocDBClusterSnapshotConfig(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "192.168.0.0/16"
+
+  tags = {
+   Name = %q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "192.168.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_docdb_subnet_group" "test" {
+  name       = %q
+  subnet_ids = ["${aws_subnet.test.*.id}"]
+}
+
+resource "aws_docdb_cluster" "test" {
+  cluster_identifier   = %q
+  db_subnet_group_name = "${aws_docdb_subnet_group.test.name}"
+  master_password      = "barbarbarbar"
+  master_username      = "foo"
+  skip_final_snapshot  = true
+}
+
+resource "aws_docdb_cluster_snapshot" "test" {
+  db_cluster_identifier          = "${aws_docdb_cluster.test.id}"
+  db_cluster_snapshot_identifier = %q
+}
+`, rName, rName, rName, rName, rName)
+}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -339,6 +339,48 @@ func validateDocDBParamGroupNamePrefix(v interface{}, k string) (ws []string, er
 	return
 }
 
+func validateDocDBClusterIdentifier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	return
+}
+
+func validateDocDBClusterSnapshotIdentifier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	return
+}
+
 func validateElbName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) == 0 {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1007,6 +1007,10 @@
                             <a href="/docs/providers/aws/r/docdb_cluster_parameter_group.html">aws_docdb_cluster_parameter_group</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-docdb-cluster-snapshot") %>>
+                            <a href="/docs/providers/aws/r/docdb_cluster_snapshot.html">aws_docdb_cluster_snapshot</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-docdb-subnet-group") %>>
                             <a href="/docs/providers/aws/r/docdb_subnet_group.html">aws_docdb_subnet_group</a>
                         </li>

--- a/website/docs/r/docdb_cluster_snapshot.html.markdown
+++ b/website/docs/r/docdb_cluster_snapshot.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "aws"
+page_title: "AWS: aws_docdb_cluster_snapshot"
+sidebar_current: "docs-aws-resource-docdb-cluster-snapshot"
+description: |-
+  Manages a DocDB database cluster snapshot.
+---
+
+# aws_docdb_cluster_snapshot
+
+Manages a DocDB database cluster snapshot for DocDB clusters.
+
+## Example Usage
+
+```hcl
+resource "aws_docdb_cluster_snapshot" "example" {
+  db_cluster_identifier          = "${aws_docdb_cluster.example.id}"
+  db_cluster_snapshot_identifier = "resourcetestsnapshot1234"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `db_cluster_identifier` - (Required) The DocDB Cluster Identifier from which to take the snapshot.
+* `db_cluster_snapshot_identifier` - (Required) The Identifier for the snapshot.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `availability_zones` - List of EC2 Availability Zones that instances in the DocDB cluster snapshot can be restored in.
+* `db_cluster_snapshot_arn` - The Amazon Resource Name (ARN) for the DocDB Cluster Snapshot.
+* `engine` - Specifies the name of the database engine.
+* `engine_version` - Version of the database engine for this DocDB cluster snapshot.
+* `kms_key_id` - If storage_encrypted is true, the AWS KMS key identifier for the encrypted DocDB cluster snapshot.
+* `port` - Port that the DocDB cluster was listening on at the time of the snapshot.
+* `source_db_cluster_snapshot_identifier` - The DocDB Cluster Snapshot Arn that the DocDB Cluster Snapshot was copied from. It only has value in case of cross customer or cross region copy.
+* `storage_encrypted` - Specifies whether the DocDB cluster snapshot is encrypted.
+* `status` - The status of this DocDB Cluster Snapshot.
+* `vpc_id` - The VPC ID associated with the DocDB cluster snapshot.
+
+## Timeouts
+
+`aws_docdb_cluster_snapshot` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `20m`) How long to wait for the snapshot to be available.
+
+## Import
+
+`aws_docdb_cluster_snapshot` can be imported by using the cluster snapshot identifier, e.g.
+
+```
+$ terraform import aws_docdb_cluster_snapshot.example my-cluster-snapshot
+```


### PR DESCRIPTION
**This depends on my PR for aws_docdb_cluster (#7122) so must be merged after that.**

This PR forms part of #7077. 

Adds the aws_docdb_cluster_snapshot resource.

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSDocDBClusterSnapshot'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDocDBClusterSnapshot -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDocDBClusterSnapshot_basic
=== PAUSE TestAccAWSDocDBClusterSnapshot_basic
=== CONT  TestAccAWSDocDBClusterSnapshot_basic
--- PASS: TestAccAWSDocDBClusterSnapshot_basic (255.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws   255.048s
```
