### PR TITLE
tests/resource/aws_route53_record: Ensure weighted_routing_policy configurations omit equals

### DIFF
--- a/aws/resource_aws_route53_record_test.go
+++ b/aws/resource_aws_route53_record_test.go
@@ -1077,7 +1077,7 @@ resource "aws_route53_record" "www-off" {
   name = "www"
   type = "CNAME"
   ttl = "5"
-  weighted_routing_policy = {
+  weighted_routing_policy {
 	weight = 0
   }
   set_identifier = "off"


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSRoute53Record_weighted_basic (0.59s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "weighted_routing_policy" is not expected here. Did you mean to define a block of type "weighted_routing_policy"?
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSRoute53Record_weighted_basic (208.01s)
```
