### PR TITLE
Add param "enabled" to lb health checks

### DIFF
--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -93,8 +93,11 @@ the Target Group. Many parameters cannot be set to custom values for `network`
 load balancers at this time. See
 http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html
 for a complete reference.
+Keep in mind, that health checks produce actual requests to the backend.
+The underlying function is invoked when `target_type` is set to `lambda`.
 
-* `interval` - (Optional) The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. Default 30 seconds.
+* `enabled` - (Optional) Indicates whether  health checks are enabled. Defaults to true.
+* `interval` - (Optional) The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds. For `lambda` target groups, it needs to be greater as the `timeout` of the underlying `lambda`. Default 30 seconds.
 * `path` - (Required for HTTP/HTTPS ALB) The destination for the health check request. Applies to Application Load Balancers only (HTTP/HTTPS), not Network Load Balancers (TCP).
 * `port` - (Optional) The port to use to connect with the target. Valid values are either ports 1-65536, or `traffic-port`. Defaults to `traffic-port`.
 * `protocol` - (Optional) The protocol to use to connect with the target. Defaults to `HTTP`. Not applicable when `target_type` is `lambda`.


### PR DESCRIPTION
Fixes #6963

Changes proposed in this pull request:

* Support enabled flag for lb health checks

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=-run=TestAccAWSLBTargetGroup_basic'
=== RUN   TestAccAWSLBTargetGroup_basic
=== PAUSE TestAccAWSLBTargetGroup_basic
=== CONT  TestAccAWSLBTargetGroup_basic
--- PASS: TestAccAWSLBTargetGroup_basic (17.58s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	17.608s
...
```

Notes:

The API/CLI defaults for health check enabled are true for ip or instance, false for lambdas.
Specifying the health check block indicates an interest in enabling them. So this code defaults to true in any case.
