### PR TITLE
Fixing datasource pricing product test

### DIFF
--- a/aws/data_source_aws_pricing_product_test.go
+++ b/aws/data_source_aws_pricing_product_test.go
@@ -52,36 +52,40 @@ func testAccDataSourceAwsPricingProductConfigEc2(dataName string, instanceType s
 	return fmt.Sprintf(`data "aws_pricing_product" "%s" {
 		service_code = "AmazonEC2"
 	  
-		filters = [
-		  {
+		filters {
 			field = "instanceType"
 			value = "%s"
-		  },
-		  {
+		}
+
+		filters {
 			field = "operatingSystem"
 			value = "Linux"
-		  },
-		  {
+		}
+
+		filters {
 			field = "location"
 			value = "US East (N. Virginia)"
-		  },
-		  {
+		}
+
+		filters {
 			field = "preInstalledSw"
 			value = "NA"
-		  },
-		  {
+		}
+
+		filters {
 			field = "licenseModel"
 			value = "No License required"
-		  },
-		  {
+		}
+
+		filters {
 			field = "tenancy"
 			value = "Shared"
-		  },
-		  {
+		}
+
+		filters {
 			field = "capacitystatus"
 			value = "Used"
-		  },
-		]
+		}
 }
 `, dataName, instanceType)
 }
@@ -90,16 +94,15 @@ func testAccDataSourceAwsPricingProductConfigRedshift() string {
 	return fmt.Sprintf(`data "aws_pricing_product" "test" {
 		service_code = "AmazonRedshift"
 	  
-		filters = [
-		  {
+		filters {
 			field = "instanceType"
 			value = "ds1.xlarge"
-			},
-			{
+		}
+
+		filters {
 			field = "location"
 			value = "US East (N. Virginia)"
-		  },
-		]
+		}
 }
 `)
 }

--- a/website/docs/d/pricing_product.html.markdown
+++ b/website/docs/d/pricing_product.html.markdown
@@ -17,32 +17,35 @@ This data source is only available in a us-east-1 or ap-south-1 provider.
 data "aws_pricing_product" "example" {
   service_code = "AmazonEC2"
 
-  filters = [
-    {
-      field = "instanceType"
-      value = "c5.xlarge"
-    },
-    {
-      field = "operatingSystem"
-      value = "Linux"
-    },
-    {
-      field = "location"
-      value = "US East (N. Virginia)"
-    },
-    {
-      field = "preInstalledSw"
-      value = "NA"
-    },
-    {
-      field = "licenseModel"
-      value = "No License required"
-    },
-    {
-      field = "tenancy"
-      value = "Shared"
-    },
-  ]
+  filters {
+    field = "instanceType"
+    value = "c5.xlarge"
+  }
+    
+  filters {
+    field = "operatingSystem"
+     value = "Linux"
+  }
+
+  filters {
+    field = "location"
+    value = "US East (N. Virginia)"
+  }
+
+  filters {
+    field = "preInstalledSw"
+    value = "NA"
+  }
+    
+  filters {
+    field = "licenseModel"
+    value = "No License required"
+  }
+    
+  filters {
+    field = "tenancy"
+    value = "Shared"
+  }
 }
 ```
 
@@ -50,16 +53,15 @@ data "aws_pricing_product" "example" {
 data "aws_pricing_product" "example" {
   service_code = "AmazonRedshift"
 
-  filters = [
-    {
-      field = "instanceType"
-      value = "ds1.xlarge"
-    },
-    {
-      field = "location"
-      value = "US East (N. Virginia)"
-    },
-  ]
+  filters {
+   field = "instanceType"
+   value = "ds1.xlarge"
+  }
+  
+  filters {
+    field = "location"
+    value = "US East (N. Virginia)"
+  }
 }
 ```
 
@@ -76,3 +78,4 @@ data "aws_pricing_product" "example" {
 ## Attributes Reference
 
  * `result` - Set to the product returned from the API.
+


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAwsPricingProduct_ec2 (1.08s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:
        
        - Unsupported argument: An argument named "filters" is not expected here. Did you mean to define a block of type "filters"?
        - Insufficient filters blocks: At least 1 "filters" blocks are required.
FAIL
--- FAIL: TestAccDataSourceAwsPricingProduct_redshift (1.07s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:
        
        - Unsupported argument: An argument named "filters" is not expected here. Did you mean to define a block of type "filters"?
        - Insufficient filters blocks: At least 1 "filters" blocks are required.
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
=== RUN   TestAccDataSourceAwsPricingProduct_ec2
=== PAUSE TestAccDataSourceAwsPricingProduct_ec2
=== CONT  TestAccDataSourceAwsPricingProduct_ec2
--- PASS: TestAccDataSourceAwsPricingProduct_ec2 (11.35s)
=== RUN   TestAccDataSourceAwsPricingProduct_redshift
=== PAUSE TestAccDataSourceAwsPricingProduct_redshift
=== CONT  TestAccDataSourceAwsPricingProduct_redshift
--- PASS: TestAccDataSourceAwsPricingProduct_redshift (15.43s)
```
