### PR TITLE
Fix to Putting in Description for Launch Template Resource

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -47,6 +47,7 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Default:      "Managed by Terraform",
 				ValidateFunc: validation.StringLenBetween(0, 255),
 			},
 
@@ -517,6 +518,7 @@ func resourceAwsLaunchTemplateCreate(d *schema.ResourceData, meta interface{}) e
 		ClientToken:        aws.String(resource.UniqueId()),
 		LaunchTemplateName: aws.String(ltName),
 		LaunchTemplateData: launchTemplateData,
+		VersionDescription: aws.String(d.Get("description").(string)),
 	}
 
 	resp, err := conn.CreateLaunchTemplate(launchTemplateOpts)
@@ -596,6 +598,8 @@ func resourceAwsLaunchTemplateRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	log.Printf("[DEBUG] Received launch template version %q (version %d)", d.Id(), *lt.LatestVersionNumber)
+
+	d.Set("description", dltv.LaunchTemplateVersions[0].VersionDescription)
 
 	ltData := dltv.LaunchTemplateVersions[0].LaunchTemplateData
 
@@ -677,6 +681,7 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 			ClientToken:        aws.String(resource.UniqueId()),
 			LaunchTemplateId:   aws.String(d.Id()),
 			LaunchTemplateData: launchTemplateData,
+			VersionDescription: aws.String(d.Get("description").(string)),
 		}
 
 		_, createErr := conn.CreateLaunchTemplateVersion(launchTemplateVersionOpts)

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -47,7 +47,6 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "Managed by Terraform",
 				ValidateFunc: validation.StringLenBetween(0, 255),
 			},
 
@@ -518,7 +517,10 @@ func resourceAwsLaunchTemplateCreate(d *schema.ResourceData, meta interface{}) e
 		ClientToken:        aws.String(resource.UniqueId()),
 		LaunchTemplateName: aws.String(ltName),
 		LaunchTemplateData: launchTemplateData,
-		VersionDescription: aws.String(d.Get("description").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok && v.(string) != "" {
+		launchTemplateOpts.VersionDescription = aws.String(v.(string))
 	}
 
 	resp, err := conn.CreateLaunchTemplate(launchTemplateOpts)
@@ -681,7 +683,10 @@ func resourceAwsLaunchTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 			ClientToken:        aws.String(resource.UniqueId()),
 			LaunchTemplateId:   aws.String(d.Id()),
 			LaunchTemplateData: launchTemplateData,
-			VersionDescription: aws.String(d.Get("description").(string)),
+		}
+
+		if v, ok := d.GetOk("description"); ok && v.(string) != "" {
+			launchTemplateVersionOpts.VersionDescription = aws.String(v.(string))
 		}
 
 		_, createErr := conn.CreateLaunchTemplateVersion(launchTemplateVersionOpts)

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -73,7 +73,6 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "latest_version", "1"),
 					resource.TestCheckResourceAttrSet(resName, "arn"),
 					resource.TestCheckResourceAttr(resName, "ebs_optimized", ""),
-					resource.TestCheckResourceAttr(resName, "description", "Managed by Terraform"),
 				),
 			},
 		},

--- a/aws/resource_aws_launch_template_test.go
+++ b/aws/resource_aws_launch_template_test.go
@@ -73,6 +73,7 @@ func TestAccAWSLaunchTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "latest_version", "1"),
 					resource.TestCheckResourceAttrSet(resName, "arn"),
 					resource.TestCheckResourceAttr(resName, "ebs_optimized", ""),
+					resource.TestCheckResourceAttr(resName, "description", "Managed by Terraform"),
 				),
 			},
 		},
@@ -257,6 +258,34 @@ func TestAccAWSLaunchTemplate_data(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "ram_disk_id"),
 					resource.TestCheckResourceAttr(resName, "vpc_security_group_ids.#", "1"),
 					resource.TestCheckResourceAttr(resName, "tag_specifications.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchTemplate_description(t *testing.T) {
+	var template ec2.LaunchTemplate
+	resName := "aws_launch_template.foo"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchTemplateConfig_description(rName, "Test Description 1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					resource.TestCheckResourceAttr(resName, "description", "Test Description 1"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchTemplateConfig_description(rName, "Test Description 2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchTemplateExists(resName, &template),
+					resource.TestCheckResourceAttr(resName, "description", "Test Description 2"),
 				),
 			},
 		},
@@ -927,6 +956,15 @@ resource "aws_launch_template" "example" {
 	}
 }
 `, rInt)
+}
+
+func testAccAWSLaunchTemplateConfig_description(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_launch_template" "foo" {
+	name 				= "%s"
+	description = "%s"
+}
+`, rName, description)
 }
 
 const testAccAWSLaunchTemplateConfig_networkInterface = `


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7510

Changes proposed in this pull request:

* Fixed parameters to putting description
* Add default value for description

Output from acceptance testing:

```basic
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_basic -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_basic (27.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	27.682s
```

```description
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_description'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_description -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_description
=== PAUSE TestAccAWSLaunchTemplate_description
=== CONT  TestAccAWSLaunchTemplate_description
--- PASS: TestAccAWSLaunchTemplate_description (43.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	43.367s
```
