### PR TITLE
tests/provider: Implement various new sweepers

### DIFF
--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directconnect"
@@ -10,6 +12,94 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_dx_gateway_association", &resource.Sweeper{
+		Name: "aws_dx_gateway_association",
+		F:    testSweepDirectConnectGatewayAssociations,
+	})
+}
+
+func testSweepDirectConnectGatewayAssociations(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).dxconn
+	gatewayInput := &directconnect.DescribeDirectConnectGatewaysInput{}
+
+	for {
+		gatewayOutput, err := conn.DescribeDirectConnectGateways(gatewayInput)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Direct Connect Gateway sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error retrieving Direct Connect Gateways: %s", err)
+		}
+
+		for _, gateway := range gatewayOutput.DirectConnectGateways {
+			directConnectGatewayID := aws.StringValue(gateway.DirectConnectGatewayId)
+
+			associationInput := &directconnect.DescribeDirectConnectGatewayAssociationsInput{
+				DirectConnectGatewayId: gateway.DirectConnectGatewayId,
+			}
+
+			for {
+				associationOutput, err := conn.DescribeDirectConnectGatewayAssociations(associationInput)
+
+				if err != nil {
+					return fmt.Errorf("error retrieving Direct Connect Gateway (%s) Associations: %s", directConnectGatewayID, err)
+				}
+
+				for _, association := range associationOutput.DirectConnectGatewayAssociations {
+					virtualGatewayID := aws.StringValue(association.VirtualGatewayId)
+
+					if aws.StringValue(association.AssociationState) != directconnect.GatewayAssociationStateAssociated {
+						log.Printf("[INFO] Skipping Direct Connect Gateway (%s) Association in non-available (%s) state: %s", directConnectGatewayID, aws.StringValue(association.AssociationState), virtualGatewayID)
+						continue
+					}
+
+					input := &directconnect.DeleteDirectConnectGatewayAssociationInput{
+						DirectConnectGatewayId: gateway.DirectConnectGatewayId,
+						VirtualGatewayId:       association.VirtualGatewayId,
+					}
+
+					log.Printf("[INFO] Deleting Direct Connect Gateway (%s) Association: %s", directConnectGatewayID, virtualGatewayID)
+					_, err := conn.DeleteDirectConnectGatewayAssociation(input)
+
+					if isAWSErr(err, directconnect.ErrCodeClientException, "No association exists") {
+						continue
+					}
+
+					if err != nil {
+						return fmt.Errorf("error deleting Direct Connect Gateway (%s) Association (%s): %s", directConnectGatewayID, virtualGatewayID, err)
+					}
+
+					if err := waitForDirectConnectGatewayAssociationDeletion(conn, directConnectGatewayID, virtualGatewayID, 20*time.Minute); err != nil {
+						return fmt.Errorf("error waiting for Direct Connect Gateway (%s) Association (%s) to be deleted: %s", directConnectGatewayID, virtualGatewayID, err)
+					}
+				}
+
+				if aws.StringValue(associationOutput.NextToken) == "" {
+					break
+				}
+
+				associationInput.NextToken = associationOutput.NextToken
+			}
+		}
+
+		if aws.StringValue(gatewayOutput.NextToken) == "" {
+			break
+		}
+
+		gatewayInput.NextToken = gatewayOutput.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAwsDxGatewayAssociation_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 	"time"
@@ -12,6 +13,95 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ecs_service", &resource.Sweeper{
+		Name: "aws_ecs_service",
+		F:    testSweepEcsServices,
+	})
+}
+
+func testSweepEcsServices(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ecsconn
+
+	err = conn.ListClustersPages(&ecs.ListClustersInput{}, func(page *ecs.ListClustersOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, clusterARNPtr := range page.ClusterArns {
+			input := &ecs.ListServicesInput{
+				Cluster: clusterARNPtr,
+			}
+
+			err = conn.ListServicesPages(input, func(page *ecs.ListServicesOutput, isLast bool) bool {
+				if page == nil {
+					return !isLast
+				}
+
+				for _, serviceARNPtr := range page.ServiceArns {
+					describeServicesInput := &ecs.DescribeServicesInput{
+						Cluster:  clusterARNPtr,
+						Services: []*string{serviceARNPtr},
+					}
+					serviceARN := aws.StringValue(serviceARNPtr)
+
+					log.Printf("[DEBUG] Describing ECS Service: %s", serviceARN)
+					describeServicesOutput, err := conn.DescribeServices(describeServicesInput)
+
+					if isAWSErr(err, ecs.ErrCodeServiceNotFoundException, "") {
+						continue
+					}
+
+					if err != nil {
+						log.Printf("[ERROR] Error describing ECS Service (%s): %s", serviceARN, err)
+						continue
+					}
+
+					if describeServicesOutput == nil || len(describeServicesOutput.Services) == 0 {
+						continue
+					}
+
+					service := describeServicesOutput.Services[0]
+
+					if aws.StringValue(service.Status) == "INACTIVE" {
+						continue
+					}
+
+					deleteServiceInput := &ecs.DeleteServiceInput{
+						Cluster: service.ClusterArn,
+						Force:   aws.Bool(true),
+						Service: service.ServiceArn,
+					}
+
+					log.Printf("[INFO] Deleting ECS Service: %s", serviceARN)
+					_, err = conn.DeleteService(deleteServiceInput)
+
+					if err != nil {
+						log.Printf("[ERROR] Error deleting ECS Service (%s): %s", serviceARN, err)
+					}
+				}
+
+				return !isLast
+			})
+		}
+
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping ECS Service sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("error retrieving ECS Services: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSEcsService_withARN(t *testing.T) {
 	var service ecs.Service

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +11,61 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_network_interface", &resource.Sweeper{
+		Name: "aws_network_interface",
+		F:    testSweepEc2NetworkInterfaces,
+		Dependencies: []string{
+			"aws_instance",
+		},
+	})
+}
+
+func testSweepEc2NetworkInterfaces(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ec2conn
+
+	err = conn.DescribeNetworkInterfacesPages(&ec2.DescribeNetworkInterfacesInput{}, func(page *ec2.DescribeNetworkInterfacesOutput, isLast bool) bool {
+		if page == nil {
+			return !isLast
+		}
+
+		for _, networkInterface := range page.NetworkInterfaces {
+			id := aws.StringValue(networkInterface.NetworkInterfaceId)
+
+			if aws.StringValue(networkInterface.Status) != ec2.NetworkInterfaceStatusAvailable {
+				log.Printf("[INFO] Skipping EC2 Network Interface in unavailable (%s) status: %s", aws.StringValue(networkInterface.Status), id)
+				continue
+			}
+
+			input := &ec2.DeleteNetworkInterfaceInput{
+				NetworkInterfaceId: aws.String(id),
+			}
+
+			log.Printf("[INFO] Deleting EC2 Network Interface: %s", id)
+			_, err := conn.DeleteNetworkInterface(input)
+
+			if err != nil {
+				log.Printf("[ERROR] Error deleting EC2 Network Interface (%s): %s", id, err)
+			}
+		}
+
+		return !isLast
+	})
+	if err != nil {
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping EC2 Network Interface sweep for %s: %s", region, err)
+			return nil
+		}
+		return fmt.Errorf("error retrieving EC2 Network Interfaces: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSENI_importBasic(t *testing.T) {
 	resourceName := "aws_network_interface.bar"

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -18,8 +18,6 @@ func init() {
 	resource.AddTestSweepers("aws_subnet", &resource.Sweeper{
 		Name: "aws_subnet",
 		F:    testSweepSubnets,
-		// When implemented, these should be moved to aws_network_interface
-		// and aws_network_interface set as dependency here.
 		Dependencies: []string{
 			"aws_autoscaling_group",
 			"aws_batch_compute_environment",
@@ -32,12 +30,14 @@ func init() {
 			"aws_elasticache_replication_group",
 			"aws_elasticsearch_domain",
 			"aws_elb",
-			"aws_instance",
+			"aws_emr_cluster",
 			"aws_lambda_function",
 			"aws_lb",
 			"aws_mq_broker",
+			"aws_network_interface",
 			"aws_redshift_cluster",
 			"aws_spot_fleet_request",
+			"aws_vpc_endpoint",
 		},
 	})
 }

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -18,6 +18,9 @@ func init() {
 	resource.AddTestSweepers("aws_vpn_gateway", &resource.Sweeper{
 		Name: "aws_vpn_gateway",
 		F:    testSweepVPNGateways,
+		Dependencies: []string{
+			"aws_dx_gateway_association",
+		},
 	})
 }
 


### PR DESCRIPTION
These resources in particular have been a constant source of aws_vpc sweeper failures due to DependencyViolation errors or  spawling dangling resources.

Changes:
* tests/resource/aws_dx_gateway: Implement sweeper
* tests/resource/aws_dx_gateway_association: Implement sweeper
* tests/resource/aws_ecs_cluster: Implement sweeper
* tests/resource/aws_ecs_service: Implement sweeper
* tests/resource/aws_emr_cluster: Implement sweeper
* tests/resource/aws_network_interface: Implement sweeper
* tests/resource/aws_vpc_endpoint: Implement sweeper

Output from new `aws_dx_gateway` and `aws_dx_gateway_association` sweepers:

```
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_dx_gateway -timeout 10h
2019/01/24 18:41:01 [DEBUG] Running Sweepers for region (us-west-2):
2019/01/24 18:41:01 [DEBUG] Sweeper (aws_dx_gateway) has dependency (aws_dx_gateway_association), running..
...
2019/01/24 18:41:04 [INFO] Deleting Direct Connect Gateway (4882db33-8918-477b-99d9-c0df85460e84) Association: vgw-3f298d21
2019/01/24 18:41:05 [DEBUG] Waiting for state to become: [disassociated deleted]
...
2019/01/24 18:47:51 [INFO] Deleting Direct Connect Gateway: 4882db33-8918-477b-99d9-c0df85460e84
2019/01/24 18:47:51 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 18:48:02 [DEBUG] Sweeper (aws_dx_gateway_association) already ran in region (us-west-2)
2019/01/24 18:48:02 Sweeper Tests ran:
  - aws_dx_gateway_association
  - aws_dx_gateway
ok    github.com/terraform-providers/terraform-provider-aws/aws 421.904s
```

Output from new `aws_ecs_cluster` sweeper:

```
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_ecs_cluster -timeout 10h
2019/01/24 17:13:23 [DEBUG] Running Sweepers for region (us-west-2):
2019/01/24 17:13:23 [DEBUG] Sweeper (aws_ecs_cluster) has dependency (aws_ecs_service), running..
...
2019/01/24 17:13:28 [INFO] Deleting ECS Cluster: arn:aws:ecs:us-west-2:187416307283:cluster/tf-acc-cluster-svc-w-far-pes8vlyy
2019/01/24 17:13:29 [INFO] Deleting ECS Cluster: arn:aws:ecs:us-west-2:187416307283:cluster/tf-acc-cluster-svc-w-ss-daemon-sa7t172r
2019/01/24 17:13:29 [INFO] Deleting ECS Cluster: arn:aws:ecs:us-west-2:187416307283:cluster/tf-acc-cluster-svc-a9mbgm93
2019/01/24 17:13:30 [INFO] Deleting ECS Cluster: arn:aws:ecs:us-west-2:187416307283:cluster/tf-acc-cluster-svc-w-pc-chbmzqe4
2019/01/24 17:13:30 [INFO] Deleting ECS Cluster: arn:aws:ecs:us-west-2:187416307283:cluster/tf-acc-cluster-svc-w-ps-evgzf47x
2019/01/24 17:13:30 [INFO] Deleting ECS Cluster: arn:aws:ecs:us-west-2:187416307283:cluster/tf-acc-cluster-svc-w-cluster-name-w2d26ay9
2019/01/24 17:13:31 Sweeper Tests ran:
  - aws_ecs_service
  - aws_ecs_cluster
ok    github.com/terraform-providers/terraform-provider-aws/aws 8.828s
```

Output from new `aws_ecs_service` sweeper:

```
go test ./aws -v -sweep=us-west-2 -sweep-run=aws_ecs_service -timeout 10h
2019/01/24 17:02:35 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/01/24 17:02:38 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/ghost
2019/01/24 17:02:39 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/ghost
2019/01/24 17:02:40 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-rc-n7h13qhq
2019/01/24 17:02:41 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-rc-n7h13qhq
2019/01/24 17:02:42 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb
2019/01/24 17:02:43 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb
2019/01/24 17:02:44 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-ecs-svc
2019/01/24 17:02:45 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-ecs-svc
2019/01/24 17:02:46 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-lbc-ba6imyim
2019/01/24 17:02:46 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-lbc-ba6imyim
2019/01/24 17:02:47 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-l8484k9f
2019/01/24 17:02:48 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-l8484k9f
2019/01/24 17:02:49 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-arn-2mhluwt0
2019/01/24 17:02:49 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-arn-2mhluwt0
2019/01/24 17:02:51 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-ups-wmec89pz
2019/01/24 17:02:52 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-ups-wmec89pz
2019/01/24 17:02:54 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-far-88uhn1eg
2019/01/24 17:02:55 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-far-88uhn1eg
2019/01/24 17:02:57 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-39kv6nox
2019/01/24 17:02:57 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-39kv6nox
2019/01/24 17:02:58 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb-1672159059818299077
2019/01/24 17:02:59 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb-1672159059818299077
2019/01/24 17:03:00 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-2qknu3z0
2019/01/24 17:03:01 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-2qknu3z0
2019/01/24 17:03:02 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/foobar
2019/01/24 17:03:02 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/foobar
2019/01/24 17:03:03 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb
2019/01/24 17:03:04 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb
2019/01/24 17:03:05 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/ghost
2019/01/24 17:03:05 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/ghost
2019/01/24 17:03:07 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-rc-efq1774c
2019/01/24 17:03:08 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-rc-efq1774c
2019/01/24 17:03:09 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-dv-cf8qt7o2/tf-acc-svc-w-dv-cf8qt7o2
2019/01/24 17:03:09 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-dv-cf8qt7o2/tf-acc-svc-w-dv-cf8qt7o2
2019/01/24 17:03:10 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-hgkrkk7o
2019/01/24 17:03:11 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-hgkrkk7o
2019/01/24 17:03:12 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-brf0i9dk
2019/01/24 17:03:13 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-brf0i9dk
2019/01/24 17:03:14 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-rc-tkkxq49a
2019/01/24 17:03:15 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-rc-tkkxq49a
2019/01/24 17:03:16 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-dv-irg62boc
2019/01/24 17:03:17 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-dv-irg62boc
2019/01/24 17:03:18 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-ecs-service-8o2pn
2019/01/24 17:03:18 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-ecs-service-8o2pn
2019/01/24 17:03:19 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/jenkins
2019/01/24 17:03:20 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/jenkins
2019/01/24 17:03:21 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-alb-cefa6y9t
2019/01/24 17:03:22 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-alb-cefa6y9t
2019/01/24 17:03:23 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-hcgps-kg16c6hz
2019/01/24 17:03:24 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-hcgps-kg16c6hz
2019/01/24 17:03:25 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-wjgupduw
2019/01/24 17:03:26 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-nc-wjgupduw
2019/01/24 17:03:27 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-lbc-ptx0whxc
2019/01/24 17:03:28 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-lbc-ptx0whxc
2019/01/24 17:03:28 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-cluster-name-418jd0qr
2019/01/24 17:03:29 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-cluster-name-418jd0qr
2019/01/24 17:03:30 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/foobar
2019/01/24 17:03:31 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/foobar
2019/01/24 17:03:32 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-ps-2fbljxhn
2019/01/24 17:03:33 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-ps-2fbljxhn
2019/01/24 17:03:34 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-arn-xt4yuumg
2019/01/24 17:03:35 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-arn-xt4yuumg
2019/01/24 17:03:36 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-dv-a4cpy7lt
2019/01/24 17:03:36 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-dv-a4cpy7lt
2019/01/24 17:03:38 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-hcgps-jr7trtdq
2019/01/24 17:03:38 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-hcgps-jr7trtdq
2019/01/24 17:03:40 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb
2019/01/24 17:03:41 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/mongodb
2019/01/24 17:03:42 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/ghost
2019/01/24 17:03:42 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/ghost
2019/01/24 17:03:45 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/clusteryuyt7049rq/daemontime
2019/01/24 17:03:46 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/clusteryuyt7049rq/daemontime
2019/01/24 17:03:47 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/clusteryuyt7049rq/foobar
2019/01/24 17:03:47 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/clusteryuyt7049rq/foobar
2019/01/24 17:03:49 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ps-rix4rrzw/tf-acc-svc-w-ps-rix4rrzw
2019/01/24 17:03:49 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ps-rix4rrzw/tf-acc-svc-w-ps-rix4rrzw
2019/01/24 17:03:51 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/cluster4ueziwbpcm/foobar
2019/01/24 17:03:51 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/cluster4ueziwbpcm/foobar
2019/01/24 17:03:52 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-nc-n938inq9/tf-acc-svc-w-nc-n938inq9
2019/01/24 17:03:53 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-nc-n938inq9/tf-acc-svc-w-nc-n938inq9
2019/01/24 17:03:55 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ltf-4tjd6zj7/tf-acc-svc-w-ltf-4tjd6zj7
2019/01/24 17:03:55 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ltf-4tjd6zj7/tf-acc-svc-w-ltf-4tjd6zj7
2019/01/24 17:03:57 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ss-replica-hjh17uhi/tf-acc-svc-w-ss-replica-hjh17uhi
2019/01/24 17:03:58 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ss-replica-hjh17uhi/tf-acc-svc-w-ss-replica-hjh17uhi
2019/01/24 17:03:59 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/foobar
2019/01/24 17:03:59 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/foobar
2019/01/24 17:04:01 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ps-6jpkislx/tf-acc-svc-w-ps-6jpkislx
2019/01/24 17:04:02 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ps-6jpkislx/tf-acc-svc-w-ps-6jpkislx
2019/01/24 17:04:03 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-arn-voiz7aun/tf-acc-svc-w-arn-voiz7aun
2019/01/24 17:04:03 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-arn-voiz7aun/tf-acc-svc-w-arn-voiz7aun
2019/01/24 17:04:04 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-test-7946983016665875340/tf-acc-test-7946983016665875340
2019/01/24 17:04:05 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-test-7946983016665875340/tf-acc-test-7946983016665875340
2019/01/24 17:04:06 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-far-pes8vlyy
2019/01/24 17:04:06 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-w-far-pes8vlyy
2019/01/24 17:04:08 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ss-replica-m2u0uw47/tf-acc-svc-w-ss-replica-m2u0uw47
2019/01/24 17:04:08 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ss-replica-m2u0uw47/tf-acc-svc-w-ss-replica-m2u0uw47
2019/01/24 17:04:09 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/clustereh9120gfuw/foobar
2019/01/24 17:04:10 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/clustereh9120gfuw/foobar
2019/01/24 17:04:11 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-a9mbgm93
2019/01/24 17:04:12 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-svc-a9mbgm93
2019/01/24 17:04:13 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-pc-chbmzqe4/tf-acc-svc-w-pc-chbmzqe4
2019/01/24 17:04:13 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-pc-chbmzqe4/tf-acc-svc-w-pc-chbmzqe4
2019/01/24 17:04:14 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-far-car966hc/tf-acc-svc-w-far-car966hc
2019/01/24 17:04:15 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-far-car966hc/tf-acc-svc-w-far-car966hc
2019/01/24 17:04:16 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ps-evgzf47x/tf-acc-svc-w-ps-evgzf47x
2019/01/24 17:04:16 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-ps-evgzf47x/tf-acc-svc-w-ps-evgzf47x
2019/01/24 17:04:17 [DEBUG] Describing ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-cluster-name-w2d26ay9/tf-acc-svc-w-cluster-name-w2d26ay9
2019/01/24 17:04:18 [INFO] Deleting ECS Service: arn:aws:ecs:us-west-2:--OMITTED--:service/tf-acc-cluster-svc-w-cluster-name-w2d26ay9/tf-acc-svc-w-cluster-name-w2d26ay9
2019/01/24 17:04:19 Sweeper Tests ran:
  - aws_ecs_service
ok    github.com/terraform-providers/terraform-provider-aws/aws 106.135s
```

Output from new `aws_emr_cluster` sweeper:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_emr_cluster -timeout 10h
2019/01/24 19:15:48 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/01/24 19:15:51 [INFO] Deleting EMR Cluster: j-3E4XVL8JXPU3I
2019/01/24 19:17:23 [INFO] Deleting EMR Cluster: j-WT8ZM1DXPKZU
2019/01/24 19:19:56 [INFO] Deleting EMR Cluster: j-XE1Y72NTM6ZZ
2019/01/24 19:21:59 [INFO] Deleting EMR Cluster: j-3PQRTXKJ2UHF7
2019/01/24 19:24:02 [INFO] Deleting EMR Cluster: j-VD0SWPOMU8RX
2019/01/24 19:26:04 [INFO] Deleting EMR Cluster: j-3PO769FP7NB8T
2019/01/24 19:28:07 [INFO] Deleting EMR Cluster: j-3BWIBK8HKCJJV
2019/01/24 19:29:09 [INFO] Deleting EMR Cluster: j-34N886PDV3Y27
2019/01/24 19:31:12 [INFO] Deleting EMR Cluster: j-371B3HSIDCOUB
2019/01/24 19:33:14 [INFO] Deleting EMR Cluster: j-R8MXAZD7EFJD
2019/01/24 19:38:13 [INFO] Deleting EMR Cluster: j-300IC2X1O4J3L
2019/01/24 19:49:14 [INFO] Deleting EMR Cluster: j-IPXT5KK1N4ND
2019/01/24 19:51:17 [INFO] Deleting EMR Cluster: j-2I0JCMEOT50KQ
2019/01/24 19:52:50 [INFO] Deleting EMR Cluster: j-EH4QBEQ6YL55
2019/01/24 19:54:22 [INFO] Deleting EMR Cluster: j-2TYKVBZZ1GZRC
2019/01/24 19:55:54 [INFO] Deleting EMR Cluster: j-2SVTL6HITUOED
2019/01/24 19:57:58 [INFO] Deleting EMR Cluster: j-2RLTA9FJGLV5I
2019/01/24 20:00:01 [INFO] Deleting EMR Cluster: j-1EX80GI6F1OVB
2019/01/24 20:02:04 [INFO] Deleting EMR Cluster: j-7Z0TXMOMC0KZ
2019/01/24 20:03:36 Sweeper Tests ran:
  - aws_emr_cluster
ok    github.com/terraform-providers/terraform-provider-aws/aws 2004.360s
```

Output from new `aws_network_interface` sweeper:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_network_interface -timeout 10h
2019/01/24 15:13:05 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/01/24 15:13:08 [INFO] Deleting EC2 Network Interface: eni-08156e3a5e2d71349
2019/01/24 15:13:08 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-0ec559c1cc1a5d7b5
2019/01/24 15:13:08 [INFO] Deleting EC2 Network Interface: eni-04367c068611a0daf
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-05f38edee28aec0d5
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-0fde69c401547236a
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-0e4e7a60befd71ad8
2019/01/24 15:13:09 [INFO] Deleting EC2 Network Interface: eni-06baf385e0819a306
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-0925ba0ed670d99d2
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-07440de1e0f3e1888
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-01f8e10f9f5f728dc
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-08273a8c55f8640ca
2019/01/24 15:13:09 [INFO] Skipping EC2 Network Interface in unavailable (in-use) status: eni-025a7db9ad1dc1434
2019/01/24 15:13:09 Sweeper Tests ran:
  - aws_network_interface
ok    github.com/terraform-providers/terraform-provider-aws/aws 5.379s
```

Output from new `aws_vpc_endpoint` sweeper:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_vpc_endpoint -timeout 10h
2019/01/24 15:47:54 [DEBUG] Running Sweepers for region (us-west-2):
2019/01/24 15:47:54 [INFO] Building AWS region structure
2019/01/24 15:47:54 [INFO] Building AWS auth structure
2019/01/24 15:47:54 [INFO] Setting AWS metadata API timeout to 100ms
2019/01/24 15:47:54 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2019/01/24 15:47:54 [INFO] AWS Auth provider used: "SharedCredentialsProvider"
2019/01/24 15:47:54 [INFO] Initializing DeviceFarm SDK connection
2019/01/24 15:47:54 [DEBUG] Trying to get account information via sts:GetCallerIdentity
2019/01/24 15:47:55 [INFO] Deleting EC2 VPC Endpoint: vpce-0752ea32354a1db4a
2019/01/24 15:47:56 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 15:48:01 [DEBUG] Reading VPC Endpoint: vpce-0752ea32354a1db4a
2019/01/24 15:48:01 [INFO] Deleting EC2 VPC Endpoint: vpce-0dbcfb313d72621ac
2019/01/24 15:48:02 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 15:48:07 [DEBUG] Reading VPC Endpoint: vpce-0dbcfb313d72621ac
2019/01/24 15:48:07 [INFO] Deleting EC2 VPC Endpoint: vpce-00230a55dd812d45f
2019/01/24 15:48:08 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 15:48:13 [DEBUG] Reading VPC Endpoint: vpce-00230a55dd812d45f
2019/01/24 15:48:13 [INFO] Deleting EC2 VPC Endpoint: vpce-01b21967afaa2d17f
2019/01/24 15:48:13 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 15:48:18 [DEBUG] Reading VPC Endpoint: vpce-01b21967afaa2d17f
2019/01/24 15:48:19 [INFO] Deleting EC2 VPC Endpoint: vpce-08f51453d14233cf9
2019/01/24 15:48:19 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 15:48:24 [DEBUG] Reading VPC Endpoint: vpce-08f51453d14233cf9
2019/01/24 15:48:25 [INFO] Deleting EC2 VPC Endpoint: vpce-0cf1e943f3b6b78b7
2019/01/24 15:48:25 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 15:48:30 [DEBUG] Reading VPC Endpoint: vpce-0cf1e943f3b6b78b7
2019/01/24 15:48:30 [INFO] Deleting EC2 VPC Endpoint: vpce-0b6764607e7fab61e
2019/01/24 15:48:31 [DEBUG] Waiting for state to become: [deleted]
2019/01/24 15:48:36 [DEBUG] Reading VPC Endpoint: vpce-0b6764607e7fab61e
2019/01/24 15:48:37 [TRACE] Waiting 5s before next try
2019/01/24 15:48:42 [DEBUG] Reading VPC Endpoint: vpce-0b6764607e7fab61e
2019/01/24 15:48:42 [TRACE] Waiting 10s before next try
2019/01/24 15:48:52 [DEBUG] Reading VPC Endpoint: vpce-0b6764607e7fab61e
2019/01/24 15:48:53 Sweeper Tests ran:
  - aws_vpc_endpoint
ok    github.com/terraform-providers/terraform-provider-aws/aws 60.732s
```
