### PR TITLE
Fix indent in example (docs)

### DIFF
--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -114,7 +114,7 @@ resource "aws_s3_bucket" "bucket" {
 
     prefix = "log/"
 
-  tags = {
+    tags = {
       "rule"      = "log"
       "autoclean" = "true"
     }


### PR DESCRIPTION
Fixes the indent in an `aws_s3_bucket` example.
