### PR TITLE
r/aws_ssm_maintenance_window_task: Fix name/desc validation

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -86,7 +86,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 128),
+				ValidateFunc: validation.StringLenBetween(1, 128),
 			},
 
 			"priority": {
@@ -207,9 +207,15 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 		TaskType:       aws.String(d.Get("task_type").(string)),
 		ServiceRoleArn: aws.String(d.Get("service_role_arn").(string)),
 		TaskArn:        aws.String(d.Get("task_arn").(string)),
-		Name:           aws.String(d.Get("name").(string)),
-		Description:    aws.String(d.Get("description").(string)),
 		Targets:        expandAwsSsmTargets(d.Get("targets").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		params.Name = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		params.Description = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("priority"); ok {

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -25,8 +25,6 @@ func TestAccAWSSSMMaintenanceWindowTask_basic(t *testing.T) {
 				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists("aws_ssm_maintenance_window_task.target", &task),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_task.target", "name", "TestMaintenanceWindowTask"),
-					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_task.target", "description", "This resource is for test purpose only"),
 				),
 			},
 		},
@@ -51,6 +49,8 @@ func TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource(t *testing.T) {
 				Config: testAccAWSSSMMaintenanceWindowTaskBasicConfigUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMMaintenanceWindowTaskExists("aws_ssm_maintenance_window_task.target", &after),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_task.target", "name", "TestMaintenanceWindowTask"),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_task.target", "description", "This resource is for test purpose only"),
 					testAccCheckAwsSsmWindowsTaskRecreated(t, &before, &after),
 				),
 			},
@@ -143,8 +143,6 @@ resource "aws_ssm_maintenance_window_task" "target" {
   task_type = "RUN_COMMAND"
   task_arn = "AWS-RunShellScript"
   priority = 1
-  name = "TestMaintenanceWindowTask"
-  description = "This resource is for test purpose only"
   service_role_arn = "${aws_iam_role.ssm_role.arn}"
   max_concurrency = "2"
   max_errors = "1"


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6715

Changes proposed in this pull request:

* r/aws_ssm_maintenance_window_task: Allow `name` and `description` arguments to be optional and not fail validation. Test with and without `name` and `description` arguments.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTask_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSSMMaintenanceWindowTask_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSSMMaintenanceWindowTask_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== CONT  TestAccAWSSSMMaintenanceWindowTask_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (137.73s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (167.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	167.123s
```