### PR TITLE
resource/aws_cloudwatch_metric_alarm: Ensure dimensions configurations include equals

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -331,7 +331,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   threshold                 = "80"
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -351,7 +351,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   threshold                 = "80"
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -371,7 +371,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_description         = "This metric monitors ec2 cpu utilization"
   treat_missing_data        = "missing"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -391,7 +391,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_description         = "This metric monitors ec2 cpu utilization"
   treat_missing_data        = "breaching"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -411,7 +411,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_description         = "This metric monitors ec2 cpu utilization"
   evaluate_low_sample_count_percentiles = "evaluate"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -431,7 +431,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_description         = "This metric monitors ec2 cpu utilization"
   evaluate_low_sample_count_percentiles = "ignore"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -450,7 +450,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   threshold                 = "80"
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -468,7 +468,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   threshold                 = "80"
   alarm_description         = "This metric monitors ec2 cpu utilization"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }`, rInt)
@@ -536,7 +536,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   threshold           = "0"
   unit                = "Count"
 
-  dimensions {
+  dimensions = {
     InstanceId = "${aws_instance.test.id}"
   }
 }
@@ -562,7 +562,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   threshold           = "0"
   unit                = "Count"
 
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }
@@ -590,7 +590,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   threshold           = "0"
   unit                = "Count"
 
-  dimensions {
+  dimensions = {
     InstanceId = "i-abc123"
   }
 }

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
   statistic           = "Average"
   threshold           = "80"
 
-  dimensions {
+  dimensions = {
     AutoScalingGroupName = "${aws_autoscaling_group.bar.name}"
   }
 


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCloudWatchMetricAlarm_basic (0.74s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "dimensions" are not expected here. Did you mean to define argument "dimensions"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (5.32s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (11.73s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (11.73s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (12.87s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (13.96s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (15.12s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (18.48s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (18.59s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (201.32s)
```
