### PR TITLE
Added session_duration to the assume_role config

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -138,10 +138,11 @@ type Config struct {
 	Region        string
 	MaxRetries    int
 
-	AssumeRoleARN         string
-	AssumeRoleExternalID  string
-	AssumeRoleSessionName string
-	AssumeRolePolicy      string
+	AssumeRoleARN             string
+	AssumeRoleExternalID      string
+	AssumeRoleSessionName     string
+	AssumeRoleSessionDuration int
+	AssumeRolePolicy          string
 
 	AllowedAccountIds   []interface{}
 	ForbiddenAccountIds []interface{}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -868,6 +868,9 @@ func init() {
 		"assume_role_session_name": "The session name to use when assuming the role. If omitted," +
 			" no session name is passed to the AssumeRole call.",
 
+		"assume_role_session_duration": "The length of the session when assuming the role. If omitted" +
+			" the default duration of 15 minutes is used.",
+
 		"assume_role_external_id": "The external ID to use when assuming the role. If omitted," +
 			" no external ID is passed to the AssumeRole call.",
 
@@ -906,14 +909,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		assumeRole := assumeRoleList[0].(map[string]interface{})
 		config.AssumeRoleARN = assumeRole["role_arn"].(string)
 		config.AssumeRoleSessionName = assumeRole["session_name"].(string)
+		config.AssumeRoleSessionDuration = assumeRole["session_duration"].(int)
 		config.AssumeRoleExternalID = assumeRole["external_id"].(string)
 
 		if v := assumeRole["policy"].(string); v != "" {
 			config.AssumeRolePolicy = v
 		}
 
-		log.Printf("[INFO] assume_role configuration set: (ARN: %q, SessionID: %q, ExternalID: %q, Policy: %q)",
-			config.AssumeRoleARN, config.AssumeRoleSessionName, config.AssumeRoleExternalID, config.AssumeRolePolicy)
+		log.Printf("[INFO] assume_role configuration set: (ARN: %q, SessionID: %q, SessionDuration: %d, ExternalID: %q, Policy: %q)",
+			config.AssumeRoleARN, config.AssumeRoleSessionName, config.AssumeRoleSessionDuration, config.AssumeRoleExternalID, config.AssumeRolePolicy)
 	} else {
 		log.Printf("[INFO] No assume_role block read from configuration")
 	}
@@ -983,6 +987,13 @@ func assumeRoleSchema() *schema.Schema {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Description: descriptions["assume_role_session_name"],
+				},
+
+				"session_duration": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Default:     900,
+					Description: descriptions["assume_role_session_duration"],
 				},
 
 				"external_id": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -140,9 +140,10 @@ Usage:
 ```hcl
 provider "aws" {
   assume_role {
-    role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-    session_name = "SESSION_NAME"
-    external_id  = "EXTERNAL_ID"
+    role_arn         = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+    session_name     = "SESSION_NAME"
+    session_duration = "SESSION_DURATION"
+    external_id      = "EXTERNAL_ID"
   }
 }
 ```
@@ -271,6 +272,9 @@ The nested `assume_role` block supports the following:
 * `role_arn` - (Required) The ARN of the role to assume.
 
 * `session_name` - (Optional) The session name to use when making the
+  AssumeRole call.
+
+* `session_duration` - (Optional) The session duration to use when making the
   AssumeRole call.
 
 * `external_id` - (Optional) The external ID to use when making the


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7333 

Changes proposed in this pull request:

* Add a session_duration variable in the assume_role configuration block

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
=== PAUSE TestAccAWSAvailabilityZones_basic
=== RUN   TestAccAWSAvailabilityZones_stateFilter
=== PAUSE TestAccAWSAvailabilityZones_stateFilter
=== CONT  TestAccAWSAvailabilityZones_basic
=== CONT  TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_stateFilter (23.93s)
--- PASS: TestAccAWSAvailabilityZones_basic (23.99s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	24.014s
```
