### PR TITLE
Syntax highlight more docs code blocks

### DIFF
--- a/website/docs/r/iot_topic_rule.html.markdown
+++ b/website/docs/r/iot_topic_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 ## Example Usage
 
-```
+```hcl
 resource "aws_iot_topic_rule" "rule" {
   name = "MyRule"
   description = "Example rule"

--- a/website/docs/r/wafregional_xss_match_set.html.markdown
+++ b/website/docs/r/wafregional_xss_match_set.html.markdown
@@ -12,7 +12,7 @@ Provides a WAF Regional XSS Match Set Resource for use with Application Load Bal
 
 ## Example Usage
 
-```
+```hcl
 resource "aws_wafregional_xss_match_set" "xss_match_set" {
   name = "xss_match_set"
   xss_match_tuple {


### PR DESCRIPTION
Changes proposed in this pull request:

* Syntax highlight more docs code blocks. 😬:rocket:
