### PR TITLE
Mark cloudwatch_event_target docs code blocks as HCL

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -56,7 +56,7 @@ resource "aws_kinesis_stream" "test_stream" {
 
 ## Example SSM Document Usage
 
-```
+```hcl
 data "aws_iam_policy_document" "ssm_lifecycle_trust" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -145,7 +145,7 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 
 ## Example RunCommand Usage
 
-```
+```hcl
 
 resource "aws_cloudwatch_event_rule" "stop_instances" {
   name                = "StopInstance"
@@ -170,7 +170,7 @@ resource "aws_cloudwatch_event_target" "stop_instances" {
 
 ## Example ECS Run Task with Role and Task Override Usage
 
-```
+```hcl
 resource "aws_iam_role" "ecs_events" {
   name = "ecs_events"
   assume_role_policy = <<DOC


### PR DESCRIPTION
Changes proposed in this pull request:

* Mark the cloudwatch_event_target doc code blocks as HCL. These weren't syntax highlighted in the docs which was a departure from the other doc pages and not so easy to read.
