### PR TITLE
tests/resource/aws_rds_cluster: Terraform 0.12 compatible fixes for TestAccAWSRDSCluster_EncryptedCrossRegionReplication

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -2134,10 +2134,6 @@ data "aws_availability_zones" "us-east-1" {
   provider = "aws.useast1"
 }
 
-data "aws_availability_zones" "us-west-2" {
-  provider = "aws.uswest2"
-}
-
 resource "aws_rds_cluster_instance" "test_instance" {
   provider = "aws.uswest2"
   identifier = "tf-aurora-instance-%[1]d"
@@ -2161,7 +2157,6 @@ resource "aws_rds_cluster_parameter_group" "default" {
 resource "aws_rds_cluster" "test_primary" {
   provider = "aws.uswest2"
   cluster_identifier = "tf-test-primary-%[1]d"
-  availability_zones = ["${slice(data.aws_availability_zones.us-west-2.names, 0, 3)}"]
   db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.default.name}"
   database_name = "mydb"
   master_username = "foo"
@@ -2216,7 +2211,7 @@ resource "aws_subnet" "db" {
 resource "aws_db_subnet_group" "replica" {
   provider   = "aws.useast1"
   name       = "test_replica-subnet-%[1]d"
-  subnet_ids = ["${aws_subnet.db.*.id}"]
+  subnet_ids = ["${aws_subnet.db.*.id[0]}", "${aws_subnet.db.*.id[1]}", "${aws_subnet.db.*.id[2]}"]
 }
 
 resource "aws_rds_cluster" "test_replica" {


### PR DESCRIPTION
Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (0.74s)
    testing.go:568: Step 0 error: config is invalid: Incorrect attribute value type: Inappropriate value for attribute "availability_zones": element 0: string required.

--- FAIL: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (4.69s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test744740497/main.tf line 93:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1570.28s)
```
