### PR TITLE
tests/provider: Temporarily expand TypeList arguments for Terraform 0.11 and 0.12 compatibility

### DIFF
--- a/aws/data_source_aws_db_cluster_snapshot_test.go
+++ b/aws/data_source_aws_db_cluster_snapshot_test.go
@@ -140,7 +140,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_db_subnet_group" "test" {
   name       = %q
-  subnet_ids = ["${aws_subnet.test.*.id}"]
+  subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_rds_cluster" "test" {
@@ -188,7 +188,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_db_subnet_group" "test" {
   name       = %q
-  subnet_ids = ["${aws_subnet.test.*.id}"]
+  subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_rds_cluster" "test" {
@@ -236,7 +236,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_db_subnet_group" "test" {
   name       = %q
-  subnet_ids = ["${aws_subnet.test.*.id}"]
+  subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_rds_cluster" "test" {

--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -447,7 +447,7 @@ resource "aws_api_gateway_authorizer" "acctest" {
   name = "%s-cognito"
   type = "COGNITO_USER_POOLS"
   rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
-  provider_arns = ["${aws_cognito_user_pool.acctest.*.arn}"]
+  provider_arns = ["${aws_cognito_user_pool.acctest.*.arn[0]}", "${aws_cognito_user_pool.acctest.*.arn[1]}"]
 }
 `, apiGatewayName, cognitoName, authorizerName)
 }
@@ -467,7 +467,7 @@ resource "aws_api_gateway_authorizer" "acctest" {
   name = "%s-cognito-update"
   type = "COGNITO_USER_POOLS"
   rest_api_id = "${aws_api_gateway_rest_api.acctest.id}"
-  provider_arns = ["${aws_cognito_user_pool.acctest_update.*.arn}"]
+  provider_arns = ["${aws_cognito_user_pool.acctest_update.*.arn[0]}", "${aws_cognito_user_pool.acctest_update.*.arn[1]}", "${aws_cognito_user_pool.acctest_update.*.arn[2]}"]
 }
 `, apiGatewayName, cognitoName, authorizerName)
 }

--- a/aws/resource_aws_autoscaling_notification_test.go
+++ b/aws/resource_aws_autoscaling_notification_test.go
@@ -323,8 +323,28 @@ resource "aws_autoscaling_group" "bar" {
 }
 
 resource "aws_autoscaling_notification" "example" {
+  # TODO: Switch back to simple list reference when test configurations are upgraded to 0.12 syntax
   group_names = [
-    "${aws_autoscaling_group.bar.*.name}",
+    "${aws_autoscaling_group.bar.*.name[0]}",
+    "${aws_autoscaling_group.bar.*.name[1]}",
+    "${aws_autoscaling_group.bar.*.name[2]}",
+    "${aws_autoscaling_group.bar.*.name[3]}",
+    "${aws_autoscaling_group.bar.*.name[4]}",
+    "${aws_autoscaling_group.bar.*.name[5]}",
+    "${aws_autoscaling_group.bar.*.name[6]}",
+    "${aws_autoscaling_group.bar.*.name[7]}",
+    "${aws_autoscaling_group.bar.*.name[8]}",
+    "${aws_autoscaling_group.bar.*.name[9]}",
+    "${aws_autoscaling_group.bar.*.name[10]}",
+    "${aws_autoscaling_group.bar.*.name[11]}",
+    "${aws_autoscaling_group.bar.*.name[12]}",
+    "${aws_autoscaling_group.bar.*.name[13]}",
+    "${aws_autoscaling_group.bar.*.name[14]}",
+    "${aws_autoscaling_group.bar.*.name[15]}",
+    "${aws_autoscaling_group.bar.*.name[16]}",
+    "${aws_autoscaling_group.bar.*.name[17]}",
+    "${aws_autoscaling_group.bar.*.name[18]}",
+    "${aws_autoscaling_group.bar.*.name[19]}",
   ]
   notifications  = [
     "autoscaling:EC2_INSTANCE_LAUNCH",

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -689,7 +689,7 @@ func TestAccAWSCodeBuildProject_VpcConfig(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeBuildProjectConfig_VpcConfig(rName, 2),
+				Config: testAccAWSCodeBuildProjectConfig_VpcConfig2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
@@ -699,7 +699,7 @@ func TestAccAWSCodeBuildProject_VpcConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCodeBuildProjectConfig_VpcConfig(rName, 1),
+				Config: testAccAWSCodeBuildProjectConfig_VpcConfig1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 					resource.TestCheckResourceAttr(resourceName, "vpc_config.#", "1"),
@@ -1546,14 +1546,14 @@ resource "aws_codebuild_project" "test" {
 `, rName, tagKey, tagValue)
 }
 
-func testAccAWSCodeBuildProjectConfig_VpcConfig(rName string, subnetCount int) string {
+func testAccAWSCodeBuildProjectConfig_VpcConfig1(rName string) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
 
 resource "aws_subnet" "test" {
-  count = %d
+  count = 2
 
   cidr_block = "10.0.${count.index}.0/24"
   vpc_id     = "${aws_vpc.test.id}"
@@ -1588,11 +1588,60 @@ resource "aws_codebuild_project" "test" {
 
   vpc_config {
     security_group_ids = ["${aws_security_group.test.id}"]
-    subnets            = ["${aws_subnet.test.*.id}"]
+    subnets            = ["${aws_subnet.test.*.id[0]}"]
     vpc_id             = "${aws_vpc.test.id}"
   }
 }
-`, subnetCount, rName)
+`, rName)
+}
+
+func testAccAWSCodeBuildProjectConfig_VpcConfig2(rName string) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "test" {
+  count = 2
+
+  cidr_block = "10.0.${count.index}.0/24"
+  vpc_id     = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-codebuild-project"
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_codebuild_project" "test" {
+  name         = "%s"
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    location = "https://github.com/hashicorp/packer.git"
+    type     = "GITHUB"
+  }
+
+  vpc_config {
+    security_group_ids = ["${aws_security_group.test.id}"]
+    subnets            = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+    vpc_id             = "${aws_vpc.test.id}"
+  }
+}
+`, rName)
 }
 
 func testAccAWSCodeBuildProjectConfig_WindowsContainer(rName string) string {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -1553,9 +1553,7 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  count = 2
-
-  cidr_block = "10.0.${count.index}.0/24"
+  cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
   tags = {
@@ -1588,7 +1586,7 @@ resource "aws_codebuild_project" "test" {
 
   vpc_config {
     security_group_ids = ["${aws_security_group.test.id}"]
-    subnets            = ["${aws_subnet.test.*.id[0]}"]
+    subnets            = ["${aws_subnet.test.id}"]
     vpc_id             = "${aws_vpc.test.id}"
   }
 }

--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -3394,7 +3394,7 @@ resource "aws_lb_target_group" "green" {
 resource "aws_lb" "test" {
   internal = true
   name     = %q
-  subnets  = ["${aws_subnet.test.*.id}"]
+  subnets  = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_lb_listener" "test" {
@@ -3459,7 +3459,7 @@ resource "aws_ecs_service" "test" {
   network_configuration {
     assign_public_ip = true
     security_groups  = ["${aws_security_group.test.id}"]
-    subnets          = ["${aws_subnet.test.*.id}"]
+    subnets          = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
   }
 }
 


### PR DESCRIPTION
These changes are backwards (0.11) and forwards (0.12) compatible so the acceptance testing can be run in either dependency environment. This temporarily workaround will be removed when the acceptance testing configurations are switched to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSAPIGatewayAuthorizer_cognito (1.62s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test743589365/main.tf line 15:
          (source code not available)

        Inappropriate value for attribute "provider_arns": element 0: string required.

--- FAIL: TestAccAWSASGNotification_Pagination (1.78s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test668166509/main.tf line 26:
          (source code not available)

        Inappropriate value for attribute "group_names": element 0: string required.

--- FAIL: TestAccAWSCodeBuildProject_VpcConfig (1.69s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test876060979/main.tf line 101:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.

--- FAIL: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (2.27s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test610692362/main.tf line 55:
          (source code not available)

        Inappropriate value for attribute "subnets": element 0: string required.

--- FAIL: TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier (2.87s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test886332704/main.tf line 26:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.

--- FAIL: TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier (3.82s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test558959475/main.tf line 26:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.

--- FAIL: TestAccAWSDbClusterSnapshotDataSource_MostRecent (3.77s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test648461943/main.tf line 26:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.12 acceptance testing (additional fixes required in Terraform Provider SDK):

```
--- PASS: TestAccAWSAPIGatewayAuthorizer_cognito (28.76s)
--- PASS: TestAccAWSASGNotification_Pagination (118.33s)

--- FAIL: TestAccAWSCodeBuildProject_VpcConfig (58.08s)
    testing.go:568: Step 2 error: errors during apply:

        Error: [ERROR] Error updating CodeBuild project (arn:aws:codebuild:us-west-2:187416307283:project/tf-acc-test-4139231503421636272): InvalidParameter: 1 validation error(s) found.
        - minimum field size of 1, UpdateProjectInput.VpcConfig.VpcId.

--- PASS: TestAccAWSCodeDeployDeploymentGroup_ECS_BlueGreen (291.56s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterIdentifier (194.77s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_DbClusterSnapshotIdentifier (214.89s)
--- PASS: TestAccAWSDbClusterSnapshotDataSource_MostRecent (285.00s)
```
