### PR TITLE
DNS resolution for inter-region vpc peering

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,7 @@ ability to merge PRs and respond to issues.
         - [Running an Acceptance Test](#running-an-acceptance-test)
         - [Writing an Acceptance Test](#writing-an-acceptance-test)
         - [Writing and running Cross-Account Acceptance Tests](#writing-and-running-cross-account-acceptance-tests)
+        - [Writing and running Cross-Region Acceptance Tests](#writing-and-running-cross-region-acceptance-tests)
 
 <!-- /TOC -->
 
@@ -340,7 +341,7 @@ The following Go language resources provide common coding preferences that may b
 
 #### Resource Contribution Guidelines
 
-The following resource checks need to be addressed before your contribution can be merged. The exclusion of any applicable check may result in a delayed time to merge. 
+The following resource checks need to be addressed before your contribution can be merged. The exclusion of any applicable check may result in a delayed time to merge.
 
 - [ ] __Passes Testing__: All code and documentation changes must pass unit testing, code linting, and website link testing. Resource code changes must pass all acceptance testing for the resource.
 - [ ] __Avoids API Calls Across Account, Region, and Service Boundaries__: Resources should not implement cross-account, cross-region, or cross-service API calls.
@@ -747,6 +748,128 @@ export AWS_ALTERNATE_PROFILE=...
 export AWS_ALTERNATE_ACCESS_KEY_ID=...
 export AWS_ALTERNATE_SECRET_ACCESS_KEY=...
 ```
+
+#### Writing and running Cross-Region Acceptance Tests
+
+When testing requires AWS infrastructure in a second AWS region, the below changes to the normal setup will allow the management or reference of resources and data sources across regions:
+
+- In the `PreCheck` function, include `testAccMultipleRegionsPreCheck(t)` and `testAccAlternateRegionPreCheck(t)` to ensure a standardized set of information is required for cross-region testing configuration. If the infrastructure in the second AWS region is also in a second AWS account also include `testAccAlternateAccountPreCheck(t)`
+- Declare a `providers` variable at the top of the test function: `var providers []*schema.Provider`
+- Switch usage of `Providers: testAccProviders` to `ProviderFactories: testAccProviderFactories(&providers)`
+- Add `testAccAlternateRegionProviderConfig()` to the test configuration and use `provider = "aws.alternate"` for cross-region resources. The resource that is the focus of the acceptance test should _not_ use the provider alias to simplify the testing setup. If the infrastructure in the second AWS region is also in a second AWS account use `testAccAlternateAccountAlternateRegionProviderConfig()` instead
+- For any `TestStep` that includes `ImportState: true`, add the `Config` that matches the previous `TestStep` `Config`
+
+An example acceptance test implementation can be seen below:
+
+```go
+func TestAccAwsExample_basic(t *testing.T) {
+  var providers []*schema.Provider
+  resourceName := "aws_example.test"
+
+  resource.ParallelTest(t, resource.TestCase{
+    PreCheck: func() {
+      testAccPreCheck(t)
+      testAccMultipleRegionsPreCheck(t)
+      testAccAlternateRegionPreCheck(t)
+    },
+    ProviderFactories: testAccProviderFactories(&providers),
+    CheckDestroy:      testAccCheckAwsExampleDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: testAccAwsExampleConfig(),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckAwsExampleExists(resourceName),
+          // ... additional checks ...
+        ),
+      },
+      {
+        Config:            testAccAwsExampleConfig(),
+        ResourceName:      resourceName,
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+    },
+  })
+}
+
+func testAccAwsExampleConfig() string {
+  return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+# Cross region resources should be handled by the cross region provider.
+# The standardized provider alias is aws.alternate as seen below.
+resource "aws_cross_region_example" "test" {
+  provider = "aws.alternate"
+
+  # ... configuration ...
+}
+
+# The resource that is the focus of the testing should be handled by the default provider,
+# which is automatically done by not specifying the provider configuration in the resource.
+resource "aws_example" "test" {
+  # ... configuration ...
+}
+`)
+}
+```
+
+Searching for usage of `testAccAlternateRegionPreCheck` in the codebase will yield real world examples of this setup in action.
+
+Running these acceptance tests is the same as before, except if an AWS region other than the default alternate region - `us-east-1` - is required,
+in which case the following additional configuration information is required:
+
+```sh
+export AWS_ALTERNATE_REGION=...
+```
+
+#### Acceptance Testing Guidelines
+
+The Terraform AWS Provider follows common practices to ensure consistent and reliable testing across all resources in the project. While there may be older testing present that predates these guidelines, new submissions are generally expected to adhere to these items to maintain Terraform Provider quality. For any guidelines listed, contributors are encouraged to ask any questions and community reviewers are encouraged to provide review suggestions based on these guidelines to speed up the review and merge process.
+
+The below are required items that will be noted during submission review and prevent immediate merging:
+
+- [ ] __Implements CheckDestroy__: Resource testing should include a `CheckDestroy` function (typically named `testAccCheckAws{SERVICE}{RESOURCE}Destroy`) that calls the API to verify that the Terraform resource has been deleted or disassociated as appropriate. More information about `CheckDestroy` functions can be found in the [Extending Terraform TestCase documentation](https://www.terraform.io/docs/extend/testing/acceptance-tests/testcase.html#checkdestroy).
+- [ ] __Implements Exists Check Function__: Resource testing should include a `TestCheckFunc` function (typically named `testAccCheckAws{SERVICE}{RESOURCE}Exists`) that calls the API to verify that the Terraform resource has been created or associated as appropriate. Preferably, this function will also accept a pointer to an API object representing the Terraform resource from the API response that can be set for potential usage in later `TestCheckFunc`. More information about these functions can be found in the [Extending Terraform Custom Check Functions documentation](https://www.terraform.io/docs/extend/testing/acceptance-tests/testcase.html#checkdestroy).
+- [ ] __Excludes Provider Declarations__: Test configurations should not include `provider "aws" {...}` declarations. If necessary, only the provider declarations in `provider_test.go` should be used for multiple account/region or otherwise specialized testing.
+- [ ] __Passes in us-west-2 Region__: Tests default to running in `us-west-2` and at a minimum should pass in that region or include necessary `PreCheck` functions to skip the test when ran outside an expected environment.
+- [ ] __Uses resource.ParallelTest__: Tests should utilize [`resource.ParallelTest()`](https://godoc.org/github.com/hashicorp/terraform/helper/resource#ParallelTest) instead of [`resource.Test()`](https://godoc.org/github.com/hashicorp/terraform/helper/resource#Test) except where serialized testing is absolutely required.
+- [ ] __Uses fmt.Sprintf()__: Test configurations preferably should to be separated into their own functions (typically named `testAccAws{SERVICE}{RESOURCE}Config{PURPOSE}`) that call [`fmt.Sprintf()`](https://golang.org/pkg/fmt/#Sprintf) for variable injection or a string `const` for completely static configurations. Test configurations should avoid `var` or other variable injection functionality such as [`text/template`](https://golang.org/pkg/text/template/).
+- [ ] __Uses Randomized Infrastructure Naming__: Test configurations that utilize resources where a unique name is required should generate a random name. Typically this is created via `rName := acctest.RandomWithPrefix("tf-acc-test")` in the acceptance test function before generating the configuration.
+
+For resources that support import, the additional item below is required that will be noted during submission review and prevent immediate merging:
+
+- [ ] __Implements ImportState Testing__: Tests should include an additional `TestStep` configuration that verifies resource import via `ImportState: true` and `ImportStateVerify: true`. This `TestStep` should be added to all possible tests for the resource to ensure that all infrastructure configurations are properly imported into Terraform.
+
+The below are style-based items that _may_ be noted during review and are recommended for simplicity, consistency, and quality assurance:
+
+- [ ] __Uses Builtin Check Functions__: Tests should utilize already available check functions, e.g. `resource.TestCheckResourceAttr()`, to verify values in the Terraform state over creating custom `TestCheckFunc`. More information about these functions can be found in the [Extending Terraform Builtin Check Functions documentation](https://www.terraform.io/docs/extend/testing/acceptance-tests/teststep.html#builtin-check-functions).
+- [ ] __Uses TestCheckResoureAttrPair() for Data Sources__: Tests should utilize [`resource.TestCheckResourceAttrPair()`](https://godoc.org/github.com/hashicorp/terraform/helper/resource#TestCheckResourceAttrPair) to verify values in the Terraform state for data sources attributes to compare them with their expected resource attributes.
+- [ ] __Excludes Timeouts Configurations__: Test configurations should not include `timeouts {...}` configuration blocks except for explicit testing of customizable timeouts (typically very short timeouts with `ExpectError`).
+- [ ] __Implements Default and Zero Value Validation__: The basic test for a resource (typically named `TestAccAws{SERVICE}{RESOURCE}_basic`) should utilize available check functions, e.g. `resource.TestCheckResourceAttr()`, to verify default and zero values in the Terraform state for all attributes. Empty/missing configuration blocks can be verified with `resource.TestCheckResourceAttr(resourceName, "{ATTRIBUTE}.#", "0")` and empty maps with `resource.TestCheckResourceAttr(resourceName, "{ATTRIBUTE}.%", "0")`
+
+The below are location-based items that _may_ be noted during review and are recommended for consistency with testing flexibility. Resource testing is expected to pass across multiple AWS environments supported by the Terraform AWS Provider (e.g. AWS Standard and AWS GovCloud (US)). Contributors are not expected or required to perform testing outside of AWS Standard, e.g. running only in the `us-west-2` region is perfectly acceptable, however these are provided for reference:
+
+- [ ] __Uses aws_ami Data Source__: Any hardcoded AMI ID configuration, e.g. `ami-12345678`, should be replaced with the [`aws_ami` data source](https://www.terraform.io/docs/providers/aws/d/ami.html) pointing to an Amazon Linux image. A common pattern is a configuration like the below, which will likely be moved into a common configuration function in the future:
+
+  ```hcl
+  data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+    most_recent = true
+    owners      = ["amazon"]
+
+    filter {
+      name = "name"
+      values = ["amzn-ami-minimal-hvm-*"]
+    }
+    filter {
+      name = "root-device-type"
+      values = ["ebs"]
+    }
+  }
+  ```
+
+- [ ] __Uses aws_availability_zones Data Source__: Any hardcoded AWS Availability Zone configuration, e.g. `us-west-2a`, should be replaced with the [`aws_availability_zones` data source](https://www.terraform.io/docs/providers/aws/d/availability_zones.html). A common pattern is declaring `data "aws_availability_zones" "current" {}` and referencing it via `data.aws_availability_zones.current.names[0]` or `data.aws_availability_zones.current.names[count.index]` in resources utilizing `count`.
+- [ ] __Uses aws_region Data Source__: Any hardcoded AWS Region configuration, e.g. `us-west-2`, should be replaced with the [`aws_region` data source](https://www.terraform.io/docs/providers/aws/d/region.html). A common pattern is declaring `data "aws_region" "cname}` and referencing it via `data.aws_region.current.name`
+- [ ] __Uses aws_partition Data Source__: Any hardcoded AWS Partition configuration, e.g. the `aws` in a `arn:aws:SERVICE:REGION:ACCOUNT:RESOURCE` ARN, should be replaced with the [`aws_partition` data source](https://www.terraform.io/docs/providers/aws/d/partition.html). A common pattern is declaring `data "aws_partition" "current" {}` and referencing it via `data.aws_partition.current.partition`
+- [ ] __Uses Builtin ARN Check Functions__: Tests should utilize available ARN check functions, e.g. `testAccMatchResourceAttrRegionalARN()`, to validate ARN attribute values in the Terraform state over `resource.TestCheckResourceAttrSet()` and `resource.TestMatchResourceAttr()`
+- [ ] __Uses testAccCheckResourceAttrAccountID()__: Tests should utilize the available AWS Account ID check function, `testAccCheckResourceAttrAccountID()` to validate account ID attribute values in the Terraform state over `resource.TestCheckResourceAttrSet()` and `resource.TestMatchResourceAttr()`
 
 [website]: https://github.com/terraform-providers/terraform-provider-aws/tree/master/website
 [acctests]: https://github.com/hashicorp/terraform#acceptance-tests

--- a/aws/resource_aws_vpc_peering_connection.go
+++ b/aws/resource_aws_vpc_peering_connection.go
@@ -154,21 +154,11 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("peer_region", pc.AccepterVpcInfo.Region)
 	d.Set("accept_status", pc.Status.Code)
 
-	// When the VPC Peering Connection is pending acceptance,
-	// the details about accepter and/or requester peering
-	// options would not be included in the response.
-	if pc.AccepterVpcInfo.PeeringOptions != nil {
-		err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions))
-		if err != nil {
-			return fmt.Errorf("Error setting VPC Peering Connection accepter information: %s", err)
-		}
+	if err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions)); err != nil {
+		return fmt.Errorf("Error setting VPC Peering Connection accepter information: %s", err)
 	}
-
-	if pc.RequesterVpcInfo.PeeringOptions != nil {
-		err := d.Set("requester", flattenVpcPeeringConnectionOptions(pc.RequesterVpcInfo.PeeringOptions))
-		if err != nil {
-			return fmt.Errorf("Error setting VPC Peering Connection requester information: %s", err)
-		}
+	if err := d.Set("requester", flattenVpcPeeringConnectionOptions(pc.RequesterVpcInfo.PeeringOptions)); err != nil {
+		return fmt.Errorf("Error setting VPC Peering Connection requester information: %s", err)
 	}
 
 	err = d.Set("tags", tagsToMap(pc.Tags))
@@ -190,26 +180,17 @@ func resourceVPCPeeringConnectionAccept(conn *ec2.EC2, id string) (string, error
 	if err != nil {
 		return "", err
 	}
-	pc := resp.VpcPeeringConnection
 
-	return *pc.Status.Code, nil
+	return aws.StringValue(resp.VpcPeeringConnection.Status.Code), nil
 }
 
-func resourceAwsVpcPeeringConnectionModifyOptions(d *schema.ResourceData, meta interface{}) error {
+func resourceAwsVpcPeeringConnectionModifyOptions(d *schema.ResourceData, meta interface{}, crossRegionPeering bool) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	req := &ec2.ModifyVpcPeeringConnectionOptionsInput{
-		VpcPeeringConnectionId: aws.String(d.Id()),
-	}
-
-	v := d.Get("accepter").(*schema.Set).List()
-	if len(v) > 0 {
-		req.AccepterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(v[0].(map[string]interface{}))
-	}
-
-	v = d.Get("requester").(*schema.Set).List()
-	if len(v) > 0 {
-		req.RequesterPeeringConnectionOptions = expandVpcPeeringConnectionOptions(v[0].(map[string]interface{}))
+		VpcPeeringConnectionId:            aws.String(d.Id()),
+		AccepterPeeringConnectionOptions:  expandVpcPeeringConnectionOptions(d.Get("accepter").(*schema.Set).List(), crossRegionPeering),
+		RequesterPeeringConnectionOptions: expandVpcPeeringConnectionOptions(d.Get("requester").(*schema.Set).List(), crossRegionPeering),
 	}
 
 	log.Printf("[DEBUG] Modifying VPC Peering Connection options: %#v", req)
@@ -227,7 +208,7 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 		d.SetPartial("tags")
 	}
 
-	pcRaw, _, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
+	pcRaw, statusCode, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
 	if err != nil {
 		return fmt.Errorf("Error reading VPC Peering Connection: %s", err)
 	}
@@ -238,33 +219,32 @@ func resourceAwsVPCPeeringUpdate(d *schema.ResourceData, meta interface{}) error
 		return nil
 	}
 
-	pc := pcRaw.(*ec2.VpcPeeringConnection)
-
-	if _, ok := d.GetOk("auto_accept"); ok {
-		if pc.Status != nil && *pc.Status.Code == ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance {
-			status, err := resourceVPCPeeringConnectionAccept(conn, d.Id())
-			if err != nil {
-				return fmt.Errorf("Unable to accept VPC Peering Connection: %s", err)
-			}
-			log.Printf("[DEBUG] VPC Peering Connection accept status: %s", status)
+	if _, ok := d.GetOk("auto_accept"); ok && statusCode == ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance {
+		statusCode, err = resourceVPCPeeringConnectionAccept(conn, d.Id())
+		if err != nil {
+			return fmt.Errorf("Unable to accept VPC Peering Connection: %s", err)
 		}
+		log.Printf("[DEBUG] VPC Peering Connection accept status: %s", statusCode)
 	}
 
 	if d.HasChange("accepter") || d.HasChange("requester") {
-		_, ok := d.GetOk("auto_accept")
-		if !ok && pc.Status != nil && *pc.Status.Code != "active" {
+		if statusCode == ec2.VpcPeeringConnectionStateReasonCodeActive || statusCode == ec2.VpcPeeringConnectionStateReasonCodeProvisioning {
+			pc := pcRaw.(*ec2.VpcPeeringConnection)
+			crossRegionPeering := false
+			if aws.StringValue(pc.RequesterVpcInfo.Region) != aws.StringValue(pc.AccepterVpcInfo.Region) {
+				crossRegionPeering = true
+			}
+			if err := resourceAwsVpcPeeringConnectionModifyOptions(d, meta, crossRegionPeering); err != nil {
+				return fmt.Errorf("Error modifying VPC Peering Connection options: %s", err)
+			}
+		} else {
 			return fmt.Errorf("Unable to modify peering options. The VPC Peering Connection "+
 				"%q is not active. Please set `auto_accept` attribute to `true`, "+
 				"or activate VPC Peering Connection manually.", d.Id())
 		}
-
-		if err := resourceAwsVpcPeeringConnectionModifyOptions(d, meta); err != nil {
-			return fmt.Errorf("Error modifying VPC Peering Connection options: %s", err)
-		}
 	}
 
-	err = vpcPeeringConnectionWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
+	if err := vpcPeeringConnectionWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return fmt.Errorf("Error waiting for VPC Peering Connection to become available: %s", err)
 	}
 

--- a/aws/resource_aws_vpc_peering_connection_accepter_test.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter_test.go
@@ -1,16 +1,23 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSVPCPeeringConnectionAccepter_sameRegion(t *testing.T) {
+func TestAccAWSVPCPeeringConnectionAccepter_sameRegionSameAccount(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
+	resourceNameMainVpc := "aws_vpc.main"                              // Requester
+	resourceNamePeerVpc := "aws_vpc.peer"                              // Accepter
+	resourceNameConnection := "aws_vpc_peering_connection.main"        // Requester
+	resourceNameAccepter := "aws_vpc_peering_connection_accepter.peer" // Accepter
+	rName := fmt.Sprintf("terraform-testacc-pcxaccpt-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,39 +25,144 @@ func TestAccAWSVPCPeeringConnectionAccepter_sameRegion(t *testing.T) {
 		CheckDestroy: testAccAwsVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsVPCPeeringConnectionAccepterSameRegion,
+				Config: testAccAwsVPCPeeringConnectionAccepterConfigSameRegionSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSVpcPeeringConnectionExists(
-						"aws_vpc_peering_connection_accepter.peer",
-						&connection),
-					resource.TestCheckResourceAttr(
-						"aws_vpc_peering_connection_accepter.peer",
-						"accept_status", "active"),
+					testAccCheckAWSVpcPeeringConnectionExists(resourceNameAccepter, &connection),
+					// The aws_vpc_peering_connection documentation says:
+					//	vpc_id - The ID of the requester VPC
+					//	peer_vpc_id - The ID of the VPC with which you are creating the VPC Peering Connection (accepter)
+					//	peer_owner_id -  The AWS account ID of the owner of the peer VPC (accepter)
+					//	peer_region -  The region of the accepter VPC of the VPC Peering Connection
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_vpc_id", resourceNamePeerVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_owner_id", resourceNamePeerVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameConnection, "peer_region", testAccGetRegion()),
+					// The aws_vpc_peering_connection_accepter documentation says:
+					//	vpc_id - The ID of the accepter VPC
+					//	peer_vpc_id - The ID of the requester VPC
+					//	peer_owner_id - The AWS account ID of the owner of the requester VPC
+					//	peer_region - The region of the accepter VPC
+					// ** TODO
+					// ** TODO resourceAwsVPCPeeringRead() is not doing this correctly for same-account peerings
+					// ** TODO
+					// resource.TestCheckResourceAttrPair(resourceNameAccepter, "vpc_id", resourceNamePeerVpc, "id"),
+					// resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_owner_id", resourceNameMainVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "peer_region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "accept_status", "active"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSVPCPeeringConnectionAccepter_differentRegion(t *testing.T) {
-	var connection ec2.VpcPeeringConnection
-
+func TestAccAWSVPCPeeringConnectionAccepter_differentRegionSameAccount(t *testing.T) {
+	var connectionMain, connectionPeer ec2.VpcPeeringConnection
 	var providers []*schema.Provider
+	resourceNameMainVpc := "aws_vpc.main"                              // Requester
+	resourceNamePeerVpc := "aws_vpc.peer"                              // Accepter
+	resourceNameConnection := "aws_vpc_peering_connection.main"        // Requester
+	resourceNameAccepter := "aws_vpc_peering_connection_accepter.peer" // Accepter
+	rName := fmt.Sprintf("terraform-testacc-pcxaccpt-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccAwsVPCPeeringConnectionAccepterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsVPCPeeringConnectionAccepterDifferentRegion,
+				Config: testAccAwsVPCPeeringConnectionAccepterConfigDifferentRegionSameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSVpcPeeringConnectionExists(
-						"aws_vpc_peering_connection_accepter.peer",
-						&connection),
-					resource.TestCheckResourceAttr(
-						"aws_vpc_peering_connection_accepter.peer",
-						"accept_status", "active"),
+					testAccCheckAWSVpcPeeringConnectionExists(resourceNameConnection, &connectionMain),
+					testAccCheckAWSVpcPeeringConnectionExistsWithProvider(resourceNameAccepter, &connectionPeer, testAccAwsRegionProviderFunc(testAccGetAlternateRegion(), &providers)),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_vpc_id", resourceNamePeerVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_owner_id", resourceNamePeerVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameConnection, "peer_region", testAccGetAlternateRegion()),
+					// ** TODO See TestAccAWSVPCPeeringConnectionAccepter_sameRegion()
+					// resource.TestCheckResourceAttrPair(resourceNameAccepter, "vpc_id", resourceNamePeerVpc, "id"),
+					// resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_owner_id", resourceNameMainVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "peer_region", testAccGetAlternateRegion()),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "accept_status", "active"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSVPCPeeringConnectionAccepter_sameRegionDifferentAccount(t *testing.T) {
+	var connection ec2.VpcPeeringConnection
+	var providers []*schema.Provider
+	resourceNameMainVpc := "aws_vpc.main"                              // Requester
+	resourceNamePeerVpc := "aws_vpc.peer"                              // Accepter
+	resourceNameConnection := "aws_vpc_peering_connection.main"        // Requester
+	resourceNameAccepter := "aws_vpc_peering_connection_accepter.peer" // Accepter
+	rName := fmt.Sprintf("terraform-testacc-pcxaccpt-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccAwsVPCPeeringConnectionAccepterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsVPCPeeringConnectionAccepterConfigSameRegionDifferentAccount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists(resourceNameConnection, &connection),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_vpc_id", resourceNamePeerVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_owner_id", resourceNamePeerVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameConnection, "peer_region", testAccGetRegion()),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "vpc_id", resourceNamePeerVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_owner_id", resourceNameMainVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "peer_region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "accept_status", "active"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSVPCPeeringConnectionAccepter_differentRegionDifferentAccount(t *testing.T) {
+	var connection ec2.VpcPeeringConnection
+	var providers []*schema.Provider
+	resourceNameMainVpc := "aws_vpc.main"                              // Requester
+	resourceNamePeerVpc := "aws_vpc.peer"                              // Accepter
+	resourceNameConnection := "aws_vpc_peering_connection.main"        // Requester
+	resourceNameAccepter := "aws_vpc_peering_connection_accepter.peer" // Accepter
+	rName := fmt.Sprintf("terraform-testacc-pcxaccpt-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccAwsVPCPeeringConnectionAccepterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsVPCPeeringConnectionAccepterConfigDifferentRegionDifferentAccount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists(resourceNameConnection, &connection),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_vpc_id", resourceNamePeerVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameConnection, "peer_owner_id", resourceNamePeerVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameConnection, "peer_region", testAccGetAlternateRegion()),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "vpc_id", resourceNamePeerVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_vpc_id", resourceNameMainVpc, "id"),
+					resource.TestCheckResourceAttrPair(resourceNameAccepter, "peer_owner_id", resourceNameMainVpc, "owner_id"),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "peer_region", testAccGetAlternateRegion()),
+					resource.TestCheckResourceAttr(resourceNameAccepter, "accept_status", "active"),
 				),
 			},
 		},
@@ -62,75 +174,191 @@ func testAccAwsVPCPeeringConnectionAccepterDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccAwsVPCPeeringConnectionAccepterSameRegion = `
+func testAccAwsVPCPeeringConnectionAccepterConfigSameRegionSameAccount(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "main" {
-	cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-vpc-peering-conn-accepter-same-region-main"
-	}
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_vpc" "peer" {
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-vpc-peering-conn-accepter-same-region-peer"
-	}
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 // Requester's side of the connection.
-resource "aws_vpc_peering_connection" "peer" {
-	vpc_id = "${aws_vpc.main.id}"
-	peer_vpc_id = "${aws_vpc.peer.id}"
-	auto_accept = false
+resource "aws_vpc_peering_connection" "main" {
+  vpc_id      = "${aws_vpc.main.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  auto_accept = false
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-	vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
-	auto_accept = true
-}
-`
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
+  auto_accept               = true
 
-const testAccAwsVPCPeeringConnectionAccepterDifferentRegion = `
-provider "aws" {
-	alias = "main"
-	region = "us-west-2"
+  tags = {
+    Name = %[1]q
+  }
 }
-
-provider "aws" {
-	alias = "peer"
-	region = "us-east-1"
+`, rName)
 }
 
+func testAccAwsVPCPeeringConnectionAccepterConfigDifferentRegionSameAccount(rName string) string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 resource "aws_vpc" "main" {
-	provider = "aws.main"
-	cidr_block = "10.0.0.0/16"
-	tags = {
-		Name = "terraform-testacc-vpc-peering-conn-accepter-diff-region-main"
-	}
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_vpc" "peer" {
-	provider = "aws.peer"
-	cidr_block = "10.1.0.0/16"
-	tags = {
-		Name = "terraform-testacc-vpc-peering-conn-accepter-diff-region-peer"
-	}
+  provider = "aws.alternate"
+
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 // Requester's side of the connection.
-resource "aws_vpc_peering_connection" "peer" {
-	provider = "aws.main"
-	vpc_id = "${aws_vpc.main.id}"
-	peer_vpc_id = "${aws_vpc.peer.id}"
-	peer_region = "us-east-1"
-	auto_accept = false
+resource "aws_vpc_peering_connection" "main" {
+  vpc_id      = "${aws_vpc.main.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  peer_region = %[2]q
+  auto_accept = false
+
+  tags = {
+    Name = %[1]q
+  }
 }
 
 // Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "peer" {
-	provider = "aws.peer"
-	vpc_peering_connection_id = "${aws_vpc_peering_connection.peer.id}"
-	auto_accept = true
+  provider = "aws.alternate"
+
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
+  auto_accept               = true
+
+  tags = {
+    Name = %[1]q
+  }
 }
-`
+`, rName, testAccGetAlternateRegion())
+}
+
+func testAccAwsVPCPeeringConnectionAccepterConfigSameRegionDifferentAccount(rName string) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "peer" {
+  provider = "aws.alternate"
+
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_caller_identity" "peer" {
+  provider = "aws.alternate"
+}
+
+// Requester's side of the connection.
+resource "aws_vpc_peering_connection" "main" {
+  vpc_id        = "${aws_vpc.main.id}"
+  peer_vpc_id   = "${aws_vpc.peer.id}"
+  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
+  peer_region   = %[2]q
+  auto_accept   = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+ // Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider = "aws.alternate"
+
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
+  auto_accept               = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, testAccGetRegion())
+}
+
+func testAccAwsVPCPeeringConnectionAccepterConfigDifferentRegionDifferentAccount(rName string) string {
+	return testAccAlternateAccountAlternateRegionProviderConfig() + fmt.Sprintf(`
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "peer" {
+  provider = "aws.alternate"
+
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_caller_identity" "peer" {
+  provider = "aws.alternate"
+}
+
+// Requester's side of the connection.
+resource "aws_vpc_peering_connection" "main" {
+  vpc_id        = "${aws_vpc.main.id}"
+  peer_vpc_id   = "${aws_vpc.peer.id}"
+  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
+  peer_region   = %[2]q
+  auto_accept   = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+ // Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider = "aws.alternate"
+
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
+  auto_accept               = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, testAccGetAlternateRegion())
+}

--- a/aws/resource_aws_vpc_peering_connection_options.go
+++ b/aws/resource_aws_vpc_peering_connection_options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -40,7 +41,7 @@ func resourceAwsVpcPeeringConnectionOptionsRead(d *schema.ResourceData, meta int
 
 	pcRaw, _, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
 	if err != nil {
-		return fmt.Errorf("Error reading VPC Peering Connection: %s", err.Error())
+		return fmt.Errorf("error reading VPC Peering Connection: %s", err)
 	}
 
 	if pcRaw == nil {
@@ -53,26 +54,38 @@ func resourceAwsVpcPeeringConnectionOptionsRead(d *schema.ResourceData, meta int
 
 	d.Set("vpc_peering_connection_id", pc.VpcPeeringConnectionId)
 
-	if pc != nil && pc.AccepterVpcInfo != nil && pc.AccepterVpcInfo.PeeringOptions != nil {
-		err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions))
-		if err != nil {
-			return fmt.Errorf("Error setting VPC Peering Connection Options accepter information: %s", err.Error())
-		}
+	if err := d.Set("accepter", flattenVpcPeeringConnectionOptions(pc.AccepterVpcInfo.PeeringOptions)); err != nil {
+		return fmt.Errorf("error setting VPC Peering Connection Options accepter information: %s", err)
 	}
-
-	if pc != nil && pc.RequesterVpcInfo != nil && pc.RequesterVpcInfo.PeeringOptions != nil {
-		err := d.Set("requester", flattenVpcPeeringConnectionOptions(pc.RequesterVpcInfo.PeeringOptions))
-		if err != nil {
-			return fmt.Errorf("Error setting VPC Peering Connection Options requester information: %s", err.Error())
-		}
+	if err := d.Set("requester", flattenVpcPeeringConnectionOptions(pc.RequesterVpcInfo.PeeringOptions)); err != nil {
+		return fmt.Errorf("error setting VPC Peering Connection Options requester information: %s", err)
 	}
 
 	return nil
 }
 
 func resourceAwsVpcPeeringConnectionOptionsUpdate(d *schema.ResourceData, meta interface{}) error {
-	if err := resourceAwsVpcPeeringConnectionModifyOptions(d, meta); err != nil {
-		return fmt.Errorf("Error modifying VPC Peering Connection Options: %s", err.Error())
+	conn := meta.(*AWSClient).ec2conn
+
+	pcRaw, _, err := vpcPeeringConnectionRefreshState(conn, d.Id())()
+	if err != nil {
+		return fmt.Errorf("error reading VPC Peering Connection (%s): %s", d.Id(), err)
+	}
+
+	if pcRaw == nil {
+		log.Printf("[WARN] VPC Peering Connection (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	pc := pcRaw.(*ec2.VpcPeeringConnection)
+
+	crossRegionPeering := false
+	if aws.StringValue(pc.RequesterVpcInfo.Region) != aws.StringValue(pc.AccepterVpcInfo.Region) {
+		crossRegionPeering = true
+	}
+	if err := resourceAwsVpcPeeringConnectionModifyOptions(d, meta, crossRegionPeering); err != nil {
+		return fmt.Errorf("error modifying VPC Peering Connection (%s) Options: %s", d.Id(), err)
 	}
 
 	return resourceAwsVpcPeeringConnectionOptionsRead(d, meta)

--- a/aws/resource_aws_vpc_peering_connection_options_test.go
+++ b/aws/resource_aws_vpc_peering_connection_options_test.go
@@ -1,15 +1,20 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-testacc-pcxopts-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 	resourceName := "aws_vpc_peering_connection_options.test"
+	pcxResourceName := "aws_vpc_peering_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,31 +22,18 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcPeeringConnectionOptionsConfig,
+				Config: testAccVpcPeeringConnectionOptionsConfig_sameRegion_sameAccount(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"accepter.#",
-						"1",
-					),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"accepter.1102046665.allow_remote_vpc_dns_resolution",
-						"true",
-					),
-					testAccCheckAWSVpcPeeringConnectionOptions(
-						"aws_vpc_peering_connection.test",
-						"accepter",
-						&ec2.VpcPeeringConnectionOptionsDescription{
-							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
-							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
-							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
-						},
-					),
+					// Requester's view:
 					resource.TestCheckResourceAttr(
 						resourceName,
 						"requester.#",
 						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.41753983.allow_remote_vpc_dns_resolution",
+						"false",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName,
@@ -54,12 +46,42 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 						"true",
 					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
-						"aws_vpc_peering_connection.test",
+						pcxResourceName,
 						"requester",
 						&ec2.VpcPeeringConnectionOptionsDescription{
 							AllowDnsResolutionFromRemoteVpc:            aws.Bool(false),
 							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(true),
 							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(true),
+						},
+					),
+					// Accepter's view:
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_classic_link_to_remote_vpc",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_vpc_to_remote_classic_link",
+						"false",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptions(
+						pcxResourceName,
+						"accepter",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
 						},
 					),
 				),
@@ -73,26 +95,204 @@ func TestAccAWSVpcPeeringConnectionOptions_basic(t *testing.T) {
 	})
 }
 
-const testAccVpcPeeringConnectionOptionsConfig = `
+func TestAccAWSVpcPeeringConnectionOptions_differentRegionSameAccount(t *testing.T) {
+	var providers []*schema.Provider
+	rName := fmt.Sprintf("tf-testacc-pcxopts-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	resourceName := "aws_vpc_peering_connection_options.test"         // Requester
+	resourceNamePeer := "aws_vpc_peering_connection_options.peer"     // Accepter
+	pcxResourceName := "aws_vpc_peering_connection.test"              // Requester
+	pcxResourceNamePeer := "aws_vpc_peering_connection_accepter.peer" // Accepter
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcPeeringConnectionOptionsConfig_differentRegion_sameAccount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					// Requester's view:
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.1102046665.allow_classic_link_to_remote_vpc",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.1102046665.allow_vpc_to_remote_classic_link",
+						"false",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptions(
+						pcxResourceName,
+						"requester",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
+						},
+					),
+					// Accepter's view:
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.1102046665.allow_classic_link_to_remote_vpc",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.1102046665.allow_vpc_to_remote_classic_link",
+						"false",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(
+						pcxResourceNamePeer,
+						"accepter",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
+						},
+						testAccAwsRegionProviderFunc(testAccGetAlternateRegion(), &providers),
+					),
+				),
+			},
+			{
+				Config:            testAccVpcPeeringConnectionOptionsConfig_differentRegion_sameAccount(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSVpcPeeringConnectionOptions_sameRegionDifferentAccount(t *testing.T) {
+	var providers []*schema.Provider
+	rName := fmt.Sprintf("tf-testacc-pcxopts-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	resourceName := "aws_vpc_peering_connection_options.test"     // Requester
+	resourceNamePeer := "aws_vpc_peering_connection_options.peer" // Accepter
+	pcxResourceName := "aws_vpc_peering_connection.test"          // Requester
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					// Requester's view:
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.1102046665.allow_classic_link_to_remote_vpc",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.1102046665.allow_vpc_to_remote_classic_link",
+						"false",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptions(
+						pcxResourceName,
+						"requester",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
+						},
+					),
+					// Accepter's view:
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.1102046665.allow_classic_link_to_remote_vpc",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceNamePeer,
+						"accepter.1102046665.allow_vpc_to_remote_classic_link",
+						"false",
+					),
+				),
+			},
+			{
+				Config:            testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVpcPeeringConnectionOptionsConfig_sameRegion_sameAccount(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-options-test"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "peer" {
   cidr_block = "10.1.0.0/16"
   enable_dns_hostnames = true
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-options-bar"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
-  vpc_id      = "${aws_vpc.test.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
+  vpc_id = "${aws_vpc.test.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
   auto_accept = true
+  tags = {
+    Name = %[1]q
+  }
 }
 
 resource "aws_vpc_peering_connection_options" "test" {
@@ -107,4 +307,141 @@ resource "aws_vpc_peering_connection_options" "test" {
     allow_classic_link_to_remote_vpc = true
   }
 }
-`
+`, rName)
+}
+
+func testAccVpcPeeringConnectionOptionsConfig_differentRegion_sameAccount(rName string) string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "peer" {
+  provider = "aws.alternate"
+
+  cidr_block = "10.1.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+// Requester's side of the connection.
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  auto_accept = false
+  peer_region = %[2]q
+  tags = {
+    Name = %[1]q
+  }
+}
+
+// Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider = "aws.alternate"
+
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.test.id}"
+  auto_accept = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+// Requester's side of the connection.
+resource "aws_vpc_peering_connection_options" "test" {
+  # As options can't be set until the connection has been accepted
+  # create an explicit dependency on the accepter.
+  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+// Accepter's side of the connection.
+resource "aws_vpc_peering_connection_options" "peer" {
+  provider = "aws.alternate"
+
+  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+`, rName, testAccGetAlternateRegion())
+}
+
+func testAccVpcPeeringConnectionOptionsConfig_sameRegion_differentAccount(rName string) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "peer" {
+  provider = "aws.alternate"
+
+  cidr_block = "10.1.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_caller_identity" "peer" {
+  provider = "aws.alternate"
+}
+
+// Requester's side of the connection.
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  peer_owner_id = "${data.aws_caller_identity.peer.account_id}"
+  auto_accept = false
+  tags = {
+    Name = %[1]q
+  }
+}
+
+ // Accepter's side of the connection.
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  provider = "aws.alternate"
+
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.test.id}"
+  auto_accept = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+// Requester's side of the connection.
+resource "aws_vpc_peering_connection_options" "test" {
+  # As options can't be set until the connection has been accepted
+  # create an explicit dependency on the accepter.
+  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+
+// Accepter's side of the connection.
+resource "aws_vpc_peering_connection_options" "peer" {
+  provider = "aws.alternate"
+
+  vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.peer.id}"
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+}
+`, rName)
+}

--- a/aws/resource_aws_vpc_peering_connection_test.go
+++ b/aws/resource_aws_vpc_peering_connection_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -88,6 +89,7 @@ func testSweepEc2VpcPeeringConnections(region string) error {
 
 func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
 	resourceName := "aws_vpc_peering_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -99,11 +101,12 @@ func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcPeeringConfig,
+				Config: testAccVpcPeeringConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSVpcPeeringConnectionExists(
 						resourceName,
-						&connection),
+						&connection,
+					),
 				),
 			},
 			{
@@ -111,7 +114,8 @@ func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"auto_accept"},
+					"auto_accept",
+				},
 			},
 		},
 	})
@@ -119,6 +123,7 @@ func TestAccAWSVPCPeeringConnection_basic(t *testing.T) {
 
 func TestAccAWSVPCPeeringConnection_plan(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
 	resourceName := "aws_vpc_peering_connection.test"
 
 	// reach out and DELETE the VPC Peering connection outside of Terraform
@@ -136,15 +141,17 @@ func TestAccAWSVPCPeeringConnection_plan(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshIgnore: []string{"auto_accept"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSVpcPeeringConnectionDestroy,
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcPeeringConfig,
+				Config: testAccVpcPeeringConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSVpcPeeringConnectionExists(
 						resourceName,
-						&connection),
+						&connection,
+					),
 					testDestroy,
 				),
 				ExpectNonEmptyPlan: true,
@@ -155,6 +162,7 @@ func TestAccAWSVPCPeeringConnection_plan(t *testing.T) {
 
 func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
 	resourceName := "aws_vpc_peering_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -166,11 +174,13 @@ func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcPeeringConfigTags,
+				Config: testAccVpcPeeringConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSVpcPeeringConnectionExists(
 						resourceName,
-						&connection),
+						&connection,
+					),
+					testAccCheckTags(&connection.Tags, "Name", rName),
 					testAccCheckTags(&connection.Tags, "test", "bar"),
 				),
 			},
@@ -179,7 +189,8 @@ func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"auto_accept"},
+					"auto_accept",
+				},
 			},
 		},
 	})
@@ -187,6 +198,7 @@ func TestAccAWSVPCPeeringConnection_tags(t *testing.T) {
 
 func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
 	resourceName := "aws_vpc_peering_connection.test"
 
 	testAccepterChange := func(*terraform.State) error {
@@ -213,39 +225,68 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcPeeringConfigOptions,
+				Config: testAccVpcPeeringConfig_options(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSVpcPeeringConnectionExists(
 						resourceName,
-						&connection),
+						&connection,
+					),
+					// Requester's view:
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.#", "1"),
+						"requester.#",
+						"1",
+					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_remote_vpc_dns_resolution", "true"),
-					testAccCheckAWSVpcPeeringConnectionOptions(
-						resourceName, "accepter",
-						&ec2.VpcPeeringConnectionOptionsDescription{
-							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
-							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
-							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
-						}),
+						"requester.41753983.allow_remote_vpc_dns_resolution",
+						"false",
+					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.#", "1"),
+						"requester.41753983.allow_classic_link_to_remote_vpc",
+						"true",
+					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"requester.41753983.allow_classic_link_to_remote_vpc", "true"),
-					resource.TestCheckResourceAttr(
-						resourceName,
-						"requester.41753983.allow_vpc_to_remote_classic_link", "true"),
+						"requester.41753983.allow_vpc_to_remote_classic_link",
+						"true",
+					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						resourceName, "requester",
 						&ec2.VpcPeeringConnectionOptionsDescription{
 							AllowDnsResolutionFromRemoteVpc:            aws.Bool(false),
 							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(true),
 							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(true),
+						},
+					),
+					// Accepter's view:
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_classic_link_to_remote_vpc",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_vpc_to_remote_classic_link",
+						"false",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptions(
+						resourceName, "accepter",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(true),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(false),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(false),
 						},
 					),
 					testAccepterChange,
@@ -257,20 +298,66 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"auto_accept"},
+					"auto_accept",
+				},
 			},
 			{
-				Config: testAccVpcPeeringConfigOptions,
+				Config: testAccVpcPeeringConfig_options(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSVpcPeeringConnectionExists(
 						resourceName,
-						&connection),
+						&connection,
+					),
+					// Requester's view:
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.#", "1"),
+						"requester.#",
+						"1",
+					),
 					resource.TestCheckResourceAttr(
 						resourceName,
-						"accepter.1102046665.allow_remote_vpc_dns_resolution", "true"),
+						"requester.41753983.allow_remote_vpc_dns_resolution",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.41753983.allow_classic_link_to_remote_vpc",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"requester.41753983.allow_vpc_to_remote_classic_link",
+						"true",
+					),
+					testAccCheckAWSVpcPeeringConnectionOptions(
+						resourceName, "requester",
+						&ec2.VpcPeeringConnectionOptionsDescription{
+							AllowDnsResolutionFromRemoteVpc:            aws.Bool(false),
+							AllowEgressFromLocalClassicLinkToRemoteVpc: aws.Bool(true),
+							AllowEgressFromLocalVpcToRemoteClassicLink: aws.Bool(true),
+						},
+					),
+					// Accepter's view:
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_remote_vpc_dns_resolution",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_classic_link_to_remote_vpc",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accepter.1102046665.allow_vpc_to_remote_classic_link",
+						"false",
+					),
 					testAccCheckAWSVpcPeeringConnectionOptions(
 						resourceName, "accepter",
 						&ec2.VpcPeeringConnectionOptionsDescription{
@@ -286,14 +373,17 @@ func TestAccAWSVPCPeeringConnection_options(t *testing.T) {
 }
 
 func TestAccAWSVPCPeeringConnection_failedState(t *testing.T) {
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshIgnore: []string{"auto_accept"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSVpcPeeringConnectionDestroy,
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVpcPeeringConfigFailedState,
+				Config:      testAccVpcPeeringConfig_failedState(rName),
 				ExpectError: regexp.MustCompile(`.*Error waiting.*\(pcx-\w+\).*incorrect.*VPC-ID.*`),
 			},
 		},
@@ -345,6 +435,10 @@ func testAccCheckAWSVpcPeeringConnectionDestroy(s *terraform.State) error {
 }
 
 func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VpcPeeringConnection) resource.TestCheckFunc {
+	return testAccCheckAWSVpcPeeringConnectionExistsWithProvider(n, connection, testAccProviderFunc)
+}
+
+func testAccCheckAWSVpcPeeringConnectionExistsWithProvider(n string, connection *ec2.VpcPeeringConnection, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -355,7 +449,7 @@ func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VpcPeer
 			return fmt.Errorf("No VPC Peering Connection ID is set.")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		conn := providerF().Meta().(*AWSClient).ec2conn
 		resp, err := conn.DescribeVpcPeeringConnections(
 			&ec2.DescribeVpcPeeringConnectionsInput{
 				VpcPeeringConnectionIds: []*string{aws.String(rs.Primary.ID)},
@@ -374,6 +468,10 @@ func testAccCheckAWSVpcPeeringConnectionExists(n string, connection *ec2.VpcPeer
 }
 
 func testAccCheckAWSVpcPeeringConnectionOptions(n, block string, options *ec2.VpcPeeringConnectionOptionsDescription) resource.TestCheckFunc {
+	return testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(n, block, options, testAccProviderFunc)
+}
+
+func testAccCheckAWSVpcPeeringConnectionOptionsWithProvider(n, block string, options *ec2.VpcPeeringConnectionOptionsDescription, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -384,7 +482,7 @@ func testAccCheckAWSVpcPeeringConnectionOptions(n, block string, options *ec2.Vp
 			return fmt.Errorf("No VPC Peering Connection ID is set.")
 		}
 
-		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		conn := providerF().Meta().(*AWSClient).ec2conn
 		resp, err := conn.DescribeVpcPeeringConnections(
 			&ec2.DescribeVpcPeeringConnectionsInput{
 				VpcPeeringConnectionIds: []*string{aws.String(rs.Primary.ID)},
@@ -409,15 +507,22 @@ func testAccCheckAWSVpcPeeringConnectionOptions(n, block string, options *ec2.Vp
 	}
 }
 
-func TestAccAWSVPCPeeringConnection_peerRegionAndAutoAccept(t *testing.T) {
+func TestAccAWSVPCPeeringConnection_peerRegionAutoAccept(t *testing.T) {
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
 		IDRefreshIgnore: []string{"auto_accept"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSVpcPeeringConnectionDestroy,
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccVpcPeeringConfigRegionAutoAccept,
+				Config:      testAccVpcPeeringConfig_region_autoAccept(rName, true),
 				ExpectError: regexp.MustCompile(`.*peer_region cannot be set whilst auto_accept is true when creating a vpc peering connection.*`),
 			},
 		},
@@ -427,10 +532,15 @@ func TestAccAWSVPCPeeringConnection_peerRegionAndAutoAccept(t *testing.T) {
 func TestAccAWSVPCPeeringConnection_region(t *testing.T) {
 	var connection ec2.VpcPeeringConnection
 	var providers []*schema.Provider
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
 	resourceName := "aws_vpc_peering_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccMultipleRegionsPreCheck(t)
+			testAccAlternateRegionPreCheck(t)
+		},
 		IDRefreshName:   resourceName,
 		IDRefreshIgnore: []string{"auto_accept"},
 
@@ -438,84 +548,188 @@ func TestAccAWSVPCPeeringConnection_region(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSVpcPeeringConnectionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpcPeeringConfigRegion,
+				Config: testAccVpcPeeringConfig_region_autoAccept(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSVpcPeeringConnectionExists(
 						resourceName,
-						&connection),
+						&connection,
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accept_status",
+						"pending-acceptance",
+					),
 				),
 			},
 		},
 	})
 }
 
-const testAccVpcPeeringConfig = `
+// Tests the peering connection acceptance functionality for same region, same account.
+func TestAccAWSVPCPeeringConnection_accept(t *testing.T) {
+	var connection ec2.VpcPeeringConnection
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
+	resourceName := "aws_vpc_peering_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:        func() { testAccPreCheck(t) },
+		IDRefreshName:   resourceName,
+		IDRefreshIgnore: []string{"auto_accept"},
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcPeeringConfig_autoAccept(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists(
+						resourceName,
+						&connection,
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accept_status",
+						"pending-acceptance",
+					),
+				),
+			},
+			{
+				Config: testAccVpcPeeringConfig_autoAccept(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists(
+						resourceName,
+						&connection,
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accept_status",
+						"active",
+					),
+				),
+			},
+			// Tests that changing 'auto_accept' back to false keeps the connection active.
+			{
+				Config: testAccVpcPeeringConfig_autoAccept(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSVpcPeeringConnectionExists(
+						resourceName,
+						&connection,
+					),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"accept_status",
+						"active",
+					),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"auto_accept",
+				},
+			},
+		},
+	})
+}
+
+// Tests that VPC peering connection options can't be set on non-active connection.
+func TestAccAWSVPCPeeringConnection_optionsNoAutoAccept(t *testing.T) {
+	rName := fmt.Sprintf("tf-testacc-pcx-%s", acctest.RandStringFromCharSet(17, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSVpcPeeringConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVpcPeeringConfig_options_noAutoAccept(rName),
+				ExpectError: regexp.MustCompile(`.*Unable to modify peering options\. The VPC Peering Connection "pcx-\w+" is not active\..*`),
+			},
+		},
+	})
+}
+
+func testAccVpcPeeringConfig_basic(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-test"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "peer" {
   cidr_block = "10.1.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-bar"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
   vpc_id = "${aws_vpc.test.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
   auto_accept = true
+  tags = {
+    Name = %[1]q
+  }
 }
-`
+`, rName)
+}
 
-const testAccVpcPeeringConfigTags = `
+func testAccVpcPeeringConfig_tags(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-tags-test"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "peer" {
   cidr_block = "10.1.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-tags-bar"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
   vpc_id = "${aws_vpc.test.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
   auto_accept = true
   tags = {
-    test = "bar"
+	test = "bar"
+	Name = %[1]q
   }
 }
-`
+`, rName)
+}
 
-const testAccVpcPeeringConfigOptions = `
+func testAccVpcPeeringConfig_options(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-options-test"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "peer" {
   cidr_block = "10.1.0.0/16"
   enable_dns_hostnames = true
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-options-bar"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
   vpc_id = "${aws_vpc.test.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
   auto_accept = true
+  tags = {
+    Name = %[1]q
+  }
 
   accepter {
     allow_remote_vpc_dns_resolution = true
@@ -526,96 +740,125 @@ resource "aws_vpc_peering_connection" "test" {
     allow_classic_link_to_remote_vpc = true
   }
 }
-`
+`, rName)
+}
 
-const testAccVpcPeeringConfigFailedState = `
+func testAccVpcPeeringConfig_failedState(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-failed-state-test"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "bar" {
+resource "aws_vpc" "peer" {
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-failed-state-bar"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
   vpc_id = "${aws_vpc.test.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  tags = {
+    Name = %[1]q
+  }
 }
-`
-
-const testAccVpcPeeringConfigRegionAutoAccept = `
-provider "aws" {
-  alias = "main"
-  region = "us-west-2"
+`, rName)
 }
 
-provider "aws" {
-  alias = "peer"
-  region = "us-east-1"
-}
-
+func testAccVpcPeeringConfig_region_autoAccept(rName string, autoAccept bool) string {
+	return testAccAlternateRegionProviderConfig() + fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  provider = "aws.main"
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-test"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "bar" {
-  provider = "aws.peer"
+resource "aws_vpc" "peer" {
+  provider = "aws.alternate"
+
   cidr_block = "10.1.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-region-auto-accept-bar"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
-  provider = "aws.main"
   vpc_id = "${aws_vpc.test.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
-  peer_region = "us-east-1"
-  auto_accept = true
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  peer_region = %[3]q
+  auto_accept = %[2]t
+  tags = {
+    Name = %[1]q
+  }
 }
-`
-
-const testAccVpcPeeringConfigRegion = `
-provider "aws" {
-  alias = "main"
-  region = "us-west-2"
+`, rName, autoAccept, testAccGetAlternateRegion())
 }
 
-provider "aws" {
-  alias = "peer"
-  region = "us-east-1"
-}
-
+func testAccVpcPeeringConfig_autoAccept(rName string, autoAccept bool) string {
+	return fmt.Sprintf(`
 resource "aws_vpc" "test" {
-  provider = "aws.main"
   cidr_block = "10.0.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-region-test"
+    Name = %[1]q
   }
 }
 
-resource "aws_vpc" "bar" {
-  provider = "aws.peer"
+resource "aws_vpc" "peer" {
   cidr_block = "10.1.0.0/16"
   tags = {
-    Name = "terraform-testacc-vpc-peering-conn-region-bar"
+    Name = %[1]q
   }
 }
 
 resource "aws_vpc_peering_connection" "test" {
-  provider = "aws.main"
   vpc_id = "${aws_vpc.test.id}"
-  peer_vpc_id = "${aws_vpc.bar.id}"
-  peer_region = "us-east-1"
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  auto_accept = %t
+  tags = {
+    Name = %[1]q
+  }
 }
-`
+`, rName, autoAccept)
+}
+
+func testAccVpcPeeringConfig_options_noAutoAccept(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc" "peer" {
+  cidr_block = "10.1.0.0/16"
+  enable_dns_hostnames = true
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_peering_connection" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  peer_vpc_id = "${aws_vpc.peer.id}"
+  auto_accept = false
+  tags = {
+    Name = %[1]q
+  }
+
+  accepter {
+    allow_remote_vpc_dns_resolution = true
+  }
+
+  requester {
+    allow_vpc_to_remote_classic_link = true
+    allow_classic_link_to_remote_vpc = true
+  }
+}
+`, rName)
+}

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4637,37 +4637,40 @@ func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecificat
 	return result
 }
 
-func flattenVpcPeeringConnectionOptions(options *ec2.VpcPeeringConnectionOptionsDescription) []map[string]interface{} {
-	m := map[string]interface{}{}
-
-	if options.AllowDnsResolutionFromRemoteVpc != nil {
-		m["allow_remote_vpc_dns_resolution"] = *options.AllowDnsResolutionFromRemoteVpc
+func flattenVpcPeeringConnectionOptions(options *ec2.VpcPeeringConnectionOptionsDescription) []interface{} {
+	// When the VPC Peering Connection is pending acceptance,
+	// the details about accepter and/or requester peering
+	// options would not be included in the response.
+	if options == nil {
+		return []interface{}{}
 	}
 
-	if options.AllowEgressFromLocalClassicLinkToRemoteVpc != nil {
-		m["allow_classic_link_to_remote_vpc"] = *options.AllowEgressFromLocalClassicLinkToRemoteVpc
-	}
-
-	if options.AllowEgressFromLocalVpcToRemoteClassicLink != nil {
-		m["allow_vpc_to_remote_classic_link"] = *options.AllowEgressFromLocalVpcToRemoteClassicLink
-	}
-
-	return []map[string]interface{}{m}
+	return []interface{}{map[string]interface{}{
+		"allow_remote_vpc_dns_resolution":  aws.BoolValue(options.AllowDnsResolutionFromRemoteVpc),
+		"allow_classic_link_to_remote_vpc": aws.BoolValue(options.AllowEgressFromLocalClassicLinkToRemoteVpc),
+		"allow_vpc_to_remote_classic_link": aws.BoolValue(options.AllowEgressFromLocalVpcToRemoteClassicLink),
+	}}
 }
 
-func expandVpcPeeringConnectionOptions(m map[string]interface{}) *ec2.PeeringConnectionOptionsRequest {
+func expandVpcPeeringConnectionOptions(vOptions []interface{}, crossRegionPeering bool) *ec2.PeeringConnectionOptionsRequest {
+	if len(vOptions) == 0 || vOptions[0] == nil {
+		return nil
+	}
+
+	mOptions := vOptions[0].(map[string]interface{})
+
 	options := &ec2.PeeringConnectionOptionsRequest{}
 
-	if v, ok := m["allow_remote_vpc_dns_resolution"]; ok {
-		options.AllowDnsResolutionFromRemoteVpc = aws.Bool(v.(bool))
+	if v, ok := mOptions["allow_remote_vpc_dns_resolution"].(bool); ok {
+		options.AllowDnsResolutionFromRemoteVpc = aws.Bool(v)
 	}
-
-	if v, ok := m["allow_classic_link_to_remote_vpc"]; ok {
-		options.AllowEgressFromLocalClassicLinkToRemoteVpc = aws.Bool(v.(bool))
-	}
-
-	if v, ok := m["allow_vpc_to_remote_classic_link"]; ok {
-		options.AllowEgressFromLocalVpcToRemoteClassicLink = aws.Bool(v.(bool))
+	if !crossRegionPeering {
+		if v, ok := mOptions["allow_classic_link_to_remote_vpc"].(bool); ok {
+			options.AllowEgressFromLocalClassicLinkToRemoteVpc = aws.Bool(v)
+		}
+		if v, ok := mOptions["allow_vpc_to_remote_classic_link"].(bool); ok {
+			options.AllowEgressFromLocalVpcToRemoteClassicLink = aws.Bool(v)
+		}
 	}
 
 	return options

--- a/website/docs/r/vpc_peering_options.html.markdown
+++ b/website/docs/r/vpc_peering_options.html.markdown
@@ -16,7 +16,8 @@ resource with `accepter` and `requester` attributes. Do not manage options for t
 connection in both a VPC Peering Connection resource and a VPC Peering Connection Options resource.
 Doing so will cause a conflict of options and will overwrite the options.
 Using a VPC Peering Connection Options resource decouples management of the connection options from
-management of the VPC Peering Connection and allows options to be set correctly in cross-account scenarios.
+management of the VPC Peering Connection and allows options to be set correctly in cross-region and
+cross-account scenarios.
 
 Basic usage:
 
@@ -155,15 +156,13 @@ must have support for the DNS hostnames enabled. This can be done using the [`en
 (http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html) user guide for more information.
 
 * `allow_remote_vpc_dns_resolution` - (Optional) Allow a local VPC to resolve public DNS hostnames to
-private IP addresses when queried from instances in the peer VPC. This is
-[not supported](https://docs.aws.amazon.com/vpc/latest/peering/modify-peering-connections.html) for
-inter-region VPC peering.
+private IP addresses when queried from instances in the peer VPC.
 * `allow_classic_link_to_remote_vpc` - (Optional) Allow a local linked EC2-Classic instance to communicate
 with instances in a peer VPC. This enables an outbound communication from the local ClassicLink connection
-to the remote VPC.
+to the remote VPC. This option is not supported for inter-region VPC peering.
 * `allow_vpc_to_remote_classic_link` - (Optional) Allow a local VPC to communicate with a linked EC2-Classic
 instance in a peer VPC. This enables an outbound communication from the local VPC to the remote ClassicLink
-connection.
+connection. This option is not supported for inter-region VPC peering.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6730.

The heart of this PR is the addition of a cross-region-peering flag to `expandVpcPeeringConnectionOptions` and some changes in callers to be able to set this.

I took the opportunity to add a whole bunch more acceptance tests for the `aws_vpc_peering_connection`, `aws_vpc_peering_connection_accepter` and `aws_vpc_peering_connection_options` resources including some cross-account tests that will only run iif the `VPC_PEER_AWS_ACCESS_KEY_ID` and `VPC_PEER_AWS_SECRET_ACCESS_KEY` environment variables are set to values for the AWS account that accepts the VPC peering.