### PR TITLE
Fixing TestAccAWSSSMDocument for 0.12

### DIFF
--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -474,7 +474,7 @@ resource "aws_ssm_document" "foo" {
   name = "test_document-%s"
 	document_type = "Command"
 
-  permissions = {
+  permissions {
     type        = "Share"
     account_ids = "all"
   }
@@ -508,7 +508,7 @@ resource "aws_ssm_document" "foo" {
   name = "test_document-%s"
 	document_type = "Command"
 
-  permissions = {
+  permissions {
     type        = "Share"
     account_ids = "%s"
   }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11 vendoring. There is either a bug in TypeMap or we are losing functionality with 0.12. I've opened an [issue](https://github.com/hashicorp/terraform/issues/20076) in the terraform repo to confirm

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSSMDocument_update (5.42s)
    testing.go:568: Step 1 error: errors during apply:
        
        Error: permissions: 1 error(s) decoding:
        
        * '[#]' expected type 'string', got unconvertible type 'map[string]interface {}'
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test542741305/main.tf line 26:
          (source code not available)
        
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: Default error in SSM Document Test
        
        State: <no state>
FAIL
--- FAIL: TestAccAWSSSMDocument_permission_private (0.65s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "permissions" is not expected here. Did you mean to define a block of type "permissions"?
FAIL
--- FAIL: TestAccAWSSSMDocument_permission_public (0.69s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "permissions" is not expected here. Did you mean to define a block of type "permissions"?
FAIL
--- FAIL: TestAccAWSSSMDocument_permission_change (0.84s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "permissions" is not expected here. Did you mean to define a block of type "permissions"?
FAIL
--- FAIL: TestAccAWSSSMDocument_permission_batching (0.59s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "permissions" is not expected here. Did you mean to define a block of type "permissions"?
FAIL
--- FAIL: TestAccAWSSSMDocument_Tags (5.72s)
    testing.go:568: Step 1 error: errors during apply:
        
        Error: permissions: 1 error(s) decoding:
        
        * '[#]' expected type 'string', got unconvertible type 'map[string]interface {}'
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test976391796/main.tf line 30:
          (source code not available)
        
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: Default error in SSM Document Test
        
        State: <no state>
FAIL
--- FAIL: TestAccAWSSSMDocument_DocumentFormat_YAML (5.69s)
    testing.go:568: Step 1 error: errors during apply:
        
        Error: permissions: 1 error(s) decoding:
        
        * '[#]' expected type 'string', got unconvertible type 'map[string]interface {}'
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test874962005/main.tf line 20:
          (source code not available)
        
        
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: Default error in SSM Document Test
        
        State: <no state>
FAIL

```

Output from Terraform 0.12 acceptance testing 

```
--- FAIL: TestAccAWSSSMDocument_permission_public (1.86s)
    testing.go:568: Step 0 error: config is invalid: Missing key for permissions: All permissions blocks must have 1 labels (key).
--- FAIL: TestAccAWSSSMDocument_permission_batching (1.88s)
    testing.go:568: Step 0 error: config is invalid: Missing key for permissions: All permissions blocks must have 1 labels (key).
--- FAIL: TestAccAWSSSMDocument_permission_private (1.89s)
    testing.go:568: Step 0 error: config is invalid: Missing key for permissions: All permissions blocks must have 1 labels (key).
--- FAIL: TestAccAWSSSMDocument_permission_change (1.90s)
    testing.go:568: Step 0 error: config is invalid: Missing key for permissions: All permissions blocks must have 1 labels (key).
--- PASS: TestAccAWSSSMDocument_params (12.84s)
--- PASS: TestAccAWSSSMDocument_basic (13.03s)
--- PASS: TestAccAWSSSMDocument_session (13.06s)
--- PASS: TestAccAWSSSMDocument_update (21.64s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (21.82s)
--- PASS: TestAccAWSSSMDocument_Tags (29.90s)
--- PASS: TestAccAWSSSMDocument_automation (34.19s)
```
