### PR TITLE
Fixing TestAccDataSourceAWSELB for 0.12

### DIFF
--- a/aws/data_source_aws_elb_test.go
+++ b/aws/data_source_aws_elb_test.go
@@ -41,7 +41,7 @@ resource "aws_elb" "elb_test" {
   name            = "%[1]s"
   internal        = true
   security_groups = ["${aws_security_group.elb_test.id}"]
-  subnets         = ["${aws_subnet.elb_test.*.id}"]
+  subnets         = ["${aws_subnet.elb_test.0.id}", "${aws_subnet.elb_test.1.id}"]
 
   idle_timeout = 30
 


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAWSELB_basic (2.74s)
    testing.go:568: Step 0 error: errors during plan:
        
        Error: Incorrect attribute value type
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test301829939/main.tf line 6:
          (source code not available)
        
        Inappropriate value for attribute "subnets": element 0: string required.
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: Incorrect attribute value type: Inappropriate value for attribute "subnets": element 0: string required.
        
        State: <nil>
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccDataSourceAWSELB_basic (37.31s)
```
