### PR TITLE
Fixing TestAccDataSourceAwsVpcs tests

### DIFF
--- a/aws/data_source_aws_vpcs_test.go
+++ b/aws/data_source_aws_vpcs_test.go
@@ -117,7 +117,7 @@ func testAccDataSourceAwsVpcsConfig_tags(rName string) string {
 	resource "aws_vpc" "test-vpc" {
   		cidr_block = "10.0.0.0/24"
 
-  		tags {
+  		tags = {
   			Name = "testacc-vpc-%s"
   			Service = "testacc-test"
   		}
@@ -136,7 +136,7 @@ func testAccDataSourceAwsVpcsConfig_filters(rName string) string {
 	return fmt.Sprintf(`
 	resource "aws_vpc" "test-vpc" {
   		cidr_block = "192.168.0.0/25"
-  		tags {
+  		tags = {
   			Name = "testacc-vpc-%s"
   		}
 	}


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAwsVpcs_filters (0.80s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
--- FAIL: TestAccDataSourceAwsVpcs_tags (0.64s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
=== RUN   TestAccDataSourceAwsVpcs_tags
=== PAUSE TestAccDataSourceAwsVpcs_tags
=== CONT  TestAccDataSourceAwsVpcs_tags
--- PASS: TestAccDataSourceAwsVpcs_tags (22.57s)
=== RUN   TestAccDataSourceAwsVpcs_filters
=== PAUSE TestAccDataSourceAwsVpcs_filters
=== CONT  TestAccDataSourceAwsVpcs_filters
--- PASS: TestAccDataSourceAwsVpcs_filters (21.64s)
```
