### PR TITLE
r/aws_s3_bucket_object: Delete S3 objects with leading '/' in the key name

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -385,6 +385,11 @@ func resourceAwsS3BucketObjectDelete(d *schema.ResourceData, meta interface{}) e
 
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
+	// We are effectively ignoring any leading '/' in the key name as aws.Config.DisableRestProtocolURICleaning is false
+	// so we need to explicitly ignore any leading '/' in the s3.ListObjectVersions call.
+	if strings.HasPrefix(key, "/") {
+		key = key[1:]
+	}
 
 	if _, ok := d.GetOk("version_id"); ok {
 		// Bucket is versioned, we need to delete all versions


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/7262.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3BucketObject_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3BucketObject_ -timeout 120m
=== RUN   TestAccAWSS3BucketObject_source
=== PAUSE TestAccAWSS3BucketObject_source
=== RUN   TestAccAWSS3BucketObject_content
=== PAUSE TestAccAWSS3BucketObject_content
=== RUN   TestAccAWSS3BucketObject_contentBase64
=== PAUSE TestAccAWSS3BucketObject_contentBase64
=== RUN   TestAccAWSS3BucketObject_withContentCharacteristics
=== PAUSE TestAccAWSS3BucketObject_withContentCharacteristics
=== RUN   TestAccAWSS3BucketObject_updates
=== PAUSE TestAccAWSS3BucketObject_updates
=== RUN   TestAccAWSS3BucketObject_updatesWithVersioning
=== PAUSE TestAccAWSS3BucketObject_updatesWithVersioning
=== RUN   TestAccAWSS3BucketObject_kms
=== PAUSE TestAccAWSS3BucketObject_kms
=== RUN   TestAccAWSS3BucketObject_sse
=== PAUSE TestAccAWSS3BucketObject_sse
=== RUN   TestAccAWSS3BucketObject_acl
=== PAUSE TestAccAWSS3BucketObject_acl
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== RUN   TestAccAWSS3BucketObject_tags
=== PAUSE TestAccAWSS3BucketObject_tags
=== RUN   TestAccAWSS3BucketObject_tagsLeadingSlash
=== PAUSE TestAccAWSS3BucketObject_tagsLeadingSlash
=== CONT  TestAccAWSS3BucketObject_source
=== CONT  TestAccAWSS3BucketObject_sse
=== CONT  TestAccAWSS3BucketObject_updates
=== CONT  TestAccAWSS3BucketObject_kms
=== CONT  TestAccAWSS3BucketObject_updatesWithVersioning
=== CONT  TestAccAWSS3BucketObject_contentBase64
=== CONT  TestAccAWSS3BucketObject_withContentCharacteristics
=== CONT  TestAccAWSS3BucketObject_tags
=== CONT  TestAccAWSS3BucketObject_tagsLeadingSlash
=== CONT  TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_acl
=== CONT  TestAccAWSS3BucketObject_content
--- PASS: TestAccAWSS3BucketObject_content (41.44s)
--- PASS: TestAccAWSS3BucketObject_contentBase64 (42.68s)
--- PASS: TestAccAWSS3BucketObject_sse (51.63s)
--- PASS: TestAccAWSS3BucketObject_source (56.85s)
--- PASS: TestAccAWSS3BucketObject_withContentCharacteristics (59.55s)
--- PASS: TestAccAWSS3BucketObject_updatesWithVersioning (67.73s)
--- PASS: TestAccAWSS3BucketObject_updates (80.04s)
--- PASS: TestAccAWSS3BucketObject_kms (81.44s)
--- PASS: TestAccAWSS3BucketObject_acl (99.53s)
--- PASS: TestAccAWSS3BucketObject_storageClass (110.67s)
--- PASS: TestAccAWSS3BucketObject_tagsLeadingSlash (112.03s)
--- PASS: TestAccAWSS3BucketObject_tags (129.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	130.488s
```