### PR TITLE
Add members attribute to iam_group data source

### DIFF
--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -30,7 +30,7 @@ func dataSourceAwsIAMGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"members": {
+			"users": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -82,8 +82,8 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", group.Arn)
 	d.Set("path", group.Path)
 	d.Set("group_id", group.GroupId)
-	if err := d.Set("members", dataSourceUsersRead(resp.Users)); err != nil {
-		return fmt.Errorf("error setting members: %s", err)
+	if err := d.Set("users", dataSourceUsersRead(resp.Users)); err != nil {
+		return fmt.Errorf("error setting users: %s", err)
 	}
 
 	return nil

--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -82,7 +82,9 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", group.Arn)
 	d.Set("path", group.Path)
 	d.Set("group_id", group.GroupId)
-	d.Set("members", dataSourceUsersRead(resp.Users))
+	if err := d.Set("members", dataSourceUsersRead(resp.Users)); err != nil {
+		return fmt.Errorf("error setting members: %s", err)
+	}
 
 	return nil
 }

--- a/aws/data_source_aws_iam_group.go
+++ b/aws/data_source_aws_iam_group.go
@@ -30,6 +30,30 @@ func dataSourceAwsIAMGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"members": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -58,6 +82,20 @@ func dataSourceAwsIAMGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("arn", group.Arn)
 	d.Set("path", group.Path)
 	d.Set("group_id", group.GroupId)
+	d.Set("members", dataSourceUsersRead(resp.Users))
 
 	return nil
+}
+
+func dataSourceUsersRead(iamUsers []*iam.User) []map[string]interface{} {
+	users := make([]map[string]interface{}, 0, len(iamUsers))
+	for _, i := range iamUsers {
+		u := make(map[string]interface{})
+		u["arn"] = aws.StringValue(i.Arn)
+		u["user_id"] = aws.StringValue(i.UserId)
+		u["user_name"] = aws.StringValue(i.UserName)
+		u["path"] = aws.StringValue(i.Path)
+		users = append(users, u)
+	}
+	return users
 }

--- a/aws/data_source_aws_iam_group_test.go
+++ b/aws/data_source_aws_iam_group_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -44,7 +43,7 @@ func TestAccAWSDataSourceIAMGroup_users(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "path", "/"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", groupName),
-					resource.TestMatchResourceAttr("data.aws_iam_group.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:group/"+groupName)),
+					testAccCheckResourceAttrGlobalARN("data.aws_iam_group.test", "arn", "iam", fmt.Sprintf("group/%s", groupName)),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "users.#", "1"),
 					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.arn", "aws_iam_user.user", "arn"),
 					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.user_id", "aws_iam_user.user", "unique_id"),

--- a/aws/data_source_aws_iam_group_test.go
+++ b/aws/data_source_aws_iam_group_test.go
@@ -22,14 +22,14 @@ func TestAccAWSDataSourceIAMGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "path", "/"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", groupName),
-					resource.TestMatchResourceAttr("data.aws_iam_group.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:group/"+groupName)),
+					testAccCheckResourceAttrGlobalARN("data.aws_iam_group.test", "arn", "iam", fmt.Sprintf("group/%s", groupName)),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSDataSourceIAMGroup_member(t *testing.T) {
+func TestAccAWSDataSourceIAMGroup_users(t *testing.T) {
 	groupName := fmt.Sprintf("test-datasource-group-%d", acctest.RandInt())
 	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
 	groupMemberShipName := fmt.Sprintf("test-datasource-group-membership-%d", acctest.RandInt())
@@ -39,17 +39,17 @@ func TestAccAWSDataSourceIAMGroup_member(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsIAMGroupConfigMember(groupName, userName, groupMemberShipName),
+				Config: testAccAwsIAMGroupConfigWithUser(groupName, userName, groupMemberShipName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "path", "/"),
 					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", groupName),
 					resource.TestMatchResourceAttr("data.aws_iam_group.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:group/"+groupName)),
-					resource.TestCheckResourceAttr("data.aws_iam_group.test", "members.#", "1"),
-					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "members.0.arn", "aws_iam_user.user", "arn"),
-					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "members.0.user_id"),
-					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "members.0.user_name", "aws_iam_user.user", "name"),
-					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "members.0.path", "aws_iam_user.user", "path"),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "users.#", "1"),
+					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.arn", "aws_iam_user.user", "arn"),
+					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.user_id", "aws_iam_user.user", "unique_id"),
+					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.user_name", "aws_iam_user.user", "name"),
+					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "users.0.path", "aws_iam_user.user", "path"),
 				),
 			},
 		},
@@ -69,7 +69,7 @@ data "aws_iam_group" "test" {
 `, name)
 }
 
-func testAccAwsIAMGroupConfigMember(groupName, userName, membershipName string) string {
+func testAccAwsIAMGroupConfigWithUser(groupName, userName, membershipName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
 	name = "%s"

--- a/aws/data_source_aws_iam_group_test.go
+++ b/aws/data_source_aws_iam_group_test.go
@@ -29,6 +29,33 @@ func TestAccAWSDataSourceIAMGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMGroup_member(t *testing.T) {
+	groupName := fmt.Sprintf("test-datasource-group-%d", acctest.RandInt())
+	userName := fmt.Sprintf("test-datasource-user-%d", acctest.RandInt())
+	groupMemberShipName := fmt.Sprintf("test-datasource-group-membership-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsIAMGroupConfigMember(groupName, userName, groupMemberShipName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "group_id"),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "path", "/"),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "group_name", groupName),
+					resource.TestMatchResourceAttr("data.aws_iam_group.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:group/"+groupName)),
+					resource.TestCheckResourceAttr("data.aws_iam_group.test", "members.#", "1"),
+					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "members.0.arn", "aws_iam_user.user", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_group.test", "members.0.user_id"),
+					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "members.0.user_name", "aws_iam_user.user", "name"),
+					resource.TestCheckResourceAttrPair("data.aws_iam_group.test", "members.0.path", "aws_iam_user.user", "path"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAwsIAMGroupConfig(name string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_group" "group" {
@@ -40,4 +67,27 @@ data "aws_iam_group" "test" {
   group_name = "${aws_iam_group.group.name}"
 }
 `, name)
+}
+
+func testAccAwsIAMGroupConfigMember(groupName, userName, membershipName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_group" "group" {
+	name = "%s"
+	path = "/"
+}
+
+resource "aws_iam_user" "user" {
+	name = "%s"
+}
+
+resource "aws_iam_group_membership" "team" {
+	name = "%s"
+	users = ["${aws_iam_user.user.name}"]
+	group = "${aws_iam_group.group.name}"
+}
+
+data "aws_iam_group" "test" {
+	group_name = "${aws_iam_group_membership.team.group}"	
+}
+`, groupName, userName, membershipName)
 }

--- a/website/docs/d/iam_group.html.markdown
+++ b/website/docs/d/iam_group.html.markdown
@@ -31,3 +31,15 @@ data "aws_iam_group" "example" {
 * `path` - The path to the group.
 
 * `group_id` - The stable and unique string identifying the group.
+
+* `members` - The member of group. See supported fields below.
+
+### `members`
+
+* `arn` - The Amazon Resource Name (ARN) specifying the iam user.
+
+* `user_id` - The stable and unique string identifying the iam user.
+
+* `user_name` - The name of the iam user.
+
+* `path` - The path to the iam user.

--- a/website/docs/d/iam_group.html.markdown
+++ b/website/docs/d/iam_group.html.markdown
@@ -32,9 +32,9 @@ data "aws_iam_group" "example" {
 
 * `group_id` - The stable and unique string identifying the group.
 
-* `members` - The member of group. See supported fields below.
+* `users` - List of objects containing group member information. See supported fields below.
 
-### `members`
+### `users`
 
 * `arn` - The Amazon Resource Name (ARN) specifying the iam user.
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7076 

Changes proposed in this pull request:

* Add members attribute
* Modify document

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSDataSourceIAMGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDataSourceIAMGroup_ -timeout 120m
=== RUN   TestAccAWSDataSourceIAMGroup_basic
=== PAUSE TestAccAWSDataSourceIAMGroup_basic
=== RUN   TestAccAWSDataSourceIAMGroup_member
=== PAUSE TestAccAWSDataSourceIAMGroup_member
=== CONT  TestAccAWSDataSourceIAMGroup_basic
=== CONT  TestAccAWSDataSourceIAMGroup_member
--- PASS: TestAccAWSDataSourceIAMGroup_basic (25.23s)
--- PASS: TestAccAWSDataSourceIAMGroup_member (31.90s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	31.950s
```
