### PR TITLE
resource/aws_licensemanager_license_configuration: Ensure tags configurations use equals

### DIFF
--- a/aws/resource_aws_licensemanager_license_configuration_test.go
+++ b/aws/resource_aws_licensemanager_license_configuration_test.go
@@ -195,7 +195,7 @@ resource "aws_licensemanager_license_configuration" "example" {
     "#minimumSockets=3"
   ]
 
-  tags {
+  tags = {
     foo = "barr"
   }
 }
@@ -211,7 +211,7 @@ resource "aws_licensemanager_license_configuration" "example" {
     "#minimumSockets=3"
   ]
 
-  tags {
+  tags = {
     test = "test"
     abc = "def"
   }

--- a/website/docs/r/licensemanager_license_configuration.markdown
+++ b/website/docs/r/licensemanager_license_configuration.markdown
@@ -26,7 +26,7 @@ resource "aws_licensemanager_license_configuration" "example" {
     "#minimumSockets=2"
   ]
 
-  tags {
+  tags = {
     foo = "barr"
   }
 }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLicenseManagerLicenseConfiguration_basic (0.95s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSLicenseManagerLicenseConfiguration_update (0.67s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSLicenseManagerLicenseConfiguration_basic (12.32s)
--- PASS: TestAccAWSLicenseManagerLicenseConfiguration_update (19.82s)
```
