### PR TITLE
resource/aws_kinesis_firehose_delivery_stream: Prevent panics with expanding extended_s3 data_format_conversion

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -1500,7 +1500,7 @@ func updateExtendedS3Config(d *schema.ResourceData) *firehose.ExtendedS3Destinat
 }
 
 func expandFirehoseDataFormatConversionConfiguration(l []interface{}) *firehose.DataFormatConversionConfiguration {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -1515,7 +1515,7 @@ func expandFirehoseDataFormatConversionConfiguration(l []interface{}) *firehose.
 }
 
 func expandFirehoseInputFormatConfiguration(l []interface{}) *firehose.InputFormatConfiguration {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -1527,7 +1527,7 @@ func expandFirehoseInputFormatConfiguration(l []interface{}) *firehose.InputForm
 }
 
 func expandFirehoseDeserializer(l []interface{}) *firehose.Deserializer {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -1574,7 +1574,7 @@ func expandFirehoseOpenXJsonSerDe(l []interface{}) *firehose.OpenXJsonSerDe {
 }
 
 func expandFirehoseOutputFormatConfiguration(l []interface{}) *firehose.OutputFormatConfiguration {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -1586,7 +1586,7 @@ func expandFirehoseOutputFormatConfiguration(l []interface{}) *firehose.OutputFo
 }
 
 func expandFirehoseSerializer(l []interface{}) *firehose.Serializer {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
@@ -1650,7 +1650,7 @@ func expandFirehoseParquetSerDe(l []interface{}) *firehose.ParquetSerDe {
 }
 
 func expandFirehoseSchemaConfiguration(l []interface{}) *firehose.SchemaConfiguration {
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 


### PR DESCRIPTION
This will prevent the panics being caused by Terraform 0.12, however does not fix the new behavior in Terraform 0.12 which is causing this resource to not properly expand the configuration, which may be a Terraform provider SDK issue or require breaking changes to the resource itself.

Previous output from Terraform 0.12 acceptance testing:

```
=== CONT

panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 591 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandFirehoseDeserializer(0xc00101d850, 0x1, 0x1, 0xc)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:1534 +0x1f3
github.com/terraform-providers/terraform-provider-aws/aws.expandFirehoseInputFormatConfiguration(0xc00101d820, 0x1, 0x1, 0x1a)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:1525 +0xa4
github.com/terraform-providers/terraform-provider-aws/aws.expandFirehoseDataFormatConversionConfiguration(0xc00101d7f0, 0x1, 0x1, 0x24)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:1511 +0x128
github.com/terraform-providers/terraform-provider-aws/aws.createExtendedS3Config(0xc0002304d0, 0x4432e2f)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:1393 +0x3d8
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsKinesisFirehoseDeliveryStreamCreate(0xc0002304d0, 0x3d30c40, 0xc0001ab000, 0xc0002304d0, 0x0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_kinesis_firehose_delivery_stream.go:2053 +0xcf2
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc00022b700, 0xc000495a90, 0xc000641dc0, 0x3d30c40, 0xc0001ab000, 0x3b2f001, 0xc001c92f08, 0xc000e5bc50)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:286 +0x363
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc0001e2310, 0xc001d7f9e0, 0xc000495a90, 0xc000641dc0, 0xc001c93038, 0xc0010610e0, 0x3b320a0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:283 +0x9c
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc000eafb20, 0x4b24fe0, 0xc000d14ed0, 0xc0008a5980, 0xc000eafb20, 0xc000d14e40, 0x3c43b20)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provider.go:725 +0x85d
github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x4314700, 0xc000eafb20, 0x4b24fe0, 0xc000d14ed0, 0xc0001e3110, 0x0, 0x0, 0x0, 0xc0019db260, 0x20)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/github.com/hashicorp/terraform/internal/tfplugin5/tfplugin5.pb.go:3157 +0x23e
github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc0007ee1c0, 0x4b32680, 0xc000892600, 0xc0018cc900, 0xc000d1d7a0, 0x836eb20, 0x0, 0x0, 0x0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc/server.go:1026 +0x4cd
github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc.(*Server).handleStream(0xc0007ee1c0, 0x4b32680, 0xc000892600, 0xc0018cc900, 0x0)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc/server.go:1252 +0x1311
github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc00071bc70, 0xc0007ee1c0, 0x4b32680, 0xc000892600, 0xc0018cc900)
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc/server.go:699 +0x9f
created by github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
	/opt/teamcity-agent/work/2e10e023da0c7520/src/github.com/terraform-providers/terraform-provider-aws/vendor/google.golang.org/grpc/server.go:697 +0xa1
```

Output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (24.20s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Deserializer must not be null
```
