### PR TITLE
tests/service/s3: Skip cross-region errors in sweeper

### DIFF
--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -95,7 +95,7 @@ func testSweepS3BucketObjects(region string) error {
 			continue
 		}
 
-		if isAWSErr(err, "BucketRegionError", "") {
+		if isAWSErr(err, "AuthorizationHeaderMalformed", "region") || isAWSErr(err, "BucketRegionError", "") {
 			log.Printf("[INFO] Skipping S3 Bucket (%s) Objects: %s", bucketName, err)
 			continue
 		}

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -78,7 +78,7 @@ func testSweepS3Buckets(region string) error {
 				return nil
 			}
 
-			if isAWSErr(err, "BucketRegionError", "") {
+			if isAWSErr(err, "AuthorizationHeaderMalformed", "region") || isAWSErr(err, "BucketRegionError", "") {
 				log.Printf("[INFO] Skipping S3 Bucket (%s): %s", name, err)
 				return nil
 			}


### PR DESCRIPTION
Previous output from test sweeper:

```
[21:58:38][Step 2/4] 2019/02/01 21:58:38 [DEBUG] [aws-sdk-go] <?xml version="1.0" encoding="UTF-8"?>
[21:58:38][Step 2/4] <Error><Code>AuthorizationHeaderMalformed</Code><Message>The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-west-2'</Message><Region>us-west-2</Region><RequestId>4665822608E6F703</RequestId><HostId>l6NnYOZcqnpn34lmKiLwwLh67CBzY9hkNMXkYjkjB0EwqtcGemXLno1whekgoqLSBw79Gyz/Bq8=</HostId></Error>
[21:58:38][Step 2/4] 2019/02/01 21:58:38 [DEBUG] [aws-sdk-go] DEBUG: Validate Response s3/ListObjectVersions failed, not retrying, error AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-west-2'
[21:58:38][Step 2/4]  status code: 400, request id: 4665822608E6F703, host id: l6NnYOZcqnpn34lmKiLwwLh67CBzY9hkNMXkYjkjB0EwqtcGemXLno1whekgoqLSBw79Gyz/Bq8=
[21:58:38][Step 2/4] 2019/02/01 21:58:38 [ERR] error running (aws_s3_bucket): error listing S3 Bucket (tf-test-bucket-3159900406244729302) Objects: AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-west-2'
[21:58:38][Step 2/4]  status code: 400, request id: 4665822608E6F703, host id: l6NnYOZcqnpn34lmKiLwwLh67CBzY9hkNMXkYjkjB0EwqtcGemXLno1whekgoqLSBw79Gyz/Bq8=
[21:58:38][Step 2/4] FAIL github.com/terraform-providers/terraform-provider-aws/aws 7.873s
[21:58:38][Step 2/4] Process exited with code 1
[21:58:38][Step 2/4] Process exited with code 1 (Step: Pre-Sweeper (Command Line))
[21:58:38][Step 2/4] Step Pre-Sweeper (Command Line) failed
```

Output from test sweeper:

```
go test ./aws -v -sweep=us-east-1,us-west-2 -sweep-run=aws_s3_bucket -timeout 10h
2019/02/01 17:10:10 [DEBUG] Running Sweepers for region (us-east-1):
...
2019/02/01 17:10:11 [INFO] Skipping S3 Bucket: config-bucket-067819342479
2019/02/01 17:10:11 [INFO] Skipping S3 Bucket: foo-project-test-bucket-2
2019/02/01 17:10:12 [INFO] Skipping S3 Bucket (tf-test-bucket-3159900406244729302) Objects: AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-west-2'
	status code: 400, request id: 62AE60CF31806E7E, host id: bVpUHvo1sDuQzifZyvHuLDrUTyMT1i0o76ActSH9eXY5GUHuq6Vni5/yT0iFPiI8bRRI/z+NJIg=
2019/02/01 17:10:12 [DEBUG] Sweeper (aws_s3_bucket) has dependency (aws_s3_bucket_object), running..
2019/02/01 17:10:12 [DEBUG] Sweeper (aws_s3_bucket_object) already ran in region (us-east-1)
...
2019/02/01 17:10:12 [INFO] Skipping S3 Bucket: config-bucket-067819342479
2019/02/01 17:10:12 [INFO] Skipping S3 Bucket: foo-project-test-bucket-2
2019/02/01 17:10:12 [INFO] Deleting S3 Bucket: tf-test-bucket-3159900406244729302
2019/02/01 17:10:12 [DEBUG] Waiting for state to become: [success]
2019/02/01 17:10:13 [INFO] Skipping S3 Bucket (tf-test-bucket-3159900406244729302): AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-west-2'
	status code: 400, request id: BCED35D8B843E435, host id: Vl7Fy8VrW2tUdZzb5MLxYAA3UiBZK1olkiirUclEtaAfvHSctsMI4bQxOBFfxYvJpoqMqcExTF0=
2019/02/01 17:10:13 Sweeper Tests ran:
	- aws_s3_bucket_object
	- aws_s3_bucket
2019/02/01 17:10:13 [DEBUG] Running Sweepers for region (us-west-2):
...
2019/02/01 17:10:14 [INFO] Skipping S3 Bucket: config-bucket-067819342479
2019/02/01 17:10:14 [INFO] Skipping S3 Bucket: foo-project-test-bucket-2
2019/02/01 17:10:14 [DEBUG] Sweeper (aws_s3_bucket) has dependency (aws_s3_bucket_object), running..
2019/02/01 17:10:14 [DEBUG] Sweeper (aws_s3_bucket_object) already ran in region (us-west-2)
...
2019/02/01 17:10:15 [INFO] Skipping S3 Bucket: config-bucket-067819342479
2019/02/01 17:10:15 [INFO] Skipping S3 Bucket: foo-project-test-bucket-2
2019/02/01 17:10:15 [INFO] Deleting S3 Bucket: tf-test-bucket-3159900406244729302
2019/02/01 17:10:15 [DEBUG] Waiting for state to become: [success]
2019/02/01 17:10:16 Sweeper Tests ran:
	- aws_s3_bucket_object
	- aws_s3_bucket
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.283s
```
