### PR TITLE
r/rds_cluster_endpoint: fix import statement formatting

### DIFF
--- a/aws/resource_aws_rds_cluster_endpoint_test.go
+++ b/aws/resource_aws_rds_cluster_endpoint_test.go
@@ -2,17 +2,17 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/terraform"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSRDSClusterEndpoint_basic(t *testing.T) {


### PR DESCRIPTION
No issue

Changes proposed in this pull request:

* fix import statement formatting in cluster_endpoint_test.go

Output from acceptance testing: n/a

This change kept popping up in my git diff locally. I'm not sure if it was my IDE that kept auto-formatting the file, but running `goimports` on the file manually makes the same change so I thought i'd go ahead and submit the formatting fix.
