### PR TITLE
tests/resource/aws_dms_replication_instance: Temporarily use expanded subnet_ids references

### DIFF
--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -717,7 +717,7 @@ resource "aws_subnet" "test" {
 resource "aws_dms_replication_subnet_group" "test" {
   replication_subnet_group_description = %q
   replication_subnet_group_id          = %q
-  subnet_ids                           = ["${aws_subnet.test.*.id}"]
+  subnet_ids                           = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_dms_replication_instance" "test" {
@@ -790,7 +790,7 @@ resource "aws_subnet" "test" {
 resource "aws_dms_replication_subnet_group" "test" {
   replication_subnet_group_description = %q
   replication_subnet_group_id          = %q
-  subnet_ids                           = ["${aws_subnet.test.*.id}"]
+  subnet_ids                           = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_dms_replication_instance" "test" {


### PR DESCRIPTION
This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId (2.52s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test693717039/main.tf line 27:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId (421.12s)
--- PASS: TestAccAWSDmsReplicationInstance_VpcSecurityGroupIds (463.49s)
```
