### PR TITLE
Add aws_elastic_beanstalk_application Data Source

### DIFF
--- a/aws/data_source_aws_elastic_beanstalk_application.go
+++ b/aws/data_source_aws_elastic_beanstalk_application.go
@@ -1,0 +1,87 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsElasticBeanstalkApplication() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsElasticBeanstalkApplicationRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"appversion_lifecycle": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"service_role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_age_in_days": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"delete_source_from_s3": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsElasticBeanstalkApplicationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).elasticbeanstalkconn
+
+	// Get the name and description
+	name := d.Get("name").(string)
+
+	resp, err := conn.DescribeApplications(&elasticbeanstalk.DescribeApplicationsInput{
+		ApplicationNames: []*string{aws.String(name)},
+	})
+	if err != nil {
+		return fmt.Errorf("Error describing Applications (%s): %s", name, err)
+	}
+
+	if len(resp.Applications) > 1 || len(resp.Applications) < 1 {
+		return fmt.Errorf("Error %d Applications matched, expected 1", len(resp.Applications))
+	}
+
+	app := resp.Applications[0]
+
+	d.SetId(name)
+	d.Set("arn", app.ApplicationArn)
+	d.Set("name", app.ApplicationName)
+	d.Set("description", app.Description)
+
+	if app.ResourceLifecycleConfig != nil {
+		d.Set("appversion_lifecycle", flattenResourceLifecycleConfig(app.ResourceLifecycleConfig))
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_elastic_beanstalk_application_test.go
+++ b/aws/data_source_aws_elastic_beanstalk_application_test.go
@@ -1,0 +1,45 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAwsElasticBeanstalkApplicationDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceResourceName := "data.aws_elastic_beanstalk_application.test"
+	resourceName := "aws_elastic_beanstalk_application.tftest"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsElasticBeanstalkApplicationDataSourceConfig_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceResourceName, "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "description", dataSourceResourceName, "description"),
+					resource.TestCheckResourceAttr(dataSourceResourceName, "appversion_lifecycle.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "appversion_lifecycle.0.service_role", dataSourceResourceName, "appversion_lifecycle.0.service_role"),
+					resource.TestCheckResourceAttrPair(resourceName, "appversion_lifecycle.0.max_age_in_days", dataSourceResourceName, "appversion_lifecycle.0.max_age_in_days"),
+					resource.TestCheckResourceAttrPair(resourceName, "appversion_lifecycle.0.delete_source_from_s3", dataSourceResourceName, "appversion_lifecycle.0.delete_source_from_s3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsElasticBeanstalkApplicationDataSourceConfig_Basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_elastic_beanstalk_application" "test" {
+  name = "${aws_elastic_beanstalk_application.tftest.name}"
+}
+`, testAccBeanstalkAppConfigWithMaxAge(rName))
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -206,6 +206,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_efs_mount_target":                   dataSourceAwsEfsMountTarget(),
 			"aws_eip":                                dataSourceAwsEip(),
 			"aws_eks_cluster":                        dataSourceAwsEksCluster(),
+			"aws_elastic_beanstalk_application":      dataSourceAwsElasticBeanstalkApplication(),
 			"aws_elastic_beanstalk_hosted_zone":      dataSourceAwsElasticBeanstalkHostedZone(),
 			"aws_elastic_beanstalk_solution_stack":   dataSourceAwsElasticBeanstalkSolutionStack(),
 			"aws_elasticache_cluster":                dataSourceAwsElastiCacheCluster(),

--- a/website/docs/d/elastic_beanstalk_application.html.markdown
+++ b/website/docs/d/elastic_beanstalk_application.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elastic_beanstalk_application"
+sidebar_current: "docs-aws-datasource-elastic-beanstalk-application"
+description: |-
+  Retrieve information about an Elastic Beanstalk Application
+---
+
+# Data Source: aws_elastic_beanstalk_application
+
+Retrieve information about an Elastic Beanstalk Application.
+
+## Example Usage
+
+```hcl
+data "aws_elastic_beanstalk_application" "example" {
+  name = "example"
+}
+
+output "arn" {
+  value = "${data.aws_elastic_beanstalk_application.example.arn}"
+}
+
+output "description" {
+  value = "${data.aws_elastic_beanstalk_application.example.description}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the application
+
+## Attributes Reference
+
+* `id` - The name of the application
+* `arn` - The Amazon Resource Name (ARN) of the application.
+* `description` - Short description of the application
+
+Application version lifecycle (`appversion_lifecycle`) supports the nested attribute containing.
+
+* `service_role` - The ARN of an IAM service role under which the application version is deleted.  Elastic Beanstalk must have permission to assume this role.
+* `max_count` - The maximum number of application versions to retain.
+* `max_age_in_days` - The number of days to retain an application version.
+* `delete_source_from_s3` - Specifies whether delete a version's source bundle from S3 when the application version is deleted.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #3838

Changes proposed in this pull request:

* Add  data source `aws_elastic_beanstalk_application`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsElasticBeanstalkApplicationDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsElasticBeanstalkApplicationDataSource_basic -timeout 120m
=== RUN   TestAccAwsElasticBeanstalkApplicationDataSource_basic
=== PAUSE TestAccAwsElasticBeanstalkApplicationDataSource_basic
=== CONT  TestAccAwsElasticBeanstalkApplicationDataSource_basic
--- PASS: TestAccAwsElasticBeanstalkApplicationDataSource_basic (34.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.452s
```
