### PR TITLE
docs/resource/aws_ram_resource_share: Ensure tags configurations use equals

### DIFF
--- a/website/docs/r/ram_resource_share.markdown
+++ b/website/docs/r/ram_resource_share.markdown
@@ -17,7 +17,7 @@ resource "aws_ram_resource_share" "example" {
   name                      = "example"
   allow_external_principals = true
 
-  tags {
+  tags = {
     Environment = "Production"
   }
 }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.
