### PR TITLE
resource/aws_codepipeline: Ensure configuration argument configurations include equals

### DIFF
--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -261,7 +261,7 @@ resource "aws_codepipeline" "bar" {
       version          = "1"
       output_artifacts = ["test"]
 
-      configuration {
+      configuration = {
         Owner  = "lifesum-terraform"
         Repo   = "test"
         Branch = "master"
@@ -280,7 +280,7 @@ resource "aws_codepipeline" "bar" {
       input_artifacts = ["test"]
       version         = "1"
 
-      configuration {
+      configuration = {
         ProjectName = "test"
       }
     }
@@ -373,7 +373,7 @@ resource "aws_codepipeline" "bar" {
       version          = "1"
       output_artifacts = ["bar"]
 
-      configuration {
+      configuration = {
         Owner  = "foo-terraform"
         Repo   = "bar"
         Branch = "stable"
@@ -392,7 +392,7 @@ resource "aws_codepipeline" "bar" {
       input_artifacts = ["bar"]
       version         = "1"
 
-      configuration {
+      configuration = {
         ProjectName = "foo"
       }
     }
@@ -480,7 +480,7 @@ resource "aws_codepipeline" "bar" {
       version          = "1"
       output_artifacts = ["test"]
 
-      configuration {
+      configuration = {
         Owner  = "lifesum-terraform"
         Repo   = "test"
         Branch = "master"
@@ -500,7 +500,7 @@ resource "aws_codepipeline" "bar" {
       output_artifacts = [""]
       version          = "1"
 
-      configuration {
+      configuration = {
         ProjectName = "test"
       }
     }
@@ -646,7 +646,7 @@ resource "aws_codepipeline" "bar" {
       version          = "1"
       output_artifacts = ["bar"]
 
-      configuration {
+      configuration = {
         Owner  = "foo-terraform"
         Repo   = "bar"
         Branch = "stable"
@@ -666,7 +666,7 @@ resource "aws_codepipeline" "bar" {
       output_artifacts = ["baz"]
       version          = "1"
 
-      configuration {
+      configuration = {
         ProjectName = "foo"
       }
     }
@@ -684,13 +684,14 @@ resource "aws_codepipeline" "bar" {
       role_arn        = "${aws_iam_role.codepipeline_action_role.arn}"
       version         = "1"
 
-      configuration {
+      configuration = {
         ActionMode    = "CHANGE_SET_REPLACE"
         ChangeSetName = "changeset"
         StackName     = "stack"
         TemplatePath  = "baz::template.yaml"
       }
     }
-  }}
+  }
+}
 `, rName, rName, rName, rName)
 }

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -265,7 +265,7 @@ resource "aws_codepipeline" "bar" {
       version          = "1"
       output_artifacts = ["test"]
 
-      configuration {
+      configuration = {
         Owner  = "lifesum-terraform"
         Repo   = "test"
         Branch = "master"
@@ -284,7 +284,7 @@ resource "aws_codepipeline" "bar" {
       input_artifacts = ["test"]
       version         = "1"
 
-      configuration {
+      configuration = {
         ProjectName = "test"
       }
     }

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -101,7 +101,7 @@ resource "aws_codepipeline" "foo" {
       version          = "1"
       output_artifacts = ["test"]
 
-      configuration {
+      configuration = {
         Owner  = "my-organization"
         Repo   = "test"
         Branch = "master"
@@ -120,7 +120,7 @@ resource "aws_codepipeline" "foo" {
       input_artifacts = ["test"]
       version         = "1"
 
-      configuration {
+      configuration = {
         ProjectName = "test"
       }
     }

--- a/website/docs/r/codepipeline_webhook.markdown
+++ b/website/docs/r/codepipeline_webhook.markdown
@@ -38,7 +38,7 @@ resource "aws_codepipeline" "bar" {
       version          = "1"
       output_artifacts = ["test"]
 
-      configuration {
+      configuration = {
         Owner  = "my-organization"
         Repo   = "test"
         Branch = "master"
@@ -57,7 +57,7 @@ resource "aws_codepipeline" "bar" {
       input_artifacts = ["test"]
       version         = "1"
 
-      configuration {
+      configuration = {
         ProjectName = "test"
       }
     }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCodePipeline_basic (0.56s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported block type: Blocks of type "configuration" are not expected here. Did you mean to define argument "configuration"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "configuration" are not expected here. Did you mean to define argument "configuration"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- FAIL: TestAccAWSCodePipeline_emptyArtifacts (24.29s)
    testing.go:568: Step 0 error: Check failed: Check 11/11 error: aws_codepipeline.bar: Attribute 'stage.1.action.0.output_artifacts.#' expected "0", got "1"
--- PASS: TestAccAWSCodePipeline_Import_basic (34.30s)
--- FAIL: TestAccAWSCodePipeline_basic (38.42s)
    testing.go:568: Step 1 error: errors during apply:

        Error: [ERROR] Error updating CodePipeline (test-pipeline-w293z0i8jk): InvalidParameter: 3 validation error(s) found.
        - minimum field size of 3, UpdatePipelineInput.Pipeline.ArtifactStore.Location.
        - minimum field size of 1, UpdatePipelineInput.Pipeline.Stages[0].Name.
        - minimum field size of 1, UpdatePipelineInput.Pipeline.Stages[1].Name.

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test341704784/main.tf line 108:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Check failed: Default error in CodePipeline Test

        State: <no state>
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (48.08s)

--- PASS: TestAccAWSCodePipelineWebhook_basic (40.64s)
--- PASS: TestAccAWSCodePipelineWebhook_ipAuth (35.35s)
--- PASS: TestAccAWSCodePipelineWebhook_unauthenticated (35.66s)
```
