### PR TITLE
resource/aws_kms_grant: Ensure encryption_context_equals configurations use equals in testing and documentation

### DIFF
--- a/aws/resource_aws_kms_grant_test.go
+++ b/aws/resource_aws_kms_grant_test.go
@@ -204,7 +204,7 @@ resource "aws_kms_grant" "%s" {
 	grantee_principal = "${aws_iam_role.tf-acc-test-role.arn}"
 	operations = [ "RetireGrant", "DescribeKey" ]
 	constraints {
-		%s {
+		%s = {
 			%s
 		}
 	}

--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -42,7 +42,7 @@ resource "aws_kms_grant" "a" {
   operations        = ["Encrypt", "Decrypt", "GenerateDataKey"]
 
   constraints {
-    encryption_context_equals {
+    encryption_context_equals = {
       Department = "Finance"
     }
   }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSKmsGrant_withConstraints (0.80s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "encryption_context_equals" are not expected here. Did you mean to define argument "encryption_context_equals"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSKmsGrant_withConstraints (74.24s)
```
