### PR TITLE
Fixing TestAccDataSourceAWSLambdaFunction tests

### DIFF
--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -350,7 +350,7 @@ resource "aws_lambda_function" "acctest_create" {
   handler = "exports.example"
   runtime = "nodejs8.10"
 
-  vpc_config = {
+  vpc_config {
     subnet_ids = ["${aws_subnet.lambda.id}"]
     security_group_ids = ["${aws_security_group.lambda.id}"]
   }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
------- Stdout: -------
=== RUN   TestAccDataSourceAWSLambdaFunction_vpc
=== PAUSE TestAccDataSourceAWSLambdaFunction_vpc
=== CONT  TestAccDataSourceAWSLambdaFunction_vpc
--- FAIL: TestAccDataSourceAWSLambdaFunction_vpc (0.62s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "vpc_config" is not expected here. Did you mean to define a block of type "vpc_config"?
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
=== RUN   TestAccDataSourceAWSLambdaFunction_vpc
=== PAUSE TestAccDataSourceAWSLambdaFunction_vpc
=== CONT  TestAccDataSourceAWSLambdaFunction_vpc
--- PASS: TestAccDataSourceAWSLambdaFunction_vpc (36.86s)
```
