### PR TITLE
s3_bucket: Limit no of expiration blocks to 1

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -243,6 +243,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Set:      expirationHash,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"date": {
@@ -264,6 +265,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 						},
 						"noncurrent_version_expiration": {
 							Type:     schema.TypeSet,
+							MaxItems: 1,
 							Optional: true,
 							Set:      expirationHash,
 							Elem: &schema.Resource{


### PR DESCRIPTION
Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_'
```
```
=== RUN   TestAccAWSS3Bucket_importBasic
=== PAUSE TestAccAWSS3Bucket_importBasic
=== RUN   TestAccAWSS3Bucket_importWithPolicy
=== PAUSE TestAccAWSS3Bucket_importWithPolicy
=== RUN   TestAccAWSS3Bucket_basic
=== PAUSE TestAccAWSS3Bucket_basic
=== RUN   TestAccAWSS3Bucket_namePrefix
=== PAUSE TestAccAWSS3Bucket_namePrefix
=== RUN   TestAccAWSS3Bucket_generatedName
=== PAUSE TestAccAWSS3Bucket_generatedName
=== RUN   TestAccAWSS3Bucket_region
=== PAUSE TestAccAWSS3Bucket_region
=== RUN   TestAccAWSS3Bucket_acceleration
=== PAUSE TestAccAWSS3Bucket_acceleration
=== RUN   TestAccAWSS3Bucket_RequestPayer
=== PAUSE TestAccAWSS3Bucket_RequestPayer
=== RUN   TestAccAWSS3Bucket_Policy
=== PAUSE TestAccAWSS3Bucket_Policy
=== RUN   TestAccAWSS3Bucket_UpdateAcl
=== PAUSE TestAccAWSS3Bucket_UpdateAcl
=== RUN   TestAccAWSS3Bucket_Website_Simple
=== PAUSE TestAccAWSS3Bucket_Website_Simple
=== RUN   TestAccAWSS3Bucket_WebsiteRedirect
=== PAUSE TestAccAWSS3Bucket_WebsiteRedirect
=== RUN   TestAccAWSS3Bucket_WebsiteRoutingRules
=== PAUSE TestAccAWSS3Bucket_WebsiteRoutingRules
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== RUN   TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== PAUSE TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== RUN   TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== PAUSE TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== RUN   TestAccAWSS3Bucket_shouldFailNotFound
=== PAUSE TestAccAWSS3Bucket_shouldFailNotFound
=== RUN   TestAccAWSS3Bucket_Versioning
=== PAUSE TestAccAWSS3Bucket_Versioning
=== RUN   TestAccAWSS3Bucket_Cors_Update
=== PAUSE TestAccAWSS3Bucket_Cors_Update
=== RUN   TestAccAWSS3Bucket_Cors_Delete
=== PAUSE TestAccAWSS3Bucket_Cors_Delete
=== RUN   TestAccAWSS3Bucket_Cors_EmptyOrigin
=== PAUSE TestAccAWSS3Bucket_Cors_EmptyOrigin
=== RUN   TestAccAWSS3Bucket_Logging
=== PAUSE TestAccAWSS3Bucket_Logging
=== RUN   TestAccAWSS3Bucket_Lifecycle
=== PAUSE TestAccAWSS3Bucket_Lifecycle
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== RUN   TestAccAWSS3Bucket_Replication
=== PAUSE TestAccAWSS3Bucket_Replication
=== RUN   TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== PAUSE TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== PAUSE TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== PAUSE TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== RUN   TestAccAWSS3Bucket_ReplicationSchemaV2
=== PAUSE TestAccAWSS3Bucket_ReplicationSchemaV2
=== RUN   TestAccAWSS3Bucket_objectLock
=== PAUSE TestAccAWSS3Bucket_objectLock
=== CONT  TestAccAWSS3Bucket_importBasic
=== CONT  TestAccAWSS3Bucket_shouldFailNotFound
=== CONT  TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation
=== CONT  TestAccAWSS3Bucket_Replication
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== CONT  TestAccAWSS3Bucket_objectLock
=== CONT  TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled
=== CONT  TestAccAWSS3Bucket_ReplicationSchemaV2
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutPrefix
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed
=== CONT  TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
=== CONT  TestAccAWSS3Bucket_ReplicationWithoutStorageClass
=== CONT  TestAccAWSS3Bucket_Lifecycle
=== CONT  TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical
=== CONT  TestAccAWSS3Bucket_WebsiteRoutingRules
=== CONT  TestAccAWSS3Bucket_WebsiteRedirect
=== CONT  TestAccAWSS3Bucket_Website_Simple
=== CONT  TestAccAWSS3Bucket_UpdateAcl
=== CONT  TestAccAWSS3Bucket_Policy
=== CONT  TestAccAWSS3Bucket_RequestPayer
=== CONT  TestAccAWSS3Bucket_acceleration
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (43.62s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (98.71s)
=== CONT  TestAccAWSS3Bucket_region
--- FAIL: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (100.83s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_s3_bucket.bucket
          versioning.0.enabled: "false" => "true"

        STATE:
...
=== CONT  TestAccAWSS3Bucket_generatedName
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (112.00s)
=== CONT  TestAccAWSS3Bucket_namePrefix
--- FAIL: TestAccAWSS3Bucket_region (19.97s)
    testing.go:538: Step 0 error: Check failed: Check 1/2 error: BucketRegionError: incorrect region, the bucket is not in 'us-west-2' region
        	status code: 301, request id: , host id:
=== CONT  TestAccAWSS3Bucket_basic
--- PASS: TestAccAWSS3Bucket_importBasic (145.48s)
=== CONT  TestAccAWSS3Bucket_importWithPolicy
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (158.85s)
=== CONT  TestAccAWSS3Bucket_Logging
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (172.58s)
=== CONT  TestAccAWSS3Bucket_Cors_EmptyOrigin
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (177.77s)
=== CONT  TestAccAWSS3Bucket_Cors_Delete
--- PASS: TestAccAWSS3Bucket_generatedName (87.34s)
=== CONT  TestAccAWSS3Bucket_Cors_Update
--- PASS: TestAccAWSS3Bucket_namePrefix (86.48s)
=== CONT  TestAccAWSS3Bucket_Versioning
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (220.17s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (238.71s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (246.06s)
--- PASS: TestAccAWSS3Bucket_importWithPolicy (104.87s)
--- PASS: TestAccAWSS3Bucket_objectLock (251.03s)
--- PASS: TestAccAWSS3Bucket_basic (150.82s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (271.20s)
--- PASS: TestAccAWSS3Bucket_Policy (281.62s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (295.49s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (295.52s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (118.28s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (149.17s)
--- PASS: TestAccAWSS3Bucket_Lifecycle (322.52s)
--- PASS: TestAccAWSS3Bucket_acceleration (300.98s)
--- PASS: TestAccAWSS3Bucket_Logging (186.87s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (356.98s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (172.03s)
--- PASS: TestAccAWSS3Bucket_Versioning (249.73s)
--- PASS: TestAccAWSS3Bucket_Replication (488.06s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (502.43s)
```

cc @antonbabenko 