### PR TITLE
service/ec2: Various Terraform 0.12 syntax fixes

### DIFF
--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -336,7 +336,7 @@ resource "aws_instance" "web" {
 }
 
 data "aws_instance" "web-instance" {
-  instance_tags {
+  instance_tags = {
     Name = "${aws_instance.web.tags["Name"]}"
     TestSeed = "%d"
   }

--- a/aws/data_source_aws_instances_test.go
+++ b/aws/data_source_aws_instances_test.go
@@ -87,7 +87,11 @@ resource "aws_instance" "test" {
 data "aws_instances" "test" {
   filter {
     name = "instance-id"
-    values = ["${aws_instance.test.*.id}"]
+    values = [
+      "${aws_instance.test.*.id[0]}",
+      "${aws_instance.test.*.id[1]}",
+      "${aws_instance.test.*.id[2]}",
+    ]
   }
 }
 `
@@ -121,7 +125,7 @@ resource "aws_instance" "test" {
 }
 
 data "aws_instances" "test" {
-  instance_tags {
+  instance_tags = {
     Name      = "${aws_instance.test.0.tags["Name"]}"
     SecondTag = "${aws_instance.test.1.tags["Name"]}"
   }
@@ -157,7 +161,7 @@ resource "aws_instance" "test" {
 }
 
 data "aws_instances" "test" {
-  instance_tags {
+  instance_tags = {
     Name = "${aws_instance.test.0.tags["Name"]}"
   }
   

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -25,7 +25,7 @@ and you'd need to re-run `apply` every time an instance comes up or dies.
 
 ```hcl
 data "aws_instances" "test" {
-  instance_tags {
+  instance_tags = {
     Role = "HardWorker"
   }
 


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Changes:
* data-source/aws_instance(s): Ensure instance_tags configurations use equals
* tests/data-source/aws_instances: Temporarily expand values references

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSInstanceDataSource_tags (0.65s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "instance_tags" are not expected here. Did you mean to define argument "instance_tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSInstancesDataSource_basic (2.30s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test513715773/main.tf line 30:
          (source code not available)

        Inappropriate value for attribute "values": element 0: string required.

--- FAIL: TestAccAWSInstancesDataSource_instance_state_names (0.58s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "instance_tags" are not expected here. Did you mean to define argument "instance_tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSInstancesDataSource_tags (0.58s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "instance_tags" are not expected here. Did you mean to define argument "instance_tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSInstanceDataSource_tags (120.47s)

--- PASS: TestAccAWSInstancesDataSource_tags (108.85s)
--- PASS: TestAccAWSInstancesDataSource_instance_state_names (108.88s)
--- PASS: TestAccAWSInstancesDataSource_basic (118.74s)
```
