### PR TITLE
tests/resource/aws_batch_job_queue: Omit equals for compute_resources configuration

### DIFF
--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -307,7 +307,7 @@ resource "aws_subnet" "test_acc" {
 
 resource "aws_batch_compute_environment" "test_environment" {
   compute_environment_name = "tf_acctest_batch_compute_environment_%[1]d"
-  compute_resources = {
+  compute_resources {
     instance_role = "${aws_iam_role.aws_batch_service_role.arn}"
     instance_type = ["m3.medium"]
     max_vcpus = 1


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSBatchJobQueue_basic (0.57s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "compute_resources" is not expected here. Did you mean to define a block of type "compute_resources"?
--- FAIL: TestAccAWSBatchJobQueue_disappears (0.60s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "compute_resources" is not expected here. Did you mean to define a block of type "compute_resources"?
--- FAIL: TestAccAWSBatchJobQueue_update (0.60s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "compute_resources" is not expected here. Did you mean to define a block of type "compute_resources"?
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSBatchJobQueue_disappears (81.51s)
--- PASS: TestAccAWSBatchJobQueue_basic (89.84s)
--- PASS: TestAccAWSBatchJobQueue_update (109.29s)
```
