### PR TITLE
Add support for resource_aws_ses_identity_notification_topic import

### DIFF
--- a/aws/resource_aws_ses_identity_notification_topic.go
+++ b/aws/resource_aws_ses_identity_notification_topic.go
@@ -18,7 +18,7 @@ func resourceAwsSesNotificationTopic() *schema.Resource {
 		Update: resourceAwsSesNotificationTopicSet,
 		Delete: resourceAwsSesNotificationTopicDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceAwsSesNotificationImport,
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -82,6 +82,9 @@ func resourceAwsSesNotificationTopicRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+	d.Set("identity", identity)
+	d.Set("notification_type", notificationType)
+
 	getOpts := &ses.GetIdentityNotificationAttributesInput{
 		Identities: []*string{aws.String(identity)},
 	}
@@ -137,16 +140,6 @@ func resourceAwsSesNotificationTopicDelete(d *schema.ResourceData, meta interfac
 	}
 
 	return resourceAwsSesNotificationTopicRead(d, meta)
-}
-
-func resourceAwsSesNotificationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	identity, notificationType, err := decodeSesIdentityNotificationTopicId(d.Id())
-	if err != nil {
-		return nil, err
-	}
-	d.Set("identity", identity)
-	d.Set("notification_type", notificationType)
-	return []*schema.ResourceData{d}, nil
 }
 
 func decodeSesIdentityNotificationTopicId(id string) (string, string, error) {

--- a/aws/resource_aws_ses_identity_notification_topic.go
+++ b/aws/resource_aws_ses_identity_notification_topic.go
@@ -17,6 +17,9 @@ func resourceAwsSesNotificationTopic() *schema.Resource {
 		Read:   resourceAwsSesNotificationTopicRead,
 		Update: resourceAwsSesNotificationTopicSet,
 		Delete: resourceAwsSesNotificationTopicDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsSesNotificationImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"topic_arn": {
@@ -134,6 +137,16 @@ func resourceAwsSesNotificationTopicDelete(d *schema.ResourceData, meta interfac
 	}
 
 	return resourceAwsSesNotificationTopicRead(d, meta)
+}
+
+func resourceAwsSesNotificationImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	identity, notificationType, err := decodeSesIdentityNotificationTopicId(d.Id())
+	if err != nil {
+		return nil, err
+	}
+	d.Set("identity", identity)
+	d.Set("notification_type", notificationType)
+	return []*schema.ResourceData{d}, nil
 }
 
 func decodeSesIdentityNotificationTopicId(id string) (string, string, error) {

--- a/aws/resource_aws_ses_identity_notification_topic_test.go
+++ b/aws/resource_aws_ses_identity_notification_topic_test.go
@@ -41,6 +41,30 @@ func TestAccAwsSESIdentityNotificationTopic_basic(t *testing.T) {
 	})
 }
 
+func TestAccAwsSESIdentityNotification_importBasic(t *testing.T) {
+	resourceName := "aws_ses_identity_notification_topic.test"
+	domain := fmt.Sprintf(
+		"%s.terraformtesting.com",
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	topicName := fmt.Sprintf("test-topic-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESIdentityNotificationTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccAwsSESIdentityNotificationTopicConfig_update, domain, topicName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsSESIdentityNotificationTopicDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).sesConn
 

--- a/aws/resource_aws_ses_identity_notification_topic_test.go
+++ b/aws/resource_aws_ses_identity_notification_topic_test.go
@@ -17,6 +17,7 @@ func TestAccAwsSESIdentityNotificationTopic_basic(t *testing.T) {
 		"%s.terraformtesting.com",
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	topicName := fmt.Sprintf("test-topic-%d", acctest.RandInt())
+	resourceName := "aws_ses_identity_notification_topic.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -28,33 +29,14 @@ func TestAccAwsSESIdentityNotificationTopic_basic(t *testing.T) {
 			{
 				Config: fmt.Sprintf(testAccAwsSESIdentityNotificationTopicConfig_basic, domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESIdentityNotificationTopicExists("aws_ses_identity_notification_topic.test"),
+					testAccCheckAwsSESIdentityNotificationTopicExists(resourceName),
 				),
 			},
 			{
 				Config: fmt.Sprintf(testAccAwsSESIdentityNotificationTopicConfig_update, domain, topicName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsSESIdentityNotificationTopicExists("aws_ses_identity_notification_topic.test"),
+					testAccCheckAwsSESIdentityNotificationTopicExists(resourceName),
 				),
-			},
-		},
-	})
-}
-
-func TestAccAwsSESIdentityNotification_importBasic(t *testing.T) {
-	resourceName := "aws_ses_identity_notification_topic.test"
-	domain := fmt.Sprintf(
-		"%s.terraformtesting.com",
-		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
-	topicName := fmt.Sprintf("test-topic-%d", acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsSESIdentityNotificationTopicDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(testAccAwsSESIdentityNotificationTopicConfig_update, domain, topicName),
 			},
 			{
 				ResourceName:      resourceName,

--- a/website/docs/r/ses_identity_notification_topic.markdown
+++ b/website/docs/r/ses_identity_notification_topic.markdown
@@ -43,5 +43,5 @@ In this example, `example.com` is the SES Identity and `Bounce` is the Notificat
 To import the ID above, it would look as follows:
 
 ```
-$ import aws_ses_identity_notification_topic.test example.com|Bounce
+$ terraform import aws_ses_identity_notification_topic.test 'example.com|Bounce'
 ```

--- a/website/docs/r/ses_identity_notification_topic.markdown
+++ b/website/docs/r/ses_identity_notification_topic.markdown
@@ -27,3 +27,21 @@ The following arguments are supported:
 * `topic_arn` - (Optional) The Amazon Resource Name (ARN) of the Amazon SNS topic. Can be set to "" (an empty string) to disable publishing.
 * `notification_type` - (Required) The type of notifications that will be published to the specified Amazon SNS topic. Valid Values: *Bounce*, *Complaint* or *Delivery*.
 * `identity` - (Required) The identity for which the Amazon SNS topic will be set. You can specify an identity by using its name or by using its Amazon Resource Name (ARN).
+
+## Import
+
+Identity Notification Topics can be imported using ID of the record. The ID is made up as IDENTITY|TYPE where IDENTITY is the SES Identity and TYPE is the Notification Type.
+
+e.g.
+
+```
+example.com|Bounce
+```
+
+In this example, `example.com` is the SES Identity and `Bounce` is the Notification Type.
+
+To import the ID above, it would look as follows:
+
+```
+$ import aws_ses_identity_notification_topic.test example.com|Bounce
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Add support to aws_ses_identity_notification_topic for import
* Update aws_ses_identity_notification_topic docs

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsSESIdentityNotification'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsSESIdentityNotification -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsSESIdentityNotificationTopic_basic
=== PAUSE TestAccAwsSESIdentityNotificationTopic_basic
=== RUN   TestAccAwsSESIdentityNotification_importBasic
=== PAUSE TestAccAwsSESIdentityNotification_importBasic
=== CONT  TestAccAwsSESIdentityNotificationTopic_basic
=== CONT  TestAccAwsSESIdentityNotification_importBasic
--- PASS: TestAccAwsSESIdentityNotification_importBasic (14.79s)
--- PASS: TestAccAwsSESIdentityNotificationTopic_basic (23.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       23.528s
```
