### PR TITLE
Feature/separate route table association import

### DIFF
--- a/aws/resource_aws_route_table_association.go
+++ b/aws/resource_aws_route_table_association.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -18,6 +19,9 @@ func resourceAwsRouteTableAssociation() *schema.Resource {
 		Read:   resourceAwsRouteTableAssociationRead,
 		Update: resourceAwsRouteTableAssociationUpdate,
 		Delete: resourceAwsRouteTableAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsRouteTableAssociationImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"subnet_id": {
@@ -32,6 +36,43 @@ func resourceAwsRouteTableAssociation() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceAwsRouteTableAssociationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idData := strings.Split(d.Id(), "/")
+	if len(idData) != 2 {
+		return nil, fmt.Errorf("ID needs to be in the form of <route-table-id>/<subnet-id>")
+	}
+
+	conn := meta.(*AWSClient).ec2conn
+	rtRaw, _, err := resourceAwsRouteTableStateRefreshFunc(
+		conn, idData[0])()
+	if err != nil {
+		return nil, err
+	}
+	if rtRaw == nil {
+		return nil, nil
+	}
+	rt := rtRaw.(*ec2.RouteTable)
+
+	found := false
+	for _, a := range rt.Associations {
+		if *a.SubnetId == idData[1] {
+			if err = d.Set("subnet_id", idData[1]); err != nil {
+				return nil, err
+			}
+			if err = d.Set("route_table_id", idData[0]); err != nil {
+				return nil, err
+			}
+			d.SetId(*a.RouteTableAssociationId)
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("association with subnet %s not found", idData[1])
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAwsRouteTableAssociationCreate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_route_table_association.go
+++ b/aws/resource_aws_route_table_association.go
@@ -58,6 +58,7 @@ func resourceAwsRouteTableAssociationImport(d *schema.ResourceData, meta interfa
 	found := false
 	for _, a := range rt.Associations {
 		if *a.SubnetId == idData[1] {
+			found = true
 			if err = d.Set("subnet_id", idData[1]); err != nil {
 				return nil, err
 			}

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -32,3 +32,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the association
 
+## Import
+
+Route table associations can be imported by providing the id in the following format:
+
+```
+$ terraform import aws_route_table_association.imported <route_table_id>/<subnet_id>
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Enable importing of AWS route table associations
  * Without the problems surrounding the importing of those associations en masse when a route table is imported

Output from acceptance testing:

```
ptittle@ptittle98-mac ~/src/go/src/github.com/terraform-providers/terraform-provider-aws (feature/separate_route_table_association_import) $ make testacc TESTARGS='-run=TestAccAWSRouteTableAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRouteTableAssociation -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRouteTableAssociation_basic
=== PAUSE TestAccAWSRouteTableAssociation_basic
=== CONT  TestAccAWSRouteTableAssociation_basic
--- PASS: TestAccAWSRouteTableAssociation_basic (64.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	67.027s
```
