### PR TITLE
Fixing TestAccDataSourceAWSLBListener for 0.12

### DIFF
--- a/aws/data_source_aws_lb_listener_test.go
+++ b/aws/data_source_aws_lb_listener_test.go
@@ -122,7 +122,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.0.id}", "${aws_subnet.alb_test.1.id}"]
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -241,7 +241,7 @@ resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.0.id}", "${aws_subnet.alb_test.1.id}"]
 
   idle_timeout               = 30
   enable_deletion_protection = false
@@ -349,7 +349,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = false
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.0.id}", "${aws_subnet.alb_test.1.id}"]
 
   idle_timeout               = 30
   enable_deletion_protection = false


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAWSLBListener_BackwardsCompatibility (2.35s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test875255022/main.tf line 17:
          (source code not available)
        
        Inappropriate value for attribute "subnets": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: Incorrect attribute value type: Inappropriate value for attribute "subnets": element 0: string required.
        
        State: <nil>
FAIL
--- FAIL: TestAccDataSourceAWSLBListener_basic (2.37s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test108929042/main.tf line 17:
          (source code not available)
        
        Inappropriate value for attribute "subnets": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: Incorrect attribute value type: Inappropriate value for attribute "subnets": element 0: string required.
        
        State: <nil>
FAIL
--- FAIL: TestAccDataSourceAWSLBListener_https (2.41s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test612674486/main.tf line 19:
          (source code not available)
        
        Inappropriate value for attribute "subnets": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: Incorrect attribute value type: Inappropriate value for attribute "subnets": element 0: string required.
        
        State: <nil>
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccDataSourceAWSLBListener_https (206.40s)
--- PASS: TestAccDataSourceAWSLBListener_BackwardsCompatibility (225.18s)
--- PASS: TestAccDataSourceAWSLBListener_basic (226.98s)
```
