### PR TITLE
tests/resource/aws_ssm_association: Fix Terraform 0.12 syntax

### DIFF
--- a/aws/resource_aws_ssm_association_test.go
+++ b/aws/resource_aws_ssm_association_test.go
@@ -365,7 +365,7 @@ func testAccCheckAWSSSMAssociationDestroy(s *terraform.State) error {
 func testAccAWSSSMAssociationBasicConfigWithParameters(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<-DOC
   {
@@ -394,8 +394,8 @@ resource "aws_ssm_document" "foo_document" {
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
-  parameters {
+  name = "${aws_ssm_document.foo_document.name}"
+  parameters = {
   	Directory = "myWorkSpace"
   }
   targets {
@@ -408,7 +408,7 @@ resource "aws_ssm_association" "foo" {
 func testAccAWSSSMAssociationBasicConfigWithParametersUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<-DOC
   {
@@ -437,8 +437,8 @@ resource "aws_ssm_document" "foo_document" {
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
-  parameters {
+  name = "${aws_ssm_document.foo_document.name}"
+  parameters = {
   	Directory = "myWorkSpaceUpdated"
   }
   targets {
@@ -533,7 +533,7 @@ resource "aws_instance" "foo" {
 }
 
 resource "aws_ssm_document" "foo_document" {
-  name    = "${var.name}",
+  name    = "${var.name}"
 	document_type = "Command"
   content = <<DOC
   {
@@ -557,7 +557,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name        = "${var.name}",
+  name        = "${var.name}"
   instance_id = "${aws_instance.foo.id}"
 }
 `, rName)
@@ -566,7 +566,7 @@ resource "aws_ssm_association" "foo" {
 func testAccAWSSSMAssociationBasicConfigWithDocumentVersion(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "foo_document" {
-  name    = "test_document_association-%s",
+  name    = "test_document_association-%s"
 	document_type = "Command"
   content = <<DOC
   {
@@ -590,7 +590,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name        = "test_document_association-%s",
+  name        = "test_document_association-%s"
   document_version = "${aws_ssm_document.foo_document.latest_version}"
   targets {
     key = "tag:Name"
@@ -603,7 +603,7 @@ resource "aws_ssm_association" "foo" {
 func testAccAWSSSMAssociationBasicConfigWithScheduleExpression(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
   {
@@ -627,7 +627,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
+  name = "${aws_ssm_document.foo_document.name}"
   schedule_expression = "cron(0 16 ? * TUE *)"
   targets {
     key = "tag:Name"
@@ -639,7 +639,7 @@ resource "aws_ssm_association" "foo" {
 func testAccAWSSSMAssociationBasicConfigWithScheduleExpressionUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
   {
@@ -663,7 +663,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
+  name = "${aws_ssm_document.foo_document.name}"
   schedule_expression = "cron(0 16 ? * WED *)"
   targets {
     key = "tag:Name"
@@ -680,7 +680,7 @@ resource "aws_s3_bucket" "output_location" {
 }
 
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
   {
@@ -704,7 +704,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
+  name = "${aws_ssm_document.foo_document.name}"
   targets {
     key = "tag:Name"
     values = ["acceptanceTest"]
@@ -729,7 +729,7 @@ resource "aws_s3_bucket" "output_location_updated" {
 }
 
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
   {
@@ -753,7 +753,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
+  name = "${aws_ssm_document.foo_document.name}"
   targets {
     key = "tag:Name"
     values = ["acceptanceTest"]
@@ -778,7 +778,7 @@ resource "aws_s3_bucket" "output_location_updated" {
 }
 
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
   {
@@ -802,7 +802,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
+  name = "${aws_ssm_document.foo_document.name}"
   targets {
     key = "tag:Name"
     values = ["acceptanceTest"]
@@ -817,7 +817,7 @@ resource "aws_ssm_association" "foo" {
 func testAccAWSSSMAssociationBasicConfigWithAssociationName(rName, assocName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "foo_document" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
   {
@@ -840,7 +840,7 @@ DOC
 }
 
 resource "aws_ssm_association" "foo" {
-  name = "${aws_ssm_document.foo_document.name}",
+  name = "${aws_ssm_document.foo_document.name}"
   association_name = "%s"
   targets {
     key = "tag:Name"
@@ -853,7 +853,7 @@ resource "aws_ssm_association" "foo" {
 func testAccAWSSSMAssociationConfigWithAssociationNameAndScheduleExpression(rName, associationName, scheduleExpression string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "test" {
-  name = "test_document_association-%s",
+  name = "test_document_association-%s"
   document_type = "Command"
   content = <<DOC
   {
@@ -877,7 +877,7 @@ DOC
 
 resource "aws_ssm_association" "test" {
   association_name    = %q
-  name                = "${aws_ssm_document.test.name}",
+  name                = "${aws_ssm_document.test.name}"
   schedule_expression = %q
 
   targets {


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSSMAssociation_basic (0.44s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test861046325/main.tf:53,26-27: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSSSMAssociation_withAssociationName (0.45s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test907381073/main.tf:3,43-44: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression (0.45s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test724321574/main.tf:3,43-44: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSSSMAssociation_withDocumentVersion (0.45s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test392197379/main.tf:3,51-52: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSSSMAssociation_withOutputLocation (0.41s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test294655612/main.tf:8,48-49: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSSSMAssociation_withParameters (0.52s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test200950895/main.tf:3,48-49: Missing newline after argument; An argument definition must end with a newline.

--- FAIL: TestAccAWSSSMAssociation_withScheduleExpression (0.42s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test520368594/main.tf:3,48-49: Missing newline after argument; An argument definition must end with a newline.
```

Output from Terraform 0.12 acceptance testing (additional fixes required upstream in Terraform Provider SDK):

```
--- PASS: TestAccAWSSSMAssociation_basic (130.96s)
--- PASS: TestAccAWSSSMAssociation_withAssociationName (27.60s)
--- PASS: TestAccAWSSSMAssociation_withAssociationNameAndScheduleExpression (25.77s)
--- PASS: TestAccAWSSSMAssociation_withDocumentVersion (15.81s)
--- PASS: TestAccAWSSSMAssociation_withParameters (24.19s)
--- PASS: TestAccAWSSSMAssociation_withScheduleExpression (25.88s)

--- FAIL: TestAccAWSSSMAssociation_withTargets (18.79s)
    testing.go:568: Step 1 error: errors during apply:

        Error: Error updating SSM association: InvalidParameter: 1 validation error(s) found.
        - minimum field size of 1, UpdateAssociationInput.Targets[0].Key.

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test477585431/main.tf line 37:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Check failed: Default error in SSM Association Test

        State: <no state>

--- FAIL: TestAccAWSSSMAssociation_withOutputLocation (45.09s)
    testing.go:568: Step 1 error: Check failed: Check 3/3 error: aws_ssm_association.foo: Attribute 'output_location.0.s3_key_prefix' expected "SSMAssociation", got ""
```
