### PR TITLE
resource/aws_dlm_lifecycle_policy: Ensure tags_to_add and target_tags configurations include equals

### DIFF
--- a/aws/resource_aws_dlm_lifecycle_policy_test.go
+++ b/aws/resource_aws_dlm_lifecycle_policy_test.go
@@ -188,7 +188,7 @@ resource "aws_dlm_lifecycle_policy" "basic" {
       }
     }
 
-    target_tags {
+    target_tags = {
       tf-acc-test = "basic"
     }
   }
@@ -239,14 +239,14 @@ resource "aws_dlm_lifecycle_policy" "full" {
         count = 10
       }
 
-      tags_to_add {
+      tags_to_add = {
         tf-acc-test-added = "full"
       }
 
       copy_tags = false
     }
 
-    target_tags {
+    target_tags = {
       tf-acc-test = "full"
     }
   }
@@ -297,14 +297,14 @@ resource "aws_dlm_lifecycle_policy" "full" {
         count = 100
       }
 
-      tags_to_add {
+      tags_to_add = {
         tf-acc-test-added = "full-updated"
       }
 
       copy_tags = true
     }
 
-    target_tags {
+    target_tags = {
       tf-acc-test = "full-updated"
     }
   }

--- a/website/docs/r/dlm_lifecycle_policy.markdown
+++ b/website/docs/r/dlm_lifecycle_policy.markdown
@@ -83,14 +83,14 @@ resource "aws_dlm_lifecycle_policy" "example" {
         count = 14
       }
 
-      tags_to_add {
+      tags_to_add = {
         SnapshotCreator = "DLM"
       }
 
       copy_tags = false
     }
 
-    target_tags {
+    target_tags = {
       Snapshot = "true"
     }
   }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSDlmLifecyclePolicy_Basic (0.65s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Missing required argument: The argument "target_tags" is required, but no definition was found.
        - Unsupported block type: Blocks of type "target_tags" are not expected here. Did you mean to define argument "target_tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK -- https://github.com/hashicorp/terraform/issues/20084):

```
--- PASS: TestAccAWSDlmLifecyclePolicy_Basic (14.58s)
=== CONT  TestAccAWSDlmLifecyclePolicy_Full
panic: interface conversion: interface {} is nil, not []interface {}

goroutine 1431 [running]:
github.com/zclconf/go-cty/cty.Value.HasIndex(0x5716a20, 0xc0008eaa70, 0x0, 0x0, 0x57169a0, 0xc0000be96a, 0x4fd6100, 0xc0036e1080, 0x472f120, 0xc0036e0d50, ...)
  /Users/bflad/go/pkg/mod/github.com/zclconf/go-cty@v0.0.0-20181231001355-67e3da15e430/cty/value_ops.go:738 +0xa7d
```
