### PR TITLE
tests/provider: Remove prefix-based conditionals and fix various bugs in sweepers

### DIFF
--- a/aws/aws_sweeper_test.go
+++ b/aws/aws_sweeper_test.go
@@ -20,7 +20,8 @@ func sharedClientForRegion(region string) (interface{}, error) {
 	}
 
 	conf := &Config{
-		Region: region,
+		MaxRetries: 5,
+		Region:     region,
 	}
 
 	// configures a default client for the region, using the above env vars

--- a/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/aws/resource_aws_api_gateway_rest_api_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 	"time"
 
@@ -28,27 +27,8 @@ func testSweepAPIGatewayRestApis(region string) error {
 	}
 	conn := client.(*AWSClient).apigateway
 
-	// https://github.com/terraform-providers/terraform-provider-aws/issues/3808
-	prefixes := []string{
-		"test",
-		"tf_acc_",
-		"tf-acc-",
-	}
-
 	err = conn.GetRestApisPages(&apigateway.GetRestApisInput{}, func(page *apigateway.GetRestApisOutput, lastPage bool) bool {
 		for _, item := range page.Items {
-			skip := true
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(*item.Name, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping API Gateway REST API: %s", *item.Name)
-				continue
-			}
-
 			input := &apigateway.DeleteRestApiInput{
 				RestApiId: item.Id,
 			}

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -49,18 +49,6 @@ func testSweepAutoscalingGroups(region string) error {
 	}
 
 	for _, asg := range resp.AutoScalingGroups {
-		var testOptGroup bool
-		for _, testName := range []string{"foobar", "terraform-", "tf-test", "tf-asg-"} {
-			if strings.HasPrefix(*asg.AutoScalingGroupName, testName) {
-				testOptGroup = true
-				break
-			}
-		}
-
-		if !testOptGroup {
-			continue
-		}
-
 		deleteopts := autoscaling.DeleteAutoScalingGroupInput{
 			AutoScalingGroupName: asg.AutoScalingGroupName,
 			ForceDelete:          aws.Bool(true),

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -32,10 +31,6 @@ func testSweepBatchComputeEnvironments(region string) error {
 	}
 	conn := client.(*AWSClient).batchconn
 
-	prefixes := []string{
-		"tf_acc",
-	}
-
 	out, err := conn.DescribeComputeEnvironments(&batch.DescribeComputeEnvironmentsInput{})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
@@ -46,17 +41,6 @@ func testSweepBatchComputeEnvironments(region string) error {
 	}
 	for _, computeEnvironment := range out.ComputeEnvironments {
 		name := computeEnvironment.ComputeEnvironmentName
-		skip := true
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(*name, prefix) {
-				skip = false
-				break
-			}
-		}
-		if skip {
-			log.Printf("[INFO] Skipping Batch Compute Environment: %s", *name)
-			continue
-		}
 
 		log.Printf("[INFO] Disabling Batch Compute Environment: %s", *name)
 		err := disableBatchComputeEnvironment(*name, 20*time.Minute, conn)

--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -55,10 +54,6 @@ func testSweepCloudWatchEventPermissions(region string) error {
 
 	for _, statement := range policyDoc.Statements {
 		sid := statement.Sid
-
-		if !strings.HasPrefix(sid, "TestAcc") {
-			continue
-		}
 
 		log.Printf("[INFO] Deleting CloudWatch Event Permission %s", sid)
 		_, err := conn.RemovePermission(&events.RemovePermissionInput{

--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -47,10 +46,6 @@ func testSweepCloudWatchEventRules(region string) error {
 
 		for _, rule := range output.Rules {
 			name := aws.StringValue(rule.Name)
-
-			if !strings.HasPrefix(name, "tf") {
-				continue
-			}
 
 			log.Printf("[INFO] Deleting CloudWatch Event Rule %s", name)
 			_, err := conn.DeleteRule(&events.DeleteRuleInput{

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -51,10 +50,6 @@ func testSweepCognitoUserPools(region string) error {
 
 		for _, userPool := range output.UserPools {
 			name := aws.StringValue(userPool.Name)
-
-			if !strings.HasPrefix(name, "tf_acc_") {
-				continue
-			}
 
 			log.Printf("[INFO] Deleting Cognito User Pool %s", name)
 			_, err := conn.DeleteUserPool(&cognitoidentityprovider.DeleteUserPoolInput{

--- a/aws/resource_aws_config_configuration_aggregator_test.go
+++ b/aws/resource_aws_config_configuration_aggregator_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -45,10 +44,6 @@ func testSweepConfigConfigurationAggregators(region string) error {
 	log.Printf("[INFO] Found %d config configuration aggregators", len(resp.ConfigurationAggregators))
 
 	for _, agg := range resp.ConfigurationAggregators {
-		if !strings.HasPrefix(*agg.ConfigurationAggregatorName, "tf-") {
-			continue
-		}
-
 		log.Printf("[INFO] Deleting config configuration aggregator %s", *agg.ConfigurationAggregatorName)
 		_, err := conn.DeleteConfigurationAggregator(&configservice.DeleteConfigurationAggregatorInput{
 			ConfigurationAggregatorName: agg.ConfigurationAggregatorName,

--- a/aws/resource_aws_datasync_agent_test.go
+++ b/aws/resource_aws_datasync_agent_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,10 +48,7 @@ func testSweepDataSyncAgents(region string) error {
 
 		for _, agent := range output.Agents {
 			name := aws.StringValue(agent.Name)
-			if !strings.HasPrefix(name, "tf-acc-test-") {
-				log.Printf("[INFO] Skipping DataSync Agent: %s", name)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting DataSync Agent: %s", name)
 			input := &datasync.DeleteAgentInput{
 				AgentArn: agent.AgentArn,

--- a/aws/resource_aws_datasync_task_test.go
+++ b/aws/resource_aws_datasync_task_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,10 +48,7 @@ func testSweepDataSyncTasks(region string) error {
 
 		for _, task := range output.Tasks {
 			name := aws.StringValue(task.Name)
-			if !strings.HasPrefix(name, "tf-acc-test") {
-				log.Printf("[INFO] Skipping DataSync Task: %s", name)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting DataSync Task: %s", name)
 			input := &datasync.DeleteTaskInput{
 				TaskArn: task.TaskArn,

--- a/aws/resource_aws_dax_cluster_test.go
+++ b/aws/resource_aws_dax_cluster_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -47,10 +46,6 @@ func testSweepDAXClusters(region string) error {
 	log.Printf("[INFO] Found %d DAX clusters", len(resp.Clusters))
 
 	for _, cluster := range resp.Clusters {
-		if !strings.HasPrefix(*cluster.ClusterName, "tf-") {
-			continue
-		}
-
 		log.Printf("[INFO] Deleting DAX cluster %s", *cluster.ClusterName)
 		_, err := conn.DeleteCluster(&dax.DeleteClusterInput{
 			ClusterName: cluster.ClusterName,

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,25 +30,8 @@ func testSweepDbInstances(region string) error {
 	}
 	conn := client.(*AWSClient).rdsconn
 
-	prefixes := []string{
-		"foobarbaz-test-terraform-",
-		"foobarbaz-enhanced-monitoring-",
-		"mydb-rds-",
-		"terraform-",
-		"tf-",
-	}
-
 	err = conn.DescribeDBInstancesPages(&rds.DescribeDBInstancesInput{}, func(out *rds.DescribeDBInstancesOutput, lastPage bool) bool {
 		for _, dbi := range out.DBInstances {
-			hasPrefix := false
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(*dbi.DBInstanceIdentifier, prefix) {
-					hasPrefix = true
-				}
-			}
-			if !hasPrefix {
-				continue
-			}
 			log.Printf("[INFO] Deleting DB instance: %s", *dbi.DBInstanceIdentifier)
 
 			_, err := conn.DeleteDBInstance(&rds.DeleteDBInstanceInput{

--- a/aws/resource_aws_db_option_group_test.go
+++ b/aws/resource_aws_db_option_group_test.go
@@ -42,14 +42,7 @@ func testSweepDbOptionGroups(region string) error {
 	}
 
 	for _, og := range resp.OptionGroupsList {
-		var testOptGroup bool
-		for _, testName := range []string{"option-group-test-terraform-", "tf-test", "tf-acc-test", "tf-option-test"} {
-			if strings.HasPrefix(*og.OptionGroupName, testName) {
-				testOptGroup = true
-			}
-		}
-
-		if !testOptGroup {
+		if strings.HasPrefix(aws.StringValue(og.OptionGroupName), "default") {
 			continue
 		}
 

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -44,12 +44,6 @@ func testSweepDirectoryServiceDirectories(region string) error {
 
 		for _, directory := range resp.DirectoryDescriptions {
 			id := aws.StringValue(directory.DirectoryId)
-			name := aws.StringValue(directory.Name)
-
-			if name != "corp.notexample.com" && name != "terraformtesting.com" {
-				log.Printf("[INFO] Skipping Directory Service Directory: %s / %s", id, name)
-				continue
-			}
 
 			deleteDirectoryInput := directoryservice.DeleteDirectoryInput{
 				DirectoryId: directory.DirectoryId,

--- a/aws/resource_aws_dynamodb_table_test.go
+++ b/aws/resource_aws_dynamodb_table_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,20 +29,8 @@ func testSweepDynamoDbTables(region string) error {
 	}
 	conn := client.(*AWSClient).dynamodbconn
 
-	prefixes := []string{
-		"TerraformTest",
-		"tf-acc-test-",
-		"tf-autoscaled-table-",
-	}
-
 	err = conn.ListTablesPages(&dynamodb.ListTablesInput{}, func(out *dynamodb.ListTablesOutput, lastPage bool) bool {
 		for _, tableName := range out.TableNames {
-			for _, prefix := range prefixes {
-				if !strings.HasPrefix(*tableName, prefix) {
-					log.Printf("[INFO] Skipping DynamoDB Table: %s", *tableName)
-					continue
-				}
-			}
 			log.Printf("[INFO] Deleting DynamoDB Table: %s", *tableName)
 
 			err := deleteAwsDynamoDbTable(*tableName, conn)

--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -3,10 +3,8 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
-	"testing"
-
 	"regexp"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -34,23 +32,10 @@ func testSweepEbsVolumes(region string) error {
 
 	err = conn.DescribeVolumesPages(&ec2.DescribeVolumesInput{}, func(page *ec2.DescribeVolumesOutput, lastPage bool) bool {
 		for _, volume := range page.Volumes {
-			var nameTag string
 			id := aws.StringValue(volume.VolumeId)
 
 			if aws.StringValue(volume.State) != ec2.VolumeStateAvailable {
 				log.Printf("[INFO] Skipping unavailable EC2 EBS Volume: %s", id)
-				continue
-			}
-
-			for _, volumeTag := range volume.Tags {
-				if aws.StringValue(volumeTag.Key) == "Name" {
-					nameTag = aws.StringValue(volumeTag.Value)
-					break
-				}
-			}
-
-			if !strings.HasPrefix(nameTag, "tf-acc-test-") {
-				log.Printf("[INFO] Skipping EC2 EBS Volume: %s", id)
 				continue
 			}
 

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -48,11 +47,6 @@ func testSweepEksClusters(region string) error {
 
 		for _, cluster := range out.Clusters {
 			name := aws.StringValue(cluster)
-
-			if !strings.HasPrefix(name, "tf-acc-test-") {
-				log.Printf("[INFO] Skipping EKS Cluster: %s", name)
-				continue
-			}
 
 			log.Printf("[INFO] Deleting EKS Cluster: %s", name)
 			err := deleteEksCluster(conn, name)

--- a/aws/resource_aws_elastic_beanstalk_application_test.go
+++ b/aws/resource_aws_elastic_beanstalk_application_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -45,22 +44,6 @@ func testSweepBeanstalkApplications(region string) error {
 	}
 
 	for _, bsa := range resp.Applications {
-		var testOptGroup bool
-		for _, testName := range []string{
-			"terraform-",
-			"tf-test-",
-			"tf_acc_",
-			"tf-acc-",
-		} {
-			if strings.HasPrefix(*bsa.ApplicationName, testName) {
-				testOptGroup = true
-			}
-		}
-
-		if !testOptGroup {
-			continue
-		}
-
 		_, err := beanstalkconn.DeleteApplication(
 			&elasticbeanstalk.DeleteApplicationInput{
 				ApplicationName: bsa.ApplicationName,

--- a/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -51,23 +50,6 @@ func testSweepBeanstalkEnvironments(region string) error {
 	}
 
 	for _, bse := range resp.Environments {
-		var testOptGroup bool
-		for _, testName := range []string{
-			"terraform-",
-			"tf-test-",
-			"tf_acc_",
-			"tf-acc-",
-		} {
-			if strings.HasPrefix(*bse.EnvironmentName, testName) {
-				testOptGroup = true
-			}
-		}
-
-		if !testOptGroup {
-			log.Printf("Skipping (%s) (%s)", *bse.EnvironmentName, *bse.EnvironmentId)
-			continue
-		}
-
 		log.Printf("Trying to terminate (%s) (%s)", *bse.EnvironmentName, *bse.EnvironmentId)
 
 		_, err := beanstalkconn.TerminateEnvironment(

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -36,12 +36,6 @@ func testSweepElasticacheClusters(region string) error {
 	}
 	conn := client.(*AWSClient).elasticacheconn
 
-	prefixes := []string{
-		"tf-",
-		"tf-test-",
-		"tf-acc-test-",
-	}
-
 	err = conn.DescribeCacheClustersPages(&elasticache.DescribeCacheClustersInput{}, func(page *elasticache.DescribeCacheClustersOutput, isLast bool) bool {
 		if len(page.CacheClusters) == 0 {
 			log.Print("[DEBUG] No Elasticache Replicaton Groups to sweep")
@@ -50,17 +44,7 @@ func testSweepElasticacheClusters(region string) error {
 
 		for _, cluster := range page.CacheClusters {
 			id := aws.StringValue(cluster.CacheClusterId)
-			skip := true
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(id, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping Elasticache Cluster: %s", id)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting Elasticache Cluster: %s", id)
 			err := deleteElasticacheCacheCluster(conn, id)
 			if err != nil {

--- a/aws/resource_aws_elasticache_replication_group_test.go
+++ b/aws/resource_aws_elasticache_replication_group_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,12 +30,6 @@ func testSweepElasticacheReplicationGroups(region string) error {
 	}
 	conn := client.(*AWSClient).elasticacheconn
 
-	prefixes := []string{
-		"tf-",
-		"tf-test-",
-		"tf-acc-test-",
-	}
-
 	err = conn.DescribeReplicationGroupsPages(&elasticache.DescribeReplicationGroupsInput{}, func(page *elasticache.DescribeReplicationGroupsOutput, isLast bool) bool {
 		if len(page.ReplicationGroups) == 0 {
 			log.Print("[DEBUG] No Elasticache Replicaton Groups to sweep")
@@ -45,17 +38,7 @@ func testSweepElasticacheReplicationGroups(region string) error {
 
 		for _, replicationGroup := range page.ReplicationGroups {
 			id := aws.StringValue(replicationGroup.ReplicationGroupId)
-			skip := true
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(id, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping Elasticache Replication Group: %s", id)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting Elasticache Replication Group: %s", id)
 			err := deleteElasticacheReplicationGroup(id, conn)
 			if err != nil {

--- a/aws/resource_aws_elasticache_security_group_test.go
+++ b/aws/resource_aws_elasticache_security_group_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -33,12 +32,6 @@ func testSweepElasticacheCacheSecurityGroups(region string) error {
 	}
 	conn := client.(*AWSClient).elasticacheconn
 
-	prefixes := []string{
-		"tf-",
-		"tf-test-",
-		"tf-acc-test-",
-	}
-
 	err = conn.DescribeCacheSecurityGroupsPages(&elasticache.DescribeCacheSecurityGroupsInput{}, func(page *elasticache.DescribeCacheSecurityGroupsOutput, isLast bool) bool {
 		if len(page.CacheSecurityGroups) == 0 {
 			log.Print("[DEBUG] No Elasticache Cache Security Groups to sweep")
@@ -47,17 +40,12 @@ func testSweepElasticacheCacheSecurityGroups(region string) error {
 
 		for _, securityGroup := range page.CacheSecurityGroups {
 			name := aws.StringValue(securityGroup.CacheSecurityGroupName)
-			skip := true
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(name, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
+
+			if name == "default" {
 				log.Printf("[INFO] Skipping Elasticache Cache Security Group: %s", name)
 				continue
 			}
+
 			log.Printf("[INFO] Deleting Elasticache Cache Security Group: %s", name)
 			_, err := conn.DeleteCacheSecurityGroup(&elasticache.DeleteCacheSecurityGroupInput{
 				CacheSecurityGroupName: aws.String(name),

--- a/aws/resource_aws_elasticsearch_domain_test.go
+++ b/aws/resource_aws_elasticsearch_domain_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,11 +28,6 @@ func testSweepElasticSearchDomains(region string) error {
 	}
 	conn := client.(*AWSClient).esconn
 
-	prefixes := []string{
-		"tf-test-",
-		"tf-acc-test-",
-	}
-
 	out, err := conn.ListDomainNames(&elasticsearch.ListDomainNamesInput{})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
@@ -43,17 +37,6 @@ func testSweepElasticSearchDomains(region string) error {
 		return fmt.Errorf("Error retrieving Elasticsearch Domains: %s", err)
 	}
 	for _, domain := range out.DomainNames {
-		skip := true
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(*domain.DomainName, prefix) {
-				skip = false
-				break
-			}
-		}
-		if skip {
-			log.Printf("[INFO] Skipping Elasticsearch Domain: %s", *domain.DomainName)
-			continue
-		}
 		log.Printf("[INFO] Deleting Elasticsearch Domain: %s", *domain.DomainName)
 
 		_, err := conn.DeleteElasticsearchDomain(&elasticsearch.DeleteElasticsearchDomainInput{

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -33,10 +32,6 @@ func testSweepELBs(region string) error {
 	}
 	conn := client.(*AWSClient).elbconn
 
-	prefixes := []string{
-		"test-elb-",
-	}
-
 	err = conn.DescribeLoadBalancersPages(&elb.DescribeLoadBalancersInput{}, func(out *elb.DescribeLoadBalancersOutput, isLast bool) bool {
 		if len(out.LoadBalancerDescriptions) == 0 {
 			log.Println("[INFO] No ELBs found for sweeping")
@@ -44,17 +39,6 @@ func testSweepELBs(region string) error {
 		}
 
 		for _, lb := range out.LoadBalancerDescriptions {
-			skip := true
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(*lb.LoadBalancerName, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping ELB: %s", *lb.LoadBalancerName)
-				continue
-			}
 			log.Printf("[INFO] Deleting ELB: %s", *lb.LoadBalancerName)
 
 			_, err := conn.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{

--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -39,10 +38,6 @@ func testSweepGameliftAliases(region string) error {
 		log.Printf("[INFO] Found %d Gamelift Aliases", len(resp.Aliases))
 
 		for _, alias := range resp.Aliases {
-			if !strings.HasPrefix(*alias.Name, "tf_acc_alias_") {
-				continue
-			}
-
 			log.Printf("[INFO] Deleting Gamelift Alias %q", *alias.AliasId)
 			_, err := conn.DeleteAlias(&gamelift.DeleteAliasInput{
 				AliasId: alias.AliasId,

--- a/aws/resource_aws_gamelift_build_test.go
+++ b/aws/resource_aws_gamelift_build_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,10 +45,6 @@ func testSweepGameliftBuilds(region string) error {
 	log.Printf("[INFO] Found %d Gamelift Builds", len(resp.Builds))
 
 	for _, build := range resp.Builds {
-		if !strings.HasPrefix(*build.Name, testAccGameliftBuildPrefix) {
-			continue
-		}
-
 		log.Printf("[INFO] Deleting Gamelift Build %q", *build.BuildId)
 		_, err := conn.DeleteBuild(&gamelift.DeleteBuildInput{
 			BuildId: build.BuildId,

--- a/aws/resource_aws_gamelift_fleet_test.go
+++ b/aws/resource_aws_gamelift_fleet_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -50,10 +49,6 @@ func testSweepGameliftFleets(region string) error {
 		log.Printf("[INFO] Found %d Gamelift Fleets", len(out.FleetAttributes))
 
 		for _, attr := range out.FleetAttributes {
-			if !strings.HasPrefix(*attr.Name, testAccGameliftFleetPrefix) {
-				continue
-			}
-
 			log.Printf("[INFO] Deleting Gamelift Fleet %q", *attr.FleetId)
 			err := resource.Retry(60*time.Minute, func() *resource.RetryError {
 				_, err := conn.DeleteFleet(&gamelift.DeleteFleetInput{

--- a/aws/resource_aws_gamelift_game_session_queue_test.go
+++ b/aws/resource_aws_gamelift_game_session_queue_test.go
@@ -2,11 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
-
-	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/gamelift"
@@ -49,10 +47,6 @@ func testSweepGameliftGameSessionQueue(region string) error {
 	log.Printf("[INFO] Found %d Gamelift Session Queue", len(out.GameSessionQueues))
 
 	for _, queue := range out.GameSessionQueues {
-		if !strings.HasPrefix(*queue.Name, testAccGameliftGameSessionQueuePrefix) {
-			continue
-		}
-
 		log.Printf("[INFO] Deleting Gamelift Session Queue %q", *queue.Name)
 		_, err := conn.DeleteGameSessionQueue(&gamelift.DeleteGameSessionQueueInput{
 			Name: aws.String(*queue.Name),

--- a/aws/resource_aws_glue_classifier_test.go
+++ b/aws/resource_aws_glue_classifier_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,10 +26,6 @@ func testSweepGlueClassifiers(region string) error {
 	}
 	conn := client.(*AWSClient).glueconn
 
-	prefixes := []string{
-		"tf-acc-test-",
-	}
-
 	input := &glue.GetClassifiersInput{}
 	err = conn.GetClassifiersPages(input, func(page *glue.GetClassifiersOutput, lastPage bool) bool {
 		if len(page.Classifiers) == 0 {
@@ -38,8 +33,6 @@ func testSweepGlueClassifiers(region string) error {
 			return false
 		}
 		for _, classifier := range page.Classifiers {
-			skip := true
-
 			var name string
 			if classifier.GrokClassifier != nil {
 				name = aws.StringValue(classifier.GrokClassifier.Name)
@@ -50,17 +43,6 @@ func testSweepGlueClassifiers(region string) error {
 			}
 			if name == "" {
 				log.Printf("[WARN] Unable to determine Glue Classifier name: %#v", classifier)
-				continue
-			}
-
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(name, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping Glue Classifier: %s", name)
 				continue
 			}
 

--- a/aws/resource_aws_glue_connection_test.go
+++ b/aws/resource_aws_glue_connection_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,10 +27,6 @@ func testSweepGlueConnections(region string) error {
 	conn := client.(*AWSClient).glueconn
 	catalogID := client.(*AWSClient).accountid
 
-	prefixes := []string{
-		"tf-acc-test-",
-	}
-
 	input := &glue.GetConnectionsInput{
 		CatalogId: aws.String(catalogID),
 	}
@@ -41,23 +36,12 @@ func testSweepGlueConnections(region string) error {
 			return false
 		}
 		for _, connection := range page.ConnectionList {
-			skip := true
-			name := connection.Name
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(*name, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping Glue Connection: %s", *name)
-				continue
-			}
+			name := aws.StringValue(connection.Name)
 
-			log.Printf("[INFO] Deleting Glue Connection: %s", *name)
-			err := deleteGlueConnection(conn, catalogID, *name)
+			log.Printf("[INFO] Deleting Glue Connection: %s", name)
+			err := deleteGlueConnection(conn, catalogID, name)
 			if err != nil {
-				log.Printf("[ERROR] Failed to delete Glue Connection %s: %s", *name, err)
+				log.Printf("[ERROR] Failed to delete Glue Connection %s: %s", name, err)
 			}
 		}
 		return !lastPage

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,10 +37,6 @@ func testSweepGlueCrawlers(region string) error {
 		}
 		for _, crawler := range page.Crawlers {
 			name := aws.StringValue(crawler.Name)
-			if !strings.HasPrefix(name, "tf-acc-test-") {
-				log.Printf("[INFO] Skipping Glue Crawler: %s", name)
-				continue
-			}
 
 			log.Printf("[INFO] Deleting Glue Crawler: %s", name)
 			_, err := conn.DeleteCrawler(&glue.DeleteCrawlerInput{

--- a/aws/resource_aws_glue_security_configuration_test.go
+++ b/aws/resource_aws_glue_security_configuration_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -43,11 +42,6 @@ func testSweepGlueSecurityConfigurations(region string) error {
 
 		for _, securityConfiguration := range output.SecurityConfigurations {
 			name := aws.StringValue(securityConfiguration.Name)
-
-			if !strings.HasPrefix(name, "tf-acc-test") {
-				log.Printf("[INFO] Skipping Glue Security Configuration: %s", name)
-				continue
-			}
 
 			log.Printf("[INFO] Deleting Glue Security Configuration: %s", name)
 			err := deleteGlueSecurityConfiguration(conn, name)

--- a/aws/resource_aws_glue_trigger_test.go
+++ b/aws/resource_aws_glue_trigger_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,10 +26,6 @@ func testSweepGlueTriggers(region string) error {
 	}
 	conn := client.(*AWSClient).glueconn
 
-	prefixes := []string{
-		"tf-acc-test-",
-	}
-
 	input := &glue.GetTriggersInput{}
 	err = conn.GetTriggersPages(input, func(page *glue.GetTriggersOutput, lastPage bool) bool {
 		if page == nil || len(page.Triggers) == 0 {
@@ -38,18 +33,7 @@ func testSweepGlueTriggers(region string) error {
 			return false
 		}
 		for _, trigger := range page.Triggers {
-			skip := true
 			name := aws.StringValue(trigger.Name)
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(name, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping Glue Trigger: %s", name)
-				continue
-			}
 
 			log.Printf("[INFO] Deleting Glue Trigger: %s", name)
 			err := deleteGlueJob(conn, name)

--- a/aws/resource_aws_iam_server_certificate_test.go
+++ b/aws/resource_aws_iam_server_certificate_test.go
@@ -27,23 +27,8 @@ func testSweepIamServerCertificates(region string) error {
 	}
 	conn := client.(*AWSClient).iamconn
 
-	prefixes := []string{
-		"tf-acctest-",
-		"test_cert_",
-		"terraform-test-cert-",
-	}
-
 	err = conn.ListServerCertificatesPages(&iam.ListServerCertificatesInput{}, func(out *iam.ListServerCertificatesOutput, lastPage bool) bool {
 		for _, sc := range out.ServerCertificateMetadataList {
-			hasPrefix := false
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(*sc.ServerCertificateName, prefix) {
-					hasPrefix = true
-				}
-			}
-			if !hasPrefix {
-				continue
-			}
 			log.Printf("[INFO] Deleting IAM Server Certificate: %s", *sc.ServerCertificateName)
 
 			_, err := conn.DeleteServerCertificate(&iam.DeleteServerCertificateInput{

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -43,23 +42,10 @@ func testSweepInstances(region string) error {
 
 		for _, reservation := range page.Reservations {
 			for _, instance := range reservation.Instances {
-				var nameTag string
 				id := aws.StringValue(instance.InstanceId)
 
 				if instance.State != nil && aws.StringValue(instance.State.Name) == ec2.InstanceStateNameTerminated {
 					log.Printf("[INFO] Skipping terminated EC2 Instance: %s", id)
-					continue
-				}
-
-				for _, instanceTag := range instance.Tags {
-					if aws.StringValue(instanceTag.Key) == "Name" {
-						nameTag = aws.StringValue(instanceTag.Value)
-						break
-					}
-				}
-
-				if !strings.HasPrefix(nameTag, "tf-acc-test-") {
-					log.Printf("[INFO] Skipping EC2 Instance: %s", id)
 					continue
 				}
 

--- a/aws/resource_aws_internet_gateway_test.go
+++ b/aws/resource_aws_internet_gateway_test.go
@@ -30,17 +30,7 @@ func testSweepInternetGateways(region string) error {
 	}
 	conn := client.(*AWSClient).ec2conn
 
-	req := &ec2.DescribeInternetGatewaysInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag-value"),
-				Values: []*string{
-					aws.String("terraform-testacc-*"),
-					aws.String("tf-acc-test-*"),
-				},
-			},
-		},
-	}
+	req := &ec2.DescribeInternetGatewaysInput{}
 	resp, err := conn.DescribeInternetGateways(req)
 	if err != nil {
 		if testSweepSkipSweepError(err) {
@@ -55,8 +45,35 @@ func testSweepInternetGateways(region string) error {
 		return nil
 	}
 
+	defaultVPCID := ""
+	describeVpcsInput := &ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("isDefault"),
+				Values: aws.StringSlice([]string{"true"}),
+			},
+		},
+	}
+
+	describeVpcsOutput, err := conn.DescribeVpcs(describeVpcsInput)
+
+	if err != nil {
+		return fmt.Errorf("Error describing VPCs: %s", err)
+	}
+
+	if describeVpcsOutput != nil && len(describeVpcsOutput.Vpcs) == 1 {
+		defaultVPCID = aws.StringValue(describeVpcsOutput.Vpcs[0].VpcId)
+	}
+
 	for _, internetGateway := range resp.InternetGateways {
+		isDefaultVPCInternetGateway := false
+
 		for _, attachment := range internetGateway.Attachments {
+			if aws.StringValue(attachment.VpcId) == defaultVPCID {
+				isDefaultVPCInternetGateway = true
+				break
+			}
+
 			input := &ec2.DetachInternetGatewayInput{
 				InternetGatewayId: internetGateway.InternetGatewayId,
 				VpcId:             attachment.VpcId,
@@ -80,6 +97,11 @@ func testSweepInternetGateways(region string) error {
 			if _, err = stateConf.WaitForState(); err != nil {
 				return fmt.Errorf("error waiting for VPN Gateway (%s) to detach from VPC (%s): %s", aws.StringValue(internetGateway.InternetGatewayId), aws.StringValue(attachment.VpcId), err)
 			}
+		}
+
+		if isDefaultVPCInternetGateway {
+			log.Printf("[DEBUG] Skipping Default VPC Internet Gateway: %s", aws.StringValue(internetGateway.InternetGatewayId))
+			continue
 		}
 
 		input := &ec2.DeleteInternetGatewayInput{

--- a/aws/resource_aws_key_pair_test.go
+++ b/aws/resource_aws_key_pair_test.go
@@ -35,18 +35,7 @@ func testSweepKeyPairs(region string) error {
 
 	log.Printf("Destroying the tmp keys in (%s)", client.(*AWSClient).region)
 
-	resp, err := ec2conn.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("key-name"),
-				Values: []*string{
-					aws.String("tf-acctest*"),
-					aws.String("tf_acc*"),
-					aws.String("tmp-key*"),
-				},
-			},
-		},
-	})
+	resp, err := ec2conn.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{})
 	if err != nil {
 		if testSweepSkipSweepError(err) {
 			log.Printf("[WARN] Skipping EC2 Key Pair sweep for %s: %s", region, err)

--- a/aws/resource_aws_kms_key_test.go
+++ b/aws/resource_aws_kms_key_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -46,18 +45,6 @@ func testSweepKmsKeys(region string) error {
 				continue
 			}
 
-			tOut, err := conn.ListResourceTags(&kms.ListResourceTagsInput{
-				KeyId: k.KeyId,
-			})
-			if err != nil {
-				log.Printf("Error: Failed to get tags for key %q: %s", *k.KeyId, err)
-				return false
-			}
-			if !kmsTagHasPrefix(tOut.Tags, "Name", "tf-acc-test-kms-key-") {
-				// Skip keys which don't have designated tag
-				continue
-			}
-
 			_, err = conn.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
 				KeyId:               k.KeyId,
 				PendingWindowInDays: aws.Int64(int64(7)),
@@ -78,15 +65,6 @@ func testSweepKmsKeys(region string) error {
 	}
 
 	return nil
-}
-
-func kmsTagHasPrefix(tags []*kms.Tag, key, prefix string) bool {
-	for _, t := range tags {
-		if *t.TagKey == key && strings.HasPrefix(*t.TagValue, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 func TestAccAWSKmsKey_importBasic(t *testing.T) {

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -49,17 +49,6 @@ func testSweepLambdaFunctions(region string) error {
 	}
 
 	for _, f := range resp.Functions {
-		var testOptGroup bool
-		for _, testName := range []string{"tf_test", "tf_acc_"} {
-			if strings.HasPrefix(*f.FunctionName, testName) {
-				testOptGroup = true
-			}
-		}
-
-		if !testOptGroup {
-			continue
-		}
-
 		_, err := lambdaconn.DeleteFunction(
 			&lambda.DeleteFunctionInput{
 				FunctionName: f.FunctionName,

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -43,10 +42,6 @@ func testSweepLambdaLayerVersions(region string) error {
 	}
 
 	for _, l := range resp.Layers {
-		if !strings.HasPrefix(*l.LayerName, "tf_acc_") {
-			continue
-		}
-
 		versionResp, err := lambdaconn.ListLayerVersions(&lambda.ListLayerVersionsInput{
 			LayerName: l.LayerName,
 		})

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -44,25 +44,8 @@ func testSweepLaunchConfigurations(region string) error {
 		return nil
 	}
 
-	prefixes := []string{
-		"foobar",
-		"terraform-",
-		"tf-acc-",
-		"TestAcc",
-	}
 	for _, lc := range resp.LaunchConfigurations {
 		name := *lc.LaunchConfigurationName
-		skip := true
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(name, prefix) {
-				skip = false
-			}
-		}
-
-		if skip {
-			log.Printf("[INFO] Skipping Launch Configuration: %s", name)
-			continue
-		}
 
 		log.Printf("[INFO] Deleting Launch Configuration: %s", name)
 		_, err := autoscalingconn.DeleteLaunchConfiguration(

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -32,13 +31,6 @@ func testSweepLBTargetGroups(region string) error {
 	}
 	conn := client.(*AWSClient).elbv2conn
 
-	prefixes := []string{
-		"tf-",
-		"tf-test-",
-		"tf-acc-test-",
-		"test",
-	}
-
 	err = conn.DescribeTargetGroupsPages(&elbv2.DescribeTargetGroupsInput{}, func(page *elbv2.DescribeTargetGroupsOutput, isLast bool) bool {
 		if page == nil || len(page.TargetGroups) == 0 {
 			log.Print("[DEBUG] No LB Target Groups to sweep")
@@ -47,17 +39,7 @@ func testSweepLBTargetGroups(region string) error {
 
 		for _, targetGroup := range page.TargetGroups {
 			name := aws.StringValue(targetGroup.TargetGroupName)
-			skip := true
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(name, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping LB Target Group: %s", name)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting LB Target Group: %s", name)
 			_, err := conn.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{
 				TargetGroupArn: targetGroup.TargetGroupArn,

--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,14 +28,6 @@ func testSweepLBs(region string) error {
 	}
 	conn := client.(*AWSClient).elbv2conn
 
-	prefixes := []string{
-		"tf-",
-		"tf-test-",
-		"tf-acc-test-",
-		"test-",
-		"testacc",
-	}
-
 	err = conn.DescribeLoadBalancersPages(&elbv2.DescribeLoadBalancersInput{}, func(page *elbv2.DescribeLoadBalancersOutput, isLast bool) bool {
 		if page == nil || len(page.LoadBalancers) == 0 {
 			log.Print("[DEBUG] No LBs to sweep")
@@ -45,17 +36,7 @@ func testSweepLBs(region string) error {
 
 		for _, loadBalancer := range page.LoadBalancers {
 			name := aws.StringValue(loadBalancer.LoadBalancerName)
-			skip := true
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(name, prefix) {
-					skip = false
-					break
-				}
-			}
-			if skip {
-				log.Printf("[INFO] Skipping LB: %s", name)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting LB: %s", name)
 			_, err := conn.DeleteLoadBalancer(&elbv2.DeleteLoadBalancerInput{
 				LoadBalancerArn: loadBalancer.LoadBalancerArn,

--- a/aws/resource_aws_lightsail_static_ip_test.go
+++ b/aws/resource_aws_lightsail_static_ip_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,10 +47,6 @@ func testSweepLightsailStaticIps(region string) error {
 
 		for _, staticIp := range output.StaticIps {
 			name := aws.StringValue(staticIp.Name)
-
-			if !strings.HasPrefix(name, "tf-test-") {
-				continue
-			}
 
 			log.Printf("[INFO] Deleting Lightsail Static IP %s", name)
 			_, err := conn.ReleaseStaticIp(&lightsail.ReleaseStaticIpInput{

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -95,10 +95,6 @@ func testSweepMqBrokers(region string) error {
 	log.Printf("[DEBUG] %d MQ brokers found", len(resp.BrokerSummaries))
 
 	for _, bs := range resp.BrokerSummaries {
-		if !strings.HasPrefix(*bs.BrokerName, "tf-acc-test-") {
-			continue
-		}
-
 		log.Printf("[INFO] Deleting MQ broker %s", *bs.BrokerId)
 		_, err := conn.DeleteBroker(&mq.DeleteBrokerInput{
 			BrokerId: bs.BrokerId,

--- a/aws/resource_aws_nat_gateway_test.go
+++ b/aws/resource_aws_nat_gateway_test.go
@@ -27,17 +27,7 @@ func testSweepNatGateways(region string) error {
 	}
 	conn := client.(*AWSClient).ec2conn
 
-	req := &ec2.DescribeNatGatewaysInput{
-		Filter: []*ec2.Filter{
-			{
-				Name: aws.String("tag-value"),
-				Values: []*string{
-					aws.String("terraform-testacc-*"),
-					aws.String("tf-acc-test-*"),
-				},
-			},
-		},
-	}
+	req := &ec2.DescribeNatGatewaysInput{}
 	resp, err := conn.DescribeNatGateways(req)
 	if err != nil {
 		if testSweepSkipSweepError(err) {

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,10 +36,7 @@ func testSweepRedshiftClusters(region string) error {
 		}
 
 		for _, c := range resp.Clusters {
-			id := *c.ClusterIdentifier
-			if !strings.HasPrefix(id, "tf-redshift-cluster-") {
-				continue
-			}
+			id := aws.StringValue(c.ClusterIdentifier)
 
 			input := &redshift.DeleteClusterInput{
 				ClusterIdentifier:        c.ClusterIdentifier,
@@ -48,8 +44,7 @@ func testSweepRedshiftClusters(region string) error {
 			}
 			_, err := conn.DeleteCluster(input)
 			if err != nil {
-				log.Printf("[ERROR] Failed deleting Redshift cluster (%s): %s",
-					*c.ClusterIdentifier, err)
+				log.Printf("[ERROR] Failed deleting Redshift cluster (%s): %s", id, err)
 			}
 		}
 		return !isLast

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -27,53 +27,54 @@ func testSweepRouteTables(region string) error {
 	}
 	conn := client.(*AWSClient).ec2conn
 
-	req := &ec2.DescribeRouteTablesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag-value"),
-				Values: []*string{
-					aws.String("terraform-testacc-*"),
-					aws.String("tf-acc-test-*"),
-				},
-			},
-		},
-	}
-	resp, err := conn.DescribeRouteTables(req)
-	if err != nil {
-		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping EC2 Route Table sweep for %s: %s", region, err)
-			return nil
-		}
-		return fmt.Errorf("Error describing Route Tables: %s", err)
-	}
+	input := &ec2.DescribeRouteTablesInput{}
+	err = conn.DescribeRouteTablesPages(input, func(page *ec2.DescribeRouteTablesOutput, lastPage bool) bool {
+		for _, routeTable := range page.RouteTables {
+			isMainRouteTableAssociation := false
 
-	if len(resp.RouteTables) == 0 {
-		log.Print("[DEBUG] No Route Tables to sweep")
+			for _, routeTableAssociation := range routeTable.Associations {
+				if aws.BoolValue(routeTableAssociation.Main) {
+					isMainRouteTableAssociation = true
+					break
+				}
+
+				input := &ec2.DisassociateRouteTableInput{
+					AssociationId: routeTableAssociation.RouteTableAssociationId,
+				}
+
+				log.Printf("[DEBUG] Deleting Route Table Association: %s", input)
+				_, err := conn.DisassociateRouteTable(input)
+				if err != nil {
+					log.Printf("[ERROR] Error deleting Route Table Association (%s): %s", aws.StringValue(routeTableAssociation.RouteTableAssociationId), err)
+				}
+			}
+
+			if isMainRouteTableAssociation {
+				log.Printf("[DEBUG] Skipping Main Route Table: %s", aws.StringValue(routeTable.RouteTableId))
+				continue
+			}
+
+			input := &ec2.DeleteRouteTableInput{
+				RouteTableId: routeTable.RouteTableId,
+			}
+
+			log.Printf("[DEBUG] Deleting Route Table: %s", input)
+			_, err := conn.DeleteRouteTable(input)
+			if err != nil {
+				log.Printf("[ERROR] Error deleting Route Table (%s): %s", aws.StringValue(routeTable.RouteTableId), err)
+			}
+		}
+
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping EC2 Route Table sweep for %s: %s", region, err)
 		return nil
 	}
 
-	for _, routeTable := range resp.RouteTables {
-		for _, routeTableAssociation := range routeTable.Associations {
-			input := &ec2.DisassociateRouteTableInput{
-				AssociationId: routeTableAssociation.RouteTableAssociationId,
-			}
-
-			log.Printf("[DEBUG] Deleting Route Table Association: %s", input)
-			_, err := conn.DisassociateRouteTable(input)
-			if err != nil {
-				return fmt.Errorf("error deleting Route Table Association (%s): %s", aws.StringValue(routeTableAssociation.RouteTableAssociationId), err)
-			}
-		}
-
-		input := &ec2.DeleteRouteTableInput{
-			RouteTableId: routeTable.RouteTableId,
-		}
-
-		log.Printf("[DEBUG] Deleting Route Table: %s", input)
-		_, err := conn.DeleteRouteTable(input)
-		if err != nil {
-			return fmt.Errorf("error deleting Route Table (%s): %s", aws.StringValue(routeTable.RouteTableId), err)
-		}
+	if err != nil {
+		return fmt.Errorf("Error describing Route Tables: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -31,9 +31,7 @@ func testSweepSagemakerModels(region string) error {
 	}
 	conn := client.(*AWSClient).sagemakerconn
 
-	req := &sagemaker.ListModelsInput{
-		NameContains: aws.String("terraform-testacc-sagemaker-model"),
-	}
+	req := &sagemaker.ListModelsInput{}
 	resp, err := conn.ListModels(req)
 	if err != nil {
 		return fmt.Errorf("error listing models: %s", err)

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,10 +36,7 @@ func testSweepSecretsManagerSecrets(region string) error {
 
 		for _, secret := range page.SecretList {
 			name := aws.StringValue(secret.Name)
-			if !strings.HasPrefix(name, "tf-acc-test-") {
-				log.Printf("[INFO] Skipping Secrets Manager Secret: %s", name)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting Secrets Manager Secret: %s", name)
 			input := &secretsmanager.DeleteSecretInput{
 				ForceDeleteWithoutRecovery: aws.Bool(true),

--- a/aws/resource_aws_storagegateway_gateway_test.go
+++ b/aws/resource_aws_storagegateway_gateway_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -36,10 +35,7 @@ func testSweepStorageGatewayGateways(region string) error {
 
 		for _, gateway := range page.Gateways {
 			name := aws.StringValue(gateway.GatewayName)
-			if !strings.HasPrefix(name, "tf-acc-test-") {
-				log.Printf("[INFO] Skipping Storage Gateway Gateway: %s", name)
-				continue
-			}
+
 			log.Printf("[INFO] Deleting Storage Gateway Gateway: %s", name)
 			input := &storagegateway.DeleteGatewayInput{
 				GatewayARN: gateway.GatewayARN,

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -49,17 +50,7 @@ func testSweepSubnets(region string) error {
 	}
 	conn := client.(*AWSClient).ec2conn
 
-	req := &ec2.DescribeSubnetsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag-value"),
-				Values: []*string{
-					aws.String("terraform-testacc-*"),
-					aws.String("tf-acc-*"),
-				},
-			},
-		},
-	}
+	req := &ec2.DescribeSubnetsInput{}
 	resp, err := conn.DescribeSubnets(req)
 	if err != nil {
 		if testSweepSkipSweepError(err) {
@@ -83,14 +74,27 @@ func testSweepSubnets(region string) error {
 			continue
 		}
 
-		// delete the subnet
-		_, err := conn.DeleteSubnet(&ec2.DeleteSubnetInput{
+		input := &ec2.DeleteSubnetInput{
 			SubnetId: subnet.SubnetId,
+		}
+
+		// Handle eventual consistency, especially with lingering ENIs from Load Balancers and Lambda
+		err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+			_, err := conn.DeleteSubnet(input)
+
+			if isAWSErr(err, "DependencyViolation", "") {
+				return resource.RetryableError(err)
+			}
+
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
 		})
+
 		if err != nil {
-			return fmt.Errorf(
-				"Error deleting Subnet (%s): %s",
-				*subnet.SubnetId, err)
+			return fmt.Errorf("Error deleting Subnet (%s): %s", aws.StringValue(subnet.SubnetId), err)
 		}
 	}
 

--- a/aws/resource_aws_vpc_test.go
+++ b/aws/resource_aws_vpc_test.go
@@ -38,17 +38,7 @@ func testSweepVPCs(region string) error {
 	}
 	conn := client.(*AWSClient).ec2conn
 
-	req := &ec2.DescribeVpcsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag-value"),
-				Values: []*string{
-					aws.String("terraform-testacc-*"),
-					aws.String("tf-acc-test-*"),
-				},
-			},
-		},
-	}
+	req := &ec2.DescribeVpcsInput{}
 	resp, err := conn.DescribeVpcs(req)
 	if err != nil {
 		if testSweepSkipSweepError(err) {
@@ -64,6 +54,11 @@ func testSweepVPCs(region string) error {
 	}
 
 	for _, vpc := range resp.Vpcs {
+		if aws.BoolValue(vpc.IsDefault) {
+			log.Printf("[DEBUG] Skipping Default VPC: %s", aws.StringValue(vpc.VpcId))
+			continue
+		}
+
 		input := &ec2.DeleteVpcInput{
 			VpcId: vpc.VpcId,
 		}

--- a/aws/resource_aws_waf_regex_match_set_test.go
+++ b/aws/resource_aws_waf_regex_match_set_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -43,10 +42,6 @@ func testSweepWafRegexMatchSet(region string) error {
 	}
 
 	for _, s := range resp.RegexMatchSets {
-		if !strings.HasPrefix(*s.Name, "tfacc") {
-			continue
-		}
-
 		resp, err := conn.GetRegexMatchSet(&waf.GetRegexMatchSetInput{
 			RegexMatchSetId: s.RegexMatchSetId,
 		})

--- a/aws/resource_aws_waf_rule_group_test.go
+++ b/aws/resource_aws_waf_rule_group_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,10 +43,6 @@ func testSweepWafRuleGroups(region string) error {
 	}
 
 	for _, group := range resp.RuleGroups {
-		if !strings.HasPrefix(*group.Name, "tfacc") {
-			continue
-		}
-
 		rResp, err := conn.ListActivatedRulesInRuleGroup(&waf.ListActivatedRulesInRuleGroupInput{
 			RuleGroupId: group.RuleGroupId,
 		})

--- a/aws/resource_aws_wafregional_regex_match_set_test.go
+++ b/aws/resource_aws_wafregional_regex_match_set_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,10 +43,6 @@ func testSweepWafRegionalRegexMatchSet(region string) error {
 	}
 
 	for _, s := range resp.RegexMatchSets {
-		if !strings.HasPrefix(*s.Name, "tfacc") {
-			continue
-		}
-
 		resp, err := conn.GetRegexMatchSet(&waf.GetRegexMatchSetInput{
 			RegexMatchSetId: s.RegexMatchSetId,
 		})

--- a/aws/resource_aws_wafregional_rule_group_test.go
+++ b/aws/resource_aws_wafregional_rule_group_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,10 +43,6 @@ func testSweepWafRegionalRuleGroups(region string) error {
 	}
 
 	for _, group := range resp.RuleGroups {
-		if !strings.HasPrefix(*group.Name, "tfacc") {
-			continue
-		}
-
 		rResp, err := conn.ListActivatedRulesInRuleGroup(&waf.ListActivatedRulesInRuleGroupInput{
 			RuleGroupId: group.RuleGroupId,
 		})


### PR DESCRIPTION
## Background

When Terraform AWS Provider acceptance testing fails in various ways, AWS resources can be orphaned and left behind in the AWS account used. Test sweepers were created as a solution to be run before/after the actual acceptance tests to help clean up these dangling resources to:

* Ensure the AWS account in question is not being charged for AWS resources which do not serve any real purpose other than the testing itself
* Prevent AWS service limits from being breached
* Prevent test failures from non-randomized resource naming

They were initially designed with the hope that the sweepers could be ran in coexistence with existing, non-Terraform AWS Provider acceptance testing infrastructure. To enable this behavior, the sweepers were constrained to naming-based prefixes to attempt to match only acceptance testing related resources.

Over the past year as the amount and complexity of Terraform AWS Provider testing has grown, the sweepers have consistently trended towards more failure than success, preventing our daily and ad-hoc CI testing from completing without manual intervention or bypassing the sweepers. There are a few contributing factors to this trend:

* Existing acceptance testing was never fully migrated to consistent naming patterns to match the sweepers. Tracking down misconfigurations in existing tests was not automated.
* No automated tooling during pull request reviews were in place to ensure new acceptance testing matched the naming patterns
* EC2 VPC and EC2 Subnet DependencyViolations were constantly the worst offenders, but EC2 does not make it easy to discover what resources are causing the violation quickly

The solution to problems outlined above is to simply remove the naming-based prefixes from the sweepers. This ensures we do not miss any resources (that have a sweeper). When verifying the new sweepers, a few corner cases were discovered and fixed.

There are some notable exclusions from the sweeper updates:
* IAM Roles/Users: We still want to allow internal usage of the AWS accounts by certain roles/users
* S3 Buckets: There are still many AWS-owned and internal buckets that need to be reconciled first

It is important to note that the usage of the sweepers by non-HashiCorp provider developers has never been recommended or encouraged due to their inconsistently implemented destructive nature.

## Changes

* tests/provider: Remove naming-based prefixes from sweepers
* tests/provider: Configure sweeper AWS client with 5 MaxRetries (previously 0 and could fail with retryable errors like ThrottlingException in Elastic Beanstalk)
* tests/resource/aws_internet_gateway: Ensure default VPC internet gateway is not removed (default VPC with IGW is required by many acceptance tests)
* tests/resource/aws_network_acl: Ensure magic IPv6 deny rule is ignored during sweeping
* tests/resource/aws_route_table: Ensure main route table association is not attempted for sweeper removal
* tests/resource/aws_security_group: Use paginated function for sweeper
* tests/resource/aws_subnet: Allow up to 5 minutes for sweeper removal to handle lingering ENIs from LBs and Lambda
* tests/resource/aws_vpc: Ensure default VPC is not attempted for sweeper removal

Output from sweepers:

```
2019/02/08 16:22:00 Sweeper Tests ran:
	- aws_directory_service_directory
	- aws_glue_trigger
	- aws_lb
	- aws_vpc_endpoint
	- aws_kinesis_firehose_delivery_stream
	- aws_internet_gateway
	- aws_lightsail_static_ip
	- aws_nat_gateway
	- aws_security_group
	- aws_cognito_user_pool
	- aws_dynamodb_table
	- aws_lb_target_group
	- aws_iam_role
	- aws_s3_bucket
	- aws_eks_cluster
	- aws_network_acl
	- aws_vpn_gateway
	- aws_cloudwatch_event_rule
	- aws_ec2_transit_gateway
	- aws_glue_classifier
	- aws_wafregional_rule_group
	- aws_appmesh_mesh
	- aws_launch_configuration
	- aws_dx_gateway
	- aws_glue_job
	- aws_instance
	- aws_elb
	- aws_mq_broker
	- aws_db_option_group
	- aws_elasticache_cluster
	- aws_storagegateway_gateway
	- aws_appmesh_virtual_router
	- aws_db_instance
	- aws_ecs_cluster
	- aws_config_configuration_recorder
	- aws_beanstalk_environment
	- aws_subnet
	- aws_emr_cluster
	- aws_gamelift_alias
	- aws_api_gateway_rest_api
	- aws_waf_rule_group
	- aws_iam_user
	- aws_route_table
	- aws_wafregional_regex_match_set
	- aws_glue_crawler
	- aws_datasync_task
	- aws_config_configuration_aggregator
	- aws_s3_bucket_object
	- aws_elasticache_replication_group
	- aws_autoscaling_group
	- aws_redshift_cluster
	- aws_elasticsearch_domain
	- aws_glue_security_configuration
	- aws_vpc
	- aws_acmpca_certificate_authority
	- aws_lambda_layer
	- aws_datasync_agent
	- aws_gamelift_game_session_queue
	- aws_network_interface
	- aws_gamelift_build
	- aws_config_aggregate_authorization
	- aws_ec2_transit_gateway_vpc_attachment
	- aws_batch_compute_environment
	- aws_ebs_volume
	- aws_dax_cluster
	- aws_config_delivery_channel
	- aws_ec2_capacity_reservation
	- aws_datasync_location_nfs
	- aws_batch_job_queue
	- aws_waf_regex_match_set
	- aws_licensemanager_license_configuration
	- aws_cloudfront_distribution
	- aws_cloudwatch_event_permission
	- aws_kms_key
	- aws_dx_gateway_association
	- aws_secretsmanager_secret
	- aws_lambda_function
	- aws_beanstalk_application
	- aws_key_pair
	- aws_appmesh_route
	- aws_gamelift_fleet
	- aws_glue_connection
	- aws_iam_service_linked_role
	- aws_datasync_location_s3
	- aws_ecs_service
	- aws_spot_fleet_request
	- aws_datasync_location_efs
	- aws_sagemaker_model
	- aws_elasticache_security_group
	- aws_iam_server_certificate
```
