### PR TITLE
tests/resource/aws_emr_cluster: Syntax fixes for Terraform 0.12

### DIFF
--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -734,7 +734,6 @@ func testAccCheckAWSEmrClusterExists(n string, v *emr.Cluster) resource.TestChec
 func testAccAWSEmrClusterConfig_bootstrap(r string) string {
 	return fmt.Sprintf(`
 resource "aws_emr_cluster" "test" {
-  count                = 1
   name                 = "%s"
   release_label        = "emr-5.0.0"
   applications         = ["Hadoop", "Hive"]
@@ -755,23 +754,21 @@ resource "aws_emr_cluster" "test" {
     name = "runif"
     args = ["instance.isMaster=true", "echo running on master node"]
   }
-  bootstrap_action = [
-    {
-      path = "s3://${aws_s3_bucket.tester.bucket}/testscript.sh"
-      name = "test"
-      args = ["1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-      ]
-    },
-  ]
+  bootstrap_action {
+    path = "s3://${aws_s3_bucket.tester.bucket}/testscript.sh"
+    name = "test"
+    args = ["1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+    ]
+  }
 }
 resource "aws_iam_instance_profile" "emr_profile" {
   name = "%s_profile"
@@ -2549,18 +2546,17 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  instance_group = [
-    {
-      instance_role = "CORE"
-      instance_type = "c4.large"
-      instance_count = "1"
-      ebs_config {
-        size = "40"
-        type = "gp2"
-        volumes_per_instance = 1
-      }
-      bid_price = "0.30"
-      autoscaling_policy = <<EOT
+  instance_group {
+    instance_role = "CORE"
+    instance_type = "c4.large"
+    instance_count = "1"
+    ebs_config {
+      size = "40"
+      type = "gp2"
+      volumes_per_instance = 1
+    }
+    bid_price = "0.30"
+    autoscaling_policy = <<EOT
 {
   "Constraints": {
     "MinCapacity": 1,
@@ -2593,13 +2589,13 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   ]
 }
 EOT
-    },
-    {
-      instance_role = "MASTER"
-      instance_type = "c4.large"
-      instance_count = 1
-    }
-  ]
+  }
+
+  instance_group {
+    instance_role = "MASTER"
+    instance_type = "c4.large"
+    instance_count = 1
+  }
 
   tags = {
     role     = "rolename"
@@ -2899,18 +2895,17 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  instance_group = [
-    {
-      instance_role = "CORE"
-      instance_type = "c4.large"
-      instance_count = "1"
-      ebs_config {
-        size = "40"
-        type = "gp2"
-        volumes_per_instance = 1
-      }
-      bid_price = "0.30"
-      autoscaling_policy = <<EOT
+  instance_group {
+    instance_role = "CORE"
+    instance_type = "c4.large"
+    instance_count = "1"
+    ebs_config {
+      size = "40"
+      type = "gp2"
+      volumes_per_instance = 1
+    }
+    bid_price = "0.30"
+    autoscaling_policy = <<EOT
 {
   "Constraints": {
     "MinCapacity": 1,
@@ -2943,13 +2938,13 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   ]
 }
 EOT
-    },
-    {
-      instance_role = "MASTER"
-      instance_type = "c4.large"
-      instance_count = 1
-    }
-  ]
+  }
+
+  instance_group {
+    instance_role = "MASTER"
+    instance_type = "c4.large"
+    instance_count = 1
+  }
 
   tags = {
     role     = "rolename"
@@ -3249,18 +3244,17 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  instance_group = [
-    {
-      instance_role = "CORE"
-      instance_type = "c4.large"
-      instance_count = "1"
-      ebs_config {
-        size = "500"
-        type = "st1"
-        volumes_per_instance = 1
-      }
-      bid_price = "0.30"
-      autoscaling_policy = <<EOT
+  instance_group {
+    instance_role = "CORE"
+    instance_type = "c4.large"
+    instance_count = "1"
+    ebs_config {
+      size = "500"
+      type = "st1"
+      volumes_per_instance = 1
+    }
+    bid_price = "0.30"
+    autoscaling_policy = <<EOT
 {
   "Constraints": {
     "MinCapacity": 1,
@@ -3293,13 +3287,13 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   ]
 }
 EOT
-    },
-    {
-      instance_role = "MASTER"
-      instance_type = "c4.large"
-      instance_count = 1
-    }
-  ]
+  }
+
+  instance_group {
+    instance_role = "MASTER"
+    instance_type = "c4.large"
+    instance_count = 1
+  }
 
   tags = {
     role     = "rolename"
@@ -3597,18 +3591,17 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  instance_group = [
-    {
-      instance_role = "CORE"
-      instance_type = "c4.large"
-      instance_count = "1"
-      ebs_config {
-        size = "500"
-        type = "st1"
-        volumes_per_instance = 1
-      }
-      bid_price = "0.30"
-      autoscaling_policy = <<EOT
+  instance_group {
+    instance_role = "CORE"
+    instance_type = "c4.large"
+    instance_count = "1"
+    ebs_config {
+      size = "500"
+      type = "st1"
+      volumes_per_instance = 1
+    }
+    bid_price = "0.30"
+    autoscaling_policy = <<EOT
 {
   "Constraints": {
     "MinCapacity": 1,
@@ -3641,13 +3634,13 @@ resource "aws_emr_cluster" "tf-test-cluster" {
   ]
 }
 EOT
-    },
-    {
-      instance_role = "MASTER"
-      instance_type = "c4.large"
-      instance_count = 1
-    }
-  ]
+  }
+
+  instance_group {
+    instance_role = "MASTER"
+    instance_type = "c4.large"
+    instance_count = 1
+  }
 
   tags = {
     role     = "rolename"


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSEMRCluster_bootstrap_ordering (0.68s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "bootstrap_action" is not expected here. Did you mean to define a block of type "bootstrap_action"?

--- FAIL: TestAccAWSEMRCluster_instance_group (0.47s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test851546480/main.tf:19,18-19: Missing key/value separator; Expected an equals sign ("=") to mark the beginning of the attribute value.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- PASS: TestAccAWSEMRCluster_additionalInfo (423.14s)
--- PASS: TestAccAWSEMRCluster_basic (447.48s)
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (456.33s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (443.69s)
--- PASS: TestAccAWSEMRCluster_custom_ami_id (641.39s)
--- PASS: TestAccAWSEMRCluster_keepJob (488.85s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (424.54s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (837.65s)
--- PASS: TestAccAWSEMRCluster_s3Logging (645.01s)
--- PASS: TestAccAWSEMRCluster_security_config (486.82s)
--- PASS: TestAccAWSEMRCluster_Step_Basic (489.84s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (426.16s)
--- PASS: TestAccAWSEMRCluster_tags (809.35s)
--- PASS: TestAccAWSEMRCluster_terminationProtected (467.29s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (874.48s)

--- FAIL: TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 (477.74s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_emr_cluster.tf-test-cluster
          applications.#:                                     "1" => "1"
          applications.0:                                     "Spark" => "Spark"
          autoscaling_role:                                   "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_2172273272529519576" => "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_2172273272529519576"
          bootstrap_action.#:                                 "1" => "1"
          bootstrap_action.0.args.#:                          "2" => "2"
          bootstrap_action.0.args.0:                          "instance.isMaster=true" => "instance.isMaster=true"
          bootstrap_action.0.args.1:                          "echo running on master node" => "echo running on master node"
          bootstrap_action.0.name:                            "runif" => "runif"
          bootstrap_action.0.path:                            "s3://elasticmapreduce/bootstrap-actions/run-if" => "s3://elasticmapreduce/bootstrap-actions/run-if"
          cluster_state:                                      "WAITING" => "WAITING"
          core_instance_count:                                "1" => "1"
          core_instance_type:                                 "c4.large" => "c4.large"
          ebs_root_volume_size:                               "0" => "0"
          ec2_attributes.#:                                   "1" => "1"
          ec2_attributes.0.additional_master_security_groups: "" => ""
          ec2_attributes.0.additional_slave_security_groups:  "" => ""
          ec2_attributes.0.emr_managed_master_security_group: "sg-0d408e28706df7df4" => "sg-0d408e28706df7df4"
          ec2_attributes.0.emr_managed_slave_security_group:  "sg-0d408e28706df7df4" => "sg-0d408e28706df7df4"
          ec2_attributes.0.instance_profile:                  "arn:aws:iam::187416307283:instance-profile/emr_profile_2172273272529519576" => "arn:aws:iam::187416307283:instance-profile/emr_profile_2172273272529519576"
          ec2_attributes.0.key_name:                          "" => ""
          ec2_attributes.0.service_access_security_group:     "" => ""
          ec2_attributes.0.subnet_id:                         "subnet-05a540246d4a2ba65" => "subnet-05a540246d4a2ba65"
          id:                                                 "j-1LF039SZJPDMN" => "j-1LF039SZJPDMN"
          instance_group.#:                                   "2" => "2"
          instance_group.0.autoscaling_policy:                "" => ""
          instance_group.0.bid_price:                         "" => ""
          instance_group.0.ebs_config:                        "" => "<computed>"
          instance_group.0.ebs_config.#:                      "1" => ""
          instance_group.0.ebs_config.0.iops:                 "0" => ""
          instance_group.0.ebs_config.0.size:                 "32" => ""
          instance_group.0.ebs_config.0.type:                 "gp2" => ""
          instance_group.0.ebs_config.0.volumes_per_instance: "1" => ""
          instance_group.0.id:                                "ig-IY9UN7EDVKC6" => "<computed>"
          instance_group.0.instance_count:                    "1" => "1"
          instance_group.0.instance_role:                     "MASTER" => "MASTER"
          instance_group.0.instance_type:                     "c4.large" => "c4.large"
          instance_group.0.name:                              "" => ""
          instance_group.1.autoscaling_policy:                "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}" => "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}"
          instance_group.1.bid_price:                         "0.30" => "0.30"
          instance_group.1.ebs_config.#:                      "1" => "1"
          instance_group.1.ebs_config.0.iops:                 "0" => ""
          instance_group.1.ebs_config.0.size:                 "500" => "500"
          instance_group.1.ebs_config.0.type:                 "st1" => "st1"
          instance_group.1.ebs_config.0.volumes_per_instance: "1" => "1"
          instance_group.1.id:                                "ig-2MY4S3L825K15" => "<computed>"
          instance_group.1.instance_count:                    "1" => "1"
          instance_group.1.instance_role:                     "CORE" => "CORE"
          instance_group.1.instance_type:                     "c4.large" => "c4.large"
          instance_group.1.name:                              "" => ""
          keep_job_flow_alive_when_no_steps:                  "true" => "true"
          log_uri:                                            "" => ""
          master_instance_type:                               "c4.large" => "c4.large"
          master_public_dns:                                  "ec2-54-213-104-113.us-west-2.compute.amazonaws.com" => "ec2-54-213-104-113.us-west-2.compute.amazonaws.com"
          name:                                               "emr-test-2172273272529519576" => "emr-test-2172273272529519576"
          release_label:                                      "emr-4.6.0" => "emr-4.6.0"
          scale_down_behavior:                                "TERMINATE_AT_TASK_COMPLETION" => "TERMINATE_AT_TASK_COMPLETION"
          security_configuration:                             "" => ""
          service_role:                                       "arn:aws:iam::187416307283:role/iam_emr_default_role_2172273272529519576" => "arn:aws:iam::187416307283:role/iam_emr_default_role_2172273272529519576"
          step.#:                                             "0" => "0"
          tags.dns_zone:                                      "env_zone" => "env_zone"
          tags.env:                                           "env" => "env"
          tags.name:                                          "name-env" => "name-env"
          tags.role:                                          "rolename" => "rolename"
          termination_protection:                             "false" => "false"
          visible_to_all_users:                               "true" => "true"

--- FAIL: TestAccAWSEMRCluster_updateAutoScalingPolicy (611.98s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_emr_cluster.tf-test-cluster
          applications.#:                                     "1" => "1"
          applications.0:                                     "Spark" => "Spark"
          autoscaling_role:                                   "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_6463462520769556656" => "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_6463462520769556656"
          bootstrap_action.#:                                 "1" => "1"
          bootstrap_action.0.args.#:                          "2" => "2"
          bootstrap_action.0.args.0:                          "instance.isMaster=true" => "instance.isMaster=true"
          bootstrap_action.0.args.1:                          "echo running on master node" => "echo running on master node"
          bootstrap_action.0.name:                            "runif" => "runif"
          bootstrap_action.0.path:                            "s3://elasticmapreduce/bootstrap-actions/run-if" => "s3://elasticmapreduce/bootstrap-actions/run-if"
          cluster_state:                                      "WAITING" => "WAITING"
          core_instance_count:                                "1" => "1"
          core_instance_type:                                 "c4.large" => "c4.large"
          ebs_root_volume_size:                               "0" => "0"
          ec2_attributes.#:                                   "1" => "1"
          ec2_attributes.0.additional_master_security_groups: "" => ""
          ec2_attributes.0.additional_slave_security_groups:  "" => ""
          ec2_attributes.0.emr_managed_master_security_group: "sg-05c8fd43f287a1d1a" => "sg-05c8fd43f287a1d1a"
          ec2_attributes.0.emr_managed_slave_security_group:  "sg-05c8fd43f287a1d1a" => "sg-05c8fd43f287a1d1a"
          ec2_attributes.0.instance_profile:                  "arn:aws:iam::187416307283:instance-profile/emr_profile_6463462520769556656" => "arn:aws:iam::187416307283:instance-profile/emr_profile_6463462520769556656"
          ec2_attributes.0.key_name:                          "" => ""
          ec2_attributes.0.service_access_security_group:     "" => ""
          ec2_attributes.0.subnet_id:                         "subnet-06b005e7809a19be3" => "subnet-06b005e7809a19be3"
          id:                                                 "j-685VS7LCBV3K" => "j-685VS7LCBV3K"
          instance_group.#:                                   "2" => "2"
          instance_group.0.autoscaling_policy:                "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}" => ""
          instance_group.0.bid_price:                         "0.30" => ""
          instance_group.0.ebs_config:                        "" => "<computed>"
          instance_group.0.ebs_config.#:                      "1" => ""
          instance_group.0.ebs_config.0.iops:                 "0" => ""
          instance_group.0.ebs_config.0.size:                 "500" => ""
          instance_group.0.ebs_config.0.type:                 "st1" => ""
          instance_group.0.ebs_config.0.volumes_per_instance: "1" => ""
          instance_group.0.id:                                "ig-1IC9KDC48LU27" => "<computed>"
          instance_group.0.instance_count:                    "1" => "1"
          instance_group.0.instance_role:                     "CORE" => "MASTER"
          instance_group.0.instance_type:                     "c4.large" => "c4.large"
          instance_group.0.name:                              "" => ""
          instance_group.1.autoscaling_policy:                "" => "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}"
          instance_group.1.bid_price:                         "" => "0.30"
          instance_group.1.ebs_config.#:                      "1" => "1"
          instance_group.1.ebs_config.0.iops:                 "0" => ""
          instance_group.1.ebs_config.0.size:                 "32" => "500"
          instance_group.1.ebs_config.0.type:                 "gp2" => "st1"
          instance_group.1.ebs_config.0.volumes_per_instance: "1" => "1"
          instance_group.1.id:                                "ig-3BPR4W5TYI1D1" => "<computed>"
          instance_group.1.instance_count:                    "1" => "1"
          instance_group.1.instance_role:                     "MASTER" => "CORE"
          instance_group.1.instance_type:                     "c4.large" => "c4.large"
          instance_group.1.name:                              "" => ""
          keep_job_flow_alive_when_no_steps:                  "true" => "true"
          log_uri:                                            "" => ""
          master_instance_type:                               "c4.large" => "c4.large"
          master_public_dns:                                  "ec2-34-217-129-92.us-west-2.compute.amazonaws.com" => "ec2-34-217-129-92.us-west-2.compute.amazonaws.com"
          name:                                               "emr-test-6463462520769556656" => "emr-test-6463462520769556656"
          release_label:                                      "emr-4.6.0" => "emr-4.6.0"
          scale_down_behavior:                                "TERMINATE_AT_TASK_COMPLETION" => "TERMINATE_AT_TASK_COMPLETION"
          security_configuration:                             "" => ""
          service_role:                                       "arn:aws:iam::187416307283:role/iam_emr_default_role_6463462520769556656" => "arn:aws:iam::187416307283:role/iam_emr_default_role_6463462520769556656"
          step.#:                                             "0" => "0"
          tags.dns_zone:                                      "env_zone" => "env_zone"
          tags.env:                                           "env" => "env"
          tags.name:                                          "name-env" => "name-env"
          tags.role:                                          "rolename" => "rolename"
          termination_protection:                             "false" => "false"
          visible_to_all_users:                               "true" => "true"

--- FAIL: TestAccAWSEMRCluster_instance_group (465.02s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_emr_cluster.tf-test-cluster
          applications.#:                                     "1" => "1"
          applications.0:                                     "Spark" => "Spark"
          autoscaling_role:                                   "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_5019046473525496522" => "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_5019046473525496522"
          bootstrap_action.#:                                 "1" => "1"
          bootstrap_action.0.args.#:                          "2" => "2"
          bootstrap_action.0.args.0:                          "instance.isMaster=true" => "instance.isMaster=true"
          bootstrap_action.0.args.1:                          "echo running on master node" => "echo running on master node"
          bootstrap_action.0.name:                            "runif" => "runif"
          bootstrap_action.0.path:                            "s3://elasticmapreduce/bootstrap-actions/run-if" => "s3://elasticmapreduce/bootstrap-actions/run-if"
          cluster_state:                                      "WAITING" => "WAITING"
          configurations:                                     "test-fixtures/emr_configurations.json" => "test-fixtures/emr_configurations.json"
          core_instance_count:                                "1" => "1"
          core_instance_type:                                 "c4.large" => "c4.large"
          ebs_root_volume_size:                               "0" => "0"
          ec2_attributes.#:                                   "1" => "1"
          ec2_attributes.0.additional_master_security_groups: "" => ""
          ec2_attributes.0.additional_slave_security_groups:  "" => ""
          ec2_attributes.0.emr_managed_master_security_group: "sg-0a09f56bb9fa4bd7e" => "sg-0a09f56bb9fa4bd7e"
          ec2_attributes.0.emr_managed_slave_security_group:  "sg-0a09f56bb9fa4bd7e" => "sg-0a09f56bb9fa4bd7e"
          ec2_attributes.0.instance_profile:                  "arn:aws:iam::187416307283:instance-profile/emr_profile_5019046473525496522" => "arn:aws:iam::187416307283:instance-profile/emr_profile_5019046473525496522"
          ec2_attributes.0.key_name:                          "" => ""
          ec2_attributes.0.service_access_security_group:     "" => ""
          ec2_attributes.0.subnet_id:                         "subnet-0c6c7f3efdc53bc37" => "subnet-0c6c7f3efdc53bc37"
          id:                                                 "j-GVF5LOGNBJT5" => "j-GVF5LOGNBJT5"
          instance_group.#:                                   "2" => "2"
          instance_group.0.autoscaling_policy:                "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}" => "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}"
          instance_group.0.bid_price:                         "0.30" => "0.30"
          instance_group.0.ebs_config.#:                      "1" => "1"
          instance_group.0.ebs_config.0.iops:                 "0" => ""
          instance_group.0.ebs_config.0.size:                 "40" => "40"
          instance_group.0.ebs_config.0.type:                 "gp2" => "gp2"
          instance_group.0.ebs_config.0.volumes_per_instance: "1" => "1"
          instance_group.0.id:                                "ig-2D6QZ1VV7Y2KD" => "<computed>"
          instance_group.0.instance_count:                    "1" => "1"
          instance_group.0.instance_role:                     "CORE" => "CORE"
          instance_group.0.instance_type:                     "c4.large" => "c4.large"
          instance_group.0.name:                              "" => ""
          instance_group.1.autoscaling_policy:                "" => ""
          instance_group.1.bid_price:                         "" => ""
          instance_group.1.ebs_config:                        "" => "<computed>"
          instance_group.1.ebs_config.#:                      "1" => ""
          instance_group.1.ebs_config.0.iops:                 "0" => ""
          instance_group.1.ebs_config.0.size:                 "32" => ""
          instance_group.1.ebs_config.0.type:                 "gp2" => ""
          instance_group.1.ebs_config.0.volumes_per_instance: "1" => ""
          instance_group.1.id:                                "ig-FBAHLGCBQABX" => "<computed>"
          instance_group.1.instance_count:                    "1" => "1"
          instance_group.1.instance_role:                     "MASTER" => "MASTER"
          instance_group.1.instance_type:                     "c4.large" => "c4.large"
          instance_group.1.name:                              "" => ""
          keep_job_flow_alive_when_no_steps:                  "true" => "true"
          log_uri:                                            "" => ""
          master_instance_type:                               "c4.large" => "c4.large"
          master_public_dns:                                  "ec2-54-190-132-64.us-west-2.compute.amazonaws.com" => "ec2-54-190-132-64.us-west-2.compute.amazonaws.com"
          name:                                               "emr-test-5019046473525496522" => "emr-test-5019046473525496522"
          release_label:                                      "emr-4.6.0" => "emr-4.6.0"
          scale_down_behavior:                                "TERMINATE_AT_TASK_COMPLETION" => "TERMINATE_AT_TASK_COMPLETION"
          security_configuration:                             "" => ""
          service_role:                                       "arn:aws:iam::187416307283:role/iam_emr_default_role_5019046473525496522" => "arn:aws:iam::187416307283:role/iam_emr_default_role_5019046473525496522"
          step.#:                                             "0" => "0"
          tags.dns_zone:                                      "env_zone" => "env_zone"
          tags.env:                                           "env" => "env"
          tags.name:                                          "name-env" => "name-env"
          tags.role:                                          "rolename" => "rolename"
          termination_protection:                             "false" => "false"
          visible_to_all_users:                               "true" => "true"

--- FAIL: TestAccAWSEMRCluster_instance_group_update (508.52s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_emr_cluster.tf-test-cluster
          applications.#:                                     "1" => "1"
          applications.0:                                     "Spark" => "Spark"
          autoscaling_role:                                   "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_3971774632508800688" => "arn:aws:iam::187416307283:role/EMR_AutoScaling_DefaultRole_3971774632508800688"
          bootstrap_action.#:                                 "1" => "1"
          bootstrap_action.0.args.#:                          "2" => "2"
          bootstrap_action.0.args.0:                          "instance.isMaster=true" => "instance.isMaster=true"
          bootstrap_action.0.args.1:                          "echo running on master node" => "echo running on master node"
          bootstrap_action.0.name:                            "runif" => "runif"
          bootstrap_action.0.path:                            "s3://elasticmapreduce/bootstrap-actions/run-if" => "s3://elasticmapreduce/bootstrap-actions/run-if"
          cluster_state:                                      "WAITING" => "WAITING"
          configurations:                                     "test-fixtures/emr_configurations.json" => "test-fixtures/emr_configurations.json"
          core_instance_count:                                "1" => "1"
          core_instance_type:                                 "c4.large" => "c4.large"
          ebs_root_volume_size:                               "0" => "0"
          ec2_attributes.#:                                   "1" => "1"
          ec2_attributes.0.additional_master_security_groups: "" => ""
          ec2_attributes.0.additional_slave_security_groups:  "" => ""
          ec2_attributes.0.emr_managed_master_security_group: "sg-0337897b71cf8eacf" => "sg-0337897b71cf8eacf"
          ec2_attributes.0.emr_managed_slave_security_group:  "sg-0337897b71cf8eacf" => "sg-0337897b71cf8eacf"
          ec2_attributes.0.instance_profile:                  "arn:aws:iam::187416307283:instance-profile/emr_profile_3971774632508800688" => "arn:aws:iam::187416307283:instance-profile/emr_profile_3971774632508800688"
          ec2_attributes.0.key_name:                          "" => ""
          ec2_attributes.0.service_access_security_group:     "" => ""
          ec2_attributes.0.subnet_id:                         "subnet-07963665a4a3de94a" => "subnet-07963665a4a3de94a"
          id:                                                 "j-1E7Y5DA4AU7R5" => "j-1E7Y5DA4AU7R5"
          instance_group.#:                                   "2" => "2"
          instance_group.0.autoscaling_policy:                "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}" => "{\"Constraints\":{\"MaxCapacity\":2,\"MinCapacity\":1},\"Rules\":[{\"Action\":{\"SimpleScalingPolicyConfiguration\":{\"AdjustmentType\":\"CHANGE_IN_CAPACITY\",\"CoolDown\":300,\"ScalingAdjustment\":1}},\"Description\":\"Scale out if YARNMemoryAvailablePercentage is less than 15\",\"Name\":\"ScaleOutMemoryPercentage\",\"Trigger\":{\"CloudWatchAlarmDefinition\":{\"ComparisonOperator\":\"LESS_THAN\",\"EvaluationPeriods\":1,\"MetricName\":\"YARNMemoryAvailablePercentage\",\"Namespace\":\"AWS/ElasticMapReduce\",\"Period\":300,\"Statistic\":\"AVERAGE\",\"Threshold\":15,\"Unit\":\"PERCENT\"}}}]}"
          instance_group.0.bid_price:                         "0.30" => "0.30"
          instance_group.0.ebs_config.#:                      "1" => "1"
          instance_group.0.ebs_config.0.iops:                 "0" => ""
          instance_group.0.ebs_config.0.size:                 "40" => "40"
          instance_group.0.ebs_config.0.type:                 "gp2" => "gp2"
          instance_group.0.ebs_config.0.volumes_per_instance: "1" => "1"
          instance_group.0.id:                                "ig-3OBWF8T156HDM" => "<computed>"
          instance_group.0.instance_count:                    "1" => "1"
          instance_group.0.instance_role:                     "CORE" => "CORE"
          instance_group.0.instance_type:                     "c4.large" => "c4.large"
          instance_group.0.name:                              "" => ""
          instance_group.1.autoscaling_policy:                "" => ""
          instance_group.1.bid_price:                         "" => ""
          instance_group.1.ebs_config:                        "" => "<computed>"
          instance_group.1.ebs_config.#:                      "1" => ""
          instance_group.1.ebs_config.0.iops:                 "0" => ""
          instance_group.1.ebs_config.0.size:                 "32" => ""
          instance_group.1.ebs_config.0.type:                 "gp2" => ""
          instance_group.1.ebs_config.0.volumes_per_instance: "1" => ""
          instance_group.1.id:                                "ig-37YSNUZGASCN3" => "<computed>"
          instance_group.1.instance_count:                    "1" => "1"
          instance_group.1.instance_role:                     "MASTER" => "MASTER"
          instance_group.1.instance_type:                     "c4.large" => "c4.large"
          instance_group.1.name:                              "" => ""
          keep_job_flow_alive_when_no_steps:                  "true" => "true"
          log_uri:                                            "" => ""
          master_instance_type:                               "c4.large" => "c4.large"
          master_public_dns:                                  "ec2-34-221-245-2.us-west-2.compute.amazonaws.com" => "ec2-34-221-245-2.us-west-2.compute.amazonaws.com"
          name:                                               "emr-test-3971774632508800688" => "emr-test-3971774632508800688"
          release_label:                                      "emr-4.6.0" => "emr-4.6.0"
          scale_down_behavior:                                "TERMINATE_AT_TASK_COMPLETION" => "TERMINATE_AT_TASK_COMPLETION"
          security_configuration:                             "" => ""
          service_role:                                       "arn:aws:iam::187416307283:role/iam_emr_default_role_3971774632508800688" => "arn:aws:iam::187416307283:role/iam_emr_default_role_3971774632508800688"
          step.#:                                             "0" => "0"
          tags.dns_zone:                                      "env_zone" => "env_zone"
          tags.env:                                           "env" => "env"
          tags.name:                                          "name-env" => "name-env"
          tags.role:                                          "rolename" => "rolename"
          termination_protection:                             "false" => "false"
          visible_to_all_users:                               "true" => "true"

```
