### PR TITLE
Fixing TestAccDataSourceCloudHsm2Cluster_basic for 0.12

### DIFF
--- a/aws/data_source_aws_cloudhsm2_cluster_test.go
+++ b/aws/data_source_aws_cloudhsm2_cluster_test.go
@@ -61,7 +61,7 @@ resource "aws_subnet" "cloudhsm2_test_subnets" {
 
 resource "aws_cloudhsm_v2_cluster" "cluster" {
   hsm_type = "hsm1.medium"  
-  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.*.id}"]
+  subnet_ids = ["${aws_subnet.cloudhsm2_test_subnets.0.id}", "${aws_subnet.cloudhsm2_test_subnets.1.id}"]
   tags = {
     Name = "tf-acc-aws_cloudhsm_v2_cluster-data-source-basic-%d"
   }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceCloudHsm2Cluster_basic (4.60s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test424929787/main.tf line 31:
          (source code not available)
        
        Inappropriate value for attribute "subnet_ids": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: Incorrect attribute value type: Inappropriate value for attribute "subnet_ids": element 0: string required.
        
        State: <nil>
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
=== RUN   TestAccDataSourceCloudHsm2Cluster_basic
--- PASS: TestAccDataSourceCloudHsm2Cluster_basic (281.24s)
```
