### PR TITLE
Add read timeout to resource_aws_ecs_service

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -26,6 +26,10 @@ func resourceAwsEcsService() *schema.Resource {
 			State: resourceAwsEcsServiceImport,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(2 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -1038,6 +1042,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 		Target:     []string{"INACTIVE"},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 1 * time.Second,
+
 		Refresh: func() (interface{}, string, error) {
 			log.Printf("[DEBUG] Checking if ECS service %s is INACTIVE", d.Id())
 			resp, err := conn.DescribeServices(&ecs.DescribeServicesInput{


### PR DESCRIPTION
Changes proposed in this pull request:
We have some issues with hitting ECS Describe limits as we have a lot of ECS resources at this point, so it would be nice to configure a longer timeout than the default of 2 to prevent terraform from timing out.

* Add read timeout to aws_ecs_service

Output from acceptance testing: 

Had some tests fail due to some configuration and aws limits but this is a small change.
Let me know if you need me to complete a full test run

```
make testacc TESTARGS='-run=TestAccAWSEcsService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEcsService -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEcsServiceDataSource_basic
=== PAUSE TestAccAWSEcsServiceDataSource_basic
=== RUN   TestAccAWSEcsService_withARN
=== PAUSE TestAccAWSEcsService_withARN
=== RUN   TestAccAWSEcsService_basicImport
=== PAUSE TestAccAWSEcsService_basicImport
=== RUN   TestAccAWSEcsService_disappears
=== PAUSE TestAccAWSEcsService_disappears
=== RUN   TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== PAUSE TestAccAWSEcsService_withUnnormalizedPlacementStrategy
=== RUN   TestAccAWSEcsService_withFamilyAndRevision
=== PAUSE TestAccAWSEcsService_withFamilyAndRevision
=== RUN   TestAccAWSEcsService_withRenamedCluster
=== PAUSE TestAccAWSEcsService_withRenamedCluster
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== PAUSE TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== RUN   TestAccAWSEcsService_withIamRole
=== PAUSE TestAccAWSEcsService_withIamRole
=== RUN   TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== PAUSE TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== RUN   TestAccAWSEcsService_withDeploymentValues
=== PAUSE TestAccAWSEcsService_withDeploymentValues
=== RUN   TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== PAUSE TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== RUN   TestAccAWSEcsService_withLbChanges
=== PAUSE TestAccAWSEcsService_withLbChanges
=== RUN   TestAccAWSEcsService_withEcsClusterName
=== PAUSE TestAccAWSEcsService_withEcsClusterName
=== RUN   TestAccAWSEcsService_withAlb
=== PAUSE TestAccAWSEcsService_withAlb
=== RUN   TestAccAWSEcsService_withPlacementStrategy
=== PAUSE TestAccAWSEcsService_withPlacementStrategy
=== RUN   TestAccAWSEcsService_withPlacementConstraints
=== PAUSE TestAccAWSEcsService_withPlacementConstraints
=== RUN   TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== PAUSE TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== RUN   TestAccAWSEcsService_withLaunchTypeFargate
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargate
=== RUN   TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== PAUSE TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== RUN   TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== PAUSE TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategy
=== RUN   TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== PAUSE TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== RUN   TestAccAWSEcsService_withReplicaSchedulingStrategy
=== PAUSE TestAccAWSEcsService_withReplicaSchedulingStrategy
=== RUN   TestAccAWSEcsService_withServiceRegistries
=== PAUSE TestAccAWSEcsService_withServiceRegistries
=== RUN   TestAccAWSEcsService_withServiceRegistries_container
=== PAUSE TestAccAWSEcsService_withServiceRegistries_container
=== RUN   TestAccAWSEcsService_Tags
=== PAUSE TestAccAWSEcsService_Tags
=== RUN   TestAccAWSEcsService_ManagedTags
=== PAUSE TestAccAWSEcsService_ManagedTags
=== RUN   TestAccAWSEcsService_PropagateTags
=== PAUSE TestAccAWSEcsService_PropagateTags
=== CONT  TestAccAWSEcsServiceDataSource_basic
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum
=== CONT  TestAccAWSEcsService_withPlacementStrategy
=== CONT  TestAccAWSEcsService_withDaemonSchedulingStrategy
=== CONT  TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration
=== CONT  TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion
=== CONT  TestAccAWSEcsService_withLaunchTypeFargate
=== CONT  TestAccAWSEcsService_withPlacementConstraints_emptyExpression
=== CONT  TestAccAWSEcsService_withAlb
=== CONT  TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== CONT  TestAccAWSEcsService_withEcsClusterName
=== CONT  TestAccAWSEcsService_withLbChanges
=== CONT  TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred
=== CONT  TestAccAWSEcsService_withDeploymentValues
=== CONT  TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy
=== CONT  TestAccAWSEcsService_withIamRole
=== CONT  TestAccAWSEcsService_Tags
=== CONT  TestAccAWSEcsService_PropagateTags
=== CONT  TestAccAWSEcsService_withPlacementConstraints
=== CONT  TestAccAWSEcsService_ManagedTags
--- FAIL: TestAccAWSEcsService_ManagedTags (6.07s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_ecs_service.test: 1 error occurred:
        	* aws_ecs_service.test: InvalidParameterException: The new ARN and resource ID format must be enabled to work with ECS managed tags. Opt in to the new format and try again.
        	status code: 400, request id: 0b0fe569-20f8-11e9-9342-4d907d7500ee "tf-acc-test-8927583637643808161"




=== CONT  TestAccAWSEcsService_withServiceRegistries
--- FAIL: TestAccAWSEcsService_Tags (6.12s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_ecs_service.test: 1 error occurred:
        	* aws_ecs_service.test: InvalidParameterException: The new ARN and resource ID format must be enabled to add tags to the service. Opt in to the new format and try again.
        	status code: 400, request id: 0b24092c-20f8-11e9-aec7-236a2b13d6dd "tf-acc-test-5626065118540751641"




=== CONT  TestAccAWSEcsService_withServiceRegistries_container
--- FAIL: TestAccAWSEcsService_PropagateTags (6.12s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_ecs_service.test: 1 error occurred:
        	* aws_ecs_service.test: InvalidParameterException: The new ARN and resource ID format must be enabled to work with ECS managed tags. Opt in to the new format and try again.
        	status code: 400, request id: 0b1cdd41-20f8-11e9-8315-85c4088b7e2f "tf-acc-test-8438769165236684514"




=== CONT  TestAccAWSEcsService_withFamilyAndRevision
--- PASS: TestAccAWSEcsService_withEcsClusterName (11.99s)
=== CONT  TestAccAWSEcsService_withUnnormalizedPlacementStrategy
--- PASS: TestAccAWSEcsServiceDataSource_basic (12.30s)
=== CONT  TestAccAWSEcsService_basicImport
--- FAIL: TestAccAWSEcsService_withServiceRegistries_container (6.18s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpc.test: 1 error occurred:
        	* aws_vpc.test: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
        	status code: 400, request id: 55d337ea-bcb5-4680-ad05-fa4a6f87e1f0




=== CONT  TestAccAWSEcsService_withReplicaSchedulingStrategy
--- PASS: TestAccAWSEcsService_withPlacementConstraints (12.48s)
=== CONT  TestAccAWSEcsService_withARN
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (16.08s)
=== CONT  TestAccAWSEcsService_withRenamedCluster
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (16.13s)
=== CONT  TestAccAWSEcsService_disappears
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (16.38s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (15.56s)
--- FAIL: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (30.03s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpc.main: 1 error occurred:
        	* aws_vpc.main: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
        	status code: 400, request id: 29dc98a6-bc7a-40f7-8e6c-8a5f95f87cc7




--- PASS: TestAccAWSEcsService_disappears (17.97s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (34.52s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (34.55s)
--- FAIL: TestAccAWSEcsService_withServiceRegistries (28.64s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpc.test: 1 error occurred:
        	* aws_vpc.test: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
        	status code: 400, request id: b9d71148-0203-425f-b3e9-fb91a61ec346




--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (27.40s)
--- PASS: TestAccAWSEcsService_withARN (40.20s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (48.96s)
--- PASS: TestAccAWSEcsService_basicImport (45.62s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (48.30s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (82.01s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (91.62s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (111.84s)
--- PASS: TestAccAWSEcsService_withIamRole (155.71s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (201.80s)
--- PASS: TestAccAWSEcsService_withAlb (216.79s)
--- PASS: TestAccAWSEcsService_withLbChanges (250.82s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (267.12s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	268.017s
```
