### PR TITLE
Ecs service lb list

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -1061,21 +1061,6 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func resourceAwsEcsLoadBalancerHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-
-	buf.WriteString(fmt.Sprintf("%s-", m["elb_name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["container_name"].(string)))
-	buf.WriteString(fmt.Sprintf("%d-", m["container_port"].(int)))
-
-	if s := m["target_group_arn"].(string); s != "" {
-		buf.WriteString(fmt.Sprintf("%s-", s))
-	}
-
-	return hashcode.String(buf.String())
-}
-
 func buildFamilyAndRevisionFromARN(arn string) string {
 	return strings.Split(arn, "/")[1]
 }

--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -148,7 +148,7 @@ func resourceAwsEcsService() *schema.Resource {
 			},
 
 			"load_balancer": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				MaxItems: 1,
@@ -179,7 +179,6 @@ func resourceAwsEcsService() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceAwsEcsLoadBalancerHash,
 			},
 			"network_configuration": {
 				Type:     schema.TypeList,
@@ -417,7 +416,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 		input.PlatformVersion = aws.String(v.(string))
 	}
 
-	loadBalancers := expandEcsLoadBalancers(d.Get("load_balancer").(*schema.Set).List())
+	loadBalancers := expandEcsLoadBalancers(d.Get("load_balancer").([]interface{}))
 	if len(loadBalancers) > 0 {
 		log.Printf("[DEBUG] Adding ECS load balancers: %s", loadBalancers)
 		input.LoadBalancers = loadBalancers


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7315

Changes proposed in this pull request:

* change `load_balancer` attribute to be `TypeList`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEcsService_ -timeout 120m
=== RUN   TestAccAWSEcsService_withARN
=== PAUSE TestAccAWSEcsService_withARN
=== RUN   TestAccAWSEcsService_basicImport
=== PAUSE TestAccAWSEcsService_basicImport
=== RUN   TestAccAWSEcsService_disappears
=== PAUSE TestAccAWSEcsService_disappears
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== PAUSE TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
=== PAUSE TestAccAWSEcsService_withFamilyAndRevision
=== RUN   TestAccAWSEcsService_withRenamedCluster
=== PAUSE TestAccAWSEcsService_withRenamedCluster
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== PAUSE TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== RUN   TestAccAWSEcsService_withIamRole
=== PAUSE TestAccAWSEcsService_withIamRole
=== RUN   TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== PAUSE TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== RUN   TestAccAWSEcsService_withDeploymentValues
=== PAUSE TestAccAWSEcsService_withDeploymentValues
=== RUN   TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== PAUSE TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== RUN   TestAccAWSEcsService_withLbChanges
=== PAUSE TestAccAWSEcsService_withLbChanges
=== RUN   TestAccAWSEcsService_withEcsClusterName
=== PAUSE TestAccAWSEcsService_withEcsClusterName
=== RUN   TestAccAWSEcsService_withAlb
=== PAUSE TestAccAWSEcsService_withAlb
=== RUN   TestAccAWSEcsService_withPlacementStrategy
=== PAUSE TestAccAWSEcsService_withPlacementStrategy
=== RUN   TestAccAWSEcsService_withPlacementConstraints
=== PAUSE TestAccAWSEcsService_withPlacementConstraints
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== PAUSE TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargate
=== RUN   TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== PAUSE TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategy
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== RUN   TestAccAWSEcsService_withReplicaSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withReplicaSchedulingStrategy
=== RUN   TestAccAWSEcsService_withServiceRegistries
=== PAUSE TestAccAWSEcsService_withServiceRegistries
=== RUN   TestAccAWSEcsService_withServiceRegistries_container
=== PAUSE TestAccAWSEcsService_withServiceRegistries_container
=== RUN   TestAccAWSEcsService_Tags
=== PAUSE TestAccAWSEcsService_Tags
=== RUN   TestAccAWSEcsService_ManagedTags
=== PAUSE TestAccAWSEcsService_ManagedTags
=== RUN   TestAccAWSEcsService_PropagateTags
=== PAUSE TestAccAWSEcsService_PropagateTags
=== CONT  TestAccAWSEcsService_withARN
=== CONT  TestAccAWSEcsService_withPlacementConstraints
=== CONT  TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== CONT  TestAccAWSEcsService_PropagateTags
=== CONT  TestAccAWSEcsService_ManagedTags
=== CONT  TestAccAWSEcsService_Tags
=== CONT  TestAccAWSEcsService_withServiceRegistries_container
=== CONT  TestAccAWSEcsService_withServiceRegistries
=== CONT  TestAccAWSEcsService_withEcsClusterName
=== CONT  TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== CONT  TestAccAWSEcsService_withPlacementStrategy
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== CONT  TestAccAWSEcsService_withAlb
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategy
=== CONT  TestAccAWSEcsService_withDeploymentValues
=== CONT  TestAccAWSEcsService_withLaunchTypeFargate
=== CONT  TestAccAWSEcsService_withLbChanges
=== CONT  TestAccAWSEcsService_withFamilyAndRevision
=== CONT  TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== CONT  TestAccAWSEcsService_withReplicaSchedulingStrategy
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (14.11s)
=== CONT  TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
--- PASS: TestAccAWSEcsService_withDeploymentValues (17.38s)
=== CONT  TestAccAWSEcsService_disappears
--- PASS: TestAccAWSEcsService_withEcsClusterName (26.10s)
=== CONT  TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (12.64s)
=== CONT  TestAccAWSEcsService_basicImport
--- PASS: TestAccAWSEcsService_withPlacementConstraints (27.56s)
=== CONT  TestAccAWSEcsService_withPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (29.77s)
=== CONT  TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (9.73s)
=== CONT  TestAccAWSEcsService_withIamRole
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (35.88s)
=== CONT  TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_ManagedTags (36.02s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (36.28s)
--- PASS: TestAccAWSEcsService_disappears (20.57s)
--- PASS: TestAccAWSEcsService_withARN (39.29s)
--- PASS: TestAccAWSEcsService_Tags (44.23s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (45.82s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (26.61s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (60.28s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (33.50s)
--- PASS: TestAccAWSEcsService_basicImport (35.24s)
--- PASS: TestAccAWSEcsService_PropagateTags (83.10s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (86.15s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (90.53s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (137.53s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (140.35s)
--- PASS: TestAccAWSEcsService_withIamRole (176.73s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (230.26s)
--- PASS: TestAccAWSEcsService_withAlb (245.98s)
--- PASS: TestAccAWSEcsService_withLbChanges (283.24s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (250.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	286.139s
```
