### PR TITLE
tests/resource/aws_ecr_repository: Manually construct repository_url value in testAccCheckAWSEcrRepositoryRepositoryURL

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -5,14 +5,11 @@ import (
 	"log"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
-
-	"github.com/aws/aws-sdk-go/service/organizations"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-
+	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -193,14 +190,6 @@ func testAccGetPartition() string {
 		return partition.ID()
 	}
 	return "aws"
-}
-
-func testAccGetServiceEndpoint(service string) string {
-	endpoint, err := endpoints.DefaultResolver().EndpointFor(service, testAccGetRegion())
-	if err != nil {
-		return ""
-	}
-	return strings.TrimPrefix(endpoint.URL, "https://")
 }
 
 func testAccEC2ClassicPreCheck(t *testing.T) {

--- a/aws/resource_aws_ecr_repository_test.go
+++ b/aws/resource_aws_ecr_repository_test.go
@@ -122,7 +122,7 @@ func testAccCheckAWSEcrRepositoryRegistryID(resourceName string) resource.TestCh
 
 func testAccCheckAWSEcrRepositoryRepositoryURL(resourceName, repositoryName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		attributeValue := fmt.Sprintf("%s.dkr.%s/%s", testAccGetAccountID(), testAccGetServiceEndpoint("ecr"), repositoryName)
+		attributeValue := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", testAccGetAccountID(), testAccGetRegion(), repositoryName)
 		return resource.TestCheckResourceAttr(resourceName, "repository_url", attributeValue)(s)
 	}
 }


### PR DESCRIPTION
Reference: https://github.com/aws/aws-sdk-go/issues/2441

The "ecr" endpoint service name was removed in the default endpoint resolvers of the AWS Go SDK in preference of "api.ecr" for PrivateLink support. Instead of updating this small test function to perform additional string manipulation of the endpoint result from the AWS Go SDK, this simply constructs the repository_url value with the region name and AWS Standard/GovCloud domain.

Previous output from acceptance testing (since AWS Go SDK v1.16.26):

```
--- FAIL: TestAccAWSEcrRepository_basic (2.62s)
    testing.go:568: Step 0 error: Check failed: Check 5/5 error: aws_ecr_repository.default: Attribute 'repository_url' expected "*******.dkr./tf-acc-test-1198045183293346913", got "*******.dkr.ecr.us-west-2.amazonaws.com/tf-acc-test-1198045183293346913"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSEcrRepository_basic (12.22s)
```
