### PR TITLE
[WIP] Adding Origin Groups Resources to CloudFront

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -948,21 +948,41 @@ func originGroupHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["origin_id"].(string)))
 
 	if v, ok := m["failover_criteria"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", customHeadersHash(v.(*schema.Set))))
-	}
-	if v, ok := m["custom_origin_config"]; ok {
 		if s := v.(*schema.Set).List(); len(s) > 0 {
-			buf.WriteString(fmt.Sprintf("%d-", customOriginConfigHash((s[0].(map[string]interface{})))))
+			buf.WriteString(fmt.Sprintf("%d-", failoverCriteriaHash((s[0].(map[string]interface{})))))
 		}
 	}
-	if v, ok := m["origin_path"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-	}
-	if v, ok := m["s3_origin_config"]; ok {
+	if v, ok := m["members"]; ok {
 		if s := v.(*schema.Set).List(); len(s) > 0 {
-			buf.WriteString(fmt.Sprintf("%d-", s3OriginConfigHash((s[0].(map[string]interface{})))))
+			buf.WriteString(fmt.Sprintf("%d-", membersHash((s[0].(map[string]interface{})))))
 		}
 	}
+
+	return hashcode.String(buf.String())
+}
+
+func failoverCriteriaHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	for _, v := range m["status_codes"].([]interface{}) {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+	return hashcode.String(buf.String())
+}
+
+func membersHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	for _, v := range s.List() {
+		buf.WriteString(fmt.Sprintf("%d-", originGroupMembersHash(v)))
+	}
+	return hashcode.String(buf.String())
+}
+
+func originGroupMembersHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["origin_id"]))
 	return hashcode.String(buf.String())
 }
 

--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -890,11 +890,6 @@ func expandOriginGroupMember(m map[string]interface{}) *cloudfront.OriginGroupMe
 	}
 }
 
-func expandOrderedGroupMember(as *schema.Set) *string {
-	s := as.List()
-	return aws.String(s[0].(map[string]interface{})["origin_id"].(string))
-}
-
 func flattenOrigin(or *cloudfront.Origin) map[string]interface{} {
 	m := make(map[string]interface{})
 	m["origin_id"] = *or.Id
@@ -954,7 +949,7 @@ func originGroupHash(v interface{}) int {
 	}
 	if v, ok := m["members"]; ok {
 		if s := v.(*schema.Set).List(); len(s) > 0 {
-			buf.WriteString(fmt.Sprintf("%d-", membersHash((s[0].(map[string]interface{})))))
+			buf.WriteString(fmt.Sprintf("%d-", membersHash(s[0].(map[string]interface{}))))
 		}
 	}
 
@@ -973,7 +968,8 @@ func failoverCriteriaHash(v interface{}) int {
 func membersHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	for _, v := range s.List() {
+	members := m["ordered_origin_group_member"]
+	for _, v := range members.([]interface{}) {
 		buf.WriteString(fmt.Sprintf("%d-", originGroupMembersHash(v)))
 	}
 	return hashcode.String(buf.String())

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -583,6 +583,58 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 					},
 				},
 			},
+			"origin_group": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"origin_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.NoZeroValues,
+						},
+						"failover_criteria": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"status_codes": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Schema{
+											Type:     schema.TypeInt,
+											MinItems: 1,
+										},
+									},
+								},
+							},
+						},
+						"members": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ordered_origin_group_member": {
+										Type:     schema.TypeList,
+										Required: true,
+										MinItems: 2,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"origin_id": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.NoZeroValues,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"price_class": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -586,6 +586,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 			"origin_group": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Set: originGroupHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"origin_id": {
@@ -597,6 +598,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							MaxItems: 1,
+							Set: failoverCriteriaHash,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"status_codes": {
@@ -613,11 +615,13 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"members": {
 							Type:     schema.TypeSet,
 							Required: true,
+							Set: membersHash,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"ordered_origin_group_member": {
 										Type:     schema.TypeList,
 										Required: true,
+										Set: originGroupHash,
 										MinItems: 2,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -621,7 +621,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"ordered_origin_group_member": {
 										Type:     schema.TypeList,
 										Required: true,
-										Set:      originGroupHash,
 										MinItems: 2,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -586,7 +586,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 			"origin_group": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Set: originGroupHash,
+				Set:      originGroupHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"origin_id": {
@@ -598,7 +598,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Type:     schema.TypeSet,
 							Required: true,
 							MaxItems: 1,
-							Set: failoverCriteriaHash,
+							Set:      failoverCriteriaHash,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"status_codes": {
@@ -615,13 +615,13 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"members": {
 							Type:     schema.TypeSet,
 							Required: true,
-							Set: membersHash,
+							Set:      membersHash,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"ordered_origin_group_member": {
 										Type:     schema.TypeList,
 										Required: true,
-										Set: originGroupHash,
+										Set:      originGroupHash,
 										MinItems: 2,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/examples/cloudfront-origin-failover/main.tf
+++ b/examples/cloudfront-origin-failover/main.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "failover_distribution" {
     origin_id = "${local.origin_group}"
 
     failover_criteria {
-      status_codes = [403, 404, 500, 502]
+      status_codes = [403, 404, 500, 502, 503, 504]
     }
 
     members {

--- a/examples/cloudfront-origin-failover/main.tf
+++ b/examples/cloudfront-origin-failover/main.tf
@@ -1,0 +1,91 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+resource "aws_s3_bucket" "primary" {
+  bucket = "${var.primary_bucket_name}"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket" "backup" {
+  bucket = "${var.backup_bucket_name}"
+  acl    = "private"
+}
+
+locals {
+  primary_s3_origin = "primaryS3"
+  backup_s3_origin  = "failoverS3"
+  origin_group      = "groupS3"
+}
+
+resource "aws_cloudfront_origin_access_identity" "default" {
+  comment = "Testing Origin Access Identity"
+}
+
+resource "aws_cloudfront_distribution" "failover_distribution" {
+  comment = "testing distribution for origin failover"
+  enabled = true
+
+  restrictions = {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  origin {
+    domain_name = "${aws_s3_bucket.primary.bucket_regional_domain_name}"
+    origin_id   = "${local.primary_s3_origin}"
+
+    s3_origin_config {
+      origin_access_identity = "${aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path}"
+    }
+  }
+
+  origin {
+    domain_name = "${aws_s3_bucket.backup.bucket_regional_domain_name}"
+    origin_id   = "${local.backup_s3_origin}"
+
+    s3_origin_config {
+      origin_access_identity = "${aws_cloudfront_origin_access_identity.default.cloudfront_access_identity_path}"
+    }
+  }
+
+  origin_group {
+    origin_id = "${local.origin_group}"
+
+    failover_criteria {
+      status_codes = [403, 404, 500, 502]
+    }
+
+    members {
+      ordered_origin_group_member {
+        origin_id = "${local.primary_s3_origin}"
+      }
+
+      ordered_origin_group_member {
+        origin_id = "${local.backup_s3_origin}"
+      }
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${local.origin_group}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/examples/cloudfront-origin-failover/variables.tf
+++ b/examples/cloudfront-origin-failover/variables.tf
@@ -1,0 +1,14 @@
+variable "aws_region" {
+  description = "The AWS region to create things in."
+  default     = "us-east-1"
+}
+
+variable "primary_bucket_name" {
+  description = "The bucket name for the primary s3 bucket."
+  default     = "terraform-testing-origin-failover"
+}
+
+variable "backup_bucket_name" {
+  description = "The bucket name for the backup s3 bucket."
+  default     = "terraform-testing-backup-origin-failover"
+}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Issue: #6547 

Changes proposed in this pull request:

* Adding Origin groups as a resource in `resource_aws_cloudfront_distribution`.
* Modifying `cloudfront_distribution_configuration` to include configuration for origin groups.
* Adding an example of using origin groups in the `example` folder.

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudFrontDistribution_OriginGroups -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_OriginGroups
=== PAUSE TestAccAWSCloudFrontDistribution_OriginGroups
=== CONT  TestAccAWSCloudFrontDistribution_OriginGroups
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (1135.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1135.223s

```

Heya! This is our first time working with terraform and the terraform-provider-aws, so we would like to get comments/advice on improving this WIP PR. We are still implementing tests for `cloudfront_distribution_configuration_structure_test`. Thanks!