### PR TITLE
Changing aws elastic cache cluster_id validation to allow 30 characters.

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -202,9 +202,9 @@ func validateNeptuneEngine() schema.SchemaValidateFunc {
 
 func validateElastiCacheClusterId(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if (len(value) < 1) || (len(value) > 20) {
+	if (len(value) < 1) || (len(value) > 30) {
 		errors = append(errors, fmt.Errorf(
-			"%q (%q) must contain from 1 to 20 alphanumeric characters or hyphens", k, value))
+			"%q (%q) must contain from 1 to 30 alphanumeric characters or hyphens", k, value))
 	}
 	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
The current elastic cache validator does not allow more than 20 characters in the cluster_id leading to terraform apply issues for clusters imported from AWS that have cluster_id > 20 characters. They fail with error:

```
Error: aws_elasticache_cluster.helloworld-redis-3: "cluster_id" ("helloworld-redis-3-0015-002") must contain from 1 to 20 alphanumeric characters or hyphens
```

Changes proposed in this pull request:

* Changing aws elastic cache cluster_id validation to allow 30 characters.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAvailabilityZones -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAvailabilityZones_basic
=== PAUSE TestAccAWSAvailabilityZones_basic
=== RUN   TestAccAWSAvailabilityZones_stateFilter
=== PAUSE TestAccAWSAvailabilityZones_stateFilter
=== CONT  TestAccAWSAvailabilityZones_basic
=== CONT  TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_basic (7.81s)
--- PASS: TestAccAWSAvailabilityZones_stateFilter (7.81s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.627s
...
```
