### PR TITLE
Fix typo: inatance -> instance

### DIFF
--- a/website/docs/r/opsworks_rds_db_instance.html.markdown
+++ b/website/docs/r/opsworks_rds_db_instance.html.markdown
@@ -28,7 +28,7 @@ resource "aws_opsworks_rds_db_instance" "my_instance" {
 
 The following arguments are supported:
 
-* `stack_id` - (Required) The stack to register a db inatance for. Changing this will force a new resource.
+* `stack_id` - (Required) The stack to register a db instance for. Changing this will force a new resource.
 * `rds_db_instance_arn` - (Required) The db instance to register for this stack. Changing this will force a new resource.
 * `db_user` - (Required) A db username
 * `db_password` - (Required) A db password


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Fix typo

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
