### PR TITLE
Update kms grant documentation

### DIFF
--- a/website/docs/r/kms_grant.html.markdown
+++ b/website/docs/r/kms_grant.html.markdown
@@ -65,8 +65,8 @@ The following arguments are supported:
 
 The `constraints` block supports the following arguments:
 
-* `encryption_context_equals` - (Optional) A list of key-value pairs that must be present in the encryption context of certain subsequent operations that the grant allows. Conflicts with `encryption_context_subset`.
-* `encryption_context_subset` - (Optional) A list of key-value pairs, all of which must be present in the encryption context of certain subsequent operations that the grant allows. Conflicts with `encryption_context_equals`.
+* `encryption_context_equals` - (Optional) A list of key-value pairs that must match the encryption context in subsequent cryptographic operation requests. The grant allows the operation only when the encryption context in the request is the same as the encryption context specified in this constraint. Conflicts with `encryption_context_subset`.
+* `encryption_context_subset` - (Optional) A list of key-value pairs that must be included in the encryption context of subsequent cryptographic operation requests. The grant allows the cryptographic operation only when the encryption context in the request includes the key-value pairs specified in this constraint, although it can include additional key-value pairs. Conflicts with `encryption_context_equals`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
 * Reasoning for docs update: Current descriptions for EncryptionContextEquals and Subset seem to be mismatched.
 * Relevant Terraform version: Relevant to current version and previous versions.

Proposed changes are [taken from aws documentation](https://docs.aws.amazon.com/kms/latest/APIReference/API_GrantConstraints.html)