### PR TITLE
tests/resource/aws_network_acl: Ensure ingress and egress configurations omit equals

### DIFF
--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -690,7 +690,7 @@ resource "aws_subnet" "blob" {
 
 resource "aws_network_acl" "foos" {
   vpc_id = "${aws_vpc.foo.id}"
-  ingress = {
+  ingress {
     protocol = "tcp"
     rule_no = 1
     action = "allow"
@@ -707,10 +707,6 @@ resource "aws_network_acl" "foos" {
 `
 
 const testAccAWSNetworkAclIpv6VpcConfig = `
-provider "aws" {
-  region = "us-east-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   assign_generated_ipv6_cidr_block = true
@@ -722,7 +718,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_network_acl" "foos" {
   vpc_id = "${aws_vpc.foo.id}"
-  ingress = {
+  ingress {
     protocol = "tcp"
     rule_no = 1
     action = "allow"
@@ -755,7 +751,7 @@ resource "aws_subnet" "blob" {
 
 resource "aws_network_acl" "foos" {
   vpc_id = "${aws_vpc.foo.id}"
-  ingress = {
+  ingress {
     protocol = "tcp"
     rule_no = 1
     action = "deny"
@@ -763,7 +759,7 @@ resource "aws_network_acl" "foos" {
     from_port = 0
     to_port = 22
   }
-  ingress = {
+  ingress {
     protocol = "tcp"
     rule_no = 2
     action = "deny"
@@ -798,7 +794,7 @@ resource "aws_subnet" "blob" {
 
 resource "aws_network_acl" "foos" {
   vpc_id = "${aws_vpc.foo.id}"
-  ingress = {
+  ingress {
     protocol = "tcp"
     rule_no = 1
     action = "Allow"
@@ -832,7 +828,7 @@ resource "aws_subnet" "blob" {
 
 resource "aws_network_acl" "foos" {
   vpc_id = "${aws_vpc.foo.id}"
-  ingress = {
+  ingress {
     protocol = "tcp"
     rule_no = 1
     action = "deny"
@@ -866,7 +862,7 @@ resource "aws_subnet" "blob" {
 
 resource "aws_network_acl" "bond" {
   vpc_id = "${aws_vpc.foo.id}"
-  egress = {
+  egress {
     protocol = "tcp"
     rule_no = 2
     action = "allow"
@@ -875,7 +871,7 @@ resource "aws_network_acl" "bond" {
     to_port = 443
   }
 
-  egress = {
+  egress {
     protocol = "-1"
     rule_no = 4
     action = "allow"
@@ -884,7 +880,7 @@ resource "aws_network_acl" "bond" {
     to_port = 0
   }
 
-  egress = {
+  egress {
     protocol = "tcp"
     rule_no = 1
     action = "allow"
@@ -893,7 +889,7 @@ resource "aws_network_acl" "bond" {
     to_port = 80
   }
 
-  egress = {
+  egress {
     protocol = "tcp"
     rule_no = 3
     action = "allow"
@@ -928,7 +924,7 @@ resource "aws_subnet" "blob" {
 
 resource "aws_network_acl" "bar" {
   vpc_id = "${aws_vpc.foo.id}"
-  egress = {
+  egress {
     protocol = "tcp"
     rule_no = 2
     action = "allow"
@@ -937,7 +933,7 @@ resource "aws_network_acl" "bar" {
     to_port = 443
   }
 
-  ingress = {
+  ingress {
     protocol = "tcp"
     rule_no = 1
     action = "allow"


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (0.64s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "ingress" is not expected here. Did you mean to define a block of type "ingress"?

--- FAIL: TestAccAWSNetworkAcl_EgressAndIngressRules (0.56s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "egress" is not expected here. Did you mean to define a block of type "egress"?
        - Unsupported argument: An argument named "ingress" is not expected here. Did you mean to define a block of type "ingress"?

--- FAIL: TestAccAWSNetworkAcl_OnlyEgressRules (0.60s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test831355750/main.tf:29,3-9: Attribute redefined; The argument "egress" was already set at /opt/teamcity-agent/temp/buildTmp/tf-test831355750/main.tf:20,3-9. Each argument may be set only once., and 2 other diagnostic(s)

--- FAIL: TestAccAWSNetworkAcl_OnlyIngressRules_basic (0.43s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test867164090/main.tf:28,3-10: Attribute redefined; The argument "ingress" was already set at /opt/teamcity-agent/temp/buildTmp/tf-test867164090/main.tf:20,3-10. Each argument may be set only once.

--- FAIL: TestAccAWSNetworkAcl_OnlyIngressRules_update (0.43s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test262142492/main.tf:28,3-10: Attribute redefined; The argument "ingress" was already set at /opt/teamcity-agent/temp/buildTmp/tf-test262142492/main.tf:20,3-10. Each argument may be set only once.

--- FAIL: TestAccAWSNetworkAcl_importBasic (0.74s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "egress" is not expected here. Did you mean to define a block of type "egress"?
        - Unsupported argument: An argument named "ingress" is not expected here. Did you mean to define a block of type "ingress"?

--- FAIL: TestAccAWSNetworkAcl_ipv6Rules (0.82s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "ingress" is not expected here. Did you mean to define a block of type "ingress"?

--- FAIL: TestAccAWSNetworkAcl_ipv6VpcRules (0.57s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "ingress" is not expected here. Did you mean to define a block of type "ingress"?
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- FAIL: TestAccAWSNetworkAcl_EgressAndIngressRules (21.95s)
    testing.go:568: Step 0 error: Check failed: 2 errors occurred:
          * Check 2/14 error: aws_network_acl.bar: Attribute 'ingress.1871939009.protocol' expected "6", got "tcp"
          * Check 8/14 error: aws_network_acl.bar: Attribute 'egress.3111164687.protocol' expected "6", got "tcp"

--- FAIL: TestAccAWSNetworkAcl_ipv6Rules (27.79s)
    testing.go:568: Step 0 error: Check failed: Check 3/8 error: aws_network_acl.foos: Attribute 'ingress.1976110835.protocol' expected "6", got "tcp"

--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (29.36s)
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (29.58s)
--- FAIL: TestAccAWSNetworkAcl_importBasic (29.74s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) (len=2) {
         (string) (len=26) "egress.3111164687.protocol": (string) (len=1) "6",
         (string) (len=27) "ingress.1871939009.protocol": (string) (len=1) "6"
        }

        (map[string]string) (len=2) {
         (string) (len=26) "egress.3111164687.protocol": (string) (len=3) "tcp",
         (string) (len=27) "ingress.1871939009.protocol": (string) (len=3) "tcp"
        }

--- FAIL: TestAccAWSNetworkAcl_OnlyIngressRules_update (29.77s)
    testing.go:568: Step 0 error: Check failed: 1 error occurred:
          * Check 3/11 error: aws_network_acl.foos: Attribute 'ingress.401088754.protocol' expected "6", got "tcp"

--- FAIL: TestAccAWSNetworkAcl_OnlyIngressRules_basic (30.07s)
    testing.go:568: Step 0 error: Check failed: 1 error occurred:
          * Check 2/8 error: aws_network_acl.foos: Attribute 'ingress.4245812720.protocol' expected "6", got "tcp"

--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (36.45s)
```
