### PR TITLE
docs: Ensure tags configurations use equals

### DIFF
--- a/examples/cloudhsm/main.tf
+++ b/examples/cloudhsm/main.tf
@@ -7,7 +7,7 @@ data "aws_availability_zones" "available" {}
 resource "aws_vpc" "cloudhsm2_vpc" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
   }
 }
@@ -19,7 +19,7 @@ resource "aws_subnet" "cloudhsm2_subnets" {
   map_public_ip_on_launch = false
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
-  tags {
+  tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
   }
 }
@@ -28,7 +28,7 @@ resource "aws_cloudhsm_v2_cluster" "cloudhsm_v2_cluster" {
   hsm_type   = "hsm1.medium"
   subnet_ids = ["${aws_subnet.cloudhsm2_subnets.*.id}"]
 
-  tags {
+  tags = {
     Name = "example-aws_cloudhsm_v2_cluster"
   }
 }

--- a/examples/cognito-user-pool/main.tf
+++ b/examples/cognito-user-pool/main.tf
@@ -142,7 +142,7 @@ resource "aws_cognito_user_pool" "pool" {
     sns_caller_arn = "${aws_iam_role.cidp.arn}"
   }
 
-  tags {
+  tags = {
     "Name"    = "FooBar"
     "Project" = "Terraform"
   }

--- a/examples/eip/main.tf
+++ b/examples/eip/main.tf
@@ -62,7 +62,7 @@ resource "aws_instance" "web" {
   user_data = "${file("userdata.sh")}"
 
   #Instance tags
-  tags {
+  tags = {
     Name = "eip-example"
   }
 }

--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -46,7 +46,7 @@ resource "aws_security_group" "demo-cluster" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "terraform-eks-demo"
   }
 }

--- a/examples/eks-getting-started/vpc.tf
+++ b/examples/eks-getting-started/vpc.tf
@@ -11,8 +11,8 @@ resource "aws_vpc" "demo" {
 
   tags = "${
     map(
-     "Name", "terraform-eks-demo-node",
-     "kubernetes.io/cluster/${var.cluster-name}", "shared",
+      "Name", "terraform-eks-demo-node",
+      "kubernetes.io/cluster/${var.cluster-name}", "shared",
     )
   }"
 }
@@ -26,8 +26,8 @@ resource "aws_subnet" "demo" {
 
   tags = "${
     map(
-     "Name", "terraform-eks-demo-node",
-     "kubernetes.io/cluster/${var.cluster-name}", "shared",
+      "Name", "terraform-eks-demo-node",
+      "kubernetes.io/cluster/${var.cluster-name}", "shared",
     )
   }"
 }
@@ -35,7 +35,7 @@ resource "aws_subnet" "demo" {
 resource "aws_internet_gateway" "demo" {
   vpc_id = "${aws_vpc.demo.id}"
 
-  tags {
+  tags = {
     Name = "terraform-eks-demo"
   }
 }

--- a/examples/elb/main.tf
+++ b/examples/elb/main.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "default" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "tf_test"
   }
 }
@@ -17,7 +17,7 @@ resource "aws_subnet" "tf_test_subnet" {
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
 
-  tags {
+  tags = {
     Name = "tf_test_subnet"
   }
 }
@@ -25,7 +25,7 @@ resource "aws_subnet" "tf_test_subnet" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.default.id}"
 
-  tags {
+  tags = {
     Name = "tf_test_ig"
   }
 }
@@ -38,7 +38,7 @@ resource "aws_route_table" "r" {
     gateway_id = "${aws_internet_gateway.gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "aws_route_table"
   }
 }
@@ -168,7 +168,7 @@ resource "aws_instance" "web" {
 
   #Instance tags
 
-  tags {
+  tags = {
     Name = "elb-example"
   }
 }

--- a/examples/rds/sg.tf
+++ b/examples/rds/sg.tf
@@ -17,7 +17,7 @@ resource "aws_security_group" "default" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.sg_name}"
   }
 }

--- a/examples/rds/subnets.tf
+++ b/examples/rds/subnets.tf
@@ -3,7 +3,7 @@ resource "aws_subnet" "subnet_1" {
   cidr_block        = "${var.subnet_1_cidr}"
   availability_zone = "${var.az_1}"
 
-  tags {
+  tags = {
     Name = "main_subnet1"
   }
 }
@@ -13,7 +13,7 @@ resource "aws_subnet" "subnet_2" {
   cidr_block        = "${var.subnet_2_cidr}"
   availability_zone = "${var.az_2}"
 
-  tags {
+  tags = {
     Name = "main_subnet2"
   }
 }

--- a/website/docs/guides/eks-getting-started.html.md
+++ b/website/docs/guides/eks-getting-started.html.md
@@ -157,7 +157,7 @@ resource "aws_subnet" "demo" {
 resource "aws_internet_gateway" "demo" {
   vpc_id = "${aws_vpc.demo.id}"
 
-  tags {
+  tags = {
     Name = "terraform-eks-demo"
   }
 }
@@ -244,7 +244,7 @@ resource "aws_security_group" "demo-cluster" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "terraform-eks-demo"
   }
 }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11. I will also synchronize this change over to the HashiCorp Learn repository for the EKS Getting Started Guide.