### PR TITLE
service/elb: Various Terraform 0.12 syntax fixes

### DIFF
--- a/aws/resource_aws_load_balancer_backend_server_policy_test.go
+++ b/aws/resource_aws_load_balancer_backend_server_policy_test.go
@@ -190,7 +190,7 @@ resource "aws_load_balancer_policy" "test-pubkey-policy0" {
   load_balancer_name = "${aws_elb.test-lb.name}"
   policy_name = "test-pubkey-policy0"
   policy_type_name = "PublicKeyPolicyType"
-  policy_attribute = {
+  policy_attribute {
     name = "PublicKey"
     value = "${replace(replace(replace(tls_private_key.example0.public_key_pem, "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
   }
@@ -200,7 +200,7 @@ resource "aws_load_balancer_policy" "test-backend-auth-policy0" {
   load_balancer_name = "${aws_elb.test-lb.name}"
   policy_name = "test-backend-auth-policy0"
   policy_type_name = "BackendServerAuthenticationPolicyType"
-  policy_attribute = {
+  policy_attribute {
     name = "PublicKeyPolicyName"
     value = "${aws_load_balancer_policy.test-pubkey-policy0.policy_name}"
   }
@@ -289,7 +289,7 @@ resource "aws_load_balancer_policy" "test-pubkey-policy0" {
   load_balancer_name = "${aws_elb.test-lb.name}"
   policy_name = "test-pubkey-policy0"
   policy_type_name = "PublicKeyPolicyType"
-  policy_attribute = {
+  policy_attribute {
     name = "PublicKey"
     value = "${replace(replace(replace(tls_private_key.example0.public_key_pem, "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
   }
@@ -299,7 +299,7 @@ resource "aws_load_balancer_policy" "test-pubkey-policy1" {
   load_balancer_name = "${aws_elb.test-lb.name}"
   policy_name = "test-pubkey-policy1"
   policy_type_name = "PublicKeyPolicyType"
-  policy_attribute = {
+  policy_attribute {
     name = "PublicKey"
     value = "${replace(replace(replace(tls_private_key.example1.public_key_pem, "\n", ""), "-----BEGIN PUBLIC KEY-----", ""), "-----END PUBLIC KEY-----", "")}"
   }
@@ -309,7 +309,7 @@ resource "aws_load_balancer_policy" "test-backend-auth-policy0" {
   load_balancer_name = "${aws_elb.test-lb.name}"
   policy_name = "test-backend-auth-policy0"
   policy_type_name = "BackendServerAuthenticationPolicyType"
-  policy_attribute = {
+  policy_attribute {
     name = "PublicKeyPolicyName"
     value = "${aws_load_balancer_policy.test-pubkey-policy1.policy_name}"
   }

--- a/aws/resource_aws_load_balancer_listener_policy_test.go
+++ b/aws/resource_aws_load_balancer_listener_policy_test.go
@@ -168,7 +168,7 @@ resource "aws_load_balancer_policy" "magic-cookie-sticky" {
   load_balancer_name = "${aws_elb.test-lb.name}"
   policy_name = "%s"
   policy_type_name = "AppCookieStickinessPolicyType"
-  policy_attribute = {
+  policy_attribute {
     name = "CookieName"
     value = "magic_cookie"
   }
@@ -205,7 +205,7 @@ resource "aws_load_balancer_policy" "magic-cookie-sticky" {
   load_balancer_name = "${aws_elb.test-lb.name}"
   policy_name = "%s"
   policy_type_name = "AppCookieStickinessPolicyType"
-  policy_attribute = {
+  policy_attribute {
     name = "CookieName"
     value = "unicorn_cookie"
   }

--- a/aws/resource_aws_load_balancer_policy_test.go
+++ b/aws/resource_aws_load_balancer_policy_test.go
@@ -259,7 +259,7 @@ func testAccAWSLoadBalancerPolicyConfig_basic(rInt int) string {
 		load_balancer_name = "${aws_elb.test-lb.name}"
 		policy_name = "test-policy-%d"
 		policy_type_name = "AppCookieStickinessPolicyType"
-		policy_attribute = {
+		policy_attribute {
 			name = "CookieName"
 			value = "magic_cookie"
 		}
@@ -288,7 +288,7 @@ func testAccAWSLoadBalancerPolicyConfig_updateWhileAssigned0(rInt int) string {
 		load_balancer_name = "${aws_elb.test-lb.name}"
 		policy_name = "test-policy-%d"
 		policy_type_name = "AppCookieStickinessPolicyType"
-		policy_attribute = {
+		policy_attribute {
 			name = "CookieName"
 			value = "magic_cookie"
 		}
@@ -325,7 +325,7 @@ func testAccAWSLoadBalancerPolicyConfig_updateWhileAssigned1(rInt int) string {
 		load_balancer_name = "${aws_elb.test-lb.name}"
 		policy_name = "test-policy-%d"
 		policy_type_name = "AppCookieStickinessPolicyType"
-		policy_attribute = {
+		policy_attribute {
 			name = "CookieName"
 			value = "unicorn_cookie"
 		}

--- a/website/docs/r/load_balancer_backend_server_policy.html.markdown
+++ b/website/docs/r/load_balancer_backend_server_policy.html.markdown
@@ -36,7 +36,7 @@ resource "aws_load_balancer_policy" "wu-tang-ca-pubkey-policy" {
   policy_name        = "wu-tang-ca-pubkey-policy"
   policy_type_name   = "PublicKeyPolicyType"
 
-  policy_attribute = {
+  policy_attribute {
     name  = "PublicKey"
     value = "${file("wu-tang-pubkey")}"
   }
@@ -47,7 +47,7 @@ resource "aws_load_balancer_policy" "wu-tang-root-ca-backend-auth-policy" {
   policy_name        = "wu-tang-root-ca-backend-auth-policy"
   policy_type_name   = "BackendServerAuthenticationPolicyType"
 
-  policy_attribute = {
+  policy_attribute {
     name  = "PublicKeyPolicyName"
     value = "${aws_load_balancer_policy.wu-tang-root-ca-pubkey-policy.policy_name}"
   }

--- a/website/docs/r/load_balancer_listener_policy.html.markdown
+++ b/website/docs/r/load_balancer_listener_policy.html.markdown
@@ -36,12 +36,12 @@ resource "aws_load_balancer_policy" "wu-tang-ssl" {
   policy_name        = "wu-tang-ssl"
   policy_type_name   = "SSLNegotiationPolicyType"
 
-  policy_attribute = {
+  policy_attribute {
     name  = "ECDHE-ECDSA-AES128-GCM-SHA256"
     value = "true"
   }
 
-  policy_attribute = {
+  policy_attribute {
     name  = "Protocol-TLSv1.2"
     value = "true"
   }

--- a/website/docs/r/load_balancer_policy.html.markdown
+++ b/website/docs/r/load_balancer_policy.html.markdown
@@ -35,7 +35,7 @@ resource "aws_load_balancer_policy" "wu-tang-ca-pubkey-policy" {
   policy_name        = "wu-tang-ca-pubkey-policy"
   policy_type_name   = "PublicKeyPolicyType"
 
-  policy_attribute = {
+  policy_attribute {
     name  = "PublicKey"
     value = "${file("wu-tang-pubkey")}"
   }
@@ -46,7 +46,7 @@ resource "aws_load_balancer_policy" "wu-tang-root-ca-backend-auth-policy" {
   policy_name        = "wu-tang-root-ca-backend-auth-policy"
   policy_type_name   = "BackendServerAuthenticationPolicyType"
 
-  policy_attribute = {
+  policy_attribute {
     name  = "PublicKeyPolicyName"
     value = "${aws_load_balancer_policy.wu-tang-root-ca-pubkey-policy.policy_name}"
   }
@@ -57,12 +57,12 @@ resource "aws_load_balancer_policy" "wu-tang-ssl" {
   policy_name        = "wu-tang-ssl"
   policy_type_name   = "SSLNegotiationPolicyType"
 
-  policy_attribute = {
+  policy_attribute {
     name  = "ECDHE-ECDSA-AES128-GCM-SHA256"
     value = "true"
   }
 
-  policy_attribute = {
+  policy_attribute {
     name  = "Protocol-TLSv1.2"
     value = "true"
   }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Changes:
* resource/aws_load_balancer_backend_server_policy: Ensure policy_attribute configurations omit equals in testing and documentation
* resource/aws_load_balancer_listener_policy: Ensure policy_attribute configurations omit equals in testing and documentation
* resource/aws_load_balancer_policy: Ensure policy_attribute configurations omit equals in testing and documentation

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLoadBalancerBackendServerPolicy_basic (0.63s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "policy_attribute" is not expected here. Did you mean to define a block of type "policy_attribute"?
        - Unsupported argument: An argument named "policy_attribute" is not expected here. Did you mean to define a block of type "policy_attribute"?

--- FAIL: TestAccAWSLoadBalancerListenerPolicy_basic (0.59s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "policy_attribute" is not expected here. Did you mean to define a block of type "policy_attribute"?

--- FAIL: TestAccAWSLoadBalancerPolicy_basic (0.59s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "policy_attribute" is not expected here. Did you mean to define a block of type "policy_attribute"?

--- FAIL: TestAccAWSLoadBalancerPolicy_disappears (0.58s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "policy_attribute" is not expected here. Did you mean to define a block of type "policy_attribute"?

--- FAIL: TestAccAWSLoadBalancerPolicy_updateWhileAssigned (0.71s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "policy_attribute" is not expected here. Did you mean to define a block of type "policy_attribute"?
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSLoadBalancerPolicy_basic (21.62s)
--- PASS: TestAccAWSLoadBalancerPolicy_disappears (26.83s)
--- PASS: TestAccAWSLoadBalancerPolicy_updateWhileAssigned (37.25s)
--- PASS: TestAccAWSLoadBalancerListenerPolicy_basic (45.16s)
--- PASS: TestAccAWSLoadBalancerBackendServerPolicy_basic (68.92s)
```
