### PR TITLE
r/kinesis_analytics_application: support multiple outputs

### DIFF
--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -261,6 +261,29 @@ func TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream(t *testing.T) {
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_outputsMultiple(t *testing.T) {
+	var application kinesisanalytics.ApplicationDetail
+	resName := "aws_kinesis_analytics_application.test"
+	rInt1 := acctest.RandInt()
+	rInt2 := acctest.RandInt()
+	step := testAccKinesisAnalyticsApplication_prereq(rInt1) + testAccKinesisAnalyticsApplication_outputsMultiple(rInt1, rInt2)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: step,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
+					resource.TestCheckResourceAttr(resName, "outputs.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisAnalyticsApplication_outputsAdd(t *testing.T) {
 	var before, after kinesisanalytics.ApplicationDetail
 	resName := "aws_kinesis_analytics_application.test"
@@ -648,6 +671,47 @@ resource "aws_kinesis_analytics_application" "test" {
   }
 }
 `, rInt, rInt)
+}
+
+func testAccKinesisAnalyticsApplication_outputsMultiple(rInt1, rInt2 int) string {
+	return fmt.Sprintf(`
+resource "aws_kinesis_stream" "test1" {
+  name = "testAcc-%d"
+  shard_count = 1
+}
+
+resource "aws_kinesis_stream" "test2" {
+  name = "testAcc-%d"
+  shard_count = 1
+}
+
+resource "aws_kinesis_analytics_application" "test" {
+  name = "testAcc-%d"
+  code = "testCode\n"
+
+  outputs = {
+    name = "test_name1"
+    kinesis_stream = {
+      resource_arn = "${aws_kinesis_stream.test1.arn}"
+      role_arn = "${aws_iam_role.test.arn}"
+    }
+    schema = {
+      record_format_type = "JSON"
+    }
+  }
+
+  outputs = {
+    name = "test_name2"
+    kinesis_stream = {
+      resource_arn = "${aws_kinesis_stream.test2.arn}"
+      role_arn = "${aws_iam_role.test.arn}"
+    }
+    schema = {
+      record_format_type = "JSON"
+    }
+  }
+}
+`, rInt1, rInt2, rInt1)
 }
 
 func testAccKinesisAnalyticsApplicationConfigOutputsLambda(rInt int) string {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7506

Changes proposed in this pull request:

* support mutliple outputs

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisAnalyticsApplication_'
==> Fixing source code with gofmt...
gofmt -s -w ./aws
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSKinesisAnalyticsApplication_ -timeout 120m
=== RUN   TestAccAWSKinesisAnalyticsApplication_basic
=== PAUSE TestAccAWSKinesisAnalyticsApplication_basic
=== RUN   TestAccAWSKinesisAnalyticsApplication_update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_update
=== RUN   TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_basic
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_update
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== CONT  TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsAdd
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (8.12s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (12.06s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (24.67s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (28.16s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (32.06s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (32.33s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (32.50s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (45.36s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (87.07s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (87.08s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (87.62s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (101.93s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (102.58s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (169.84s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (169.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	169.903s
```
