### PR TITLE
tests/resource/aws_codedeploy_deployment_group: Terraform 0.12 syntax fixes

### DIFF
--- a/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -3088,7 +3088,7 @@ data "aws_subnet" "test" {
 resource "aws_launch_configuration" "foo_lc" {
   image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
-  "name_prefix" = "foo-lc-"
+  name_prefix = "foo-lc-"
 
   lifecycle {
     create_before_destroy = true
@@ -3164,7 +3164,7 @@ data "aws_subnet" "test" {
 resource "aws_launch_configuration" "foo_lc" {
   image_id = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
   instance_type = "t2.micro"
-  "name_prefix" = "foo-lc-"
+  name_prefix = "foo-lc-"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Removes extraneous argument quotes. Backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (28.36s)
    testing.go:568: Step 1 error: /opt/teamcity-agent/temp/buildTmp/tf-test156689011/main.tf:85,3-4: Invalid argument name; Argument names must not be quoted.

--- FAIL: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (0.46s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test259318088/main.tf:85,3-4: Invalid argument name; Argument names must not be quoted.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update (31.48s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete (38.02s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create (192.00s)
--- PASS: TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update_with_asg (270.49s)
```
