### PR TITLE
tests/provider: Use GO111MODULE=off and GOFLAGS=-mod=vendor with gometalinter

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,7 +32,7 @@ websitefmtcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	@gometalinter ./$(PKG_NAME)
+	@GO111MODULE=off GOFLAGS=-mod=vendor gometalinter ./$(PKG_NAME)
 
 tools:
 	GO111MODULE=off go get -u github.com/alecthomas/gometalinter


### PR DESCRIPTION
The Go module issues seem to be getting worse with respect to scanning too many files. This is to test more explicit behavior on TravisCI.