### PR TITLE
resource/aws_launch_template: Prevent crashes with empty configuration blocks for top-level attributes

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -1008,6 +1008,9 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 		bdms := v.([]interface{})
 
 		for _, bdm := range bdms {
+			if bdm == nil {
+				continue
+			}
 			blockDeviceMapping, err := readBlockDeviceMappingFromConfig(bdm.(map[string]interface{}))
 			if err != nil {
 				return nil, err
@@ -1020,7 +1023,7 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 	if v, ok := d.GetOk("capacity_reservation_specification"); ok {
 		crs := v.([]interface{})
 
-		if len(crs) > 0 {
+		if len(crs) > 0 && crs[0] != nil {
 			opts.CapacityReservationSpecification = readCapacityReservationSpecificationFromConfig(crs[0].(map[string]interface{}))
 		}
 	}
@@ -1028,7 +1031,7 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 	if v, ok := d.GetOk("credit_specification"); ok && (strings.HasPrefix(instanceType, "t2") || strings.HasPrefix(instanceType, "t3")) {
 		cs := v.([]interface{})
 
-		if len(cs) > 0 {
+		if len(cs) > 0 && cs[0] != nil {
 			opts.CreditSpecification = readCreditSpecificationFromConfig(cs[0].(map[string]interface{}))
 		}
 	}
@@ -1046,7 +1049,7 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 	if v, ok := d.GetOk("iam_instance_profile"); ok {
 		iip := v.([]interface{})
 
-		if len(iip) > 0 {
+		if len(iip) > 0 && iip[0] != nil {
 			opts.IamInstanceProfile = readIamInstanceProfileFromConfig(iip[0].(map[string]interface{}))
 		}
 	}
@@ -1054,7 +1057,7 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 	if v, ok := d.GetOk("instance_market_options"); ok {
 		imo := v.([]interface{})
 
-		if len(imo) > 0 {
+		if len(imo) > 0 && imo[0] != nil {
 			instanceMarketOptions, err := readInstanceMarketOptionsFromConfig(imo[0].(map[string]interface{}))
 			if err != nil {
 				return nil, err
@@ -1068,6 +1071,9 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 		lsList := v.(*schema.Set).List()
 
 		for _, ls := range lsList {
+			if ls == nil {
+				continue
+			}
 			licenseSpecifications = append(licenseSpecifications, readLicenseSpecificationFromConfig(ls.(map[string]interface{})))
 		}
 		opts.LicenseSpecifications = licenseSpecifications
@@ -1075,7 +1081,7 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 
 	if v, ok := d.GetOk("monitoring"); ok {
 		m := v.([]interface{})
-		if len(m) > 0 {
+		if len(m) > 0 && m[0] != nil {
 			mData := m[0].(map[string]interface{})
 			monitoring := &ec2.LaunchTemplatesMonitoringRequest{
 				Enabled: aws.Bool(mData["enabled"].(bool)),
@@ -1089,6 +1095,9 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 		niList := v.([]interface{})
 
 		for _, ni := range niList {
+			if ni == nil {
+				continue
+			}
 			niData := ni.(map[string]interface{})
 			networkInterface := readNetworkInterfacesFromConfig(niData)
 			networkInterfaces = append(networkInterfaces, networkInterface)
@@ -1099,7 +1108,7 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 	if v, ok := d.GetOk("placement"); ok {
 		p := v.([]interface{})
 
-		if len(p) > 0 {
+		if len(p) > 0 && p[0] != nil {
 			opts.Placement = readPlacementFromConfig(p[0].(map[string]interface{}))
 		}
 	}
@@ -1109,6 +1118,9 @@ func buildLaunchTemplateData(d *schema.ResourceData) (*ec2.RequestLaunchTemplate
 		t := v.([]interface{})
 
 		for _, ts := range t {
+			if ts == nil {
+				continue
+			}
 			tsData := ts.(map[string]interface{})
 			tags := tagsFromMap(tsData["tags"].(map[string]interface{}))
 			tagSpecification := &ec2.LaunchTemplateTagSpecificationRequest{

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -430,6 +430,28 @@ func TestAccAWSLaunchTemplate_creditSpecification_t3(t *testing.T) {
 	})
 }
 
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/6757
+func TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock(t *testing.T) {
+	var template1 ec2.LaunchTemplate
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_launch_template.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfigIamInstanceProfileEmptyConfigurationBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resourceName, &template1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchTemplate_networkInterface(t *testing.T) {
 	var template ec2.LaunchTemplate
 	resName := "aws_launch_template.test"
@@ -878,6 +900,16 @@ resource "aws_launch_template" "foo" {
   }
 }
 `, instanceType, rName, cpuCredits)
+}
+
+func testAccAWSLaunchTemplateConfigIamInstanceProfileEmptyConfigurationBlock(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "test" {
+  name = %q
+
+  iam_instance_profile {}
+}
+`, rName)
 }
 
 func testAccAWSLaunchTemplateConfig_licenseSpecification(rInt int) string {


### PR DESCRIPTION
Fixes #6757

Previous output from acceptance testing:

```
=== CONT  TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 186 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.buildLaunchTemplateData(0xc0007d6b60, 0x48f2231, 0x4, 0x3dc1ec0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_launch_template.go:1050 +0x267a
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsLaunchTemplateCreate(0xc0007d6b60, 0x42d8aa0, 0xc000b52700, 0xc0007d6b60, 0x0)
	/Users/bflad/go/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_launch_template.go:511 +0xcb
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLaunchTemplate_basic (12.87s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (49.76s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (50.41s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (12.33s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (18.20s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (12.19s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (12.17s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (12.48s)
--- PASS: TestAccAWSLaunchTemplate_data (12.55s)
--- PASS: TestAccAWSLaunchTemplate_disappears (9.73s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (46.99s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (12.18s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (13.97s)
--- PASS: TestAccAWSLaunchTemplate_importData (13.56s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (49.17s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (14.21s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (31.96s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (12.38s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (12.41s)
--- PASS: TestAccAWSLaunchTemplate_tags (21.92s)
--- PASS: TestAccAWSLaunchTemplate_update (56.76s)
```
