### PR TITLE
tests/resource/aws_db_parameter_group: Update TestAccAWSDBParameterGroup_limit syntax for 0.12

### DIFF
--- a/aws/resource_aws_db_parameter_group_test.go
+++ b/aws/resource_aws_db_parameter_group_test.go
@@ -663,47 +663,175 @@ resource "aws_db_parameter_group" "large" {
 	family = "mysql5.6"
 	description = "RDS default parameter group: Exceed default AWS parameter group limit of twenty"
 
-    parameter { name = "binlog_cache_size"                   value = 131072                                            }
-    parameter { name = "character_set_client"                value = "utf8"                                            }
-    parameter { name = "character_set_connection"            value = "utf8"                                            }
-    parameter { name = "character_set_database"              value = "utf8"                                            }
-    parameter { name = "character_set_filesystem"            value = "utf8"                                            }
-    parameter { name = "character_set_results"               value = "utf8"                                            }
-    parameter { name = "character_set_server"                value = "utf8"                                            }
-    parameter { name = "collation_connection"                value = "utf8_general_ci"                                 }
-    parameter { name = "collation_server"                    value = "utf8_general_ci"                                 }
-    parameter { name = "event_scheduler"                     value = "ON"                                              }
-    parameter { name = "innodb_buffer_pool_dump_at_shutdown" value = 1                                                 }
-    parameter { name = "innodb_file_format"                  value = "Barracuda"                                       }
-    parameter { name = "innodb_flush_log_at_trx_commit"      value = 0                                                 }
-    parameter { name = "innodb_io_capacity"                  value = 2000                                              }
-    parameter { name = "innodb_io_capacity_max"              value = 3000                                              }
-    parameter { name = "innodb_lock_wait_timeout"            value = 120                                               }
-    parameter { name = "innodb_max_dirty_pages_pct"          value = 90                                                }
-    parameter { name = "innodb_open_files"                   value = 4000              apply_method = "pending-reboot" }
-    parameter { name = "innodb_read_io_threads"              value = 64                apply_method = "pending-reboot" }
-    parameter { name = "innodb_thread_concurrency"           value = 0                                                 }
-    parameter { name = "innodb_write_io_threads"             value = 64                apply_method = "pending-reboot" }
-    parameter { name = "join_buffer_size"                    value = 16777216                                          }
-    parameter { name = "key_buffer_size"                     value = 67108864                                          }
-    parameter { name = "log_bin_trust_function_creators"     value = 1                                                 }
-    parameter { name = "log_warnings"                        value = 2                                                 }
-    parameter { name = "log_output"                          value = "FILE"                                            }
-    parameter { name = "max_allowed_packet"                  value = 1073741824                                        }
-    parameter { name = "max_connect_errors"                  value = 100                                               }
-    parameter { name = "max_connections"                     value = 3200                                              }
-    parameter { name = "max_heap_table_size"                 value = 67108864                                          }
-    parameter { name = "performance_schema"                  value = 1                 apply_method = "pending-reboot" }
-    parameter { name = "performance_schema_users_size"       value = 1048576           apply_method = "pending-reboot" }
-    parameter { name = "query_cache_limit"                   value = 2097152                                           }
-    parameter { name = "query_cache_min_res_unit"            value = 512                                               }
-    parameter { name = "query_cache_size"                    value = 67108864                                          }
-    parameter { name = "slow_query_log"                      value = 1                                                 }
-    parameter { name = "sort_buffer_size"                    value = 16777216                                          }
-    parameter { name = "sync_binlog"                         value = 0                                                 }
-    parameter { name = "table_open_cache"                    value = 4096                                              }
-    parameter { name = "tmp_table_size"                      value = 67108864                                          }
-    parameter { name = "tx_isolation"                        value = "REPEATABLE-READ"                                 }
+    parameter {
+      name = "binlog_cache_size"
+      value = 131072
+    }
+    parameter {
+      name = "character_set_client"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_connection"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_database"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_filesystem"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_results"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_server"
+      value = "utf8"
+    }
+    parameter {
+      name = "collation_connection"
+      value = "utf8_general_ci"
+    }
+    parameter {
+      name = "collation_server"
+      value = "utf8_general_ci"
+    }
+    parameter {
+      name = "event_scheduler"
+      value = "ON"
+    }
+    parameter {
+      name = "innodb_buffer_pool_dump_at_shutdown"
+      value = 1
+    }
+    parameter {
+      name = "innodb_file_format"
+      value = "Barracuda"
+    }
+    parameter {
+      name = "innodb_flush_log_at_trx_commit"
+      value = 0
+    }
+    parameter {
+      name = "innodb_io_capacity"
+      value = 2000
+    }
+    parameter {
+      name = "innodb_io_capacity_max"
+      value = 3000
+    }
+    parameter {
+      name = "innodb_lock_wait_timeout"
+      value = 120
+    }
+    parameter {
+      name = "innodb_max_dirty_pages_pct"
+      value = 90
+    }
+    parameter {
+      name = "innodb_open_files"
+      value = 4000
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "innodb_read_io_threads"
+      value = 64
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "innodb_thread_concurrency"
+      value = 0
+    }
+    parameter {
+      name = "innodb_write_io_threads"
+      value = 64
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "join_buffer_size"
+      value = 16777216
+    }
+    parameter {
+      name = "key_buffer_size"
+      value = 67108864
+    }
+    parameter {
+      name = "log_bin_trust_function_creators"
+      value = 1
+    }
+    parameter {
+      name = "log_warnings"
+      value = 2
+    }
+    parameter {
+      name = "log_output"
+      value = "FILE"
+    }
+    parameter {
+      name = "max_allowed_packet"
+      value = 1073741824
+    }
+    parameter {
+      name = "max_connect_errors"
+      value = 100
+    }
+    parameter {
+      name = "max_connections"
+      value = 3200
+    }
+    parameter {
+      name = "max_heap_table_size"
+      value = 67108864
+    }
+    parameter {
+      name = "performance_schema"
+      value = 1
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "performance_schema_users_size"
+      value = 1048576
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "query_cache_limit"
+      value = 2097152
+    }
+    parameter {
+      name = "query_cache_min_res_unit"
+      value = 512
+    }
+    parameter {
+      name = "query_cache_size"
+      value = 67108864
+    }
+    parameter {
+      name = "slow_query_log"
+      value = 1
+    }
+    parameter {
+      name = "sort_buffer_size"
+      value = 16777216
+    }
+    parameter {
+      name = "sync_binlog"
+      value = 0
+    }
+    parameter {
+      name = "table_open_cache"
+      value = 4096
+    }
+    parameter {
+      name = "tmp_table_size"
+      value = 67108864
+    }
+    parameter {
+      name = "tx_isolation"
+      value = "REPEATABLE-READ"
+    }
 }`, n)
 }
 
@@ -713,47 +841,175 @@ resource "aws_db_parameter_group" "large" {
 	name = "%s"
 	family = "mysql5.6"
 	description = "Updated RDS default parameter group: Exceed default AWS parameter group limit of twenty"
-    parameter { name = "binlog_cache_size"                   value = 131072                                            }
-    parameter { name = "character_set_client"                value = "utf8"                                            }
-    parameter { name = "character_set_connection"            value = "utf8"                                            }
-    parameter { name = "character_set_database"              value = "utf8"                                            }
-    parameter { name = "character_set_filesystem"            value = "utf8"                                            }
-    parameter { name = "character_set_results"               value = "utf8"                                            }
-    parameter { name = "character_set_server"                value = "utf8"                                            }
-    parameter { name = "collation_connection"                value = "utf8_general_ci"                                 }
-    parameter { name = "collation_server"                    value = "utf8_general_ci"                                 }
-    parameter { name = "event_scheduler"                     value = "ON"                                              }
-    parameter { name = "innodb_buffer_pool_dump_at_shutdown" value = 1                                                 }
-    parameter { name = "innodb_file_format"                  value = "Barracuda"                                       }
-    parameter { name = "innodb_flush_log_at_trx_commit"      value = 0                                                 }
-    parameter { name = "innodb_io_capacity"                  value = 2000                                              }
-    parameter { name = "innodb_io_capacity_max"              value = 3000                                              }
-    parameter { name = "innodb_lock_wait_timeout"            value = 120                                               }
-    parameter { name = "innodb_max_dirty_pages_pct"          value = 90                                                }
-    parameter { name = "innodb_open_files"                   value = 4000              apply_method = "pending-reboot" }
-    parameter { name = "innodb_read_io_threads"              value = 64                apply_method = "pending-reboot" }
-    parameter { name = "innodb_thread_concurrency"           value = 0                                                 }
-    parameter { name = "innodb_write_io_threads"             value = 64                apply_method = "pending-reboot" }
-    parameter { name = "join_buffer_size"                    value = 16777216                                          }
-    parameter { name = "key_buffer_size"                     value = 67108864                                          }
-    parameter { name = "log_bin_trust_function_creators"     value = 1                                                 }
-    parameter { name = "log_warnings"                        value = 2                                                 }
-    parameter { name = "log_output"                          value = "FILE"                                            }
-    parameter { name = "max_allowed_packet"                  value = 1073741824                                        }
-    parameter { name = "max_connect_errors"                  value = 100                                               }
-    parameter { name = "max_connections"                     value = 3200                                              }
-    parameter { name = "max_heap_table_size"                 value = 67108864                                          }
-    parameter { name = "performance_schema"                  value = 1                 apply_method = "pending-reboot" }
-    parameter { name = "performance_schema_users_size"       value = 1048576           apply_method = "pending-reboot" }
-    parameter { name = "query_cache_limit"                   value = 2097152                                           }
-    parameter { name = "query_cache_min_res_unit"            value = 512                                               }
-    parameter { name = "query_cache_size"                    value = 67108864                                          }
-    parameter { name = "slow_query_log"                      value = 1                                                 }
-    parameter { name = "sort_buffer_size"                    value = 16777216                                          }
-    parameter { name = "sync_binlog"                         value = 0                                                 }
-    parameter { name = "table_open_cache"                    value = 4096                                              }
-    parameter { name = "tmp_table_size"                      value = 67108864                                          }
-    parameter { name = "tx_isolation"                        value = "REPEATABLE-READ"                                 }
+    parameter {
+      name = "binlog_cache_size"
+      value = 131072
+    }
+    parameter {
+      name = "character_set_client"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_connection"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_database"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_filesystem"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_results"
+      value = "utf8"
+    }
+    parameter {
+      name = "character_set_server"
+      value = "utf8"
+    }
+    parameter {
+      name = "collation_connection"
+      value = "utf8_general_ci"
+    }
+    parameter {
+      name = "collation_server"
+      value = "utf8_general_ci"
+    }
+    parameter {
+      name = "event_scheduler"
+      value = "ON"
+    }
+    parameter {
+      name = "innodb_buffer_pool_dump_at_shutdown"
+      value = 1
+    }
+    parameter {
+      name = "innodb_file_format"
+      value = "Barracuda"
+    }
+    parameter {
+      name = "innodb_flush_log_at_trx_commit"
+      value = 0
+    }
+    parameter {
+      name = "innodb_io_capacity"
+      value = 2000
+    }
+    parameter {
+      name = "innodb_io_capacity_max"
+      value = 3000
+    }
+    parameter {
+      name = "innodb_lock_wait_timeout"
+      value = 120
+    }
+    parameter {
+      name = "innodb_max_dirty_pages_pct"
+      value = 90
+    }
+    parameter {
+      name = "innodb_open_files"
+      value = 4000
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "innodb_read_io_threads"
+      value = 64
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "innodb_thread_concurrency"
+      value = 0
+    }
+    parameter {
+      name = "innodb_write_io_threads"
+      value = 64
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "join_buffer_size"
+      value = 16777216
+    }
+    parameter {
+      name = "key_buffer_size"
+      value = 67108864
+    }
+    parameter {
+      name = "log_bin_trust_function_creators"
+      value = 1
+    }
+    parameter {
+      name = "log_warnings"
+      value = 2
+    }
+    parameter {
+      name = "log_output"
+      value = "FILE"
+    }
+    parameter {
+      name = "max_allowed_packet"
+      value = 1073741824
+    }
+    parameter {
+      name = "max_connect_errors"
+      value = 100
+    }
+    parameter {
+      name = "max_connections"
+      value = 3200
+    }
+    parameter {
+      name = "max_heap_table_size"
+      value = 67108864
+    }
+    parameter {
+      name = "performance_schema"
+      value = 1
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "performance_schema_users_size"
+      value = 1048576
+      apply_method = "pending-reboot"
+    }
+    parameter {
+      name = "query_cache_limit"
+      value = 2097152
+    }
+    parameter {
+      name = "query_cache_min_res_unit"
+      value = 512
+    }
+    parameter {
+      name = "query_cache_size"
+      value = 67108864
+    }
+    parameter {
+      name = "slow_query_log"
+      value = 1
+    }
+    parameter {
+      name = "sort_buffer_size"
+      value = 16777216
+    }
+    parameter {
+      name = "sync_binlog"
+      value = 0
+    }
+    parameter {
+      name = "table_open_cache"
+      value = 4096
+    }
+    parameter {
+      name = "tmp_table_size"
+      value = 67108864
+    }
+    parameter {
+      name = "tx_isolation"
+      value = "REPEATABLE-READ"
+    }
 }`, n)
 }
 


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSDBParameterGroup_limit (0.46s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test375589049/main.tf:7,62-67: Invalid single-argument block definition; A single-line block definition must end with a closing brace immediately after its single argument definition.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- FAIL: TestAccAWSDBParameterGroup_limit (15.12s)
    testing.go:568: Step 0 error: Check failed: Check 57/87 error: aws_db_parameter_group.large: Attribute 'parameter.1937131004.value' expected "on", got "ON"
```
