### PR TITLE
tests/resource/aws_lb_listener_rule: Various Terraform 0.12 syntax and test fixes

### DIFF
--- a/aws/resource_aws_lb_listener_rule_test.go
+++ b/aws/resource_aws_lb_listener_rule_test.go
@@ -107,7 +107,7 @@ func TestAccAWSLBListenerRuleBackwardsCompatibility(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "listener_arn"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "priority", "100"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.#", "1"),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.static", "action.0.order", "1"),
+					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.order", "1"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.type", "forward"),
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "action.0.target_group_arn"),
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "action.0.redirect.#", "0"),
@@ -329,8 +329,8 @@ func TestAccAWSLBListenerRule_priority(t *testing.T) {
 			{
 				Config: testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSLBListenerRuleExists("aws_lb_listener_rule.50000", &rule),
-					resource.TestCheckResourceAttr("aws_lb_listener_rule.50000", "priority", "50000"),
+					testAccCheckAWSLBListenerRuleExists("aws_lb_listener_rule.priority50000", &rule),
+					resource.TestCheckResourceAttr("aws_lb_listener_rule.priority50000", "priority", "50000"),
 				),
 			},
 			{
@@ -608,7 +608,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -719,7 +719,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -830,7 +830,7 @@ resource "aws_alb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -949,7 +949,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1050,7 +1050,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1144,7 +1144,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1267,7 +1267,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1364,7 +1364,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1538,7 +1538,7 @@ resource "aws_lb_listener_rule" "parallelism" {
 
 func testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName string) string {
 	return testAccAWSLBListenerRuleConfig_priorityBase(lbName, targetGroupName) + fmt.Sprintf(`
-resource "aws_lb_listener_rule" "50000" {
+resource "aws_lb_listener_rule" "priority50000" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 50000
 
@@ -1558,7 +1558,7 @@ resource "aws_lb_listener_rule" "50000" {
 // priority out of range (1, 50000)
 func testAccAWSLBListenerRuleConfig_priority50001(lbName, targetGroupName string) string {
 	return testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName) + fmt.Sprintf(`
-resource "aws_lb_listener_rule" "50001" {
+resource "aws_lb_listener_rule" "priority50001" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
 
   action {
@@ -1576,7 +1576,7 @@ resource "aws_lb_listener_rule" "50001" {
 
 func testAccAWSLBListenerRuleConfig_priorityInUse(lbName, targetGroupName string) string {
 	return testAccAWSLBListenerRuleConfig_priority50000(lbName, targetGroupName) + fmt.Sprintf(`
-resource "aws_lb_listener_rule" "50000_in_use" {
+resource "aws_lb_listener_rule" "priority50000_in_use" {
   listener_arn = "${aws_lb_listener.front_end.arn}"
   priority     = 50000
 
@@ -1605,7 +1605,7 @@ func testAccAWSLBListenerRuleConfig_cognito(lbName string, targetGroupName strin
       user_pool_client_id = "${aws_cognito_user_pool_client.test.id}"
       user_pool_domain = "${aws_cognito_user_pool_domain.test.domain}"
 
-      authentication_request_extra_params {
+      authentication_request_extra_params = {
         param  = "test"
       }
     }
@@ -1667,7 +1667,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1783,7 +1783,7 @@ func testAccAWSLBListenerRuleConfig_oidc(lbName string, targetGroupName string, 
       token_endpoint = "https://example.com/token_endpoint"
       user_info_endpoint = "https://example.com/user_info_endpoint"
 
-      authentication_request_extra_params {
+      authentication_request_extra_params = {
         param  = "test"
       }
     }
@@ -1845,7 +1845,7 @@ resource "aws_lb" "alb_test" {
   name            = "%s"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
-  subnets         = ["${aws_subnet.alb_test.*.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id[0]}", "${aws_subnet.alb_test.*.id[1]}"]
 
   idle_timeout = 30
   enable_deletion_protection = false
@@ -1948,7 +1948,7 @@ resource "aws_lb_listener_rule" "test" {
       token_endpoint         = "https://example.com/token_endpoint"
       user_info_endpoint     = "https://example.com/user_info_endpoint"
 
-      authentication_request_extra_params {
+      authentication_request_extra_params = {
         param  = "test"
       }
     }
@@ -2010,7 +2010,7 @@ resource "aws_lb" "test" {
   internal                   = true
   name                       = "${var.rName}"
   security_groups            = ["${aws_security_group.test.id}"]
-  subnets                    = ["${aws_subnet.test.*.id}"]
+  subnets                    = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_lb_target_group" "test" {


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Changes:
* tests/resource/aws_lb_listener_rule: Ensure authentication_request_extra_params configurations use equals
* tests/resource/aws_lb_listener_rule: Temporarily use expanded subnets references
* tests/resource/aws_lb_listener_rule: Fix resource name typo in TestAccAWSLBListenerRuleBackwardsCompatibility TestCheck (unrelated to syntax fixes but previously failing)
* tests/resource/aws_lb_listener_rule: Fix resource naming in TestAccAWSLBListenerRule_priority configurations

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLBListenerRuleBackwardsCompatibility (208.64s)
    testing.go:568: Step 0 error: Check failed: 1 error occurred:
          * Check 6/14 error: Not found: aws_lb_listener_rule.static in [root]

--- FAIL: TestAccAWSLBListenerRule_priority (323.18s)
    testing.go:568: Step 5 error: /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test460870076/main.tf:95,33-40: Invalid resource name; A name must start with a letter and may contain only letters, digits, underscores, and dashes.

--- FAIL: TestAccAWSLBListenerRule_basic (3.94s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test013185120/main.tf line 31:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.

--- FAIL: TestAccAWSLBListenerRule_cognito (0.94s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "authentication_request_extra_params" are not expected here. Did you mean to define argument "authentication_request_extra_params"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSLBListenerRule_Action_Order (240.96s)
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (234.45s)
--- PASS: TestAccAWSLBListenerRule_basic (237.02s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (250.64s)
--- PASS: TestAccAWSLBListenerRule_cognito (240.74s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (185.82s)
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (2.06s)
--- PASS: TestAccAWSLBListenerRule_oidc (235.37s)
--- PASS: TestAccAWSLBListenerRule_priority (380.15s)
--- PASS: TestAccAWSLBListenerRule_redirect (258.12s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (250.87s)
--- PASS: TestAccAWSLBListenerRuleBackwardsCompatibility (216.63s)
```
