### PR TITLE
resource/aws_api_gateway_integration: Ensure request_templates TypeMap configuration in testing and documentation includes equals

### DIFF
--- a/aws/resource_aws_api_gateway_method_settings_test.go
+++ b/aws/resource_aws_api_gateway_method_settings_test.go
@@ -498,7 +498,7 @@ resource "aws_api_gateway_integration" "test" {
   http_method = "${aws_api_gateway_method.test.http_method}"
   type        = "MOCK"
 
-  request_templates {
+  request_templates = {
     "application/xml" = <<EOF
 {
    "body" : $input.json('$')

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -45,7 +45,7 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   }
 
   # Transforms the incoming XML request to JSON
-  request_templates {
+  request_templates = {
     "application/xml" = <<EOF
 {
    "body" : $input.json('$')

--- a/website/docs/r/api_gateway_method_settings.html.markdown
+++ b/website/docs/r/api_gateway_method_settings.html.markdown
@@ -60,7 +60,7 @@ resource "aws_api_gateway_integration" "test" {
   http_method = "${aws_api_gateway_method.test.http_method}"
   type        = "MOCK"
 
-  request_templates {
+  request_templates = {
     "application/xml" = <<EOF
 {
    "body" : $input.json('$')


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test823728758/main.tf:35,5-6: Invalid argument name; Argument names must not be quoted.
```

Output from Terraform 0.12 acceptance testing (new test failure will be addressed separately):

```

--- PASS: TestAccAWSAPIGatewayMethodSettings_basic (22.56s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_Multiple (35.26s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_UnauthorizedCacheControlHeaderStrategy (33.84s)
--- FAIL: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingRateLimit (17.79s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_api_gateway_method_settings.test
          id:                                                    "gwtr2bckzf-dev-test/GET" => "gwtr2bckzf-dev-test/GET"
          method_path:                                           "test/GET" => "test/GET"
          rest_api_id:                                           "gwtr2bckzf" => "gwtr2bckzf"
          settings.#:                                            "1" => "1"
          settings.0.cache_data_encrypted:                       "false" => "false"
          settings.0.cache_ttl_in_seconds:                       "0" => "0"
          settings.0.caching_enabled:                            "false" => "false"
          settings.0.data_trace_enabled:                         "false" => "false"
          settings.0.logging_level:                              "" => ""
          settings.0.metrics_enabled:                            "false" => "false"
          settings.0.require_authorization_for_cache_control:    "false" => "false"
          settings.0.throttling_burst_limit:                     "0" => "0"
          settings.0.throttling_rate_limit:                      "1.1" => "1.1"
          settings.0.unauthorized_cache_control_header_strategy: "" => ""
          stage_name:                                            "dev" => "dev"
...
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_ThrottlingBurstLimit (34.13s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_RequireAuthorizationForCacheControl (33.95s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_DataTraceEnabled (34.86s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_MetricsEnabled (33.79s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_LoggingLevel (33.60s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheTtlInSeconds (34.28s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CachingEnabled (35.13s)
--- PASS: TestAccAWSAPIGatewayMethodSettings_Settings_CacheDataEncrypted (33.22s)
```
