### PR TITLE
Fix anchors for launch_template docs

### DIFF
--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -117,7 +117,7 @@ The following arguments are supported:
 * `instance_type` - The type of the instance.
 * `kernel_id` - The kernel ID.
 * `key_name` - The key name to use for the instance.
-* `license_specification` - A list of license specifications to associate with. See [License Specifications](#license-specificiations) below for more details.
+* `license_specification` - A list of license specifications to associate with. See [License Specification](#license-specification) below for more details.
 * `monitoring` - The monitoring option for the instance. See [Monitoring](#monitoring) below for more details.
 * `network_interfaces` - Customize network interfaces to be attached at instance boot time. See [Network
   Interfaces](#network-interfaces) below for more details.
@@ -126,7 +126,7 @@ The following arguments are supported:
 * `security_group_names` - A list of security group names to associate with. If you are creating Instances in a VPC, use
   `vpc_security_group_ids` instead.
 * `vpc_security_group_ids` - A list of security group IDs to associate with.
-* `tag_specifications` - The tags to apply to the resources during launch. See [Tags](#tags) below for more details.
+* `tag_specifications` - The tags to apply to the resources during launch. See [Tag Specifications](#tag-specifications) below for more details.
 * `tags` - (Optional) A mapping of tags to assign to the launch template.
 * `user_data` - The Base64-encoded user data to provide when launching the instance.
 
@@ -198,7 +198,7 @@ The `iam_instance_profile` block supports the following:
 * `arn` - The Amazon Resource Name (ARN) of the instance profile.
 * `name` - The name of the instance profile.
 
-### License Specifications
+### License Specification
 
 Associate one of more license configurations.
 
@@ -264,7 +264,7 @@ The `placement` block supports the following:
 * `spread_domain` - Reserved for future use.
 * `tenancy` - The tenancy of the instance (if the instance is running in a VPC). Can be `default`, `dedicated`, or `host`.
 
-### Tags
+### Tag Specifications
 
 The tags to apply to the resources during launch. You can tag instances and volumes. More information can be found in the [EC2 API documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateTagSpecificationRequest.html).
 


### PR DESCRIPTION
* "Tags" in tag_specification argument is meant to reference Tag Specification header was referencing the argument one line below. 
  * This only occurs on terraform.io, not when viewing in github.
* Spelling correction in license-specifications

Reasoning: Minor fixes
Urgency: Low