### PR TITLE
tests/provider: Increase gometalinter deadline from 5m to 10m

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,5 +1,5 @@
 {
-    "Deadline": "5m",
+    "Deadline": "10m",
     "Enable": [
         "deadcode",
         "errcheck",


### PR DESCRIPTION
After the switch from `gosimple` and `unused` to `staticcheck` (https://github.com/terraform-providers/terraform-provider-aws/pull/7242), occassionally TravisCI and locally will hit the 5 minute gometalinter deadline with the increased workload, presumably from the addition of `megacheck` checks in `staticcheck`.

Since deadline failures are generally more related to resource contention rather than systematic failures with the linters themselves (e.g. runaway lint processes), we opt here to increase the deadline from 5 minutes to 10 minutes.
