### PR TITLE
tests/service/docdb: Temporarily use expanded references

### DIFF
--- a/aws/resource_aws_docdb_cluster_instance_test.go
+++ b/aws/resource_aws_docdb_cluster_instance_test.go
@@ -326,7 +326,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_docdb_cluster" "default" {
   cluster_identifier = "tf-docdb-cluster-test-%d"
-  availability_zones = ["${data.aws_availability_zones.available.names}"]
+  availability_zones = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   master_username    = "foo"
   master_password    = "mustbeeightcharaters"
   skip_final_snapshot = true

--- a/aws/resource_aws_docdb_cluster_snapshot_test.go
+++ b/aws/resource_aws_docdb_cluster_snapshot_test.go
@@ -134,7 +134,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_docdb_subnet_group" "test" {
   name       = %q
-  subnet_ids = ["${aws_subnet.test.*.id}"]
+  subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 }
 
 resource "aws_docdb_cluster" "test" {

--- a/aws/resource_aws_docdb_cluster_test.go
+++ b/aws/resource_aws_docdb_cluster_test.go
@@ -706,7 +706,7 @@ func testAccDocDBClusterConfig_Port(rInt, port int) string {
 data "aws_availability_zones" "available" {}
 
 resource "aws_docdb_cluster" "test" {
-  availability_zones              = ["${data.aws_availability_zones.available.names}"]
+  availability_zones              = ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   cluster_identifier              = "tf-acc-test-%d"
   db_cluster_parameter_group_name = "default.docdb3.6"
   engine                          = "docdb"


### PR DESCRIPTION
These were from recently merged pull requests and have syntax that is incompatible with Terraform 0.12. This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSDocDBClusterInstance_az (2.04s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test482154120/main.tf line 6:
          (source code not available)

        Inappropriate value for attribute "availability_zones": element 0: string
        required.

--- FAIL: TestAccAWSDocDBClusterSnapshot_basic (2.01s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test699729194/main.tf line 26:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.

--- FAIL: TestAccAWSDocDBCluster_Port (2.15s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test810236062/main.tf line 5:
          (source code not available)

        Inappropriate value for attribute "availability_zones": element 0: string
        required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSDocDBClusterSnapshot_basic (221.32s)
--- PASS: TestAccAWSDocDBCluster_Port (236.08s)
--- PASS: TestAccAWSDocDBClusterInstance_az (700.93s)
```
