### PR TITLE
tests/resource/aws_sns_topic_subscription: Fix Terraform 0.12 syntax

### DIFF
--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -493,7 +493,7 @@ resource "aws_api_gateway_method_response" "test" {
   http_method = "${aws_api_gateway_method.test.http_method}"
   status_code = "200"
 
-  response_parameters {
+  response_parameters = {
     "method.response.header.Access-Control-Allow-Origin" = true
   }
 }
@@ -514,7 +514,7 @@ resource "aws_api_gateway_integration_response" "test" {
   http_method = "${aws_api_gateway_method.test.http_method}"
   status_code = "${aws_api_gateway_method_response.test.status_code}"
 
-  response_parameters {
+  response_parameters = {
     "method.response.header.Access-Control-Allow-Origin" = "'*'"
   }
 }
@@ -617,7 +617,7 @@ resource "aws_api_gateway_method_response" "test" {
   http_method = "${aws_api_gateway_method.test.http_method}"
   status_code = "200"
 
-  response_parameters {
+  response_parameters = {
     "method.response.header.Access-Control-Allow-Origin" = true
   }
 }
@@ -638,7 +638,7 @@ resource "aws_api_gateway_integration_response" "test" {
   http_method = "${aws_api_gateway_method.test.http_method}"
   status_code = "${aws_api_gateway_method_response.test.status_code}"
 
-  response_parameters {
+  response_parameters = {
     "method.response.header.Access-Control-Allow-Origin" = "'*'"
   }
 }
@@ -762,7 +762,7 @@ resource "aws_lambda_function" "authorizer" {
   runtime          = "nodejs6.10"
 
   environment {
-    variables {
+    variables = {
         AUTH_USER="%s"
         AUTH_PASS="%s"
     }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11. The remaining configuration error requires this upstream issue: https://github.com/hashicorp/terraform/issues/20098

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (0.44s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test250105636/main.tf:25,5-6: Invalid argument name; Argument names must not be quoted.

--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (0.60s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test092280804/main.tf:26,5-6: Invalid argument name; Argument names must not be quoted.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (1.70s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambda_confirm_sns.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (1.70s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Error in function call: Call to function "file" failed: contents of test-fixtures/lambda_confirm_sns.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
        - Error in function call: Call to function "file" failed: contents of test-fixtures/lambda_basic_authorizer.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
```
