### PR TITLE
service/ec2: Fix dangling resources in DHCP Options Set data source test

### DIFF
--- a/aws/data_source_aws_vpc_dhcp_options_test.go
+++ b/aws/data_source_aws_vpc_dhcp_options_test.go
@@ -74,6 +74,13 @@ func TestAccDataSourceAwsVpcDhcpOptions_Filter(t *testing.T) {
 				Config:      testAccDataSourceAwsVpcDhcpOptionsConfig_Filter(rInt, 2),
 				ExpectError: regexp.MustCompile(`Multiple matching EC2 DHCP Options found`),
 			},
+			{
+				// We have one last empty step here because otherwise we'll leave the
+				// test case with resources in the state and an erroneous config, and
+				// thus the automatic destroy step will fail. This ensures we end with
+				// both an empty state and a valid config.
+				Config: `/* this config intentionally left blank */`,
+			},
 		},
 	})
 }


### PR DESCRIPTION
`TestAccDataSourceAwsVpcDhcpOptions_Filter` was previously ending with a configuration containing errors. In the 0.11-sourced SDK this is for some reason silently ignored, with the test leaving behind a dangling DHCP options set in the target account. In the 0.12-sourced SDK this became an error as expected, because running "terraform destroy" with an erroneous config is normally blocked, and so this test would've begun failing after SDK upgrade.

By adding an additional step with an empty config here, we behave as if the user responded to the error in the previous step by deleting all of the resource blocks from the configuration and trying `terraform apply` again. That final step then succeeds, in the process destroying the resources created in previous steps, and allowing the test to conclude with a valid configuration and empty state.

Fixes hashicorp/terraform#20035.

Output from acceptance testing:

```
TF_ACC=1 go test ./aws -run ^TestAccDataSourceAwsVpcDhcpOptions_Filter$ -v
=== RUN   TestAccDataSourceAwsVpcDhcpOptions_Filter
=== PAUSE TestAccDataSourceAwsVpcDhcpOptions_Filter
=== CONT  TestAccDataSourceAwsVpcDhcpOptions_Filter
--- PASS: TestAccDataSourceAwsVpcDhcpOptions_Filter (17.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	18.207s
```
