### PR TITLE
tests/resource/aws_lb: Temporarily use expanded subnets references

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -1035,7 +1035,7 @@ func testAccAWSLBConfig_basic(lbName string) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1102,7 +1102,7 @@ func testAccAWSLBConfig_enableHttp2(lbName string, http2 bool) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
   
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1171,7 +1171,7 @@ func testAccAWSLBConfig_enableDeletionProtection(lbName string, deletion_protect
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
   
   idle_timeout = 30
   enable_deletion_protection = %t
@@ -1399,7 +1399,7 @@ func testAccAWSLBConfigBackwardsCompatibility(lbName string) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1466,7 +1466,7 @@ func testAccAWSLBConfig_updateSubnets(lbName string) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1533,7 +1533,7 @@ func testAccAWSLBConfig_generatedName() string {
 resource "aws_lb" "lb_test" {
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1609,7 +1609,7 @@ resource "aws_lb" "lb_test" {
   name            = ""
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1690,7 +1690,7 @@ resource "aws_lb" "lb_test" {
   name_prefix     = "tf-lb-"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1756,7 +1756,7 @@ func testAccAWSLBConfig_updatedTags(lbName string) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1824,7 +1824,7 @@ func testAccAWSLBConfig_accessLogs(enabled bool, lbName, bucketName, bucketPrefi
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 50
   enable_deletion_protection = false
@@ -1936,7 +1936,7 @@ func testAccAWSLBConfig_nosg(lbName string) string {
 	return fmt.Sprintf(`resource "aws_lb" "lb_test" {
   name            = "%s"
   internal        = true
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1979,7 +1979,7 @@ func testAccAWSLBConfig_updateSecurityGroups(lbName string) string {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}", "${aws_security_group.alb_test_2.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false


### PR DESCRIPTION
This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLB_basic (9.58s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test050160700/main.tf line 5:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSLB_noSecurityGroup (189.70s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateHttp2 (332.56s)
--- PASS: TestAccAWSLB_generatedName (223.02s)
--- PASS: TestAccAWSLB_generatesNameForZeroValue (223.53s)
--- FAIL: TestAccAWSLB_updatedSubnets (239.49s)
    testing.go:568: Step 1 error: Check failed: 1 error occurred:
          * Check 2/3 error: aws_lb.lb_test: Attribute 'subnets.#' expected "3", got "2"

--- PASS: TestAccAWSLB_tags (258.02s)
--- PASS: TestAccAWSLB_basic (344.91s)
--- PASS: TestAccAWSLB_namePrefix (369.14s)
--- PASS: TestAccAWSLB_applicationLoadBalancer_updateDeletionProtection (373.70s)
--- FAIL: TestAccAWSLB_updatedSecurityGroups (386.23s)
    testing.go:568: Step 1 error: Check failed: 1 error occurred:
          * Check 2/3 error: aws_lb.lb_test: Attribute 'security_groups.#' expected "2", got "1"

--- FAIL: TestAccAWSLB_accesslogs (863.41s)
    testing.go:568: Step 2 error: errors during apply:

        Error: Failure configuring LB attributes: ValidationError: The value of 'access_logs.s3.bucket' cannot be empty
```
