### PR TITLE
tests/resource/aws_batch_job_definition: Omit equals for configuration blocks

### DIFF
--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -185,10 +185,10 @@ resource "aws_batch_job_definition" "test" {
 		param1 = "val1"
 		param2 = "val2"
 	}
-	retry_strategy = {
+	retry_strategy {
 		attempts = 1
 	}
-	timeout = {
+	timeout {
 		attempt_duration_seconds = 60
 	}
 	container_properties = <<CONTAINER_PROPERTIES


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSBatchJobDefinition_basic (0.65s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "retry_strategy" is not expected here. Did you mean to define a block of type "retry_strategy"?
        - Unsupported argument: An argument named "timeout" is not expected here. Did you mean to define a block of type "timeout"?
--- FAIL: TestAccAWSBatchJobDefinition_updateForcesNewResource (0.55s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "retry_strategy" is not expected here. Did you mean to define a block of type "retry_strategy"?
        - Unsupported argument: An argument named "timeout" is not expected here. Did you mean to define a block of type "timeout"?
```

Output from Terraform 0.12 acceptance testing (new test failure will be addressed separately):

```
--- PASS: TestAccAWSBatchJobDefinition_basic (11.16s)
--- FAIL: TestAccAWSBatchJobDefinition_updateForcesNewResource (13.09s)
    testing.go:568: Step 1 error: errors during plan:

        Error: Provider produced invalid plan

        Provider "aws" has indicated "requires replacement" on
        aws_batch_job_definition.test for a non-existent attribute path
        cty.Path{cty.GetAttrStep{Name:"retry_strategy"},
        cty.IndexStep{Key:cty.NumberIntVal(0)}, cty.GetAttrStep{Name:"attempts"}}.

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```
