### PR TITLE
Remove outdated info in cognito_user_pool_client.generate_secret DOCS

### DIFF
--- a/website/docs/r/cognito_user_pool_client.markdown
+++ b/website/docs/r/cognito_user_pool_client.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 * `callback_urls` - (Optional) List of allowed callback URLs for the identity providers.
 * `default_redirect_uri` - (Optional) The default redirect URI. Must be in the list of callback URLs.
 * `explicit_auth_flows` - (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH).
-* `generate_secret` - (Optional) Should an application secret be generated. AWS JavaScript SDK requires this to be false.
+* `generate_secret` - (Optional) Should an application secret be generated.
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers.
 * `name` - (Required) The name of the application client.
 * `read_attributes` - (Optional) List of user pool attributes the application client can read from.


### PR DESCRIPTION
Currently, the description of the `generate_secret` attribute on `cognito_user_pool_client` is as such:
> Should an application secret be generated. AWS JavaScript SDK requires this to be false.

I very much remember this to be true a couple months back.

However, when reading the [AWS JS SDK Doc](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CognitoIdentityServiceProvider.html#adminInitiateAuth-property) now, the following is stated under `adminInitiateAuth:AuthParameters`:

> For ADMIN_NO_SRP_AUTH: USERNAME (required), **SECRET_HASH (if app client is configured with client secret)**, PASSWORD (required), DEVICE_KEY

To me this seems like the AWS JS SDK now is supporting a client secret as well.

That's why I propose to remove the sentence from the terraform docs as well.