### PR TITLE
Fixing tests for TestAccDataSourceAWSLB 0.12

### DIFF
--- a/aws/data_source_aws_lb_test.go
+++ b/aws/data_source_aws_lb_test.go
@@ -93,7 +93,7 @@ func testAccDataSourceAWSLBConfigBasic(lbName string) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.0.id}", "${aws_subnet.alb_test.1.id}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -168,7 +168,7 @@ func testAccDataSourceAWSLBConfigBackardsCompatibility(albName string) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.0.id}", "${aws_subnet.alb_test.1.id}"]
 
   idle_timeout = 30
   enable_deletion_protection = false


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAWSLB_basic (2.43s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test055385227/main.tf line 5:
          (source code not available)
        
        Inappropriate value for attribute "subnets": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: Incorrect attribute value type: Inappropriate value for attribute "subnets": element 0: string required.
        
        State: <nil>
FAIL
--- FAIL: TestAccDataSourceAWSLBTargetGroupBackwardsCompatibility (2.63s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test399426904/main.tf line 16:
          (source code not available)
        
        Inappropriate value for attribute "subnets": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: 2 problems:
        
        - Error retrieving LB Target Group: TargetGroupNotFound: One or more target groups not found
        	status code: 400, request id: 64246854-1926-11e9-9402-f1e834e4469f
        - Incorrect attribute value type: Inappropriate value for attribute "subnets": element 0: string required.
        
        State: <nil>
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccDataSourceAWSLB_basic (226.75s)
--- PASS: TestAccDataSourceAWSLBBackwardsCompatibility (237.46s)
```
