### PR TITLE
service/ecs: Various Terraform 0.12 syntax fixes and error expectations

### DIFF
--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -82,7 +82,7 @@ func TestAccAWSEcsService_basicImport(t *testing.T) {
 				ImportStateId:     fmt.Sprintf("%s/nonexistent", clusterName),
 				ImportState:       true,
 				ImportStateVerify: false,
-				ExpectError:       regexp.MustCompile(`Please verify the ID is correct`),
+				ExpectError:       regexp.MustCompile(`(Please verify the ID is correct|Cannot import non-existent remote object)`),
 			},
 		},
 	})
@@ -1361,7 +1361,7 @@ resource "aws_ecs_service" "main" {
   launch_type = "FARGATE"
   network_configuration {
     security_groups = ["${aws_security_group.allow_all_a.id}", "${aws_security_group.allow_all_b.id}"]
-    subnets = ["${aws_subnet.main.*.id}"]
+    subnets = ["${aws_subnet.main.*.id[0]}", "${aws_subnet.main.*.id[1]}"]
     assign_public_ip = %s
   }
 }
@@ -1374,7 +1374,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "main" {
   cidr_block = "10.10.0.0/16"
-  tags {
+  tags = {
     Name = "terraform-testacc-ecs-service-with-launch-type-fargate-and-platform-version"
   }
 }
@@ -1384,7 +1384,7 @@ resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
   availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "tf-acc-ecs-service-with-launch-type-fargate-and-platform-version"
   }
 }
@@ -1449,7 +1449,7 @@ resource "aws_ecs_service" "main" {
   platform_version = %q
   network_configuration {
     security_groups = ["${aws_security_group.allow_all_a.id}", "${aws_security_group.allow_all_b.id}"]
-    subnets = ["${aws_subnet.main.*.id}"]
+    subnets = ["${aws_subnet.main.*.id[0]}", "${aws_subnet.main.*.id[1]}"]
     assign_public_ip = false
   }
 }
@@ -1556,7 +1556,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_lb" "main" {
   name     = "%s"
   internal = true
-  subnets  = ["${aws_subnet.main.*.id}"]
+  subnets  = ["${aws_subnet.main.*.id[0]}", "${aws_subnet.main.*.id[1]}"]
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -1683,7 +1683,7 @@ EOF
 
 resource "aws_elb" "main" {
   internal = true
-  subnets  = ["${aws_subnet.test.*.id}"]
+  subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 
   listener {
     instance_port = 8080
@@ -1834,7 +1834,7 @@ EOF
 
 resource "aws_elb" "main" {
   internal = true
-  subnets  = ["${aws_subnet.test.*.id}"]
+  subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 
   listener {
     instance_port = %[6]d
@@ -2087,7 +2087,7 @@ resource "aws_lb_target_group" "test" {
 resource "aws_lb" "main" {
   name            = "%s"
   internal        = true
-  subnets         = ["${aws_subnet.main.*.id}"]
+  subnets         = ["${aws_subnet.main.*.id[0]}", "${aws_subnet.main.*.id[1]}"]
 }
 
 resource "aws_lb_listener" "front_end" {
@@ -2208,7 +2208,7 @@ resource "aws_ecs_service" "main" {
   desired_count = 1
   network_configuration {
     security_groups = [%s]
-    subnets = ["${aws_subnet.main.*.id}"]
+    subnets = ["${aws_subnet.main.*.id[0]}", "${aws_subnet.main.*.id[1]}"]
   }
 }
 `, sg1Name, sg2Name, clusterName, tdName, svcName, securityGroups)
@@ -2289,7 +2289,7 @@ resource "aws_ecs_service" "test" {
   }
   network_configuration {
     security_groups = ["${aws_security_group.test.id}"]
-    subnets = ["${aws_subnet.test.*.id}"]
+    subnets = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 }
 `, rName, rName, rName, clusterName, tdName, svcName)
@@ -2464,7 +2464,7 @@ resource "aws_subnet" "test" {
 resource "aws_lb" "test" {
   internal = true
   name     = %q
-  subnets  = ["${aws_subnet.test.*.id}"]
+  subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_lb_listener" "test" {

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -1008,11 +1008,11 @@ TASK_DEFINITION
     docker_volume_configuration {
         driver = "local"
         scope  = "shared"
-        driver_opts {
+        driver_opts = {
             device = "tmpfs"
             uid    = "1000"
         }
-        labels {
+        labels = {
             environment = "test"
             stack       = "april"
         }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Changes:
* tests/resource/aws_ecs_service: Temporarily use expanded subnet_ids references - Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.
* tests/resource/aws_ecs_service: Ensure tags configurations in TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion use equals
* tests/resource/aws_ecs_service: Expect either Terraform 0.11 or Terraform 0.12 error for non-existent imports
* tests/resource/aws_ecs_task_definition: Ensure driver_opts and labels configurations use equals

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSEcsService_basicImport (33.46s)
    testing.go:561: Step 2, expected error:

        Cannot import non-existent remote object: While attempting to import an existing object to aws_ecs_service.jenkins, the provider detected that no object exists with the given id. Only pre-existing objects can be imported; check that the id is correct and that it is associated with the provider's configured region or endpoint, or use "terraform apply" to create a new remote object for this resource.

        To match:

        Please verify the ID is correct

--- FAIL: TestAccAWSEcsService_withAlb (3.47s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test765633051/main.tf line 99:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.

--- FAIL: TestAccAWSEcsTaskDefinition_withDockerVolume (0.60s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported block type: Blocks of type "driver_opts" are not expected here. Did you mean to define argument "driver_opts"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "labels" are not expected here. Did you mean to define argument "labels"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- PASS: TestAccAWSEcsService_basicImport (33.86s)
--- PASS: TestAccAWSEcsService_disappears (20.87s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (277.39s)
--- PASS: TestAccAWSEcsService_ManagedTags (30.91s)
--- PASS: TestAccAWSEcsService_PropagateTags (94.82s)
--- PASS: TestAccAWSEcsService_Tags (49.55s)
--- PASS: TestAccAWSEcsService_withAlb (222.27s)
--- PASS: TestAccAWSEcsService_withARN (38.31s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (15.80s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (22.00s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (171.67s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (41.24s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (18.79s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (41.68s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (48.17s)
--- PASS: TestAccAWSEcsService_withIamRole (180.52s)
--- FAIL: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (637.23s)
    testing.go:568: Step 1 error: errors during apply:

        Error: error updating ECS Service (arn:aws:ecs:us-west-2:187416307283:service/tf-acc-cluster-svc-w-nc-n938inq9/tf-acc-svc-w-nc-n938inq9): InvalidParameterException: subnets can not be empty.

--- FAIL: TestAccAWSEcsService_withLaunchTypeFargate (649.46s)
    testing.go:568: Step 1 error: errors during apply:

        Error: error updating ECS Service (arn:aws:ecs:us-west-2:187416307283:service/tf-acc-cluster-svc-w-ltf-4tjd6zj7/tf-acc-svc-w-ltf-4tjd6zj7): InvalidParameterException: subnets can not be empty.

--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (124.72s)
--- PASS: TestAccAWSEcsService_withLbChanges (280.67s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (34.04s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (19.39s)
=== CONT  TestAccAWSEcsService_withPlacementStrategy
panic: interface conversion: interface {} is nil, not []interface {}

goroutine 22316 [running]:
github.com/zclconf/go-cty/cty.Value.HasIndex(0x5716ba0, 0xc00ced7380, 0x0, 0x0, 0x5716b20, 0xc0000bc96a, 0x4fd6100, 0xc014a4bc80, 0x472f120, 0xc012a8bb60, ...)
  /Users/bflad/go/pkg/mod/github.com/zclconf/go-cty@v0.0.0-20181231001355-67e3da15e430/cty/value_ops.go:738 +0xa7d

--- PASS: TestAccAWSEcsService_withRenamedCluster (53.06s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (41.67s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (151.54s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (140.75s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (22.68s)

--- PASS: TestAccAWSEcsTaskDefinition_withDockerVolume (10.90s)
```
