### PR TITLE
data-source/aws_kms_secrets: Ensure context configurations use equals in testing and documentation

### DIFF
--- a/aws/data_source_aws_kms_secrets_test.go
+++ b/aws/data_source_aws_kms_secrets_test.go
@@ -96,9 +96,9 @@ data "aws_kms_secrets" "test" {
     name    = "secret1"
     payload = %q
 
-     context {
-       name = "value"
-     }
+    context = {
+      name = "value"
+    }
   }
 }
 `, payload)

--- a/website/docs/d/kms_secrets.html.markdown
+++ b/website/docs/d/kms_secrets.html.markdown
@@ -33,7 +33,7 @@ data "aws_kms_secrets" "example" {
     name    = "master_password"
     payload = "AQECAHgaPa0J8WadplGCqqVAr4HNvDaFSQ+NaiwIBhmm6qDSFwAAAGIwYAYJKoZIhvcNAQcGoFMwUQIBADBMBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDI+LoLdvYv8l41OhAAIBEIAfx49FFJCLeYrkfMfAw6XlnxP23MmDBdqP8dPp28OoAQ=="
 
-    context {
+    context = {
       foo = "bar"
     }
   }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSKmsSecretsDataSource_basic (23.87s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "context" are not expected here. Did you mean to define argument "context"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSKmsSecretsDataSource_basic (74.36s)
```
