### PR TITLE
Fixing TestAccDataSourceAWSLBTargetGroup for 0.12

### DIFF
--- a/aws/data_source_aws_lb_target_group_test.go
+++ b/aws/data_source_aws_lb_target_group_test.go
@@ -138,7 +138,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.0.id}", "${aws_subnet.alb_test.1.id}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -246,7 +246,7 @@ resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.0.id}", "${aws_subnet.alb_test.1.id}"]
 
   idle_timeout = 30
   enable_deletion_protection = false


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility (2.63s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test399426904/main.tf line 16:
          (source code not available)
        
        Inappropriate value for attribute "subnets": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: 2 problems:
        
        - Error retrieving LB Target Group: TargetGroupNotFound: One or more target groups not found
        	status code: 400, request id: 64246854-1926-11e9-9402-f1e834e4469f
        - Incorrect attribute value type: Inappropriate value for attribute "subnets": element 0: string required.
        
        State: <nil>
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility (227.27s)
```
