### PR TITLE
Fix S3 bucket lifecycle rule filters with a single tag and no prefix

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1011,6 +1011,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		lifecycleRules = make([]map[string]interface{}, 0, len(lifecycle.Rules))
 
 		for _, lifecycleRule := range lifecycle.Rules {
+			log.Printf("[DEBUG] S3 bucket: %s, read lifecycle rule: %v", d.Id(), lifecycleRule)
 			rule := make(map[string]interface{})
 
 			// ID

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1033,6 +1033,10 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 					if filter.Prefix != nil && *filter.Prefix != "" {
 						rule["prefix"] = *filter.Prefix
 					}
+					// Tag
+					if filter.Tag != nil {
+						rule["tags"] = tagsToMapS3([]*s3.Tag{filter.Tag})
+					}
 				}
 			} else {
 				if lifecycleRule.Prefix != nil {

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -867,7 +867,7 @@ func TestAccAWSS3Bucket_Logging(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
+func TestAccAWSS3Bucket_LifecycleBasic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -942,6 +942,16 @@ func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
 						"aws_s3_bucket.bucket", "lifecycle_rule.3.tags.tagKey", "tagValue"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.3.tags.terraform", "hashicorp"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.4.id", "id5"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.4.tags.tagKey", "tagValue"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.4.tags.terraform", "hashicorp"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.4.transition.460947558.days", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.4.transition.460947558.storage_class", "GLACIER"),
 				),
 			},
 			{
@@ -2539,6 +2549,20 @@ resource "aws_s3_bucket" "bucket" {
       date = "2016-01-12"
     }
   }
+	lifecycle_rule {
+		id = "id5"
+		enabled = true
+
+		tags = {
+			"tagKey" = "tagValue"
+			"terraform" = "hashicorp"
+		}
+
+		transition {
+			days = 0
+			storage_class = "GLACIER"
+		}
+	}
 }
 `, randInt)
 }

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -952,6 +952,14 @@ func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
 						"aws_s3_bucket.bucket", "lifecycle_rule.4.transition.460947558.days", "0"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.4.transition.460947558.storage_class", "GLACIER"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.5.id", "id6"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.5.tags.tagKey", "tagValue"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.5.transition.460947558.days", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.5.transition.460947558.storage_class", "GLACIER"),
 				),
 			},
 			{
@@ -2556,6 +2564,19 @@ resource "aws_s3_bucket" "bucket" {
 		tags = {
 			"tagKey" = "tagValue"
 			"terraform" = "hashicorp"
+		}
+
+		transition {
+			days = 0
+			storage_class = "GLACIER"
+		}
+	}
+	lifecycle_rule {
+		id = "id6"
+		enabled = true
+
+		tags = {
+			"tagKey" = "tagValue"
 		}
 
 		transition {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7156 

Changes proposed in this pull request:

* support S3 bucket lifecycle rule filters with a single tag and no prefix

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_LifecycleBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_LifecycleBasic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]

=== RUN   TestAccAWSS3Bucket_LifecycleBasic
=== PAUSE TestAccAWSS3Bucket_LifecycleBasic
=== CONT  TestAccAWSS3Bucket_LifecycleBasic
--- PASS: TestAccAWSS3Bucket_LifecycleBasic (141.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       141.443s
```

TODO:
- [ ] verify fix in real situation
- [x] generate lifecycle rules with a single tag and no prefix the same way the web console does

Notes:

* Rather than trying to add an acceptance test that creates a lifecycle rule with a single tag and no prefix the same way the web console would have done, I've settled to adapt the provider's update implementation to match the web console behavior.

* Adding unit tests would probably be a good thing but this would require extracting lifecycle rules expanding/flattening code into functions and make the diff way less readable.