### PR TITLE
tests/resource/aws_api_gateway_stage: Ensure variables TypeMap configuration includes equals

### DIFF
--- a/aws/resource_aws_api_gateway_stage_test.go
+++ b/aws/resource_aws_api_gateway_stage_test.go
@@ -266,7 +266,7 @@ resource "aws_api_gateway_stage" "test" {
   cache_cluster_enabled = true
   cache_cluster_size = "0.5"
   xray_tracing_enabled = true
-  variables {
+  variables = {
     one = "1"
     two = "2"
   }
@@ -286,7 +286,7 @@ resource "aws_api_gateway_stage" "test" {
   cache_cluster_enabled = false
   description = "Hello world"
   xray_tracing_enabled = false
-  variables {
+  variables = {
     one = "1"
     three = "3"
   }
@@ -310,7 +310,7 @@ resource "aws_api_gateway_stage" "test" {
   deployment_id = "${aws_api_gateway_deployment.dev.id}"
   cache_cluster_enabled = true
   cache_cluster_size = "0.5"
-  variables {
+  variables = {
     one = "1"
     two = "2"
   }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSAPIGatewayStage_basic (0.68s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "variables" are not expected here. Did you mean to define argument "variables"? If so, use the equals sign to assign it a value.
--- FAIL: TestAccAWSAPIGatewayStage_accessLogSettings (0.61s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "variables" are not expected here. Did you mean to define argument "variables"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing (new test failure will need to be addressed separately):

```
--- PASS: TestAccAWSAPIGatewayStage_basic (436.76s)
--- FAIL: TestAccAWSAPIGatewayStage_accessLogSettings (230.29s)
    testing.go:568: Step 1 error: errors during apply:

        Error: Updating API Gateway Stage failed: BadRequestException: Access Log value must not be empty
```
