### PR TITLE
tests/resource/aws_emr_instance_group: Fix Terraform 0.12 syntax

### DIFF
--- a/aws/resource_aws_emr_instance_group_test.go
+++ b/aws/resource_aws_emr_instance_group_test.go
@@ -426,8 +426,8 @@ func testAccAWSEmrInstanceGroupConfig_ebsBasic(r int) string {
     instance_type  = "c4.large"
     ebs_optimized = true
     ebs_config {
-      "size" = 10,
-      "type" = "gp2",
+      size = 10
+      type = "gp2"
     }
   }
 	`, r, r, r, r, r, r)


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSEMRInstanceGroup_ebsBasic (0.52s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test436378105/main.tf:275,7-8: Invalid argument name; Argument names must not be quoted.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSEMRInstanceGroup_ebsBasic (609.82s)
```
