### PR TITLE
tests/provider: Temporarily use expanded data.aws_availability_zones.available.names references

### DIFF
--- a/aws/data_source_aws_autoscaling_group_test.go
+++ b/aws/data_source_aws_autoscaling_group_test.go
@@ -77,7 +77,7 @@ resource "aws_autoscaling_group" "foo" {
   desired_capacity          = 0
   force_delete              = true
   launch_configuration      = "${aws_launch_configuration.data_source_aws_autoscaling_group_test.name}"
-  availability_zones	    = ["${data.aws_availability_zones.available.names}"]
+  availability_zones	    = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
 }
 
 resource "aws_autoscaling_group" "bar" {
@@ -89,7 +89,7 @@ resource "aws_autoscaling_group" "bar" {
   desired_capacity          = 0
   force_delete              = true
   launch_configuration      = "${aws_launch_configuration.data_source_aws_autoscaling_group_test.name}"
-  availability_zones	    = ["${data.aws_availability_zones.available.names}"]
+  availability_zones	    = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
 }
 
 data "aws_autoscaling_group" "good_match" {

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -327,7 +327,7 @@ resource "aws_launch_configuration" "test" {
 }
 
 resource "aws_autoscaling_group" "test" {
-  availability_zones   = ["${data.aws_availability_zones.available.names}"]
+  availability_zones   = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
   name                 = "%s"
   max_size             = 0
   min_size             = 0

--- a/aws/resource_aws_neptune_cluster_instance_test.go
+++ b/aws/resource_aws_neptune_cluster_instance_test.go
@@ -285,7 +285,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_neptune_cluster" "default" {
   cluster_identifier 	= "tf-neptune-cluster-test-%d"
-  availability_zones 	= ["${data.aws_availability_zones.available.names}"]
+  availability_zones 	= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
   skip_final_snapshot 	= true
 }
 

--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -441,7 +441,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_rds_cluster" "default" {
   cluster_identifier = "tf-aurora-cluster-test-%d"
-  availability_zones = ["${data.aws_availability_zones.available.names}"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   database_name      = "mydb"
   master_username    = "foo"
   master_password    = "mustbeeightcharaters"

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -1848,10 +1848,7 @@ resource "aws_rds_cluster" "default" {
 
 func testAccAWSClusterConfig_EngineVersion(rInt int, engine, engineVersion string) string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {}
-
 resource "aws_rds_cluster" "test" {
-  availability_zones              = ["${data.aws_availability_zones.available.names}"]
   cluster_identifier              = "tf-acc-test-%d"
   database_name                   = "mydb"
   db_cluster_parameter_group_name = "default.aurora-postgresql9.6"
@@ -1866,11 +1863,7 @@ resource "aws_rds_cluster" "test" {
 
 func testAccAWSClusterConfig_EngineVersionWithPrimaryInstance(rInt int, engine, engineVersion string) string {
 	return fmt.Sprintf(`
-
-data "aws_availability_zones" "available" {}
-
 resource "aws_rds_cluster" "test" {
-  availability_zones              = ["${data.aws_availability_zones.available.names}"]
   cluster_identifier              = "tf-acc-test-%d"
   database_name                   = "mydb"
   db_cluster_parameter_group_name = "default.aurora-postgresql9.6"
@@ -1892,10 +1885,7 @@ resource "aws_rds_cluster_instance" "test" {
 
 func testAccAWSClusterConfig_Port(rInt, port int) string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {}
-
 resource "aws_rds_cluster" "test" {
-  availability_zones              = ["${data.aws_availability_zones.available.names}"]
   cluster_identifier              = "tf-acc-test-%d"
   database_name                   = "mydb"
   db_cluster_parameter_group_name = "default.aurora-postgresql9.6"


### PR DESCRIPTION
As well as remove extraneous references in RDS Cluster testing where possible. This change is backwards (0.11) and forwards (0.12) compatible. Its not pretty, but is a workaround for a lack of a simple cross-compatible unknown TypeList to TypeList reference until the provider test configurations are eventually migrated to 0.12 only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSAutoscalingPolicy_basic (2.89s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test226640772/main.tf line 21:
          (source code not available)

        Inappropriate value for attribute "availability_zones": element 0: string
        required.
```

Output from Terraform 0.11 acceptance testing:

```
--- PASS: TestAccAWSAutoscalingPolicy_basic (42.40s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAwsAutoScalingGroupDataSource_basic (50.28s)
--- PASS: TestAccAWSAutoscalingPolicy_disappears (44.22s)
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (48.61s)
--- PASS: TestAccAWSAutoscalingPolicy_upgrade (48.66s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (56.13s)
--- PASS: TestAccAWSAutoscalingPolicy_zerovalue (74.47s)
--- PASS: TestAccAWSAutoscalingPolicy_basic (81.88s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (84.55s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (816.01s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (67.60s)
--- PASS: TestAccAWSRDSCluster_Port (251.66s)
--- PASS: TestAccAWSRDSClusterInstance_az (817.02s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1207.86s)
```
