### PR TITLE
tests/resource/aws_mq_broker: Temporarily use expanded subnet_ids references

### DIFF
--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -756,7 +756,7 @@ resource "aws_mq_broker" "test" {
   }
   publicly_accessible = true
   security_groups = ["${aws_security_group.mq1.id}", "${aws_security_group.mq2.id}"]
-  subnet_ids = ["${aws_subnet.private.*.id}"]
+  subnet_ids = ["${aws_subnet.private.*.id[0]}", "${aws_subnet.private.*.id[1]}"]
   user {
     username = "Test"
     password = "TestTest1234"


### PR DESCRIPTION
This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSMqBroker_allFieldsCustomVpc (2.31s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test760206742/main.tf line 84:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSMqBroker_allFieldsCustomVpc (2105.97s)
```
