### PR TITLE
tests/resource/aws_dax_cluster: Ensure tags configurations include equals

### DIFF
--- a/aws/resource_aws_dax_cluster_test.go
+++ b/aws/resource_aws_dax_cluster_test.go
@@ -323,7 +323,7 @@ func testAccAWSDAXClusterConfig(rString string) string {
 		  replication_factor = 1
 		  description        = "test cluster"
 
-		  tags {
+		  tags = {
 		    foo = "bar"
 		  }
 		}
@@ -339,7 +339,7 @@ func testAccAWSDAXClusterConfigWithEncryption(rString string, enabled bool) stri
 		  replication_factor = 1
 		  description        = "test cluster"
 
-		  tags {
+		  tags = {
 		    foo = "bar"
 		  }
 


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSDAXCluster_basic (0.65s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSDAXCluster_basic (645.79s)
--- PASS: TestAccAWSDAXCluster_encryption_disabled (662.67s)
--- PASS: TestAccAWSDAXCluster_encryption_enabled (724.28s)
--- PASS: TestAccAWSDAXCluster_importBasic (771.14s)
--- PASS: TestAccAWSDAXCluster_resize (1313.50s)
```
