### PR TITLE
Update DynamoDB billing_mode

### DIFF
--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -405,6 +405,8 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 
+		req.ProvisionedThroughput = expandDynamoDbProvisionedThroughput(capacityMap, billingMode)
+
 		_, err := conn.UpdateTable(req)
 		if err != nil {
 			return fmt.Errorf("Error updating DynamoDB Table (%s) billing mode: %s", d.Id(), err)

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -513,6 +513,30 @@ func TestAccAWSDynamoDbTable_BillingMode(t *testing.T) {
 	})
 }
 
+func TestAccAWSDynamoDbTable_BillingModeUpdate(t *testing.T) {
+	rName := acctest.RandomWithPrefix("TerraformTestTable-")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDynamoDbBilling_PayPerRequest(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynamoDbTableHasBilling_PayPerRequest("aws_dynamodb_table.basic-dynamodb-table"),
+				),
+			},
+			{
+				Config: testAccAWSDynamoDbBilling_Provisioned(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDynamoDbTableHasBilling_Provisioned("aws_dynamodb_table.basic-dynamodb-table"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDynamoDbTable_streamSpecification(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
 
@@ -1139,6 +1163,39 @@ func testAccCheckDynamoDbTableHasBilling_PayPerRequest(n string) resource.TestCh
 	}
 }
 
+func testAccCheckDynamoDbTableHasBilling_Provisioned(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DynamoDB table name specified!")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+		params := &dynamodb.DescribeTableInput{
+			TableName: aws.String(rs.Primary.ID),
+		}
+		resp, err := conn.DescribeTable(params)
+
+		if err != nil {
+			return err
+		}
+		table := resp.Table
+
+		if table.BillingModeSummary == nil {
+			return fmt.Errorf("Billing Mode summary was empty, expected summary to exist and contain billing mode %s", dynamodb.BillingModeProvisioned)
+		} else if aws.StringValue(table.BillingModeSummary.BillingMode) != dynamodb.BillingModeProvisioned {
+			return fmt.Errorf("Billing Mode was %s, not %s!", aws.StringValue(table.BillingModeSummary.BillingMode), dynamodb.BillingModeProvisioned)
+
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckDynamoDbTableWasUpdated(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1265,6 +1322,24 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
   name = "%s"
   billing_mode = "PAY_PER_REQUEST"
   hash_key = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+`, rName)
+}
+
+func testAccAWSDynamoDbBilling_Provisioned(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "basic-dynamodb-table" {
+  name = "%s"
+  billing_mode = "PROVISIONED"
+  hash_key = "TestTableHashKey"
+
+  read_capacity = 5
+  write_capacity = 5
 
   attribute {
     name = "TestTableHashKey"


### PR DESCRIPTION
Fixes #7097 

Ensure that capacity is included in request when switching billing_mode from PAY_PER_REQUEST to PROVISIONED 

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Ensure that capacity is included in request when switching billing_mode from PAY_PER_REQUEST to PROVISIONED 

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

=== RUN   TestAccAWSDynamoDbTableItem_basic
=== PAUSE TestAccAWSDynamoDbTableItem_basic
=== RUN   TestAccAWSDynamoDbTableItem_rangeKey
=== PAUSE TestAccAWSDynamoDbTableItem_rangeKey
=== RUN   TestAccAWSDynamoDbTableItem_withMultipleItems
=== PAUSE TestAccAWSDynamoDbTableItem_withMultipleItems
=== RUN   TestAccAWSDynamoDbTableItem_update
=== PAUSE TestAccAWSDynamoDbTableItem_update
=== RUN   TestAccAWSDynamoDbTableItem_updateWithRangeKey
=== PAUSE TestAccAWSDynamoDbTableItem_updateWithRangeKey
=== RUN   TestAccAWSDynamoDbTable_importBasic
=== PAUSE TestAccAWSDynamoDbTable_importBasic
=== RUN   TestAccAWSDynamoDbTable_importTags
=== PAUSE TestAccAWSDynamoDbTable_importTags
=== RUN   TestAccAWSDynamoDbTable_importTimeToLive
=== PAUSE TestAccAWSDynamoDbTable_importTimeToLive
=== RUN   TestAccAWSDynamoDbTable_basic
=== PAUSE TestAccAWSDynamoDbTable_basic
=== RUN   TestAccAWSDynamoDbTable_extended
=== PAUSE TestAccAWSDynamoDbTable_extended
=== RUN   TestAccAWSDynamoDbTable_enablePitr
=== PAUSE TestAccAWSDynamoDbTable_enablePitr
=== RUN   TestAccAWSDynamoDbTable_BillingMode
=== PAUSE TestAccAWSDynamoDbTable_BillingMode
=== RUN   TestAccAWSDynamoDbTable_BillingModeUpdate
=== PAUSE TestAccAWSDynamoDbTable_BillingModeUpdate
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
=== PAUSE TestAccAWSDynamoDbTable_streamSpecification
=== RUN   TestAccAWSDynamoDbTable_streamSpecificationValidation
=== PAUSE TestAccAWSDynamoDbTable_streamSpecificationValidation
=== RUN   TestAccAWSDynamoDbTable_tags
=== PAUSE TestAccAWSDynamoDbTable_tags
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== RUN   TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== PAUSE TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== RUN   TestAccAWSDynamoDbTable_ttl
=== PAUSE TestAccAWSDynamoDbTable_ttl
=== RUN   TestAccAWSDynamoDbTable_attributeUpdate
=== PAUSE TestAccAWSDynamoDbTable_attributeUpdate
=== RUN   TestAccAWSDynamoDbTable_attributeUpdateValidation
=== PAUSE TestAccAWSDynamoDbTable_attributeUpdateValidation
=== RUN   TestAccAWSDynamoDbTable_encryption
=== PAUSE TestAccAWSDynamoDbTable_encryption
=== CONT  TestAccAWSDynamoDbTableItem_basic
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateCapacity
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes
=== CONT  TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes
=== CONT  TestAccAWSDynamoDbTable_encryption
=== CONT  TestAccAWSDynamoDbTable_attributeUpdateValidation
=== CONT  TestAccAWSDynamoDbTable_attributeUpdate
=== CONT  TestAccAWSDynamoDbTable_BillingModeUpdate
--- PASS: TestAccAWSDynamoDbTable_attributeUpdateValidation (5.62s)
=== CONT  TestAccAWSDynamoDbTable_ttl
--- PASS: TestAccAWSDynamoDbTable_ttl (101.56s)
=== CONT  TestAccAWSDynamoDbTable_streamSpecificationValidation
--- PASS: TestAccAWSDynamoDbTable_streamSpecificationValidation (3.67s)
=== CONT  TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTableItem_basic (125.93s)
=== CONT  TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_BillingModeUpdate (155.03s)
=== CONT  TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateNonKeyAttributes (228.25s)
=== CONT  TestAccAWSDynamoDbTableItem_update
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateCapacity (242.30s)
=== CONT  TestAccAWSDynamoDbTable_BillingMode
--- PASS: TestAccAWSDynamoDbTable_encryption (249.74s)
=== CONT  TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_tags (138.77s)
=== CONT  TestAccAWSDynamoDbTable_enablePitr
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (162.65s)
=== CONT  TestAccAWSDynamoDbTableItem_updateWithRangeKey
--- PASS: TestAccAWSDynamoDbTable_importTags (151.81s)
=== CONT  TestAccAWSDynamoDbTable_extended
--- PASS: TestAccAWSDynamoDbTableItem_update (141.01s)
=== CONT  TestAccAWSDynamoDbTableItem_withMultipleItems
--- PASS: TestAccAWSDynamoDbTable_importBasic (150.88s)
=== CONT  TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTableItem_updateWithRangeKey (140.50s)
=== CONT  TestAccAWSDynamoDbTableItem_rangeKey
--- PASS: TestAccAWSDynamoDbTableItem_withMultipleItems (127.45s)
=== CONT  TestAccAWSDynamoDbTable_importTimeToLive
--- PASS: TestAccAWSDynamoDbTable_basic (120.45s)
--- PASS: TestAccAWSDynamoDbTable_BillingMode (292.59s)
--- PASS: TestAccAWSDynamoDbTableItem_rangeKey (122.47s)
--- PASS: TestAccAWSDynamoDbTable_gsiUpdateOtherAttributes (539.11s)
--- PASS: TestAccAWSDynamoDbTable_attributeUpdate (540.93s)
--- PASS: TestAccAWSDynamoDbTable_extended (236.27s)
--- PASS: TestAccAWSDynamoDbTable_importTimeToLive (143.15s)
--- PASS: TestAccAWSDynamoDbTable_enablePitr (550.55s)
PASS
ok      github.com/nathmclean/terraform-provider-aws/aws        815.296s
...
```