### PR TITLE
Issue #7016 support http namespaces in service discovery 

### DIFF
--- a/aws/resource_aws_service_discovery_service.go
+++ b/aws/resource_aws_service_discovery_service.go
@@ -32,9 +32,14 @@ func resourceAwsServiceDiscoveryService() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"namespace_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"dns_config": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -133,12 +138,20 @@ func resourceAwsServiceDiscoveryServiceCreate(d *schema.ResourceData, meta inter
 	conn := meta.(*AWSClient).sdconn
 
 	input := &servicediscovery.CreateServiceInput{
-		Name:      aws.String(d.Get("name").(string)),
-		DnsConfig: expandServiceDiscoveryDnsConfig(d.Get("dns_config").([]interface{})[0].(map[string]interface{})),
+		Name: aws.String(d.Get("name").(string)),
+	}
+
+	dnsConfig := d.Get("dns_config").([]interface{})
+	if len(dnsConfig) > 0 {
+		input.DnsConfig = expandServiceDiscoveryDnsConfig(dnsConfig[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("namespace_id"); ok {
+		input.NamespaceId = aws.String(v.(string))
 	}
 
 	hcconfig := d.Get("health_check_config").([]interface{})
@@ -182,6 +195,7 @@ func resourceAwsServiceDiscoveryServiceRead(d *schema.ResourceData, meta interfa
 	d.Set("arn", service.Arn)
 	d.Set("name", service.Name)
 	d.Set("description", service.Description)
+	d.Set("namespace_id", service.NamespaceId)
 	d.Set("dns_config", flattenServiceDiscoveryDnsConfig(service.DnsConfig))
 	d.Set("health_check_config", flattenServiceDiscoveryHealthCheckConfig(service.HealthCheckConfig))
 	d.Set("health_check_custom_config", flattenServiceDiscoveryHealthCheckCustomConfig(service.HealthCheckCustomConfig))
@@ -195,13 +209,17 @@ func resourceAwsServiceDiscoveryServiceUpdate(d *schema.ResourceData, meta inter
 		Id: aws.String(d.Id()),
 	}
 
-	sc := &servicediscovery.ServiceChange{
-		DnsConfig: expandServiceDiscoveryDnsConfigChange(d.Get("dns_config").([]interface{})[0].(map[string]interface{})),
+	sc := &servicediscovery.ServiceChange{}
+
+	if d.HasChange("dns_config") {
+		dnsConfig := d.Get("dns_config").([]interface{})
+		sc.DnsConfig = expandServiceDiscoveryDnsConfigChange(dnsConfig[0].(map[string]interface{}))
 	}
 
 	if d.HasChange("description") {
 		sc.Description = aws.String(d.Get("description").(string))
 	}
+
 	if d.HasChange("health_check_config") {
 		hcconfig := d.Get("health_check_config").([]interface{})
 		sc.HealthCheckConfig = expandServiceDiscoveryHealthCheckConfig(hcconfig[0].(map[string]interface{}))
@@ -265,18 +283,32 @@ func expandServiceDiscoveryDnsConfig(configured map[string]interface{}) *service
 }
 
 func flattenServiceDiscoveryDnsConfig(config *servicediscovery.DnsConfig) []map[string]interface{} {
+	if config == nil {
+		return nil
+	}
+
 	result := map[string]interface{}{}
 
-	result["namespace_id"] = *config.NamespaceId
-	result["routing_policy"] = *config.RoutingPolicy
-	drs := make([]map[string]interface{}, 0)
-	for _, v := range config.DnsRecords {
-		dr := map[string]interface{}{}
-		dr["ttl"] = *v.TTL
-		dr["type"] = *v.Type
-		drs = append(drs, dr)
+	if config.NamespaceId != nil {
+		result["namespace_id"] = *config.NamespaceId
 	}
-	result["dns_records"] = drs
+	if config.RoutingPolicy != nil {
+		result["routing_policy"] = *config.RoutingPolicy
+	}
+	if config.DnsRecords != nil {
+		drs := make([]map[string]interface{}, 0)
+		for _, v := range config.DnsRecords {
+			dr := map[string]interface{}{}
+			dr["ttl"] = *v.TTL
+			dr["type"] = *v.Type
+			drs = append(drs, dr)
+		}
+		result["dns_records"] = drs
+	}
+
+	if len(result) < 1 {
+		return nil
+	}
 
 	return []map[string]interface{}{result}
 }

--- a/aws/resource_aws_service_discovery_service.go
+++ b/aws/resource_aws_service_discovery_service.go
@@ -36,6 +36,7 @@ func resourceAwsServiceDiscoveryService() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"dns_config": {
 				Type:     schema.TypeList,
@@ -209,11 +210,8 @@ func resourceAwsServiceDiscoveryServiceUpdate(d *schema.ResourceData, meta inter
 		Id: aws.String(d.Id()),
 	}
 
-	sc := &servicediscovery.ServiceChange{}
-
-	if d.HasChange("dns_config") {
-		dnsConfig := d.Get("dns_config").([]interface{})
-		sc.DnsConfig = expandServiceDiscoveryDnsConfigChange(dnsConfig[0].(map[string]interface{}))
+	sc := &servicediscovery.ServiceChange{
+		DnsConfig: expandServiceDiscoveryDnsConfigChange(d.Get("dns_config").([]interface{})[0].(map[string]interface{})),
 	}
 
 	if d.HasChange("description") {

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -78,6 +78,25 @@ func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 	})
 }
 
+func TestAccAWSServiceDiscoveryService_http(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDiscoveryServiceConfig_http(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsServiceDiscoveryServiceExists("aws_service_discovery_service.test"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "namespace_id"),
+					resource.TestCheckResourceAttrSet("aws_service_discovery_service.test", "arn"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSServiceDiscoveryService_import(t *testing.T) {
 	resourceName := "aws_service_discovery_service.test"
 
@@ -231,4 +250,18 @@ resource "aws_service_discovery_service" "test" {
   }
 }
 `, rName, rName, th, path)
+}
+
+func testAccServiceDiscoveryServiceConfig_http(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_service_discovery_http_namespace" "test" {
+  name = "tf-sd-ns-%s"
+  description = "test"
+}
+
+resource "aws_service_discovery_service" "test" {
+  name = "tf-sd-%s"
+  namespace_id = "${aws_service_discovery_http_namespace.test.id}"
+}
+`, rName, rName)
 }

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -75,9 +75,10 @@ The following arguments are supported:
 
 * `name` - (Required, ForceNew) The name of the service.
 * `description` - (Optional) The description of the service.
-* `dns_config` - (Required) A complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance.
+* `dns_config` - (Optional) A complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance.
 * `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces.
 * `health_check_custom_config` - (Optional, ForceNew) A complex type that contains settings for ECS managed health checks.
+* `namespace_id` - (Optional) The ID of the namespace that you want to use to create the service.
 
 ### dns_config
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7016 

Changes proposed in this pull request:

* Change 1
support http namespaces in service discovery service.

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSServiceDiscoveryService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSServiceDiscoveryService_ -timeout 120m
=== RUN   TestAccAWSServiceDiscoveryService_private
=== PAUSE TestAccAWSServiceDiscoveryService_private
=== RUN   TestAccAWSServiceDiscoveryService_public
=== PAUSE TestAccAWSServiceDiscoveryService_public
=== RUN   TestAccAWSServiceDiscoveryService_http
=== PAUSE TestAccAWSServiceDiscoveryService_http
=== RUN   TestAccAWSServiceDiscoveryService_import
=== PAUSE TestAccAWSServiceDiscoveryService_import
=== CONT  TestAccAWSServiceDiscoveryService_private
=== CONT  TestAccAWSServiceDiscoveryService_import
=== CONT  TestAccAWSServiceDiscoveryService_http
=== CONT  TestAccAWSServiceDiscoveryService_public
--- PASS: TestAccAWSServiceDiscoveryService_http (122.07s)
--- PASS: TestAccAWSServiceDiscoveryService_public (165.72s)
--- PASS: TestAccAWSServiceDiscoveryService_import (201.34s)
--- PASS: TestAccAWSServiceDiscoveryService_private (264.69s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws
...
```
