### PR TITLE
resource/aws_budgets_budget: Ensure cost_filters configuration uses equals while cost_types omits equals

### DIFF
--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -322,7 +322,7 @@ resource "aws_budgets_budget" "foo" {
  	limit_unit = "{{.BudgetLimit.Unit}}"
 	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
  	time_unit = "{{.TimeUnit}}"
-	cost_filters {
+	cost_filters = {
 		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
 	}
 }
@@ -342,7 +342,7 @@ resource "aws_budgets_budget" "foo" {
  	limit_unit = "{{.BudgetLimit.Unit}}"
 	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
  	time_unit = "{{.TimeUnit}}"
-	cost_filters {
+	cost_filters = {
 		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
 	}
 }
@@ -360,7 +360,7 @@ resource "aws_budgets_budget" "foo" {
 	budget_type = "{{.BudgetType}}"
  	limit_amount = "{{.BudgetLimit.Amount}}"
  	limit_unit = "{{.BudgetLimit.Unit}}"
-	cost_types = {
+	cost_types {
 		include_tax = "{{.CostTypes.IncludeTax}}"
 		include_subscription = "{{.CostTypes.IncludeSubscription}}"
 		use_blended = "{{.CostTypes.UseBlended}}"
@@ -368,7 +368,7 @@ resource "aws_budgets_budget" "foo" {
 	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
 	time_period_end = "{{.TimePeriod.End.Format "2006-01-02_15:04"}}"
  	time_unit = "{{.TimeUnit}}"
-	cost_filters {
+	cost_filters = {
 		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
 	}
 }
@@ -388,7 +388,7 @@ resource "aws_budgets_budget" "foo" {
  	limit_unit = "{{.BudgetLimit.Unit}}"
 	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
  	time_unit = "{{.TimeUnit}}"
-	cost_filters {
+	cost_filters = {
 		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
 	}
 }
@@ -406,7 +406,7 @@ resource "aws_budgets_budget" "foo" {
 	budget_type = "{{.BudgetType}}"
  	limit_amount = "{{.BudgetLimit.Amount}}"
  	limit_unit = "{{.BudgetLimit.Unit}}"
-	cost_types = {
+	cost_types {
 		include_tax = "{{.CostTypes.IncludeTax}}"
 		include_subscription = "{{.CostTypes.IncludeSubscription}}"
 		use_blended = "{{.CostTypes.UseBlended}}"
@@ -414,7 +414,7 @@ resource "aws_budgets_budget" "foo" {
 	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
 	time_period_end = "{{.TimePeriod.End.Format "2006-01-02_15:04"}}"
  	time_unit = "{{.TimeUnit}}"
-	cost_filters {
+	cost_filters = {
 		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
 	}
 }

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -22,7 +22,7 @@ resource "aws_budgets_budget" "ec2" {
   time_period_start = "2017-07-01_00:00"
   time_unit         = "MONTHLY"
 
-  cost_filters {
+  cost_filters = {
     Service = "Amazon Elastic Compute Cloud - Compute"
   }
 }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSBudgetsBudget_basic (0.42s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test927042667/main.tf:10,3-4: Invalid argument name; Argument names must not be quoted.
--- FAIL: TestAccAWSBudgetsBudget_prefix (0.44s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test644368621/main.tf:10,3-4: Invalid argument name; Argument names must not be quoted.

--- FAIL: TestAccAWSBudgetsBudget_prefix (9.75s)
    testing.go:568: Step 1 error: config is invalid: Unsupported argument: An argument named "cost_types" is not expected here. Did you mean to define a block of type "cost_types"?
--- FAIL: TestAccAWSBudgetsBudget_basic (11.52s)
    testing.go:568: Step 2 error: config is invalid: Unsupported argument: An argument named "cost_types" is not expected here. Did you mean to define a block of type "cost_types"?
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSBudgetsBudget_prefix (16.46s)
--- PASS: TestAccAWSBudgetsBudget_basic (17.97s)
```
