### PR TITLE
tests/resource/aws_s3_bucket_public_access_block: Ensure tags configurations use equals

### DIFF
--- a/aws/resource_aws_s3_bucket_public_access_block_test.go
+++ b/aws/resource_aws_s3_bucket_public_access_block_test.go
@@ -319,7 +319,7 @@ func testAccAWSS3BucketPublicAccessBlockConfig(bucketName, blockPublicAcls, bloc
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
 	bucket = "%s"
-	tags {
+	tags = {
 		TestName = "TestACCAWSS3BucketPublicAccessBlock_basic"
 	}
 }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSS3BucketPublicAccessBlock_basic (1.11s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSS3BucketPublicAccessBlock_disappears (0.91s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (0.85s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (0.83s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (0.67s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSS3BucketPublicAccessBlock_basic (36.63s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicAcls (73.01s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_BlockPublicPolicy (64.58s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_disappears (30.28s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_IgnorePublicAcls (89.06s)
--- PASS: TestAccAWSS3BucketPublicAccessBlock_RestrictPublicBuckets (65.75s)
```
