### PR TITLE
tests/resource/aws_elasticache_replication_group: Temporarily use expanded subnet_ids references

### DIFF
--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -1436,7 +1436,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_elasticache_subnet_group" "test" {
   name       = "%[1]s"
-  subnet_ids = ["${aws_subnet.test.*.id}"]
+  subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_elasticache_replication_group" "test" {


### PR DESCRIPTION
This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (2.07s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test660389604/main.tf line 25:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverDisabled (1178.44s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters (1582.39s)
--- PASS: TestAccAWSElasticacheReplicationGroup_NumberCacheClusters_Failover_AutoFailoverEnabled (1618.99s)
```
