### PR TITLE
data-source/aws_glue_script: Provide full example and test configurations

### DIFF
--- a/aws/data_source_aws_glue_script_test.go
+++ b/aws/data_source_aws_glue_script_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -15,9 +16,9 @@ func TestAccDataSourceAWSGlueScript_Language_Python(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSGlueScriptConfig_Language("PYTHON"),
+				Config: testAccDataSourceAWSGlueScriptConfigPython(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "python_script"),
+					resource.TestMatchResourceAttr(dataSourceName, "python_script", regexp.MustCompile(`from awsglue\.job import Job`)),
 				),
 			},
 		},
@@ -32,21 +33,207 @@ func TestAccDataSourceAWSGlueScript_Language_Scala(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAWSGlueScriptConfig_Language("SCALA"),
+				Config: testAccDataSourceAWSGlueScriptConfigScala(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "scala_code"),
+					resource.TestMatchResourceAttr(dataSourceName, "scala_code", regexp.MustCompile(`import com\.amazonaws\.services\.glue\.util\.Job`)),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAWSGlueScriptConfig_Language(language string) string {
+func testAccDataSourceAWSGlueScriptConfigPython() string {
 	return fmt.Sprintf(`
 data "aws_glue_script" "test" {
-  dag_edge = []
-  dag_node = []
-  language = "%s"
+  language = "PYTHON"
+
+  dag_edge {
+    source = "datasource0"
+    target = "applymapping1"
+  }
+
+  dag_edge {
+    source = "applymapping1"
+    target = "selectfields2"
+  }
+
+  dag_edge {
+    source = "selectfields2"
+    target = "resolvechoice3"
+  }
+
+  dag_edge {
+    source = "resolvechoice3"
+    target = "datasink4"
+  }
+
+  dag_node {
+    id        = "datasource0"
+    node_type = "DataSource"
+
+    args {
+      name  = "database"
+      value = "\"SourceDatabase\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"SourceTable\""
+    }
+  }
+
+  dag_node {
+    id        = "applymapping1"
+    node_type = "ApplyMapping"
+
+    args {
+      name  = "mapping"
+      value = "[(\"column1\", \"string\", \"column1\", \"string\")]"
+    }
+  }
+
+  dag_node {
+    id        = "selectfields2"
+    node_type = "SelectFields"
+
+    args {
+      name  = "paths"
+      value = "[\"column1\"]"
+    }
+  }
+
+  dag_node {
+    id        = "resolvechoice3"
+    node_type = "ResolveChoice"
+
+    args {
+      name  = "choice"
+      value = "\"MATCH_CATALOG\""
+    }
+
+    args {
+      name  = "database"
+      value = "\"DestinationDatabase\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"DestinationTable\""
+    }
+  }
+
+  dag_node {
+    id        = "datasink4"
+    node_type = "DataSink"
+
+    args {
+      name  = "database"
+      value = "\"DestinationDatabase\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"DestinationTable\""
+    }
+  }
 }
-`, language)
+`)
+}
+
+func testAccDataSourceAWSGlueScriptConfigScala() string {
+	return fmt.Sprintf(`
+data "aws_glue_script" "test" {
+  language = "SCALA"
+
+  dag_edge {
+    source = "datasource0"
+    target = "applymapping1"
+  }
+
+  dag_edge {
+    source = "applymapping1"
+    target = "selectfields2"
+  }
+
+  dag_edge {
+    source = "selectfields2"
+    target = "resolvechoice3"
+  }
+
+  dag_edge {
+    source = "resolvechoice3"
+    target = "datasink4"
+  }
+
+  dag_node {
+    id        = "datasource0"
+    node_type = "DataSource"
+
+    args {
+      name  = "database"
+      value = "\"SourceDatabase\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"SourceTable\""
+    }
+  }
+
+  dag_node {
+    id        = "applymapping1"
+    node_type = "ApplyMapping"
+
+    args {
+      name  = "mappings"
+      value = "[(\"column1\", \"string\", \"column1\", \"string\")]"
+    }
+  }
+
+  dag_node {
+    id        = "selectfields2"
+    node_type = "SelectFields"
+
+    args {
+      name  = "paths"
+      value = "[\"column1\"]"
+    }
+  }
+
+  dag_node {
+    id        = "resolvechoice3"
+    node_type = "ResolveChoice"
+
+    args {
+      name  = "choice"
+      value = "\"MATCH_CATALOG\""
+    }
+
+    args {
+      name  = "database"
+      value = "\"DestinationDatabase\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"DestinationTable\""
+    }
+  }
+
+  dag_node {
+    id        = "datasink4"
+    node_type = "DataSink"
+
+    args {
+      name  = "database"
+      value = "\"DestinationDatabase\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"DestinationTable\""
+    }
+  }
+}
+`)
 }

--- a/website/docs/d/glue_script.html.markdown
+++ b/website/docs/d/glue_script.html.markdown
@@ -18,13 +18,95 @@ Use this data source to generate a Glue script from a Directed Acyclic Graph (DA
 data "aws_glue_script" "example" {
   language = "PYTHON"
 
-  dag_edge = []
+  dag_edge {
+    source = "datasource0"
+    target = "applymapping1"
+  }
 
-  # ...
+  dag_edge {
+    source = "applymapping1"
+    target = "selectfields2"
+  }
 
-  dag_node = []
+  dag_edge {
+    source = "selectfields2"
+    target = "resolvechoice3"
+  }
 
-  # ...
+  dag_edge {
+    source = "resolvechoice3"
+    target = "datasink4"
+  }
+
+  dag_node {
+    id        = "datasource0"
+    node_type = "DataSource"
+
+    args {
+      name  = "database"
+      value = "\"${aws_glue_catalog_database.source.name}\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"${aws_glue_catalog_table.source.name}\""
+    }
+  }
+
+  dag_node {
+    id        = "applymapping1"
+    node_type = "ApplyMapping"
+
+    args {
+      name  = "mapping"
+      value = "[(\"column1\", \"string\", \"column1\", \"string\")]"
+    }
+  }
+
+  dag_node {
+    id        = "selectfields2"
+    node_type = "SelectFields"
+
+    args {
+      name  = "paths"
+      value = "[\"column1\"]"
+    }
+  }
+
+  dag_node {
+    id        = "resolvechoice3"
+    node_type = "ResolveChoice"
+
+    args {
+      name  = "choice"
+      value = "\"MATCH_CATALOG\""
+    }
+
+    args {
+      name  = "database"
+      value = "\"${aws_glue_catalog_database.destination.name}\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"${aws_glue_catalog_table.destination.name}\""
+    }
+  }
+
+  dag_node {
+    id        = "datasink4"
+    node_type = "DataSink"
+
+    args {
+      name  = "database"
+      value = "\"${aws_glue_catalog_database.destination.name}\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"${aws_glue_catalog_table.destination.name}\""
+    }
+  }
 }
 
 output "python_script" {
@@ -38,13 +120,95 @@ output "python_script" {
 data "aws_glue_script" "example" {
   language = "SCALA"
 
-  dag_edge = []
+  dag_edge {
+    source = "datasource0"
+    target = "applymapping1"
+  }
 
-  # ...
+  dag_edge {
+    source = "applymapping1"
+    target = "selectfields2"
+  }
 
-  dag_node = []
+  dag_edge {
+    source = "selectfields2"
+    target = "resolvechoice3"
+  }
 
-  # ...
+  dag_edge {
+    source = "resolvechoice3"
+    target = "datasink4"
+  }
+
+  dag_node {
+    id        = "datasource0"
+    node_type = "DataSource"
+
+    args {
+      name  = "database"
+      value = "\"${aws_glue_catalog_database.source.name}\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"${aws_glue_catalog_table.source.name}\""
+    }
+  }
+
+  dag_node {
+    id        = "applymapping1"
+    node_type = "ApplyMapping"
+
+    args {
+      name  = "mappings"
+      value = "[(\"column1\", \"string\", \"column1\", \"string\")]"
+    }
+  }
+
+  dag_node {
+    id        = "selectfields2"
+    node_type = "SelectFields"
+
+    args {
+      name  = "paths"
+      value = "[\"column1\"]"
+    }
+  }
+
+  dag_node {
+    id        = "resolvechoice3"
+    node_type = "ResolveChoice"
+
+    args {
+      name  = "choice"
+      value = "\"MATCH_CATALOG\""
+    }
+
+    args {
+      name  = "database"
+      value = "\"${aws_glue_catalog_database.destination.name}\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"${aws_glue_catalog_table.destination.name}\""
+    }
+  }
+
+  dag_node {
+    id        = "datasink4"
+    node_type = "DataSink"
+
+    args {
+      name  = "database"
+      value = "\"${aws_glue_catalog_database.destination.name}\""
+    }
+
+    args {
+      name  = "table_name"
+      value = "\"${aws_glue_catalog_table.destination.name}\""
+    }
+  }
 }
 
 output "scala_code" {


### PR DESCRIPTION
During original development, the configuration of a working setup with `dag_edges` and `dag_nodes` was unknown. It turns out a working configuration is required for Terraform 0.12 anyways since the previous empty list syntax (`= []`) is incompatible with the configuration parser and the working configuration is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccDataSourceAWSGlueScript_Language_Python (0.58s)
    testing.go:568: Step 0 error: config is invalid: 4 problems:

        - Unsupported argument: An argument named "dag_edge" is not expected here. Did you mean to define a block of type "dag_edge"?
        - Unsupported argument: An argument named "dag_node" is not expected here. Did you mean to define a block of type "dag_node"?
        - Insufficient dag_edge blocks: At least 1 "dag_edge" blocks are required.
        - Insufficient dag_node blocks: At least 1 "dag_node" blocks are required.

--- FAIL: TestAccDataSourceAWSGlueScript_Language_Scala (0.58s)
    testing.go:568: Step 0 error: config is invalid: 4 problems:

        - Unsupported argument: An argument named "dag_edge" is not expected here. Did you mean to define a block of type "dag_edge"?
        - Unsupported argument: An argument named "dag_node" is not expected here. Did you mean to define a block of type "dag_node"?
        - Insufficient dag_edge blocks: At least 1 "dag_edge" blocks are required.
        - Insufficient dag_node blocks: At least 1 "dag_node" blocks are required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccDataSourceAWSGlueScript_Language_Scala (11.56s)
--- PASS: TestAccDataSourceAWSGlueScript_Language_Python (11.68s)
```
