### PR TITLE
tests/resource/aws_ses_event_destination: Fix Terraform 0.12 syntax

### DIFF
--- a/aws/resource_aws_ses_event_destination_test.go
+++ b/aws/resource_aws_ses_event_destination_test.go
@@ -193,7 +193,7 @@ resource "aws_ses_event_destination" "kinesis" {
 }
 
 resource "aws_ses_event_destination" "cloudwatch" {
-  name = "%s",
+  name = "%s"
   configuration_set_name = "${aws_ses_configuration_set.test.name}"
   enabled = true
   matching_types = ["bounce", "send"]


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSESEventDestination_basic (0.45s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test591008274/main.tf:82,48-49: Missing newline after argument; An argument definition must end with a newline.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSSESEventDestination_basic (157.86s)
```
