### PR TITLE
tests/service/cloudhsmv2: Temporarily use expanded subnet_ids references

### DIFF
--- a/aws/resource_aws_cloudhsm2_cluster_test.go
+++ b/aws/resource_aws_cloudhsm2_cluster_test.go
@@ -67,7 +67,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
 
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type = "hsm1.medium"  
-  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id}"]
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
   tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-resource-basic-%d"
   }

--- a/aws/resource_aws_cloudhsm2_hsm_test.go
+++ b/aws/resource_aws_cloudhsm2_hsm_test.go
@@ -66,7 +66,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
 
 resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
   hsm_type = "hsm1.medium"  
-  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id}"]
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id[0]}", "${aws_subnet.cloudhsm2_test_subnets.*.id[1]}"]
   tags = {
     Name = "tf-acc-aws_cloudhsm_v2_hsm-resource-basic-%d"
   }


### PR DESCRIPTION
This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCloudHsm2Cluster_basic (2.23s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test557819526/main.tf line 31:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
--- FAIL: TestAccAWSCloudHsm2Hsm_basic (2.12s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test683213962/main.tf line 31:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.11 acceptance testing:

```
--- PASS: TestAccAWSCloudHsm2Cluster_basic (368.93s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSCloudHsm2Cluster_basic (328.01s)
--- PASS: TestAccAWSCloudHsm2Hsm_basic (664.43s)
```
