### PR TITLE
issue #7417 aws_ec2_transit_gateway_vpc_attachment error when auto_ac…

### DIFF
--- a/aws/ec2_transit_gateway.go
+++ b/aws/ec2_transit_gateway.go
@@ -544,7 +544,10 @@ func waitForEc2TransitGatewayRouteTableAssociationDeletion(conn *ec2.EC2, transi
 func waitForEc2TransitGatewayRouteTableAttachmentCreation(conn *ec2.EC2, transitGatewayAttachmentID string) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ec2.TransitGatewayAttachmentStatePending},
-		Target:  []string{ec2.TransitGatewayAttachmentStateAvailable},
+		Target: []string{
+			ec2.TransitGatewayAttachmentStatePendingAcceptance,
+			ec2.TransitGatewayAttachmentStateAvailable,
+		},
 		Refresh: ec2TransitGatewayVpcAttachmentRefreshFunc(conn, transitGatewayAttachmentID),
 		Timeout: 10 * time.Minute,
 	}


### PR DESCRIPTION
…cept_shared_attachments is disabled

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7417 

Changes proposed in this pull request:

* Change 1
Included the `pendingAcceptance` as one of the `Target` value for resource creation.