### PR TITLE
tests/provider: Increase golangci-lint deadline to 5 minutes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,4 +23,5 @@ linters-settings:
     ignore: github.com/hashicorp/terraform/helper/schema:ForceNew|Set,fmt:.*,io:Close
 
 run:
+  deadline: 5m
   modules-download-mode: vendor


### PR DESCRIPTION
Increase the deadline for slower machines as this is a large codebase with slower linters enabled. We allow the higher deadline to simply protect from runaway linting processes and want to prevent false positive failures, especially during pull request testing. Configured per: https://github.com/golangci/golangci-lint/#configuration

Occassional previous output from linting in TravisCI:

```
$ make lint
==> Checking source code against linters...
ERRO Deadline exceeded: try increase it by passing --deadline option
make: *** [lint] Error 4
The command "make lint" exited with 2.
```
