### PR TITLE
tests/resource/aws_cloudtrail: Fix syntax for Terraform 0.12

### DIFF
--- a/aws/resource_aws_cloudtrail_test.go
+++ b/aws/resource_aws_cloudtrail_test.go
@@ -1178,7 +1178,7 @@ POLICY
 }
 
 func testAccAWSCloudTrailConfig_tags(cloudTrailRandInt int) string {
-	tagsString := `tags {
+	tagsString := `tags = {
 		Foo = "moo"
 		Pooh = "hi"
 	}`
@@ -1191,7 +1191,7 @@ func testAccAWSCloudTrailConfig_tags(cloudTrailRandInt int) string {
 }
 
 func testAccAWSCloudTrailConfig_tagsModified(cloudTrailRandInt int) string {
-	tagsString := `tags {
+	tagsString := `tags = {
 		Foo = "moo"
 		Pooh = "hi"
 		Moo = "boom"


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCloudTrail (209.69s)
    --- FAIL: TestAccAWSCloudTrail/Trail (209.69s)
        --- FAIL: TestAccAWSCloudTrail/Trail/tags (0.51s)
            testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
        --- PASS: TestAccAWSCloudTrail/Trail/tags (93.14s)
```
