### PR TITLE
lambda_function: add layers support to resource and data source

### DIFF
--- a/aws/data_source_aws_lambda_function.go
+++ b/aws/data_source_aws_lambda_function.go
@@ -40,6 +40,14 @@ func dataSourceAwsLambdaFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"layers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"memory_size": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -95,6 +95,29 @@ func TestAccDataSourceAWSLambdaFunction_alias(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAWSLambdaFunction_layers(t *testing.T) {
+	rString := acctest.RandString(7)
+	roleName := fmt.Sprintf("tf-acctest-d-lambda-function-layer-role-%s", rString)
+	policyName := fmt.Sprintf("tf-acctest-d-lambda-function-layer-policy-%s", rString)
+	sgName := fmt.Sprintf("tf-acctest-d-lambda-function-layer-sg-%s", rString)
+	funcName := fmt.Sprintf("tf-acctest-d-lambda-function-layer-func-%s", rString)
+	layerName := fmt.Sprintf("tf-acctest-d-lambda-function-layer-layer-%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaFunctionConfigLayers(roleName, policyName, sgName, funcName, layerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_lambda_function.acctest", "arn"),
+					resource.TestCheckResourceAttr("data.aws_lambda_function.acctest", "layers.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAWSLambdaFunction_vpc(t *testing.T) {
 	rString := acctest.RandString(7)
 	roleName := fmt.Sprintf("tf-acctest-d-lambda-function-vpc-role-%s", rString)
@@ -291,6 +314,30 @@ data "aws_lambda_function" "acctest" {
   qualifier     = "${aws_lambda_alias.alias.name}"
 }
 `, funcName, funcName)
+}
+
+func testAccDataSourceAWSLambdaFunctionConfigLayers(roleName, policyName, sgName, funcName, layerName string) string {
+	return fmt.Sprintf(testAccDataSourceAWSLambdaFunctionConfigBase(roleName, policyName, sgName)+`
+resource "aws_lambda_layer_version" "acctest_create" {
+  filename = "test-fixtures/lambdatest.zip"
+  layer_name = "%s"
+  compatible_runtimes = ["nodejs8.10"]
+}
+
+resource "aws_lambda_function" "acctest_create" {
+  function_name = "%s"
+  description = "%s"
+  filename = "test-fixtures/lambdatest.zip"
+  role = "${aws_iam_role.lambda.arn}"
+  handler = "exports.example"
+  runtime = "nodejs8.10"
+  layers = ["${aws_lambda_layer_version.acctest_create.layer_arn}"]
+}
+
+data "aws_lambda_function" "acctest" {
+  function_name = "${aws_lambda_function.acctest_create.function_name}"
+}
+`, layerName, funcName, funcName)
 }
 
 func testAccDataSourceAWSLambdaFunctionConfigVPC(roleName, policyName, sgName, funcName string) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1487,6 +1487,14 @@ func flattenLambdaEnvironment(lambdaEnv *lambda.EnvironmentResponse) []interface
 	return []interface{}{envs}
 }
 
+func flattenLambdaLayers(layers []*lambda.Layer) []interface{} {
+	arns := make([]*string, len(layers))
+	for i, layer := range layers {
+		arns[i] = layer.Arn
+	}
+	return flattenStringList(arns)
+}
+
 func flattenLambdaVpcConfigResponse(s *lambda.VpcConfigResponse) []map[string]interface{} {
 	settings := make(map[string]interface{})
 

--- a/website/docs/d/lambda_function.html.markdown
+++ b/website/docs/d/lambda_function.html.markdown
@@ -41,6 +41,7 @@ In addition to all arguments above, the following attributes are exported:
 * `invoke_arn` - The ARN to be used for invoking Lambda Function from API Gateway.
 * `kms_key_arn` - The ARN for the KMS encryption key.
 * `last_modified` - The date this resource was last modified.
+* `layers` - A list of Lambda Layer ARNs attached to your Lambda Function.
 * `memory_size` - Amount of memory in MB your Lambda Function can use at runtime.
 * `qualified_arn` - The Amazon Resource Name (ARN) identifying your Lambda Function Version
 * `reserved_concurrent_executions` - The amount of reserved concurrent executions for this lambda function.

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -116,6 +116,7 @@ large files efficiently.
 * `handler` - (Required) The function [entrypoint][3] in your code.
 * `role` - (Required) IAM role attached to the Lambda Function. This governs both who / what can invoke your Lambda Function, as well as what resources our Lambda Function has access to. See [Lambda Permission Model][4] for more details.
 * `description` - (Optional) Description of what your Lambda Function does.
+* `layers` - (Optional) List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers][10]
 * `memory_size` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
 * `runtime` - (Required) See [Runtimes][6] for valid values.
 * `timeout` - (Optional) The amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5]
@@ -174,6 +175,7 @@ For **environment** the following attributes are supported:
 [7]: http://docs.aws.amazon.com/lambda/latest/dg/vpc.html
 [8]: https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html
 [9]: https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html
+[10]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
 
 ## Timeouts
 


### PR DESCRIPTION
refs #6651 (depends on #6782)
- add layers attribute to resource and data source
- update documentation

TODO:
- [x] add tests once #6782 is merged

Changes proposed in this pull request:

* Add `layers` attribute to r/lambda_function and d/lambda_function

Output from acceptance testing: (waiting on aforementioned PR)

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction'

...
```
