### PR TITLE
Fixing TestAccAWSSsmDocumentDataSource for 0.12

### DIFF
--- a/aws/data_source_aws_ssm_document_test.go
+++ b/aws/data_source_aws_ssm_document_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSSsmDocumentDataSource_basic(t *testing.T) {
 	resourceName := "data.aws_ssm_document.test"
-	name := "test_document"
+	name := fmt.Sprintf("test_document-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSsmDocumentDataSource_basic (5.82s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error creating SSM document: DocumentAlreadyExists: Document with same name test_document already exists
        	status code: 400, request id: 7c1d1572-ba6a-48ca-a033-fe3420bc2678
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test141574676/main.tf line 25:
          (source code not available)
        
        
FAIL
```

Output from Terraform 0.12 acceptance testing 

```
--- PASS: TestAccAWSSsmDocumentDataSource_basic (23.02s)
```
