### PR TITLE
resource/aws_acm_certificate: Prevent crash with empty SubjectAlternativeNames

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -277,10 +277,10 @@ func resourceAwsAcmCertificateUpdate(d *schema.ResourceData, meta interface{}) e
 
 func cleanUpSubjectAlternativeNames(cert *acm.CertificateDetail) []string {
 	sans := cert.SubjectAlternativeNames
-	vs := make([]string, 0, len(sans)-1)
+	vs := make([]string, 0)
 	for _, v := range sans {
-		if *v != *cert.DomainName {
-			vs = append(vs, *v)
+		if aws.StringValue(v) != aws.StringValue(cert.DomainName) {
+			vs = append(vs, aws.StringValue(v))
 		}
 	}
 	return vs


### PR DESCRIPTION
Fixes #7103

Its possible to import certificates into ACM with an IP address CommonName, which leaves SubjectAlternativeNames empty in the API response. The resource previously assumed there was always one element in the list (the domain name).

Previous output from acceptance testing:

```
=== CONT  TestAccAWSAcmCertificate_imported_IpAddress
panic: runtime error: makeslice: cap out of range

goroutine 437 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.cleanUpSubjectAlternativeNames(0xc000962fc0, 0x48ed811, 0x3, 0x3dbe1a0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_acm_certificate.go:280 +0x71
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsAcmCertificateRead.func1(0xc000872cd0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_acm_certificate.go:213 +0x284
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAcmCertificate_imported_IpAddress (14.29s)
--- PASS: TestAccAWSAcmCertificate_imported_DomainName (22.19s)
```
