### PR TITLE
r/aws_s3_bucket_object: Allow empty object

### DIFF
--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -193,10 +193,6 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("error decoding content_base64: %s", err)
 		}
 		body = bytes.NewReader(contentRaw)
-	} else {
-		// S3 allows the creation of zero-byte objects
-		content := ""
-		body = bytes.NewReader([]byte(content))
 	}
 
 	bucket := d.Get("bucket").(string)

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -194,7 +194,9 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 		}
 		body = bytes.NewReader(contentRaw)
 	} else {
-		return fmt.Errorf("Must specify \"source\", \"content\", or \"content_base64\" field")
+		// S3 allows the creation of zero-byte objects
+		content := ""
+		body = bytes.NewReader([]byte(content))
 	}
 
 	bucket := d.Get("bucket").(string)

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -145,6 +145,28 @@ func testSweepS3BucketObjects(region string) error {
 	return nil
 }
 
+func TestAccAWSS3BucketObject_empty(t *testing.T) {
+	var obj s3.GetObjectOutput
+	resourceName := "aws_s3_bucket_object.object"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {},
+				Config:    testAccAWSS3BucketObjectConfigEmpty(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(resourceName, &obj),
+					testAccCheckAWSS3BucketObjectBody(&obj, ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3BucketObject_source(t *testing.T) {
 	var obj s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.object"
@@ -779,6 +801,19 @@ func testAccAWSS3BucketObjectCreateTempFile(t *testing.T, data string) string {
 	}
 
 	return filename
+}
+
+func testAccAWSS3BucketObjectConfigEmpty(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket" {
+  bucket = "tf-object-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "object" {
+  bucket = "${aws_s3_bucket.object_bucket.bucket}"
+  key = "test-key"
+}
+`, randInt)
 }
 
 func testAccAWSS3BucketObjectConfigSource(randInt int, source string) string {

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -84,9 +84,9 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to put the file in.
 * `key` - (Required) The name of the object once it is in the bucket.
-* `source` - (Required unless `content` or `content_base64` is set) The path to a file that will be read and uploaded as raw bytes for the object content.
-* `content` - (Required unless `source` or `content_base64` is set) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
-* `content_base64` - (Required unless `source` or `content` is set) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for small content such as the result of the `gzipbase64` function with small text strings. For larger objects, use `source` to stream the content from a disk file.
+* `source` - (Optional, conflicts with `content` and `content_base64`) The path to a file that will be read and uploaded as raw bytes for the object content.
+* `content` - (Optional, conflicts with `source` and `content_base64`) Literal string value to use as the object content, which will be uploaded as UTF-8-encoded text.
+* `content_base64` - (Optional, conflicts with `source` and `content`) Base64-encoded data that will be decoded and uploaded as raw bytes for the object content. This allows safely uploading non-UTF8 binary data, but is recommended only for small content such as the result of the `gzipbase64` function with small text strings. For larger objects, use `source` to stream the content from a disk file.
 * `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Defaults to "private".
 * `cache_control` - (Optional) Specifies caching behavior along the request/reply chain Read [w3c cache_control](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) for further details.
 * `content_disposition` - (Optional) Specifies presentational information for the object. Read [w3c content_disposition](http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1) for further information.
@@ -105,8 +105,7 @@ use the exported `arn` attribute:
       `kms_key_id = "${aws_kms_key.foo.arn}"`
 * `tags` - (Optional) A mapping of tags to assign to the object.
 
-Either `source` or `content` must be provided to specify the bucket content.
-These two arguments are mutually-exclusive.
+If no content is provided through `source`, `content` or `content_base64`, then the object will be empty.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Allow empty S3 objects.

~~I haven't written a test for this since I am not sure it requires one.~~ I have compiled and tested it live, with both `content = ""` and without `source`, `content`, and `content_base64` altogether.

I recently wanted to be able to create empty S3 objects, to use them with `website_redirect`. There is no point in putting any data in those objects.

Currently I am using:

```hcl
resource "aws_s3_bucket_object" "login" {
  bucket           = "${aws_s3_bucket.bucket.bucket}"
  key              = "login"
  content          = "dummy"
  website_redirect = "https://accounts.example.com/login"
  acl              = "public-read"
}
```

An empty object like this can also be created with the awscli:
```
aws s3api put-object --bucket example.com --key login --website-redirect-location https://accounts.example.com/login
```

~~Let me know if you think a new test is necessary, and I will write one.~~ Thank you!
