### PR TITLE
resource/aws_cognito_identity_pool_roles_attachment: Ensure roles configurations use equals in testing and documentation

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
@@ -189,7 +189,7 @@ resource "aws_cognito_identity_pool" "main" {
   identity_pool_name               = "identity pool %[1]s"
   allow_unauthenticated_identities = false
 
-  supported_login_providers {
+  supported_login_providers = {
     "graph.facebook.com" = "7346241598935555"
   }
 }
@@ -304,7 +304,7 @@ func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name string) strin
 resource "aws_cognito_identity_pool_roles_attachment" "main" {
   identity_pool_id = "${aws_cognito_identity_pool.main.id}"
 
-  roles {
+  roles = {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
   }
 }
@@ -329,7 +329,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
     }
   }
 
-  roles {
+  roles = {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
   }
 }
@@ -361,7 +361,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
     }
   }
 
-  roles {
+  roles = {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
   }
 }
@@ -385,7 +385,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
     }
   }
 
-  roles {
+  roles = {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
   }
 }
@@ -403,7 +403,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
     type                      = "Rules"
   }
 
-  roles {
+  roles = {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
   }
 }
@@ -428,7 +428,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
     }
   }
 
-  roles {
+  roles = {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
   }
 }

--- a/website/docs/r/cognito_identity_pool_roles_attachment.markdown
+++ b/website/docs/r/cognito_identity_pool_roles_attachment.markdown
@@ -89,7 +89,7 @@ resource "aws_cognito_identity_pool_roles_attachment" "main" {
     }
   }
 
-  roles {
+  roles = {
     "authenticated" = "${aws_iam_role.authenticated.arn}"
   }
 }


### PR DESCRIPTION
We have validated that the behavior of schema attributes with TypeMap of Resource will continue to effectively be TypeMap of String in Terraform 0.12. This change is backwards compatible with Terraform 0.11. The other `supported_login_providers` change was already handled for other files in #7253.

Output from Terraform 0.11 acceptance testing:

```
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (7.30s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (7.30s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (7.42s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (17.80s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (29.11s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (6.89s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (7.05s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (7.10s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (17.95s)
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (30.01s)
```
