### PR TITLE
Catch AccessDenied permission errors when creating aws_iam_user_login…

### DIFF
--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -126,6 +126,10 @@ func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface
 		UserName: aws.String(username),
 	})
 	if err != nil {
+		// Catch AccessDenid errors (e.g. because we have no iam:GetLoginProfile permissions)
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AccessDenied" {
+			return err
+		}
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() != "NoSuchEntity" {
 			// If there is already a login profile, bring it under management (to prevent
 			// resource creation diffs) - we will never modify it, but obviously cannot

--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -122,23 +122,24 @@ func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface
 	passwordResetRequired := d.Get("password_reset_required").(bool)
 	passwordLength := d.Get("password_length").(int)
 
+	// DEPRECATED: Automatic import will be removed in a future major version update
+	// https://github.com/terraform-providers/terraform-provider-aws/issues/7536
 	_, err = iamconn.GetLoginProfile(&iam.GetLoginProfileInput{
 		UserName: aws.String(username),
 	})
-	if err != nil {
-		// Catch AccessDenid errors (e.g. because we have no iam:GetLoginProfile permissions)
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "AccessDenied" {
-			return err
-		}
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() != "NoSuchEntity" {
-			// If there is already a login profile, bring it under management (to prevent
-			// resource creation diffs) - we will never modify it, but obviously cannot
-			// set the password.
-			d.SetId(username)
-			d.Set("key_fingerprint", "")
-			d.Set("encrypted_password", "")
-			return nil
-		}
+
+	// If there is already a login profile, bring it under management (to prevent
+	// resource creation diffs) - we will never modify it, but obviously cannot
+	// set the password.
+	if err == nil {
+		d.SetId(username)
+		d.Set("key_fingerprint", "")
+		d.Set("encrypted_password", "")
+		return nil
+	}
+
+	if !isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		return fmt.Errorf("Error checking for existing IAM User Login Profile: %s", err)
 	}
 
 	initialPassword := generateIAMPassword(passwordLength)


### PR DESCRIPTION
…_profile resources.

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7518

Changes proposed in this pull request:

* AccessDenied errors are no longer silently ignored

I dont understand the rationale of the "error != NoSuchEntity" part below my changes.
My fix merely catches the AccessDenied error issue.

If someone knows why the error handling is written as-is, please explain.