### PR TITLE
service/cognito: Various Terraform 0.12 syntax fixes

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_test.go
+++ b/aws/resource_aws_cognito_identity_pool_test.go
@@ -275,7 +275,7 @@ resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %s"
   allow_unauthenticated_identities = false
 
-  supported_login_providers {
+  supported_login_providers = {
     "graph.facebook.com" = "7346241598935555"
   }
 }
@@ -288,7 +288,7 @@ resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %s"
   allow_unauthenticated_identities = false
 
-  supported_login_providers {
+  supported_login_providers = {
     "graph.facebook.com"  = "7346241598935552"
     "accounts.google.com" = "123456789012.apps.googleusercontent.com"
   }

--- a/aws/resource_aws_cognito_identity_provider_test.go
+++ b/aws/resource_aws_cognito_identity_provider_test.go
@@ -123,7 +123,7 @@ resource "aws_cognito_identity_provider" "test" {
   provider_name = "Google"
   provider_type = "Google"
 
-  provider_details {
+  provider_details = {
     attributes_url                = "https://people.googleapis.com/v1/people/me?personFields="
     attributes_url_add_attributes = "true"
     authorize_scopes              = "email"
@@ -135,7 +135,7 @@ resource "aws_cognito_identity_provider" "test" {
     token_url                     = "https://www.googleapis.com/oauth2/v4/token"
   }
 
-  attribute_mapping {
+  attribute_mapping = {
     email    = "email"
     username = "sub"
   }

--- a/aws/resource_aws_cognito_resource_server.go
+++ b/aws/resource_aws_cognito_resource_server.go
@@ -146,7 +146,9 @@ func resourceAwsCognitoResourceServerRead(d *schema.ResourceData, meta interface
 		scopeIdentifier := fmt.Sprintf("%s/%s", aws.StringValue(resp.ResourceServer.Identifier), elem["scope_name"].(string))
 		scopeIdentifiers = append(scopeIdentifiers, scopeIdentifier)
 	}
-	d.Set("scope_identifiers", scopeIdentifiers)
+	if err := d.Set("scope_identifiers", scopeIdentifiers); err != nil {
+		return fmt.Errorf("error setting scope_identifiers: %s", err)
+	}
 	return nil
 }
 

--- a/aws/resource_aws_cognito_resource_server_test.go
+++ b/aws/resource_aws_cognito_resource_server_test.go
@@ -186,12 +186,12 @@ resource "aws_cognito_resource_server" "main" {
   identifier = "%s"
   name = "%s"
 
-  scope = {
+  scope {
     scope_name = "scope_1_name"
     scope_description = "scope_1_description"
   }
 
-  scope = {
+  scope {
     scope_name = "scope_2_name"
     scope_description = "scope_2_description"
   }
@@ -211,7 +211,7 @@ resource "aws_cognito_resource_server" "main" {
   identifier = "%s"
   name = "%s"
 
-  scope = {
+  scope {
     scope_name = "scope_1_name_updated"
     scope_description = "scope_1_description"
   }

--- a/website/docs/r/cognito_identity_pool.markdown
+++ b/website/docs/r/cognito_identity_pool.markdown
@@ -34,7 +34,7 @@ resource "aws_cognito_identity_pool" "main" {
     server_side_token_check = false
   }
 
-  supported_login_providers {
+  supported_login_providers = {
     "graph.facebook.com"  = "7346241598935552"
     "accounts.google.com" = "123456789012.apps.googleusercontent.com"
   }

--- a/website/docs/r/cognito_identity_pool_roles_attachment.markdown
+++ b/website/docs/r/cognito_identity_pool_roles_attachment.markdown
@@ -17,7 +17,7 @@ resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool"
   allow_unauthenticated_identities = false
 
-  supported_login_providers {
+  supported_login_providers = {
     "graph.facebook.com" = "7346241598935555"
   }
 }

--- a/website/docs/r/cognito_identity_provider.html.markdown
+++ b/website/docs/r/cognito_identity_provider.html.markdown
@@ -23,13 +23,13 @@ resource "aws_cognito_identity_provider" "example_provider" {
   provider_name = "Google"
   provider_type = "Google"
 
-  provider_details {
+  provider_details = {
     authorize_scopes = "email"
     client_id        = "your client_id"
     client_secret    = "your client_secret"
   }
 
-  attribute_mapping {
+  attribute_mapping = {
     email    = "email"
     username = "sub"
   }

--- a/website/docs/r/cognito_resource_server.markdown
+++ b/website/docs/r/cognito_resource_server.markdown
@@ -38,10 +38,10 @@ resource "aws_cognito_resource_server" "resource" {
   identifier = "https://example.com"
   name       = "example"
 
-  scope = [{
+  scope {
     scope_name        = "sample-scope"
     scope_description = "a Sample Scope Description"
-  }]
+  }
 
   user_pool_id = "${aws_cognito_user_pool.pool.id}"
 }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Changes:
* resource/aws_cognito_identity_pool: Ensure supported_login_providers configuration include equals in testing and documentation
* resource/aws_cognito_identity_provider: Ensure attribute_mapping and provider_details configurations include equals in testing and documentation
* resource/aws_cognito_resource_server: Omit scope configuration equals in testing and documentation

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCognitoIdentityProvider_basic (1.58s)
    testing.go:568: Step 0 error: config is invalid: 3 problems:

        - Missing required argument: The argument "provider_details" is required, but no definition was found.
        - Unsupported block type: Blocks of type "provider_details" are not expected here. Did you mean to define argument "provider_details"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "attribute_mapping" are not expected here. Did you mean to define argument "attribute_mapping"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSCognitoIdentityPool_supportedLoginProviders (0.50s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test903661443/main.tf:7,5-6: Invalid argument name; Argument names must not be quoted.

--- FAIL: TestAccAWSCognitoResourceServer_scope (0.64s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test540721977/main.tf:11,3-8: Attribute redefined; The argument "scope" was already set at /opt/teamcity-agent/temp/buildTmp/tf-test540721977/main.tf:6,3-8. Each argument may be set only once.
```

Output from Terraform 0.12 acceptance testing (additional Terraform Provider SDK fixes required):

```
--- PASS: TestAccAWSCognitoIdentityPool_supportedLoginProviders (25.17s)
--- PASS: TestAccAWSCognitoIdentityProvider_basic (14.50s)
--- FAIL: TestAccAWSCognitoResourceServer_scope (29.79s)
    testing.go:568: Step 3 error: Check failed: 1 error occurred:
        	* Check 3/3 error: aws_cognito_resource_server.main: Attribute 'scope_identifiers.#' expected "0", got "1"
```
