### PR TITLE
testing/provider: Enable gosimple linter in gometalinter and TravisCI

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -4,6 +4,7 @@
         "deadcode",
         "errcheck",
         "gofmt",
+        "gosimple",
         "ineffassign",
         "interfacer",
         "misspell",

--- a/aws/resource_aws_globalaccelerator_accelerator_test.go
+++ b/aws/resource_aws_globalaccelerator_accelerator_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAwsGlobalAcceleratorAccelerator_basic(t *testing.T) {
 	resourceName := "aws_globalaccelerator_accelerator.example"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
-	ipRegex := regexp.MustCompile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}")
+	ipRegex := regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/tagsRAM.go
+++ b/aws/tagsRAM.go
@@ -67,7 +67,7 @@ func tagIgnoredRAM(t *ram.Tag) bool {
 	filter := []string{"^aws:"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
-		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+		if r, _ := regexp.MatchString(v, *t.Key); r {
 			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
 			return true
 		}

--- a/aws/tags_sagemaker.go
+++ b/aws/tags_sagemaker.go
@@ -111,7 +111,7 @@ func tagIgnoredSagemaker(t *sagemaker.Tag) bool {
 	filter := []string{"^aws:"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
-		if r, _ := regexp.MatchString(v, *t.Key); r == true {
+		if r, _ := regexp.MatchString(v, *t.Key); r {
 			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
 			return true
 		}


### PR DESCRIPTION
Closes #6343

After many fixes and being a moving target with merging pull requests, down to the final batch:

```
aws/resource_aws_globalaccelerator_accelerator_test.go:16:13:warning: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007) (gosimple)
aws/tagsRAM.go:70:45:warning: should omit comparison to bool constant, can be simplified to r (S1002) (gosimple)
aws/tags_sagemaker.go:114:45:warning: should omit comparison to bool constant, can be simplified to r (S1002) (gosimple)
```

Output from linters:

```
$ make lint
==> Checking source code against linters...
$
```
