### PR TITLE
Add support for S3 Object Lock legal holds

### DIFF
--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccDataSourceAWSS3BucketObject_basic(t *testing.T) {
+	resourceName := "aws_s3_bucket_object.object"
+	dsName := "data.aws_s3_bucket_object.obj"
 	rInt := acctest.RandInt()
 	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_basic(rInt)
 
@@ -27,19 +29,21 @@ func TestAccDataSourceAWSS3BucketObject_basic(t *testing.T) {
 			{
 				Config: resourceOnlyConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
 				),
 			},
 			{
 				Config: conf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "11"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "binary/octet-stream"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "b10a8db164e0754105b7a99be72e3fe5"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
+					testAccCheckAwsS3ObjectDataSourceExists(dsName, &dsObj),
+					resource.TestCheckResourceAttr(dsName, "content_length", "11"),
+					resource.TestCheckResourceAttr(dsName, "content_type", "binary/octet-stream"),
+					resource.TestCheckResourceAttr(dsName, "etag", "b10a8db164e0754105b7a99be72e3fe5"),
+					resource.TestMatchResourceAttr(dsName, "last_modified",
 						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckNoResourceAttr("data.aws_s3_bucket_object.obj", "body"),
+					resource.TestCheckNoResourceAttr(dsName, "body"),
+					resource.TestCheckResourceAttr(dsName, "legal_hold.#", "0"),
+					resource.TestCheckResourceAttr(dsName, "tags.%", "0"),
 				),
 			},
 		},
@@ -47,6 +51,8 @@ func TestAccDataSourceAWSS3BucketObject_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAWSS3BucketObject_readableBody(t *testing.T) {
+	resourceName := "aws_s3_bucket_object.object"
+	dsName := "data.aws_s3_bucket_object.obj"
 	rInt := acctest.RandInt()
 	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_readableBody(rInt)
 
@@ -61,19 +67,19 @@ func TestAccDataSourceAWSS3BucketObject_readableBody(t *testing.T) {
 			{
 				Config: resourceOnlyConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
 				),
 			},
 			{
 				Config: conf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "3"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "text/plain"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "a6105c0a611b41b08f1209506350279e"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
+					testAccCheckAwsS3ObjectDataSourceExists(dsName, &dsObj),
+					resource.TestCheckResourceAttr(dsName, "content_length", "3"),
+					resource.TestCheckResourceAttr(dsName, "content_type", "text/plain"),
+					resource.TestCheckResourceAttr(dsName, "etag", "a6105c0a611b41b08f1209506350279e"),
+					resource.TestMatchResourceAttr(dsName, "last_modified",
 						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "body", "yes"),
+					resource.TestCheckResourceAttr(dsName, "body", "yes"),
 				),
 			},
 		},
@@ -81,6 +87,8 @@ func TestAccDataSourceAWSS3BucketObject_readableBody(t *testing.T) {
 }
 
 func TestAccDataSourceAWSS3BucketObject_kmsEncrypted(t *testing.T) {
+	resourceName := "aws_s3_bucket_object.object"
+	dsName := "data.aws_s3_bucket_object.obj"
 	rInt := acctest.RandInt()
 	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_kmsEncrypted(rInt)
 
@@ -95,22 +103,22 @@ func TestAccDataSourceAWSS3BucketObject_kmsEncrypted(t *testing.T) {
 			{
 				Config: resourceOnlyConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
 				),
 			},
 			{
 				Config: conf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "22"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "text/plain"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "etag", regexp.MustCompile("^[a-f0-9]{32}$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "server_side_encryption", "aws:kms"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "sse_kms_key_id",
+					testAccCheckAwsS3ObjectDataSourceExists(dsName, &dsObj),
+					resource.TestCheckResourceAttr(dsName, "content_length", "22"),
+					resource.TestCheckResourceAttr(dsName, "content_type", "text/plain"),
+					resource.TestMatchResourceAttr(dsName, "etag", regexp.MustCompile("^[a-f0-9]{32}$")),
+					resource.TestCheckResourceAttr(dsName, "server_side_encryption", "aws:kms"),
+					resource.TestMatchResourceAttr(dsName, "sse_kms_key_id",
 						regexp.MustCompile(`^arn:aws:kms:[a-z]{2}-[a-z]+-\d{1}:[0-9]{12}:key/[a-z0-9-]{36}$`)),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
+					resource.TestMatchResourceAttr(dsName, "last_modified",
 						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "body", "Keep Calm and Carry On"),
+					resource.TestCheckResourceAttr(dsName, "body", "Keep Calm and Carry On"),
 				),
 			},
 		},
@@ -118,6 +126,8 @@ func TestAccDataSourceAWSS3BucketObject_kmsEncrypted(t *testing.T) {
 }
 
 func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
+	resourceName := "aws_s3_bucket_object.object"
+	dsName := "data.aws_s3_bucket_object.obj"
 	rInt := acctest.RandInt()
 	resourceOnlyConf, conf := testAccAWSDataSourceS3ObjectConfig_allParams(rInt)
 
@@ -132,35 +142,38 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 			{
 				Config: resourceOnlyConf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &rObj),
+					testAccCheckAWSS3BucketObjectExists(resourceName, &rObj),
 				),
 			},
 			{
 				Config: conf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsS3ObjectDataSourceExists("data.aws_s3_bucket_object.obj", &dsObj),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_length", "21"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_type", "application/unknown"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "etag", "723f7a6ac0c57b445790914668f98640"),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "last_modified",
+					testAccCheckAwsS3ObjectDataSourceExists(dsName, &dsObj),
+					resource.TestCheckResourceAttr(dsName, "content_length", "21"),
+					resource.TestCheckResourceAttr(dsName, "content_type", "application/unknown"),
+					resource.TestCheckResourceAttr(dsName, "etag", "723f7a6ac0c57b445790914668f98640"),
+					resource.TestMatchResourceAttr(dsName, "last_modified",
 						regexp.MustCompile("^[a-zA-Z]{3}, [0-9]+ [a-zA-Z]+ [0-9]{4} [0-9:]+ [A-Z]+$")),
-					resource.TestMatchResourceAttr("data.aws_s3_bucket_object.obj", "version_id", regexp.MustCompile("^.{32}$")),
-					resource.TestCheckNoResourceAttr("data.aws_s3_bucket_object.obj", "body"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "cache_control", "no-cache"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_disposition", "attachment"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_encoding", "identity"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_language", "en-GB"),
+					resource.TestMatchResourceAttr(dsName, "version_id", regexp.MustCompile("^.{32}$")),
+					resource.TestCheckNoResourceAttr(dsName, "body"),
+					resource.TestCheckResourceAttr(dsName, "cache_control", "no-cache"),
+					resource.TestCheckResourceAttr(dsName, "content_disposition", "attachment"),
+					resource.TestCheckResourceAttr(dsName, "content_encoding", "identity"),
+					resource.TestCheckResourceAttr(dsName, "content_language", "en-GB"),
 					// Encryption is off
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "server_side_encryption", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "sse_kms_key_id", ""),
+					resource.TestCheckResourceAttr(dsName, "server_side_encryption", ""),
+					resource.TestCheckResourceAttr(dsName, "sse_kms_key_id", ""),
 					// Supported, but difficult to reproduce in short testing time
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "storage_class", "STANDARD"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "expiration", ""),
+					resource.TestCheckResourceAttr(dsName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(dsName, "expiration", ""),
 					// Currently unsupported in aws_s3_bucket_object resource
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "expires", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "website_redirect_location", ""),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "metadata.%", "0"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "tags.%", "1"),
+					resource.TestCheckResourceAttr(dsName, "expires", ""),
+					resource.TestCheckResourceAttr(dsName, "website_redirect_location", ""),
+					resource.TestCheckResourceAttr(dsName, "metadata.%", "0"),
+					resource.TestCheckResourceAttr(dsName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dsName, "tags.Key1", "Value 1"),
+					resource.TestCheckResourceAttr(dsName, "legal_hold.#", "1"),
+					resource.TestCheckResourceAttr(dsName, "legal_hold.0.status", "ON"),
 				),
 			},
 		},
@@ -198,21 +211,21 @@ func testAccCheckAwsS3ObjectDataSourceExists(n string, obj *s3.GetObjectOutput) 
 func testAccAWSDataSourceS3ObjectConfig_basic(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%d"
 }
+
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d"
-	content = "Hello World"
+  bucket = "${aws_s3_bucket.object_bucket.bucket}"
+  key = "tf-testing-obj-%d"
+  content = "Hello World"
 }
 `, randInt, randInt)
 
 	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d"
-}
-`, resources, randInt, randInt)
+  bucket = "tf-object-test-bucket-%d"
+  key = "tf-testing-obj-%d"
+}`, resources, randInt, randInt)
 
 	return resources, both
 }
@@ -220,22 +233,22 @@ data "aws_s3_bucket_object" "obj" {
 func testAccAWSDataSourceS3ObjectConfig_readableBody(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%d"
 }
+
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d-readable"
-	content = "yes"
-	content_type = "text/plain"
+  bucket = "${aws_s3_bucket.object_bucket.bucket}"
+  key = "tf-testing-obj-%d-readable"
+  content = "yes"
+  content_type = "text/plain"
 }
 `, randInt, randInt)
 
 	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d-readable"
-}
-`, resources, randInt, randInt)
+  bucket = "tf-object-test-bucket-%d"
+  key = "tf-testing-obj-%d-readable"
+}`, resources, randInt, randInt)
 
 	return resources, both
 }
@@ -243,27 +256,28 @@ data "aws_s3_bucket_object" "obj" {
 func testAccAWSDataSourceS3ObjectConfig_kmsEncrypted(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
+  bucket = "tf-object-test-bucket-%d"
 }
+
 resource "aws_kms_key" "example" {
   description             = "TF Acceptance Test KMS key"
   deletion_window_in_days = 7
 }
+
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d-encrypted"
-	content = "Keep Calm and Carry On"
-	content_type = "text/plain"
-	kms_key_id = "${aws_kms_key.example.arn}"
+  bucket = "${aws_s3_bucket.object_bucket.bucket}"
+  key = "tf-testing-obj-%d-encrypted"
+  content = "Keep Calm and Carry On"
+  content_type = "text/plain"
+  kms_key_id = "${aws_kms_key.example.arn}"
 }
 `, randInt, randInt)
 
 	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d-encrypted"
-}
-`, resources, randInt, randInt)
+  bucket = "tf-object-test-bucket-%d"
+  key = "tf-testing-obj-%d-encrypted"
+}`, resources, randInt, randInt)
 
 	return resources, both
 }
@@ -271,35 +285,41 @@ data "aws_s3_bucket_object" "obj" {
 func testAccAWSDataSourceS3ObjectConfig_allParams(randInt int) (string, string) {
 	resources := fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
-	bucket = "tf-object-test-bucket-%d"
-	versioning {
-		enabled = true
-	}
+  bucket = "tf-object-test-bucket-%d"
+  versioning {
+    enabled = true
+  }
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket.bucket}"
-	key = "tf-testing-obj-%d-all-params"
-	content = <<CONTENT
+  bucket = "${aws_s3_bucket.object_bucket.bucket}"
+  key = "tf-testing-obj-%d-all-params"
+  content = <<CONTENT
 {"msg": "Hi there!"}
 CONTENT
-	content_type = "application/unknown"
-	cache_control = "no-cache"
-	content_disposition = "attachment"
-	content_encoding = "identity"
-	content_language = "en-GB"
-	tags = {
-		Key1 = "Value 1"
-	}
+  content_type = "application/unknown"
+  cache_control = "no-cache"
+  content_disposition = "attachment"
+  content_encoding = "identity"
+  content_language = "en-GB"
+  tags = {
+    Key1 = "Value 1"
+  }
+  legal_hold {
+    status = "ON"
+  }
+  force_delete = true
 }
 `, randInt, randInt)
 
 	both := fmt.Sprintf(`%s
 data "aws_s3_bucket_object" "obj" {
-	bucket = "tf-object-test-bucket-%d"
-	key = "tf-testing-obj-%d-all-params"
-}
-`, resources, randInt, randInt)
+  bucket = "tf-object-test-bucket-%d"
+  key = "tf-testing-obj-%d-all-params"
+}`, resources, randInt, randInt)
 
 	return resources, both
 }

--- a/aws/data_source_aws_s3_bucket_object_test.go
+++ b/aws/data_source_aws_s3_bucket_object_test.go
@@ -311,7 +311,7 @@ CONTENT
   legal_hold {
     status = "ON"
   }
-  force_delete = true
+  force_destroy = true
 }
 `, randInt, randInt)
 

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -132,14 +132,3 @@ func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.Resour
 	}
 	return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
 }
-
-// suppressUnsetContainerAttribute ignores a container attribute being unset
-// in the Terraform configuration. All child attribute differences still apply.
-// Useful when an unset container attribute is equivalent to a container attribute
-// populated with default values.
-func suppressUnsetContainerAttribute(k, old, new string, d *schema.ResourceData) bool {
-	if old == "1" && new == "0" {
-		return true
-	}
-	return false
-}

--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -132,3 +132,14 @@ func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.Resour
 	}
 	return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
 }
+
+// suppressUnsetContainerAttribute ignores a container attribute being unset
+// in the Terraform configuration. All child attribute differences still apply.
+// Useful when an unset container attribute is equivalent to a container attribute
+// populated with default values.
+func suppressUnsetContainerAttribute(k, old, new string, d *schema.ResourceData) bool {
+	if old == "1" && new == "0" {
+		return true
+	}
+	return false
+}

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -164,7 +164,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				Type:             schema.TypeList,
 				Optional:         true,
 				MaxItems:         1,
-				DiffSuppressFunc: suppressUnsetContainerAttribute,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"status": {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -154,7 +154,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				Optional: true,
 			},
 
-			"force_delete": {
+			"force_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -424,7 +424,7 @@ func resourceAwsS3BucketObjectDelete(d *schema.ResourceData, meta interface{}) e
 	// We are effectively ignoring any leading '/' in the key name as aws.Config.DisableRestProtocolURICleaning is false
 	key = strings.TrimPrefix(key, "/")
 
-	if err := deleteAllS3ObjectVersions(conn, bucketName, key, d.Get("force_delete").(bool)); err != nil {
+	if err := deleteAllS3ObjectVersions(conn, bucketName, key, d.Get("force_destroy").(bool)); err != nil {
 		return fmt.Errorf("error deleting S3 Bucket (%s) Object (%s): %s", bucketName, key, err)
 	}
 

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -592,7 +592,7 @@ func TestAccAWSS3BucketObject_legalHoldStartWithNone(t *testing.T) {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
-			// Remove legal hold but create a new object version to test force_delete
+			// Remove legal hold but create a new object version to test force_destroy
 			{
 				Config: testAccAWSS3BucketObjectConfig_noLegalHold(rInt, "changed stuff"),
 				Check: resource.ComposeTestCheckFunc(
@@ -1075,7 +1075,7 @@ resource "aws_s3_bucket_object" "object" {
   bucket = "${aws_s3_bucket.object_bucket.bucket}"
   key = "test-key"
   content = "%s"
-  force_delete = true
+  force_destroy = true
 }
 `, randInt, content)
 }
@@ -1099,7 +1099,7 @@ resource "aws_s3_bucket_object" "object" {
   legal_hold {
     status = "%s"
   }
-  force_delete = true
+  force_destroy = true
 }
 `, randInt, content, legalHoldStatus)
 }

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -190,8 +190,7 @@ func TestAccAWSS3BucketObject_content(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfigContent(rInt, "some_bucket_content"),
+				Config: testAccAWSS3BucketObjectConfigContent(rInt, "some_bucket_content"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
 					testAccCheckAWSS3BucketObjectBody(&obj, "some_bucket_content"),
@@ -212,8 +211,7 @@ func TestAccAWSS3BucketObject_contentBase64(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfigContentBase64(rInt, base64.StdEncoding.EncodeToString([]byte("some_bucket_content"))),
+				Config: testAccAWSS3BucketObjectConfigContentBase64(rInt, base64.StdEncoding.EncodeToString([]byte("some_bucket_content"))),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
 					testAccCheckAWSS3BucketObjectBody(&obj, "some_bucket_content"),
@@ -334,8 +332,7 @@ func TestAccAWSS3BucketObject_kms(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withKMSId(rInt, source),
+				Config: testAccAWSS3BucketObjectConfig_withKMSId(rInt, source),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
 					testAccCheckAWSS3BucketObjectSSE(resourceName, "aws:kms"),
@@ -360,8 +357,7 @@ func TestAccAWSS3BucketObject_sse(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withSSE(rInt, source),
+				Config: testAccAWSS3BucketObjectConfig_withSSE(rInt, source),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
 					testAccCheckAWSS3BucketObjectSSE(resourceName, "AES256"),
@@ -426,8 +422,7 @@ func TestAccAWSS3BucketObject_storageClass(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfigContent(rInt, "some_bucket_content"),
+				Config: testAccAWSS3BucketObjectConfigContent(rInt, "some_bucket_content"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
@@ -482,8 +477,7 @@ func TestAccAWSS3BucketObject_tags(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withTags(rInt, key, "stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withTags(rInt, key, "stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
@@ -494,8 +488,7 @@ func TestAccAWSS3BucketObject_tags(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withUpdatedTags(rInt, key, "stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withUpdatedTags(rInt, key, "stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj2),
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
@@ -508,8 +501,7 @@ func TestAccAWSS3BucketObject_tags(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withNoTags(rInt, key, "stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withNoTags(rInt, key, "stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj3),
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj3, &obj2),
@@ -518,8 +510,7 @@ func TestAccAWSS3BucketObject_tags(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withTags(rInt, key, "changed stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withTags(rInt, key, "changed stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj4),
 					testAccCheckAWSS3BucketObjectVersionIdDiffers(&obj4, &obj3),
@@ -546,8 +537,7 @@ func TestAccAWSS3BucketObject_tagsLeadingSlash(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withTags(rInt, key, "stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withTags(rInt, key, "stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
 					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
@@ -558,8 +548,7 @@ func TestAccAWSS3BucketObject_tagsLeadingSlash(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withUpdatedTags(rInt, key, "stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withUpdatedTags(rInt, key, "stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj2),
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
@@ -572,8 +561,7 @@ func TestAccAWSS3BucketObject_tagsLeadingSlash(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withNoTags(rInt, key, "stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withNoTags(rInt, key, "stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj3),
 					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj3, &obj2),
@@ -582,8 +570,7 @@ func TestAccAWSS3BucketObject_tagsLeadingSlash(t *testing.T) {
 				),
 			},
 			{
-				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withTags(rInt, key, "changed stuff"),
+				Config: testAccAWSS3BucketObjectConfig_withTags(rInt, key, "changed stuff"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketObjectExists(resourceName, &obj4),
 					testAccCheckAWSS3BucketObjectVersionIdDiffers(&obj4, &obj3),
@@ -593,6 +580,94 @@ func TestAccAWSS3BucketObject_tagsLeadingSlash(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "BBB"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "CCC"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketObject_legalHoldStartWithNone(t *testing.T) {
+	var obj1, obj2, obj3 s3.GetObjectOutput
+	resourceName := "aws_s3_bucket_object.object"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketObjectConfig_noLegalHold(rInt, "stuff"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
+					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.#", "0"),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketObjectConfig_withLegalHold(rInt, "stuff", "ON"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj2),
+					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
+					testAccCheckAWSS3BucketObjectBody(&obj2, "stuff"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.0.status", "ON"),
+				),
+			},
+			// Ensure it shows a difference when removing legal_hold configuration
+			{
+				Config:             testAccAWSS3BucketObjectConfig_noLegalHold(rInt, "stuff"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Remove legal hold but create a new object version to test force_delete
+			{
+				Config: testAccAWSS3BucketObjectConfig_noLegalHold(rInt, "changed stuff"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj3),
+					testAccCheckAWSS3BucketObjectVersionIdDiffers(&obj3, &obj2),
+					testAccCheckAWSS3BucketObjectBody(&obj3, "changed stuff"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.0.status", "OFF"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketObject_legalHoldStartWithOn(t *testing.T) {
+	var obj1, obj2 s3.GetObjectOutput
+	resourceName := "aws_s3_bucket_object.object"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketObjectConfig_withLegalHold(rInt, "stuff", "ON"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj1),
+					testAccCheckAWSS3BucketObjectBody(&obj1, "stuff"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.0.status", "ON"),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketObjectConfig_withLegalHold(rInt, "stuff", "OFF"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj2),
+					testAccCheckAWSS3BucketObjectVersionIdEquals(&obj2, &obj1),
+					testAccCheckAWSS3BucketObjectBody(&obj2, "stuff"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "legal_hold.0.status", "OFF"),
+				),
+			},
+			// Ensure it shows no difference when removing legal_hold configuration
+			{
+				Config:             testAccAWSS3BucketObjectConfig_noLegalHold(rInt, "stuff"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -1009,4 +1084,49 @@ resource "aws_s3_bucket_object" "object" {
   content = "%s"
 }
 `, randInt, key, content)
+}
+
+func testAccAWSS3BucketObjectConfig_noLegalHold(randInt int, content string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket" {
+  bucket = "tf-object-test-bucket-%d"
+  versioning {
+    enabled = true
+  }
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_object" "object" {
+  bucket = "${aws_s3_bucket.object_bucket.bucket}"
+  key = "test-key"
+  content = "%s"
+  force_delete = true
+}
+`, randInt, content)
+}
+
+func testAccAWSS3BucketObjectConfig_withLegalHold(randInt int, content, legalHoldStatus string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket" {
+  bucket = "tf-object-test-bucket-%d"
+  versioning {
+    enabled = true
+  }
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_object" "object" {
+  bucket = "${aws_s3_bucket.object_bucket.bucket}"
+  key = "test-key"
+  content = "%s"
+  legal_hold {
+    status = "%s"
+  }
+  force_delete = true
+}
+`, randInt, content, legalHoldStatus)
 }

--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -83,3 +83,8 @@ In addition to all arguments above, the following attributes are exported:
 * `version_id` - The latest version ID of the object returned.
 * `website_redirect_location` - If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.
 * `tags`  - A mapping of tags assigned to the object.
+* `legal_hold` - A configuration of [object lock legal holds](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds) (documented below).
+
+The `legal_hold` object has the following attributes:
+
+* `status` - Indicates whether the object has a Legal Hold in place. Valid values are `ON` and `OFF`.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -320,7 +320,7 @@ The following arguments are supported:
 * `policy` - (Optional) A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a `terraform plan`. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](/docs/providers/aws/guides/iam-policy-documents.html).
 
 * `tags` - (Optional) A mapping of tags to assign to the bucket.
-* `force_destroy` - (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
+* `force_destroy` - (Optional, Default:false ) A boolean that indicates all objects (including any locked objects) should be deleted from the bucket so that the bucket can be destroyed without error. These objects are *not* recoverable.
 * `website` - (Optional) A website object (documented below).
 * `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) (documented below).
 * `versioning` - (Optional) A state of [versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) (documented below)

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -108,7 +108,7 @@ This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
 use the exported `arn` attribute:
       `kms_key_id = "${aws_kms_key.foo.arn}"`
 * `tags` - (Optional) A mapping of tags to assign to the object.
-* `force_delete` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
+* `force_destroy` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
 Default is `false`.
 * `legal_hold` - (Optional) A configuration of [object lock legal holds](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds) (documented below).
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -108,9 +108,16 @@ This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
 use the exported `arn` attribute:
       `kms_key_id = "${aws_kms_key.foo.arn}"`
 * `tags` - (Optional) A mapping of tags to assign to the object.
+* `force_delete` - (Optional) Allow the object to be deleted by removing any legal hold on any object version.
+Default is `false`.
+* `legal_hold` - (Optional) A configuration of [object lock legal holds](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-legal-holds) (documented below).
 
-Either `source` or `content` must be provided to specify the bucket content.
-These two arguments are mutually-exclusive.
+Either `source`, `content`, `content_base64` or must be provided to specify the bucket content.
+These three arguments are mutually-exclusive.
+
+The `legal_hold` object supports the following:
+
+* `status` - (Required) Indicates whether the object has a Legal Hold in place. Valid values are `ON` and `OFF`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/7158.

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3BucketObject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_legalHoldStartWithNone
=== PAUSE TestAccAWSS3BucketObject_legalHoldStartWithNone
=== RUN   TestAccAWSS3BucketObject_legalHoldStartWithOn
=== PAUSE TestAccAWSS3BucketObject_legalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_source
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketObject_updates
=== CONT  TestAccAWSS3BucketObject_legalHoldStartWithNone
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_contentBase64
=== CONT  TestAccAWSS3BucketObject_content
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_legalHoldStartWithOn
=== CONT  TestAccAWSS3BucketObject_tags
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (54.90s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (55.74s)
--- PASS: TestAccAWSS3BucketObject_content (57.67s)
--- PASS: TestAccAWSS3BucketObject_sse (58.27s)
--- PASS: TestAccAWSS3BucketObject_source (59.09s)
--- PASS: TestAccAWSS3BucketObject_updates (85.93s)
--- PASS: TestAccAWSS3BucketObject_kms (86.52s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (87.73s)
--- PASS: TestAccAWSS3BucketObject_acl (113.61s)
--- PASS: TestAccAWSS3BucketObject_legalHoldStartWithOn (115.63s)
--- PASS: TestAccAWSS3BucketObject_tags (127.97s)
--- PASS: TestAccAWSS3BucketObject_legalHoldStartWithNone (129.84s)
--- PASS: TestAccAWSS3BucketObject_storageClass (136.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	137.319s
```

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAWSS3BucketObject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketObject_basic
=== PAUSE TestAccDataSourceAWSS3BucketObject_basic
=== RUN   TestAccDataSourceAWSS3BucketObject_readableBody
=== PAUSE TestAccDataSourceAWSS3BucketObject_readableBody
=== RUN   TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== PAUSE TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== RUN   TestAccDataSourceAWSS3BucketObject_allParams
=== PAUSE TestAccDataSourceAWSS3BucketObject_allParams
=== CONT  TestAccDataSourceAWSS3BucketObject_basic
=== CONT  TestAccDataSourceAWSS3BucketObject_kmsEncrypted
=== CONT  TestAccDataSourceAWSS3BucketObject_readableBody
=== CONT  TestAccDataSourceAWSS3BucketObject_allParams
--- PASS: TestAccDataSourceAWSS3BucketObject_basic (49.58s)
--- PASS: TestAccDataSourceAWSS3BucketObject_readableBody (50.28s)
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (52.94s)
--- PASS: TestAccDataSourceAWSS3BucketObject_kmsEncrypted (75.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	91.353s
```