### PR TITLE
tests/resource/aws_ssm_activation: Fix Terraform 0.12 syntax

### DIFF
--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -150,7 +150,7 @@ resource "aws_iam_role_policy_attachment" "test_attach" {
 }
 
 resource "aws_ssm_activation" "foo" {
-  name               = "test_ssm_activation-%s",
+  name               = "test_ssm_activation-%s"
   description        = "Test"
   iam_role           = "${aws_iam_role.test_role.name}"
   registration_limit = "5"
@@ -185,7 +185,7 @@ resource "aws_iam_role_policy_attachment" "test_attach" {
 }
 
 resource "aws_ssm_activation" "foo" {
-  name               = "test_ssm_activation-%[1]s",
+  name               = "test_ssm_activation-%[1]s"
   description        = "Test"
   expiration_date    = "%[2]s"
   iam_role           = "${aws_iam_role.test_role.name}"


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSSMActivation_basic (0.41s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test868190439/main.tf:26,56-57: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSSSMActivation_expirationDate (0.51s)
    testing.go:561: Step 0, expected error:

        /opt/teamcity-agent/temp/buildTmp/tf-test572685278/main.tf:26,56-57: Missing newline after argument; An argument definition must end with a newline.

        To match:

        invalid RFC3339 timestamp
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSSSMActivation_basic (31.62s)
--- PASS: TestAccAWSSSMActivation_expirationDate (31.70s)
```
