### PR TITLE
tests/resource/aws_kinesis_analytics_application: Fix TestAccAWSKinesisAnalyticsApplication_outputsMultiple syntax for Terraform 0.12

### DIFF
--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -689,24 +689,24 @@ resource "aws_kinesis_analytics_application" "test" {
   name = "testAcc-%d"
   code = "testCode\n"
 
-  outputs = {
+  outputs {
     name = "test_name1"
-    kinesis_stream = {
+    kinesis_stream {
       resource_arn = "${aws_kinesis_stream.test1.arn}"
       role_arn = "${aws_iam_role.test.arn}"
     }
-    schema = {
+    schema {
       record_format_type = "JSON"
     }
   }
 
-  outputs = {
+  outputs {
     name = "test_name2"
-    kinesis_stream = {
+    kinesis_stream {
       resource_arn = "${aws_kinesis_stream.test2.arn}"
       role_arn = "${aws_iam_role.test.arn}"
     }
-    schema = {
+    schema {
       record_format_type = "JSON"
     }
   }


### PR DESCRIPTION
These changes are backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (0.42s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test759977676/main.tf:42,3-10: Attribute redefined; The argument "outputs" was already set at /opt/teamcity-agent/temp/buildTmp/tf-test759977676/main.tf:31,3-10. Each argument may be set only once.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (89.35s)
```
