### PR TITLE
Additional (computed) Direct Connect attributes

### DIFF
--- a/aws/resource_aws_dx_bgp_peer.go
+++ b/aws/resource_aws_dx_bgp_peer.go
@@ -57,6 +57,14 @@ func resourceAwsDxBgpPeer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"bgp_peer_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"aws_device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -141,6 +149,8 @@ func resourceAwsDxBgpPeerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("bgp_auth_key", bgpPeer.AuthKey)
 	d.Set("customer_address", bgpPeer.CustomerAddress)
 	d.Set("bgp_status", bgpPeer.BgpStatus)
+	d.Set("bgp_peer_id", bgpPeer.BgpPeerId)
+	d.Set("aws_device", bgpPeer.AwsDeviceV2)
 
 	return nil
 }

--- a/aws/resource_aws_dx_connection.go
+++ b/aws/resource_aws_dx_connection.go
@@ -48,6 +48,14 @@ func resourceAwsDxConnection() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchema(),
+			"has_logical_redundancy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"aws_device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -116,6 +124,8 @@ func resourceAwsDxConnectionRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("bandwidth", connection.Bandwidth)
 	d.Set("location", connection.Location)
 	d.Set("jumbo_frame_capable", connection.JumboFrameCapable)
+	d.Set("has_logical_redundancy", connection.HasLogicalRedundancy)
+	d.Set("aws_device", connection.AwsDeviceV2)
 
 	err1 := getTagsDX(conn, d, arn)
 	return err1

--- a/aws/resource_aws_dx_hosted_private_virtual_interface.go
+++ b/aws/resource_aws_dx_hosted_private_virtual_interface.go
@@ -88,6 +88,10 @@ func resourceAwsDxHostedPrivateVirtualInterface() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"aws_device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -172,6 +176,7 @@ func resourceAwsDxHostedPrivateVirtualInterfaceRead(d *schema.ResourceData, meta
 	d.Set("owner_account_id", vif.OwnerAccount)
 	d.Set("mtu", vif.Mtu)
 	d.Set("jumbo_frame_capable", vif.JumboFrameCapable)
+	d.Set("aws_device", vif.AwsDeviceV2)
 
 	return nil
 }

--- a/aws/resource_aws_dx_hosted_public_virtual_interface.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface.go
@@ -84,6 +84,10 @@ func resourceAwsDxHostedPublicVirtualInterface() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				MinItems: 1,
 			},
+			"aws_device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -177,6 +181,7 @@ func resourceAwsDxHostedPublicVirtualInterfaceRead(d *schema.ResourceData, meta 
 	d.Set("amazon_address", vif.AmazonAddress)
 	d.Set("route_filter_prefixes", flattenDxRouteFilterPrefixes(vif.RouteFilterPrefixes))
 	d.Set("owner_account_id", vif.OwnerAccount)
+	d.Set("aws_device", vif.AwsDeviceV2)
 
 	return nil
 }

--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -55,7 +55,15 @@ func resourceAwsDxLag() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"jumbo_frame_capable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
+			"has_logical_redundancy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -135,6 +143,8 @@ func resourceAwsDxLagRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", lag.LagName)
 	d.Set("connections_bandwidth", lag.ConnectionsBandwidth)
 	d.Set("location", lag.Location)
+	d.Set("jumbo_frame_capable", lag.JumboFrameCapable)
+	d.Set("has_logical_redundancy", lag.HasLogicalRedundancy)
 
 	err1 := getTagsDX(conn, d, arn)
 	return err1

--- a/aws/resource_aws_dx_private_virtual_interface.go
+++ b/aws/resource_aws_dx_private_virtual_interface.go
@@ -189,6 +189,7 @@ func resourceAwsDxPrivateVirtualInterfaceRead(d *schema.ResourceData, meta inter
 	d.Set("dx_gateway_id", vif.DirectConnectGatewayId)
 	d.Set("mtu", vif.Mtu)
 	d.Set("jumbo_frame_capable", vif.JumboFrameCapable)
+	d.Set("aws_device", vif.AwsDeviceV2)
 	err1 := getTagsDX(conn, d, d.Get("arn").(string))
 	return err1
 }

--- a/aws/resource_aws_dx_public_virtual_interface.go
+++ b/aws/resource_aws_dx_public_virtual_interface.go
@@ -81,6 +81,10 @@ func resourceAwsDxPublicVirtualInterface() *schema.Resource {
 				MinItems: 1,
 			},
 			"tags": tagsSchema(),
+			"aws_device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -160,6 +164,7 @@ func resourceAwsDxPublicVirtualInterfaceRead(d *schema.ResourceData, meta interf
 	d.Set("customer_address", vif.CustomerAddress)
 	d.Set("amazon_address", vif.AmazonAddress)
 	d.Set("route_filter_prefixes", flattenDxRouteFilterPrefixes(vif.RouteFilterPrefixes))
+	d.Set("aws_device", vif.AwsDeviceV2)
 	err1 := getTagsDX(conn, d, d.Get("arn").(string))
 	return err1
 }

--- a/website/docs/r/dx_bgp_peer.html.markdown
+++ b/website/docs/r/dx_bgp_peer.html.markdown
@@ -39,6 +39,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the BGP peer.
 * `bgp_status` - The Up/Down state of the BGP peer.
+* `bgp_peer_id` - The ID of the BGP peer.
+* `aws_device` - The Direct Connect endpoint on which the BGP peer terminates.
 
 ## Timeouts
 

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -36,6 +36,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the connection.
 * `arn` - The ARN of the connection.
 * `jumbo_frame_capable` - Boolean value representing if jumbo frames have been enabled for this connection.
+* `has_logical_redundancy` - Indicates whether the connection supports a secondary BGP peer in the same address family (IPv4/IPv6).
+* `aws_device` - The Direct Connect endpoint on which the physical connection terminates.
 
 ## Import
 

--- a/website/docs/r/dx_hosted_private_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface.html.markdown
@@ -46,6 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the virtual interface.
 * `arn` - The ARN of the virtual interface.
 * `jumbo_frame_capable` - Indicates whether jumbo frames (9001 MTU) are supported.
+* `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
 
 ## Timeouts
 

--- a/website/docs/r/dx_hosted_public_virtual_interface.html.markdown
+++ b/website/docs/r/dx_hosted_public_virtual_interface.html.markdown
@@ -53,6 +53,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the virtual interface.
 * `arn` - The ARN of the virtual interface.
+* `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
 
 ## Timeouts
 

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -39,6 +39,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the LAG.
 * `arn` - The ARN of the LAG.
+* `jumbo_frame_capable` -Indicates whether jumbo frames (9001 MTU) are supported.
+* `has_logical_redundancy` - Indicates whether the LAG supports a secondary BGP peer in the same address family (IPv4/IPv6).
 
 ## Import
 

--- a/website/docs/r/dx_private_virtual_interface.html.markdown
+++ b/website/docs/r/dx_private_virtual_interface.html.markdown
@@ -48,6 +48,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the virtual interface.
 * `arn` - The ARN of the virtual interface.
 * `jumbo_frame_capable` - Indicates whether jumbo frames (9001 MTU) are supported.
+* `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
 
 ## Timeouts
 

--- a/website/docs/r/dx_public_virtual_interface.html.markdown
+++ b/website/docs/r/dx_public_virtual_interface.html.markdown
@@ -52,6 +52,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the virtual interface.
 * `arn` - The ARN of the virtual interface.
+* `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6493.

Additional `Computed` attributes:

* `aws_device` for
  * `aws_dx_bgp_peer` resource
  * `aws_dx_connection` resource
  * `aws_hosted_private_virtual_interface` resource
  * `aws_hosted_public_virtual_interface` resource
  * `aws_private_virtual_interface` resource
  * `aws_public_virtual_interface` resource
* `bgp_peer_id` for
  * `aws_dx_bgp_peer` resource
* `has_logical_redundancy` for
  * `aws_dx_connection` resource
  * `aws_dx_lag` resource
* `jumbo_frame_capable` for
  * `aws_dx_lag` resource - Related to https://github.com/terraform-providers/terraform-provider-aws/pull/6143