### PR TITLE
resource/aws_api_gateway_method_settings: Prevent crash when using cache_data_encrypted

### DIFF
--- a/aws/resource_aws_api_gateway_method_settings.go
+++ b/aws/resource_aws_api_gateway_method_settings.go
@@ -188,7 +188,7 @@ func resourceAwsApiGatewayMethodSettingsUpdate(d *schema.ResourceData, meta inte
 		ops = append(ops, &apigateway.PatchOperation{
 			Op:    aws.String("replace"),
 			Path:  aws.String(prefix + "caching/dataEncrypted"),
-			Value: aws.String(fmt.Sprintf("%d", d.Get("settings.0.cache_data_encrypted").(int))),
+			Value: aws.String(fmt.Sprintf("%t", d.Get("settings.0.cache_data_encrypted").(bool))),
 		})
 	}
 	if d.HasChange("settings.0.require_authorization_for_cache_control") {

--- a/aws/resource_aws_api_gateway_method_settings_test.go
+++ b/aws/resource_aws_api_gateway_method_settings_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestAccAWSAPIGatewayMethodSettings_basic(t *testing.T) {
 	var stage apigateway.Stage
-	rInt := acctest.RandInt()
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,26 +23,351 @@ func TestAccAWSAPIGatewayMethodSettings_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayMethodSettingsConfig(rInt),
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsLoggingLevel(rName, "INFO"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayMethodSettingsExists("aws_api_gateway_method_settings.test", &stage),
-					testAccCheckAWSAPIGatewayMethodSettings_metricsEnabled(&stage, "test/GET", true),
-					testAccCheckAWSAPIGatewayMethodSettings_loggingLevel(&stage, "test/GET", "INFO"),
-					resource.TestCheckResourceAttr("aws_api_gateway_method_settings.test", "settings.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_method_settings.test", "settings.0.metrics_enabled", "true"),
-					resource.TestCheckResourceAttr("aws_api_gateway_method_settings.test", "settings.0.logging_level", "INFO"),
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "INFO"),
 				),
 			},
+		},
+	})
+}
 
+func TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayMethodSettingsConfigUpdate(rInt),
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheDataEncrypted(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSAPIGatewayMethodSettingsExists("aws_api_gateway_method_settings.test", &stage),
-					testAccCheckAWSAPIGatewayMethodSettings_metricsEnabled(&stage, "test/GET", false),
-					testAccCheckAWSAPIGatewayMethodSettings_loggingLevel(&stage, "test/GET", "OFF"),
-					resource.TestCheckResourceAttr("aws_api_gateway_method_settings.test", "settings.#", "1"),
-					resource.TestCheckResourceAttr("aws_api_gateway_method_settings.test", "settings.0.metrics_enabled", "false"),
-					resource.TestCheckResourceAttr("aws_api_gateway_method_settings.test", "settings.0.logging_level", "OFF"),
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_data_encrypted", "true"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheDataEncrypted(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_data_encrypted", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheTtlInSeconds(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_ttl_in_seconds", "1"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheTtlInSeconds(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.cache_ttl_in_seconds", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsCachingEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.caching_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsCachingEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.caching_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsDataTraceEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.data_trace_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsDataTraceEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.data_trace_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsLoggingLevel(rName, "INFO"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					testAccCheckAWSAPIGatewayMethodSettings_loggingLevel(&stage1, "test/GET", "INFO"),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "INFO"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsLoggingLevel(rName, "OFF"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					testAccCheckAWSAPIGatewayMethodSettings_loggingLevel(&stage2, "test/GET", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "OFF"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsMetricsEnabled(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					testAccCheckAWSAPIGatewayMethodSettings_metricsEnabled(&stage1, "test/GET", true),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.metrics_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsMetricsEnabled(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					testAccCheckAWSAPIGatewayMethodSettings_metricsEnabled(&stage2, "test/GET", false),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.metrics_enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_Multiple(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsMultiple(rName, "INFO", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					testAccCheckAWSAPIGatewayMethodSettings_metricsEnabled(&stage1, "test/GET", true),
+					testAccCheckAWSAPIGatewayMethodSettings_loggingLevel(&stage1, "test/GET", "INFO"),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.metrics_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "INFO"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsMultiple(rName, "OFF", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					testAccCheckAWSAPIGatewayMethodSettings_metricsEnabled(&stage2, "test/GET", false),
+					testAccCheckAWSAPIGatewayMethodSettings_loggingLevel(&stage2, "test/GET", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.metrics_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.logging_level", "OFF"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsRequireAuthorizationForCacheControl(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.require_authorization_for_cache_control", "true"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsRequireAuthorizationForCacheControl(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.require_authorization_for_cache_control", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingBurstLimit(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_burst_limit", "1"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingBurstLimit(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_burst_limit", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingRateLimit(rName, 1.1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_rate_limit", "1.1"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingRateLimit(rName, 2.2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.throttling_rate_limit", "2.2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy(t *testing.T) {
+	var stage1, stage2 apigateway.Stage
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_api_gateway_method_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayMethodSettingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsUnauthorizedCacheControlHeaderStrategy(rName, "SUCCEED_WITH_RESPONSE_HEADER"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage1),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.unauthorized_cache_control_header_strategy", "SUCCEED_WITH_RESPONSE_HEADER"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayMethodSettingsConfigSettingsUnauthorizedCacheControlHeaderStrategy(rName, "SUCCEED_WITHOUT_RESPONSE_HEADER"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayMethodSettingsExists(resourceName, &stage2),
+					resource.TestCheckResourceAttr(resourceName, "settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.unauthorized_cache_control_header_strategy", "SUCCEED_WITHOUT_RESPONSE_HEADER"),
 				),
 			},
 		},
@@ -95,8 +421,8 @@ func testAccCheckAWSAPIGatewayMethodSettingsExists(n string, res *apigateway.Sta
 		conn := testAccProvider.Meta().(*AWSClient).apigateway
 
 		req := &apigateway.GetStageInput{
-			StageName: aws.String(s.RootModule().Resources["aws_api_gateway_deployment.test"].Primary.Attributes["stage_name"]),
-			RestApiId: aws.String(s.RootModule().Resources["aws_api_gateway_rest_api.test"].Primary.ID),
+			StageName: aws.String(rs.Primary.Attributes["stage_name"]),
+			RestApiId: aws.String(rs.Primary.Attributes["rest_api_id"]),
 		}
 		out, err := conn.GetStage(req)
 		if err != nil {
@@ -118,8 +444,8 @@ func testAccCheckAWSAPIGatewayMethodSettingsDestroy(s *terraform.State) error {
 		}
 
 		req := &apigateway.GetStageInput{
-			StageName: aws.String(s.RootModule().Resources["aws_api_gateway_deployment.test"].Primary.Attributes["stage_name"]),
-			RestApiId: aws.String(s.RootModule().Resources["aws_api_gateway_rest_api.test"].Primary.ID),
+			StageName: aws.String(rs.Primary.Attributes["stage_name"]),
+			RestApiId: aws.String(rs.Primary.Attributes["rest_api_id"]),
 		}
 		out, err := conn.GetStage(req)
 		if err == nil {
@@ -133,17 +459,15 @@ func testAccCheckAWSAPIGatewayMethodSettingsDestroy(s *terraform.State) error {
 		if awsErr.Code() != "NotFoundException" {
 			return err
 		}
-
-		return nil
 	}
 
 	return nil
 }
 
-func testAccAWSAPIGatewayMethodSettingsConfig(rInt int) string {
+func testAccAWSAPIGatewayMethodSettingsConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
-  name = "tf-acc-test-apig-method-%d"
+  name = %q
 }
 
 resource "aws_api_gateway_resource" "test" {
@@ -187,79 +511,160 @@ resource "aws_api_gateway_deployment" "test" {
   depends_on = ["aws_api_gateway_integration.test"]
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
   stage_name = "dev"
+}`, rName)
 }
 
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheDataEncrypted(rName string, cacheDataEncrypted bool) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    cache_data_encrypted = %t
+  }
+}
+`, cacheDataEncrypted)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsCacheTtlInSeconds(rName string, cacheTtlInSeconds int) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    cache_ttl_in_seconds = %d
+  }
+}
+`, cacheTtlInSeconds)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsCachingEnabled(rName string, cachingEnabled bool) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    caching_enabled = %t
+  }
+}
+`, cachingEnabled)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsDataTraceEnabled(rName string, dataTraceEnabled bool) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    data_trace_enabled = %t
+  }
+}
+`, dataTraceEnabled)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsLoggingLevel(rName, loggingLevel string) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    logging_level = %q
+  }
+}
+`, loggingLevel)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsMetricsEnabled(rName string, metricsEnabled bool) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    metrics_enabled = %t
+  }
+}
+`, metricsEnabled)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsMultiple(rName, loggingLevel string, metricsEnabled bool) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
   stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
   method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
 
   settings {
-  	metrics_enabled = true
-	logging_level = "INFO"
+    logging_level   = %q
+    metrics_enabled = %t
   }
 }
-`, rInt)
+`, loggingLevel, metricsEnabled)
 }
 
-func testAccAWSAPIGatewayMethodSettingsConfigUpdate(rInt int) string {
-	return fmt.Sprintf(`
-resource "aws_api_gateway_rest_api" "test" {
-  name = "tf-acc-test-apig-method-%d"
-}
-
-resource "aws_api_gateway_resource" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
-  path_part = "test"
-}
-
-resource "aws_api_gateway_method" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "GET"
-  authorization = "NONE"
-
-  request_models = {
-    "application/json" = "Error"
-  }
-
-  request_parameters = {
-    "method.request.header.Content-Type" = false,
-	  "method.request.querystring.page" = true
-  }
-}
-
-resource "aws_api_gateway_integration" "test" {
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  resource_id = "${aws_api_gateway_resource.test.id}"
-  http_method = "${aws_api_gateway_method.test.http_method}"
-  type        = "MOCK"
-
-  request_templates {
-    "application/xml" = <<EOF
-{
-   "body" : $input.json('$')
-}
-EOF
-  }
-}
-
-resource "aws_api_gateway_deployment" "test" {
-  depends_on = ["aws_api_gateway_integration.test"]
-  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
-  stage_name = "dev"
-}
-
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsRequireAuthorizationForCacheControl(rName string, requireAuthorizationForCacheControl bool) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
 resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
   rest_api_id = "${aws_api_gateway_rest_api.test.id}"
   stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
-  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
 
   settings {
-  	metrics_enabled = false
-	logging_level = "OFF"
+    require_authorization_for_cache_control = %t
   }
 }
-`, rInt)
+`, requireAuthorizationForCacheControl)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingBurstLimit(rName string, throttlingBurstLimit int) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    throttling_burst_limit = %d
+  }
+}
+`, throttlingBurstLimit)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsThrottlingRateLimit(rName string, throttlingRateLimit float32) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    throttling_rate_limit = %f
+  }
+}
+`, throttlingRateLimit)
+}
+
+func testAccAWSAPIGatewayMethodSettingsConfigSettingsUnauthorizedCacheControlHeaderStrategy(rName, unauthorizedCacheControlHeaderStrategy string) string {
+	return testAccAWSAPIGatewayMethodSettingsConfigBase(rName) + fmt.Sprintf(`
+resource "aws_api_gateway_method_settings" "test" {
+  method_path = "${aws_api_gateway_resource.test.path_part}/${aws_api_gateway_method.test.http_method}"
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name  = "${aws_api_gateway_deployment.test.stage_name}"
+
+  settings {
+    unauthorized_cache_control_header_strategy = %q
+  }
+}
+`, unauthorizedCacheControlHeaderStrategy)
 }


### PR DESCRIPTION
Fixes #6902 

Changes:
* tests/resource/aws_api_gateway_method_settings: Create tests for all settings
* resource/aws_api_gateway_method_settings: Prevent crash when using cache_data_encrypted

Previous output from acceptance testing:

```
=== CONT  TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted
panic: interface conversion: interface {} is bool, not int

goroutine 519 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsApiGatewayMethodSettingsUpdate(0xc000785a40, 0x42d9860, 0xc000600000, 0xc000785a40, 0x0)
  /Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_api_gateway_method_settings.go:191 +0x26ec
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (23.32s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted (34.66s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds (33.43s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled (33.14s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled (33.50s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel (33.71s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled (33.61s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_Multiple (34.50s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl (33.43s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit (34.99s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit (33.86s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy (34.21s)
```
