### PR TITLE
tests/resource/aws_route_table: Fix syntax for Terraform 0.12

### DIFF
--- a/aws/import_aws_route_table_test.go
+++ b/aws/import_aws_route_table_test.go
@@ -97,13 +97,8 @@ resource "aws_internet_gateway" "gw" {
   }
 }
 
-variable "private_subnet_cidrs" {
-  default = "10.0.0.0/24"
-}
-
 resource "aws_nat_gateway" "nat" {
-  count         = "${length(split(",", var.private_subnet_cidrs))}"
-  allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
+  allocation_id = "${aws_eip.nat.id}"
   subnet_id     = "${aws_subnet.tf_test_subnet.id}"
 
   tags = {
@@ -112,7 +107,6 @@ resource "aws_nat_gateway" "nat" {
 }
 
 resource "aws_route_table" "mod" {
-  count  = "${length(split(",", var.private_subnet_cidrs))}"
   vpc_id = "${aws_vpc.default.id}"
 
   tags = {
@@ -125,7 +119,7 @@ resource "aws_route_table" "mod" {
 resource "aws_route" "mod-1" {
   route_table_id         = "${aws_route_table.mod.id}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.nat.*.id, count.index)}"
+  nat_gateway_id         = "${aws_nat_gateway.nat.id}"
 }
 
 resource "aws_route" "mod" {
@@ -137,7 +131,7 @@ resource "aws_route" "mod" {
 resource "aws_vpc_endpoint" "s3" {
   vpc_id          = "${aws_vpc.default.id}"
   service_name    = "com.amazonaws.us-west-2.s3"
-  route_table_ids = ["${aws_route_table.mod.*.id}"]
+  route_table_ids = ["${aws_route_table.mod.id}"]
 }
 
 ### vpc bar


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11. Please note the new test failure highlights an issue with "complex" importing that can be seen with other resources and will be reported upstream.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSRouteTable_complex (0.73s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Missing resource instance key: Because aws_route_table.mod has "count" set, its attributes must be accessed on specific instances.

        For example, to correlate with indices of a referring resource, use:
            aws_route_table.mod[count.index]
        - Missing resource instance key: Because aws_route_table.mod has "count" set, its attributes must be accessed on specific instances.

        For example, to correlate with indices of a referring resource, use:
            aws_route_table.mod[count.index]
```

Output from acceptance testing (requires additional fixes in the Terraform Provider SDK):

```
--- FAIL: TestAccAWSRouteTable_complex (211.83s)
    testing.go:568: Step 1 error: 2 problems:

        - Cannot import non-existent remote object: While attempting to import an existing object to aws_route_table.mod-2, the provider detected that no object exists with the given id. Only pre-existing objects can be imported; check that the id is correct and that it is associated with the provider's configured region or endpoint, or use "terraform apply" to create a new remote object for this resource.
        - Cannot import non-existent remote object: While attempting to import an existing object to aws_route_table.mod-1, the provider detected that no object exists with the given id. Only pre-existing objects can be imported; check that the id is correct and that it is associated with the provider's configured region or endpoint, or use "terraform apply" to create a new remote object for this resource.
```
