### PR TITLE
tests/resource/aws_ssm_document: Ensure permissions configurations use equals

### DIFF
--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -474,7 +474,7 @@ resource "aws_ssm_document" "foo" {
   name = "test_document-%s"
 	document_type = "Command"
 
-  permissions {
+  permissions = {
     type        = "Share"
     account_ids = "all"
   }
@@ -508,7 +508,7 @@ resource "aws_ssm_document" "foo" {
   name = "test_document-%s"
 	document_type = "Command"
 
-  permissions {
+  permissions = {
     type        = "Share"
     account_ids = "%s"
   }


### PR DESCRIPTION
We have validated that the behavior of schema attributes with TypeMap of Resource will continue to effectively be TypeMap of String in Terraform 0.12. This change is backwards compatible with Terraform 0.11.

Output from Terraform 0.11 acceptance testing:

```
--- PASS: TestAccAWSSSMDocument_permission_private (12.41s)
--- PASS: TestAccAWSSSMDocument_permission_public (12.49s)
--- PASS: TestAccAWSSSMDocument_permission_batching (13.32s)
--- PASS: TestAccAWSSSMDocument_permission_change (24.73s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSSSMDocument_permission_public (11.15s)
--- PASS: TestAccAWSSSMDocument_permission_private (11.19s)
--- PASS: TestAccAWSSSMDocument_permission_batching (11.91s)
--- PASS: TestAccAWSSSMDocument_permission_change (25.14s)
```
