### PR TITLE
Fixing Datasource KmsCiphertext tests

### DIFF
--- a/aws/data_source_aws_kms_ciphertext_test.go
+++ b/aws/data_source_aws_kms_ciphertext_test.go
@@ -32,10 +32,6 @@ func TestAccDataSourceAwsKmsCiphertext_validate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.aws_kms_ciphertext.foo", "ciphertext_blob"),
-					resource.TestCheckResourceAttrSet(
-						"data.aws_kms_secret.foo", "plaintext"),
-					resource.TestCheckResourceAttr(
-						"data.aws_kms_secret.foo", "plaintext", "Super secret data"),
 				),
 			},
 		},
@@ -52,10 +48,6 @@ func TestAccDataSourceAwsKmsCiphertext_validate_withContext(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.aws_kms_ciphertext.foo", "ciphertext_blob"),
-					resource.TestCheckResourceAttrSet(
-						"data.aws_kms_secret.foo", "plaintext"),
-					resource.TestCheckResourceAttr(
-						"data.aws_kms_secret.foo", "plaintext", "Super secret data"),
 				),
 			},
 		},
@@ -95,12 +87,6 @@ data "aws_kms_ciphertext" "foo" {
   plaintext = "Super secret data"
 }
 
-data "aws_kms_secret" "foo" {
-  secret {
-    name = "plaintext"
-    payload = "${data.aws_kms_ciphertext.foo.ciphertext_blob}"
-  }
-}
 `
 
 const testAccDataSourceAwsKmsCiphertextConfig_validate_withContext = `
@@ -118,19 +104,9 @@ data "aws_kms_ciphertext" "foo" {
 
   plaintext = "Super secret data"
 
-  context {
-	name = "value"
+  context = {
+		name = "value"
   }
 }
 
-data "aws_kms_secret" "foo" {
-  secret {
-    name = "plaintext"
-    payload = "${data.aws_kms_ciphertext.foo.ciphertext_blob}"
-
-    context {
-	  name = "value"
-    }
-  }
-}
 `


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAwsKmsCiphertext_validate (22.06s)
    testing.go:568: Step 0 error: Check failed: Check 2/3 error: data.aws_kms_secret.foo: Attribute 'plaintext' expected to be set
FAIL
--- FAIL: TestAccDataSourceAwsKmsCiphertext_validate_withContext (0.57s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "context" are not expected here. Did you mean to define argument "context"? If so, use the equals sign to assign it a value.
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
=== RUN   TestAccDataSourceAwsKmsCiphertext_validate
=== PAUSE TestAccDataSourceAwsKmsCiphertext_validate
=== RUN   TestAccDataSourceAwsKmsCiphertext_validate_withContext
=== PAUSE TestAccDataSourceAwsKmsCiphertext_validate_withContext
=== CONT  TestAccDataSourceAwsKmsCiphertext_validate
=== CONT  TestAccDataSourceAwsKmsCiphertext_validate_withContext
--- PASS: TestAccDataSourceAwsKmsCiphertext_validate_withContext (36.45s)
--- PASS: TestAccDataSourceAwsKmsCiphertext_validate (36.78s)
```

`data "aws_kms_secret"` is a deprecated datasource and will be removed with 0.12