### PR TITLE
tests/resource/aws_lb_listener: Various Terraform 0.12 syntax fixes

### DIFF
--- a/aws/resource_aws_lb_listener_test.go
+++ b/aws/resource_aws_lb_listener_test.go
@@ -403,7 +403,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -499,7 +499,7 @@ resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -597,7 +597,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = false
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -736,7 +736,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -818,7 +818,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -886,7 +886,7 @@ resource "aws_lb" "test" {
   name            = "%s"
   internal        = false
   security_groups = ["${aws_security_group.test.id}"]
-  subnets         = ["${aws_subnet.test.*.id}"]
+  subnets         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   enable_deletion_protection = false
 }
 
@@ -1014,7 +1014,7 @@ resource "aws_lb_listener" "test" {
       user_pool_client_id = "${aws_cognito_user_pool_client.test.id}"
       user_pool_domain = "${aws_cognito_user_pool_domain.test.domain}"
 
-      authentication_request_extra_params {
+      authentication_request_extra_params = {
         param  = "test"
       }
     }
@@ -1034,7 +1034,7 @@ resource "aws_lb" "test" {
   name            = "%s"
   internal        = false
   security_groups = ["${aws_security_group.test.id}"]
-  subnets         = ["${aws_subnet.test.*.id}"]
+  subnets         = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   enable_deletion_protection = false
 }
 
@@ -1144,7 +1144,7 @@ resource "aws_lb_listener" "test" {
       token_endpoint = "https://example.com/token_endpoint"
       user_info_endpoint = "https://example.com/user_info_endpoint"
 
-      authentication_request_extra_params {
+      authentication_request_extra_params = {
         param  = "test"
       }
     }
@@ -1185,7 +1185,7 @@ resource "aws_lb_listener" "test" {
       token_endpoint         = "https://example.com/token_endpoint"
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
-      authentication_request_extra_params {
+      authentication_request_extra_params = {
         param  = "test"
       }
     }
@@ -1229,7 +1229,7 @@ resource "aws_lb" "test" {
   internal                   = true
   name                       = "${var.rName}"
   security_groups            = ["${aws_security_group.test.id}"]
-  subnets                    = ["${aws_subnet.test.*.id}"]
+  subnets                    = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_lb_target_group" "test" {


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Changes:
* tests/resource/aws_lb_listener: Ensure authentication_request_extra_params configurations use equals
* tests/resource/aws_lb_listener: Temporarily use expanded subnets references

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLBListener_basic (4.25s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test145409224/main.tf line 16:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.

--- FAIL: TestAccAWSLBListener_cognito (1.54s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "authentication_request_extra_params" are not expected here. Did you mean to define argument "authentication_request_extra_params"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSLBListener_BackwardsCompatibility (193.54s)
--- PASS: TestAccAWSLBListener_https (194.03s)
--- PASS: TestAccAWSLBListener_redirect (203.99s)
--- PASS: TestAccAWSLBListener_basic (214.76s)
--- PASS: TestAccAWSLBListener_fixedResponse (475.74s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (213.00s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (214.66s)
--- PASS: TestAccAWSLBListener_cognito (255.30s)
--- PASS: TestAccAWSLBListener_oidc (308.55s)
```
