### PR TITLE
Add logs_config schema to aws_codebuild_project

### DIFF
--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -94,6 +94,8 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "environment.2300252877.privileged_mode", "false"),
 					resource.TestCheckResourceAttr(resourceName, "environment.2300252877.type", "LINUX_CONTAINER"),
 					resource.TestCheckResourceAttr(resourceName, "environment.2300252877.image_pull_credentials_type", "CODEBUILD"),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", "DISABLED"),
 					resource.TestMatchResourceAttr(resourceName, "service_role", regexp.MustCompile(`^arn:[^:]+:iam::[^:]+:role/tf-acc-test-[0-9]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "source.1441597390.auth.#", "0"),
@@ -381,7 +383,51 @@ func TestAccAWSCodeBuildProject_Environment_Certificate(t *testing.T) {
 	})
 }
 
-func TestAccAWSCodeBuildProject_LogsConfig(t *testing.T) {
+func TestAccAWSCodeBuildProject_LogsConfig_CloudWatchLogs(t *testing.T) {
+	var project codebuild.Project
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_codebuild_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_LogsConfig_CloudWatchLogs(rName, "ENABLED", "group-name", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.group_name", "group-name"),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.stream_name", ""),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_LogsConfig_CloudWatchLogs(rName, "ENABLED", "group-name", "stream-name"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.group_name", "group-name"),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.stream_name", "stream-name"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_LogsConfig_CloudWatchLogs(rName, "DISABLED", "", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", "DISABLED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildProject_LogsConfig_S3Logs(t *testing.T) {
 	var project codebuild.Project
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	bName := acctest.RandomWithPrefix("tf-acc-test-bucket")
@@ -393,15 +439,34 @@ func TestAccAWSCodeBuildProject_LogsConfig(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCodeBuildProjectConfig_LogsConfig(rName, bName),
+				Config: testAccAWSCodeBuildProjectConfig_LogsConfig_S3Logs(rName, bName, "ENABLED", bName+"/build-log", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
-					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.status", "ENABLED"),
-					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.group_name", "build-log"),
-					resource.TestCheckResourceAttr(resourceName, "logs_config.0.cloudwatch_logs.0.stream_name", "build-log"),
 					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", "ENABLED"),
 					resource.TestMatchResourceAttr(resourceName, "logs_config.0.s3_logs.0.location", regexp.MustCompile(`tf-acc-test-bucket-[0-9]+/build-log$`)),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.encryption_disabled", "false"),
 				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_LogsConfig_S3Logs(rName, bName, "ENABLED", bName+"/build-log", true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", "ENABLED"),
+					resource.TestMatchResourceAttr(resourceName, "logs_config.0.s3_logs.0.location", regexp.MustCompile(`tf-acc-test-bucket-[0-9]+/build-log$`)),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.encryption_disabled", "true"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_LogsConfig_S3Logs(rName, bName, "DISABLED", "", false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "logs_config.0.s3_logs.0.status", "DISABLED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1536,7 +1601,39 @@ resource "aws_secretsmanager_secret_version" "test" {
 `, rName)
 }
 
-func testAccAWSCodeBuildProjectConfig_LogsConfig(rName, bName string) string {
+func testAccAWSCodeBuildProjectConfig_LogsConfig_CloudWatchLogs(rName, status, gName, sName string) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = "%s"
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    location = "https://github.com/hashicorp/packer.git"
+	type     = "GITHUB"
+  }
+  
+  logs_config {
+    cloudwatch_logs {
+	  status = %q
+	  group_name  = %q
+	  stream_name = %q
+    }
+  }
+}
+`, rName, status, gName, sName)
+}
+
+func testAccAWSCodeBuildProjectConfig_LogsConfig_S3Logs(rName, bName, status, location string, encryptionDisabled bool) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + testAccAWSCodeBuildProjectConfig_Base_Bucket(bName) + fmt.Sprintf(`
 resource "aws_codebuild_project" "test" {
   name         = "%s"
@@ -1554,22 +1651,18 @@ resource "aws_codebuild_project" "test" {
 
   source {
     location = "https://github.com/hashicorp/packer.git"
-    type     = "GITHUB"
+	type     = "GITHUB"
   }
   
   logs_config {
-    cloudwatch_logs {
-      status = "ENABLED"
-      group_name = "build-log"
-      stream_name = "build-log"
-    }
     s3_logs {
-      status = "ENABLED"
-      location = "${aws_s3_bucket.test.arn}/build-log"
+	  status   = %q
+	  location = %q
+	  encryption_disabled = %t
     }
   }
 }
-`, rName)
+`, rName, status, location, encryptionDisabled)
 }
 
 func testAccAWSCodeBuildProjectConfig_Source_Auth(rName, authResource, authType string) string {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -118,14 +118,13 @@ resource "aws_codebuild_project" "example" {
 
   logs_config {
     cloudwatch_logs {
-      status = "ENABLED"
       group_name = "log-group"
       stream_name = "log-stream"
     }
 
     s3_logs {
       status = "ENABLED"
-      location = "${aws_s3_bucket.example.arn}/build-log"
+      location = "${aws_s3_bucket.example.id}/build-log"
     }
   }
 
@@ -253,14 +252,15 @@ The following arguments are supported:
 
 `cloudwatch_logs` supports the following:
 
-* `status` - (Required) Current status of logs in CloudWatch Logs for a build project. Valid values: `ENABLED`, `DISABLED`.
+* `status` - (Optional) Current status of logs in CloudWatch Logs for a build project. Valid values: `ENABLED`, `DISABLED`. Defaults to `ENABLED`.
 * `group_name` - (Optional) The group name of the logs in CloudWatch Logs.
 * `stream_name` - (Optional) The stream name of the logs in CloudWatch Logs.
 
 `s3_logs` supports the following:
 
-* `status` - (Required) Current status of logs in S3 for a build project. Valid values: `ENABLED`, `DISABLED`.
-* `location` - (Optional) The ARN of the S3 bucket and the path prefix for S3 logs.
+* `status` - (Optional) Current status of logs in S3 for a build project. Valid values: `ENABLED`, `DISABLED`. Defaults to `DISABLED`.
+* `location` - (Optional) The name of the S3 bucket and the path prefix for S3 logs. Must be set if status is `ENABLED`, otherwise it must be empty.
+* `encryption_disabled` - (Optional) Set to `true` if you do not want S3 logs encrypted. Defaults to `false`.
 
 `source` supports the following:
 

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -116,6 +116,19 @@ resource "aws_codebuild_project" "example" {
     }
   }
 
+  logs_config {
+    cloudwatch_logs {
+      status = "ENABLED"
+      group_name = "log-group"
+      stream_name = "log-stream"
+    }
+
+    s3_logs {
+      status = "ENABLED"
+      location = "${aws_s3_bucket.example.arn}/build-log"
+    }
+  }
+
   source {
     type            = "GITHUB"
     location        = "https://github.com/mitchellh/packer.git"
@@ -193,6 +206,7 @@ The following arguments are supported:
 * `cache` - (Optional) Information about the cache storage for the project. Cache blocks are documented below.
 * `description` - (Optional) A short description of the project.
 * `encryption_key` - (Optional) The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.
+* `logs_config` - (Optional) Configuration for the builds to store log data to CloudWatch or S3.
 * `service_role` - (Required) The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `vpc_config` - (Optional) Configuration for the builds to run inside a VPC. VPC config blocks are documented below.
@@ -231,6 +245,22 @@ The following arguments are supported:
 * `name` - (Required) The environment variable's name or key.
 * `value` - (Required) The environment variable's value.
 * `type` - (Optional) The type of environment variable. Valid values: `PARAMETER_STORE`, `PLAINTEXT`.
+
+`logs_config` supports the following:
+
+* `cloudwatch_logs` - (Optional) Configuration for the builds to store logs to CloudWatch
+* `s3_logs` - (Optional) Configuration for the builds to store logs to S3.
+
+`cloudwatch_logs` supports the following:
+
+* `status` - (Required) Current status of logs in CloudWatch Logs for a build project. Valid values: `ENABLED`, `DISABLED`.
+* `group_name` - (Optional) The group name of the logs in CloudWatch Logs.
+* `stream_name` - (Optional) The stream name of the logs in CloudWatch Logs.
+
+`s3_logs` supports the following:
+
+* `status` - (Required) Current status of logs in S3 for a build project. Valid values: `ENABLED`, `DISABLED`.
+* `location` - (Optional) The ARN of the S3 bucket and the path prefix for S3 logs.
 
 `source` supports the following:
 


### PR DESCRIPTION
Fixes #6312

Changes proposed in this pull request:

* Adds `logs_config` parameter block to `aws_codebuild_project`.

Example:

```hcl
resource "aws_codebuild_project" "test" {
...
  logs_config {
    cloudwatch_logs {
      status = "ENABLED|DISABLED"
      group_name = "..."
      stream_name = "..."
    }
    s3_logs {
      status = "ENABLED|DISABLED"
      location = "..." # ARN of an S3 bucket and the path prefix for S3 logs
    }
  }
...
}
```

Output from acceptance testing:

```sh
make testacc TESTARGS='-run TestAccAWSCodeBuildProject_LogsConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run TestAccAWSCodeBuildProject_LogsConfig -timeout 120m
?   	github.com/srhaber/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCodeBuildProject_LogsConfig
=== PAUSE TestAccAWSCodeBuildProject_LogsConfig
=== CONT  TestAccAWSCodeBuildProject_LogsConfig
--- PASS: TestAccAWSCodeBuildProject_LogsConfig (24.99s)
PASS
ok  	github.com/srhaber/terraform-provider-aws/aws	  26.301s
```
