### PR TITLE
tests/resource/aws_sns_sms_preferences: Fix Terraform 0.12 syntax

### DIFF
--- a/aws/resource_aws_sns_sms_preferences_test.go
+++ b/aws/resource_aws_sns_sms_preferences_test.go
@@ -143,9 +143,9 @@ resource "aws_sns_sms_preferences" "test_pref" {
 `
 const testAccAWSSNSSMSPreferencesConfig_almostAll = `
 resource "aws_sns_sms_preferences" "test_pref" {
-	monthly_spend_limit = "1",
-	default_sms_type = "Transactional",
-	usage_report_s3_bucket = "some-bucket",
+	monthly_spend_limit = "1"
+	default_sms_type = "Transactional"
+	usage_report_s3_bucket = "some-bucket"
 }
 `
 const testAccAWSSNSSMSPreferencesConfig_deliveryRole = `
@@ -188,7 +188,7 @@ POLICY
 }
 
 resource "aws_sns_sms_preferences" "test_pref" {
-	delivery_status_iam_role_arn = "${aws_iam_role.test_smsdelivery_role.arn}",
-	delivery_status_success_sampling_rate = "75",
+	delivery_status_iam_role_arn = "${aws_iam_role.test_smsdelivery_role.arn}"
+	delivery_status_success_sampling_rate = "75"
 }
 `


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSNSSMSPreferences (9.10s)
    --- FAIL: TestAccAWSSNSSMSPreferences/deliveryRole (0.46s)
        testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test818181650/main.tf:41,76-77: Missing newline after argument; An argument definition must end with a newline.
    --- PASS: TestAccAWSSNSSMSPreferences/empty (3.95s)
    --- FAIL: TestAccAWSSNSSMSPreferences/almostAll (0.37s)
        testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test655623523/main.tf:3,27-28: Missing newline after argument; An argument definition must end with a newline.
    --- PASS: TestAccAWSSNSSMSPreferences/defaultSMSType (4.32s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSSNSSMSPreferences (38.38s)
    --- PASS: TestAccAWSSNSSMSPreferences/empty (10.32s)
    --- PASS: TestAccAWSSNSSMSPreferences/almostAll (8.75s)
    --- PASS: TestAccAWSSNSSMSPreferences/defaultSMSType (9.64s)
    --- PASS: TestAccAWSSNSSMSPreferences/deliveryRole (9.67s)
```
