### PR TITLE
Fixing TestAccAWSSsmResourceDataSync for 0.12

### DIFF
--- a/aws/resource_aws_ssm_resource_data_sync_test.go
+++ b/aws/resource_aws_ssm_resource_data_sync_test.go
@@ -120,7 +120,7 @@ func testAccSsmResourceDataSyncConfig(rInt int, rName string) string {
 
     resource "aws_ssm_resource_data_sync" "foo" {
       name = "tf-test-ssm-%s"
-      s3_destination = {
+      s3_destination {
         bucket_name = "${aws_s3_bucket.hoge.bucket}"
         region = "${aws_s3_bucket.hoge.region}"
       }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSsmResourceDataSync_import (0.82s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:
        
        - Unsupported argument: An argument named "s3_destination" is not expected here. Did you mean to define a block of type "s3_destination"?
        - Insufficient s3_destination blocks: At least 1 "s3_destination" blocks are required.
FAIL
--- FAIL: TestAccAWSSsmResourceDataSync_basic (0.63s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:
        
        - Unsupported argument: An argument named "s3_destination" is not expected here. Did you mean to define a block of type "s3_destination"?
        - Insufficient s3_destination blocks: At least 1 "s3_destination" blocks are required.
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccAWSSsmResourceDataSync_basic (24.08s)
--- PASS: TestAccAWSSsmResourceDataSync_import (24.89s)
```
