### PR TITLE
tests/resource/aws_elasticsearch_domain: Ensure advanced_options configurations use equals

### DIFF
--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -792,7 +792,7 @@ func testAccESDomainConfig_ClusterUpdate(randInt, instanceInt, snapshotInt int) 
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
 
-  advanced_options {
+  advanced_options = {
     "indices.fielddata.cache.size" = 80
   }
 
@@ -822,7 +822,7 @@ resource "aws_elasticsearch_domain" "example" {
 
 	elasticsearch_version = "6.0"
 
-  advanced_options {
+  advanced_options = {
     "indices.fielddata.cache.size" = 80
   }
 
@@ -868,7 +868,7 @@ resource "aws_elasticsearch_domain" "example" {
 
 	elasticsearch_version = "6.0"
 
-  advanced_options {
+  advanced_options = {
     "indices.fielddata.cache.size" = 80
   }
 
@@ -1026,7 +1026,7 @@ func testAccESDomainConfig_complex(randInt int) string {
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
 
-  advanced_options {
+  advanced_options = {
     "indices.fielddata.cache.size" = 80
   }
 


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSElasticSearchDomain_complex (0.43s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test242235666/main.tf:6,5-6: Invalid argument name; Argument names must not be quoted.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- PASS: TestAccAWSElasticSearchDomain_complex (868.54s)
--- FAIL: TestAccAWSElasticSearchDomain_update_volume_type (1284.46s)
    testing.go:568: Step 1 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_elasticsearch_domain.example
          advanced_options.indices.fielddata.cache.size:    "80" => "80"
          arn:                                              "arn:aws:es:us-west-2:187416307283:domain/tf-test-8233238646703530573" => "arn:aws:es:us-west-2:187416307283:domain/tf-test-8233238646703530573"
          cluster_config.#:                                 "1" => "1"
          cluster_config.0.dedicated_master_count:          "0" => ""
          cluster_config.0.dedicated_master_enabled:        "false" => ""
          cluster_config.0.dedicated_master_type:           "" => ""
          cluster_config.0.instance_count:                  "1" => "2"
          cluster_config.0.instance_type:                   "i3.large.elasticsearch" => ""
          cluster_config.0.zone_awareness_enabled:          "false" => "true"
          cognito_options.#:                                "1" => "1"
          cognito_options.0.enabled:                        "false" => "false"
          cognito_options.0.identity_pool_id:               "" => ""
          cognito_options.0.role_arn:                       "" => ""
          cognito_options.0.user_pool_id:                   "" => ""
          domain_id:                                        "187416307283/tf-test-8233238646703530573" => "187416307283/tf-test-8233238646703530573"
          domain_name:                                      "tf-test-8233238646703530573" => "tf-test-8233238646703530573"
          ebs_options.#:                                    "1" => "1"
          ebs_options.0.ebs_enabled:                        "false" => "false"
          ebs_options.0.iops:                               "0" => "0"
          ebs_options.0.volume_size:                        "0" => "0"
          ebs_options.0.volume_type:                        "" => ""
          elasticsearch_version:                            "6.0" => "6.0"
          encrypt_at_rest.#:                                "1" => "1"
          encrypt_at_rest.0.enabled:                        "false" => "false"
          encrypt_at_rest.0.kms_key_id:                     "" => ""
          endpoint:                                         "search-tf-test-8233238646703530573-n6vy77wt3jtrnsef4f5taiqhee.us-west-2.es.amazonaws.com" => "search-tf-test-8233238646703530573-n6vy77wt3jtrnsef4f5taiqhee.us-west-2.es.amazonaws.com"
          id:                                               "arn:aws:es:us-west-2:187416307283:domain/tf-test-8233238646703530573" => "arn:aws:es:us-west-2:187416307283:domain/tf-test-8233238646703530573"
          kibana_endpoint:                                  "search-tf-test-8233238646703530573-n6vy77wt3jtrnsef4f5taiqhee.us-west-2.es.amazonaws.com/_plugin/kibana/" => "search-tf-test-8233238646703530573-n6vy77wt3jtrnsef4f5taiqhee.us-west-2.es.amazonaws.com/_plugin/kibana/"
          node_to_node_encryption.#:                        "1" => "1"
          node_to_node_encryption.0.enabled:                "false" => "false"
          snapshot_options.#:                               "1" => "1"
          snapshot_options.0.automated_snapshot_start_hour: "0" => "0"

--- FAIL: TestAccAWSElasticSearchDomain_update (1525.49s)
    testing.go:568: Step 1 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_elasticsearch_domain.example
          advanced_options.indices.fielddata.cache.size:    "80" => "80"
          arn:                                              "arn:aws:es:us-west-2:187416307283:domain/tf-test-6732428643916274117" => "arn:aws:es:us-west-2:187416307283:domain/tf-test-6732428643916274117"
          cluster_config.#:                                 "1" => "1"
          cluster_config.0.dedicated_master_count:          "0" => ""
          cluster_config.0.dedicated_master_enabled:        "false" => ""
          cluster_config.0.dedicated_master_type:           "" => ""
          cluster_config.0.instance_count:                  "4" => ""
          cluster_config.0.instance_type:                   "m3.medium.elasticsearch" => "t2.micro.elasticsearch"
          cluster_config.0.zone_awareness_enabled:          "false" => "true"
          cognito_options.#:                                "1" => "1"
          cognito_options.0.enabled:                        "false" => "false"
          cognito_options.0.identity_pool_id:               "" => ""
          cognito_options.0.role_arn:                       "" => ""
          cognito_options.0.user_pool_id:                   "" => ""
          domain_id:                                        "187416307283/tf-test-6732428643916274117" => "187416307283/tf-test-6732428643916274117"
          domain_name:                                      "tf-test-6732428643916274117" => "tf-test-6732428643916274117"
          ebs_options.#:                                    "1" => "1"
          ebs_options.0.ebs_enabled:                        "true" => "true"
          ebs_options.0.iops:                               "0" => "0"
          ebs_options.0.volume_size:                        "10" => "10"
          ebs_options.0.volume_type:                        "gp2" => "gp2"
          elasticsearch_version:                            "1.5" => "1.5"
          encrypt_at_rest.#:                                "1" => "1"
          encrypt_at_rest.0.enabled:                        "false" => "false"
          encrypt_at_rest.0.kms_key_id:                     "" => ""
          endpoint:                                         "search-tf-test-6732428643916274117-kevu3vz52z62a5lmrse65i6oky.us-west-2.es.amazonaws.com" => "search-tf-test-6732428643916274117-kevu3vz52z62a5lmrse65i6oky.us-west-2.es.amazonaws.com"
          id:                                               "arn:aws:es:us-west-2:187416307283:domain/tf-test-6732428643916274117" => "arn:aws:es:us-west-2:187416307283:domain/tf-test-6732428643916274117"
          kibana_endpoint:                                  "search-tf-test-6732428643916274117-kevu3vz52z62a5lmrse65i6oky.us-west-2.es.amazonaws.com/_plugin/kibana/" => "search-tf-test-6732428643916274117-kevu3vz52z62a5lmrse65i6oky.us-west-2.es.amazonaws.com/_plugin/kibana/"
          node_to_node_encryption.#:                        "1" => "1"
          node_to_node_encryption.0.enabled:                "false" => "false"
          snapshot_options.#:                               "1" => "1"
          snapshot_options.0.automated_snapshot_start_hour: "23" => "23"

--- PASS: TestAccAWSElasticSearchDomain_update_version (3724.06s)
```
