### PR TITLE
Added public_dns and private_dns to aws_eip

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -70,8 +70,20 @@ func resourceAwsEip() *schema.Resource {
 				Computed: true,
 			},
 
+			"public_dns": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"private_ip": {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"private_dns": {
+				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 
@@ -220,8 +232,28 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		d.Set("network_interface", "")
 	}
+
+	region := *ec2conn.Config.Region
 	d.Set("private_ip", address.PrivateIpAddress)
+	if address.PrivateIpAddress != nil {
+		dashIP := strings.Replace(*address.PrivateIpAddress, ".", "-", -1)
+
+		if region == "us-east-1" {
+			d.Set("private_dns", fmt.Sprintf("ip-%s.ec2.internal", dashIP))
+		} else {
+			d.Set("private_dns", fmt.Sprintf("ip-%s.%s.compute.internal", dashIP, region))
+		}
+	}
 	d.Set("public_ip", address.PublicIp)
+	if address.PublicIp != nil {
+		dashIP := strings.Replace(*address.PublicIp, ".", "-", -1)
+
+		if region == "us-east-1" {
+			d.Set("public_dns", fmt.Sprintf("ec2-%s.compute-1.amazonaws.com", dashIP))
+		} else {
+			d.Set("public_dns", fmt.Sprintf("ec2-%s.%s.compute.amazonaws.com", dashIP, region))
+		}
+	}
 	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
 
 	// On import (domain never set, which it must've been if we created),

--- a/website/docs/d/eip.html.markdown
+++ b/website/docs/d/eip.html.markdown
@@ -71,6 +71,10 @@ In addition to all arguments above, the following attributes are exported:
 * `network_interface_id` - The ID of the network interface.
 * `network_interface_owner_id` - The ID of the AWS account that owns the network interface.
 * `private_ip` - The private IP address associated with the Elastic IP address.
+* `private_dns` - The Private DNS associated with the Elastic IP address.
 * `public_ip` - Public IP address of Elastic IP.
+* `public_dns` - Public DNS associated with the Elastic IP address.
 * `public_ipv4_pool` - The ID of an address pool.
 * `tags` - Key-value map of tags associated with Elastic IP.
+
+~> **Note:** The data source computes the `public_dns` and `private_dns` attributes according to the [VPC DNS Guide](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames) as they are not available with the EC2 API.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -117,12 +117,16 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Contains the EIP allocation ID.
 * `private_ip` - Contains the private IP address (if in VPC).
+* `private_dns` - The Private DNS associated with the Elastic IP address (if in VPC).
 * `associate_with_private_ip` - Contains the user specified private IP address
 (if in VPC).
 * `public_ip` - Contains the public IP address.
+* `public_dns` - Public DNS associated with the Elastic IP address.
 * `instance` - Contains the ID of the attached instance.
 * `network_interface` - Contains the ID of the attached network interface.
 * `public_ipv4_pool` - EC2 IPv4 address pool identifier (if in VPC).
+
+~> **Note:** The resource computes the `public_dns` and `private_dns` attributes according to the [VPC DNS Guide](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames) as they are not available with the EC2 API.
 
 ## Timeouts
 `aws_eip` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #1149

Changes proposed in this pull request:

* Added public_dns and private_dns for aws_eip data and resource

Looking at the discussion in https://github.com/terraform-providers/terraform-provider-aws/pull/3731 this seems like a more simple implementation than using the reverse lookup.

I've created/looked up IPs in different regions (us-east-1, us-west-1, us-east-2, eu-west-1) to double check they follow the documentation.

Could you please advise on the best way to add unit tests for the new attributes? 

Thanks

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
=== PAUSE TestAccAWSAvailabilityZones_basic
=== RUN   TestAccAWSAvailabilityZones_stateFilter
=== PAUSE TestAccAWSAvailabilityZones_stateFilter
=== CONT  TestAccAWSAvailabilityZones_basic
=== CONT  TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_stateFilter (25.13s)
--- PASS: TestAccAWSAvailabilityZones_basic (25.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.153s
...
```
