### PR TITLE
Fixing TestAccAWSUserLoginProfile for 0.12

### DIFF
--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -112,7 +113,7 @@ func checkIAMPwdPolicy(pass []byte) bool {
 func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	encryptionKey, err := encryption.RetrieveGPGKey(d.Get("pgp_key").(string))
+	encryptionKey, err := encryption.RetrieveGPGKey(strings.TrimSpace(d.Get("pgp_key").(string)))
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -310,7 +310,8 @@ resource "aws_iam_user_login_profile" "user" {
   user            = "${aws_iam_user.user.name}"
   password_length = %d
   pgp_key         = <<EOF
-%sEOF
+%s
+EOF
 }
 `, testAccAWSUserLoginProfileConfig_base(rName, path), passwordLength, pgpKey)
 }
@@ -322,7 +323,8 @@ func testAccAWSUserLoginProfileConfig_Required(rName, path, pgpKey string) strin
 resource "aws_iam_user_login_profile" "user" {
   user    = "${aws_iam_user.user.name}"
   pgp_key = <<EOF
-%sEOF
+%s
+EOF
 }
 `, testAccAWSUserLoginProfileConfig_base(rName, path), pgpKey)
 }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSUserLoginProfile_notAKey (0.45s)
    testing.go:561: Step 0, expected error:
        
        Unterminated template string: On /opt/teamcity-agent/temp/buildTmp/tf-test212308321/main.tf line 40: No closing marker was found for the string.
        
        To match:
        
        Error encrypting Password
        
        
FAIL
--- FAIL: TestAccAWSUserLoginProfile_keybaseDoesntExist (0.47s)
    testing.go:561: Step 0, expected error:
        
        Unterminated template string: On /opt/teamcity-agent/temp/buildTmp/tf-test385575677/main.tf line 40: No closing marker was found for the string.
        
        To match:
        
        Error retrieving Public Key
        
        
FAIL
--- FAIL: TestAccAWSUserLoginProfile_keybase (0.53s)
    testing.go:568: Step 0 error: Unterminated template string: On /opt/teamcity-agent/temp/buildTmp/tf-test049866227/main.tf line 40: No closing marker was found for the string.
FAIL
--- FAIL: TestAccAWSUserLoginProfile_basic (0.54s)
    testing.go:568: Step 0 error: Unterminated template string: On /opt/teamcity-agent/temp/buildTmp/tf-test700240308/main.tf line 65: No closing marker was found for the string.
FAIL
--- FAIL: TestAccAWSUserLoginProfile_PasswordLength (0.46s)
    testing.go:568: Step 0 error: Unterminated template string: On /opt/teamcity-agent/temp/buildTmp/tf-test243469318/main.tf line 66: No closing marker was found for the string.
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccAWSUserLoginProfile_notAKey (11.61s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (12.21s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (25.74s)
--- PASS: TestAccAWSUserLoginProfile_keybase (26.12s)
--- PASS: TestAccAWSUserLoginProfile_basic (34.55s)
```
