### PR TITLE
r/aws_appmesh_virtual_node: Add support for listener health checks

### DIFF
--- a/aws/resource_aws_virtual_node_test.go
+++ b/aws/resource_aws_virtual_node_test.go
@@ -81,11 +81,27 @@ func testAccAwsAppmeshVirtualNode_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "spec.0.listener.#", "1"),
 					resource.TestCheckResourceAttr(
-						resourceName, "spec.0.listener.2279702354.port_mapping.#", "1"),
+						resourceName, "spec.0.listener.433446196.health_check.#", "1"),
 					resource.TestCheckResourceAttr(
-						resourceName, "spec.0.listener.2279702354.port_mapping.0.port", "8080"),
+						resourceName, "spec.0.listener.433446196.health_check.0.healthy_threshold", "3"),
 					resource.TestCheckResourceAttr(
-						resourceName, "spec.0.listener.2279702354.port_mapping.0.protocol", "http"),
+						resourceName, "spec.0.listener.433446196.health_check.0.interval_millis", "5000"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.health_check.0.path", "/ping"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.health_check.0.port", "8080"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.health_check.0.protocol", "http"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.health_check.0.timeout_millis", "2000"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.health_check.0.unhealthy_threshold", "5"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.port_mapping.#", "1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.port_mapping.0.port", "8080"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.433446196.port_mapping.0.protocol", "http"),
 					resource.TestCheckResourceAttr(
 						resourceName, "spec.0.service_discovery.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -120,11 +136,25 @@ func testAccAwsAppmeshVirtualNode_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "spec.0.listener.#", "1"),
 					resource.TestCheckResourceAttr(
-						resourceName, "spec.0.listener.563508454.port_mapping.#", "1"),
+						resourceName, "spec.0.listener.3446683576.health_check.#", "1"),
 					resource.TestCheckResourceAttr(
-						resourceName, "spec.0.listener.563508454.port_mapping.0.port", "8081"),
+						resourceName, "spec.0.listener.3446683576.health_check.0.healthy_threshold", "4"),
 					resource.TestCheckResourceAttr(
-						resourceName, "spec.0.listener.563508454.port_mapping.0.protocol", "http"),
+						resourceName, "spec.0.listener.3446683576.health_check.0.interval_millis", "7000"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.3446683576.health_check.0.port", "8081"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.3446683576.health_check.0.protocol", "tcp"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.3446683576.health_check.0.timeout_millis", "3000"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.3446683576.health_check.0.unhealthy_threshold", "9"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.3446683576.port_mapping.#", "1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.3446683576.port_mapping.0.port", "8081"),
+					resource.TestCheckResourceAttr(
+						resourceName, "spec.0.listener.3446683576.port_mapping.0.protocol", "http"),
 					resource.TestCheckResourceAttr(
 						resourceName, "spec.0.service_discovery.#", "1"),
 					resource.TestCheckResourceAttr(
@@ -226,6 +256,15 @@ resource "aws_appmesh_virtual_node" "foo" {
         port     = 8080
         protocol = "http"
       }
+
+      health_check {
+        protocol            = "http"
+        path                = "/ping"
+        healthy_threshold   = 3
+        unhealthy_threshold = 5
+        timeout_millis      = 2000
+        interval_millis     = 5000
+      }
     }
 
     service_discovery {
@@ -255,6 +294,15 @@ resource "aws_appmesh_virtual_node" "foo" {
       port_mapping {
         port     = 8081
         protocol = "http"
+      }
+
+      health_check {
+        protocol            = "tcp"
+        port                = 8081
+        healthy_threshold   = 4
+        unhealthy_threshold = 9
+        timeout_millis      = 3000
+        interval_millis     = 7000
       }
     }
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4854,6 +4854,34 @@ func expandAppmeshVirtualNodeSpec(vSpec []interface{}) *appmesh.VirtualNodeSpec 
 
 			mListener := vListener.(map[string]interface{})
 
+			if vHealthCheck, ok := mListener["health_check"].([]interface{}); ok && len(vHealthCheck) > 0 && vHealthCheck[0] != nil {
+				mHealthCheck := vHealthCheck[0].(map[string]interface{})
+
+				listener.HealthCheck = &appmesh.HealthCheckPolicy{}
+
+				if vHealthyThreshold, ok := mHealthCheck["healthy_threshold"].(int); ok && vHealthyThreshold > 0 {
+					listener.HealthCheck.HealthyThreshold = aws.Int64(int64(vHealthyThreshold))
+				}
+				if vIntervalMillis, ok := mHealthCheck["interval_millis"].(int); ok && vIntervalMillis > 0 {
+					listener.HealthCheck.IntervalMillis = aws.Int64(int64(vIntervalMillis))
+				}
+				if vPath, ok := mHealthCheck["path"].(string); ok && vPath != "" {
+					listener.HealthCheck.Path = aws.String(vPath)
+				}
+				if vPort, ok := mHealthCheck["port"].(int); ok && vPort > 0 {
+					listener.HealthCheck.Port = aws.Int64(int64(vPort))
+				}
+				if vProtocol, ok := mHealthCheck["protocol"].(string); ok && vProtocol != "" {
+					listener.HealthCheck.Protocol = aws.String(vProtocol)
+				}
+				if vTimeoutMillis, ok := mHealthCheck["timeout_millis"].(int); ok && vTimeoutMillis > 0 {
+					listener.HealthCheck.TimeoutMillis = aws.Int64(int64(vTimeoutMillis))
+				}
+				if vUnhealthyThreshold, ok := mHealthCheck["unhealthy_threshold"].(int); ok && vUnhealthyThreshold > 0 {
+					listener.HealthCheck.UnhealthyThreshold = aws.Int64(int64(vUnhealthyThreshold))
+				}
+			}
+
 			if vPortMapping, ok := mListener["port_mapping"].([]interface{}); ok && len(vPortMapping) > 0 && vPortMapping[0] != nil {
 				mPortMapping := vPortMapping[0].(map[string]interface{})
 
@@ -4908,6 +4936,19 @@ func flattenAppmeshVirtualNodeSpec(spec *appmesh.VirtualNodeSpec) []interface{} 
 
 		for _, listener := range spec.Listeners {
 			mListener := map[string]interface{}{}
+
+			if listener.HealthCheck != nil {
+				mHealthCheck := map[string]interface{}{
+					"healthy_threshold":   int(aws.Int64Value(listener.HealthCheck.HealthyThreshold)),
+					"interval_millis":     int(aws.Int64Value(listener.HealthCheck.IntervalMillis)),
+					"path":                aws.StringValue(listener.HealthCheck.Path),
+					"port":                int(aws.Int64Value(listener.HealthCheck.Port)),
+					"protocol":            aws.StringValue(listener.HealthCheck.Protocol),
+					"timeout_millis":      int(aws.Int64Value(listener.HealthCheck.TimeoutMillis)),
+					"unhealthy_threshold": int(aws.Int64Value(listener.HealthCheck.UnhealthyThreshold)),
+				}
+				mListener["health_check"] = []interface{}{mHealthCheck}
+			}
 
 			if listener.PortMapping != nil {
 				mPortMapping := map[string]interface{}{

--- a/website/docs/r/appmesh_virtual_node.html.markdown
+++ b/website/docs/r/appmesh_virtual_node.html.markdown
@@ -12,6 +12,8 @@ Provides an AWS App Mesh virtual node resource.
 
 ## Example Usage
 
+### Basic
+
 ```hcl
 resource "aws_appmesh_virtual_node" "serviceb1" {
   name                = "serviceBv1"
@@ -24,6 +26,41 @@ resource "aws_appmesh_virtual_node" "serviceb1" {
       port_mapping {
         port     = 8080
         protocol = "http"
+      }
+    }
+
+    service_discovery {
+      dns {
+        service_name = "serviceb.simpleapp.local"
+      }
+    }
+  }
+}
+```
+
+### Listener Health Check
+
+```hcl
+resource "aws_appmesh_virtual_node" "serviceb1" {
+  name                = "serviceBv1"
+  mesh_name           = "simpleapp"
+
+  spec {
+    backends = ["servicea.simpleapp.local"]
+
+    listener {
+      port_mapping {
+        port     = 8080
+        protocol = "http"
+      }
+
+      health_check {
+        protocol            = "http"
+        path                = "/ping"
+        healthy_threshold   = 2
+        unhealthy_threshold = 2
+        timeout_millis      = 2000
+        interval_millis     = 5000
       }
     }
 
@@ -53,6 +90,7 @@ The `spec` object supports the following:
 The `listener` object supports the following:
 
 * `port_mapping` - (Required) The port mapping information for the listener.
+* `health_check` - (Optional) The health check information for the listener.
 
 The `service_discovery` object supports the following:
 
@@ -66,6 +104,16 @@ The `port_mapping` object supports the following:
 
 * `port` - (Required) The port used for the port mapping.
 * `protocol` - (Required) The protocol used for the port mapping. Valid values are `http` and `tcp`.
+
+The `health_check` object supports the following:
+
+* `healthy_threshold` - (Required) The number of consecutive successful health checks that must occur before declaring listener healthy.
+* `interval_millis`- (Required) The time period in milliseconds between each health check execution.
+* `protocol` - (Required) The protocol for the health check request. Valid values are `http` and `tcp`.
+* `timeout_millis` - (Required) The amount of time to wait when receiving a response from the health check, in milliseconds.
+* `unhealthy_threshold` - (Required) The number of consecutive failed health checks that must occur before declaring a virtual node unhealthy.
+* `path` - (Optional) The destination path for the health check request. This is only required if the specified protocol is `http`.
+* `port` - (Optional) The destination port for the health check request. This port must match the port defined in the `port_mapping` for the listener.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/7445.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAppmesh'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSAppmesh -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/Mesh
=== RUN   TestAccAWSAppmesh/Mesh/basic
=== RUN   TestAccAWSAppmesh/Route
=== RUN   TestAccAWSAppmesh/Route/basic
=== RUN   TestAccAWSAppmesh/Route/allAttributes
=== RUN   TestAccAWSAppmesh/VirtualNode
=== RUN   TestAccAWSAppmesh/VirtualNode/allAttributes
=== RUN   TestAccAWSAppmesh/VirtualNode/basic
=== RUN   TestAccAWSAppmesh/VirtualRouter
=== RUN   TestAccAWSAppmesh/VirtualRouter/basic
--- PASS: TestAccAWSAppmesh (127.65s)
    --- PASS: TestAccAWSAppmesh/Mesh (15.32s)
        --- PASS: TestAccAWSAppmesh/Mesh/basic (15.32s)
    --- PASS: TestAccAWSAppmesh/Route (45.98s)
        --- PASS: TestAccAWSAppmesh/Route/basic (17.29s)
        --- PASS: TestAccAWSAppmesh/Route/allAttributes (28.69s)
    --- PASS: TestAccAWSAppmesh/VirtualNode (40.46s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/allAttributes (25.57s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/basic (14.89s)
    --- PASS: TestAccAWSAppmesh/VirtualRouter (25.88s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/basic (25.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	143.679s
```