### PR TITLE
resource/aws_iot_thing: Ensure attributes configurations use equals

### DIFF
--- a/aws/resource_aws_iot_thing_test.go
+++ b/aws/resource_aws_iot_thing_test.go
@@ -180,7 +180,7 @@ func testAccAWSIotThingConfig_full(thingName, typeName, answer string) string {
 	return fmt.Sprintf(`
 resource "aws_iot_thing" "test" {
   name       = "%s"
-  attributes {
+  attributes = {
   	One = "11111"
   	Two = "TwoTwo"
   	Answer = "%s"

--- a/website/docs/r/iot_thing.html.markdown
+++ b/website/docs/r/iot_thing.html.markdown
@@ -16,7 +16,7 @@ Creates and manages an AWS IoT Thing.
 resource "aws_iot_thing" "example" {
   name = "example"
 
-  attributes {
+  attributes = {
     First = "examplevalue"
   }
 }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSIotThing_full (0.60s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "attributes" are not expected here. Did you mean to define argument "attributes"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- FAIL: TestAccAWSIotThing_full (317.27s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_iot_thing_type.test
          arn:                      "arn:aws:iot:us-west-2:187416307283:thingtype/tf_acc_type_zaw92zkc" => "arn:aws:iot:us-west-2:187416307283:thingtype/tf_acc_type_zaw92zkc"
          deprecated:               "false" => "false"
          id:                       "tf_acc_type_zaw92zkc" => "tf_acc_type_zaw92zkc"
          name:                     "tf_acc_type_zaw92zkc" => "tf_acc_type_zaw92zkc"
          properties.#:             "1" => ""
          properties.0.description: "" => ""
```
