### PR TITLE
resource/aws_iot_role_alias: Add initial support for IoT role aliases

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -520,6 +520,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iot_thing_principal_attachment":               resourceAwsIotThingPrincipalAttachment(),
 			"aws_iot_thing_type":                               resourceAwsIotThingType(),
 			"aws_iot_topic_rule":                               resourceAwsIotTopicRule(),
+			"aws_iot_role_alias":                               resourceAwsIotRoleAlias(),
 			"aws_key_pair":                                     resourceAwsKeyPair(),
 			"aws_kinesis_firehose_delivery_stream":             resourceAwsKinesisFirehoseDeliveryStream(),
 			"aws_kinesis_stream":                               resourceAwsKinesisStream(),

--- a/aws/resource_aws_iot_role_alias.go
+++ b/aws/resource_aws_iot_role_alias.go
@@ -57,24 +57,6 @@ func resourceAwsIotRoleAliasCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceAwsIotRoleAliasRead(d, meta)
 }
 
-func listIotRoleAliasPages(conn *iot.IoT, input *iot.ListRoleAliasesInput,
-	fn func(out *iot.ListRoleAliasesOutput, lastPage bool) bool) error {
-	for {
-		page, err := conn.ListRoleAliases(input)
-		if err != nil {
-			return err
-		}
-		lastPage := page.NextMarker == nil
-
-		shouldContinue := fn(page, lastPage)
-		if !shouldContinue || lastPage {
-			break
-		}
-		input.Marker = page.NextMarker
-	}
-	return nil
-}
-
 func getIotRoleAliasDescription(conn *iot.IoT, alias string) (*iot.RoleAliasDescription, error) {
 
 	roleAliasDescriptionOutput, err := conn.DescribeRoleAlias(&iot.DescribeRoleAliasInput{

--- a/aws/resource_aws_iot_role_alias.go
+++ b/aws/resource_aws_iot_role_alias.go
@@ -1,0 +1,162 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsIotRoleAlias() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIotRoleAliasCreate,
+		Read:   resourceAwsIotRoleAliasRead,
+		Delete: resourceAwsIotRoleAliasDelete,
+		Update: resourceAwsIotRoleAliasUpdate,
+		Schema: map[string]*schema.Schema{
+			"alias": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"credential_duration": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      3600,
+				ValidateFunc: validation.IntBetween(900, 3600),
+			},
+		},
+	}
+}
+
+func resourceAwsIotRoleAliasCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	roleAlias := d.Get("alias").(string)
+	roleArn := d.Get("role_arn").(string)
+	credentialDuration := d.Get("credential_duration").(int)
+
+	_, err := conn.CreateRoleAlias(&iot.CreateRoleAliasInput{
+		RoleAlias:                 aws.String(roleAlias),
+		RoleArn:                   aws.String(roleArn),
+		CredentialDurationSeconds: aws.Int64(int64(credentialDuration)),
+	})
+
+	if err != nil {
+		return fmt.Errorf("error creating role alias %s for role %s: %s", roleAlias, roleArn, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s|%s", roleAlias, roleArn))
+	return resourceAwsIotRoleAliasRead(d, meta)
+}
+
+func listIotRoleAliasPages(conn *iot.IoT, input *iot.ListRoleAliasesInput,
+	fn func(out *iot.ListRoleAliasesOutput, lastPage bool) bool) error {
+	for {
+		page, err := conn.ListRoleAliases(input)
+		if err != nil {
+			return err
+		}
+		lastPage := page.NextMarker == nil
+
+		shouldContinue := fn(page, lastPage)
+		if !shouldContinue || lastPage {
+			break
+		}
+		input.Marker = page.NextMarker
+	}
+	return nil
+}
+
+func getIotRoleAliasDescription(conn *iot.IoT, alias string) (*iot.RoleAliasDescription, error) {
+
+	roleAliasDescriptionOutput, err := conn.DescribeRoleAlias(&iot.DescribeRoleAliasInput{
+		RoleAlias: aws.String(alias),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if roleAliasDescriptionOutput == nil {
+		return nil, nil
+	}
+
+	return roleAliasDescriptionOutput.RoleAliasDescription, nil
+}
+
+func resourceAwsIotRoleAliasRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	alias := d.Get("alias").(string)
+
+	var roleAliasDescription *iot.RoleAliasDescription
+
+	roleAliasDescription, err := getIotRoleAliasDescription(conn, alias)
+
+	if err != nil {
+		return fmt.Errorf("error describing role alias %s: %s", alias, err)
+	}
+
+	if roleAliasDescription == nil {
+		log.Printf("[WARN] Role alias (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("role_arn", roleAliasDescription.RoleArn)
+	d.Set("credential_duration", roleAliasDescription.CredentialDurationSeconds)
+
+	return nil
+}
+
+func resourceAwsIotRoleAliasDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	alias := d.Get("alias").(string)
+
+	_, err := conn.DeleteRoleAlias(&iot.DeleteRoleAliasInput{
+		RoleAlias: aws.String(alias),
+	})
+
+	if err != nil {
+		return fmt.Errorf("error deleting role alias %s: %s", alias, err)
+	}
+
+	return nil
+}
+
+func resourceAwsIotRoleAliasUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iotconn
+
+	if d.HasChange("credential_duration") {
+		roleAliasInput := &iot.UpdateRoleAliasInput{
+			RoleAlias:                 aws.String(d.Get("alias").(string)),
+			CredentialDurationSeconds: aws.Int64(int64(d.Get("credential_duration").(int))),
+		}
+		_, err := conn.UpdateRoleAlias(roleAliasInput)
+		if err != nil {
+			return fmt.Errorf("Error updating role alias %s: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("role_arn") {
+		roleAliasInput := &iot.UpdateRoleAliasInput{
+			RoleAlias: aws.String(d.Get("alias").(string)),
+			RoleArn:   aws.String(d.Get("role_arn").(string)),
+		}
+		_, err := conn.UpdateRoleAlias(roleAliasInput)
+		if err != nil {
+			return fmt.Errorf("Error updating role alias %s: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsIotRoleAliasRead(d, meta)
+}

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -1,0 +1,343 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iot"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSIotRoleAlias_basic(t *testing.T) {
+	alias := acctest.RandomWithPrefix("RoleAlias-")
+	alias2 := acctest.RandomWithPrefix("RoleAlias2-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSIotRoleAliasDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSIotRoleAliasConfig(alias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
+					resource.TestCheckResourceAttr(
+						"aws_iot_role_alias.ra", "credential_duration", "3600"),
+				),
+			},
+			{
+				Config: testAccAWSIotRoleAliasConfigUpdate1(alias, alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
+					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+					resource.TestCheckResourceAttr(
+						"aws_iot_role_alias.ra", "credential_duration", "1800"),
+				),
+			},
+			{
+				Config: testAccAWSIotRoleAliasConfigUpdate2(alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+				),
+			},
+			{
+				Config: testAccAWSIotRoleAliasConfigUpdate3(alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+				),
+				ExpectError: regexp.MustCompile("Role alias .+? already exists for this account"),
+			},
+			{
+				Config: testAccAWSIotRoleAliasConfigUpdate4(alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+				),
+			},
+			{
+				Config: testAccAWSIotRoleAliasConfigUpdate5(alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+					resource.TestMatchResourceAttr(
+						"aws_iot_role_alias.ra2", "role_arn", regexp.MustCompile(".+?bogus")),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccCheckAWSIotRoleAliasDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).iotconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iot_role_alias" {
+			continue
+		}
+
+		alias := rs.Primary.Attributes["alias"]
+
+		input := &iot.ListRoleAliasesInput{
+			PageSize: aws.Int64(250),
+		}
+
+		var roleAlias string
+		err := listIotRoleAliasPages(conn, input, func(out *iot.ListRoleAliasesOutput, lastPage bool) bool {
+			for _, ra := range out.RoleAliases {
+				if alias == aws.StringValue(ra) {
+					roleAlias = alias
+					return false
+				}
+			}
+			return true
+		})
+
+		if err != nil {
+			return fmt.Errorf("error listing role aliases for alias %s: %s", alias, err)
+		}
+
+		if roleAlias == "" {
+			continue
+		}
+
+		return fmt.Errorf("IoT Role Alias (%s) still exists", rs.Primary.Attributes["id"])
+	}
+	return nil
+}
+
+func testAccCheckAWSIotRoleAliasExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+		alias := rs.Primary.Attributes["alias"]
+		role_arn := rs.Primary.Attributes["role_arn"]
+
+		roleAliasDescription, err := getIotRoleAliasDescription(conn, alias)
+
+		if err != nil {
+			return fmt.Errorf("Error: Failed to get role alias %s for role %s (%s): %s", alias, role_arn, n, err)
+		}
+
+		if roleAliasDescription == nil {
+			return fmt.Errorf("Error: Role alias %s is not attached to role (%s)", alias, role_arn)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSIotRoleAliasDoesNotExist(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).iotconn
+		alias := rs.Primary.Attributes["alias"]
+		role_arn := rs.Primary.Attributes["role_arn"]
+
+		roleAliasDescription, err := getIotRoleAliasDescription(conn, alias)
+
+		if err != nil {
+			return fmt.Errorf("Error: Failed to get role alias %s for role %s (%s): %s", alias, role_arn, n, err)
+		}
+
+		if roleAliasDescription != nil {
+			return fmt.Errorf("Error: Role alias %s is attached to role (%s)", alias, role_arn)
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSIotRoleAliasConfig(alias string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iot_role_alias" "ra" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role.arn}"
+}
+`, alias)
+}
+
+func testAccAWSIotRoleAliasConfigUpdate1(alias string, alias2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iot_role_alias" "ra" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role.arn}"
+  credential_duration = 1800
+}
+
+resource "aws_iot_role_alias" "ra2" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role.arn}"
+}
+`, alias, alias2)
+}
+
+func testAccAWSIotRoleAliasConfigUpdate2(alias2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iot_role_alias" "ra2" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role.arn}"
+}
+`, alias2)
+}
+
+func testAccAWSIotRoleAliasConfigUpdate3(alias2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iot_role_alias" "ra2" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role.arn}"
+}
+
+resource "aws_iot_role_alias" "ra3" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role.arn}"
+}
+`, alias2, alias2)
+}
+
+func testAccAWSIotRoleAliasConfigUpdate4(alias2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iam_role" "role2" {
+  name = "role2"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iot_role_alias" "ra2" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role2.arn}"
+}
+`, alias2)
+}
+
+func testAccAWSIotRoleAliasConfigUpdate5(alias2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name = "role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iam_role" "role2" {
+  name = "role2"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "credentials.iot.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iot_role_alias" "ra2" {
+  alias = "%s"
+  role_arn = "${aws_iam_role.role.arn}bogus"
+}
+`, alias2)
+}

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -154,35 +154,6 @@ func testAccCheckAWSIotRoleAliasExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAWSIotRoleAliasDoesNotExist(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*AWSClient).iotconn
-		alias := rs.Primary.Attributes["alias"]
-		role_arn := rs.Primary.Attributes["role_arn"]
-
-		roleAliasDescription, err := getIotRoleAliasDescription(conn, alias)
-
-		if err != nil {
-			return fmt.Errorf("Error: Failed to get role alias %s for role %s (%s): %s", alias, role_arn, n, err)
-		}
-
-		if roleAliasDescription != nil {
-			return fmt.Errorf("Error: Role alias %s is attached to role (%s)", alias, role_arn)
-		}
-
-		return nil
-	}
-}
-
 func testAccAWSIotRoleAliasConfig(alias string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "role" {

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -70,6 +70,24 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 
 }
 
+func listIotRoleAliasPages(conn *iot.IoT, input *iot.ListRoleAliasesInput,
+	fn func(out *iot.ListRoleAliasesOutput, lastPage bool) bool) error {
+	for {
+		page, err := conn.ListRoleAliases(input)
+		if err != nil {
+			return err
+		}
+		lastPage := page.NextMarker == nil
+
+		shouldContinue := fn(page, lastPage)
+		if !shouldContinue || lastPage {
+			break
+		}
+		input.Marker = page.NextMarker
+	}
+	return nil
+}
+
 func testAccCheckAWSIotRoleAliasDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).iotconn
 	for _, rs := range s.RootModule().Resources {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1602,6 +1602,10 @@
                     <li<%= sidebar_current("docs-aws-resource-iot-thing-type") %>>
                         <a href="/docs/providers/aws/r/iot_thing_type.html">aws_iot_thing_type</a>
                     </li>
+
+                    <li<%= sidebar_current("docs-aws-resource-iot-role-alias") %>>
+                        <a href="/docs/providers/aws/r/iot_role_alias.html">aws_iot_role_alias</a>
+                    </li>
                   </ul>
                 </li>
 

--- a/website/docs/r/iot_role_alias.html.markdown
+++ b/website/docs/r/iot_role_alias.html.markdown
@@ -31,7 +31,7 @@ EOF
 
 resource "aws_iot_role_alias" "alias" {
   alias    = "Thermostat-dynamodb-access-role-alias"
-  role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dynamodb-access-role"
+  role_arn = "${aws_iam_role.role.arn}"
 }
 ```
 
@@ -42,3 +42,11 @@ The following arguments are supported:
 * `alias` - (Required) The name of the role alias.
 * `role_arn` - (Required) The identity of the role to which the alias refers.
 * `credential_duration` - (Optional) The duration of the credential, in seconds. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 900 seconds (15 minutes) to 3600 seconds (60 minutes).
+
+## Import
+
+IOT Role Alias can be imported via the alias, e.g.
+
+```sh
+$ terraform import aws_iot_role_alias.example myalias
+```

--- a/website/docs/r/iot_role_alias.html.markdown
+++ b/website/docs/r/iot_role_alias.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iot_role_alias"
+sidebar_current: "docs-aws-resource-iot-role_alias"
+description: |-
+  Provides an IoT role alias.
+---
+
+# aws_iot_role_alias
+
+Provides an IoT role alias.
+
+## Example Usage
+
+```hcl
+resource "aws_iam_role" "role" {
+  name   = "dynamodb-access-role"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"Service": "credentials.iot.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iot_role_alias" "alias" {
+  alias    = "Thermostat-dynamodb-access-role-alias"
+  role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dynamodb-access-role"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `alias` - (Required) The name of the role alias.
+* `role_arn` - (Required) The identity of the role to which the alias refers.
+* `credential_duration` - (Optional) The duration of the credential, in seconds. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 900 seconds (15 minutes) to 3600 seconds (60 minutes).


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #2666

Changes proposed in this pull request:

* Add aws_iot_role_alias

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIotRoleAlias'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIotRoleAlias -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIotRoleAlias_basic
--- PASS: TestAccAWSIotRoleAlias_basic (42.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.240s
```