### PR TITLE
fix kinesis firehose input creation

### DIFF
--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -582,7 +582,12 @@ func resourceAwsKinesisAnalyticsApplicationCreate(d *schema.ResourceData, meta i
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		output, err := conn.CreateApplication(createOpts)
 		if err != nil {
+			// Kinesis Stream: https://github.com/terraform-providers/terraform-provider-aws/issues/7032
 			if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics service doesn't have sufficient privileges") {
+				return resource.RetryableError(err)
+			}
+			// Kinesis Firehose: https://github.com/terraform-providers/terraform-provider-aws/issues/7394
+			if isAWSErr(err, kinesisanalytics.ErrCodeInvalidArgumentException, "Kinesis Analytics doesn't have sufficient privileges") {
 				return resource.RetryableError(err)
 			}
 			// InvalidArgumentException: Given IAM role arn : arn:aws:iam::123456789012:role/xxx does not provide Invoke permissions on the Lambda resource : arn:aws:lambda:us-west-2:123456789012:function:yyy

--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -126,6 +126,28 @@ func TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions(t *tes
 	})
 }
 
+func TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose(t *testing.T) {
+	var application kinesisanalytics.ApplicationDetail
+	resName := "aws_kinesis_analytics_application.test"
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsKinesisFirehose(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisAnalyticsApplicationExists(resName, &application),
+					resource.TestCheckResourceAttr(resName, "inputs.#", "1"),
+					resource.TestCheckResourceAttr(resName, "inputs.0.kinesis_firehose.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream(t *testing.T) {
 	var application kinesisanalytics.ApplicationDetail
 	resName := "aws_kinesis_analytics_application.test"
@@ -567,6 +589,93 @@ resource "aws_kinesis_analytics_application" "test" {
 `, rInt, streamName, rInt, rInt)
 }
 
+func testAccKinesisAnalyticsApplication_inputsKinesisFirehose(rInt int) string {
+	return fmt.Sprintf(`
+data "aws_iam_policy_document" "trust_firehose" {
+  statement = {
+    actions = ["sts:AssumeRole"]
+    principals = {
+      type = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "firehose" {
+  name = "testAcc-firehose-%d"
+  assume_role_policy = "${data.aws_iam_policy_document.trust_firehose.json}"
+}
+
+data "aws_iam_policy_document" "trust_lambda" {
+  statement = {
+    actions = ["sts:AssumeRole"]
+    principals = {
+      type = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "testAcc-lambda-%d"
+  assume_role_policy = "${data.aws_iam_policy_document.trust_lambda.json}"
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "testacc-%d"
+  acl = "private"
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = "testAcc-%d"
+  handler       = "exports.example"
+  role          = "${aws_iam_role.lambda.arn}"
+  runtime       = "nodejs8.10"
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test" {
+  name = "testAcc-%d"
+  destination = "extended_s3" 
+  extended_s3_configuration = {
+    role_arn = "${aws_iam_role.firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.test.arn}"
+  }
+}
+
+resource "aws_kinesis_analytics_application" "test" {
+  name = "testAcc-%d"
+  code = "testCode\n"
+  inputs = {
+    name_prefix = "test_prefix"
+    kinesis_firehose = {
+      resource_arn = "${aws_kinesis_firehose_delivery_stream.test.arn}"
+      role_arn = "${aws_iam_role.test.arn}"
+    }
+    parallelism = {
+      count = 1
+    }
+    schema = {
+      record_columns = {
+        mapping = "$.test"
+        name = "test"
+        sql_type = "VARCHAR(8)"
+      }
+      record_encoding = "UTF-8"
+      record_format = {
+        mapping_parameters = {
+          csv = {
+            record_column_delimiter = ","
+            record_row_delimiter = "\n"
+          }
+        }
+      }
+    }
+  }
+}
+`, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
 func testAccKinesisAnalyticsApplication_inputsKinesisStream(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_kinesis_stream" "test" {
@@ -889,10 +998,10 @@ resource "aws_kinesis_analytics_application" "test" {
 // this is used to set up the IAM role
 func testAccKinesisAnalyticsApplication_prereq(rInt int) string {
 	return fmt.Sprintf(`
-data "aws_iam_policy_document" "test" {
-  statement {
+data "aws_iam_policy_document" "trust" {
+  statement = {
     actions = ["sts:AssumeRole"]
-    principals {
+    principals = {
       type = "Service"
       identifiers = ["kinesisanalytics.amazonaws.com"]
     }
@@ -901,7 +1010,24 @@ data "aws_iam_policy_document" "test" {
 
 resource "aws_iam_role" "test" {
   name = "testAcc-%d"
-  assume_role_policy = "${data.aws_iam_policy_document.test.json}" 
+  assume_role_policy = "${data.aws_iam_policy_document.trust.json}" 
 }
-`, rInt)
+
+data "aws_iam_policy_document" "test" {
+  statement = {
+    actions = ["firehose:*"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "test" {
+  name = "testAcc-%d"
+  policy = "${data.aws_iam_policy_document.test.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role = "${aws_iam_role.test.name}"
+  policy_arn = "${aws_iam_policy.test.arn}"
+}
+`, rInt, rInt)
 }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7394

Changes proposed in this pull request:

* fix kinesis firehose input creation

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisAnalyticsApplication_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSKinesisAnalyticsApplication_ -timeout 120m
=== RUN   TestAccAWSKinesisAnalyticsApplication_basic
=== PAUSE TestAccAWSKinesisAnalyticsApplication_basic
=== RUN   TestAccAWSKinesisAnalyticsApplication_update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_update
=== RUN   TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_basic
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== CONT  TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_update
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (8.35s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (12.82s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (21.44s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (22.09s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (25.56s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (31.62s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (32.78s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (44.93s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (85.13s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (85.13s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (85.29s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (102.97s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (103.83s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (107.01s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (167.44s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (167.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	167.507s
```
