### PR TITLE
service/elbv2: Support TLS protocol

### DIFF
--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -60,6 +60,7 @@ func resourceAwsLbListener() *schema.Resource {
 					elbv2.ProtocolEnumHttp,
 					elbv2.ProtocolEnumHttps,
 					elbv2.ProtocolEnumTcp,
+					elbv2.ProtocolEnumTls,
 				}, true),
 			},
 

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -70,6 +70,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 					elbv2.ProtocolEnumHttp,
 					elbv2.ProtocolEnumHttps,
 					elbv2.ProtocolEnumTcp,
+					elbv2.ProtocolEnumTls,
 				}, true),
 			},
 

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -175,8 +175,8 @@ The following arguments are supported:
 
 * `load_balancer_arn` - (Required, Forces New Resource) The ARN of the load balancer.
 * `port` - (Required) The port on which the load balancer is listening.
-* `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
-* `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
+* `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `TLS`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
+* `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`.
 * `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
 * `default_action` - (Required) An Action block. Action blocks are documented below.
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
 
 * `port` - (Optional) The port on which targets receive traffic, unless overridden when registering a specific target. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
-* `protocol` - (Optional) The protocol to use for routing traffic to the targets. Should be one of "TCP", "HTTP" or "HTTPS". Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
+* `protocol` - (Optional) The protocol to use for routing traffic to the targets. Should be one of "TCP", "TLS", "HTTP" or "HTTPS". Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `vpc_id` - (Optional) The identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.


### PR DESCRIPTION
Closes #7317

Changes:
* resource/aws_lb_listener: Add `TLS` to `protocol` argument validation
* resource/aws_lb_target_group: Add `TLS` to `protocol` argument validation

Output from acceptance testing:

```
--- PASS: TestAccAWSLBTargetGroup_Protocol_Tls (26.47s)
--- PASS: TestAccAWSLBListener_Protocol_Tls (354.32s)
```
