### PR TITLE
moving eks_cluster_auth link in docs 

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -180,7 +180,7 @@
                             <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-eks-cluster-auth") %>>
-                            <a href="/docs/providers/aws/d/eks_cluster.html">aws_eks_cluster_auth</a>
+                            <a href="/docs/providers/aws/d/eks_cluster_auth.html">aws_eks_cluster_auth</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-elastic-beanstalk-application") %>>
                             <a href="/docs/providers/aws/d/elastic_beanstalk_application.html">aws_elastic_beanstalk_application</a>


### PR DESCRIPTION
moving eks_cluster_auth link in the documentation from eks_cluster.html to eks_cluster_auth.html

Changes proposed in this pull request:

This is a correcting to a copy paste error in the documentation around eks_cluster_auth

Output from acceptance testing:

There is no software change here.
