### PR TITLE
tests/provider: Ensure tags configurations use equals

### DIFF
--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2870,7 +2870,7 @@ resource "aws_instance" "foo" {
 		virtual_name = "ephemeral0"
 	}
 
-	volume_tags {
+	volume_tags = {
 		Name = "acceptance-test-volume-tag"
 	}
 }
@@ -2908,7 +2908,7 @@ resource "aws_instance" "foo" {
 		virtual_name = "ephemeral0"
 	}
 
-	volume_tags {
+	volume_tags = {
 		Name = "acceptance-test-volume-tag"
 		Environment = "dev"
 	}

--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -896,7 +896,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
 	}
 
-  tags {
+  tags = {
     env = "test"
   }
 }`, sgName, brokerName)
@@ -920,7 +920,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
 	}
 
-  tags {
+  tags = {
 		env = "test2"
 		role = "test-role"
   }
@@ -945,7 +945,7 @@ resource "aws_mq_broker" "test" {
     password = "TestTest1234"
 	}
 
-  tags {
+  tags = {
 		role = "test-role"
   }
 }`, sgName, brokerName)

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -223,7 +223,7 @@ resource "aws_mq_configuration" "test" {
 </broker>
 DATA
 
-	tags {
+	tags = {
 		env = "test"
 	}
 }`, configurationName)
@@ -242,7 +242,7 @@ resource "aws_mq_configuration" "test" {
 </broker>
 DATA
 
-	tags {
+	tags = {
 		env = "test2"
 		role = "test-role"
 	}
@@ -262,7 +262,7 @@ resource "aws_mq_configuration" "test" {
 </broker>
 DATA
 
-	tags {
+	tags = {
 		role = "test-role"
 	}
 }`, configurationName)

--- a/aws/resource_aws_ram_resource_association_test.go
+++ b/aws/resource_aws_ram_resource_association_test.go
@@ -146,7 +146,7 @@ func testAccAwsRamResourceAssociationConfig(rName string) string {
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ram-resource-association"
   }
 }
@@ -155,7 +155,7 @@ resource "aws_subnet" "test" {
   cidr_block = "10.0.0.0/24"
   vpc_id     = "${aws_vpc.test.id}"
 
-  tags {
+  tags = {
     Name = "tf-acc-test-ram-resource-association"
   }
 }

--- a/aws/resource_aws_sagemaker_model_test.go
+++ b/aws/resource_aws_sagemaker_model_test.go
@@ -673,7 +673,7 @@ data "aws_iam_policy_document" "assume_role" {
 
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
-	tags {
+	tags = {
 		Name = "terraform-testacc-sagemaker-model-%s"
 	}
 }
@@ -682,7 +682,7 @@ resource "aws_subnet" "foo" {
 	cidr_block = "10.1.1.0/24"
 	availability_zone = "us-west-2a"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "terraform-testacc-sagemaker-model-foo-%s"
 	}
 }
@@ -691,7 +691,7 @@ resource "aws_subnet" "bar" {
 	cidr_block = "10.1.2.0/24"
 	availability_zone = "us-west-2b"
 	vpc_id = "${aws_vpc.foo.id}"
-	tags {
+	tags = {
 		Name = "terraform-testacc-sagemaker-model-bar-%s"
 	}
 }


### PR DESCRIPTION
These were from recently merged pull requests. The old syntax is incompatible with Terraform 0.12 and the changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSInstance_volumeTags (176.95s)
    testing.go:568: Step 1 error: config is invalid: Unsupported block type: Blocks of type "volume_tags" are not expected here. Did you mean to define argument "volume_tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSMqBroker_updateTags (0.70s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean "logs"?

--- FAIL: TestAccAWSMqConfiguration_updateTags (0.65s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAwsRamResourceAssociation_basic (0.66s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAwsRamResourceAssociation_disappears (0.76s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

--- FAIL: TestAccAWSSagemakerModel_vpcConfig (0.72s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSMqConfiguration_updateTags (22.59s)
--- PASS: TestAccAwsRamResourceAssociation_disappears (28.92s)
--- PASS: TestAccAwsRamResourceAssociation_basic (31.24s)
--- PASS: TestAccAWSSagemakerModel_vpcConfig (35.42s)
--- PASS: TestAccAWSInstance_volumeTags (123.52s)
--- PASS: TestAccAWSMqBroker_updateTags (1442.10s)
```