### PR TITLE
Fixing global rds by allowing for optional parameters on cluster

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -712,12 +712,15 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 	} else {
-		if _, ok := d.GetOk("master_password"); !ok {
-			return fmt.Errorf(`provider.aws: aws_rds_cluster: %s: "master_password": required field is not set`, d.Get("database_name").(string))
-		}
 
-		if _, ok := d.GetOk("master_username"); !ok {
-			return fmt.Errorf(`provider.aws: aws_rds_cluster: %s: "master_username": required field is not set`, d.Get("database_name").(string))
+		if _, ok := d.GetOk("global_cluster_identifier"); !ok {
+			if _, ok := d.GetOk("master_password"); !ok {
+				return fmt.Errorf(`provider.aws: aws_db_instance: %s: "master_password": required field is not set`, d.Get("name").(string))
+			}
+
+			if _, ok := d.GetOk("master_username"); !ok {
+				return fmt.Errorf(`provider.aws: aws_db_instance: %s: "master_username": required field is not set`, d.Get("name").(string))
+			}
 		}
 
 		createOpts := &rds.CreateDBClusterInput{
@@ -725,10 +728,16 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			DeletionProtection:   aws.Bool(d.Get("deletion_protection").(bool)),
 			Engine:               aws.String(d.Get("engine").(string)),
 			EngineMode:           aws.String(d.Get("engine_mode").(string)),
-			MasterUserPassword:   aws.String(d.Get("master_password").(string)),
-			MasterUsername:       aws.String(d.Get("master_username").(string)),
 			ScalingConfiguration: expandRdsScalingConfiguration(d.Get("scaling_configuration").([]interface{})),
 			Tags:                 tags,
+		}
+
+		if v, ok := d.GetOk("master_password"); ok && v.(string) != "" {
+			createOpts.MasterUserPassword = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("master_username"); ok && v.(string) != "" {
+			createOpts.MasterUsername = aws.String(v.(string))
 		}
 
 		// Need to check value > 0 due to:
@@ -783,6 +792,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("kms_key_id"); ok {
 			createOpts.KmsKeyId = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("source_region"); ok {
+			createOpts.SourceRegion = aws.String(attr.(string))
 		}
 
 		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -701,7 +701,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Add(t *testing.T) {
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRDSClusterConfig_EngineMode(rName, "global"),
+				Config: testAccAWSRDSClusterConfig_GlobalEngineMode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttr(resourceName, "global_cluster_identifier", ""),
@@ -735,7 +735,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSRDSClusterConfig_EngineMode(rName, "global"),
+				Config: testAccAWSRDSClusterConfig_GlobalEngineMode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
 					resource.TestCheckResourceAttr(resourceName, "global_cluster_identifier", ""),
@@ -2250,6 +2250,22 @@ resource "aws_rds_cluster" "test" {
 `, rName, deletionProtection)
 }
 
+func testAccAWSRDSClusterConfig_GlobalEngineMode(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_rds_cluster" "test" {
+  depends_on		   = ["aws_db_subnet_group.dbsubnet"]
+  cluster_identifier   = %q
+  engine_mode          = "global"
+  db_subnet_group_name = %q
+  master_password      = "barbarbarbar"
+  master_username      = "foo"
+  skip_final_snapshot  = true
+}
+`, testAccAWSRDSClusterConfig_GlobalNetwork(rName), rName, rName)
+}
+
 func testAccAWSRDSClusterConfig_EngineMode(rName, engineMode string) string {
 	return fmt.Sprintf(`
 resource "aws_rds_cluster" "test" {
@@ -2262,25 +2278,59 @@ resource "aws_rds_cluster" "test" {
 `, rName, engineMode)
 }
 
+func testAccAWSRDSClusterConfig_GlobalNetwork(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "azs" { }
+
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+  	Name = "terraform-acctest-rds-cluster-global-cross-region"
+  }
+}
+
+resource "aws_subnet" "subnets" {
+  count             = 2
+  vpc_id            = "${aws_vpc.vpc.id}"
+  availability_zone = "${data.aws_availability_zones.azs.names[count.index]}"
+  cidr_block        = "10.0.${count.index}.0/24"
+  tags = {
+    Name = "tf-acc-rds-cluster-global-cross-region-replica-${count.index}"
+  }
+}
+
+resource "aws_db_subnet_group" "dbsubnet" {
+  name       = %q
+  subnet_ids = ["${aws_subnet.subnets.*.id}"]
+}`, rName)
+
+}
+
 func testAccAWSRDSClusterConfig_GlobalClusterIdentifier(rName string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "aws_rds_global_cluster" "test" {
   global_cluster_identifier = %q
 }
 
 resource "aws_rds_cluster" "test" {
+  depends_on				= ["aws_db_subnet_group.dbsubnet"]
   cluster_identifier        = %q
   global_cluster_identifier = "${aws_rds_global_cluster.test.id}"
   engine_mode               = "global"
   master_password           = "barbarbarbar"
   master_username           = "foo"
   skip_final_snapshot       = true
+  db_subnet_group_name      = "${aws_db_subnet_group.dbsubnet.name}"
 }
-`, rName, rName)
+`, testAccAWSRDSClusterConfig_GlobalNetwork(rName), rName, rName)
 }
 
 func testAccAWSRDSClusterConfig_GlobalClusterIdentifier_Update(rName, globalClusterIdentifierResourceName string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "aws_rds_global_cluster" "test" {
   count = 2
 
@@ -2288,14 +2338,16 @@ resource "aws_rds_global_cluster" "test" {
 }
 
 resource "aws_rds_cluster" "test" {
+  depends_on				= ["aws_db_subnet_group.dbsubnet"]
   cluster_identifier        = %q
   global_cluster_identifier = "${%s.id}"
   engine_mode               = "global"
   master_password           = "barbarbarbar"
   master_username           = "foo"
   skip_final_snapshot       = true
+  db_subnet_group_name      = %q
 }
-`, rName, rName, globalClusterIdentifierResourceName)
+`, testAccAWSRDSClusterConfig_GlobalNetwork(rName), rName, rName, globalClusterIdentifierResourceName, rName)
 }
 
 func testAccAWSRDSClusterConfig_ScalingConfiguration(rName string, autoPause bool, maxCapacity, minCapacity, secondsUntilAutoPause int) string {

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -85,9 +85,9 @@ The following arguments are supported:
 * `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifer`.
 * `database_name` - (Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5]
 * `deletion_protection` - (Optional) If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
-* `master_password` - (Required unless a `snapshot_identifier` is provided) Password for the master DB user. Note that this may
+* `master_password` - (Required unless a `snapshot_identifier` or `global_cluster_identifier` is provided) Password for the master DB user. Note that this may
     show up in logs, and it will be stored in the state file. Please refer to the [RDS Naming Constraints][5]
-* `master_username` - (Required unless a `snapshot_identifier` is provided) Username for the master DB user. Please refer to the [RDS Naming Constraints][5]
+* `master_username` - (Required unless a `snapshot_identifier` or `global_cluster_identifier` is provided) Username for the master DB user. Please refer to the [RDS Naming Constraints][5]
 * `final_snapshot_identifier` - (Optional) The name of your final DB snapshot
     when this DB cluster is deleted. If omitted, no final snapshot will be
     made.
@@ -103,6 +103,7 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
   with the Cluster
 * `snapshot_identifier` - (Optional) Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot.
+* `global_cluster_identifier` - (Optional) The global cluster identifier specified on [`aws_rds_global_cluster`](/docs/providers/aws/r/rds_global_cluster.html).
 * `storage_encrypted` - (Optional) Specifies whether the DB cluster is encrypted. The default is `false` for `provisioned` `engine_mode` and `true` for `serverless` `engine_mode`.
 * `replication_source_identifier` - (Optional) ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications


### PR DESCRIPTION
Fixes #7212 and  #7020

TBD: Add global acc test

Changes proposed in this pull request:

* Change 1
Allow username and password to be optional when using a global cluster identifier
* Change 2
Allow source region and global cluster identifier to be set for secondary region to come online

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestAccAWSRDSCluster_GlobalClusterIdentifier'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRDSCluster_GlobalClusterIdentifier -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Add (218.57s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Update (218.81s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier (243.67s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove (250.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	250.852s

...
```
