### PR TITLE
service/transfer: Ensure tags configurations use equals

### DIFF
--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -56,7 +56,7 @@ resource "aws_transfer_server" "foo" {
   identity_provider_type = "SERVICE_MANAGED"
   logging_role = "${aws_iam_role.foo.arn}"
 
-  tags {
+  tags = {
 	NAME   = "tf-acc-test-transfer-server"
 	ENV    = "test"
   }

--- a/website/docs/r/transfer_ssh_key.html.markdown
+++ b/website/docs/r/transfer_ssh_key.html.markdown
@@ -15,7 +15,7 @@ Provides a AWS Transfer User SSH Key resource.
 resource "aws_transfer_server" "foo" {
 	identity_provider_type = "SERVICE_MANAGED"
 
-	tags {
+	tags = {
 		NAME     = "tf-acc-test-transfer-server"
 	}
 }
@@ -66,7 +66,7 @@ resource "aws_transfer_user" "foo" {
 	user_name      = "tftestuser"
 	role           = "${aws_iam_role.foo.arn}"
 
-	tags {
+	tags = {
 		NAME = "tftestuser"
 	}
 }

--- a/website/docs/r/transfer_user.html.markdown
+++ b/website/docs/r/transfer_user.html.markdown
@@ -15,7 +15,7 @@ Provides a AWS Transfer User resource. Managing SSH keys can be accomplished wit
 resource "aws_transfer_server" "foo" {
 	identity_provider_type = "SERVICE_MANAGED"
 
-	tags {
+	tags = {
 		NAME     = "tf-acc-test-transfer-server"
 	}
 }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.
