### PR TITLE
tests/service/eks: Temporarily use expanded subnet_ids references

### DIFF
--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -320,7 +320,7 @@ resource "aws_eks_cluster" "test" {
   role_arn = "${aws_iam_role.test.arn}"
 
   vpc_config {
-    subnet_ids = ["${aws_subnet.test.*.id}"]
+    subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
   depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
@@ -338,7 +338,7 @@ resource "aws_eks_cluster" "test" {
   version  = "%s"
 
   vpc_config {
-    subnet_ids = ["${aws_subnet.test.*.id}"]
+    subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
   depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
@@ -364,7 +364,7 @@ resource "aws_eks_cluster" "test" {
 
   vpc_config {
     security_group_ids = ["${aws_security_group.test.id}"]
-    subnet_ids         = ["${aws_subnet.test.*.id}"]
+    subnet_ids         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 
   depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]


### PR DESCRIPTION
This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSEksCluster_basic (2.04s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test170405272/main.tf line 62:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (1079.94s)
--- PASS: TestAccAWSEksClusterDataSource_basic (1110.37s)
--- PASS: TestAccAWSEksCluster_basic (1258.73s)
--- PASS: TestAccAWSEksCluster_Version (2433.03s)
```
