### PR TITLE
resource/aws_rds_cluster_parameter_group: Prevent missing DBClusterParameterGroupName error on creation with generated names and name_prefix

### DIFF
--- a/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/aws/resource_aws_rds_cluster_parameter_group.go
@@ -212,9 +212,9 @@ func resourceAwsRDSClusterParameterGroupUpdate(d *schema.ResourceData, meta inte
 				} else {
 					paramsToModify, parameters = parameters[:rdsClusterParameterGroupMaxParamsBulkEdit], parameters[rdsClusterParameterGroupMaxParamsBulkEdit:]
 				}
-				parameterGroupName := d.Get("name").(string)
+
 				modifyOpts := rds.ModifyDBClusterParameterGroupInput{
-					DBClusterParameterGroupName: aws.String(parameterGroupName),
+					DBClusterParameterGroupName: aws.String(d.Id()),
 					Parameters:                  paramsToModify,
 				}
 

--- a/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -175,6 +175,26 @@ func TestAccAWSDBClusterParameterGroup_namePrefix(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBClusterParameterGroup_namePrefix_Parameter(t *testing.T) {
+	var v rds.DBClusterParameterGroup
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBClusterParameterGroupConfig_namePrefix_Parameter,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBClusterParameterGroup_generatedName(t *testing.T) {
 	var v rds.DBClusterParameterGroup
 
@@ -185,6 +205,24 @@ func TestAccAWSDBClusterParameterGroup_generatedName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSDBClusterParameterGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBClusterParameterGroup_generatedName_Parameter(t *testing.T) {
+	var v rds.DBClusterParameterGroup
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBClusterParameterGroupConfig_generatedName_Parameter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
 				),
@@ -460,8 +498,32 @@ resource "aws_rds_cluster_parameter_group" "test" {
   family = "aurora5.6"
 }
 `
+
+const testAccAWSDBClusterParameterGroupConfig_namePrefix_Parameter = `
+resource "aws_rds_cluster_parameter_group" "test" {
+  name_prefix = "tf-test-"
+  family = "aurora5.6"
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8"
+  }
+}
+`
+
 const testAccAWSDBClusterParameterGroupConfig_generatedName = `
 resource "aws_rds_cluster_parameter_group" "test" {
   family = "aurora5.6"
+}
+`
+
+const testAccAWSDBClusterParameterGroupConfig_generatedName_Parameter = `
+resource "aws_rds_cluster_parameter_group" "test" {
+  family = "aurora5.6"
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8"
+  }
 }
 `


### PR DESCRIPTION
Fixes #1739
Fixes #7264

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (8.30s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_rds_cluster_parameter_group.test: 1 error occurred:
        	* aws_rds_cluster_parameter_group.test: Error modifying DB Cluster Parameter Group: InvalidParameterValue: The parameter DBClusterParameterGroupName must be provided and must not be blank.
        	status code: 400, request id: e2a07ba0-ba60-4d24-a8ee-3d7a86cf1793

--- FAIL: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (8.43s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_rds_cluster_parameter_group.test: 1 error occurred:
        	* aws_rds_cluster_parameter_group.test: Error modifying DB Cluster Parameter Group: InvalidParameterValue: The parameter DBClusterParameterGroupName must be provided and must not be blank.
        	status code: 400, request id: 895b9f34-c88e-46ec-8006-0ee61096cff1
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDBClusterParameterGroup_disappears (10.98s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix (12.80s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName (12.99s)
--- PASS: TestAccAWSDBClusterParameterGroup_namePrefix_Parameter (13.53s)
--- PASS: TestAccAWSDBClusterParameterGroup_generatedName_Parameter (13.60s)
--- PASS: TestAccAWSDBClusterParameterGroup_withApplyMethod (14.34s)
--- PASS: TestAccAWSDBClusterParameterGroup_importBasic (15.56s)
--- PASS: TestAccAWSDBClusterParameterGroup_basic (24.07s)
```
