### PR TITLE
tests/resource/aws_subnet: Skip sweeping default subnet for Availability Zone

### DIFF
--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -74,6 +74,14 @@ func testSweepSubnets(region string) error {
 	}
 
 	for _, subnet := range resp.Subnets {
+		if subnet == nil {
+			continue
+		}
+
+		if aws.BoolValue(subnet.DefaultForAz) {
+			continue
+		}
+
 		// delete the subnet
 		_, err := conn.DeleteSubnet(&ec2.DeleteSubnetInput{
 			SubnetId: subnet.SubnetId,


### PR DESCRIPTION
The `aws_default_subnet` testing sets tagging that is accidentally also triggered by the `aws_subnet` test sweepers. Removing the default subnets should be handled separately by a future `aws_default_subnet` test sweeper, if desired, as removing them breaks a lot of dependent acceptance tests currently.
