### PR TITLE
Add position to aws_ses_receipt_rule example

### DIFF
--- a/website/docs/r/ses_receipt_rule.html.markdown
+++ b/website/docs/r/ses_receipt_rule.html.markdown
@@ -24,10 +24,12 @@ resource "aws_ses_receipt_rule" "store" {
   add_header_action {
     header_name  = "Custom-Header"
     header_value = "Added by SES"
+    position     = 1
   }
 
   s3_action {
     bucket_name = "emails"
+    position    = 2
   }
 }
 ```


### PR DESCRIPTION
All of the actions require the `position` argument, update the example to include these.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAvailabilityZones'

...
```
