### PR TITLE
tests/resource/aws_elastic_transcoder_pipeline: Fix syntax for Terraform 0.12

### DIFF
--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -460,7 +460,7 @@ resource "aws_elastictranscoder_pipeline" "baz" {
     storage_class = "Standard"
   }
 
-  content_config_permissions = {
+  content_config_permissions {
     grantee_type = "Group"
     grantee      = "AuthenticatedUsers"
     access       = ["FullControl"]
@@ -471,7 +471,7 @@ resource "aws_elastictranscoder_pipeline" "baz" {
     storage_class = "Standard"
   }
 
-  thumbnail_config_permissions = {
+  thumbnail_config_permissions {
     grantee_type = "Group"
     grantee      = "AuthenticatedUsers"
     access       = ["FullControl"]


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSElasticTranscoderPipeline_withPermissions (0.63s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "content_config_permissions" is not expected here. Did you mean to define a block of type "content_config_permissions"?
        - Unsupported argument: An argument named "thumbnail_config_permissions" is not expected here. Did you mean to define a block of type "thumbnail_config_permissions"?
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSElasticTranscoderPipeline_withPermissions (26.87s)
```
