### PR TITLE
resource/aws_cloudwatch_metric_alarm: Ensure dimensions configurations use equals (part deux)

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -533,7 +533,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 			period      = "120"
 			stat        = "Average"
 			unit        = "Count"
-			dimensions {
+			dimensions = {
 				InstanceId = "i-abc123"
 			}
 		}
@@ -569,7 +569,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 			period      = "120"
 			stat        = "Average"
 			unit        = "Count"
-			dimensions {
+			dimensions = {
 				InstanceId = "i-abc123"
 			}
 		}
@@ -596,7 +596,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 			period      = "120"
 			stat        = "Average"
 			unit        = "Count"
-			dimensions {
+			dimensions = {
 				InstanceId = "i-abc123"
 			}
 		}

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -81,7 +81,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 			period      = "120"
 			stat        = "Sum"
 			unit        = "Count"
-			dimensions {
+			dimensions = {
 				LoadBalancer = "app/web"
 			}
 		}
@@ -94,7 +94,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 			period      = "120"
 			stat        = "Sum"
 			unit        = "Count"
-			dimensions {
+			dimensions = {
 				LoadBalancer = "app/web"
 			}
 		}


### PR DESCRIPTION
These came in during a recent pull request merge and the old syntax is incompatible with Terraform 0.12. The new syntax is backwards and forwards compatible.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCloudWatchMetricAlarm_expression (0.68s)
    testing.go:561: Step 0, expected error:

        config is invalid: Unsupported block type: Blocks of type "dimensions" are not expected here. Did you mean to define argument "dimensions"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (19.21s)
```
