### PR TITLE
fixing TestAccDataSourceAWSMqBroker for 0.12

### DIFF
--- a/aws/data_source_aws_mq_broker_test.go
+++ b/aws/data_source_aws_mq_broker_test.go
@@ -168,8 +168,8 @@ resource "aws_mq_broker" "acctest" {
   }
 
   publicly_accessible = true
-  security_groups     = ["${aws_security_group.acctest.*.id}"]
-  subnet_ids          = ["${aws_subnet.acctest.*.id}"]
+  security_groups     = ["${aws_security_group.acctest.0.id}", "${aws_security_group.acctest.1.id}"]
+  subnet_ids          = ["${aws_subnet.acctest.0.id}", "${aws_subnet.acctest.1.id}"]
 
   user {
     username = "Ender"


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
=== CONT  TestAccDataSourceAWSMqBroker_basic
--- FAIL: TestAccDataSourceAWSMqBroker_basic (2.83s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test708940181/main.tf line 86:
          (source code not available)
        
        Inappropriate value for attribute "security_groups": element 0: string
        required.
        
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test708940181/main.tf line 87:
          (source code not available)
        
        Inappropriate value for attribute "subnet_ids": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: 2 problems:
        
        - Incorrect attribute value type: Inappropriate value for attribute "subnet_ids": element 0: string required.
        - Incorrect attribute value type: Inappropriate value for attribute "security_groups": element 0: string required.
        
        State: <nil>
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
=== RUN   TestAccDataSourceAWSMqBroker_basic
=== PAUSE TestAccDataSourceAWSMqBroker_basic
=== CONT  TestAccDataSourceAWSMqBroker_basic
--- PASS: TestAccDataSourceAWSMqBroker_basic (1340.01s)
```
