### PR TITLE
Add 'aws_ec2_client_vpn_endpoint.tags' attribute

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint.go
@@ -120,7 +120,7 @@ func resourceAwsEc2ClientVpnEndpointCreate(d *schema.ResourceData, meta interfac
 		ClientCidrBlock:      aws.String(d.Get("client_cidr_block").(string)),
 		ServerCertificateArn: aws.String(d.Get("server_certificate_arn").(string)),
 		TransportProtocol:    aws.String(d.Get("transport_protocol").(string)),
-		TagSpecifications:    tagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeClientVpnEndpoint),
+		TagSpecifications:    ec2TagSpecificationsFromMap(d.Get("tags").(map[string]interface{}), ec2.ResourceTypeClientVpnEndpoint),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -229,17 +229,17 @@ func resourceAwsEc2ClientVpnEndpointRead(d *schema.ResourceData, meta interface{
 
 	err = d.Set("authentication_options", flattenAuthOptsConfig(result.ClientVpnEndpoints[0].AuthenticationOptions))
 	if err != nil {
-		return err
+		return fmt.Errorf("error setting authentication_options: %s", err)
 	}
 
 	err = d.Set("connection_log_options", flattenConnLoggingConfig(result.ClientVpnEndpoints[0].ConnectionLogOptions))
 	if err != nil {
-		return err
+		return fmt.Errorf("error setting connection_log_options: %s", err)
 	}
 
 	err = d.Set("tags", tagsToMap(result.ClientVpnEndpoints[0].Tags))
 	if err != nil {
-		return err
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil
@@ -319,9 +319,8 @@ func resourceAwsEc2ClientVpnEndpointUpdate(d *schema.ResourceData, meta interfac
 
 	if err := setTags(conn, d); err != nil {
 		return err
-	} else {
-		d.SetPartial("tags")
 	}
+	d.SetPartial("tags")
 
 	d.Partial(false)
 	return resourceAwsEc2ClientVpnEndpointRead(d, meta)

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -477,8 +477,8 @@ func tagsMapToRaw(m map[string]string) map[string]interface{} {
 	return raw
 }
 
-// tagSpecificationsFromMap returns the tag specifications for the given map of data and resource type.
-func tagSpecificationsFromMap(m map[string]interface{}, t string) []*ec2.TagSpecification {
+// ec2TagSpecificationsFromMap returns the tag specifications for the given map of data m and resource type t.
+func ec2TagSpecificationsFromMap(m map[string]interface{}, t string) []*ec2.TagSpecification {
 	if len(m) == 0 {
 		return nil
 	}

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -476,3 +476,17 @@ func tagsMapToRaw(m map[string]string) map[string]interface{} {
 
 	return raw
 }
+
+// tagSpecificationsFromMap returns the tag specifications for the given map of data and resource type.
+func tagSpecificationsFromMap(m map[string]interface{}, t string) []*ec2.TagSpecification {
+	if len(m) == 0 {
+		return nil
+	}
+
+	return []*ec2.TagSpecification{
+		{
+			ResourceType: aws.String(t),
+			Tags:         tagsFromMap(m),
+		},
+	}
+}

--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws_ec2_client_vpn_endpoint
 
-Provides an AWS Client VPN endpoint for OpenVPN clients. For more information on usage, please see the 
+Provides an AWS Client VPN endpoint for OpenVPN clients. For more information on usage, please see the
 [AWS Client VPN Administrator's Guide](https://docs.aws.amazon.com/vpn/latest/clientvpn-admin/what-is.html).
 
 ## Example Usage
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `transport_protocol` - (Optional) The transport protocol to be used by the VPN session. Default value is `udp`.
 * `authentication_options` - (Required) Information about the authentication method to be used to authenticate clients.
 * `connection_log_options` - (Required) Information about the client connection logging options.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ### `authentication_options` Argument Reference
 
@@ -64,7 +65,7 @@ One of the following arguments must be supplied:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the Client VPN endpoint. 
+* `id` - The ID of the Client VPN endpoint.
 * `dns_name` - The DNS name to be used by clients when establishing their VPN session.
 * `status` - The current state of the Client VPN endpoint.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/7603.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsEc2ClientVpnEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsEc2ClientVpnEndpoint_ -timeout 120m
=== RUN   TestAccAwsEc2ClientVpnEndpoint_basic
--- PASS: TestAccAwsEc2ClientVpnEndpoint_basic (24.33s)
=== RUN   TestAccAwsEc2ClientVpnEndpoint_msAD
--- PASS: TestAccAwsEc2ClientVpnEndpoint_msAD (1764.63s)
=== RUN   TestAccAwsEc2ClientVpnEndpoint_withLogGroup
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withLogGroup (37.06s)
=== RUN   TestAccAwsEc2ClientVpnEndpoint_withDNSServers
--- PASS: TestAccAwsEc2ClientVpnEndpoint_withDNSServers (32.11s)
=== RUN   TestAccAwsEc2ClientVpnEndpoint_tags
--- PASS: TestAccAwsEc2ClientVpnEndpoint_tags (44.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1903.023s
```