### PR TITLE
Issue #7351: aws_ssm_resource_data_sync - doesn't support update

### DIFF
--- a/aws/resource_aws_ssm_resource_data_sync.go
+++ b/aws/resource_aws_ssm_resource_data_sync.go
@@ -35,23 +35,28 @@ func resourceAwsSsmResourceDataSync() *schema.Resource {
 						"kms_key_arn": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"bucket_name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"prefix": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"region": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"sync_format": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  ssm.ResourceDataSyncS3FormatJsonSerDe,
+							ForceNew: true,
 						},
 					},
 				},

--- a/aws/resource_aws_ssm_resource_data_sync_test.go
+++ b/aws/resource_aws_ssm_resource_data_sync_test.go
@@ -26,6 +26,29 @@ func TestAccAWSSsmResourceDataSync_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSsmResourceDataSync_update(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSsmResourceDataSyncDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSsmResourceDataSyncConfig(acctest.RandInt(), rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSsmResourceDataSyncExists("aws_ssm_resource_data_sync.foo"),
+				),
+			},
+			{
+				Config: testAccSsmResourceDataSyncConfigUpdate(acctest.RandInt(), rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSsmResourceDataSyncExists("aws_ssm_resource_data_sync.foo"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSsmResourceDataSync_import(t *testing.T) {
 	resourceName := "aws_ssm_resource_data_sync.foo"
 
@@ -123,6 +146,59 @@ func testAccSsmResourceDataSyncConfig(rInt int, rName string) string {
       s3_destination {
         bucket_name = "${aws_s3_bucket.hoge.bucket}"
         region = "${aws_s3_bucket.hoge.region}"
+      }
+    }
+    `, rInt, rInt, rInt, rName)
+}
+
+func testAccSsmResourceDataSyncConfigUpdate(rInt int, rName string) string {
+	return fmt.Sprintf(`
+    resource "aws_s3_bucket" "hoge" {
+      bucket = "tf-test-bucket-%d"
+      region = "us-west-2"
+      force_destroy = true
+    }
+
+    resource "aws_s3_bucket_policy" "hoge" {
+      bucket = "${aws_s3_bucket.hoge.bucket}"
+      policy = <<EOF
+{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "SSMBucketPermissionsCheck",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ssm.amazonaws.com"
+                },
+                "Action": "s3:GetBucketAcl",
+                "Resource": "arn:aws:s3:::tf-test-bucket-%d"
+            },
+            {
+                "Sid": " SSMBucketDelivery",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "ssm.amazonaws.com"
+                },
+                "Action": "s3:PutObject",
+                "Resource": ["arn:aws:s3:::tf-test-bucket-%d/*"],
+                "Condition": {
+                    "StringEquals": {
+                        "s3:x-amz-acl": "bucket-owner-full-control"
+                    }
+                }
+            }
+          ]
+      }
+      EOF
+    }
+
+    resource "aws_ssm_resource_data_sync" "foo" {
+      name = "tf-test-ssm-%s"
+      s3_destination {
+        bucket_name = "${aws_s3_bucket.hoge.bucket}"
+        region = "${aws_s3_bucket.hoge.region}"
+        prefix = "test-"
       }
     }
     `, rInt, rInt, rInt, rName)


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7351 

Changes proposed in this pull request:

* Change 1
updated  resource schema to recreate the resource

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSsmResourceDataSync_update'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSSsmResourceDataSync_update -timeout 120m
=== RUN   TestAccAWSSsmResourceDataSync_update
=== PAUSE TestAccAWSSsmResourceDataSync_update
=== CONT  TestAccAWSSsmResourceDataSync_update
--- PASS: TestAccAWSSsmResourceDataSync_update (161.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	161.274s
...
```
