### PR TITLE
Add support for AutoScaling Scaling Policy Import

### DIFF
--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -19,6 +20,9 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 		Read:   resourceAwsAutoscalingPolicyRead,
 		Update: resourceAwsAutoscalingPolicyUpdate,
 		Delete: resourceAwsAutoscalingPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsAutoscalingPolicyImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {
@@ -274,6 +278,22 @@ func resourceAwsAutoscalingPolicyDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
+}
+
+func resourceAwsAutoscalingPolicyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format (%q), expected <asg-name>/<policy-name>", d.Id())
+	}
+
+	asgName := idParts[0]
+	policyName := idParts[1]
+
+	d.Set("name", policyName)
+	d.Set("autoscaling_group_name", asgName)
+	d.SetId(policyName)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 // PutScalingPolicy can safely resend all parameters without destroying the

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -55,6 +55,12 @@ func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_autoscaling_policy.foobar_simple",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.foobar_simple"),
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSAutoscalingPolicyConfig_basicUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
@@ -304,6 +310,17 @@ func testAccCheckAWSAutoscalingPolicyDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSAutoscalingPolicyImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["autoscaling_group_name"], rs.Primary.Attributes["name"]), nil
+	}
 }
 
 func testAccAWSAutoscalingPolicyConfig_base(name string) string {

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -157,3 +157,11 @@ The following arguments are supported for backwards compatibility but should not
 * `autoscaling_group_name` - The scaling policy's assigned autoscaling group.
 * `adjustment_type` - The scaling policy's adjustment type.
 * `policy_type` - The scaling policy's type.
+
+## Import
+
+AutoScaling scaling policy can be imported using the role autoscaling_group_name and name separated by `/`.
+
+```
+$ terraform import aws_autoscaling_policy.test-policy asg-name/policy-name
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #6578

Changes proposed in this pull request:

* Add import support for `aws_autoscaling_policy`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAutoscalingPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAutoscalingPolicy_basic -timeout 120m
=== RUN   TestAccAWSAutoscalingPolicy_basic
=== PAUSE TestAccAWSAutoscalingPolicy_basic
=== CONT  TestAccAWSAutoscalingPolicy_basic
--- PASS: TestAccAWSAutoscalingPolicy_basic (95.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	95.539s
```
