### PR TITLE
resource/aws_autoscaling_policy: Properly read step_adjustment into Terraform state

### DIFF
--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -235,8 +235,12 @@ func resourceAwsAutoscalingPolicyRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("arn", p.PolicyARN)
 	d.Set("name", p.PolicyName)
 	d.Set("scaling_adjustment", p.ScalingAdjustment)
-	d.Set("step_adjustment", flattenStepAdjustments(p.StepAdjustments))
-	d.Set("target_tracking_configuration", flattenTargetTrackingConfiguration(p.TargetTrackingConfiguration))
+	if err := d.Set("step_adjustment", flattenStepAdjustments(p.StepAdjustments)); err != nil {
+		return fmt.Errorf("error setting step_adjustment: %s", err)
+	}
+	if err := d.Set("target_tracking_configuration", flattenTargetTrackingConfiguration(p.TargetTrackingConfiguration)); err != nil {
+		return fmt.Errorf("error setting target_tracking_configuration: %s", err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -61,6 +61,18 @@ func TestAccAWSAutoscalingPolicy_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				ResourceName:      "aws_autoscaling_policy.foobar_step",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.foobar_step"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_autoscaling_policy.foobar_target_tracking",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.foobar_target_tracking"),
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSAutoscalingPolicyConfig_basicUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
@@ -192,6 +204,12 @@ func TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "scaling_adjustment", "0"),
 				),
 			},
+			{
+				ResourceName:      "aws_autoscaling_policy.foobar_simple",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.foobar_simple"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -212,6 +230,12 @@ func TestAccAWSAutoscalingPolicy_TargetTrack_Predefined(t *testing.T) {
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.test", &policy),
 				),
 			},
+			{
+				ResourceName:      "aws_autoscaling_policy.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -231,6 +255,12 @@ func TestAccAWSAutoscalingPolicy_TargetTrack_Custom(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalingPolicyExists("aws_autoscaling_policy.test", &policy),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_policy.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -255,6 +285,18 @@ func TestAccAWSAutoscalingPolicy_zerovalue(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "min_adjustment_magnitude", "1"),
 					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_step", "estimated_instance_warmup", "0"),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_policy.foobar_simple",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.foobar_simple"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_autoscaling_policy.foobar_step",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAutoscalingPolicyImportStateIdFunc("aws_autoscaling_policy.foobar_step"),
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1078,13 +1078,13 @@ func flattenStepAdjustments(adjustments []*autoscaling.StepAdjustment) []map[str
 	result := make([]map[string]interface{}, 0, len(adjustments))
 	for _, raw := range adjustments {
 		a := map[string]interface{}{
-			"scaling_adjustment": *raw.ScalingAdjustment,
+			"scaling_adjustment": aws.Int64Value(raw.ScalingAdjustment),
 		}
 		if raw.MetricIntervalUpperBound != nil {
-			a["metric_interval_upper_bound"] = *raw.MetricIntervalUpperBound
+			a["metric_interval_upper_bound"] = fmt.Sprintf("%g", aws.Float64Value(raw.MetricIntervalUpperBound))
 		}
 		if raw.MetricIntervalLowerBound != nil {
-			a["metric_interval_lower_bound"] = *raw.MetricIntervalLowerBound
+			a["metric_interval_lower_bound"] = fmt.Sprintf("%g", aws.Float64Value(raw.MetricIntervalLowerBound))
 		}
 		result = append(result, a)
 	}

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -807,7 +807,7 @@ func TestFlattenStepAdjustments(t *testing.T) {
 	expanded := []*autoscaling.StepAdjustment{
 		{
 			MetricIntervalLowerBound: aws.Float64(1.0),
-			MetricIntervalUpperBound: aws.Float64(2.0),
+			MetricIntervalUpperBound: aws.Float64(2.5),
 			ScalingAdjustment:        aws.Int64(int64(1)),
 		},
 	}
@@ -816,11 +816,11 @@ func TestFlattenStepAdjustments(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected result to have value, but got nil")
 	}
-	if result["metric_interval_lower_bound"] != float64(1.0) {
-		t.Fatalf("expected metric_interval_lower_bound to be 1.0, but got %d", result["metric_interval_lower_bound"])
+	if result["metric_interval_lower_bound"] != "1" {
+		t.Fatalf("expected metric_interval_lower_bound to be 1, but got %s", result["metric_interval_lower_bound"])
 	}
-	if result["metric_interval_upper_bound"] != float64(2.0) {
-		t.Fatalf("expected metric_interval_upper_bound to be 1.0, but got %d", result["metric_interval_upper_bound"])
+	if result["metric_interval_upper_bound"] != "2.5" {
+		t.Fatalf("expected metric_interval_upper_bound to be 2.5, but got %s", result["metric_interval_upper_bound"])
 	}
 	if result["scaling_adjustment"] != int64(1) {
 		t.Fatalf("expected scaling_adjustment to be 1, but got %d", result["scaling_adjustment"])


### PR DESCRIPTION
This pull request builds on top of #7195 and only requires review of https://github.com/terraform-providers/terraform-provider-aws/commit/5fd80c159a3c1728afe01379eaa95d9c99aa779f

Previously, the resource was silently failing to read this attribute and therefore unable to perform drift detection or properly import the resource (currently being added).

```
--- FAIL: TestAccAWSAutoscalingPolicy_basic (85.72s)
    testing.go:538: Step 2 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=4) {
         (string) (len=17) "step_adjustment.#": (string) (len=1) "1",
         (string) (len=54) "step_adjustment.2042107634.metric_interval_lower_bound": (string) (len=1) "2",
         (string) (len=54) "step_adjustment.2042107634.metric_interval_upper_bound": (string) "",
         (string) (len=45) "step_adjustment.2042107634.scaling_adjustment": (string) (len=1) "1"
        }
```

Returning the error from `d.Set()`:

```
--- FAIL: TestAccAWSAutoscalingPolicy_basic (14.03s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_autoscaling_policy.foobar_step: 1 error occurred:
        	* aws_autoscaling_policy.foobar_step: error setting step_adjustment: step_adjustment.0.metric_interval_lower_bound: '' expected type 'string', got unconvertible type 'float64'
```

Output from acceptance testing after adjustments:

```
--- PASS: TestAccAWSAutoscalingPolicy_zerovalue (44.61s)
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (46.60s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (48.75s)
--- PASS: TestAccAWSAutoscalingPolicy_disappears (72.73s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (74.47s)
--- PASS: TestAccAWSAutoscalingPolicy_upgrade (76.43s)
--- PASS: TestAccAWSAutoscalingPolicy_basic (82.25s)
```