### PR TITLE
Issue #7466 Add security_group_id attribute to aws_directory_service_directory for ADConnector 

### DIFF
--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -453,8 +453,10 @@ func resourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta inter
 	d.Set("connect_settings", flattenDSConnectSettings(dir.DnsIpAddrs, dir.ConnectSettings))
 	d.Set("enable_sso", dir.SsoEnabled)
 
-	if dir.VpcSettings != nil {
-		d.Set("security_group_id", *dir.VpcSettings.SecurityGroupId)
+	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector {
+		d.Set("security_group_id", aws.StringValue(dir.ConnectSettings.SecurityGroupId))
+	} else {
+		d.Set("security_group_id", aws.StringValue(dir.VpcSettings.SecurityGroupId))
 	}
 
 	tagList, err := dsconn.ListTagsForResource(&directoryservice.ListTagsForResourceInput{

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -230,6 +230,7 @@ func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
 				Config: testAccDirectoryServiceDirectoryConfig_connector,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.connector"),
+					resource.TestCheckResourceAttrSet("aws_directory_service_directory.connector", "security_group_id"),
 				),
 			},
 		},

--- a/website/docs/r/directory_service_directory.html.markdown
+++ b/website/docs/r/directory_service_directory.html.markdown
@@ -156,7 +156,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The directory identifier.
 * `access_url` - The access URL for the directory, such as `http://alias.awsapps.com`.
 * `dns_ip_addresses` - A list of IP addresses of the DNS servers for the directory or connector.
-* `security_group_id` - The ID of the security group created by the directory (`SimpleAD` or `MicrosoftAD` only).
+* `security_group_id` - The ID of the security group created by the directory.
 
 
 ## Import


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7466 

Changes proposed in this pull request:

* Change 1
Add security_group_id attribute to aws_directory_service_directory for ADConnector 

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_connector'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSDirectoryServiceDirectory_connector -timeout 120m
=== RUN   TestAccAWSDirectoryServiceDirectory_connector
=== PAUSE TestAccAWSDirectoryServiceDirectory_connector
=== CONT  TestAccAWSDirectoryServiceDirectory_connector
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (1116.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws
...
```
