### PR TITLE
Feature/add tags for aws mq resources

### DIFF
--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -346,11 +346,7 @@ func resourceAwsMqBrokerRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if err = getTagsMQ(conn, d, aws.StringValue(out.BrokerArn)); err != nil {
-		return err
-	}
-
-	return nil
+	return getTagsMQ(conn, d, aws.StringValue(out.BrokerArn))
 }
 
 func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_mq_broker.go
+++ b/aws/resource_aws_mq_broker.go
@@ -203,6 +203,7 @@ func resourceAwsMqBroker() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -236,6 +237,9 @@ func resourceAwsMqBrokerCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := d.GetOk("subnet_ids"); ok {
 		input.SubnetIds = expandStringList(v.(*schema.Set).List())
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = tagsFromMapGeneric(v.(map[string]interface{}))
 	}
 
 	log.Printf("[INFO] Creating MQ Broker: %s", input)
@@ -338,8 +342,15 @@ func resourceAwsMqBrokerRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	users := flattenMqUsers(rawUsers, d.Get("user").(*schema.Set).List())
-	err = d.Set("user", users)
-	return err
+	if err = d.Set("user", users); err != nil {
+		return err
+	}
+
+	if err = getTagsMQ(conn, d, aws.StringValue(out.BrokerArn)); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -395,6 +406,10 @@ func resourceAwsMqBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if tagErr := setTagsMQ(conn, d, d.Get("arn").(string)); tagErr != nil {
+		return fmt.Errorf("error setting mq broker tags: %s", tagErr)
 	}
 
 	return nil

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -564,6 +564,46 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 	})
 }
 
+func TestAccAWSMqBroker_updateTags(t *testing.T) {
+	sgName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMqBrokerConfig_updateTags1(sgName, brokerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists("aws_mq_broker.test"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.env", "test"),
+				),
+			},
+			// Adding new user + modify existing
+			{
+				Config: testAccMqBrokerConfig_updateTags2(sgName, brokerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists("aws_mq_broker.test"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.env", "test2"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.role", "test-role"),
+				),
+			},
+			// Deleting user + modify existing
+			{
+				Config: testAccMqBrokerConfig_updateTags3(sgName, brokerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqBrokerExists("aws_mq_broker.test"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_mq_broker.test", "tags.role", "test-role"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsMqBrokerDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).mqconn
 
@@ -834,6 +874,79 @@ resource "aws_mq_broker" "test" {
     username = "second"
     password = "TestTest2222"
     groups = ["admin"]
+  }
+}`, sgName, brokerName)
+}
+
+func testAccMqBrokerConfig_updateTags1(sgName, brokerName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = "%s"
+}
+
+resource "aws_mq_broker" "test" {
+  apply_immediately = true
+  broker_name = "%s"
+  engine_type = "ActiveMQ"
+  engine_version = "5.15.0"
+  host_instance_type = "mq.t2.micro"
+	security_groups = ["${aws_security_group.test.id}"]
+  user {
+    username = "Test"
+    password = "TestTest1234"
+	}
+
+  tags {
+    env = "test"
+  }
+}`, sgName, brokerName)
+}
+
+func testAccMqBrokerConfig_updateTags2(sgName, brokerName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = "%s"
+}
+
+resource "aws_mq_broker" "test" {
+  apply_immediately = true
+  broker_name = "%s"
+  engine_type = "ActiveMQ"
+  engine_version = "5.15.0"
+  host_instance_type = "mq.t2.micro"
+	security_groups = ["${aws_security_group.test.id}"]
+  user {
+    username = "Test"
+    password = "TestTest1234"
+	}
+
+  tags {
+		env = "test2"
+		role = "test-role"
+  }
+}`, sgName, brokerName)
+}
+
+func testAccMqBrokerConfig_updateTags3(sgName, brokerName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = "%s"
+}
+
+resource "aws_mq_broker" "test" {
+  apply_immediately = true
+  broker_name = "%s"
+  engine_type = "ActiveMQ"
+  engine_version = "5.15.0"
+  host_instance_type = "mq.t2.micro"
+	security_groups = ["${aws_security_group.test.id}"]
+  user {
+    username = "Test"
+    password = "TestTest1234"
+	}
+
+  tags {
+		role = "test-role"
   }
 }`, sgName, brokerName)
 }

--- a/aws/resource_aws_mq_configuration.go
+++ b/aws/resource_aws_mq_configuration.go
@@ -67,6 +67,7 @@ func resourceAwsMqConfiguration() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -78,6 +79,10 @@ func resourceAwsMqConfigurationCreate(d *schema.ResourceData, meta interface{}) 
 		EngineType:    aws.String(d.Get("engine_type").(string)),
 		EngineVersion: aws.String(d.Get("engine_version").(string)),
 		Name:          aws.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = tagsFromMapGeneric(v.(map[string]interface{}))
 	}
 
 	log.Printf("[INFO] Creating MQ Configuration: %s", input)
@@ -130,6 +135,10 @@ func resourceAwsMqConfigurationRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("data", string(b))
 
+	if err = getTagsMQ(conn, d, aws.StringValue(out.Arn)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -151,6 +160,10 @@ func resourceAwsMqConfigurationUpdate(d *schema.ResourceData, meta interface{}) 
 	_, err := conn.UpdateConfiguration(&input)
 	if err != nil {
 		return err
+	}
+
+	if tagErr := setTagsMQ(conn, d, d.Get("arn").(string)); tagErr != nil {
+		return fmt.Errorf("error setting mq configuration tags: %s", err)
 	}
 
 	return resourceAwsMqConfigurationRead(d, meta)

--- a/aws/resource_aws_mq_configuration.go
+++ b/aws/resource_aws_mq_configuration.go
@@ -135,11 +135,7 @@ func resourceAwsMqConfigurationRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("data", string(b))
 
-	if err = getTagsMQ(conn, d, aws.StringValue(out.Arn)); err != nil {
-		return err
-	}
-
-	return nil
+	return getTagsMQ(conn, d, aws.StringValue(out.Arn))
 }
 
 func resourceAwsMqConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -71,6 +71,43 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 	})
 }
 
+func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
+	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMqConfigurationConfig_updateTags1(configurationName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
+					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.env", "test"),
+				),
+			},
+			{
+				Config: testAccMqConfigurationConfig_updateTags2(configurationName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
+					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.env", "test2"),
+					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.role", "test-role"),
+				),
+			},
+			{
+				Config: testAccMqConfigurationConfig_updateTags3(configurationName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsMqConfigurationExists("aws_mq_configuration.test"),
+					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_mq_configuration.test", "tags.role", "test-role"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsMqConfigurationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).mqconn
 
@@ -170,5 +207,63 @@ resource "aws_mq_configuration" "test" {
   </plugins>
 </broker>
 DATA
+}`, configurationName)
+}
+
+func testAccMqConfigurationConfig_updateTags1(configurationName string) string {
+	return fmt.Sprintf(`
+resource "aws_mq_configuration" "test" {
+  description = "TfAccTest MQ Configuration"
+  name = "%s"
+  engine_type = "ActiveMQ"
+  engine_version = "5.15.0"
+  data = <<DATA
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<broker xmlns="http://activemq.apache.org/schema/core">
+</broker>
+DATA
+
+	tags {
+		env = "test"
+	}
+}`, configurationName)
+}
+
+func testAccMqConfigurationConfig_updateTags2(configurationName string) string {
+	return fmt.Sprintf(`
+resource "aws_mq_configuration" "test" {
+  description = "TfAccTest MQ Configuration"
+  name = "%s"
+  engine_type = "ActiveMQ"
+  engine_version = "5.15.0"
+  data = <<DATA
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<broker xmlns="http://activemq.apache.org/schema/core">
+</broker>
+DATA
+
+	tags {
+		env = "test2"
+		role = "test-role"
+	}
+}`, configurationName)
+}
+
+func testAccMqConfigurationConfig_updateTags3(configurationName string) string {
+	return fmt.Sprintf(`
+resource "aws_mq_configuration" "test" {
+  description = "TfAccTest MQ Configuration"
+  name = "%s"
+  engine_type = "ActiveMQ"
+  engine_version = "5.15.0"
+  data = <<DATA
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<broker xmlns="http://activemq.apache.org/schema/core">
+</broker>
+DATA
+
+	tags {
+		role = "test-role"
+	}
 }`, configurationName)
 }

--- a/aws/tagsMQ.go
+++ b/aws/tagsMQ.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mq"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// getTags is a helper to get the tags for a resource. It expects the
+// tags field to be named "tags"
+func getTagsMQ(conn *mq.MQ, d *schema.ResourceData, arn string) error {
+	resp, err := conn.ListTags(&mq.ListTagsInput{
+		ResourceArn: aws.String(arn),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("tags", tagsToMapGeneric(resp.Tags)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsMQ(conn *mq.MQ, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsGeneric(o, n)
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			keys := make([]*string, 0, len(remove))
+			for k := range remove {
+				keys = append(keys, aws.String(k))
+			}
+
+			_, err := conn.DeleteTags(&mq.DeleteTagsInput{
+				ResourceArn: aws.String(arn),
+				TagKeys:     keys,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+
+			_, err := conn.CreateTags(&mq.CreateTagsInput{
+				ResourceArn: aws.String(arn),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -67,6 +67,7 @@ The following arguments are supported:
 * `maintenance_window_start_time` - (Optional) Maintenance window start time. See below.
 * `logs` - (Optional) Logging configuration of the broker. See below.
 * `user` - (Optional) The list of all ActiveMQ usernames for the specified broker. See below.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ### Nested Fields
 

--- a/website/docs/r/mq_configuration.html.markdown
+++ b/website/docs/r/mq_configuration.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `engine_type` - (Required) The type of broker engine.
 * `engine_version` - (Required) The version of the broker engine.
 * `name` - (Required) The name of the configuration
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6740

Changes proposed in this pull request:

* Add mq broker tags
* Add mq configuration tags

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMqBroker_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSMqBroker_ -timeout 120m
=== RUN   TestAccAWSMqBroker_basic
=== PAUSE TestAccAWSMqBroker_basic
=== RUN   TestAccAWSMqBroker_allFieldsDefaultVpc
=== PAUSE TestAccAWSMqBroker_allFieldsDefaultVpc
=== RUN   TestAccAWSMqBroker_allFieldsCustomVpc
=== PAUSE TestAccAWSMqBroker_allFieldsCustomVpc
=== RUN   TestAccAWSMqBroker_updateUsers
=== PAUSE TestAccAWSMqBroker_updateUsers
=== RUN   TestAccAWSMqBroker_updateTags
=== PAUSE TestAccAWSMqBroker_updateTags
=== CONT  TestAccAWSMqBroker_basic
=== CONT  TestAccAWSMqBroker_allFieldsCustomVpc
=== CONT  TestAccAWSMqBroker_allFieldsDefaultVpc
=== CONT  TestAccAWSMqBroker_updateTags
=== CONT  TestAccAWSMqBroker_updateUsers
--- PASS: TestAccAWSMqBroker_basic (985.07s)
--- PASS: TestAccAWSMqBroker_updateUsers (1389.87s)
--- PASS: TestAccAWSMqBroker_updateTags (1523.68s)
--- PASS: TestAccAWSMqBroker_allFieldsDefaultVpc (2086.34s)
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (2109.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	2109.099s
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMqConfiguration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSMqConfiguration_ -timeout 120m
=== RUN   TestAccAWSMqConfiguration_basic
=== PAUSE TestAccAWSMqConfiguration_basic
=== RUN   TestAccAWSMqConfiguration_withData
=== PAUSE TestAccAWSMqConfiguration_withData
=== RUN   TestAccAWSMqConfiguration_updateTags
=== PAUSE TestAccAWSMqConfiguration_updateTags
=== CONT  TestAccAWSMqConfiguration_basic
=== CONT  TestAccAWSMqConfiguration_updateTags
=== CONT  TestAccAWSMqConfiguration_withData
--- PASS: TestAccAWSMqConfiguration_withData (24.75s)
--- PASS: TestAccAWSMqConfiguration_basic (38.48s)
--- PASS: TestAccAWSMqConfiguration_updateTags (52.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	52.318s
```
