### PR TITLE
tests/service/glue: Syntax fixes for Terraform 0.12

### DIFF
--- a/aws/resource_aws_glue_catalog_database_test.go
+++ b/aws/resource_aws_glue_catalog_database_test.go
@@ -213,7 +213,7 @@ resource "aws_glue_catalog_database" "test" {
   name = "my_test_catalog_database_%d"
   description = "%s"
   location_uri = "my-location"
-  parameters {
+  parameters = {
 	param1 = "value1"
 	param2 = true
 	param3 = 50

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -324,76 +324,80 @@ resource "aws_glue_catalog_database" "test" {
 }
 
 resource "aws_glue_catalog_table" "test" {
-  name = "my_test_catalog_table_%d"
-  database_name = "${aws_glue_catalog_database.test.name}"
-  description = "%s"
-  owner = "my_owner"
-  retention = 1
+  name               = "my_test_catalog_table_%d"
+  database_name      = "${aws_glue_catalog_database.test.name}"
+  description        = "%s"
+  owner              = "my_owner"
+  retention          = 1
+  table_type         = "VIRTUAL_VIEW"
+  view_expanded_text = "view_expanded_text_1"
+  view_original_text = "view_original_text_1"
+
   storage_descriptor {
-    columns = [
-     {
+    bucket_columns            = ["bucket_column_1"]
+    compressed                = false
+    input_format              = "SequenceFileInputFormat"
+    location                  = "my_location"
+    number_of_buckets         = 1
+    output_format             = "SequenceFileInputFormat"
+    stored_as_sub_directories = false
+
+    parameters = {
+      param1 = "param1_val"
+    }
+
+    columns {
        name = "my_column_1"
        type = "int"
        comment = "my_column1_comment"
-     },
-     {
+    }
+
+    columns {
        name = "my_column_2"
        type = "string"
        comment = "my_column2_comment"
-     }
-    ]
-	location = "my_location"
-	input_format = "SequenceFileInputFormat"
-	output_format = "SequenceFileInputFormat"
-	compressed = false
-	number_of_buckets = 1
-	ser_de_info {
+    }
+
+    ser_de_info {
       name = "ser_de_name"
-      parameters {
+      parameters = {
         param1 = "param_val_1"
       }
       serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
-	}
-	bucket_columns = ["bucket_column_1"]
-	sort_columns = [
-      {
-        column = "my_column_1"
-        sort_order = 1
-      }
-	]
-	parameters {
-      param1 = "param1_val"
-	}
-	skewed_info {
+    }
+
+    sort_columns {
+      column = "my_column_1"
+      sort_order = 1
+    }
+
+    skewed_info {
       skewed_column_names = [
         "my_column_1"
       ]
-      skewed_column_value_location_maps {
+      skewed_column_value_location_maps = {
         my_column_1 = "my_column_1_val_loc_map"
       }
       skewed_column_values = [
         "skewed_val_1"
       ]
-	}
-	stored_as_sub_directories = false
-  }
-  partition_keys = [
-    {
-      name = "my_column_1"
-      type = "int"
-      comment = "my_column_1_comment"
-    },
-    {
-      name = "my_column_2"
-      type = "string"
-      comment = "my_column_2_comment"
     }
-  ]
-  view_original_text = "view_original_text_1"
-  view_expanded_text = "view_expanded_text_1"
-  table_type = "VIRTUAL_VIEW"
-  parameters {
-  	param1 = "param1_val"
+  }
+
+  partition_keys {
+    name = "my_column_1"
+    type = "int"
+    comment = "my_column_1_comment"
+  }
+
+  partition_keys {
+    name = "my_column_2"
+    type = "string"
+    comment = "my_column_2_comment"
+  }
+
+  parameters = {
+    param1 = "param1_val"
   }
 }
 `, rInt, rInt, desc)
@@ -406,80 +410,84 @@ resource "aws_glue_catalog_database" "test" {
 }
 
 resource "aws_glue_catalog_table" "test" {
-  name = "my_test_catalog_table_%d"
-  database_name = "${aws_glue_catalog_database.test.name}"
-  description = "A test table from terraform2"
-  owner = "my_owner2"
-  retention = 2
+  name               = "my_test_catalog_table_%d"
+  database_name      = "${aws_glue_catalog_database.test.name}"
+  description        = "A test table from terraform2"
+  owner              = "my_owner2"
+  retention          = 2
+  table_type         = "EXTERNAL_TABLE"
+  view_expanded_text = "view_expanded_text_12"
+  view_original_text = "view_original_text_12"
+
   storage_descriptor {
-    columns = [
-     {
-       name = "my_column_12"
-       type = "date"
-       comment = "my_column1_comment2"
-     },
-     {
-       name = "my_column_22"
-       type = "timestamp"
-       comment = "my_column2_comment2"
-     }
+    bucket_columns = [
+      "bucket_column_12",
+      "bucket_column_2"
     ]
-	location = "my_location2"
-	input_format = "TextInputFormat"
-	output_format = "TextInputFormat"
-	compressed = true
-	number_of_buckets = 12
-	ser_de_info {
+    compressed                = true
+    input_format              = "TextInputFormat"
+    location                  = "my_location2"
+    number_of_buckets         = 12
+    output_format             = "TextInputFormat"
+    stored_as_sub_directories = true
+
+    parameters = {
+      param12 = "param1_val2"
+    }
+
+    columns {
+      name = "my_column_12"
+      type = "date"
+      comment = "my_column1_comment2"
+    }
+
+    columns {
+      name = "my_column_22"
+      type = "timestamp"
+      comment = "my_column2_comment2"
+    }
+
+    ser_de_info {
       name = "ser_de_name2"
-      parameters {
+      parameters = {
         param2 = "param_val_12"
       }
       serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe2"
-	}
-	bucket_columns = [
-      "bucket_column_12",
-      "bucket_column_2"
-	]
-	sort_columns = [
-      {
-        column = "my_column_12"
-        sort_order = 0
-      }
-	]
-	parameters {
-      param12 = "param1_val2"
-	}
-	skewed_info {
+    }
+
+    skewed_info {
       skewed_column_names = [
         "my_column_12"
       ]
-      skewed_column_value_location_maps {
+      skewed_column_value_location_maps = {
         my_column_12 = "my_column_1_val_loc_map2"
       }
       skewed_column_values = [
         "skewed_val_12",
-		"skewed_val_2"
+        "skewed_val_2"
       ]
-	}
-	stored_as_sub_directories = true
-  }
-  partition_keys = [
-    {
-      name = "my_column_12"
-      type = "date"
-      comment = "my_column_1_comment2"
-    },
-    {
-      name = "my_column_22"
-      type = "timestamp"
-      comment = "my_column_2_comment2"
     }
-  ]
-  view_original_text = "view_original_text_12"
-  view_expanded_text = "view_expanded_text_12"
-  table_type = "EXTERNAL_TABLE"
-  parameters {
-  	param2 = "param1_val2"
+
+    sort_columns {
+      column = "my_column_12"
+      sort_order = 0
+    }
+  }
+
+  partition_keys {
+    name = "my_column_12"
+    type = "date"
+    comment = "my_column_1_comment2"
+  }
+
+  partition_keys {
+    name = "my_column_22"
+    type = "timestamp"
+    comment = "my_column_2_comment2"
+  }
+
+  parameters = {
+    param2 = "param1_val2"
   }
 }
 `, rInt, rInt)


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSGlueCatalogDatabase_full (3.41s)
    testing.go:568: Step 1 error: config is invalid: Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCatalogDatabase_importBasic (0.63s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCatalogTable_full (0.78s)
    testing.go:568: Step 0 error: config is invalid: 7 problems:

        - Unsupported argument: An argument named "partition_keys" is not expected here. Did you mean to define a block of type "partition_keys"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported argument: An argument named "sort_columns" is not expected here. Did you mean to define a block of type "sort_columns"?
        - Unsupported argument: An argument named "columns" is not expected here. Did you mean to define a block of type "columns"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "skewed_column_value_location_maps" are not expected here. Did you mean to define argument "skewed_column_value_location_maps"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCatalogTable_importBasic (0.60s)
    testing.go:568: Step 0 error: config is invalid: 7 problems:

        - Unsupported argument: An argument named "partition_keys" is not expected here. Did you mean to define a block of type "partition_keys"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported argument: An argument named "columns" is not expected here. Did you mean to define a block of type "columns"?
        - Unsupported argument: An argument named "sort_columns" is not expected here. Did you mean to define a block of type "sort_columns"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "skewed_column_value_location_maps" are not expected here. Did you mean to define argument "skewed_column_value_location_maps"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCatalogTable_update_addValues (3.57s)
    testing.go:568: Step 1 error: config is invalid: 7 problems:

        - Unsupported argument: An argument named "partition_keys" is not expected here. Did you mean to define a block of type "partition_keys"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported argument: An argument named "columns" is not expected here. Did you mean to define a block of type "columns"?
        - Unsupported argument: An argument named "sort_columns" is not expected here. Did you mean to define a block of type "sort_columns"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "skewed_column_value_location_maps" are not expected here. Did you mean to define argument "skewed_column_value_location_maps"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCatalogTable_update_replaceValues (0.62s)
    testing.go:568: Step 0 error: config is invalid: 7 problems:

        - Unsupported argument: An argument named "partition_keys" is not expected here. Did you mean to define a block of type "partition_keys"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported argument: An argument named "columns" is not expected here. Did you mean to define a block of type "columns"?
        - Unsupported argument: An argument named "sort_columns" is not expected here. Did you mean to define a block of type "sort_columns"?
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "parameters" are not expected here. Did you mean to define argument "parameters"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "skewed_column_value_location_maps" are not expected here. Did you mean to define argument "skewed_column_value_location_maps"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCrawler_JdbcTarget (0.64s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Missing required argument: The argument "connection_properties" is required, but no definition was found.
        - Unsupported block type: Blocks of type "connection_properties" are not expected here. Did you mean to define argument "connection_properties"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (0.70s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Missing required argument: The argument "connection_properties" is required, but no definition was found.
        - Unsupported block type: Blocks of type "connection_properties" are not expected here. Did you mean to define argument "connection_properties"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCrawler_JdbcTarget_Multiple (0.64s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Missing required argument: The argument "connection_properties" is required, but no definition was found.
        - Unsupported block type: Blocks of type "connection_properties" are not expected here. Did you mean to define argument "connection_properties"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSGlueCrawler_S3Target_Exclusions (0.76s)
    testing.go:568: Step 0 error: config is invalid: Incorrect attribute value type: Inappropriate value for attribute "exclusions": element 0: string required.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- PASS: TestAccAWSGlueCatalogDatabase_recreates (12.65s)
--- PASS: TestAccAWSGlueCatalogDatabase_importBasic (12.99s)
--- FAIL: TestAccAWSGlueCatalogDatabase_full (16.24s)
    testing.go:568: Step 1 error: Check failed: Check 5/6 error: aws_glue_catalog_database.test: Attribute 'parameters.param2' expected "1", got "true"

--- PASS: TestAccAWSGlueCatalogTable_basic (12.99s)
--- PASS: TestAccAWSGlueCatalogTable_full (13.35s)
--- PASS: TestAccAWSGlueCatalogTable_importBasic (14.59s)
--- FAIL: TestAccAWSGlueCatalogTable_update_replaceValues (18.40s)
    testing.go:568: Step 1 error: Check failed: Check 7/43 error: aws_glue_catalog_table.test: Attribute 'storage_descriptor.0.columns.0.name' not found
--- PASS: TestAccAWSGlueCatalogTable_update_addValues (21.70s)

--- FAIL: TestAccAWSGlueCrawler_JdbcTarget (33.59s)
    testing.go:568: Step 1 error: errors during apply:

        Error: error updating Glue crawler: InvalidInputException: Connection name cannot be equal to null or empty.
          status code: 400, request id: b4f2f66a-1f35-11e9-a914-47fb9cd5a754

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test537421395/main.tf line 51:
          (source code not available)

--- FAIL: TestAccAWSGlueCrawler_JdbcTarget_Multiple (35.33s)
    testing.go:568: Step 1 error: errors during apply:

        Error: One of the following configurations is required: dynamodb_target, jdbc_target, s3_target

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test042624312/main.tf line 51:
          (source code not available)

--- FAIL: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (35.73s)
    testing.go:568: Step 1 error: errors during apply:

        Error: error updating Glue crawler: InvalidInputException: Connection name cannot be equal to null or empty.
          status code: 400, request id: b65ebaad-1f35-11e9-a914-47fb9cd5a754

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test890607927/main.tf line 52:
          (source code not available)

--- FAIL: TestAccAWSGlueCrawler_S3Target_Exclusions (71.37s)
    testing.go:568: Step 1 error: errors during apply:

        Error: error updating Glue crawler: InvalidInputException: Targets are not defined
          status code: 400, request id: cb6dcfdc-1f35-11e9-8ead-81f74e5dfe82

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test443078466/main.tf line 41:
          (source code not available)

--- FAIL: TestAccAWSGlueCrawler_S3Target_Multiple (80.94s)
    testing.go:568: Step 1 error: errors during apply:

        Error: One of the following configurations is required: dynamodb_target, jdbc_target, s3_target

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test023933725/main.tf line 40:
          (source code not available)
```
