### PR TITLE
docs/data-source/aws_elastic_beanstalk_application: Add missing sidebar link

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -176,6 +176,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-eks-cluster") %>>
                             <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-elastic-beanstalk-application") %>>
+                            <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-elastic-beanstalk-hosted-zone") %>>
                             <a href="/docs/providers/aws/d/elastic_beanstalk_hosted_zone.html">aws_elastic_beanstalk_hosted_zone</a>
                         </li>


### PR DESCRIPTION
On the tin. Page is already up, just missing the sidebar link: https://www.terraform.io/docs/providers/aws/d/elastic_beanstalk_application.html