### PR TITLE
resource/aws_autoscaling_group: Ensure launch_template configuration in tests and documentation omits equals

### DIFF
--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -2789,7 +2789,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity = 0
   max_size = 0
   min_size = 0
-  launch_template = {
+  launch_template {
     id = "${aws_launch_template.foobar.id}"
     version = "${aws_launch_template.foobar.default_version}"
   }
@@ -2872,7 +2872,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity = 0
   max_size = 0
   min_size = 0
-  launch_template = {
+  launch_template {
     name = "foobar2"
   }
 }
@@ -2917,7 +2917,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity = 0
   max_size = 0
   min_size = 0
-  launch_template = {
+  launch_template {
     id = "${aws_launch_template.foobar.id}"
     version = "$$Latest"
   }

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -993,7 +993,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity = 0
   max_size = 0
   min_size = 0
-  launch_template = {
+  launch_template {
     id = "${aws_launch_template.foo.id}"
     version = "${aws_launch_template.foo.latest_version}"
   }
@@ -1028,7 +1028,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity = 0
   max_size = 0
   min_size = 0
-  launch_template = {
+  launch_template {
     id = "${aws_launch_template.foo.id}"
     version = "${aws_launch_template.foo.latest_version}"
   }

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -81,7 +81,7 @@ resource "aws_autoscaling_group" "bar" {
   max_size           = 1
   min_size           = 1
 
-  launch_template = {
+  launch_template {
     id      = "${aws_launch_template.foobar.id}"
     version = "$$Latest"
   }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSAutoScalingGroup_launchTemplate (0.62s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "launch_template" is not expected here. Did you mean to define a block of type "launch_template"?
```

Output from Terraform 0.12 acceptance testing (new failure will need to be addressed seperately):

```
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (52.91s)
--- FAIL: TestAccAWSAutoScalingGroup_launchTemplate_update (53.76s)
    testing.go:568: Step 3 error: errors during apply:

        Error: Error updating Autoscaling group: ValidationError: Invalid launch template version: either '$Default', '$Latest', or a numeric version are allowed.
        	status code: 400, request id: f5f7c480-1a1d-11e9-b84d-a3ce0c2e314b

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test329221421/main.tf line 44:
          (source code not available)

--- PASS: TestAccAWSLaunchTemplate_update (55.76s)
```
