### PR TITLE
add import feature to vpc endpoint route table association resources

### DIFF
--- a/website/docs/r/vpc_endpoint_route_table_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_route_table_association.html.markdown
@@ -31,3 +31,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - A hash of the EC2 Route Table and VPC Endpoint identifiers.
+
+## Import
+
+VPC Endpoint route table associations can be imported by providing the id in the following format:
+
+```
+$ terraform import aws_vpc_endpoint_route_table_association.imported <route_table_id>/<vpc_endpoint_id>
+```


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Add import feature to VPC endpoint route table associations

Output from acceptance testing:

```
ptittle@ptittle98-mac ~/src/go/src/github.com/terraform-providers/terraform-provider-aws (feature/add_import_to_vpc_endpoint_rt_assoc) $ make testacc TESTARGS='-run=TestAccAWSVpcEndpointRouteTableAssociation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSVpcEndpointRouteTableAssociation -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSVpcEndpointRouteTableAssociation_basic
=== PAUSE TestAccAWSVpcEndpointRouteTableAssociation_basic
=== CONT  TestAccAWSVpcEndpointRouteTableAssociation_basic
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (38.18s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	39.858s
```
