### PR TITLE
resource/aws_sagemaker_notebook_instance: Ensure tags configurations use equals in testing and documentation

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -320,7 +320,7 @@ resource "aws_sagemaker_notebook_instance" "foo" {
 	name = "%s"
 	role_arn = "${aws_iam_role.foo.arn}"
 	instance_type = "ml.t2.medium"
-	tags {
+	tags = {
 		foo = "bar"
 	}
 }
@@ -349,7 +349,7 @@ resource "aws_sagemaker_notebook_instance" "foo" {
 	name = "%s"
 	role_arn = "${aws_iam_role.foo.arn}"
 	instance_type = "ml.t2.medium"
-	tags {
+	tags = {
 		bar = "baz"
 	}
 }

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -20,7 +20,7 @@ resource "aws_sagemaker_notebook_instance" "ni" {
   role_arn = "${aws_iam_role.role.arn}"
   instance_type = "ml.t2.medium"
 
-  tags {
+  tags = {
     Name = "foo"
   }
 }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSagemakerNotebookInstance_tags (0.61s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSSagemakerNotebookInstance_tags (354.43s)
```
