### PR TITLE
resource/aws_iot_topic_rule: Prevent panic with missing SQS UseBase64 attribute in API response

### DIFF
--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2992,9 +2992,9 @@ func flattenIoTRuleSqsActions(actions []*iot.Action) []map[string]interface{} {
 		result := make(map[string]interface{})
 		v := a.Sqs
 		if v != nil {
-			result["role_arn"] = *v.RoleArn
-			result["use_base64"] = *v.UseBase64
-			result["queue_url"] = *v.QueueUrl
+			result["role_arn"] = aws.StringValue(v.RoleArn)
+			result["use_base64"] = aws.BoolValue(v.UseBase64)
+			result["queue_url"] = aws.StringValue(v.QueueUrl)
 
 			results = append(results, result)
 		}


### PR DESCRIPTION
Fixes #7334 

Terraform requires the attribute in the configuration block, so it is safe to parse `nil` to `false`.

Output from acceptance testing:

```
--- PASS: TestAccAWSIoTTopicRule_lambda (8.86s)
--- PASS: TestAccAWSIoTTopicRule_basic (9.29s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchalarm (9.29s)
--- PASS: TestAccAWSIoTTopicRule_s3 (9.31s)
--- PASS: TestAccAWSIoTTopicRule_cloudwatchmetric (9.35s)
--- PASS: TestAccAWSIoTTopicRule_sns (9.35s)
--- PASS: TestAccAWSIoTTopicRule_firehose (9.39s)
--- PASS: TestAccAWSIoTTopicRule_republish (9.41s)
--- PASS: TestAccAWSIoTTopicRule_sqs (9.43s)
--- PASS: TestAccAWSIoTTopicRule_kinesis (9.43s)
--- PASS: TestAccAWSIoTTopicRule_importbasic (9.96s)
--- PASS: TestAccAWSIoTTopicRule_elasticsearch (13.07s)
--- PASS: TestAccAWSIoTTopicRule_firehose_separator (13.55s)
```
