### PR TITLE
Update example linked role in Elasticsearch docs

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -152,7 +152,7 @@ resource "aws_security_group" "es" {
 }
 
 resource "aws_iam_service_linked_role" "es" {
-  aws_service_name = "elasticsearch.amazonaws.com"
+  aws_service_name = "es.amazonaws.com"
 }
 
 resource "aws_elasticsearch_domain" "es" {


### PR DESCRIPTION
Right now, an example in the docs for the `elasticsearch_domain` resource includes an `aws_iam_service_linked_role` with a service name of `elasticsearch.amazonaws.com`. This isn't the right domain – it's `es.amazonaws.com` – and running the code against AWS causes it to throw an error.

This updates that example to use the correct domain.