### PR TITLE
resource/aws_opsworks_application: Ensure app_source, environment, and ssl_configuration configurations omit equals in testing and documentation

### DIFF
--- a/aws/resource_aws_opsworks_application_test.go
+++ b/aws/resource_aws_opsworks_application_test.go
@@ -317,15 +317,21 @@ func testAccAwsOpsworksApplicationCreate(name string) string {
 	return testAccAwsOpsworksStackConfigVpcCreate(name) +
 		fmt.Sprintf(`
 resource "aws_opsworks_application" "tf-acc-app" {
-  stack_id = "${aws_opsworks_stack.tf-acc.id}"
-  name = "%s"
-  type = "other"
-  enable_ssl = false
-  app_source ={
+  document_root = "foo"
+  enable_ssl    = false
+  name          = %q
+  stack_id      = "${aws_opsworks_stack.tf-acc.id}"
+  type          = "other"
+
+  app_source {
     type = "other"
   }
-	environment = { key = "key1" value = "value1" secure = false}
-	document_root = "foo"
+
+  environment {
+    key    = "key1"
+    value  = "value1"
+    secure = false
+  }
 }
 `, name)
 }
@@ -334,12 +340,16 @@ func testAccAwsOpsworksApplicationUpdate(name string) string {
 	return testAccAwsOpsworksStackConfigVpcCreate(name) +
 		fmt.Sprintf(`
 resource "aws_opsworks_application" "tf-acc-app" {
-  stack_id = "${aws_opsworks_stack.tf-acc.id}"
-  name = "%s"
-  type = "rails"
-  domains = ["example.com", "sub.example.com"]
-  enable_ssl = true
-  ssl_configuration = {
+  auto_bundle_on_deploy = "true"
+  document_root         = "root"
+  domains               = ["example.com", "sub.example.com"]
+  enable_ssl            = true
+  name                  = %q
+  rails_env             = "staging"
+  stack_id              = "${aws_opsworks_stack.tf-acc.id}"
+  type                  = "rails"
+
+  ssl_configuration {
     private_key = <<EOS
 -----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQCikCm00x/ybpc9esWOwK2JcyWAj3nUwsdW6Kbq8gsf/ndYAveD
@@ -371,16 +381,23 @@ V/YEvOqdAiy5NEWBztHx8HvB9G4=
 -----END CERTIFICATE-----
 EOS
   }
-  app_source = {
+
+  app_source {
     type = "git"
     revision = "master"
     url = "https://github.com/aws/example.git"
   }
-	environment = { key = "key1" value = "value1" secure = false}
-	environment = { key = "key2" value = "value2" }
-	document_root = "root"
-  auto_bundle_on_deploy = "true"
-  rails_env = "staging"
+
+  environment {
+    key    = "key1"
+    value  = "value1"
+    secure = false
+  }
+
+  environment {
+    key   = "key2"
+    value = "value2"
+  }
 }
 `, name)
 }

--- a/website/docs/r/opsworks_application.html.markdown
+++ b/website/docs/r/opsworks_application.html.markdown
@@ -25,13 +25,13 @@ resource "aws_opsworks_application" "foo-app" {
     "sub.example.com",
   ]
 
-  environment = {
+  environment {
     key    = "key"
     value  = "value"
     secure = false
   }
 
-  app_source = {
+  app_source {
     type     = "git"
     revision = "master"
     url      = "https://github.com/example.git"
@@ -39,7 +39,7 @@ resource "aws_opsworks_application" "foo-app" {
 
   enable_ssl = true
 
-  ssl_configuration = {
+  ssl_configuration {
     private_key = "${file("./foobar.key")}"
     certificate = "${file("./foobar.crt")}"
   }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSOpsworksApplication (0.44s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test607820899/main.tf:103,31-36: Missing attribute separator; Expected a newline or comma to mark the beginning of the next attribute.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- FAIL: TestAccAWSOpsworksApplication (44.96s)
    testing.go:568: Step 1 error: Check failed: Check 2/24 error: Unnexpected environment: [{
          Key: "key2",
          Secure: true,
          Value: "*****FILTERED*****"
        }]
```
