### PR TITLE
r/aws_ec2_client_vpn_endpoint_network_association: Adding option to apply additional security groups to target network

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_network_association.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association.go
@@ -31,7 +31,7 @@ func resourceAwsEc2ClientVpnNetworkAssociation() *schema.Resource {
 			"security_groups": {
 				Type:     schema.TypeSet,
 				MaxItems: 5,
-				Required: true,
+				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,

--- a/aws/resource_aws_ec2_client_vpn_network_association_test.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association_test.go
@@ -224,73 +224,73 @@ resource "aws_ec2_client_vpn_network_association" "test" {
 func testAccEc2ClientVpnNetworkAssociationSecurityGroups(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-subnet-%s"
-	}
+  cidr_block = "10.1.0.0/16"
+  tags = {
+    Name = "terraform-testacc-subnet-%s"
+  }
 }
 
 resource "aws_subnet" "test" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.test.id}"
-	map_public_ip_on_launch = true
-	tags = {
-		Name = "tf-acc-subnet-%s"
-	}
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.test.id}"
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "tf-acc-subnet-%s"
+  }
 }
 
 resource "aws_security_group" "test1" {
-	name = "terraform_acceptance_test_example_1"
-	description = "Used in the terraform acceptance tests"
-	vpc_id = "${aws_vpc.test.id}"
+  name = "terraform_acceptance_test_example_1"
+  description = "Used in the terraform acceptance tests"
+  vpc_id = "${aws_vpc.test.id}"
 
-	ingress {
-		protocol = "tcp"
-		from_port = 22
-		to_port = 22
-		cidr_blocks = ["10.1.1.0/24"]
-	}
+  ingress {
+    protocol = "tcp"
+	from_port = 22
+	to_port = 22
+	cidr_blocks = ["10.1.1.0/24"]
+  }
 
-	ingress {
-		protocol = "tcp"
-		from_port = 80
-		to_port = 80
-		cidr_blocks = ["10.1.1.0/24"]
-	}
+  ingress {
+    protocol = "tcp"
+    from_port = 80
+    to_port = 80
+    cidr_blocks = ["10.1.1.0/24"]
+  }
 
-	egress {
-		protocol = "-1"
-		from_port = 0
-		to_port = 0
-		cidr_blocks = ["10.1.0.0/16"]
-	}
+  egress {
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
+    cidr_blocks = ["10.1.0.0/16"]
+  }
 }
 
 resource "aws_security_group" "test2" {
-	name = "terraform_acceptance_test_example_2"
-	description = "Used in the terraform acceptance tests"
-	vpc_id = "${aws_vpc.test.id}"
+  name = "terraform_acceptance_test_example_2"
+  description = "Used in the terraform acceptance tests"
+  vpc_id = "${aws_vpc.test.id}"
 
-	ingress {
-		protocol = "tcp"
-		from_port = 22
-		to_port = 22
-		cidr_blocks = ["10.1.2.0/24"]
-	}
+  ingress {
+    protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    cidr_blocks = ["10.1.2.0/24"]
+  }
 
-	ingress {
-		protocol = "tcp"
-		from_port = 80
-		to_port = 80
-		cidr_blocks = ["10.1.2.0/24"]
-	}
+  ingress {
+    protocol = "tcp"
+    from_port = 80
+    to_port = 80
+    cidr_blocks = ["10.1.2.0/24"]
+  }
 
-	egress {
-		protocol = "-1"
-		from_port = 0
-		to_port = 0
-		cidr_blocks = ["10.1.0.0/16"]
-	}
+  egress {
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
+    cidr_blocks = ["10.1.0.0/16"]
+  }
 }
 
 resource "tls_private_key" "example" {

--- a/aws/resource_aws_ec2_client_vpn_network_association_test.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association_test.go
@@ -62,10 +62,17 @@ func TestAccAwsEc2ClientVpnNetworkAssociation_securityGroups(t *testing.T) {
 		CheckDestroy: testAccCheckAwsEc2ClientVpnNetworkAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEc2ClientVpnNetworkAssociationSecurityGroups(rStr),
+				Config: testAccEc2ClientVpnNetworkAssociationTwoSecurityGroups(rStr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsEc2ClientVpnNetworkAssociationExists("aws_ec2_client_vpn_network_association.test", &assoc1),
 					resource.TestCheckResourceAttr("aws_ec2_client_vpn_network_association.test", "security_groups.#", "2"),
+				),
+			},
+			{
+				Config: testAccEc2ClientVpnNetworkAssociationOneSecurityGroup(rStr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsEc2ClientVpnNetworkAssociationExists("aws_ec2_client_vpn_network_association.test", &assoc1),
+					resource.TestCheckResourceAttr("aws_ec2_client_vpn_network_association.test", "security_groups.#", "1"),
 				),
 			},
 		},
@@ -216,12 +223,13 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 
 resource "aws_ec2_client_vpn_network_association" "test" {
   client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.test.id}"
-  subnet_id = "${aws_subnet.test.id}"
+	subnet_id              = "${aws_subnet.test.id}"
+	security_groups        = [""]
 }
 `, rName, rName, rName)
 }
 
-func testAccEc2ClientVpnNetworkAssociationSecurityGroups(rName string) string {
+func testAccEc2ClientVpnNetworkAssociationTwoSecurityGroups(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -339,6 +347,128 @@ resource "aws_ec2_client_vpn_network_association" "test" {
   client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.test.id}"
   subnet_id              = "${aws_subnet.test.id}"
   security_groups        = ["${aws_security_group.test1.id}", "${aws_security_group.test2.id}"]
+}
+`, rName, rName, rName)
+}
+
+func testAccEc2ClientVpnNetworkAssociationOneSecurityGroup(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+  tags = {
+    Name = "terraform-testacc-subnet-%s"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block              = "10.1.1.0/24"
+  vpc_id                  = "${aws_vpc.test.id}"
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "tf-acc-subnet-%s"
+  }
+}
+
+resource "aws_security_group" "test1" {
+  name        = "terraform_acceptance_test_example_1"
+  description = "Used in the terraform acceptance tests"
+  vpc_id      = "${aws_vpc.test.id}"
+
+  ingress {
+		protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    cidr_blocks = ["10.1.1.0/24"]
+  }
+
+  ingress {
+    protocol = "tcp"
+    from_port = 80
+    to_port = 80
+    cidr_blocks = ["10.1.1.0/24"]
+  }
+
+  egress {
+    protocol = "-1"
+    from_port = 0
+    to_port = 0
+    cidr_blocks = ["10.1.0.0/16"]
+  }
+}
+
+resource "aws_security_group" "test2" {
+  name        = "terraform_acceptance_test_example_2"
+  description = "Used in the terraform acceptance tests"
+  vpc_id      = "${aws_vpc.test.id}"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
+    cidr_blocks = ["10.1.2.0/24"]
+  }
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["10.1.2.0/24"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["10.1.0.0/16"]
+  }
+}
+
+resource "tls_private_key" "example" {
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "example" {
+  key_algorithm   = "RSA"
+  private_key_pem = "${tls_private_key.example.private_key_pem}"
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+
+  validity_period_hours = 12
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_acm_certificate" "cert" {
+  private_key      = "${tls_private_key.example.private_key_pem}"
+  certificate_body = "${tls_self_signed_cert.example.cert_pem}"
+}
+
+resource "aws_ec2_client_vpn_endpoint" "test" {
+  description            = "terraform-testacc-clientvpn-%s"
+  server_certificate_arn = "${aws_acm_certificate.cert.arn}"
+  client_cidr_block      = "10.0.0.0/16"
+
+  authentication_options {
+    type                       = "certificate-authentication"
+    root_certificate_chain_arn = "${aws_acm_certificate.cert.arn}"
+  }
+
+  connection_log_options {
+    enabled = false
+  }
+}
+
+resource "aws_ec2_client_vpn_network_association" "test" {
+  client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.test.id}"
+  subnet_id              = "${aws_subnet.test.id}"
+  security_groups        = ["${aws_security_group.test1.id}"]
 }
 `, rName, rName, rName)
 }

--- a/aws/resource_aws_ec2_client_vpn_network_association_test.go
+++ b/aws/resource_aws_ec2_client_vpn_network_association_test.go
@@ -231,8 +231,8 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.1.1.0/24"
-  vpc_id = "${aws_vpc.test.id}"
+  cidr_block              = "10.1.1.0/24"
+  vpc_id                  = "${aws_vpc.test.id}"
   map_public_ip_on_launch = true
   tags = {
     Name = "tf-acc-subnet-%s"
@@ -240,15 +240,15 @@ resource "aws_subnet" "test" {
 }
 
 resource "aws_security_group" "test1" {
-  name = "terraform_acceptance_test_example_1"
+  name        = "terraform_acceptance_test_example_1"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id      = "${aws_vpc.test.id}"
 
   ingress {
-    protocol = "tcp"
-	from_port = 22
-	to_port = 22
-	cidr_blocks = ["10.1.1.0/24"]
+		protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    cidr_blocks = ["10.1.1.0/24"]
   }
 
   ingress {
@@ -267,28 +267,28 @@ resource "aws_security_group" "test1" {
 }
 
 resource "aws_security_group" "test2" {
-  name = "terraform_acceptance_test_example_2"
+  name        = "terraform_acceptance_test_example_2"
   description = "Used in the terraform acceptance tests"
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id      = "${aws_vpc.test.id}"
 
   ingress {
-    protocol = "tcp"
-    from_port = 22
-    to_port = 22
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
     cidr_blocks = ["10.1.2.0/24"]
   }
 
   ingress {
-    protocol = "tcp"
-    from_port = 80
-    to_port = 80
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
     cidr_blocks = ["10.1.2.0/24"]
   }
 
   egress {
-    protocol = "-1"
-    from_port = 0
-    to_port = 0
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
     cidr_blocks = ["10.1.0.0/16"]
   }
 }
@@ -321,12 +321,12 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_ec2_client_vpn_endpoint" "test" {
-  description = "terraform-testacc-clientvpn-%s"
+  description            = "terraform-testacc-clientvpn-%s"
   server_certificate_arn = "${aws_acm_certificate.cert.arn}"
-  client_cidr_block = "10.0.0.0/16"
+  client_cidr_block      = "10.0.0.0/16"
 
   authentication_options {
-    type = "certificate-authentication"
+    type                       = "certificate-authentication"
     root_certificate_chain_arn = "${aws_acm_certificate.cert.arn}"
   }
 
@@ -337,9 +337,8 @@ resource "aws_ec2_client_vpn_endpoint" "test" {
 
 resource "aws_ec2_client_vpn_network_association" "test" {
   client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.test.id}"
-  subnet_id 			 = "${aws_subnet.test.id}"
-  security_groups 		 = ["${aws_security_group.test1.id}", "${aws_security_group.test2.id}"]
-  vpc_id 				 = "${aws_vpc.test.id}"
+  subnet_id              = "${aws_subnet.test.id}"
+  security_groups        = ["${aws_security_group.test1.id}", "${aws_security_group.test2.id}"]
 }
 `, rName, rName, rName)
 }

--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -27,8 +27,7 @@ The following arguments are supported:
 
 * `client_vpn_endpoint_id` - (Required) The ID of the Client VPN endpoint.
 * `subnet_id` - (Required) The ID of the subnet to associate with the Client VPN endpoint.
-* `security_groups` - (Optional) A list of up to five security groups to apply to the target network.
-* `vpc_id` - (Optional) The ID of the VPC in which the target network is locatated.  This is a required argument for assigning security groups to a network association.
+* `security_groups` - (Optional) A list of up to five custom security groups to apply to the target network. Not populating this parameter will result in the subnet inheriting the default VPC security group.
 
 ## Attributes Reference
 

--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -15,8 +15,9 @@ Provides network associations for AWS Client VPN endpoints. For more information
 
 ```hcl
 resource "aws_ec2_client_vpn_network_association" "example" {
-  client_vpn_endpoint_id = "${aws_ec2_client_vpn_endpoint.example.id}"
-  subnet_id = "${aws_subnet.example.id}"
+  client_vpn_endpoint_id  = "${aws_ec2_client_vpn_endpoint.example.id}"
+  subnet_id               = "${aws_subnet.example.id}"
+
 }
 ```
 
@@ -26,6 +27,8 @@ The following arguments are supported:
 
 * `client_vpn_endpoint_id` - (Required) The ID of the Client VPN endpoint.
 * `subnet_id` - (Required) The ID of the subnet to associate with the Client VPN endpoint.
+* `security_groups` - (Optional) A list of up to five security groups to apply to the target network.
+* `vpc_id` - (Optional) The ID of the VPC in which the target network is locatated.  This is a required argument for assigning security groups to a network association.
 
 ## Attributes Reference
 
@@ -33,5 +36,5 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID of the target network association.
 * `security_groups` - The IDs of the security groups applied to the target network association.
+* `vpc_id` - The ID of the VPC in which the target network (subnet) is located.
 * `status` - The current state of the target network association.
-* `vpc_id` - The ID of the VPC in which the target network (subnet) is located. 

--- a/website/docs/r/ec2_client_vpn_network_association.html.markdown
+++ b/website/docs/r/ec2_client_vpn_network_association.html.markdown
@@ -11,13 +11,23 @@ description: |-
 Provides network associations for AWS Client VPN endpoints. For more information on usage, please see the 
 [AWS Client VPN Administrator's Guide](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is.html).
 
-## Example Usage
+## Example Usage (w/ default VPC security group)
 
 ```hcl
 resource "aws_ec2_client_vpn_network_association" "example" {
   client_vpn_endpoint_id  = "${aws_ec2_client_vpn_endpoint.example.id}"
   subnet_id               = "${aws_subnet.example.id}"
+  security_groups         = [""]
+}
+```
 
+## Example Usage (w/ custom security groups)
+
+```hcl
+resource "aws_ec2_client_vpn_network_association" "example" {
+  client_vpn_endpoint_id  = "${aws_ec2_client_vpn_endpoint.example.id}"
+  subnet_id               = "${aws_subnet.example.id}"
+  security_groups         = ["${aws_security_group.example1.id}", "${aws_security_group.example2.id}"]
 }
 ```
 
@@ -27,7 +37,7 @@ The following arguments are supported:
 
 * `client_vpn_endpoint_id` - (Required) The ID of the Client VPN endpoint.
 * `subnet_id` - (Required) The ID of the subnet to associate with the Client VPN endpoint.
-* `security_groups` - (Optional) A list of up to five custom security groups to apply to the target network. Not populating this parameter will result in the subnet inheriting the default VPC security group.
+* `security_groups` - (Required) A list of up to five custom security groups to apply to the target network. Not populating this parameter will result in the subnet inheriting the default VPC security group.  Regardless of what you choose,  you must define this parameter due to the AWS API automatically assigning the default VPC security group if no other groups are included in the call.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #7495

Changes proposed in this pull request:

* Making `vpc_id` and `security_groups` actual parameters so we can use those values to add additional security groups to a target network.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsEc2ClientVpnNetworkAssociation_securityGroups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsEc2ClientVpnNetworkAssociation_securityGroups -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsEc2ClientVpnNetworkAssociation_securityGroups
=== PAUSE TestAccAwsEc2ClientVpnNetworkAssociation_securityGroups
=== CONT  TestAccAwsEc2ClientVpnNetworkAssociation_securityGroups
--- PASS: TestAccAwsEc2ClientVpnNetworkAssociation_securityGroups (455.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	455.527s
```
