### PR TITLE
Fix crash on unsuccessful flow log creation

### DIFF
--- a/aws/resource_aws_flow_log.go
+++ b/aws/resource_aws_flow_log.go
@@ -142,6 +142,10 @@ func resourceAwsLogFlowCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating Flow Log for (%s), error: %s", resourceId, err)
 	}
 
+	if len(resp.Unsuccessful) > 0 {
+		return fmt.Errorf("Error creating Flow Log for (%s), error: %s", resourceId, *resp.Unsuccessful[0].Error.Message)
+	}
+
 	if len(resp.FlowLogIds) > 1 {
 		return fmt.Errorf("Error: multiple Flow Logs created for (%s)", resourceId)
 	}


### PR DESCRIPTION
Changes proposed in this pull request:

* Error instead of crashing when the flow log's destination S3 bucket is not accessible.

Crash reproducer:
```
resource "aws_vpc" "main" {
  cidr_block = "10.17.29.0/24"
}

resource "aws_flow_log" "main" {
  log_destination_type = "s3"
  log_destination      = "arn:aws:s3:::does-not-exist"
  vpc_id               = "${aws_vpc.main.id}"
  traffic_type         = "ALL"
}
```

Actual output:
```
panic: runtime error: index out of range
[... crash text ...]
````
due to https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_flow_log.go#L149 referencing the 0th element of the empty list `resp.FlowLogIds`

Output with PR:
```
Error: Error applying plan:

1 error(s) occurred:

* aws_flow_log.main: 1 error(s) occurred:

* aws_flow_log.main: Error creating Flow Log for (vpc-X), error: Access Denied for LogDestination: does-not-exist. Please check LogDestination permission
```