### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Ensure processing_configuration, processors, and parameters configurations omit equals in testing and documentation

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -1440,16 +1440,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   extended_s3_configuration {
     role_arn = "${aws_iam_role.firehose.arn}"
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
-    processing_configuration = [{
-    	enabled = "false",
-    	processors = [{
-    		type = "Lambda"
-    		parameters = [{
-    			parameter_name = "LambdaArn"
-    			parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-    		}]
-    	}]
-    }],
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
     s3_backup_mode = "Disabled"
   }
 }
@@ -1757,16 +1757,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     role_arn = "${aws_iam_role.firehose.arn}"
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
     kms_key_arn = "${aws_kms_key.test.arn}"
-    processing_configuration = [{
-    	enabled = "false",
-    	processors = [{
-    		type = "Lambda"
-    		parameters = [{
-    			parameter_name = "LambdaArn"
-    			parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-    		}]
-    	}]
-    }]
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
   }
 }
 `
@@ -1779,16 +1779,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   extended_s3_configuration {
     role_arn = "${aws_iam_role.firehose.arn}"
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
-    processing_configuration = [{
-    	enabled = "false",
-    	processors = [{
-    		type = "NotLambda"
-    		parameters = [{
-    			parameter_name = "LambdaArn"
-    			parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-    		}]
-    	}]
-    }]
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "NotLambda"
+        parameters {
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
   }
 }
 `
@@ -1801,16 +1801,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   extended_s3_configuration {
     role_arn = "${aws_iam_role.firehose.arn}"
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
-    processing_configuration = [{
-    	enabled = "false",
-    	processors = [{
-    		type = "Lambda"
-    		parameters = [{
-    			parameter_name = "NotLambdaArn"
-    			parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-    		}]
-    	}]
-    }]
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name = "NotLambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
   }
 }
 `
@@ -1823,16 +1823,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   extended_s3_configuration {
     role_arn = "${aws_iam_role.firehose.arn}"
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
-    processing_configuration = [{
-    	enabled = "false",
-    	processors = [{
-    		type = "Lambda"
-    		parameters = [{
-    			parameter_name = "LambdaArn"
-    			parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-    		}]
-    	}]
-    }]
+    processing_configuration {
+      enabled = false
+      processors {
+        type = "Lambda"
+        parameters {
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+      }
+    }
     buffer_size = 10
     buffer_interval = 400
     compression_format = "GZIP"
@@ -1899,16 +1899,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     data_table_name = "test-table"
     copy_options = "GZIP"
     data_table_columns = "test-col"
-    processing_configuration = [{
-      enabled = false,
-      processors = [{
+    processing_configuration {
+      enabled = false
+      processors {
         type = "Lambda"
-        parameters = [{
+        parameters {
           parameter_name = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-        }]
-      }]
-    }]
+        }
+      }
+    }
   }
 }`
 
@@ -1945,34 +1945,29 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     hec_acknowledgment_timeout = 600
     hec_endpoint_type = "Event"
     s3_backup_mode = "FailedEventsOnly"
-    processing_configuration = [
-      {
-        enabled = "true"
-        processors = [
-          {
-            type = "Lambda"
-            parameters = [
-              {
-                parameter_name = "LambdaArn"
-                parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-              },
-              {
-                parameter_name = "RoleArn"
-                parameter_value = "${aws_iam_role.firehose.arn}"
-              },
-              {
-                parameter_name = "BufferSizeInMBs"
-                parameter_value = 1
-              },
-              {
-                parameter_name = "BufferIntervalInSeconds"
-                parameter_value = 120
-              }
-            ]
-          }
-        ]
+    processing_configuration {
+      enabled = true
+      processors {
+        type = "Lambda"
+
+        parameters {
+          parameter_name = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
+        }
+        parameters {
+          parameter_name = "RoleArn"
+          parameter_value = "${aws_iam_role.firehose.arn}"
+        }
+        parameters {
+          parameter_name = "BufferSizeInMBs"
+          parameter_value = 1
+        }
+        parameters {
+          parameter_name = "BufferIntervalInSeconds"
+          parameter_value = 120
+        }
       }
-    ]
+    }
   }
 }`
 
@@ -2041,16 +2036,16 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream_es" {
     index_name = "test"
     type_name = "test"
     buffering_interval = 500
-    processing_configuration = [{
-      enabled = "false",
-      processors = [{
+    processing_configuration {
+      enabled = false
+      processors {
         type = "Lambda"
-        parameters = [{
+        parameters {
           parameter_name = "LambdaArn"
           parameter_value = "${aws_lambda_function.lambda_function_test.arn}:$LATEST"
-        }]
-      }]
-    }]
+        }
+      }
+    }
   }
 }`
 

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -25,24 +25,18 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
     role_arn   = "${aws_iam_role.firehose_role.arn}"
     bucket_arn = "${aws_s3_bucket.bucket.arn}"
 
-    processing_configuration = [
-      {
-        enabled = "true"
+    processing_configuration {
+      enabled = "true"
 
-        processors = [
-          {
-            type = "Lambda"
+      processors {
+        type = "Lambda"
 
-            parameters = [
-              {
-                parameter_name  = "LambdaArn"
-                parameter_value = "${aws_lambda_function.lambda_processor.arn}:$LATEST"
-              },
-            ]
-          },
-        ]
-      },
-    ]
+        parameters {
+          parameter_name  = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_processor.arn}:$LATEST"
+        }
+      }
+    }
   }
 }
 
@@ -209,24 +203,18 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     index_name = "test"
     type_name  = "test"
 
-    processing_configuration = [
-      {
-        enabled = "true"
+    processing_configuration {
+      enabled = "true"
 
-        processors = [
-          {
-            type = "Lambda"
+      processors {
+        type = "Lambda"
 
-            parameters = [
-              {
-                parameter_name  = "LambdaArn"
-                parameter_value = "${aws_lambda_function.lambda_processor.arn}:$LATEST"
-              },
-            ]
-          },
-        ]
-      },
-    ]
+        parameters {
+          parameter_name  = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_processor.arn}:$LATEST"
+        }
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (645.47s)
    testing.go:568: Step 1 error: config is invalid: Unsupported argument: An argument named "processing_configuration" is not expected here. Did you mean to define a block of type "processing_configuration"?

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (0.58s)
    testing.go:561: Step 0, expected error:

        config is invalid: Unsupported argument: An argument named "processing_configuration" is not expected here. Did you mean to define a block of type "processing_configuration"?

        To match:

        must be one of 'LambdaArn', 'NumberOfRetries'

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (0.61s)
    testing.go:561: Step 0, expected error:

        config is invalid: Unsupported argument: An argument named "processing_configuration" is not expected here. Did you mean to define a block of type "processing_configuration"?

        To match:

        must be 'Lambda'

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (0.59s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "processing_configuration" is not expected here. Did you mean to define a block of type "processing_configuration"?

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (0.44s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test369208788/main.tf:145,7-8: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (0.54s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test582087725/main.tf:145,7-8: Missing newline after argument; An argument definition must end with a newline.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (1.58s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (1.59s)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (100.03s)
    testing.go:568: Step 1 error: errors during apply:

        Error: Error Updating Kinesis Firehose Delivery Stream: "terraform-kinesis-firehose-basicsplunktest-5117781729330898256"
        InvalidParameter: 2 validation error(s) found.
        - minimum field size of 1, UpdateDestinationInput.SplunkDestinationUpdate.S3Update.BucketARN.
        - minimum field size of 1, UpdateDestinationInput.SplunkDestinationUpdate.S3Update.RoleARN.

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test243512280/main.tf line 170:
          (source code not available)

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (102.96s)
    testing.go:568: Step 1 error: errors during apply:

        Error: Error Updating Kinesis Firehose Delivery Stream: "terraform-kinesis-firehose-basictest-6781643581593217393"
        InvalidParameter: 2 validation error(s) found.
        - minimum field size of 1, UpdateDestinationInput.ExtendedS3DestinationUpdate.BucketARN.
        - minimum field size of 1, UpdateDestinationInput.ExtendedS3DestinationUpdate.RoleARN.

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test134887329/main.tf line 155:
          (source code not available)

--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (138.23s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (138.55s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (150.44s)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (927.15s)
    testing.go:568: Step 1 error: errors during apply:

        Error: Error Updating Kinesis Firehose Delivery Stream: "terraform-kinesis-firehose-basicredshifttest-384461740180170111"
        InvalidParameter: 7 validation error(s) found.
        - minimum field size of 1, UpdateDestinationInput.RedshiftDestinationUpdate.ClusterJDBCURL.
        - minimum field size of 6, UpdateDestinationInput.RedshiftDestinationUpdate.Password.
        - minimum field size of 1, UpdateDestinationInput.RedshiftDestinationUpdate.RoleARN.
        - minimum field size of 1, UpdateDestinationInput.RedshiftDestinationUpdate.Username.
        - minimum field size of 1, UpdateDestinationInput.RedshiftDestinationUpdate.CopyCommand.DataTableName.
        - minimum field size of 1, UpdateDestinationInput.RedshiftDestinationUpdate.S3Update.BucketARN.
        - minimum field size of 1, UpdateDestinationInput.RedshiftDestinationUpdate.S3Update.RoleARN.

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test622720873/main.tf line 173:
          (source code not available)

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (951.08s)
    testing.go:568: Step 1 error: errors during apply:

        Error: Error Updating Kinesis Firehose Delivery Stream: "terraform-kinesis-firehose-es-4235360875258436010"
        InvalidParameter: 4 validation error(s) found.
        - minimum field size of 1, UpdateDestinationInput.ElasticsearchDestinationUpdate.DomainARN.
        - minimum field size of 1, UpdateDestinationInput.ElasticsearchDestinationUpdate.IndexName.
        - minimum field size of 1, UpdateDestinationInput.ElasticsearchDestinationUpdate.RoleARN.
        - minimum field size of 1, UpdateDestinationInput.ElasticsearchDestinationUpdate.TypeName.

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test854467459/main.tf line 184:
          (source code not available)
```
