### PR TITLE
chore: fix small typo in lambda layer docs

### DIFF
--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -21,7 +21,7 @@ resource "aws_lambda_layer_version" "lambda_layer" {
   filename = "lambda_layer_payload.zip"
   layer_name = "lambda_layer_name"
   
-  compatible_runtimes = ["nodejs8.10", nodejs6.10"]
+  compatible_runtimes = ["nodejs8.10", "nodejs6.10"]
 }
 ```
 


### PR DESCRIPTION
fix a very small typo in the documentation of `aws_lambda_layer_version`: missing a `"`