### PR TITLE
Fix to use expandStringList function for group_names and notifications

### DIFF
--- a/aws/resource_aws_autoscaling_notification.go
+++ b/aws/resource_aws_autoscaling_notification.go
@@ -43,8 +43,8 @@ func resourceAwsAutoscalingNotification() *schema.Resource {
 
 func resourceAwsAutoscalingNotificationCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
-	gl := convertSetToList(d.Get("group_names").(*schema.Set))
-	nl := convertSetToList(d.Get("notifications").(*schema.Set))
+	gl := expandStringList(d.Get("group_names").(*schema.Set).List())
+	nl := expandStringList(d.Get("notifications").(*schema.Set).List())
 
 	topic := d.Get("topic_arn").(string)
 	if err := addNotificationConfigToGroupsWithTopic(conn, gl, nl, topic); err != nil {
@@ -59,7 +59,7 @@ func resourceAwsAutoscalingNotificationCreate(d *schema.ResourceData, meta inter
 
 func resourceAwsAutoscalingNotificationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
-	gl := convertSetToList(d.Get("group_names").(*schema.Set))
+	gl := expandStringList(d.Get("group_names").(*schema.Set).List())
 
 	opts := &autoscaling.DescribeNotificationConfigurationsInput{
 		AutoScalingGroupNames: gl,
@@ -120,7 +120,7 @@ func resourceAwsAutoscalingNotificationUpdate(d *schema.ResourceData, meta inter
 
 	// Notifications API call is a PUT, so we don't need to diff the list, just
 	// push whatever it is and AWS sorts it out
-	nl := convertSetToList(d.Get("notifications").(*schema.Set))
+	nl := expandStringList(d.Get("notifications").(*schema.Set).List())
 
 	o, n := d.GetChange("group_names")
 	if o == nil {
@@ -130,10 +130,8 @@ func resourceAwsAutoscalingNotificationUpdate(d *schema.ResourceData, meta inter
 		n = new(schema.Set)
 	}
 
-	os := o.(*schema.Set)
-	ns := n.(*schema.Set)
-	remove := convertSetToList(os.Difference(ns))
-	add := convertSetToList(ns.Difference(os))
+	remove := expandStringList(o.(*schema.Set).List())
+	add := expandStringList(n.(*schema.Set).List())
 
 	topic := d.Get("topic_arn").(string)
 
@@ -143,7 +141,7 @@ func resourceAwsAutoscalingNotificationUpdate(d *schema.ResourceData, meta inter
 
 	var update []*string
 	if d.HasChange("notifications") {
-		update = convertSetToList(d.Get("group_names").(*schema.Set))
+		update = expandStringList(d.Get("group_names").(*schema.Set).List())
 	} else {
 		update = add
 	}
@@ -191,18 +189,10 @@ func removeNotificationConfigToGroupsWithTopic(conn *autoscaling.AutoScaling, gr
 
 func resourceAwsAutoscalingNotificationDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).autoscalingconn
-	gl := convertSetToList(d.Get("group_names").(*schema.Set))
+
+	gl := expandStringList(d.Get("group_names").(*schema.Set).List())
 
 	topic := d.Get("topic_arn").(string)
 	err := removeNotificationConfigToGroupsWithTopic(conn, gl, topic)
 	return err
-}
-
-func convertSetToList(s *schema.Set) (nl []*string) {
-	l := s.List()
-	for _, n := range l {
-		nl = append(nl, aws.String(n.(string)))
-	}
-
-	return nl
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
No issue.

Changes proposed in this pull request:

* Fix to use `expandStringList` at [aws/structure.go#L924-L933](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/structure.go#L924-L933)
  * `expandStringList` can skip unexpected value like #6435

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSASGNotification_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSASGNotification_ -timeout 120m
=== RUN   TestAccAWSASGNotification_basic
=== PAUSE TestAccAWSASGNotification_basic
=== RUN   TestAccAWSASGNotification_update
=== PAUSE TestAccAWSASGNotification_update
=== RUN   TestAccAWSASGNotification_Pagination
=== PAUSE TestAccAWSASGNotification_Pagination
=== CONT  TestAccAWSASGNotification_basic
=== CONT  TestAccAWSASGNotification_Pagination
=== CONT  TestAccAWSASGNotification_update
--- PASS: TestAccAWSASGNotification_Pagination (145.24s)
--- PASS: TestAccAWSASGNotification_basic (183.25s)
--- PASS: TestAccAWSASGNotification_update (243.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	243.467s
```
