### PR TITLE
service/cloudformation: Ensure parameters configurations in testing and documentation use equals

### DIFF
--- a/aws/data_source_aws_cloudformation_export_test.go
+++ b/aws/data_source_aws_cloudformation_export_test.go
@@ -62,7 +62,7 @@ STACK
 }
 resource "aws_cloudformation_stack" "yaml" {
   name = "%s2"
-  parameters {
+  parameters = {
     CIDR = "10.10.10.0/24"
   }
   timeout_in_minutes = 6

--- a/aws/data_source_aws_cloudformation_stack_test.go
+++ b/aws/data_source_aws_cloudformation_stack_test.go
@@ -42,7 +42,7 @@ func testAccCheckAwsCloudFormationStackDataSourceConfig_basic(stackName string) 
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "cfs" {
   name = "%s"
-  parameters {
+  parameters = {
     CIDR = "10.10.10.0/24"
   }
   timeout_in_minutes = 6
@@ -117,7 +117,7 @@ func testAccCheckAwsCloudFormationStackDataSourceConfig_yaml(stackName string) s
 	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "yaml" {
   name = "%s"
-  parameters {
+  parameters = {
     CIDR = "10.10.10.0/24"
   }
   timeout_in_minutes = 6

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -395,7 +395,7 @@ resource "aws_cloudformation_stack" "asg-demo" {
 }
 BODY
 
-  parameters {
+  parameters = {
     TopicName = "%[1]s"
   }
 }
@@ -460,7 +460,7 @@ resource "aws_cloudformation_stack" "full" {
   }
 }
 STACK
-  parameters {
+  parameters = {
     VpcCIDR = "10.0.0.0/16"
   }
 
@@ -518,7 +518,7 @@ func testAccAWSCloudFormationStackConfig_allAttributesWithBodies_modified(stackN
 var tpl_testAccAWSCloudFormationStackConfig_withParams = `
 resource "aws_cloudformation_stack" "with_params" {
   name = "%[1]s"
-  parameters {
+  parameters = {
     VpcCIDR = "%[2]s"
   }
   template_body = <<STACK
@@ -598,7 +598,7 @@ resource "aws_s3_bucket_object" "object" {
 
 resource "aws_cloudformation_stack" "with-url-and-params" {
   name = "%[1]s"
-  parameters {
+  parameters = {
     VpcCIDR = "%[3]s"
   }
   template_url = "https://${aws_s3_bucket.b.id}.s3-us-west-2.amazonaws.com/${aws_s3_bucket_object.object.key}"
@@ -644,7 +644,7 @@ resource "aws_s3_bucket_object" "object" {
 
 resource "aws_cloudformation_stack" "with-url-and-params-and-yaml" {
   name = "%[1]s"
-  parameters {
+  parameters = {
     VpcCIDR = "%[3]s"
   }
   template_url = "https://${aws_s3_bucket.b.id}.s3-us-west-2.amazonaws.com/${aws_s3_bucket_object.object.key}"

--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -16,7 +16,7 @@ Provides a CloudFormation Stack resource.
 resource "aws_cloudformation_stack" "network" {
   name = "networking-stack"
 
-  parameters {
+  parameters = {
     VPCCidr = "10.0.0.0/16"
   }
 


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCloudFormationStack_allAttributes (0.60s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSCloudformationExportDataSource_basic (70.41s)
--- PASS: TestAccAWSCloudFormationStack_basic (63.99s)
--- PASS: TestAccAWSCloudFormationStack_defaultParams (68.18s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_basic (70.36s)
--- PASS: TestAccAWSCloudFormationStack_dataSource_yaml (78.82s)
--- PASS: TestAccAWSCloudFormationStack_allAttributes (82.00s)
--- PASS: TestAccAWSCloudFormationStack_yaml (83.42s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_withYaml (97.87s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate (115.93s)
--- PASS: TestAccAWSCloudFormationStack_withUrl_withParams (170.49s)
--- PASS: TestAccAWSCloudFormationStack_withParams (124.74s)
```
