### PR TITLE
Bump AWS SDK to v1.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.0.0 // indirect
 	github.com/apparentlymart/go-textseg v1.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.16.32
+	github.com/aws/aws-sdk-go v1.17.0
 	github.com/beevik/etree v1.0.1
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go v1.16.32 h1:/grHp+bt3OAVWkdCQv2YtXkWuu58SuTlH1U8tp25n1c=
-github.com/aws/aws-sdk-go v1.16.32/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.17.0 h1:+pbWEdKxH1qlLb07as1+auEVvx+IxkaDzQLwMzbK1tI=
+github.com/aws/aws-sdk-go v1.17.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beevik/etree v1.0.1 h1:lWzdj5v/Pj1X360EV7bUudox5SRipy4qZLjY0rhb0ck=
 github.com/beevik/etree v1.0.1/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -321,9 +321,33 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"us-east-1-fips": endpoint{
+					Hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"us-east-2": endpoint{},
+				"us-east-2-fips": endpoint{
+					Hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"us-west-1": endpoint{},
+				"us-west-1-fips": endpoint{
+					Hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"us-west-2": endpoint{},
+				"us-west-2-fips": endpoint{
+					Hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
 			},
 		},
 		"apigateway": service{
@@ -383,6 +407,7 @@ var awsPartition = partition{
 			},
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
@@ -479,6 +504,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -873,7 +899,9 @@ var awsPartition = partition{
 				Protocols: []string{"https"},
 			},
 			Endpoints: endpoints{
+				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
@@ -991,6 +1019,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -1191,6 +1220,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
@@ -1293,11 +1323,17 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips": endpoint{
+					Hostname: "es-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"sa-east-1": endpoint{},
+				"us-east-1": endpoint{},
+				"us-east-2": endpoint{},
+				"us-west-1": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"events": service{
@@ -1586,6 +1622,12 @@ var awsPartition = partition{
 		"kms": service{
 
 			Endpoints: endpoints{
+				"ProdFips": endpoint{
+					Hostname: "kms-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
 				"ap-south-1":     endpoint{},
@@ -1622,6 +1664,22 @@ var awsPartition = partition{
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
 				"us-west-1":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"license-manager": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -1840,6 +1898,12 @@ var awsPartition = partition{
 		"neptune": service{
 
 			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{
+					Hostname: "rds.ap-northeast-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ap-northeast-1",
+					},
+				},
 				"ap-southeast-1": endpoint{
 					Hostname: "rds.ap-southeast-1.amazonaws.com",
 					CredentialScope: credentialScope{
@@ -2018,6 +2082,8 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-west-1":      endpoint{},
 				"us-east-1":      endpoint{},
@@ -2469,6 +2535,7 @@ var awsPartition = partition{
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
@@ -2851,6 +2918,7 @@ var awsPartition = partition{
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
 				"ca-central-1":   endpoint{},
@@ -3206,6 +3274,12 @@ var awscnPartition = partition{
 				"cn-northwest-1": endpoint{},
 			},
 		},
+		"gamelift": service{
+
+			Endpoints: endpoints{
+				"cn-north-1": endpoint{},
+			},
+		},
 		"glacier": service{
 			Defaults: endpoint{
 				Protocols: []string{"http", "https"},
@@ -3486,6 +3560,12 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{},
 			},
 		},
+		"athena": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"autoscaling": service{
 
 			Endpoints: endpoints{
@@ -3663,6 +3743,12 @@ var awsusgovPartition = partition{
 		"es": service{
 
 			Endpoints: endpoints{
+				"fips": endpoint{
+					Hostname: "es-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -3687,6 +3773,12 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{
 					Protocols: []string{"http", "https"},
 				},
+			},
+		},
+		"glue": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
 			},
 		},
 		"guardduty": service{
@@ -3738,6 +3830,12 @@ var awsusgovPartition = partition{
 		"kms": service{
 
 			Endpoints: endpoints{
+				"ProdFips": endpoint{
+					Hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -3971,6 +4069,12 @@ var awsusgovPartition = partition{
 						Region: "us-gov-west-1",
 					},
 				},
+			},
+		},
+		"workspaces": service{
+
+			Endpoints: endpoints{
+				"us-gov-west-1": endpoint{},
 			},
 		},
 	},

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.16.32"
+const SDKVersion = "1.17.0"

--- a/vendor/github.com/aws/aws-sdk-go/service/athena/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/athena/api.go
@@ -57,12 +57,14 @@ func (c *Athena) BatchGetNamedQueryRequest(input *BatchGetNamedQueryInput) (req 
 // BatchGetNamedQuery API operation for Amazon Athena.
 //
 // Returns the details of a single named query or a list of up to 50 queries,
-// which you provide as an array of query ID strings. Use ListNamedQueries to
-// get the list of named query IDs. If information could not be retrieved for
-// a submitted query ID, information about the query ID submitted is listed
-// under UnprocessedNamedQueryId. Named queries are different from executed
-// queries. Use BatchGetQueryExecution to get details about each unique query
-// execution, and ListQueryExecutions to get a list of query execution IDs.
+// which you provide as an array of query ID strings. Requires you to have access
+// to the workgroup in which the queries were saved. Use ListNamedQueriesInput
+// to get the list of named query IDs in the specified workgroup. If information
+// could not be retrieved for a submitted query ID, information about the query
+// ID submitted is listed under UnprocessedNamedQueryId. Named queries differ
+// from executed queries. Use BatchGetQueryExecutionInput to get details about
+// each unique query execution, and ListQueryExecutionsInput to get a list of
+// query execution IDs.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -148,9 +150,10 @@ func (c *Athena) BatchGetQueryExecutionRequest(input *BatchGetQueryExecutionInpu
 //
 // Returns the details of a single query execution or a list of up to 50 query
 // executions, which you provide as an array of query execution ID strings.
-// To get a list of query execution IDs, use ListQueryExecutions. Query executions
-// are different from named (saved) queries. Use BatchGetNamedQuery to get details
-// about named queries.
+// Requires you to have access to the workgroup in which the queries ran. To
+// get a list of query execution IDs, use ListQueryExecutionsInput$WorkGroup.
+// Query executions differ from named (saved) queries. Use BatchGetNamedQueryInput
+// to get details about named queries.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -234,7 +237,8 @@ func (c *Athena) CreateNamedQueryRequest(input *CreateNamedQueryInput) (req *req
 
 // CreateNamedQuery API operation for Amazon Athena.
 //
-// Creates a named query.
+// Creates a named query in the specified workgroup. Requires that you have
+// access to the workgroup.
 //
 // For code samples using the AWS SDK for Java, see Examples and Code Samples
 // (http://docs.aws.amazon.com/athena/latest/ug/code-samples.html) in the Amazon
@@ -273,6 +277,91 @@ func (c *Athena) CreateNamedQuery(input *CreateNamedQueryInput) (*CreateNamedQue
 // for more information on using Contexts.
 func (c *Athena) CreateNamedQueryWithContext(ctx aws.Context, input *CreateNamedQueryInput, opts ...request.Option) (*CreateNamedQueryOutput, error) {
 	req, out := c.CreateNamedQueryRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opCreateWorkGroup = "CreateWorkGroup"
+
+// CreateWorkGroupRequest generates a "aws/request.Request" representing the
+// client's request for the CreateWorkGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateWorkGroup for more information on using the CreateWorkGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateWorkGroupRequest method.
+//    req, resp := client.CreateWorkGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/CreateWorkGroup
+func (c *Athena) CreateWorkGroupRequest(input *CreateWorkGroupInput) (req *request.Request, output *CreateWorkGroupOutput) {
+	op := &request.Operation{
+		Name:       opCreateWorkGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateWorkGroupInput{}
+	}
+
+	output = &CreateWorkGroupOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// CreateWorkGroup API operation for Amazon Athena.
+//
+// Creates a workgroup with the specified name.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Athena's
+// API operation CreateWorkGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerException "InternalServerException"
+//   Indicates a platform issue, which may be due to a transient condition or
+//   outage.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   Indicates that something is wrong with the input to the request. For example,
+//   a required parameter may be missing or out of range.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/CreateWorkGroup
+func (c *Athena) CreateWorkGroup(input *CreateWorkGroupInput) (*CreateWorkGroupOutput, error) {
+	req, out := c.CreateWorkGroupRequest(input)
+	return out, req.Send()
+}
+
+// CreateWorkGroupWithContext is the same as CreateWorkGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateWorkGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Athena) CreateWorkGroupWithContext(ctx aws.Context, input *CreateWorkGroupInput, opts ...request.Option) (*CreateWorkGroupOutput, error) {
+	req, out := c.CreateWorkGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -323,7 +412,8 @@ func (c *Athena) DeleteNamedQueryRequest(input *DeleteNamedQueryInput) (req *req
 
 // DeleteNamedQuery API operation for Amazon Athena.
 //
-// Deletes a named query.
+// Deletes the named query if you have access to the workgroup in which the
+// query was saved.
 //
 // For code samples using the AWS SDK for Java, see Examples and Code Samples
 // (http://docs.aws.amazon.com/athena/latest/ug/code-samples.html) in the Amazon
@@ -362,6 +452,92 @@ func (c *Athena) DeleteNamedQuery(input *DeleteNamedQueryInput) (*DeleteNamedQue
 // for more information on using Contexts.
 func (c *Athena) DeleteNamedQueryWithContext(ctx aws.Context, input *DeleteNamedQueryInput, opts ...request.Option) (*DeleteNamedQueryOutput, error) {
 	req, out := c.DeleteNamedQueryRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDeleteWorkGroup = "DeleteWorkGroup"
+
+// DeleteWorkGroupRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteWorkGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteWorkGroup for more information on using the DeleteWorkGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteWorkGroupRequest method.
+//    req, resp := client.DeleteWorkGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/DeleteWorkGroup
+func (c *Athena) DeleteWorkGroupRequest(input *DeleteWorkGroupInput) (req *request.Request, output *DeleteWorkGroupOutput) {
+	op := &request.Operation{
+		Name:       opDeleteWorkGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteWorkGroupInput{}
+	}
+
+	output = &DeleteWorkGroupOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteWorkGroup API operation for Amazon Athena.
+//
+// Deletes the workgroup with the specified name. The primary workgroup cannot
+// be deleted.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Athena's
+// API operation DeleteWorkGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerException "InternalServerException"
+//   Indicates a platform issue, which may be due to a transient condition or
+//   outage.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   Indicates that something is wrong with the input to the request. For example,
+//   a required parameter may be missing or out of range.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/DeleteWorkGroup
+func (c *Athena) DeleteWorkGroup(input *DeleteWorkGroupInput) (*DeleteWorkGroupOutput, error) {
+	req, out := c.DeleteWorkGroupRequest(input)
+	return out, req.Send()
+}
+
+// DeleteWorkGroupWithContext is the same as DeleteWorkGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteWorkGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Athena) DeleteWorkGroupWithContext(ctx aws.Context, input *DeleteWorkGroupInput, opts ...request.Option) (*DeleteWorkGroupOutput, error) {
+	req, out := c.DeleteWorkGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -411,7 +587,8 @@ func (c *Athena) GetNamedQueryRequest(input *GetNamedQueryInput) (req *request.R
 
 // GetNamedQuery API operation for Amazon Athena.
 //
-// Returns information about a single query.
+// Returns information about a single query. Requires that you have access to
+// the workgroup in which the query was saved.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -495,8 +672,9 @@ func (c *Athena) GetQueryExecutionRequest(input *GetQueryExecutionInput) (req *r
 
 // GetQueryExecution API operation for Amazon Athena.
 //
-// Returns information about a single execution of a query. Each time a query
-// executes, information about the query execution is saved with a unique ID.
+// Returns information about a single execution of a query if you have access
+// to the workgroup in which the query ran. Each time a query executes, information
+// about the query execution is saved with a unique ID.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -586,9 +764,10 @@ func (c *Athena) GetQueryResultsRequest(input *GetQueryResultsInput) (req *reque
 
 // GetQueryResults API operation for Amazon Athena.
 //
-// Returns the results of a single query execution specified by QueryExecutionId.
-// This request does not execute the query but returns results. Use StartQueryExecution
-// to run a query.
+// Returns the results of a single query execution specified by QueryExecutionId
+// if you have access to the workgroup in which the query ran. This request
+// does not execute the query but returns results. Use StartQueryExecution to
+// run a query.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -678,6 +857,90 @@ func (c *Athena) GetQueryResultsPagesWithContext(ctx aws.Context, input *GetQuer
 	return p.Err()
 }
 
+const opGetWorkGroup = "GetWorkGroup"
+
+// GetWorkGroupRequest generates a "aws/request.Request" representing the
+// client's request for the GetWorkGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See GetWorkGroup for more information on using the GetWorkGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the GetWorkGroupRequest method.
+//    req, resp := client.GetWorkGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/GetWorkGroup
+func (c *Athena) GetWorkGroupRequest(input *GetWorkGroupInput) (req *request.Request, output *GetWorkGroupOutput) {
+	op := &request.Operation{
+		Name:       opGetWorkGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetWorkGroupInput{}
+	}
+
+	output = &GetWorkGroupOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetWorkGroup API operation for Amazon Athena.
+//
+// Returns information about the workgroup with the speficied name.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Athena's
+// API operation GetWorkGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerException "InternalServerException"
+//   Indicates a platform issue, which may be due to a transient condition or
+//   outage.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   Indicates that something is wrong with the input to the request. For example,
+//   a required parameter may be missing or out of range.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/GetWorkGroup
+func (c *Athena) GetWorkGroup(input *GetWorkGroupInput) (*GetWorkGroupOutput, error) {
+	req, out := c.GetWorkGroupRequest(input)
+	return out, req.Send()
+}
+
+// GetWorkGroupWithContext is the same as GetWorkGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetWorkGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Athena) GetWorkGroupWithContext(ctx aws.Context, input *GetWorkGroupInput, opts ...request.Option) (*GetWorkGroupOutput, error) {
+	req, out := c.GetWorkGroupRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListNamedQueries = "ListNamedQueries"
 
 // ListNamedQueriesRequest generates a "aws/request.Request" representing the
@@ -728,7 +991,8 @@ func (c *Athena) ListNamedQueriesRequest(input *ListNamedQueriesInput) (req *req
 
 // ListNamedQueries API operation for Amazon Athena.
 //
-// Provides a list of all available query IDs.
+// Provides a list of available query IDs only for queries saved in the specified
+// workgroup. Requires that you have access to the workgroup.
 //
 // For code samples using the AWS SDK for Java, see Examples and Code Samples
 // (http://docs.aws.amazon.com/athena/latest/ug/code-samples.html) in the Amazon
@@ -872,7 +1136,9 @@ func (c *Athena) ListQueryExecutionsRequest(input *ListQueryExecutionsInput) (re
 
 // ListQueryExecutions API operation for Amazon Athena.
 //
-// Provides a list of all available query execution IDs.
+// Provides a list of available query execution IDs for the queries in the specified
+// workgroup. Requires you to have access to the workgroup in which the queries
+// ran.
 //
 // For code samples using the AWS SDK for Java, see Examples and Code Samples
 // (http://docs.aws.amazon.com/athena/latest/ug/code-samples.html) in the Amazon
@@ -966,6 +1232,146 @@ func (c *Athena) ListQueryExecutionsPagesWithContext(ctx aws.Context, input *Lis
 	return p.Err()
 }
 
+const opListWorkGroups = "ListWorkGroups"
+
+// ListWorkGroupsRequest generates a "aws/request.Request" representing the
+// client's request for the ListWorkGroups operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListWorkGroups for more information on using the ListWorkGroups
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListWorkGroupsRequest method.
+//    req, resp := client.ListWorkGroupsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/ListWorkGroups
+func (c *Athena) ListWorkGroupsRequest(input *ListWorkGroupsInput) (req *request.Request, output *ListWorkGroupsOutput) {
+	op := &request.Operation{
+		Name:       opListWorkGroups,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
+	}
+
+	if input == nil {
+		input = &ListWorkGroupsInput{}
+	}
+
+	output = &ListWorkGroupsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListWorkGroups API operation for Amazon Athena.
+//
+// Lists available workgroups for the account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Athena's
+// API operation ListWorkGroups for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerException "InternalServerException"
+//   Indicates a platform issue, which may be due to a transient condition or
+//   outage.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   Indicates that something is wrong with the input to the request. For example,
+//   a required parameter may be missing or out of range.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/ListWorkGroups
+func (c *Athena) ListWorkGroups(input *ListWorkGroupsInput) (*ListWorkGroupsOutput, error) {
+	req, out := c.ListWorkGroupsRequest(input)
+	return out, req.Send()
+}
+
+// ListWorkGroupsWithContext is the same as ListWorkGroups with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListWorkGroups for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Athena) ListWorkGroupsWithContext(ctx aws.Context, input *ListWorkGroupsInput, opts ...request.Option) (*ListWorkGroupsOutput, error) {
+	req, out := c.ListWorkGroupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+// ListWorkGroupsPages iterates over the pages of a ListWorkGroups operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListWorkGroups method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListWorkGroups operation.
+//    pageNum := 0
+//    err := client.ListWorkGroupsPages(params,
+//        func(page *ListWorkGroupsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *Athena) ListWorkGroupsPages(input *ListWorkGroupsInput, fn func(*ListWorkGroupsOutput, bool) bool) error {
+	return c.ListWorkGroupsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListWorkGroupsPagesWithContext same as ListWorkGroupsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Athena) ListWorkGroupsPagesWithContext(ctx aws.Context, input *ListWorkGroupsInput, fn func(*ListWorkGroupsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListWorkGroupsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListWorkGroupsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	cont := true
+	for p.Next() && cont {
+		cont = fn(p.Page().(*ListWorkGroupsOutput), !p.HasNextPage())
+	}
+	return p.Err()
+}
+
 const opStartQueryExecution = "StartQueryExecution"
 
 // StartQueryExecutionRequest generates a "aws/request.Request" representing the
@@ -1010,7 +1416,8 @@ func (c *Athena) StartQueryExecutionRequest(input *StartQueryExecutionInput) (re
 
 // StartQueryExecution API operation for Amazon Athena.
 //
-// Runs (executes) the SQL query statements contained in the Query string.
+// Runs the SQL query statements contained in the Query. Requires you to have
+// access to the workgroup in which the query ran.
 //
 // For code samples using the AWS SDK for Java, see Examples and Code Samples
 // (http://docs.aws.amazon.com/athena/latest/ug/code-samples.html) in the Amazon
@@ -1033,8 +1440,7 @@ func (c *Athena) StartQueryExecutionRequest(input *StartQueryExecutionInput) (re
 //   a required parameter may be missing or out of range.
 //
 //   * ErrCodeTooManyRequestsException "TooManyRequestsException"
-//   Indicates that the request was throttled and includes the reason for throttling,
-//   for example, the limit of concurrent queries has been exceeded.
+//   Indicates that the request was throttled.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/StartQueryExecution
 func (c *Athena) StartQueryExecution(input *StartQueryExecutionInput) (*StartQueryExecutionOutput, error) {
@@ -1103,7 +1509,8 @@ func (c *Athena) StopQueryExecutionRequest(input *StopQueryExecutionInput) (req 
 
 // StopQueryExecution API operation for Amazon Athena.
 //
-// Stops a query execution.
+// Stops a query execution. Requires you to have access to the workgroup in
+// which the query ran.
 //
 // For code samples using the AWS SDK for Java, see Examples and Code Samples
 // (http://docs.aws.amazon.com/athena/latest/ug/code-samples.html) in the Amazon
@@ -1142,6 +1549,92 @@ func (c *Athena) StopQueryExecution(input *StopQueryExecutionInput) (*StopQueryE
 // for more information on using Contexts.
 func (c *Athena) StopQueryExecutionWithContext(ctx aws.Context, input *StopQueryExecutionInput, opts ...request.Option) (*StopQueryExecutionOutput, error) {
 	req, out := c.StopQueryExecutionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateWorkGroup = "UpdateWorkGroup"
+
+// UpdateWorkGroupRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateWorkGroup operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateWorkGroup for more information on using the UpdateWorkGroup
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateWorkGroupRequest method.
+//    req, resp := client.UpdateWorkGroupRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/UpdateWorkGroup
+func (c *Athena) UpdateWorkGroupRequest(input *UpdateWorkGroupInput) (req *request.Request, output *UpdateWorkGroupOutput) {
+	op := &request.Operation{
+		Name:       opUpdateWorkGroup,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateWorkGroupInput{}
+	}
+
+	output = &UpdateWorkGroupOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// UpdateWorkGroup API operation for Amazon Athena.
+//
+// Updates the workgroup with the specified name. The workgroup's name cannot
+// be changed.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Athena's
+// API operation UpdateWorkGroup for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerException "InternalServerException"
+//   Indicates a platform issue, which may be due to a transient condition or
+//   outage.
+//
+//   * ErrCodeInvalidRequestException "InvalidRequestException"
+//   Indicates that something is wrong with the input to the request. For example,
+//   a required parameter may be missing or out of range.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/athena-2017-05-18/UpdateWorkGroup
+func (c *Athena) UpdateWorkGroup(input *UpdateWorkGroupInput) (*UpdateWorkGroupOutput, error) {
+	req, out := c.UpdateWorkGroupRequest(input)
+	return out, req.Send()
+}
+
+// UpdateWorkGroupWithContext is the same as UpdateWorkGroup with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateWorkGroup for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Athena) UpdateWorkGroupWithContext(ctx aws.Context, input *UpdateWorkGroupInput, opts ...request.Option) (*UpdateWorkGroupOutput, error) {
+	req, out := c.UpdateWorkGroupRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1422,18 +1915,21 @@ type CreateNamedQueryInput struct {
 	// Database is a required field
 	Database *string `min:"1" type:"string" required:"true"`
 
-	// A brief explanation of the query.
+	// The query description.
 	Description *string `min:"1" type:"string"`
 
-	// The plain language name for the query.
+	// The query name.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// The text of the query itself. In other words, all query statements.
+	// The contents of the query with all query statements.
 	//
 	// QueryString is a required field
 	QueryString *string `min:"1" type:"string" required:"true"`
+
+	// The name of the workgroup in which the named query is being created.
+	WorkGroup *string `type:"string"`
 }
 
 // String returns the string representation
@@ -1510,6 +2006,12 @@ func (s *CreateNamedQueryInput) SetQueryString(v string) *CreateNamedQueryInput 
 	return s
 }
 
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *CreateNamedQueryInput) SetWorkGroup(v string) *CreateNamedQueryInput {
+	s.WorkGroup = &v
+	return s
+}
+
 type CreateNamedQueryOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1531,6 +2033,87 @@ func (s CreateNamedQueryOutput) GoString() string {
 func (s *CreateNamedQueryOutput) SetNamedQueryId(v string) *CreateNamedQueryOutput {
 	s.NamedQueryId = &v
 	return s
+}
+
+type CreateWorkGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The configuration for the workgroup, which includes the location in Amazon
+	// S3 where query results are stored, the encryption configuration, if any,
+	// used for encrypting query results, whether the Amazon CloudWatch Metrics
+	// are enabled for the workgroup, the limit for the amount of bytes scanned
+	// (cutoff) per query, if it is specified, and whether workgroup's settings
+	// (specified with EnforceWorkGroupConfiguration) in the WorkGroupConfiguration
+	// override client-side settings. See WorkGroupConfiguration$EnforceWorkGroupConfiguration.
+	Configuration *WorkGroupConfiguration `type:"structure"`
+
+	// The workgroup description.
+	Description *string `type:"string"`
+
+	// The workgroup name.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s CreateWorkGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateWorkGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateWorkGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateWorkGroupInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Configuration != nil {
+		if err := s.Configuration.Validate(); err != nil {
+			invalidParams.AddNested("Configuration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *CreateWorkGroupInput) SetConfiguration(v *WorkGroupConfiguration) *CreateWorkGroupInput {
+	s.Configuration = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateWorkGroupInput) SetDescription(v string) *CreateWorkGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateWorkGroupInput) SetName(v string) *CreateWorkGroupInput {
+	s.Name = &v
+	return s
+}
+
+type CreateWorkGroupOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateWorkGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CreateWorkGroupOutput) GoString() string {
+	return s.String()
 }
 
 // A piece of data (a field in the table).
@@ -1594,6 +2177,68 @@ func (s DeleteNamedQueryOutput) GoString() string {
 	return s.String()
 }
 
+type DeleteWorkGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The option to delete the workgroup and its contents even if the workgroup
+	// contains any named queries.
+	RecursiveDeleteOption *bool `type:"boolean"`
+
+	// The unique name of the workgroup to delete.
+	//
+	// WorkGroup is a required field
+	WorkGroup *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteWorkGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteWorkGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteWorkGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteWorkGroupInput"}
+	if s.WorkGroup == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkGroup"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRecursiveDeleteOption sets the RecursiveDeleteOption field's value.
+func (s *DeleteWorkGroupInput) SetRecursiveDeleteOption(v bool) *DeleteWorkGroupInput {
+	s.RecursiveDeleteOption = &v
+	return s
+}
+
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *DeleteWorkGroupInput) SetWorkGroup(v string) *DeleteWorkGroupInput {
+	s.WorkGroup = &v
+	return s
+}
+
+type DeleteWorkGroupOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteWorkGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteWorkGroupOutput) GoString() string {
+	return s.String()
+}
+
 // If query results are encrypted in Amazon S3, indicates the encryption option
 // used (for example, SSE-KMS or CSE-KMS) and key information.
 type EncryptionConfiguration struct {
@@ -1602,6 +2247,10 @@ type EncryptionConfiguration struct {
 	// Indicates whether Amazon S3 server-side encryption with Amazon S3-managed
 	// keys (SSE-S3), server-side encryption with KMS-managed keys (SSE-KMS), or
 	// client-side encryption with KMS-managed keys (CSE-KMS) is used.
+	//
+	// If a query runs in a workgroup and the workgroup overrides client-side settings,
+	// then the workgroup's setting for encryption is used. It specifies whether
+	// query results must be encrypted, for all queries that run in this workgroup.
 	//
 	// EncryptionOption is a required field
 	EncryptionOption *string `type:"string" required:"true" enum:"EncryptionOption"`
@@ -1775,7 +2424,7 @@ type GetQueryResultsInput struct {
 
 	// The token that specifies where to start pagination if a previous request
 	// was truncated.
-	NextToken *string `type:"string"`
+	NextToken *string `min:"1" type:"string"`
 
 	// The unique ID of the query execution.
 	//
@@ -1796,6 +2445,9 @@ func (s GetQueryResultsInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *GetQueryResultsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "GetQueryResultsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
 	if s.QueryExecutionId == nil {
 		invalidParams.Add(request.NewErrParamRequired("QueryExecutionId"))
 	}
@@ -1828,7 +2480,7 @@ type GetQueryResultsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A token to be used by the next request if this request is truncated.
-	NextToken *string `type:"string"`
+	NextToken *string `min:"1" type:"string"`
 
 	// The results of the query execution.
 	ResultSet *ResultSet `type:"structure"`
@@ -1865,6 +2517,67 @@ func (s *GetQueryResultsOutput) SetUpdateCount(v int64) *GetQueryResultsOutput {
 	return s
 }
 
+type GetWorkGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the workgroup.
+	//
+	// WorkGroup is a required field
+	WorkGroup *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetWorkGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetWorkGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetWorkGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetWorkGroupInput"}
+	if s.WorkGroup == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkGroup"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *GetWorkGroupInput) SetWorkGroup(v string) *GetWorkGroupInput {
+	s.WorkGroup = &v
+	return s
+}
+
+type GetWorkGroupOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the workgroup.
+	WorkGroup *WorkGroup `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetWorkGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetWorkGroupOutput) GoString() string {
+	return s.String()
+}
+
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *GetWorkGroupOutput) SetWorkGroup(v *WorkGroup) *GetWorkGroupOutput {
+	s.WorkGroup = v
+	return s
+}
+
 type ListNamedQueriesInput struct {
 	_ struct{} `type:"structure"`
 
@@ -1873,7 +2586,10 @@ type ListNamedQueriesInput struct {
 
 	// The token that specifies where to start pagination if a previous request
 	// was truncated.
-	NextToken *string `type:"string"`
+	NextToken *string `min:"1" type:"string"`
+
+	// The name of the workgroup from which the named queries are being returned.
+	WorkGroup *string `type:"string"`
 }
 
 // String returns the string representation
@@ -1884,6 +2600,19 @@ func (s ListNamedQueriesInput) String() string {
 // GoString returns the string representation
 func (s ListNamedQueriesInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListNamedQueriesInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListNamedQueriesInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetMaxResults sets the MaxResults field's value.
@@ -1898,6 +2627,12 @@ func (s *ListNamedQueriesInput) SetNextToken(v string) *ListNamedQueriesInput {
 	return s
 }
 
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *ListNamedQueriesInput) SetWorkGroup(v string) *ListNamedQueriesInput {
+	s.WorkGroup = &v
+	return s
+}
+
 type ListNamedQueriesOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -1905,7 +2640,7 @@ type ListNamedQueriesOutput struct {
 	NamedQueryIds []*string `min:"1" type:"list"`
 
 	// A token to be used by the next request if this request is truncated.
-	NextToken *string `type:"string"`
+	NextToken *string `min:"1" type:"string"`
 }
 
 // String returns the string representation
@@ -1938,7 +2673,10 @@ type ListQueryExecutionsInput struct {
 
 	// The token that specifies where to start pagination if a previous request
 	// was truncated.
-	NextToken *string `type:"string"`
+	NextToken *string `min:"1" type:"string"`
+
+	// The name of the workgroup from which queries are being returned.
+	WorkGroup *string `type:"string"`
 }
 
 // String returns the string representation
@@ -1949,6 +2687,19 @@ func (s ListQueryExecutionsInput) String() string {
 // GoString returns the string representation
 func (s ListQueryExecutionsInput) GoString() string {
 	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListQueryExecutionsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListQueryExecutionsInput"}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
 }
 
 // SetMaxResults sets the MaxResults field's value.
@@ -1963,11 +2714,17 @@ func (s *ListQueryExecutionsInput) SetNextToken(v string) *ListQueryExecutionsIn
 	return s
 }
 
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *ListQueryExecutionsInput) SetWorkGroup(v string) *ListQueryExecutionsInput {
+	s.WorkGroup = &v
+	return s
+}
+
 type ListQueryExecutionsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A token to be used by the next request if this request is truncated.
-	NextToken *string `type:"string"`
+	NextToken *string `min:"1" type:"string"`
 
 	// The unique IDs of each query execution as an array of strings.
 	QueryExecutionIds []*string `min:"1" type:"list"`
@@ -1995,8 +2752,89 @@ func (s *ListQueryExecutionsOutput) SetQueryExecutionIds(v []*string) *ListQuery
 	return s
 }
 
-// A query, where QueryString is the SQL query statements that comprise the
-// query.
+type ListWorkGroupsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum number of workgroups to return in this request.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// A token to be used by the next request if this request is truncated.
+	NextToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation
+func (s ListWorkGroupsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListWorkGroupsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListWorkGroupsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListWorkGroupsInput"}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListWorkGroupsInput) SetMaxResults(v int64) *ListWorkGroupsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListWorkGroupsInput) SetNextToken(v string) *ListWorkGroupsInput {
+	s.NextToken = &v
+	return s
+}
+
+type ListWorkGroupsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// A token to be used by the next request if this request is truncated.
+	NextToken *string `min:"1" type:"string"`
+
+	// The list of workgroups, including their names, descriptions, creation times,
+	// and states.
+	WorkGroups []*WorkGroupSummary `type:"list"`
+}
+
+// String returns the string representation
+func (s ListWorkGroupsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListWorkGroupsOutput) GoString() string {
+	return s.String()
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListWorkGroupsOutput) SetNextToken(v string) *ListWorkGroupsOutput {
+	s.NextToken = &v
+	return s
+}
+
+// SetWorkGroups sets the WorkGroups field's value.
+func (s *ListWorkGroupsOutput) SetWorkGroups(v []*WorkGroupSummary) *ListWorkGroupsOutput {
+	s.WorkGroups = v
+	return s
+}
+
+// A query, where QueryString is the list of SQL query statements that comprise
+// the query.
 type NamedQuery struct {
 	_ struct{} `type:"structure"`
 
@@ -2005,10 +2843,10 @@ type NamedQuery struct {
 	// Database is a required field
 	Database *string `min:"1" type:"string" required:"true"`
 
-	// A brief description of the query.
+	// The query description.
 	Description *string `min:"1" type:"string"`
 
-	// The plain-language name of the query.
+	// The query name.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
@@ -2020,6 +2858,9 @@ type NamedQuery struct {
 	//
 	// QueryString is a required field
 	QueryString *string `min:"1" type:"string" required:"true"`
+
+	// The name of the workgroup that contains the named query.
+	WorkGroup *string `type:"string"`
 }
 
 // String returns the string representation
@@ -2062,6 +2903,12 @@ func (s *NamedQuery) SetQueryString(v string) *NamedQuery {
 	return s
 }
 
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *NamedQuery) SetWorkGroup(v string) *NamedQuery {
+	s.WorkGroup = &v
+	return s
+}
+
 // Information about a single instance of a query execution.
 type QueryExecution struct {
 	_ struct{} `type:"structure"`
@@ -2076,7 +2923,10 @@ type QueryExecution struct {
 	QueryExecutionId *string `type:"string"`
 
 	// The location in Amazon S3 where query results were stored and the encryption
-	// option, if any, used for query results.
+	// option, if any, used for query results. These are known as "client-side settings".
+	// If workgroup settings override client-side settings, then the query uses
+	// the location for the query results and the encryption configuration that
+	// are specified for the workgroup.
 	ResultConfiguration *ResultConfiguration `type:"structure"`
 
 	// The type of query statement that was run. DDL indicates DDL query statements.
@@ -2092,6 +2942,9 @@ type QueryExecution struct {
 	// The completion date, current state, submission time, and state change reason
 	// (if applicable) for the query execution.
 	Status *QueryExecutionStatus `type:"structure"`
+
+	// The name of the workgroup in which the query ran.
+	WorkGroup *string `type:"string"`
 }
 
 // String returns the string representation
@@ -2143,6 +2996,12 @@ func (s *QueryExecution) SetStatistics(v *QueryExecutionStatistics) *QueryExecut
 // SetStatus sets the Status field's value.
 func (s *QueryExecution) SetStatus(v *QueryExecutionStatus) *QueryExecution {
 	s.Status = v
+	return s
+}
+
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *QueryExecution) SetWorkGroup(v string) *QueryExecution {
+	s.WorkGroup = &v
 	return s
 }
 
@@ -2228,9 +3087,9 @@ type QueryExecutionStatus struct {
 	// The state of query execution. QUEUED state is listed but is not used by Athena
 	// and is reserved for future use. RUNNING indicates that the query has been
 	// submitted to the service, and Athena will execute the query as soon as resources
-	// are available. SUCCEEDED indicates that the query completed without error.
+	// are available. SUCCEEDED indicates that the query completed without errors.
 	// FAILED indicates that the query experienced an error and did not complete
-	// processing.CANCELLED indicates that user input interrupted query execution.
+	// processing. CANCELLED indicates that a user input interrupted query execution.
 	State *string `type:"string" enum:"QueryExecutionState"`
 
 	// Further detail about the status of the query.
@@ -2275,19 +3134,30 @@ func (s *QueryExecutionStatus) SetSubmissionDateTime(v time.Time) *QueryExecutio
 }
 
 // The location in Amazon S3 where query results are stored and the encryption
-// option, if any, used for query results.
+// option, if any, used for query results. These are known as "client-side settings".
+// If workgroup settings override client-side settings, then the query uses
+// the location for the query results and the encryption configuration that
+// are specified for the workgroup.
 type ResultConfiguration struct {
 	_ struct{} `type:"structure"`
 
 	// If query results are encrypted in Amazon S3, indicates the encryption option
-	// used (for example, SSE-KMS or CSE-KMS) and key information.
+	// used (for example, SSE-KMS or CSE-KMS) and key information. This is a client-side
+	// setting. If workgroup settings override client-side settings, then the query
+	// uses the encryption configuration that is specified for the workgroup, and
+	// also uses the location for storing query results specified in the workgroup.
+	// See WorkGroupConfiguration$EnforceWorkGroupConfiguration and Workgroup Settings
+	// Override Client-Side Settings (https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html).
 	EncryptionConfiguration *EncryptionConfiguration `type:"structure"`
 
 	// The location in Amazon S3 where your query results are stored, such as s3://path/to/query/bucket/.
-	// For more information, see Queries and Query Result Files.  (http://docs.aws.amazon.com/athena/latest/ug/querying.html)
-	//
-	// OutputLocation is a required field
-	OutputLocation *string `type:"string" required:"true"`
+	// For more information, see Queries and Query Result Files. (https://docs.aws.amazon.com/athena/latest/ug/querying.html)
+	// If workgroup settings override client-side settings, then the query uses
+	// the location for the query results and the encryption configuration that
+	// are specified for the workgroup. The "workgroup settings override" is specified
+	// in EnforceWorkGroupConfiguration (true/false) in the WorkGroupConfiguration.
+	// See WorkGroupConfiguration$EnforceWorkGroupConfiguration.
+	OutputLocation *string `type:"string"`
 }
 
 // String returns the string representation
@@ -2303,9 +3173,6 @@ func (s ResultConfiguration) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *ResultConfiguration) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "ResultConfiguration"}
-	if s.OutputLocation == nil {
-		invalidParams.Add(request.NewErrParamRequired("OutputLocation"))
-	}
 	if s.EncryptionConfiguration != nil {
 		if err := s.EncryptionConfiguration.Validate(); err != nil {
 			invalidParams.AddNested("EncryptionConfiguration", err.(request.ErrInvalidParams))
@@ -2327,6 +3194,91 @@ func (s *ResultConfiguration) SetEncryptionConfiguration(v *EncryptionConfigurat
 // SetOutputLocation sets the OutputLocation field's value.
 func (s *ResultConfiguration) SetOutputLocation(v string) *ResultConfiguration {
 	s.OutputLocation = &v
+	return s
+}
+
+// The information about the updates in the query results, such as output location
+// and encryption configuration for the query results.
+type ResultConfigurationUpdates struct {
+	_ struct{} `type:"structure"`
+
+	// The encryption configuration for the query results.
+	EncryptionConfiguration *EncryptionConfiguration `type:"structure"`
+
+	// The location in Amazon S3 where your query results are stored, such as s3://path/to/query/bucket/.
+	// For more information, see Queries and Query Result Files. (https://docs.aws.amazon.com/athena/latest/ug/querying.html)
+	// If workgroup settings override client-side settings, then the query uses
+	// the location for the query results and the encryption configuration that
+	// are specified for the workgroup. The "workgroup settings override" is specified
+	// in EnforceWorkGroupConfiguration (true/false) in the WorkGroupConfiguration.
+	// See WorkGroupConfiguration$EnforceWorkGroupConfiguration.
+	OutputLocation *string `type:"string"`
+
+	// If set to "true", indicates that the previously-specified encryption configuration
+	// (also known as the client-side setting) for queries in this workgroup should
+	// be ignored and set to null. If set to "false" or not set, and a value is
+	// present in the EncryptionConfiguration in ResultConfigurationUpdates (the
+	// client-side setting), the EncryptionConfiguration in the workgroup's ResultConfiguration
+	// will be updated with the new value. For more information, see Workgroup Settings
+	// Override Client-Side Settings (https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html).
+	RemoveEncryptionConfiguration *bool `type:"boolean"`
+
+	// If set to "true", indicates that the previously-specified query results location
+	// (also known as a client-side setting) for queries in this workgroup should
+	// be ignored and set to null. If set to "false" or not set, and a value is
+	// present in the OutputLocation in ResultConfigurationUpdates (the client-side
+	// setting), the OutputLocation in the workgroup's ResultConfiguration will
+	// be updated with the new value. For more information, see Workgroup Settings
+	// Override Client-Side Settings (https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html).
+	RemoveOutputLocation *bool `type:"boolean"`
+}
+
+// String returns the string representation
+func (s ResultConfigurationUpdates) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ResultConfigurationUpdates) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ResultConfigurationUpdates) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ResultConfigurationUpdates"}
+	if s.EncryptionConfiguration != nil {
+		if err := s.EncryptionConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("EncryptionConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEncryptionConfiguration sets the EncryptionConfiguration field's value.
+func (s *ResultConfigurationUpdates) SetEncryptionConfiguration(v *EncryptionConfiguration) *ResultConfigurationUpdates {
+	s.EncryptionConfiguration = v
+	return s
+}
+
+// SetOutputLocation sets the OutputLocation field's value.
+func (s *ResultConfigurationUpdates) SetOutputLocation(v string) *ResultConfigurationUpdates {
+	s.OutputLocation = &v
+	return s
+}
+
+// SetRemoveEncryptionConfiguration sets the RemoveEncryptionConfiguration field's value.
+func (s *ResultConfigurationUpdates) SetRemoveEncryptionConfiguration(v bool) *ResultConfigurationUpdates {
+	s.RemoveEncryptionConfiguration = &v
+	return s
+}
+
+// SetRemoveOutputLocation sets the RemoveOutputLocation field's value.
+func (s *ResultConfigurationUpdates) SetRemoveOutputLocation(v bool) *ResultConfigurationUpdates {
+	s.RemoveOutputLocation = &v
 	return s
 }
 
@@ -2436,10 +3388,14 @@ type StartQueryExecutionInput struct {
 	QueryString *string `min:"1" type:"string" required:"true"`
 
 	// Specifies information about where and how to save the results of the query
-	// execution.
-	//
-	// ResultConfiguration is a required field
-	ResultConfiguration *ResultConfiguration `type:"structure" required:"true"`
+	// execution. If the query runs in a workgroup, then workgroup's settings may
+	// override query settings. This affects the query results location. The workgroup
+	// settings override is specified in EnforceWorkGroupConfiguration (true/false)
+	// in the WorkGroupConfiguration. See WorkGroupConfiguration$EnforceWorkGroupConfiguration.
+	ResultConfiguration *ResultConfiguration `type:"structure"`
+
+	// The name of the workgroup in which the query is being started.
+	WorkGroup *string `type:"string"`
 }
 
 // String returns the string representation
@@ -2463,9 +3419,6 @@ func (s *StartQueryExecutionInput) Validate() error {
 	}
 	if s.QueryString != nil && len(*s.QueryString) < 1 {
 		invalidParams.Add(request.NewErrParamMinLen("QueryString", 1))
-	}
-	if s.ResultConfiguration == nil {
-		invalidParams.Add(request.NewErrParamRequired("ResultConfiguration"))
 	}
 	if s.QueryExecutionContext != nil {
 		if err := s.QueryExecutionContext.Validate(); err != nil {
@@ -2505,6 +3458,12 @@ func (s *StartQueryExecutionInput) SetQueryString(v string) *StartQueryExecution
 // SetResultConfiguration sets the ResultConfiguration field's value.
 func (s *StartQueryExecutionInput) SetResultConfiguration(v *ResultConfiguration) *StartQueryExecutionInput {
 	s.ResultConfiguration = v
+	return s
+}
+
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *StartQueryExecutionInput) SetWorkGroup(v string) *StartQueryExecutionInput {
+	s.WorkGroup = &v
 	return s
 }
 
@@ -2655,6 +3614,386 @@ func (s *UnprocessedQueryExecutionId) SetQueryExecutionId(v string) *Unprocessed
 	return s
 }
 
+type UpdateWorkGroupInput struct {
+	_ struct{} `type:"structure"`
+
+	// The workgroup configuration that will be updated for the given workgroup.
+	ConfigurationUpdates *WorkGroupConfigurationUpdates `type:"structure"`
+
+	// The workgroup description.
+	Description *string `type:"string"`
+
+	// The workgroup state that will be updated for the given workgroup.
+	State *string `type:"string" enum:"WorkGroupState"`
+
+	// The specified workgroup that will be updated.
+	//
+	// WorkGroup is a required field
+	WorkGroup *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s UpdateWorkGroupInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateWorkGroupInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateWorkGroupInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateWorkGroupInput"}
+	if s.WorkGroup == nil {
+		invalidParams.Add(request.NewErrParamRequired("WorkGroup"))
+	}
+	if s.ConfigurationUpdates != nil {
+		if err := s.ConfigurationUpdates.Validate(); err != nil {
+			invalidParams.AddNested("ConfigurationUpdates", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetConfigurationUpdates sets the ConfigurationUpdates field's value.
+func (s *UpdateWorkGroupInput) SetConfigurationUpdates(v *WorkGroupConfigurationUpdates) *UpdateWorkGroupInput {
+	s.ConfigurationUpdates = v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateWorkGroupInput) SetDescription(v string) *UpdateWorkGroupInput {
+	s.Description = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *UpdateWorkGroupInput) SetState(v string) *UpdateWorkGroupInput {
+	s.State = &v
+	return s
+}
+
+// SetWorkGroup sets the WorkGroup field's value.
+func (s *UpdateWorkGroupInput) SetWorkGroup(v string) *UpdateWorkGroupInput {
+	s.WorkGroup = &v
+	return s
+}
+
+type UpdateWorkGroupOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateWorkGroupOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s UpdateWorkGroupOutput) GoString() string {
+	return s.String()
+}
+
+// A workgroup, which contains a name, description, creation time, state, and
+// other configuration, listed under WorkGroup$Configuration. Each workgroup
+// enables you to isolate queries for you or your group of users from other
+// queries in the same account, to configure the query results location and
+// the encryption configuration (known as workgroup settings), to enable sending
+// query metrics to Amazon CloudWatch, and to establish per-query data usage
+// control limits for all queries in a workgroup. The workgroup settings override
+// is specified in EnforceWorkGroupConfiguration (true/false) in the WorkGroupConfiguration.
+// See WorkGroupConfiguration$EnforceWorkGroupConfiguration.
+type WorkGroup struct {
+	_ struct{} `type:"structure"`
+
+	// The configuration of the workgroup, which includes the location in Amazon
+	// S3 where query results are stored, the encryption configuration, if any,
+	// used for query results; whether the Amazon CloudWatch Metrics are enabled
+	// for the workgroup; whether workgroup settings override client-side settings;
+	// and the data usage limit for the amount of data scanned per query, if it
+	// is specified. The workgroup settings override is specified in EnforceWorkGroupConfiguration
+	// (true/false) in the WorkGroupConfiguration. See WorkGroupConfiguration$EnforceWorkGroupConfiguration.
+	Configuration *WorkGroupConfiguration `type:"structure"`
+
+	// The date and time the workgroup was created.
+	CreationTime *time.Time `type:"timestamp"`
+
+	// The workgroup description.
+	Description *string `type:"string"`
+
+	// The workgroup name.
+	//
+	// Name is a required field
+	Name *string `type:"string" required:"true"`
+
+	// The state of the workgroup: ENABLED or DISABLED.
+	State *string `type:"string" enum:"WorkGroupState"`
+}
+
+// String returns the string representation
+func (s WorkGroup) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s WorkGroup) GoString() string {
+	return s.String()
+}
+
+// SetConfiguration sets the Configuration field's value.
+func (s *WorkGroup) SetConfiguration(v *WorkGroupConfiguration) *WorkGroup {
+	s.Configuration = v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *WorkGroup) SetCreationTime(v time.Time) *WorkGroup {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *WorkGroup) SetDescription(v string) *WorkGroup {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *WorkGroup) SetName(v string) *WorkGroup {
+	s.Name = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *WorkGroup) SetState(v string) *WorkGroup {
+	s.State = &v
+	return s
+}
+
+// The configuration of the workgroup, which includes the location in Amazon
+// S3 where query results are stored, the encryption option, if any, used for
+// query results, whether the Amazon CloudWatch Metrics are enabled for the
+// workgroup and whether workgroup settings override query settings, and the
+// data usage limit for the amount of data scanned per query, if it is specified.
+// The workgroup settings override is specified in EnforceWorkGroupConfiguration
+// (true/false) in the WorkGroupConfiguration. See WorkGroupConfiguration$EnforceWorkGroupConfiguration.
+type WorkGroupConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The upper data usage limit (cutoff) for the amount of bytes a single query
+	// in a workgroup is allowed to scan.
+	BytesScannedCutoffPerQuery *int64 `min:"1e+07" type:"long"`
+
+	// If set to "true", the settings for the workgroup override client-side settings.
+	// If set to "false", client-side settings are used. For more information, see
+	// Workgroup Settings Override Client-Side Settings (https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html).
+	EnforceWorkGroupConfiguration *bool `type:"boolean"`
+
+	// Indicates that the Amazon CloudWatch metrics are enabled for the workgroup.
+	PublishCloudWatchMetricsEnabled *bool `type:"boolean"`
+
+	// The configuration for the workgroup, which includes the location in Amazon
+	// S3 where query results are stored and the encryption option, if any, used
+	// for query results.
+	ResultConfiguration *ResultConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkGroupConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s WorkGroupConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkGroupConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkGroupConfiguration"}
+	if s.BytesScannedCutoffPerQuery != nil && *s.BytesScannedCutoffPerQuery < 1e+07 {
+		invalidParams.Add(request.NewErrParamMinValue("BytesScannedCutoffPerQuery", 1e+07))
+	}
+	if s.ResultConfiguration != nil {
+		if err := s.ResultConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("ResultConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBytesScannedCutoffPerQuery sets the BytesScannedCutoffPerQuery field's value.
+func (s *WorkGroupConfiguration) SetBytesScannedCutoffPerQuery(v int64) *WorkGroupConfiguration {
+	s.BytesScannedCutoffPerQuery = &v
+	return s
+}
+
+// SetEnforceWorkGroupConfiguration sets the EnforceWorkGroupConfiguration field's value.
+func (s *WorkGroupConfiguration) SetEnforceWorkGroupConfiguration(v bool) *WorkGroupConfiguration {
+	s.EnforceWorkGroupConfiguration = &v
+	return s
+}
+
+// SetPublishCloudWatchMetricsEnabled sets the PublishCloudWatchMetricsEnabled field's value.
+func (s *WorkGroupConfiguration) SetPublishCloudWatchMetricsEnabled(v bool) *WorkGroupConfiguration {
+	s.PublishCloudWatchMetricsEnabled = &v
+	return s
+}
+
+// SetResultConfiguration sets the ResultConfiguration field's value.
+func (s *WorkGroupConfiguration) SetResultConfiguration(v *ResultConfiguration) *WorkGroupConfiguration {
+	s.ResultConfiguration = v
+	return s
+}
+
+// The configuration information that will be updated for this workgroup, which
+// includes the location in Amazon S3 where query results are stored, the encryption
+// option, if any, used for query results, whether the Amazon CloudWatch Metrics
+// are enabled for the workgroup, whether the workgroup settings override the
+// client-side settings, and the data usage limit for the amount of bytes scanned
+// per query, if it is specified.
+type WorkGroupConfigurationUpdates struct {
+	_ struct{} `type:"structure"`
+
+	// The upper limit (cutoff) for the amount of bytes a single query in a workgroup
+	// is allowed to scan.
+	BytesScannedCutoffPerQuery *int64 `min:"1e+07" type:"long"`
+
+	// If set to "true", the settings for the workgroup override client-side settings.
+	// If set to "false" client-side settings are used. For more information, see
+	// Workgroup Settings Override Client-Side Settings (https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html).
+	EnforceWorkGroupConfiguration *bool `type:"boolean"`
+
+	// Indicates whether this workgroup enables publishing metrics to Amazon CloudWatch.
+	PublishCloudWatchMetricsEnabled *bool `type:"boolean"`
+
+	// Indicates that the data usage control limit per query is removed. WorkGroupConfiguration$BytesScannedCutoffPerQuery
+	RemoveBytesScannedCutoffPerQuery *bool `type:"boolean"`
+
+	// The result configuration information about the queries in this workgroup
+	// that will be updated. Includes the updated results location and an updated
+	// option for encrypting query results.
+	ResultConfigurationUpdates *ResultConfigurationUpdates `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkGroupConfigurationUpdates) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s WorkGroupConfigurationUpdates) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *WorkGroupConfigurationUpdates) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "WorkGroupConfigurationUpdates"}
+	if s.BytesScannedCutoffPerQuery != nil && *s.BytesScannedCutoffPerQuery < 1e+07 {
+		invalidParams.Add(request.NewErrParamMinValue("BytesScannedCutoffPerQuery", 1e+07))
+	}
+	if s.ResultConfigurationUpdates != nil {
+		if err := s.ResultConfigurationUpdates.Validate(); err != nil {
+			invalidParams.AddNested("ResultConfigurationUpdates", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBytesScannedCutoffPerQuery sets the BytesScannedCutoffPerQuery field's value.
+func (s *WorkGroupConfigurationUpdates) SetBytesScannedCutoffPerQuery(v int64) *WorkGroupConfigurationUpdates {
+	s.BytesScannedCutoffPerQuery = &v
+	return s
+}
+
+// SetEnforceWorkGroupConfiguration sets the EnforceWorkGroupConfiguration field's value.
+func (s *WorkGroupConfigurationUpdates) SetEnforceWorkGroupConfiguration(v bool) *WorkGroupConfigurationUpdates {
+	s.EnforceWorkGroupConfiguration = &v
+	return s
+}
+
+// SetPublishCloudWatchMetricsEnabled sets the PublishCloudWatchMetricsEnabled field's value.
+func (s *WorkGroupConfigurationUpdates) SetPublishCloudWatchMetricsEnabled(v bool) *WorkGroupConfigurationUpdates {
+	s.PublishCloudWatchMetricsEnabled = &v
+	return s
+}
+
+// SetRemoveBytesScannedCutoffPerQuery sets the RemoveBytesScannedCutoffPerQuery field's value.
+func (s *WorkGroupConfigurationUpdates) SetRemoveBytesScannedCutoffPerQuery(v bool) *WorkGroupConfigurationUpdates {
+	s.RemoveBytesScannedCutoffPerQuery = &v
+	return s
+}
+
+// SetResultConfigurationUpdates sets the ResultConfigurationUpdates field's value.
+func (s *WorkGroupConfigurationUpdates) SetResultConfigurationUpdates(v *ResultConfigurationUpdates) *WorkGroupConfigurationUpdates {
+	s.ResultConfigurationUpdates = v
+	return s
+}
+
+// The summary information for the workgroup, which includes its name, state,
+// description, and the date and time it was created.
+type WorkGroupSummary struct {
+	_ struct{} `type:"structure"`
+
+	// The workgroup creation date and time.
+	CreationTime *time.Time `type:"timestamp"`
+
+	// The workgroup description.
+	Description *string `type:"string"`
+
+	// The name of the workgroup.
+	Name *string `type:"string"`
+
+	// The state of the workgroup.
+	State *string `type:"string" enum:"WorkGroupState"`
+}
+
+// String returns the string representation
+func (s WorkGroupSummary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s WorkGroupSummary) GoString() string {
+	return s.String()
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *WorkGroupSummary) SetCreationTime(v time.Time) *WorkGroupSummary {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *WorkGroupSummary) SetDescription(v string) *WorkGroupSummary {
+	s.Description = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *WorkGroupSummary) SetName(v string) *WorkGroupSummary {
+	s.Name = &v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *WorkGroupSummary) SetState(v string) *WorkGroupSummary {
+	s.State = &v
+	return s
+}
+
 const (
 	// ColumnNullableNotNull is a ColumnNullable enum value
 	ColumnNullableNotNull = "NOT_NULL"
@@ -2710,4 +4049,12 @@ const (
 const (
 	// ThrottleReasonConcurrentQueryLimitExceeded is a ThrottleReason enum value
 	ThrottleReasonConcurrentQueryLimitExceeded = "CONCURRENT_QUERY_LIMIT_EXCEEDED"
+)
+
+const (
+	// WorkGroupStateEnabled is a WorkGroupState enum value
+	WorkGroupStateEnabled = "ENABLED"
+
+	// WorkGroupStateDisabled is a WorkGroupState enum value
+	WorkGroupStateDisabled = "DISABLED"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/athena/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/athena/errors.go
@@ -21,7 +21,6 @@ const (
 	// ErrCodeTooManyRequestsException for service response error code
 	// "TooManyRequestsException".
 	//
-	// Indicates that the request was throttled and includes the reason for throttling,
-	// for example, the limit of concurrent queries has been exceeded.
+	// Indicates that the request was throttled.
 	ErrCodeTooManyRequestsException = "TooManyRequestsException"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/efs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/efs/api.go
@@ -98,8 +98,9 @@ func (c *EFS) CreateFileSystemRequest(input *CreateFileSystemInput) (req *reques
 // After the file system is fully created, Amazon EFS sets its lifecycle state
 // to available, at which point you can create one or more mount targets for
 // the file system in your VPC. For more information, see CreateMountTarget.
-// You mount your Amazon EFS file system on an EC2 instances in your VPC via
-// the mount target. For more information, see Amazon EFS: How it Works (http://docs.aws.amazon.com/efs/latest/ug/how-it-works.html).
+// You mount your Amazon EFS file system on an EC2 instances in your VPC by
+// using the mount target. For more information, see Amazon EFS: How it Works
+// (http://docs.aws.amazon.com/efs/latest/ug/how-it-works.html).
 //
 // This operation requires permissions for the elasticfilesystem:CreateFileSystem
 // action.
@@ -205,7 +206,7 @@ func (c *EFS) CreateMountTargetRequest(input *CreateMountTargetInput) (req *requ
 // CreateMountTarget API operation for Amazon Elastic File System.
 //
 // Creates a mount target for a file system. You can then mount the file system
-// on EC2 instances via the mount target.
+// on EC2 instances by using the mount target.
 //
 // You can create one mount target in each Availability Zone in your VPC. All
 // EC2 instances in a VPC within a given Availability Zone share a single mount
@@ -231,9 +232,9 @@ func (c *EFS) CreateMountTargetRequest(input *CreateMountTargetInput) (req *requ
 // a MountTargetId and an IpAddress. You use this IP address when mounting the
 // file system in an EC2 instance. You can also use the mount target's DNS name
 // when mounting the file system. The EC2 instance on which you mount the file
-// system via the mount target can resolve the mount target's DNS name to its
-// IP address. For more information, see How it Works: Implementation Overview
-// (http://docs.aws.amazon.com/efs/latest/ug/how-it-works.html#how-it-works-implementation).
+// system by using the mount target can resolve the mount target's DNS name
+// to its IP address. For more information, see How it Works: Implementation
+// Overview (http://docs.aws.amazon.com/efs/latest/ug/how-it-works.html#how-it-works-implementation).
 //
 // Note that you can create mount targets for a file system in only one VPC,
 // and there can be only one mount target per Availability Zone. That is, if
@@ -278,7 +279,7 @@ func (c *EFS) CreateMountTargetRequest(input *CreateMountTargetInput) (req *requ
 // target creation status by calling the DescribeMountTargets operation, which
 // among other things returns the mount target state.
 //
-// We recommend you create a mount target in each of the Availability Zones.
+// We recommend that you create a mount target in each of the Availability Zones.
 // There are cost considerations for using a file system in an Availability
 // Zone through a mount target created in another Availability Zone. For more
 // information, see Amazon EFS (http://aws.amazon.com/efs/). In addition, by
@@ -624,14 +625,14 @@ func (c *EFS) DeleteMountTargetRequest(input *DeleteMountTargetInput) (req *requ
 //
 // Deletes the specified mount target.
 //
-// This operation forcibly breaks any mounts of the file system via the mount
-// target that is being deleted, which might disrupt instances or applications
+// This operation forcibly breaks any mounts of the file system by using the
+// mount target that is being deleted, which might disrupt instances or applications
 // using those mounts. To avoid applications getting cut off abruptly, you might
 // consider unmounting any mounts of the mount target, if feasible. The operation
-// also deletes the associated network interface. Uncommitted writes may be
+// also deletes the associated network interface. Uncommitted writes might be
 // lost, but breaking a mount target using this operation does not corrupt the
 // file system itself. The file system you created remains. You can mount an
-// EC2 instance in your VPC via another mount target.
+// EC2 instance in your VPC by using another mount target.
 //
 // This operation requires permissions for the following action on the file
 // system:
@@ -839,18 +840,16 @@ func (c *EFS) DescribeFileSystemsRequest(input *DescribeFileSystemsInput) (req *
 //
 // When retrieving all file system descriptions, you can optionally specify
 // the MaxItems parameter to limit the number of descriptions in a response.
-// If more file system descriptions remain, Amazon EFS returns a NextMarker,
-// an opaque token, in the response. In this case, you should send a subsequent
-// request with the Marker request parameter set to the value of NextMarker.
+// Currently, this number is automatically set to 10. If more file system descriptions
+// remain, Amazon EFS returns a NextMarker, an opaque token, in the response.
+// In this case, you should send a subsequent request with the Marker request
+// parameter set to the value of NextMarker.
 //
 // To retrieve a list of your file system descriptions, this operation is used
 // in an iterative process, where DescribeFileSystems is called first without
 // the Marker and then the operation continues to call it with the Marker parameter
 // set to the value of the NextMarker from the previous response until the response
 // has no NextMarker.
-//
-// The implementation may return fewer than MaxItems file system descriptions
-// while still including a NextMarker value.
 //
 // The order of file systems returned in the response of one DescribeFileSystems
 // call and the order of file systems returned across the responses of a multi-call
@@ -895,6 +894,100 @@ func (c *EFS) DescribeFileSystems(input *DescribeFileSystemsInput) (*DescribeFil
 // for more information on using Contexts.
 func (c *EFS) DescribeFileSystemsWithContext(ctx aws.Context, input *DescribeFileSystemsInput, opts ...request.Option) (*DescribeFileSystemsOutput, error) {
 	req, out := c.DescribeFileSystemsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeLifecycleConfiguration = "DescribeLifecycleConfiguration"
+
+// DescribeLifecycleConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeLifecycleConfiguration operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeLifecycleConfiguration for more information on using the DescribeLifecycleConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeLifecycleConfigurationRequest method.
+//    req, resp := client.DescribeLifecycleConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeLifecycleConfiguration
+func (c *EFS) DescribeLifecycleConfigurationRequest(input *DescribeLifecycleConfigurationInput) (req *request.Request, output *DescribeLifecycleConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opDescribeLifecycleConfiguration,
+		HTTPMethod: "GET",
+		HTTPPath:   "/2015-02-01/file-systems/{FileSystemId}/lifecycle-configuration",
+	}
+
+	if input == nil {
+		input = &DescribeLifecycleConfigurationInput{}
+	}
+
+	output = &DescribeLifecycleConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeLifecycleConfiguration API operation for Amazon Elastic File System.
+//
+// Returns the current LifecycleConfiguration object for the specified Amazon
+// EFS file system. EFS lifecycle management uses the LifecycleConfiguration
+// to identify which files to move to the EFS Infrequent Access (IA) storage
+// class. For a file system without a LifecycleConfiguration, the call returns
+// an empty array in the response.
+//
+// This operation requires permissions for the elasticfilesystem:DescribeLifecycleConfiguration
+// operation.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic File System's
+// API operation DescribeLifecycleConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalServerError "InternalServerError"
+//   Returned if an error occurred on the server side.
+//
+//   * ErrCodeBadRequest "BadRequest"
+//   Returned if the request is malformed or contains an error such as an invalid
+//   parameter value or a missing required parameter.
+//
+//   * ErrCodeFileSystemNotFound "FileSystemNotFound"
+//   Returned if the specified FileSystemId value doesn't exist in the requester's
+//   AWS account.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/DescribeLifecycleConfiguration
+func (c *EFS) DescribeLifecycleConfiguration(input *DescribeLifecycleConfigurationInput) (*DescribeLifecycleConfigurationOutput, error) {
+	req, out := c.DescribeLifecycleConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// DescribeLifecycleConfigurationWithContext is the same as DescribeLifecycleConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeLifecycleConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EFS) DescribeLifecycleConfigurationWithContext(ctx aws.Context, input *DescribeLifecycleConfigurationInput, opts ...request.Option) (*DescribeLifecycleConfigurationOutput, error) {
+	req, out := c.DescribeLifecycleConfigurationRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1298,6 +1391,125 @@ func (c *EFS) ModifyMountTargetSecurityGroups(input *ModifyMountTargetSecurityGr
 // for more information on using Contexts.
 func (c *EFS) ModifyMountTargetSecurityGroupsWithContext(ctx aws.Context, input *ModifyMountTargetSecurityGroupsInput, opts ...request.Option) (*ModifyMountTargetSecurityGroupsOutput, error) {
 	req, out := c.ModifyMountTargetSecurityGroupsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opPutLifecycleConfiguration = "PutLifecycleConfiguration"
+
+// PutLifecycleConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the PutLifecycleConfiguration operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See PutLifecycleConfiguration for more information on using the PutLifecycleConfiguration
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the PutLifecycleConfigurationRequest method.
+//    req, resp := client.PutLifecycleConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/PutLifecycleConfiguration
+func (c *EFS) PutLifecycleConfigurationRequest(input *PutLifecycleConfigurationInput) (req *request.Request, output *PutLifecycleConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opPutLifecycleConfiguration,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/2015-02-01/file-systems/{FileSystemId}/lifecycle-configuration",
+	}
+
+	if input == nil {
+		input = &PutLifecycleConfigurationInput{}
+	}
+
+	output = &PutLifecycleConfigurationOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// PutLifecycleConfiguration API operation for Amazon Elastic File System.
+//
+// Enables lifecycle management by creating a new LifecycleConfiguration object.
+// A LifecycleConfiguration defines when files in an Amazon EFS file system
+// are automatically transitioned to the lower-cost EFS Infrequent Access (IA)
+// storage class. A LifecycleConfiguration applies to all files in a file system.
+//
+// Each Amazon EFS file system supports one lifecycle configuration, which applies
+// to all files in the file system. If a LifecycleConfiguration already exists
+// for the specified file system, a PutLifecycleConfiguration call modifies
+// the existing configuration. A PutLifecycleConfiguration call with an empty
+// LifecyclePolicies array in the request body deletes any existing LifecycleConfiguration
+// and disables lifecycle management.
+//
+// You can enable lifecycle management only for EFS file systems created after
+// the release of EFS infrequent access.
+//
+// In the request, specify the following:
+//
+//    * The ID for the file system for which you are creating a lifecycle management
+//    configuration.
+//
+//    * A LifecyclePolicies array of LifecyclePolicy objects that define when
+//    files are moved to the IA storage class. The array can contain only one
+//    "TransitionToIA": "AFTER_30_DAYS"LifecyclePolicy object.
+//
+// This operation requires permissions for the elasticfilesystem:PutLifecycleConfiguration
+// operation.
+//
+// To apply a LifecycleConfiguration object to an encrypted file system, you
+// need the same AWS Key Management Service (AWS KMS) permissions as when you
+// created the encrypted file system.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Elastic File System's
+// API operation PutLifecycleConfiguration for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeBadRequest "BadRequest"
+//   Returned if the request is malformed or contains an error such as an invalid
+//   parameter value or a missing required parameter.
+//
+//   * ErrCodeInternalServerError "InternalServerError"
+//   Returned if an error occurred on the server side.
+//
+//   * ErrCodeFileSystemNotFound "FileSystemNotFound"
+//   Returned if the specified FileSystemId value doesn't exist in the requester's
+//   AWS account.
+//
+//   * ErrCodeIncorrectFileSystemLifeCycleState "IncorrectFileSystemLifeCycleState"
+//   Returned if the file system's lifecycle state is not "available".
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/elasticfilesystem-2015-02-01/PutLifecycleConfiguration
+func (c *EFS) PutLifecycleConfiguration(input *PutLifecycleConfigurationInput) (*PutLifecycleConfigurationOutput, error) {
+	req, out := c.PutLifecycleConfigurationRequest(input)
+	return out, req.Send()
+}
+
+// PutLifecycleConfigurationWithContext is the same as PutLifecycleConfiguration with the addition of
+// the ability to pass a context and additional request options.
+//
+// See PutLifecycleConfiguration for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EFS) PutLifecycleConfigurationWithContext(ctx aws.Context, input *PutLifecycleConfigurationInput, opts ...request.Option) (*PutLifecycleConfigurationOutput, error) {
+	req, out := c.PutLifecycleConfigurationRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1877,10 +2089,7 @@ type DescribeFileSystemsInput struct {
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
 
 	// (Optional) Specifies the maximum number of file systems to return in the
-	// response (integer). This parameter value must be greater than 0. The number
-	// of items that Amazon EFS returns is the minimum of the MaxItems parameter
-	// specified in the request and the service's internal maximum number of items
-	// per page.
+	// response (integer). Currently, this number is automatically set to 10.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 }
 
@@ -1976,6 +2185,72 @@ func (s *DescribeFileSystemsOutput) SetNextMarker(v string) *DescribeFileSystems
 	return s
 }
 
+type DescribeLifecycleConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the file system whose LifecycleConfiguration object you want to
+	// retrieve (String).
+	//
+	// FileSystemId is a required field
+	FileSystemId *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DescribeLifecycleConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLifecycleConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeLifecycleConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeLifecycleConfigurationInput"}
+	if s.FileSystemId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.FileSystemId != nil && len(*s.FileSystemId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileSystemId", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *DescribeLifecycleConfigurationInput) SetFileSystemId(v string) *DescribeLifecycleConfigurationInput {
+	s.FileSystemId = &v
+	return s
+}
+
+type DescribeLifecycleConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of lifecycle management policies. Currently, EFS supports a maximum
+	// of one policy per file system.
+	LifecyclePolicies []*LifecyclePolicy `type:"list"`
+}
+
+// String returns the string representation
+func (s DescribeLifecycleConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLifecycleConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetLifecyclePolicies sets the LifecyclePolicies field's value.
+func (s *DescribeLifecycleConfigurationOutput) SetLifecyclePolicies(v []*LifecyclePolicy) *DescribeLifecycleConfigurationOutput {
+	s.LifecyclePolicies = v
+	return s
+}
+
 type DescribeMountTargetSecurityGroupsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -2054,8 +2329,8 @@ type DescribeMountTargetsInput struct {
 	// the previous returning call left off.
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
 
-	// (Optional) Maximum number of mount targets to return in the response. It
-	// must be an integer with a value greater than zero.
+	// (Optional) Maximum number of mount targets to return in the response. Currently,
+	// this number is automatically set to 10.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 
 	// (Optional) ID of the mount target that you want to have described (String).
@@ -2169,7 +2444,7 @@ type DescribeTagsInput struct {
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
 
 	// (Optional) Maximum number of file system tags to return in the response.
-	// It must be an integer with a value greater than zero.
+	// Currently, this number is automatically set to 10.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 }
 
@@ -2454,6 +2729,14 @@ type FileSystemSize struct {
 	//
 	// Value is a required field
 	Value *int64 `type:"long" required:"true"`
+
+	// The latest known metered size (in bytes) of data stored in the Infrequent
+	// Access storage class.
+	ValueInIA *int64 `type:"long"`
+
+	// The latest known metered size (in bytes) of data stored in the Standard storage
+	// class.
+	ValueInStandard *int64 `type:"long"`
 }
 
 // String returns the string representation
@@ -2475,6 +2758,49 @@ func (s *FileSystemSize) SetTimestamp(v time.Time) *FileSystemSize {
 // SetValue sets the Value field's value.
 func (s *FileSystemSize) SetValue(v int64) *FileSystemSize {
 	s.Value = &v
+	return s
+}
+
+// SetValueInIA sets the ValueInIA field's value.
+func (s *FileSystemSize) SetValueInIA(v int64) *FileSystemSize {
+	s.ValueInIA = &v
+	return s
+}
+
+// SetValueInStandard sets the ValueInStandard field's value.
+func (s *FileSystemSize) SetValueInStandard(v int64) *FileSystemSize {
+	s.ValueInStandard = &v
+	return s
+}
+
+// Describes a policy used by EFS lifecycle management to transition files to
+// the Infrequent Access (IA) storage class.
+type LifecyclePolicy struct {
+	_ struct{} `type:"structure"`
+
+	// A value that indicates how long it takes to transition to the IA storage
+	// class. Currently, the only possible value is AFTER_30_DAYS.
+	//
+	// AFTER_30_DAYS indicates files that have not been read from or written to
+	// for 30 days are transitioned from the Standard storage class to the IA storage
+	// class. Metadata operations such as listing the contents of a directory don't
+	// count as a file access event.
+	TransitionToIA *string `type:"string" enum:"TransitionToIARules"`
+}
+
+// String returns the string representation
+func (s LifecyclePolicy) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LifecyclePolicy) GoString() string {
+	return s.String()
+}
+
+// SetTransitionToIA sets the TransitionToIA field's value.
+func (s *LifecyclePolicy) SetTransitionToIA(v string) *LifecyclePolicy {
+	s.TransitionToIA = &v
 	return s
 }
 
@@ -2551,7 +2877,7 @@ type MountTargetDescription struct {
 	// FileSystemId is a required field
 	FileSystemId *string `type:"string" required:"true"`
 
-	// Address at which the file system may be mounted via the mount target.
+	// Address at which the file system can be mounted by using the mount target.
 	IpAddress *string `type:"string"`
 
 	// Lifecycle state of the mount target.
@@ -2629,8 +2955,92 @@ func (s *MountTargetDescription) SetSubnetId(v string) *MountTargetDescription {
 	return s
 }
 
-// A tag is a key-value pair. Allowed characters: letters, whitespace, and numbers,
-// representable in UTF-8, and the following characters: + - = . _ : /
+type PutLifecycleConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the file system for which you are creating the LifecycleConfiguration
+	// object (String).
+	//
+	// FileSystemId is a required field
+	FileSystemId *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
+
+	// An array of LifecyclePolicy objects that define the file system's LifecycleConfiguration
+	// object. A LifecycleConfiguration object tells lifecycle management when to
+	// transition files from the Standard storage class to the Infrequent Access
+	// storage class.
+	//
+	// LifecyclePolicies is a required field
+	LifecyclePolicies []*LifecyclePolicy `type:"list" required:"true"`
+}
+
+// String returns the string representation
+func (s PutLifecycleConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutLifecycleConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutLifecycleConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutLifecycleConfigurationInput"}
+	if s.FileSystemId == nil {
+		invalidParams.Add(request.NewErrParamRequired("FileSystemId"))
+	}
+	if s.FileSystemId != nil && len(*s.FileSystemId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("FileSystemId", 1))
+	}
+	if s.LifecyclePolicies == nil {
+		invalidParams.Add(request.NewErrParamRequired("LifecyclePolicies"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFileSystemId sets the FileSystemId field's value.
+func (s *PutLifecycleConfigurationInput) SetFileSystemId(v string) *PutLifecycleConfigurationInput {
+	s.FileSystemId = &v
+	return s
+}
+
+// SetLifecyclePolicies sets the LifecyclePolicies field's value.
+func (s *PutLifecycleConfigurationInput) SetLifecyclePolicies(v []*LifecyclePolicy) *PutLifecycleConfigurationInput {
+	s.LifecyclePolicies = v
+	return s
+}
+
+type PutLifecycleConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+
+	// An array of lifecycle management policies. Currently, EFS supports a maximum
+	// of one policy per file system.
+	LifecyclePolicies []*LifecyclePolicy `type:"list"`
+}
+
+// String returns the string representation
+func (s PutLifecycleConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutLifecycleConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetLifecyclePolicies sets the LifecyclePolicies field's value.
+func (s *PutLifecycleConfigurationOutput) SetLifecyclePolicies(v []*LifecyclePolicy) *PutLifecycleConfigurationOutput {
+	s.LifecyclePolicies = v
+	return s
+}
+
+// A tag is a key-value pair. Allowed characters: letters, white space, and
+// numbers, representable in UTF-8, and the following characters: + - = . _
+// : /
 type Tag struct {
 	_ struct{} `type:"structure"`
 
@@ -2949,4 +3359,9 @@ const (
 
 	// ThroughputModeProvisioned is a ThroughputMode enum value
 	ThroughputModeProvisioned = "provisioned"
+)
+
+const (
+	// TransitionToIARulesAfter30Days is a TransitionToIARules enum value
+	TransitionToIARulesAfter30Days = "AFTER_30_DAYS"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/iot/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iot/api.go
@@ -2530,7 +2530,7 @@ func (c *IoT) CreateThingRequest(input *CreateThingInput) (req *request.Request,
 //
 // Creates a thing record in the registry.
 //
-// This is a control plane operation. See Authorization (http://docs.aws.amazon.com/iot/latest/developerguide/authorization.html)
+// This is a control plane operation. See Authorization (https://docs.aws.amazon.com/iot/latest/developerguide/authorization.html)
 // for information about authorizing control plane actions.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2627,7 +2627,7 @@ func (c *IoT) CreateThingGroupRequest(input *CreateThingGroupInput) (req *reques
 //
 // Create a thing group.
 //
-// This is a control plane operation. See Authorization (http://docs.aws.amazon.com/iot/latest/developerguide/authorization.html)
+// This is a control plane operation. See Authorization (https://docs.aws.amazon.com/iot/latest/developerguide/authorization.html)
 // for information about authorizing control plane actions.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -9725,7 +9725,7 @@ func (c *IoT) ListPrincipalPoliciesRequest(input *ListPrincipalPoliciesInput) (r
 // ListPrincipalPolicies API operation for AWS IoT.
 //
 // Lists the policies attached to the specified principal. If you use an Cognito
-// identity, the ID must be in AmazonCognito Identity format (http://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_RequestSyntax).
+// identity, the ID must be in AmazonCognito Identity format (https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_RequestSyntax).
 //
 // Note: This API is deprecated. Please use ListAttachedPolicies instead.
 //
@@ -16882,10 +16882,11 @@ func (s *Behavior) SetName(v string) *Behavior {
 type BehaviorCriteria struct {
 	_ struct{} `type:"structure"`
 
-	// The operator that relates the thing measured (metric) to the criteria (value).
+	// The operator that relates the thing measured (metric) to the criteria (containing
+	// a value.
 	ComparisonOperator *string `locationName:"comparisonOperator" type:"string" enum:"ComparisonOperator"`
 
-	// Use this to specify the period of time over which the behavior is evaluated,
+	// Use this to specify the time duration over which the behavior is evaluated,
 	// for those criteria which have a time dimension (for example, NUM_MESSAGES_SENT).
 	DurationSeconds *int64 `locationName:"durationSeconds" type:"integer"`
 
@@ -17823,10 +17824,10 @@ type CloudwatchMetricAction struct {
 	// MetricNamespace is a required field
 	MetricNamespace *string `locationName:"metricNamespace" type:"string" required:"true"`
 
-	// An optional Unix timestamp (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#about_timestamp).
+	// An optional Unix timestamp (https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#about_timestamp).
 	MetricTimestamp *string `locationName:"metricTimestamp" type:"string"`
 
-	// The metric unit (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Unit)
+	// The metric unit (https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_concepts.html#Unit)
 	// supported by CloudWatch.
 	//
 	// MetricUnit is a required field
@@ -18387,7 +18388,7 @@ type CreateDynamicThingGroupInput struct {
 
 	// The dynamic thing group search query string.
 	//
-	// See Query Syntax (http://docs.aws.amazon.com/iot/latest/developerguide/query-syntax.html)
+	// See Query Syntax (https://docs.aws.amazon.com/iot/latest/developerguide/query-syntax.html)
 	// for information about query string syntax.
 	//
 	// QueryString is a required field
@@ -19406,6 +19407,9 @@ type CreateScheduledAuditInput struct {
 	// ScheduledAuditName is a required field
 	ScheduledAuditName *string `location:"uri" locationName:"scheduledAuditName" min:"1" type:"string" required:"true"`
 
+	// Metadata which can be used to manage the scheduled audit.
+	Tags []*Tag `locationName:"tags" type:"list"`
+
 	// Which checks are performed during the scheduled audit. Checks must be enabled
 	// for your account. (Use DescribeAccountAuditConfiguration to see the list
 	// of all checks including those that are enabled or UpdateAccountAuditConfiguration
@@ -19468,6 +19472,12 @@ func (s *CreateScheduledAuditInput) SetFrequency(v string) *CreateScheduledAudit
 // SetScheduledAuditName sets the ScheduledAuditName field's value.
 func (s *CreateScheduledAuditInput) SetScheduledAuditName(v string) *CreateScheduledAuditInput {
 	s.ScheduledAuditName = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *CreateScheduledAuditInput) SetTags(v []*Tag) *CreateScheduledAuditInput {
+	s.Tags = v
 	return s
 }
 
@@ -25439,10 +25449,10 @@ type Job struct {
 	// If the job was updated, describes the reason for the update.
 	Comment *string `locationName:"comment" type:"string"`
 
-	// The time, in milliseconds since the epoch, when the job was completed.
+	// The time, in seconds since the epoch, when the job was completed.
 	CompletedAt *time.Time `locationName:"completedAt" type:"timestamp"`
 
-	// The time, in milliseconds since the epoch, when the job was created.
+	// The time, in seconds since the epoch, when the job was created.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp"`
 
 	// A short text description of the job.
@@ -25464,7 +25474,7 @@ type Job struct {
 	// Details about the job process.
 	JobProcessDetails *JobProcessDetails `locationName:"jobProcessDetails" type:"structure"`
 
-	// The time, in milliseconds since the epoch, when the job was last updated.
+	// The time, in seconds since the epoch, when the job was last updated.
 	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp"`
 
 	// Configuration for pre-signed S3 URLs.
@@ -25631,14 +25641,13 @@ type JobExecution struct {
 	// The unique identifier you assigned to the job when it was created.
 	JobId *string `locationName:"jobId" min:"1" type:"string"`
 
-	// The time, in milliseconds since the epoch, when the job execution was last
-	// updated.
+	// The time, in seconds since the epoch, when the job execution was last updated.
 	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp"`
 
-	// The time, in milliseconds since the epoch, when the job execution was queued.
+	// The time, in seconds since the epoch, when the job execution was queued.
 	QueuedAt *time.Time `locationName:"queuedAt" type:"timestamp"`
 
-	// The time, in milliseconds since the epoch, when the job execution started.
+	// The time, in seconds since the epoch, when the job execution started.
 	StartedAt *time.Time `locationName:"startedAt" type:"timestamp"`
 
 	// The status of the job execution (IN_PROGRESS, QUEUED, FAILED, SUCCEEDED,
@@ -25765,14 +25774,13 @@ type JobExecutionSummary struct {
 	// in commands which return or update job execution information.
 	ExecutionNumber *int64 `locationName:"executionNumber" type:"long"`
 
-	// The time, in milliseconds since the epoch, when the job execution was last
-	// updated.
+	// The time, in seconds since the epoch, when the job execution was last updated.
 	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp"`
 
-	// The time, in milliseconds since the epoch, when the job execution was queued.
+	// The time, in seconds since the epoch, when the job execution was queued.
 	QueuedAt *time.Time `locationName:"queuedAt" type:"timestamp"`
 
-	// The time, in milliseconds since the epoch, when the job execution started.
+	// The time, in seconds since the epoch, when the job execution started.
 	StartedAt *time.Time `locationName:"startedAt" type:"timestamp"`
 
 	// The status of the job execution.
@@ -26042,10 +26050,10 @@ func (s *JobProcessDetails) SetProcessingTargets(v []*string) *JobProcessDetails
 type JobSummary struct {
 	_ struct{} `type:"structure"`
 
-	// The time, in milliseconds since the epoch, when the job completed.
+	// The time, in seconds since the epoch, when the job completed.
 	CompletedAt *time.Time `locationName:"completedAt" type:"timestamp"`
 
-	// The time, in milliseconds since the epoch, when the job was created.
+	// The time, in seconds since the epoch, when the job was created.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp"`
 
 	// The job ARN.
@@ -26054,7 +26062,7 @@ type JobSummary struct {
 	// The unique identifier you assigned to this job when it was created.
 	JobId *string `locationName:"jobId" min:"1" type:"string"`
 
-	// The time, in milliseconds since the epoch, when the job was last updated.
+	// The time, in seconds since the epoch, when the job was last updated.
 	LastUpdatedAt *time.Time `locationName:"lastUpdatedAt" type:"timestamp"`
 
 	// The job summary status.
@@ -31202,11 +31210,11 @@ func (s *RegisterCertificateOutput) SetCertificateId(v string) *RegisterCertific
 type RegisterThingInput struct {
 	_ struct{} `type:"structure"`
 
-	// The parameters for provisioning a thing. See Programmatic Provisioning (http://docs.aws.amazon.com/iot/latest/developerguide/programmatic-provisioning.html)
+	// The parameters for provisioning a thing. See Programmatic Provisioning (https://docs.aws.amazon.com/iot/latest/developerguide/programmatic-provisioning.html)
 	// for more information.
 	Parameters map[string]*string `locationName:"parameters" type:"map"`
 
-	// The provisioning template. See Programmatic Provisioning (http://docs.aws.amazon.com/iot/latest/developerguide/programmatic-provisioning.html)
+	// The provisioning template. See Programmatic Provisioning (https://docs.aws.amazon.com/iot/latest/developerguide/programmatic-provisioning.html)
 	// for more information.
 	//
 	// TemplateBody is a required field
@@ -31903,7 +31911,7 @@ type S3Action struct {
 	BucketName *string `locationName:"bucketName" type:"string" required:"true"`
 
 	// The Amazon S3 canned ACL that controls access to the object identified by
-	// the object key. For more information, see S3 canned ACLs (http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
+	// the object key. For more information, see S3 canned ACLs (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).
 	CannedAcl *string `locationName:"cannedAcl" type:"string" enum:"CannedAccessControlList"`
 
 	// The object key.
@@ -32798,7 +32806,7 @@ type SnsAction struct {
 	// are "JSON" and "RAW". The default value of the attribute is "RAW". SNS uses
 	// this setting to determine if the payload should be parsed and relevant platform-specific
 	// bits of the payload should be extracted. To read more about SNS message formats,
-	// see http://docs.aws.amazon.com/sns/latest/dg/json-formats.html (http://docs.aws.amazon.com/sns/latest/dg/json-formats.html)
+	// see https://docs.aws.amazon.com/sns/latest/dg/json-formats.html (https://docs.aws.amazon.com/sns/latest/dg/json-formats.html)
 	// refer to their official documentation.
 	MessageFormat *string `locationName:"messageFormat" type:"string" enum:"MessageFormat"`
 
@@ -34675,7 +34683,7 @@ type TopicRulePayload struct {
 	RuleDisabled *bool `locationName:"ruleDisabled" type:"boolean"`
 
 	// The SQL statement used to query the topic. For more information, see AWS
-	// IoT SQL Reference (http://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference)
+	// IoT SQL Reference (https://docs.aws.amazon.com/iot/latest/developerguide/iot-rules.html#aws-iot-sql-reference)
 	// in the AWS IoT Developer Guide.
 	//
 	// Sql is a required field

--- a/vendor/github.com/aws/aws-sdk-go/service/iot/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iot/doc.go
@@ -10,10 +10,10 @@
 // organize resources associated with each device (Registry), configure logging,
 // and create and manage policies and credentials to authenticate devices.
 //
-// For more information about how AWS IoT works, see the Developer Guide (http://docs.aws.amazon.com/iot/latest/developerguide/aws-iot-how-it-works.html).
+// For more information about how AWS IoT works, see the Developer Guide (https://docs.aws.amazon.com/iot/latest/developerguide/aws-iot-how-it-works.html).
 //
 // For information about how to use the credentials provider for AWS IoT, see
-// Authorizing Direct Calls to AWS Services (http://docs.aws.amazon.com/iot/latest/developerguide/authorizing-direct-aws.html).
+// Authorizing Direct Calls to AWS Services (https://docs.aws.amazon.com/iot/latest/developerguide/authorizing-direct-aws.html).
 //
 // See iot package documentation for more information.
 // https://docs.aws.amazon.com/sdk-for-go/api/service/iot/

--- a/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lambda/api.go
@@ -58,7 +58,7 @@ func (c *Lambda) AddLayerVersionPermissionRequest(input *AddLayerVersionPermissi
 // AddLayerVersionPermission API operation for AWS Lambda.
 //
 // Adds permissions to the resource-based policy of a version of an AWS Lambda
-// layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 // Use this action to grant layer usage permission to other accounts. You can
 // grant permission to a single account, all AWS accounts, or all accounts in
 // an organization.
@@ -182,7 +182,7 @@ func (c *Lambda) AddPermissionRequest(input *AddPermissionInput) (req *request.R
 //
 // This action adds a statement to a resource-based permission policy for the
 // function. For more information about function policies, see Lambda Function
-// Policies (http://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html).
+// Policies (https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -284,7 +284,7 @@ func (c *Lambda) CreateAliasRequest(input *CreateAliasInput) (req *request.Reque
 
 // CreateAlias API operation for AWS Lambda.
 //
-// Creates an alias (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html)
+// Creates an alias (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html)
 // for a Lambda function version. Use aliases to provide clients with a function
 // identifier that you can update to invoke a different version.
 //
@@ -389,11 +389,11 @@ func (c *Lambda) CreateEventSourceMappingRequest(input *CreateEventSourceMapping
 //
 // For details about each event source type, see the following topics.
 //
-//    * Using AWS Lambda with Amazon Kinesis (http://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html)
+//    * Using AWS Lambda with Amazon Kinesis (https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html)
 //
-//    * Using AWS Lambda with Amazon SQS (http://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html)
+//    * Using AWS Lambda with Amazon SQS (https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html)
 //
-//    * Using AWS Lambda with Amazon DynamoDB (http://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html)
+//    * Using AWS Lambda with Amazon DynamoDB (https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html)
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -488,32 +488,34 @@ func (c *Lambda) CreateFunctionRequest(input *CreateFunctionInput) (req *request
 // CreateFunction API operation for AWS Lambda.
 //
 // Creates a Lambda function. To create a function, you need a deployment package
-// (http://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html)
-// and an execution role (http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#lambda-intro-execution-role).
+// (https://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html)
+// and an execution role (https://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#lambda-intro-execution-role).
 // The deployment package contains your function code. The execution role grants
-// the function permission to use AWS services such as Amazon CloudWatch Logs
+// the function permission to use AWS services, such as Amazon CloudWatch Logs
 // for log streaming and AWS X-Ray for request tracing.
 //
 // A function has an unpublished version, and can have published versions and
-// aliases. A published version is a snapshot of your function code and configuration
-// that can not be changed. An alias is a named resource that maps to a version,
-// and can be changed to map to a different version. Use the Publish parameter
-// to create version 1 of your function from its initial configuration.
+// aliases. The unpublished version changes when you update your function's
+// code and configuration. A published version is a snapshot of your function
+// code and configuration that can't be changed. An alias is a named resource
+// that maps to a version, and can be changed to map to a different version.
+// Use the Publish parameter to create version 1 of your function from its initial
+// configuration.
 //
 // The other parameters let you configure version-specific and function-level
 // settings. You can modify version-specific settings later with UpdateFunctionConfiguration.
 // Function-level settings apply to both the unpublished and published versions
-// of the function and include tags (TagResource) and per-function concurrency
+// of the function, and include tags (TagResource) and per-function concurrency
 // limits (PutFunctionConcurrency).
 //
-// If another account or a AWS service invokes your function, use AddPermission
+// If another account or an AWS service invokes your function, use AddPermission
 // to grant permission by creating a resource-based IAM policy. You can grant
 // permissions at the function level, on a version, or on an alias.
 //
 // To invoke your function directly, use Invoke. To invoke your function in
 // response to events in other AWS services, create an event source mapping
 // (CreateEventSourceMapping), or configure a function trigger in the other
-// service. For more information, see Invoking Functions (http://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-functions.html).
+// service. For more information, see Invoking Functions (https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-functions.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -542,7 +544,7 @@ func (c *Lambda) CreateFunctionRequest(input *CreateFunctionInput) (req *request
 //   Request throughput limit exceeded.
 //
 //   * ErrCodeCodeStorageExceededException "CodeStorageExceededException"
-//   You have exceeded your maximum total code size per account. Limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+//   You have exceeded your maximum total code size per account. Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/CreateFunction
 func (c *Lambda) CreateFunction(input *CreateFunctionInput) (*FunctionConfiguration, error) {
@@ -611,7 +613,7 @@ func (c *Lambda) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Reque
 
 // DeleteAlias API operation for AWS Lambda.
 //
-// Deletes a Lambda function alias (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
+// Deletes a Lambda function alias (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -698,7 +700,7 @@ func (c *Lambda) DeleteEventSourceMappingRequest(input *DeleteEventSourceMapping
 
 // DeleteEventSourceMapping API operation for AWS Lambda.
 //
-// Deletes an event source mapping (http://docs.aws.amazon.com/lambda/latest/dg/intro-invocation-modes.html).
+// Deletes an event source mapping (https://docs.aws.amazon.com/lambda/latest/dg/intro-invocation-modes.html).
 // You can get the identifier of a mapping from the output of ListEventSourceMappings.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -988,7 +990,7 @@ func (c *Lambda) DeleteLayerVersionRequest(input *DeleteLayerVersionInput) (req 
 
 // DeleteLayerVersion API operation for AWS Lambda.
 //
-// Deletes a version of an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// Deletes a version of an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 // Deleted versions can no longer be viewed or added to functions. To avoid
 // breaking functions, a copy of the version remains in Lambda until no functions
 // refer to it.
@@ -1073,8 +1075,8 @@ func (c *Lambda) GetAccountSettingsRequest(input *GetAccountSettingsInput) (req 
 
 // GetAccountSettings API operation for AWS Lambda.
 //
-// Retrieves details about your account's limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html)
-// and usage in a region.
+// Retrieves details about your account's limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+// and usage in an AWS Region.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1156,7 +1158,7 @@ func (c *Lambda) GetAliasRequest(input *GetAliasInput) (req *request.Request, ou
 
 // GetAlias API operation for AWS Lambda.
 //
-// Returns details about a Lambda function alias (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
+// Returns details about a Lambda function alias (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1339,9 +1341,9 @@ func (c *Lambda) GetFunctionRequest(input *GetFunctionInput) (req *request.Reque
 
 // GetFunction API operation for AWS Lambda.
 //
-// Returns information about function or function version, with a link to download
-// the deployment package that's valid for 10 minutes. If you specify a function
-// version, only details specific to that version are returned.
+// Returns information about the function or function version, with a link to
+// download the deployment package that's valid for 10 minutes. If you specify
+// a function version, only details that are specific to that version are returned.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1432,8 +1434,8 @@ func (c *Lambda) GetFunctionConfigurationRequest(input *GetFunctionConfiguration
 
 // GetFunctionConfiguration API operation for AWS Lambda.
 //
-// Returns a the version-specific settings of a Lambda function or version.
-// The output includes only options that can vary between versions of a function.
+// Returns the version-specific settings of a Lambda function or version. The
+// output includes only options that can vary between versions of a function.
 // To modify these settings, use UpdateFunctionConfiguration.
 //
 // To get all of a function's details, including function-level settings, use
@@ -1528,7 +1530,7 @@ func (c *Lambda) GetLayerVersionRequest(input *GetLayerVersionInput) (req *reque
 
 // GetLayerVersion API operation for AWS Lambda.
 //
-// Returns information about a version of an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html),
+// Returns information about a version of an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html),
 // with a link to download the layer archive that's valid for 10 minutes.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1620,7 +1622,7 @@ func (c *Lambda) GetLayerVersionPolicyRequest(input *GetLayerVersionPolicyInput)
 
 // GetLayerVersionPolicy API operation for AWS Lambda.
 //
-// Returns the permission policy for a version of an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// Returns the permission policy for a version of an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 // For more information, see AddLayerVersionPermission.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1712,7 +1714,7 @@ func (c *Lambda) GetPolicyRequest(input *GetPolicyInput) (req *request.Request, 
 
 // GetPolicy API operation for AWS Lambda.
 //
-// Returns the resource-based IAM policy (http://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html)
+// Returns the resource-based IAM policy (https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html)
 // for a function, version, or alias.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1804,26 +1806,26 @@ func (c *Lambda) InvokeRequest(input *InvokeInput) (req *request.Request, output
 
 // Invoke API operation for AWS Lambda.
 //
-// Invokes a Lambda function. You can invoke a function synchronously and wait
-// for the response, or asynchronously. To invoke a function asynchronously,
+// Invokes a Lambda function. You can invoke a function synchronously (and wait
+// for the response), or asynchronously. To invoke a function asynchronously,
 // set InvocationType to Event.
 //
 // For synchronous invocation, details about the function response, including
 // errors, are included in the response body and headers. For either invocation
-// type, you can find more information in the execution log (http://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html)
-// and trace (http://docs.aws.amazon.com/lambda/latest/dg/dlq.html). To record
+// type, you can find more information in the execution log (https://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions.html)
+// and trace (https://docs.aws.amazon.com/lambda/latest/dg/dlq.html). To record
 // function errors for asynchronous invocations, configure your function with
-// a dead letter queue (http://docs.aws.amazon.com/lambda/latest/dg/dlq.html).
+// a dead letter queue (https://docs.aws.amazon.com/lambda/latest/dg/dlq.html).
 //
-// The status code in the API response does not reflect function errors. Error
+// The status code in the API response doesn't reflect function errors. Error
 // codes are reserved for errors that prevent your function from executing,
-// such as permissions errors, limit errors (http://docs.aws.amazon.com/lambda/latest/dg/limits.html),
+// such as permissions errors, limit errors (https://docs.aws.amazon.com/lambda/latest/dg/limits.html),
 // or issues with your function's code and configuration. For example, Lambda
 // returns TooManyRequestsException if executing the function would cause you
 // to exceed a concurrency limit at either the account level (ConcurrentInvocationLimitExceeded)
 // or function level (ReservedFunctionConcurrentInvocationLimitExceeded).
 //
-// For functions with a long timeout, your client may be disconnected during
+// For functions with a long timeout, your client might be disconnected during
 // synchronous invocation while it waits for a response. Configure your HTTP
 // client, SDK, firewall, proxy, or operating system to allow for long connections
 // with timeout or keep-alive settings.
@@ -1850,7 +1852,7 @@ func (c *Lambda) InvokeRequest(input *InvokeInput) (req *request.Request, output
 //
 //   * ErrCodeRequestTooLargeException "RequestTooLargeException"
 //   The request payload exceeded the Invoke request body JSON input limit. For
-//   more information, see Limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html).
+//   more information, see Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html).
 //
 //   * ErrCodeUnsupportedMediaTypeException "UnsupportedMediaTypeException"
 //   The content type of the Invoke request body is not JSON.
@@ -2078,7 +2080,7 @@ func (c *Lambda) ListAliasesRequest(input *ListAliasesInput) (req *request.Reque
 
 // ListAliases API operation for AWS Lambda.
 //
-// Returns a list of aliases (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html)
+// Returns a list of aliases (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html)
 // for a Lambda function.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2466,9 +2468,9 @@ func (c *Lambda) ListLayerVersionsRequest(input *ListLayerVersionsInput) (req *r
 
 // ListLayerVersions API operation for AWS Lambda.
 //
-// Lists the versions of an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// Lists the versions of an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 // Versions that have been deleted aren't listed. Specify a runtime identifier
-// (http://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) to list
+// (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) to list
 // only versions that indicate that they're compatible with that runtime.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2560,9 +2562,9 @@ func (c *Lambda) ListLayersRequest(input *ListLayersInput) (req *request.Request
 
 // ListLayers API operation for AWS Lambda.
 //
-// Lists AWS Lambda layers (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+// Lists AWS Lambda layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
 // and shows information about the latest version of each. Specify a runtime
-// identifier (http://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
+// identifier (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
 // to list only layers that indicate that they're compatible with that runtime.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2650,7 +2652,7 @@ func (c *Lambda) ListTagsRequest(input *ListTagsInput) (req *request.Request, ou
 
 // ListTags API operation for AWS Lambda.
 //
-// Returns a function's tags (http://docs.aws.amazon.com/lambda/latest/dg/tagging.html).
+// Returns a function's tags (https://docs.aws.amazon.com/lambda/latest/dg/tagging.html).
 // You can also view tags with GetFunction.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2742,7 +2744,7 @@ func (c *Lambda) ListVersionsByFunctionRequest(input *ListVersionsByFunctionInpu
 
 // ListVersionsByFunction API operation for AWS Lambda.
 //
-// Returns a list of versions (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html),
+// Returns a list of versions (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html),
 // with the version-specific configuration of each.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2834,7 +2836,7 @@ func (c *Lambda) PublishLayerVersionRequest(input *PublishLayerVersionInput) (re
 
 // PublishLayerVersion API operation for AWS Lambda.
 //
-// Creates an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+// Creates an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
 // from a ZIP archive. Each time you call PublishLayerVersion with the same
 // version name, a new version is created.
 //
@@ -2864,7 +2866,7 @@ func (c *Lambda) PublishLayerVersionRequest(input *PublishLayerVersionInput) (re
 //   API, that AWS Lambda is unable to assume you will get this exception.
 //
 //   * ErrCodeCodeStorageExceededException "CodeStorageExceededException"
-//   You have exceeded your maximum total code size per account. Limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+//   You have exceeded your maximum total code size per account. Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/PublishLayerVersion
 func (c *Lambda) PublishLayerVersion(input *PublishLayerVersionInput) (*PublishLayerVersionOutput, error) {
@@ -2932,13 +2934,13 @@ func (c *Lambda) PublishVersionRequest(input *PublishVersionInput) (req *request
 
 // PublishVersion API operation for AWS Lambda.
 //
-// Creates a version (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html)
+// Creates a version (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html)
 // from the current code and configuration of a function. Use versions to create
 // a snapshot of your function code and configuration that doesn't change.
 //
-// AWS Lambda does not publish a version if the function's configuration and
-// code hasn't changed since the last version. Use UpdateFunctionCode or UpdateFunctionConfiguration
-// to update the function prior to publishing a version.
+// AWS Lambda doesn't publish a version if the function's configuration and
+// code haven't changed since the last version. Use UpdateFunctionCode or UpdateFunctionConfiguration
+// to update the function before publishing a version.
 //
 // Clients can invoke versions directly or with an alias. To create an alias,
 // use CreateAlias.
@@ -2967,7 +2969,7 @@ func (c *Lambda) PublishVersionRequest(input *PublishVersionInput) (req *request
 //   Request throughput limit exceeded.
 //
 //   * ErrCodeCodeStorageExceededException "CodeStorageExceededException"
-//   You have exceeded your maximum total code size per account. Limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+//   You have exceeded your maximum total code size per account. Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 //
 //   * ErrCodePreconditionFailedException "PreconditionFailedException"
 //   The RevisionId provided does not match the latest RevisionId for the Lambda
@@ -3044,7 +3046,7 @@ func (c *Lambda) PutFunctionConcurrencyRequest(input *PutFunctionConcurrencyInpu
 // capacity for that concurrency level.
 //
 // Concurrency settings apply to the function as a whole, including all published
-// versions and the unpublished version. Reserving concurrency both guarantees
+// versions and the unpublished version. Reserving concurrency both ensures
 // that your function has capacity to process the specified number of events
 // simultaneously, and prevents it from scaling beyond that level. Use GetFunction
 // to see the current setting for a function.
@@ -3053,7 +3055,7 @@ func (c *Lambda) PutFunctionConcurrencyRequest(input *PutFunctionConcurrencyInpu
 // concurrency for as many functions as you like, as long as you leave at least
 // 100 simultaneous executions unreserved for functions that aren't configured
 // with a per-function limit. For more information, see Managing Concurrency
-// (http://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html).
+// (https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3146,7 +3148,7 @@ func (c *Lambda) RemoveLayerVersionPermissionRequest(input *RemoveLayerVersionPe
 // RemoveLayerVersionPermission API operation for AWS Lambda.
 //
 // Removes a statement from the permissions policy for a version of an AWS Lambda
-// layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 // For more information, see AddLayerVersionPermission.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3244,7 +3246,7 @@ func (c *Lambda) RemovePermissionRequest(input *RemovePermissionInput) (req *req
 
 // RemovePermission API operation for AWS Lambda.
 //
-// Revokes function use permission from an AWS service or another account. You
+// Revokes function-use permission from an AWS service or another account. You
 // can get the ID of the statement from the output of GetPolicy.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3342,8 +3344,8 @@ func (c *Lambda) TagResourceRequest(input *TagResourceInput) (req *request.Reque
 
 // TagResource API operation for AWS Lambda.
 //
-// Adds tags (http://docs.aws.amazon.com/lambda/latest/dg/tagging.html) to a
-// function.
+// Adds tags (https://docs.aws.amazon.com/lambda/latest/dg/tagging.html) to
+// a function.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3435,8 +3437,8 @@ func (c *Lambda) UntagResourceRequest(input *UntagResourceInput) (req *request.R
 
 // UntagResource API operation for AWS Lambda.
 //
-// Removes tags (http://docs.aws.amazon.com/lambda/latest/dg/tagging.html) from
-// a function.
+// Removes tags (https://docs.aws.amazon.com/lambda/latest/dg/tagging.html)
+// from a function.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3527,7 +3529,7 @@ func (c *Lambda) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Reque
 
 // UpdateAlias API operation for AWS Lambda.
 //
-// Updates the configuration of a Lambda function alias (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
+// Updates the configuration of a Lambda function alias (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3725,7 +3727,7 @@ func (c *Lambda) UpdateFunctionCodeRequest(input *UpdateFunctionCodeInput) (req 
 //
 // Updates a Lambda function's code.
 //
-// The function's code is locked when you publish a version. You cannot modify
+// The function's code is locked when you publish a version. You can't modify
 // the code of a published version, only the unpublished version.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3752,7 +3754,7 @@ func (c *Lambda) UpdateFunctionCodeRequest(input *UpdateFunctionCodeInput) (req 
 //   Request throughput limit exceeded.
 //
 //   * ErrCodeCodeStorageExceededException "CodeStorageExceededException"
-//   You have exceeded your maximum total code size per account. Limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+//   You have exceeded your maximum total code size per account. Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 //
 //   * ErrCodePreconditionFailedException "PreconditionFailedException"
 //   The RevisionId provided does not match the latest RevisionId for the Lambda
@@ -3828,7 +3830,7 @@ func (c *Lambda) UpdateFunctionConfigurationRequest(input *UpdateFunctionConfigu
 // Modify the version-specifc settings of a Lambda function.
 //
 // These settings can vary between versions of a function and are locked when
-// you publish a version. You cannot modify the configuration of a published
+// you publish a version. You can't modify the configuration of a published
 // version, only the unpublished version.
 //
 // To configure function concurrency, use PutFunctionConcurrency. To grant invoke
@@ -3887,16 +3889,16 @@ func (c *Lambda) UpdateFunctionConfigurationWithContext(ctx aws.Context, input *
 	return out, req.Send()
 }
 
-// Limits related to concurrency and code storage. All file and storage sizes
-// are in bytes.
+// Limits that are related to concurrency and code storage. All file and storage
+// sizes are in bytes.
 type AccountLimit struct {
 	_ struct{} `type:"structure"`
 
-	// The maximum size of your function's code and layers when extracted.
+	// The maximum size of your function's code and layers when they're extracted.
 	CodeSizeUnzipped *int64 `type:"long"`
 
-	// The maximum size of a deployment package when uploaded direcly to AWS Lambda.
-	// Use Amazon S3 for larger files.
+	// The maximum size of a deployment package when it's uploaded directly to AWS
+	// Lambda. Use Amazon S3 for larger files.
 	CodeSizeZipped *int64 `type:"long"`
 
 	// The maximum number of simultaneous function executions.
@@ -3906,8 +3908,8 @@ type AccountLimit struct {
 	// and layer archives.
 	TotalCodeSize *int64 `type:"long"`
 
-	// The maximum number of simultaneous function executions, less the concurrency
-	// reserved for individual functions with PutFunctionConcurrency.
+	// The maximum number of simultaneous function executions, minus the capacity
+	// that's reserved for individual functions with PutFunctionConcurrency.
 	UnreservedConcurrentExecutions *int64 `type:"integer"`
 }
 
@@ -3958,8 +3960,8 @@ type AccountUsage struct {
 	// The number of Lambda functions.
 	FunctionCount *int64 `type:"long"`
 
-	// The amount of storage space, in bytes, in use by deployment packages and
-	// layer archives.
+	// The amount of storage space, in bytes, that's being used by deployment packages
+	// and layer archives.
 	TotalCodeSize *int64 `type:"long"`
 }
 
@@ -4178,16 +4180,17 @@ type AddPermissionInput struct {
 	// function.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
 
-	// Only update the policy if the revision ID matches the ID specified. Use this
-	// option to avoid modifying a policy that has changed since you last read it.
+	// Only update the policy if the revision ID matches the ID that's specified.
+	// Use this option to avoid modifying a policy that has changed since you last
+	// read it.
 	RevisionId *string `type:"string"`
 
-	// For AWS services, the ID of the account that owns the resource. Use instead
-	// of SourceArn to grant permission to resources owned by another account (e.g.
-	// all of an account's Amazon S3 buckets). Or use together with SourceArn to
-	// ensure that the resource is owned by the specified account. For example,
-	// an Amazon S3 bucket could be deleted by its owner and recreated by another
-	// account.
+	// For AWS services, the ID of the account that owns the resource. Use this
+	// instead of SourceArn to grant permission to resources that are owned by another
+	// account (for example, all of an account's Amazon S3 buckets). Or use it together
+	// with SourceArn to ensure that the resource is owned by the specified account.
+	// For example, an Amazon S3 bucket could be deleted by its owner and recreated
+	// by another account.
 	SourceAccount *string `type:"string"`
 
 	// For AWS services, the ARN of the AWS resource that invokes the function.
@@ -4299,7 +4302,7 @@ func (s *AddPermissionInput) SetStatementId(v string) *AddPermissionInput {
 type AddPermissionOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The permission statement added to the function policy.
+	// The permission statement that's added to the function policy.
 	Statement *string `type:"string"`
 }
 
@@ -4319,7 +4322,7 @@ func (s *AddPermissionOutput) SetStatement(v string) *AddPermissionOutput {
 	return s
 }
 
-// Provides configuration information about a Lambda function alias (http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
+// Provides configuration information about a Lambda function alias (https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html).
 type AliasConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -4338,7 +4341,7 @@ type AliasConfiguration struct {
 	// A unique identifier that changes when you update the alias.
 	RevisionId *string `type:"string"`
 
-	// The routing configuration (http://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
+	// The routing configuration (https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
 	// of the alias.
 	RoutingConfig *AliasRoutingConfiguration `type:"structure"`
 }
@@ -4389,12 +4392,12 @@ func (s *AliasConfiguration) SetRoutingConfig(v *AliasRoutingConfiguration) *Ali
 	return s
 }
 
-// A Lambda function alias's traffic shifting (http://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
-// configuration.
+// The traffic-shifting (https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
+// configuration of a Lambda function alias.
 type AliasRoutingConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the second alias, and the percentage of traffic that is routed
+	// The name of the second alias, and the percentage of traffic that's routed
 	// to it.
 	AdditionalVersionWeights map[string]*float64 `type:"map"`
 }
@@ -4421,7 +4424,7 @@ type CreateAliasInput struct {
 	// A description of the alias.
 	Description *string `type:"string"`
 
-	// The name of the lambda function.
+	// The name of the Lambda function.
 	//
 	// Name formats
 	//
@@ -4447,7 +4450,7 @@ type CreateAliasInput struct {
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
 
-	// The routing configuration (http://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
+	// The routing configuration (https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
 	// of the alias.
 	RoutingConfig *AliasRoutingConfiguration `type:"structure"`
 }
@@ -4651,7 +4654,7 @@ type CreateFunctionInput struct {
 
 	// A dead letter queue configuration that specifies the queue or topic where
 	// Lambda sends asynchronous events when they fail processing. For more information,
-	// see Dead Letter Queues (http://docs.aws.amazon.com/lambda/latest/dg/dlq.html).
+	// see Dead Letter Queues (https://docs.aws.amazon.com/lambda/latest/dg/dlq.html).
 	DeadLetterConfig *DeadLetterConfig `type:"structure"`
 
 	// A description of the function.
@@ -4677,25 +4680,25 @@ type CreateFunctionInput struct {
 	FunctionName *string `min:"1" type:"string" required:"true"`
 
 	// The name of the method within your code that Lambda calls to execute your
-	// function. The format includes the filename and can also include namespaces
+	// function. The format includes the file name. It can also include namespaces
 	// and other qualifiers, depending on the runtime. For more information, see
-	// Programming Model (http://docs.aws.amazon.com/lambda/latest/dg/programming-model-v2.html).
+	// Programming Model (https://docs.aws.amazon.com/lambda/latest/dg/programming-model-v2.html).
 	//
 	// Handler is a required field
 	Handler *string `type:"string" required:"true"`
 
-	// The ARN of the AWS Key Management Service key used to encrypt your function's
-	// environment variables. If not provided, AWS Lambda uses a default service
-	// key.
+	// The ARN of the AWS Key Management Service (AWS KMS) key that's used to encrypt
+	// your function's environment variables. If it's not provided, AWS Lambda uses
+	// a default service key.
 	KMSKeyArn *string `type:"string"`
 
-	// A list of function layers (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
-	// to add to the function's execution environment. Specify each layer by ARN,
-	// including the version.
+	// A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+	// to add to the function's execution environment. Specify each layer by its
+	// ARN, including the version.
 	Layers []*string `type:"list"`
 
 	// The amount of memory that your function has access to. Increasing the function's
-	// memory also increases it's CPU allocation. The default value is 128 MB. The
+	// memory also increases its CPU allocation. The default value is 128 MB. The
 	// value must be a multiple of 64 MB.
 	MemorySize *int64 `min:"128" type:"integer"`
 
@@ -4707,17 +4710,17 @@ type CreateFunctionInput struct {
 	// Role is a required field
 	Role *string `type:"string" required:"true"`
 
-	// The identifier of the function's runtime (http://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+	// The identifier of the function's runtime (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
 	//
 	// Runtime is a required field
 	Runtime *string `type:"string" required:"true" enum:"Runtime"`
 
-	// A list of tags (http://docs.aws.amazon.com/lambda/latest/dg/tagging.html)
+	// A list of tags (https://docs.aws.amazon.com/lambda/latest/dg/tagging.html)
 	// to apply to the function.
 	Tags map[string]*string `type:"map"`
 
-	// The amount of time that Lambda allows a function to run before terminating
-	// it. The default is 3 seconds. The maximum allowed value is 900 seconds.
+	// The amount of time that Lambda allows a function to run before stopping it.
+	// The default is 3 seconds. The maximum allowed value is 900 seconds.
 	Timeout *int64 `min:"1" type:"integer"`
 
 	// Set Mode to Active to sample and trace a subset of incoming requests with
@@ -4727,7 +4730,7 @@ type CreateFunctionInput struct {
 	// For network connectivity to AWS resources in a VPC, specify a list of security
 	// groups and subnets in the VPC. When you connect a function to a VPC, it can
 	// only access resources and the internet through that VPC. For more information,
-	// see VPC Settings (http://docs.aws.amazon.com/lambda/latest/dg/vpc.html).
+	// see VPC Settings (https://docs.aws.amazon.com/lambda/latest/dg/vpc.html).
 	VpcConfig *VpcConfig `type:"structure"`
 }
 
@@ -4876,7 +4879,7 @@ func (s *CreateFunctionInput) SetVpcConfig(v *VpcConfig) *CreateFunctionInput {
 	return s
 }
 
-// The dead letter queue (http://docs.aws.amazon.com/lambda/latest/dg/dlq.html)
+// The dead letter queue (https://docs.aws.amazon.com/lambda/latest/dg/dlq.html)
 // for failed asynchronous invocations.
 type DeadLetterConfig struct {
 	_ struct{} `type:"structure"`
@@ -4904,7 +4907,7 @@ func (s *DeadLetterConfig) SetTargetArn(v string) *DeadLetterConfig {
 type DeleteAliasInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the lambda function.
+	// The name of the Lambda function.
 	//
 	// Name formats
 	//
@@ -5111,7 +5114,7 @@ type DeleteFunctionInput struct {
 	// FunctionName is a required field
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
-	// Specify a version to delete. You cannot delete a version that is referenced
+	// Specify a version to delete. You can't delete a version that's referenced
 	// by an alias.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
 }
@@ -5264,7 +5267,7 @@ func (s *Environment) SetVariables(v map[string]*string) *Environment {
 	return s
 }
 
-// Error messages for environment variables that could not be applied.
+// Error messages for environment variables that couldn't be applied.
 type EnvironmentError struct {
 	_ struct{} `type:"structure"`
 
@@ -5301,7 +5304,7 @@ func (s *EnvironmentError) SetMessage(v string) *EnvironmentError {
 type EnvironmentResponse struct {
 	_ struct{} `type:"structure"`
 
-	// Error messages for environment variables that could not be applied.
+	// Error messages for environment variables that couldn't be applied.
 	Error *EnvironmentError `type:"structure"`
 
 	// Environment variable key-value pairs.
@@ -5424,8 +5427,8 @@ func (s *EventSourceMappingConfiguration) SetUUID(v string) *EventSourceMappingC
 type FunctionCode struct {
 	_ struct{} `type:"structure"`
 
-	// An Amazon S3 bucket in the same region as your function. The bucket can be
-	// in a different AWS account.
+	// An Amazon S3 bucket in the same AWS Region as your function. The bucket can
+	// be in a different AWS account.
 	S3Bucket *string `min:"3" type:"string"`
 
 	// The Amazon S3 key of the deployment package.
@@ -5498,10 +5501,10 @@ func (s *FunctionCode) SetZipFile(v []byte) *FunctionCode {
 type FunctionCodeLocation struct {
 	_ struct{} `type:"structure"`
 
-	// A pre-signed URL that you can use to download the deployment package.
+	// A presigned URL that you can use to download the deployment package.
 	Location *string `type:"string"`
 
-	// The service hosting the file.
+	// The service that's hosting the file.
 	RepositoryType *string `type:"string"`
 }
 
@@ -5534,7 +5537,7 @@ type FunctionConfiguration struct {
 	// The SHA256 hash of the function's deployment package.
 	CodeSha256 *string `type:"string"`
 
-	// The size of the function's deployment package in bytes.
+	// The size of the function's deployment package, in bytes.
 	CodeSize *int64 `type:"long"`
 
 	// The function's dead letter queue.
@@ -5552,27 +5555,27 @@ type FunctionConfiguration struct {
 	// The name of the function.
 	FunctionName *string `min:"1" type:"string"`
 
-	// The function Lambda calls to begin executing your function.
+	// The function that Lambda calls to begin executing your function.
 	Handler *string `type:"string"`
 
-	// The KMS key used to encrypt the function's environment variables. Only returned
-	// if you've configured a customer managed CMK.
+	// The KMS key that's used to encrypt the function's environment variables.
+	// This key is only returned if you've configured a customer-managed CMK.
 	KMSKeyArn *string `type:"string"`
 
 	// The date and time that the function was last updated, in ISO-8601 format
 	// (https://www.w3.org/TR/NOTE-datetime) (YYYY-MM-DDThh:mm:ss.sTZD).
 	LastModified *string `type:"string"`
 
-	// The function's  layers (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+	// The function's  layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 	Layers []*Layer `type:"list"`
 
 	// For Lambda@Edge functions, the ARN of the master function.
 	MasterArn *string `type:"string"`
 
-	// The memory allocated to the function
+	// The memory that's allocated to the function.
 	MemorySize *int64 `min:"128" type:"integer"`
 
-	// Represents the latest updated revision of the function or alias.
+	// The latest updated revision of the function or alias.
 	RevisionId *string `type:"string"`
 
 	// The function's execution role.
@@ -5581,8 +5584,7 @@ type FunctionConfiguration struct {
 	// The runtime environment for the Lambda function.
 	Runtime *string `type:"string" enum:"Runtime"`
 
-	// The amount of time that Lambda allows a function to run before terminating
-	// it.
+	// The amount of time that Lambda allows a function to run before stopping it.
 	Timeout *int64 `min:"1" type:"integer"`
 
 	// The function's AWS X-Ray tracing configuration.
@@ -5742,7 +5744,7 @@ func (s GetAccountSettingsInput) GoString() string {
 type GetAccountSettingsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Limits related to concurrency and code storage.
+	// Limits that are related to concurrency and code storage.
 	AccountLimit *AccountLimit `type:"structure"`
 
 	// The number of functions and amount of storage in use.
@@ -5774,7 +5776,7 @@ func (s *GetAccountSettingsOutput) SetAccountUsage(v *AccountUsage) *GetAccountS
 type GetAliasInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the lambda function.
+	// The name of the Lambda function.
 	//
 	// Name formats
 	//
@@ -6019,13 +6021,13 @@ type GetFunctionOutput struct {
 	// The deployment package of the function or version.
 	Code *FunctionCodeLocation `type:"structure"`
 
-	// The function's reserved concurrency (http://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html).
+	// The function's reserved concurrency (https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html).
 	Concurrency *PutFunctionConcurrencyOutput `type:"structure"`
 
 	// The configuration of the function or version.
 	Configuration *FunctionConfiguration `type:"structure"`
 
-	// The function's tags (http://docs.aws.amazon.com/lambda/latest/dg/tagging.html).
+	// The function's tags (https://docs.aws.amazon.com/lambda/latest/dg/tagging.html).
 	Tags map[string]*string `type:"map"`
 }
 
@@ -6409,7 +6411,7 @@ type InvokeAsyncInput struct {
 	// FunctionName is a required field
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
-	// JSON that you want to provide to your Lambda function as input.
+	// The JSON that you want to provide to your Lambda function as input.
 	//
 	// InvokeArgs is a required field
 	InvokeArgs io.ReadSeeker `type:"blob" required:"true"`
@@ -6456,13 +6458,14 @@ func (s *InvokeAsyncInput) SetInvokeArgs(v io.ReadSeeker) *InvokeAsyncInput {
 	return s
 }
 
-// Upon success, it returns empty response. Otherwise, throws an exception.
+// A success response (202 Accepted) indicates that the request is queued for
+// invocation.
 //
 // Deprecated: InvokeAsyncOutput has been deprecated
 type InvokeAsyncOutput struct {
 	_ struct{} `deprecated:"true" type:"structure"`
 
-	// It will be 202 upon success.
+	// The status code.
 	Status *int64 `location:"statusCode" type:"integer"`
 }
 
@@ -6513,8 +6516,8 @@ type InvokeInput struct {
 	//    The API response includes the function response and additional data.
 	//
 	//    * Event - Invoke the function asynchronously. Send events that fail multiple
-	//    times to the function's dead-letter queue (if configured). The API response
-	//    only includes a status code.
+	//    times to the function's dead-letter queue (if it's configured). The API
+	//    response only includes a status code.
 	//
 	//    * DryRun - Validate parameter values and verify that the user or role
 	//    has permission to invoke the function.
@@ -6523,7 +6526,7 @@ type InvokeInput struct {
 	// Set to Tail to include the execution log in the response.
 	LogType *string `location:"header" locationName:"X-Amz-Log-Type" type:"string" enum:"LogType"`
 
-	// JSON that you want to provide to your Lambda function as input.
+	// The JSON that you want to provide to your Lambda function as input.
 	Payload []byte `type:"blob" sensitive:"true"`
 
 	// Specify a version or alias to invoke a published version of the function.
@@ -6599,29 +6602,29 @@ type InvokeOutput struct {
 	_ struct{} `type:"structure" payload:"Payload"`
 
 	// The version of the function that executed. When you invoke a function with
-	// an alias, indicates which version the alias resolved to.
+	// an alias, this indicates which version the alias resolved to.
 	ExecutedVersion *string `location:"header" locationName:"X-Amz-Executed-Version" min:"1" type:"string"`
 
-	// If present, indicates that an error occured during function execution. Details
+	// If present, indicates that an error occurred during function execution. Details
 	// about the error are included in the response payload.
 	//
 	//    * Handled - The runtime caught an error thrown by the function and formatted
 	//    it into a JSON document.
 	//
-	//    * Unhandled - The runtime did not handle the error. For example, the function
+	//    * Unhandled - The runtime didn't handle the error. For example, the function
 	//    ran out of memory or timed out.
 	FunctionError *string `location:"header" locationName:"X-Amz-Function-Error" type:"string"`
 
-	// The last 4 KB of the execution log, base64 encoded.
+	// The last 4 KB of the execution log, which is base64 encoded.
 	LogResult *string `location:"header" locationName:"X-Amz-Log-Result" type:"string"`
 
 	// The response from the function, or an error object.
 	Payload []byte `type:"blob" sensitive:"true"`
 
-	// The HTTP status code will be in the 200 range for successful request. For
-	// the RequestResponse invocation type this status code will be 200. For the
-	// Event invocation type this status code will be 202. For the DryRun invocation
-	// type the status code will be 204.
+	// The HTTP status code is in the 200 range for a successful request. For the
+	// RequestResponse invocation type, this status code is 200. For the Event invocation
+	// type, this status code is 202. For the DryRun invocation type, the status
+	// code is 204.
 	StatusCode *int64 `location:"statusCode" type:"integer"`
 }
 
@@ -6665,7 +6668,7 @@ func (s *InvokeOutput) SetStatusCode(v int64) *InvokeOutput {
 	return s
 }
 
-// An AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// An AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 type Layer struct {
 	_ struct{} `type:"structure"`
 
@@ -6698,7 +6701,7 @@ func (s *Layer) SetCodeSize(v int64) *Layer {
 	return s
 }
 
-// A ZIP archive that contains the contents of an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// A ZIP archive that contains the contents of an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 // You can specify either an Amazon S3 location, or upload a layer archive directly.
 type LayerVersionContentInput struct {
 	_ struct{} `type:"structure"`
@@ -6772,7 +6775,7 @@ func (s *LayerVersionContentInput) SetZipFile(v []byte) *LayerVersionContentInpu
 	return s
 }
 
-// Details about a version of an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// Details about a version of an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 type LayerVersionContentOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -6814,7 +6817,7 @@ func (s *LayerVersionContentOutput) SetLocation(v string) *LayerVersionContentOu
 	return s
 }
 
-// Details about a version of an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// Details about a version of an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 type LayerVersionsListItem struct {
 	_ struct{} `type:"structure"`
 
@@ -6883,7 +6886,7 @@ func (s *LayerVersionsListItem) SetVersion(v int64) *LayerVersionsListItem {
 	return s
 }
 
-// Details about an AWS Lambda layer (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+// Details about an AWS Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 type LayersListItem struct {
 	_ struct{} `type:"structure"`
 
@@ -6928,7 +6931,7 @@ func (s *LayersListItem) SetLayerName(v string) *LayersListItem {
 type ListAliasesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the lambda function.
+	// The name of the Lambda function.
 	//
 	// Name formats
 	//
@@ -6947,8 +6950,8 @@ type ListAliasesInput struct {
 	// Specify a function version to only list aliases that invoke that version.
 	FunctionVersion *string `location:"querystring" locationName:"FunctionVersion" min:"1" type:"string"`
 
-	// Specify the pagination token returned by a previous request to retrieve the
-	// next page of results.
+	// Specify the pagination token that's returned by a previous request to retrieve
+	// the next page of results.
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
 
 	// Limit the number of aliases returned.
@@ -7017,7 +7020,7 @@ type ListAliasesOutput struct {
 	// A list of aliases.
 	Aliases []*AliasConfiguration `type:"list"`
 
-	// Pagination token included if more results are available.
+	// The pagination token that's included if more results are available.
 	NextMarker *string `type:"string"`
 }
 
@@ -7167,11 +7170,11 @@ type ListFunctionsInput struct {
 	// Set to ALL to include entries for all published versions of each function.
 	FunctionVersion *string `location:"querystring" locationName:"FunctionVersion" type:"string" enum:"FunctionVersion"`
 
-	// Specify the pagination token returned by a previous request to retrieve the
-	// next page of results.
+	// Specify the pagination token that's returned by a previous request to retrieve
+	// the next page of results.
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
 
-	// For Lambda@Edge functions, the region of the master function. For example,
+	// For Lambda@Edge functions, the AWS Region of the master function. For example,
 	// us-east-2 or ALL. If specified, you must set FunctionVersion to ALL.
 	MasterRegion *string `location:"querystring" locationName:"MasterRegion" type:"string"`
 
@@ -7234,7 +7237,7 @@ type ListFunctionsOutput struct {
 	// A list of Lambda functions.
 	Functions []*FunctionConfiguration `type:"list"`
 
-	// Pagination token included if more results are available.
+	// The pagination token that's included if more results are available.
 	NextMarker *string `type:"string"`
 }
 
@@ -7516,7 +7519,7 @@ func (s *ListTagsOutput) SetTags(v map[string]*string) *ListTagsOutput {
 type ListVersionsByFunctionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the lambda function.
+	// The name of the Lambda function.
 	//
 	// Name formats
 	//
@@ -7532,11 +7535,11 @@ type ListVersionsByFunctionInput struct {
 	// FunctionName is a required field
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
-	// Specify the pagination token returned by a previous request to retrieve the
-	// next page of results.
+	// Specify the pagination token that's returned by a previous request to retrieve
+	// the next page of results.
 	Marker *string `location:"querystring" locationName:"Marker" type:"string"`
 
-	// Limit the number of versions returned.
+	// Limit the number of versions that are returned.
 	MaxItems *int64 `location:"querystring" locationName:"MaxItems" min:"1" type:"integer"`
 }
 
@@ -7590,7 +7593,7 @@ func (s *ListVersionsByFunctionInput) SetMaxItems(v int64) *ListVersionsByFuncti
 type ListVersionsByFunctionOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Pagination token included if more results are available.
+	// The pagination token that's included if more results are available.
 	NextMarker *string `type:"string"`
 
 	// A list of Lambda function versions.
@@ -7622,7 +7625,7 @@ func (s *ListVersionsByFunctionOutput) SetVersions(v []*FunctionConfiguration) *
 type PublishLayerVersionInput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of compatible function runtimes (http://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+	// A list of compatible function runtimes (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
 	// Used for filtering with ListLayers and ListLayerVersions.
 	CompatibleRuntimes []*string `type:"list"`
 
@@ -7804,17 +7807,17 @@ func (s *PublishLayerVersionOutput) SetVersion(v int64) *PublishLayerVersionOutp
 type PublishVersionInput struct {
 	_ struct{} `type:"structure"`
 
-	// Only publish a version if the hash matches the value specified. Use this
-	// option to avoid publishing a version if the function code has changed since
-	// you last updated it. You can get the hash for the version you uploaded from
-	// the output of UpdateFunctionCode.
+	// Only publish a version if the hash value matches the value that's specified.
+	// Use this option to avoid publishing a version if the function code has changed
+	// since you last updated it. You can get the hash for the version that you
+	// uploaded from the output of UpdateFunctionCode.
 	CodeSha256 *string `type:"string"`
 
-	// Specify a description for the version to override the description in the
-	// function configuration.
+	// A description for the version to override the description in the function
+	// configuration.
 	Description *string `type:"string"`
 
-	// The name of the lambda function.
+	// The name of the Lambda function.
 	//
 	// Name formats
 	//
@@ -7830,9 +7833,9 @@ type PublishVersionInput struct {
 	// FunctionName is a required field
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
-	// Only update the function if the revision ID matches the ID specified. Use
-	// this option to avoid publishing a version if the function configuration has
-	// changed since you last updated it.
+	// Only update the function if the revision ID matches the ID that's specified.
+	// Use this option to avoid publishing a version if the function configuration
+	// has changed since you last updated it.
 	RevisionId *string `type:"string"`
 }
 
@@ -7955,8 +7958,8 @@ func (s *PutFunctionConcurrencyInput) SetReservedConcurrentExecutions(v int64) *
 type PutFunctionConcurrencyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The number of concurrent executions reserved for this function. For more
-	// information, see Managing Concurrency (http://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html).
+	// The number of concurrent executions that are reserved for this function.
+	// For more information, see Managing Concurrency (https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html).
 	ReservedConcurrentExecutions *int64 `type:"integer"`
 }
 
@@ -8096,8 +8099,9 @@ type RemovePermissionInput struct {
 	// of the function.
 	Qualifier *string `location:"querystring" locationName:"Qualifier" min:"1" type:"string"`
 
-	// Only update the policy if the revision ID matches the ID specified. Use this
-	// option to avoid modifying a policy that has changed since you last read it.
+	// Only update the policy if the revision ID matches the ID that's specified.
+	// Use this option to avoid modifying a policy that has changed since you last
+	// read it.
 	RevisionId *string `location:"querystring" locationName:"RevisionId" type:"string"`
 
 	// Statement ID of the permission to remove.
@@ -8371,7 +8375,7 @@ type UpdateAliasInput struct {
 	// A description of the alias.
 	Description *string `type:"string"`
 
-	// The name of the lambda function.
+	// The name of the Lambda function.
 	//
 	// Name formats
 	//
@@ -8395,11 +8399,12 @@ type UpdateAliasInput struct {
 	// Name is a required field
 	Name *string `location:"uri" locationName:"Name" min:"1" type:"string" required:"true"`
 
-	// Only update the alias if the revision ID matches the ID specified. Use this
-	// option to avoid modifying an alias that has changed since you last read it.
+	// Only update the alias if the revision ID matches the ID that's specified.
+	// Use this option to avoid modifying an alias that has changed since you last
+	// read it.
 	RevisionId *string `type:"string"`
 
-	// The routing configuration (http://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
+	// The routing configuration (https://docs.aws.amazon.com/lambda/latest/dg/lambda-traffic-shifting-using-aliases.html)
 	// of the alias.
 	RoutingConfig *AliasRoutingConfiguration `type:"structure"`
 }
@@ -8595,13 +8600,13 @@ type UpdateFunctionCodeInput struct {
 	// This has the same effect as calling PublishVersion separately.
 	Publish *bool `type:"boolean"`
 
-	// Only update the function if the revision ID matches the ID specified. Use
-	// this option to avoid modifying a function that has changed since you last
-	// read it.
+	// Only update the function if the revision ID matches the ID that's specified.
+	// Use this option to avoid modifying a function that has changed since you
+	// last read it.
 	RevisionId *string `type:"string"`
 
-	// An Amazon S3 bucket in the same region as your function. The bucket can be
-	// in a different AWS account.
+	// An Amazon S3 bucket in the same AWS Region as your function. The bucket can
+	// be in a different AWS account.
 	S3Bucket *string `min:"3" type:"string"`
 
 	// The Amazon S3 key of the deployment package.
@@ -8705,14 +8710,13 @@ type UpdateFunctionConfigurationInput struct {
 
 	// A dead letter queue configuration that specifies the queue or topic where
 	// Lambda sends asynchronous events when they fail processing. For more information,
-	// see Dead Letter Queues (http://docs.aws.amazon.com/lambda/latest/dg/dlq.html).
+	// see Dead Letter Queues (https://docs.aws.amazon.com/lambda/latest/dg/dlq.html).
 	DeadLetterConfig *DeadLetterConfig `type:"structure"`
 
-	// A short user-defined function description. AWS Lambda does not use this value.
-	// Assign a meaningful description as you see fit.
+	// A description of the function.
 	Description *string `type:"string"`
 
-	// The parent object that contains your environment's configuration settings.
+	// Environment variables that are accessible from function code during execution.
 	Environment *Environment `type:"structure"`
 
 	// The name of the Lambda function.
@@ -8731,49 +8735,50 @@ type UpdateFunctionConfigurationInput struct {
 	// FunctionName is a required field
 	FunctionName *string `location:"uri" locationName:"FunctionName" min:"1" type:"string" required:"true"`
 
-	// The function that Lambda calls to begin executing your function. For Node.js,
-	// it is the module-name.export value in your function.
+	// The name of the method within your code that Lambda calls to execute your
+	// function. The format includes the file name. It can also include namespaces
+	// and other qualifiers, depending on the runtime. For more information, see
+	// Programming Model (https://docs.aws.amazon.com/lambda/latest/dg/programming-model-v2.html).
 	Handler *string `type:"string"`
 
-	// The Amazon Resource Name (ARN) of the KMS key used to encrypt your function's
-	// environment variables. If you elect to use the AWS Lambda default service
-	// key, pass in an empty string ("") for this parameter.
+	// The ARN of the AWS Key Management Service (AWS KMS) key that's used to encrypt
+	// your function's environment variables. If it's not provided, AWS Lambda uses
+	// a default service key.
 	KMSKeyArn *string `type:"string"`
 
-	// A list of function layers (http://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
-	// to add to the function's execution environment.
+	// A list of function layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html)
+	// to add to the function's execution environment. Specify each layer by its
+	// ARN, including the version.
 	Layers []*string `type:"list"`
 
-	// The amount of memory, in MB, your Lambda function is given. AWS Lambda uses
-	// this memory size to infer the amount of CPU allocated to your function. Your
-	// function use-case determines your CPU and memory requirements. For example,
-	// a database operation might need less memory compared to an image processing
-	// function. The default value is 128 MB. The value must be a multiple of 64
-	// MB.
+	// The amount of memory that your function has access to. Increasing the function's
+	// memory also increases its CPU allocation. The default value is 128 MB. The
+	// value must be a multiple of 64 MB.
 	MemorySize *int64 `min:"128" type:"integer"`
 
-	// Only update the function if the revision ID matches the ID specified. Use
-	// this option to avoid modifying a function that has changed since you last
-	// read it.
+	// Only update the function if the revision ID matches the ID that's specified.
+	// Use this option to avoid modifying a function that has changed since you
+	// last read it.
 	RevisionId *string `type:"string"`
 
-	// The Amazon Resource Name (ARN) of the IAM role that Lambda will assume when
-	// it executes your function.
+	// The Amazon Resource Name (ARN) of the function's execution role.
 	Role *string `type:"string"`
 
-	// The runtime version for the function.
+	// The identifier of the function's runtime (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
 	Runtime *string `type:"string" enum:"Runtime"`
 
-	// The amount of time that Lambda allows a function to run before terminating
-	// it. The default is 3 seconds. The maximum allowed value is 900 seconds.
+	// The amount of time that Lambda allows a function to run before stopping it.
+	// The default is 3 seconds. The maximum allowed value is 900 seconds.
 	Timeout *int64 `min:"1" type:"integer"`
 
 	// Set Mode to Active to sample and trace a subset of incoming requests with
 	// AWS X-Ray.
 	TracingConfig *TracingConfig `type:"structure"`
 
-	// Specify security groups and subnets in a VPC to which your Lambda function
-	// needs access.
+	// For network connectivity to AWS resources in a VPC, specify a list of security
+	// groups and subnets in the VPC. When you connect a function to a VPC, it can
+	// only access resources and the internet through that VPC. For more information,
+	// see VPC Settings (https://docs.aws.amazon.com/lambda/latest/dg/vpc.html).
 	VpcConfig *VpcConfig `type:"structure"`
 }
 
@@ -8893,7 +8898,7 @@ func (s *UpdateFunctionConfigurationInput) SetVpcConfig(v *VpcConfig) *UpdateFun
 	return s
 }
 
-// The VPC security groups and subnets attached to a Lambda function.
+// The VPC security groups and subnets that are attached to a Lambda function.
 type VpcConfig struct {
 	_ struct{} `type:"structure"`
 
@@ -8926,7 +8931,7 @@ func (s *VpcConfig) SetSubnetIds(v []*string) *VpcConfig {
 	return s
 }
 
-// The VPC security groups and subnets attached to a Lambda function.
+// The VPC security groups and subnets that are attached to a Lambda function.
 type VpcConfigResponse struct {
 	_ struct{} `type:"structure"`
 

--- a/vendor/github.com/aws/aws-sdk-go/service/lambda/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lambda/doc.go
@@ -7,8 +7,8 @@
 //
 // This is the AWS Lambda API Reference. The AWS Lambda Developer Guide provides
 // additional information. For the service overview, see What is AWS Lambda
-// (http://docs.aws.amazon.com/lambda/latest/dg/welcome.html), and for information
-// about how the service works, see AWS Lambda: How it Works (http://docs.aws.amazon.com/lambda/latest/dg/lambda-introduction.html)
+// (https://docs.aws.amazon.com/lambda/latest/dg/welcome.html), and for information
+// about how the service works, see AWS Lambda: How it Works (https://docs.aws.amazon.com/lambda/latest/dg/lambda-introduction.html)
 // in the AWS Lambda Developer Guide.
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31 for more information on this service.

--- a/vendor/github.com/aws/aws-sdk-go/service/lambda/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/lambda/errors.go
@@ -7,7 +7,7 @@ const (
 	// ErrCodeCodeStorageExceededException for service response error code
 	// "CodeStorageExceededException".
 	//
-	// You have exceeded your maximum total code size per account. Limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+	// You have exceeded your maximum total code size per account. Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
 	ErrCodeCodeStorageExceededException = "CodeStorageExceededException"
 
 	// ErrCodeEC2AccessDeniedException for service response error code
@@ -123,7 +123,7 @@ const (
 	// "RequestTooLargeException".
 	//
 	// The request payload exceeded the Invoke request body JSON input limit. For
-	// more information, see Limits (http://docs.aws.amazon.com/lambda/latest/dg/limits.html).
+	// more information, see Limits (https://docs.aws.amazon.com/lambda/latest/dg/limits.html).
 	ErrCodeRequestTooLargeException = "RequestTooLargeException"
 
 	// ErrCodeResourceConflictException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
@@ -26,11 +26,16 @@ func unmarshalError(r *request.Request) {
 	// Bucket exists in a different region, and request needs
 	// to be made to the correct region.
 	if r.HTTPResponse.StatusCode == http.StatusMovedPermanently {
+		msg := fmt.Sprintf(
+			"incorrect region, the bucket is not in '%s' region at endpoint '%s'",
+			aws.StringValue(r.Config.Region),
+			aws.StringValue(r.Config.Endpoint),
+		)
+		if v := r.HTTPResponse.Header.Get("x-amz-bucket-region"); len(v) != 0 {
+			msg += fmt.Sprintf(", bucket is in '%s' region", v)
+		}
 		r.Error = awserr.NewRequestFailure(
-			awserr.New("BucketRegionError",
-				fmt.Sprintf("incorrect region, the bucket is not in '%s' region",
-					aws.StringValue(r.Config.Region)),
-				nil),
+			awserr.New("BucketRegionError", msg, nil),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)

--- a/vendor/github.com/aws/aws-sdk-go/service/secretsmanager/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/secretsmanager/api.go
@@ -1394,7 +1394,7 @@ func (c *SecretsManager) PutResourcePolicyRequest(input *PutResourcePolicyInput)
 // For more information, see Using Resource-Based Policies for AWS Secrets Manager
 // (http://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_resource-based-policies.html).
 // For the complete description of the AWS policy syntax and grammar, see IAM
-// JSON Policy Reference (http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html)
+// JSON Policy Reference (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html)
 // in the IAM User Guide.
 //
 // Minimum permissions
@@ -1815,7 +1815,7 @@ func (c *SecretsManager) RotateSecretRequest(input *RotateSecretInput) (req *req
 // clients all immediately begin to use the new version. For more information
 // about rotating secrets and how to configure a Lambda function to rotate the
 // secrets for your protected service, see Rotating Secrets in AWS Secrets Manager
-// (http://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html)
+// (https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html)
 // in the AWS Secrets Manager User Guide.
 //
 // Secrets Manager schedules the next rotation when the previous one is complete.
@@ -2400,7 +2400,7 @@ func (c *SecretsManager) UpdateSecretVersionStageRequest(input *UpdateSecretVers
 // a time. If a staging label to be added is already attached to another version,
 // then it is moved--removed from the other version first and then attached
 // to this one. For more information about staging labels, see Staging Labels
-// (http://docs.aws.amazon.com/secretsmanager/latest/userguide/terms-concepts.html#term_staging-label)
+// (https://docs.aws.amazon.com/secretsmanager/latest/userguide/terms-concepts.html#term_staging-label)
 // in the AWS Secrets Manager User Guide.
 //
 // The staging labels that you specify in the VersionStage parameter are added
@@ -2682,7 +2682,7 @@ type CreateSecretInput struct {
 	// For storing multiple values, we recommend that you use a JSON text string
 	// argument and specify key/value pairs. For information on how to format a
 	// JSON parameter for the various command line tool environments, see Using
-	// JSON for Parameters (http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
+	// JSON for Parameters (https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
 	// in the AWS CLI User Guide. For example:
 	//
 	// [{"username":"bob"},{"password":"abc123xyz456"}]
@@ -2707,7 +2707,7 @@ type CreateSecretInput struct {
 	//
 	// This parameter requires a JSON text string argument. For information on how
 	// to format a JSON parameter for the various command line tool environments,
-	// see Using JSON for Parameters (http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
+	// see Using JSON for Parameters (https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
 	// in the AWS CLI User Guide. For example:
 	//
 	// [{"Key":"CostCenter","Value":"12345"},{"Key":"environment","Value":"production"}]
@@ -4182,7 +4182,7 @@ type PutSecretValueInput struct {
 	// For storing multiple values, we recommend that you use a JSON text string
 	// argument and specify key/value pairs. For information on how to format a
 	// JSON parameter for the various command line tool environments, see Using
-	// JSON for Parameters (http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
+	// JSON for Parameters (https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
 	// in the AWS CLI User Guide.
 	//
 	// For example:
@@ -4612,7 +4612,7 @@ type SecretListEntry struct {
 	// The Amazon Resource Name (ARN) of the secret.
 	//
 	// For more information about ARNs in Secrets Manager, see Policy Resources
-	// (http://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_iam-permissions.html#iam-resources)
+	// (https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_iam-permissions.html#iam-resources)
 	// in the AWS Secrets Manager User Guide.
 	ARN *string `min:"20" type:"string"`
 
@@ -4885,7 +4885,7 @@ type TagResourceInput struct {
 	//
 	// This parameter to the API requires a JSON text string argument. For information
 	// on how to format a JSON parameter for the various command line tool environments,
-	// see Using JSON for Parameters (http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
+	// see Using JSON for Parameters (https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
 	// in the AWS CLI User Guide. For the AWS CLI, you can also use the syntax:
 	// --Tags Key="Key1",Value="Value1",Key="Key2",Value="Value2"[,…]
 	//
@@ -4985,7 +4985,7 @@ type UntagResourceInput struct {
 	//
 	// This parameter to the API requires a JSON text string argument. For information
 	// on how to format a JSON parameter for the various command line tool environments,
-	// see Using JSON for Parameters (http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
+	// see Using JSON for Parameters (https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
 	// in the AWS CLI User Guide.
 	//
 	// TagKeys is a required field
@@ -5141,7 +5141,7 @@ type UpdateSecretInput struct {
 	// For storing multiple values, we recommend that you use a JSON text string
 	// argument and specify key/value pairs. For information on how to format a
 	// JSON parameter for the various command line tool environments, see Using
-	// JSON for Parameters (http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
+	// JSON for Parameters (https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json)
 	// in the AWS CLI User Guide. For example:
 	//
 	// [{"username":"bob"},{"password":"abc123xyz456"}]

--- a/vendor/github.com/aws/aws-sdk-go/service/secretsmanager/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/secretsmanager/doc.go
@@ -7,7 +7,7 @@
 // retrieve, secrets.
 //
 // This guide provides descriptions of the Secrets Manager API. For more information
-// about using this service, see the AWS Secrets Manager User Guide (http://docs.aws.amazon.com/secretsmanager/latest/userguide/introduction.html).
+// about using this service, see the AWS Secrets Manager User Guide (https://docs.aws.amazon.com/secretsmanager/latest/userguide/introduction.html).
 //
 // API Version
 //
@@ -26,7 +26,7 @@
 // We recommend that you use the AWS SDKs to make programmatic API calls to
 // Secrets Manager. However, you also can use the Secrets Manager HTTP Query
 // API to make direct calls to the Secrets Manager web service. To learn more
-// about the Secrets Manager HTTP Query API, see Making Query Requests (http://docs.aws.amazon.com/secretsmanager/latest/userguide/query-requests.html)
+// about the Secrets Manager HTTP Query API, see Making Query Requests (https://docs.aws.amazon.com/secretsmanager/latest/userguide/query-requests.html)
 // in the AWS Secrets Manager User Guide.
 //
 // Secrets Manager supports GET and POST requests for all actions. That is,
@@ -62,7 +62,7 @@
 // (http://docs.aws.amazon.com/secretsmanager/latest/userguide/monitoring.html#monitoring_cloudtrail)
 // in the AWS Secrets Manager User Guide. To learn more about CloudTrail, including
 // how to turn it on and find your log files, see the AWS CloudTrail User Guide
-// (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/what_is_cloud_trail_top_level.html).
+// (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/what_is_cloud_trail_top_level.html).
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/secretsmanager-2017-10-17 for more information on this service.
 //

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/apparentlymart/go-cidr/cidr
 github.com/apparentlymart/go-textseg/textseg
 # github.com/armon/go-radix v1.0.0
 github.com/armon/go-radix
-# github.com/aws/aws-sdk-go v1.16.32
+# github.com/aws/aws-sdk-go v1.17.0
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr


### PR DESCRIPTION
[AWS SDK v1.17.0](https://github.com/aws/aws-sdk-go/releases/tag/v1.17.0) required for:
* https://github.com/terraform-providers/terraform-provider-aws/issues/7603

```console
$ go get github.com/aws/aws-sdk-go@v1.17.0
$ go mod tidy
$ go mod vendor
```