### PR TITLE
Fixing TestAccAWSTransferServer for 0.12

### DIFF
--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -300,7 +300,7 @@ resource "aws_transfer_server" "foo" {
   identity_provider_type = "SERVICE_MANAGED"
   logging_role = "${aws_iam_role.foo.arn}"
 
-  tags {
+  tags = {
 	NAME   = "tf-acc-test-transfer-server"
 	ENV    = "test"
   }
@@ -412,7 +412,7 @@ resource "aws_transfer_server" "foo" {
 	invocation_role 	   	= "${aws_iam_role.foo.arn}"
 	logging_role 		   	= "${aws_iam_role.foo.arn}"
 
-	tags {
+	tags = {
 	  NAME     = "tf-acc-test-transfer-server"
 	  TYPE	   = "apigateway"
 	}


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSTransferServer_basic (4.99s)
    testing.go:568: Step 2 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
        
        State: aws_transfer_server.foo:
          ID = s-eb4eaedbf546445f9
          arn = arn:aws:transfer:us-west-2:*******:server/s-eb4eaedbf546445f9
          endpoint = s-eb4eaedbf546445f9.server.transfer.us-west-2.amazonaws.com
          force_destroy = false
          identity_provider_type = SERVICE_MANAGED
          invocation_role = 
          logging_role = 
          url =
FAIL
--- FAIL: TestAccAWSTransferServer_apigateway (0.69s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccAWSTransferServer_disappears (9.53s)
--- PASS: TestAccAWSTransferServer_forcedestroy (14.33s)
--- PASS: TestAccAWSTransferServer_apigateway (16.98s)
--- PASS: TestAccAWSTransferServer_basic (22.23s)
```
