### PR TITLE
Remove max_frame_rate default value

### DIFF
--- a/aws/resource_aws_elastic_transcoder_preset.go
+++ b/aws/resource_aws_elastic_transcoder_preset.go
@@ -216,7 +216,6 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 						"max_frame_rate": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "30",
 							ForceNew: true,
 						},
 						"max_height": {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #695

This is the same as https://github.com/hashicorp/terraform/pull/11340, but even if it was merged there, it's still not merged here.

Changes proposed in this pull request:

* Remove `max_frame_rate` default value and let AWS set it.

