### PR TITLE
Issue #7501 Unable to create api_gateway_domain using aws_route53_zone.name

### DIFF
--- a/aws/resource_aws_api_gateway_domain_name.go
+++ b/aws/resource_aws_api_gateway_domain_name.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -138,8 +139,11 @@ func resourceAwsApiGatewayDomainNameCreate(d *schema.ResourceData, meta interfac
 	conn := meta.(*AWSClient).apigateway
 	log.Printf("[DEBUG] Creating API Gateway Domain Name")
 
+	name := d.Get("domain_name").(string)
+	v := strings.TrimSuffix(name, ".")
+
 	params := &apigateway.CreateDomainNameInput{
-		DomainName: aws.String(d.Get("domain_name").(string)),
+		DomainName: aws.String(v),
 	}
 
 	if v, ok := d.GetOk("certificate_arn"); ok {

--- a/aws/resource_aws_api_gateway_domain_name_test.go
+++ b/aws/resource_aws_api_gateway_domain_name_test.go
@@ -108,7 +108,7 @@ func TestAccAWSAPIGatewayDomainName_verifyDomainName(t *testing.T) {
 	var conf apigateway.DomainName
 
 	rString := acctest.RandString(8)
-	name := fmt.Sprintf("tf-acc-%s.terraformtest.com.", rString)
+	name := fmt.Sprintf("tf-acc-%s.terraformtest.com", rString)
 	commonName := "*.terraformtest.com"
 	certRe := regexp.MustCompile("^-----BEGIN CERTIFICATE-----\n")
 	keyRe := regexp.MustCompile("^-----BEGIN RSA PRIVATE KEY-----\n")
@@ -119,7 +119,7 @@ func TestAccAWSAPIGatewayDomainName_verifyDomainName(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAPIGatewayDomainNameDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAPIGatewayDomainNameConfig_CertificateName(name, commonName),
+				Config: testAccAWSAPIGatewayDomainNameConfig_CertificateName(fmt.Sprintf("%s.", name), commonName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDomainNameExists("aws_api_gateway_domain_name.test", &conf),
 					resource.TestMatchResourceAttr("aws_api_gateway_domain_name.test", "certificate_body", certRe),
@@ -131,6 +131,7 @@ func TestAccAWSAPIGatewayDomainName_verifyDomainName(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "domain_name", name),
 					resource.TestCheckResourceAttrSet("aws_api_gateway_domain_name.test", "certificate_upload_date"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7501 

Changes proposed in this pull request:

* Change 1
removing Trailing period in `domain_name` input

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSAPIGatewayDomainName_verifyDomainName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSAPIGatewayDomainName_verifyDomainName -timeout 120m
=== RUN   TestAccAWSAPIGatewayDomainName_verifyDomainName
=== PAUSE TestAccAWSAPIGatewayDomainName_verifyDomainName
=== CONT  TestAccAWSAPIGatewayDomainName_verifyDomainName
--- PASS: TestAccAWSAPIGatewayDomainName_verifyDomainName (31.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws
...
```
