### PR TITLE
resource/aws_lambda_function: Various Terraform 0.12 syntax fixes

### DIFF
--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1837,7 +1837,7 @@ resource "aws_lambda_function" "lambda_function_test" {
 data "template_file" "function_version" {
   template = "$${function_version}"
 
-  vars {
+  vars = {
     function_version = "${aws_lambda_function.lambda_function_test.version}"
   }
 }
@@ -1845,7 +1845,7 @@ data "template_file" "function_version" {
 data "template_file" "last_modified" {
   template = "$${last_modified}"
 
-  vars {
+  vars = {
     last_modified = "${aws_lambda_function.lambda_function_test.last_modified}"
   }
 }
@@ -1853,7 +1853,7 @@ data "template_file" "last_modified" {
 data "template_file" "qualified_arn" {
   template = "$${qualified_arn}"
 
-  vars {
+  vars = {
     qualified_arn = "${aws_lambda_function.lambda_function_test.qualified_arn}"
   }
 }
@@ -2013,7 +2013,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs8.10"
 
-    vpc_config = {
+    vpc_config {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}"]
         security_group_ids = ["${aws_security_group.sg_for_lambda.id}"]
     }
@@ -2029,7 +2029,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs8.10"
 
-    vpc_config = {
+    vpc_config {
         subnet_ids = ["${aws_subnet.subnet_for_lambda.id}", "${aws_subnet.subnet_for_lambda_2.id}"]
         security_group_ids = ["${aws_security_group.sg_for_lambda.id}", "${aws_security_group.sg_for_lambda_2.id}"]
     }
@@ -2286,7 +2286,7 @@ resource "aws_lambda_function" "lambda_function_local" {
 data "template_file" "last_modified" {
   template = "$${last_modified}"
 
-  vars {
+  vars = {
     last_modified = "${aws_lambda_function.lambda_function_local.last_modified}"
   }
 }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLambdaFunction_importLocalFile_VPC (0.58s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "vpc_config" is not expected here. Did you mean to define a block of type "vpc_config"?

--- FAIL: TestAccAWSLambdaFunction_versioned (1.12s)
    testing.go:568: Step 0 error: config is invalid: 3 problems:

        - Unsupported block type: Blocks of type "vars" are not expected here. Did you mean to define argument "vars"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "vars" are not expected here. Did you mean to define argument "vars"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "vars" are not expected here. Did you mean to define argument "vars"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSLambdaFunction_versionedUpdate (1.05s)
    testing.go:568: Step 0 error: config is invalid: 3 problems:

        - Unsupported block type: Blocks of type "vars" are not expected here. Did you mean to define argument "vars"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "vars" are not expected here. Did you mean to define argument "vars"? If so, use the equals sign to assign it a value.
        - Unsupported block type: Blocks of type "vars" are not expected here. Did you mean to define argument "vars"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSLambdaFunction_VPC (0.73s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "vpc_config" is not expected here. Did you mean to define a block of type "vpc_config"?

--- FAIL: TestAccAWSLambdaFunction_VPCRemoval (0.65s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "vpc_config" is not expected here. Did you mean to define a block of type "vpc_config"?

--- FAIL: TestAccAWSLambdaFunction_VPCUpdate (0.62s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "vpc_config" is not expected here. Did you mean to define a block of type "vpc_config"?

--- FAIL: TestAccAWSLambdaFunction_VPC_withInvocation (0.61s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "vpc_config" is not expected here. Did you mean to define a block of type "vpc_config"?
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (36.77s)
--- PASS: TestAccAWSLambdaFunction_versioned (42.28s)
--- FAIL: TestAccAWSLambdaFunction_versionedUpdate (48.84s)
    testing.go:568: Step 1 error: Check failed: Check 5/8 error: data.template_file.function_version: Attribute 'rendered' didn't match "^2$", got "1"
--- PASS: TestAccAWSLambdaFunction_VPC (35.31s)
--- FAIL: TestAccAWSLambdaFunction_VPCRemoval (47.13s)
    testing.go:568: Step 1 error: Check failed: Check 2/2 error: aws_lambda_function.lambda_function_test: Attribute 'vpc_config.#' expected "0", got "1"
--- FAIL: TestAccAWSLambdaFunction_VPCUpdate (50.22s)
    testing.go:568: Step 1 error: Check failed: Check 6/7 error: aws_lambda_function.lambda_function_test: Attribute 'vpc_config.0.subnet_ids.#' expected "2", got "1"
--- PASS: TestAccAWSLambdaFunction_VPC_withInvocation (88.76s)
```
