### PR TITLE
tests/resource/aws_worklink_fleet: Temporarily expand subnet_ids references

### DIFF
--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -419,11 +419,9 @@ resource "aws_worklink_fleet" "test" {
 
 	network {
 		vpc_id = "${aws_vpc.test.id}"
-		subnet_ids = ["${aws_subnet.test.*.id}"]
+		subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
 		security_group_ids = ["${aws_security_group.test.id}"]
 	}
-
-	depends_on = ["aws_vpc.test", "aws_subnet.test"]
 }
 
 `, testAccAWSWorkLinkFleetConfigNetwork_Base(r, cidrBlock), r)


### PR DESCRIPTION
This was from a recently merged pull request and has syntax that is incompatible with Terraform 0.12. This change is both backwards (0.11) and forwards (0.12) compatible to allow the configuration on both versions. Eventually the temporary workaround will be removed when we switch the provider test configurations to 0.12-only syntax.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSWorkLinkFleet_Network (2.58s)
    testing.go:568: Step 0 error: errors during plan:

        Error: Incorrect attribute value type

          on /opt/teamcity-agent/temp/buildTmp/tf-test490821325/main.tf line 44:
          (source code not available)

        Inappropriate value for attribute "subnet_ids": element 0: string required.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSWorkLinkFleet_Network (133.88s)
```
