### PR TITLE
EKS example: select node AMI specific to cluster version

### DIFF
--- a/examples/eks-getting-started/eks-worker-nodes.tf
+++ b/examples/eks-getting-started/eks-worker-nodes.tf
@@ -89,7 +89,7 @@ resource "aws_security_group_rule" "demo-node-ingress-cluster" {
 data "aws_ami" "eks-worker" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-v*"]
+    values = ["amazon-eks-node-${aws_eks_cluster.demo.version}-v*"]
   }
 
   most_recent = true

--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -477,13 +477,13 @@ This offers flexibility to scale up and down the worker nodes on demand when
 used in conjunction with AutoScaling policies (not implemented here).
 
 First, let us create a data source to fetch the latest Amazon Machine Image
-(AMI) that Amazon provides with an EKS compatible Kubernetes baked in.
+(AMI) that Amazon provides with an EKS compatible Kubernetes baked in. It will  filter for and select an AMI compatible with the specific Kubernetes version being deployed.
 
 ```hcl
 data "aws_ami" "eks-worker" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-v*"]
+    values = ["amazon-eks-node-${aws_eks_cluster.demo.version}-v*"]
   }
 
   most_recent = true

--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -477,7 +477,7 @@ This offers flexibility to scale up and down the worker nodes on demand when
 used in conjunction with AutoScaling policies (not implemented here).
 
 First, let us create a data source to fetch the latest Amazon Machine Image
-(AMI) that Amazon provides with an EKS compatible Kubernetes baked in. It will  filter for and select an AMI compatible with the specific Kubernetes version being deployed.
+(AMI) that Amazon provides with an EKS compatible Kubernetes baked in. It will filter for and select an AMI compatible with the specific Kubernetes version being deployed.
 
 ```hcl
 data "aws_ami" "eks-worker" {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Improves consistency of EKS example cluster nodes.

Changes proposed in this pull request:

* Makes use of the configured cluster's version in filtering the AMIs for the node. This avoids old / incompatible AMIs being used, even if they were published more recently than compatible ones.


Output from acceptance testing:
Doesn't change any provider code.
