### PR TITLE
Feature/add import to dhcp options associations

### DIFF
--- a/aws/resource_aws_vpc_dhcp_options_association.go
+++ b/aws/resource_aws_vpc_dhcp_options_association.go
@@ -14,6 +14,9 @@ func resourceAwsVpcDhcpOptionsAssociation() *schema.Resource {
 		Read:   resourceAwsVpcDhcpOptionsAssociationRead,
 		Update: resourceAwsVpcDhcpOptionsAssociationUpdate,
 		Delete: resourceAwsVpcDhcpOptionsAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsVpcDhcpOptionsAssociationImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"vpc_id": {
@@ -27,6 +30,27 @@ func resourceAwsVpcDhcpOptionsAssociation() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceAwsVpcDhcpOptionsAssociationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*AWSClient).ec2conn
+	// Provide the vpc_id as the id to import
+	vpcRaw, _, err := VPCStateRefreshFunc(conn, d.Id())()
+	if err != nil {
+		return nil, err
+	}
+	if vpcRaw == nil {
+		return nil, nil
+	}
+	vpc := vpcRaw.(*ec2.Vpc)
+	if err = d.Set("vpc_id", *vpc.VpcId); err != nil {
+		return nil, err
+	}
+	if err = d.Set("dhcp_options_id", *vpc.DhcpOptionsId); err != nil {
+		return nil, err
+	}
+	d.SetId(*vpc.DhcpOptionsId + "-" + *vpc.VpcId)
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAwsVpcDhcpOptionsAssociationCreate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_vpc_dhcp_options_association_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_association_test.go
@@ -30,6 +30,39 @@ func TestAccAWSDHCPOptionsAssociation_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDHCPOptionsAssociationImport_basic(t *testing.T) {
+	resourceName := "aws_vpc_dhcp_options_association.bar"
+	vpcName := "aws_vpc.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDHCPOptionsAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDHCPOptionsAssociationConfig,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: testAccDHCPOptionsAssociationVPCImportIdFunc(vpcName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDHCPOptionsAssociationVPCImportIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes["id"], nil
+	}
+}
+
 func testAccCheckDHCPOptionsAssociationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 

--- a/website/docs/r/vpc_dhcp_options_association.html.markdown
+++ b/website/docs/r/vpc_dhcp_options_association.html.markdown
@@ -35,3 +35,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the DHCP Options Set Association.
+
+## Import
+
+DHCP associations can be imported by providing the VPC ID associated with the options:
+
+```
+$ terraform import aws_vpc_dhcp_options_association.imported vpc-0f001273ec18911b1
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Provide the ability to import DHCP options associations

Output from acceptance testing:

```
ptittle@ptittle98-mac ~/src/go/src/github.com/terraform-providers/terraform-provider-aws (feature/add_import_to_dhcp_associations) $ make testacc TESTARGS='-run=TestAccAWSDHCPOptionsAssociationImport'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDHCPOptionsAssociationImport -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDHCPOptionsAssociationImport_basic
=== PAUSE TestAccAWSDHCPOptionsAssociationImport_basic
=== CONT  TestAccAWSDHCPOptionsAssociationImport_basic
--- PASS: TestAccAWSDHCPOptionsAssociationImport_basic (27.16s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	29.760s
```
