### PR TITLE
Fixing TestAccDataSourceAwsRoute53Zone

### DIFF
--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -99,7 +99,7 @@ func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
 	data "aws_route53_zone" "by_tag" {
 	 name = "${aws_route53_zone.test_private.name}"
 	 private_zone = true
-	 tags {
+	 tags = {
 		 Environment = "dev-%d"
 	 }
 	}


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
=== RUN   TestAccDataSourceAwsRoute53Zone
=== PAUSE TestAccDataSourceAwsRoute53Zone
=== CONT  TestAccDataSourceAwsRoute53Zone
--- FAIL: TestAccDataSourceAwsRoute53Zone (0.81s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing 

```
=== RUN   TestAccDataSourceAwsRoute53Zone
=== PAUSE TestAccDataSourceAwsRoute53Zone
=== CONT  TestAccDataSourceAwsRoute53Zone
--- PASS: TestAccDataSourceAwsRoute53Zone (89.93s)
```
