### PR TITLE
Update iam_user.html.markdown missing information

### DIFF
--- a/website/docs/d/iam_user.html.markdown
+++ b/website/docs/d/iam_user.html.markdown
@@ -30,3 +30,4 @@ data "aws_iam_user" "example" {
 * `path` - Path in which this user was created.
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the user.
 * `user_id` - The unique ID assigned by AWS for this user.
+* `user_name` - The name associated to this User


### PR DESCRIPTION
Based on the latest release you can use `user_name` https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/data_source_aws_iam_user.go#L33 and its not in the list

Simple change to add the `user_name` into the documentation for the data source of `aws_iam_user`