### PR TITLE
data-source/aws_iam_policy_document: Ensure principals configurations in testing and documentation omit equals

### DIFF
--- a/aws/resource_aws_appautoscaling_scheduled_action_test.go
+++ b/aws/resource_aws_appautoscaling_scheduled_action_test.go
@@ -476,7 +476,7 @@ data "aws_iam_policy_document" "autoscale_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -585,7 +585,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }

--- a/aws/resource_aws_cloudwatch_log_destination_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_policy_test.go
@@ -110,7 +110,7 @@ data "aws_region" "current" {
 data "aws_iam_policy_document" "role" {
   statement {
     effect = "Allow"
-    principals = {
+    principals {
       type = "Service"
       identifiers = [
         "logs.${data.aws_region.current.name}.amazonaws.com"
@@ -164,7 +164,7 @@ resource "aws_cloudwatch_log_destination" "test" {
 data "aws_iam_policy_document" "access" {
   statement {
     effect = "Allow"
-    principals = {
+    principals {
       type = "AWS"
       identifiers = [
         "000000000000"

--- a/aws/resource_aws_cloudwatch_log_destination_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_test.go
@@ -110,7 +110,7 @@ data "aws_region" "current" {
 data "aws_iam_policy_document" "role" {
   statement {
     effect = "Allow"
-    principals = {
+    principals {
       type = "Service"
       identifiers = [
         "logs.${data.aws_region.current.name}.amazonaws.com"
@@ -164,7 +164,7 @@ resource "aws_cloudwatch_log_destination" "test" {
 data "aws_iam_policy_document" "access" {
   statement {
     effect = "Allow"
-    principals = {
+    principals {
       type = "AWS"
       identifiers = [
         "000000000000"

--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -1287,7 +1287,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -1600,7 +1600,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -2333,7 +2333,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -2871,7 +2871,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -3221,7 +3221,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -3569,7 +3569,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -3917,7 +3917,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -4220,7 +4220,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -4533,7 +4533,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -4840,7 +4840,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -5142,7 +5142,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -5449,7 +5449,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
@@ -5844,7 +5844,7 @@ data "aws_iam_policy_document" "emr-autoscaling-role-policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1873,7 +1873,7 @@ data "aws_iam_policy_document" "logs_bucket" {
     effect    = "Allow"
     resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}/${var.bucket_prefix}${var.bucket_prefix == "" ? "" : "/"}AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
 
-    principals = {
+    principals {
       type        = "AWS"
       identifiers = ["${data.aws_elb_service_account.current.arn}"]
     }

--- a/website/docs/r/cloudwatch_log_destination_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_destination_policy.html.markdown
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "test_destination_policy" {
   statement {
     effect = "Allow"
 
-    principals = {
+    principals {
       type = "AWS"
 
       identifiers = [


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSAppautoscalingScheduledAction_EMR (0.59s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "principals" is not expected here. Did you mean to define a block of type "principals"?
```

Output from Terraform 0.12 acceptance testing (other tests will require additional updates to pass):

```
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_importBasic (102.32s)
--- PASS: TestAccAWSCloudwatchLogDestination_basic (102.32s)
--- PASS: TestAccAWSCloudwatchLogDestination_importBasic (94.94s)
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_basic (101.92s)
--- PASS: TestAccAWSAppautoscalingScheduledAction_EMR (514.02s)
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (544.24s)
```
