### PR TITLE
fixing TestAccAWSTransferUser for 0.12

### DIFF
--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -207,7 +207,7 @@ func testAccAWSTransferUserConfig_basic(rName string) string {
 resource "aws_transfer_server" "foo" {
 	identity_provider_type = "SERVICE_MANAGED"
 
-	tags {
+	tags = {
 		NAME     = "tf-acc-test-transfer-server"
 	}
 }
@@ -265,7 +265,7 @@ func testAccAWSTransferUserConfig_options(rName string) string {
 resource "aws_transfer_server" "foo" {
 	identity_provider_type = "SERVICE_MANAGED"
 	
-	tags {
+	tags = {
 		NAME     = "tf-acc-test-transfer-server"
 	}
 }
@@ -359,7 +359,7 @@ resource "aws_transfer_user" "foo" {
 	policy         = "${data.aws_iam_policy_document.foo.json}"
 	home_directory = "/home/tftestuser"
 
-	tags {
+	tags = {
 		NAME  = "tftestuser"
 		ENV   = "test"
 		ADMIN = "test"
@@ -375,7 +375,7 @@ func testAccAWSTransferUserConfig_modify(rName string) string {
 resource "aws_transfer_server" "foo" {
 	identity_provider_type = "SERVICE_MANAGED"
 	
-	tags {
+	tags = {
 		NAME     = "tf-acc-test-transfer-server"
 	}
 }
@@ -467,7 +467,7 @@ resource "aws_transfer_user" "foo" {
 	policy         = "${data.aws_iam_policy_document.foo.json}"
 	home_directory = "/test"
 
-	tags {
+	tags = {
 		NAME  = "tf-test-user"
 		TEST   = "test2"
 	}
@@ -482,7 +482,7 @@ func testAccAWSTransferUserConfig_forceNew(rName string) string {
 resource "aws_transfer_server" "foo" {
 	identity_provider_type = "SERVICE_MANAGED"
 	
-	tags {
+	tags = {
 		NAME     = "tf-acc-test-transfer-server"
 	}
 }
@@ -576,7 +576,7 @@ resource "aws_transfer_user" "foo" {
 	role           = "${aws_iam_role.foo.arn}"
 	policy         = "${data.aws_iam_policy_document.foo.json}"
 	home_directory = "/home/tftestuser2"
-	tags {
+	tags = {
 		NAME  = "tf-test-user"
 		TEST   = "test2"
 	}


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSTransferUser_basic (0.90s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
FAIL
--- FAIL: TestAccAWSTransferUser_disappears (0.73s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
FAIL
--- FAIL: TestAccAWSTransferUser_modifyWithOptions (0.73s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccAWSTransferUser_disappears (12.74s)
--- PASS: TestAccAWSTransferUser_basic (14.38s)
--- PASS: TestAccAWSTransferUser_modifyWithOptions (33.95s)
```
