### PR TITLE
tests/resource/aws_lb_listener_certificate: Temporarily use expanded subnets references

### DIFF
--- a/aws/resource_aws_lb_listener_certificate_test.go
+++ b/aws/resource_aws_lb_listener_certificate_test.go
@@ -197,7 +197,7 @@ resource "aws_lb_listener_certificate" "additional_2" {
 
 resource "aws_lb" "test" {
   name_prefix    = "%s"
-  subnets = ["${aws_subnet.test.*.id}"]
+  subnets = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   internal = true
 }
 


### PR DESCRIPTION
This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAwsLbListenerCertificate_basic (3.94s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test771028670/main.tf line 44:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.

--- FAIL: TestAccAwsLbListenerCertificate_cycle (4.06s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test410202061/main.tf line 44:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAwsLbListenerCertificate_basic (201.49s)
--- PASS: TestAccAwsLbListenerCertificate_cycle (250.37s)
```
