### PR TITLE
Update service_discovery_service.html.markdown

### DIFF
--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -14,7 +14,9 @@ Provides a Service Discovery Service resource.
 
 ```hcl
 resource "aws_vpc" "example" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
 }
 
 resource "aws_service_discovery_private_dns_namespace" "example" {


### PR DESCRIPTION
When creating a `aws_service_discovery_private_dns_namespace` one needs to enable both `enable_dns_support` and `enable_dns_hostnames`.

While trying to create such a service I tried resolving the private zone from my ec2 machine but couldn't.
I went over to the route53 web ui and noticed the following message:

```
Important
To use private hosted zones, you must set the following Amazon VPC settings to true:
enableDnsHostnames
enableDnsSupport
Learn more
```

After reading https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-updating and enabling `enable_dns_support` and `enable_dns_hostnames` I was able to resolve my private zone.