### PR TITLE
resource/aws_route53_record: Add validation for alias name and zone_id arguments

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -101,8 +101,9 @@ func resourceAwsRoute53Record() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"zone_id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 32),
 						},
 
 						"name": {
@@ -112,6 +113,7 @@ func resourceAwsRoute53Record() *schema.Resource {
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								return strings.EqualFold(old, new)
 							},
+							ValidateFunc: validation.StringLenBetween(1, 1024),
 						},
 
 						"evaluate_target_health": {


### PR DESCRIPTION
Closes #7557 

References:
* https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html

The Route53 API returns a confusing API error message when implementing an ALIAS record for Custom VPC Endpoints if the name and zone_id values are swapped:

```
--- FAIL: TestAccAWSRoute53Record_alias_vpcendpoint (363.09s)
    testing.go:531: Step 0, expected error:

        Error applying: 1 error occurred:
        	* aws_route53_record.test: 1 error occurred:
        	* aws_route53_record.test: [ERR]: Error building changeset: InvalidInput: Invalid XML ; cvc-maxLength-valid: Value 'vpce-0bd0cf7081a1a0f93-jtogpkxk.vpce-svc-0f1eac6867ad44720.us-west-2.vpce.amazonaws.com' with length = '87' is not facet-valid with respect to maxLength '32' for type 'ResourceId'.
```

This updates the resource to now report a validation error:

```
        Error applying: 1 error occurred:
        	* aws_route53_record.test: expected length of alias.0.zone_id to be in the range (1 - 32), got vpce-0ed0dbc5b2e181289-kr42z80r.vpce-svc-04a7ad6c6da00d525.us-west-2.vpce.amazonaws.com
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (423.77s)
```
