### PR TITLE
Add aws codebuild source credential resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -390,6 +390,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_codecommit_repository":                               resourceAwsCodeCommitRepository(),
 			"aws_codecommit_trigger":                                  resourceAwsCodeCommitTrigger(),
 			"aws_codebuild_project":                                   resourceAwsCodeBuildProject(),
+			"aws_codebuild_source_credential":                         resourceAwsCodeBuildSourceCredential(),
 			"aws_codebuild_webhook":                                   resourceAwsCodeBuildWebhook(),
 			"aws_codepipeline":                                        resourceAwsCodePipeline(),
 			"aws_codepipeline_webhook":                                resourceAwsCodePipelineWebhook(),

--- a/aws/resource_aws_codebuild_source_credential.go
+++ b/aws/resource_aws_codebuild_source_credential.go
@@ -1,0 +1,130 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsCodeBuildSourceCredential() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCodeBuildSourceCredentialCreate,
+		Read:   resourceAwsCodeBuildSourceCredentialRead,
+		Delete: resourceAwsCodeBuildSourceCredentialDelete,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auth_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					codebuild.AuthTypeBasicAuth,
+					codebuild.AuthTypePersonalAccessToken,
+				}, false),
+			},
+			"server_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					codebuild.ServerTypeGithub,
+					codebuild.ServerTypeBitbucket,
+					codebuild.ServerTypeGithubEnterprise,
+				}, false),
+			},
+			"token": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsCodeBuildSourceCredentialCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codebuildconn
+
+	authType := d.Get("auth_type").(string)
+
+	createOpts := &codebuild.ImportSourceCredentialsInput{
+		AuthType:   aws.String(authType),
+		ServerType: aws.String(d.Get("server_type").(string)),
+		Token:      aws.String(d.Get("token").(string)),
+	}
+
+	if attr, ok := d.GetOk("user_name"); ok && attr.(string) != "" && authType == codebuild.AuthTypeBasicAuth {
+		createOpts.Username = aws.String(attr.(string))
+	}
+
+	resp, err := conn.ImportSourceCredentials(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error importing source credentials: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.Arn))
+	d.Set("arn", resp.Arn)
+
+	return nil
+}
+
+func resourceAwsCodeBuildSourceCredentialRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codebuildconn
+
+	resp, err := conn.ListSourceCredentials(&codebuild.ListSourceCredentialsInput{})
+	if err != nil {
+		return fmt.Errorf("Error list source credentials: %s", err)
+	}
+
+	if len(resp.SourceCredentialsInfos) == 0 {
+		log.Printf("[WARN] Source Credentials(%s) is already deleted", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	resourceNotFound := true
+	for _, sourceCredentialsInfo := range resp.SourceCredentialsInfos {
+		if d.Id() == aws.StringValue(sourceCredentialsInfo.Arn) {
+			d.Set("auth_type", sourceCredentialsInfo.AuthType)
+			d.Set("server_type", sourceCredentialsInfo.ServerType)
+			resourceNotFound = false
+		}
+	}
+
+	if resourceNotFound {
+		log.Printf("[WARN] Source Credentials(%s) is already deleted", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceAwsCodeBuildSourceCredentialDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codebuildconn
+
+	deleteOpts := &codebuild.DeleteSourceCredentialsInput{
+		Arn: aws.String(d.Id()),
+	}
+
+	if _, err := conn.DeleteSourceCredentials(deleteOpts); err != nil {
+		if !isAWSErr(err, codebuild.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Source Credentials(%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_codebuild_source_credential.go
+++ b/aws/resource_aws_codebuild_source_credential.go
@@ -79,7 +79,6 @@ func resourceAwsCodeBuildSourceCredentialCreate(d *schema.ResourceData, meta int
 	}
 
 	d.SetId(aws.StringValue(resp.Arn))
-	d.Set("arn", resp.Arn)
 
 	return nil
 }

--- a/aws/resource_aws_codebuild_source_credential.go
+++ b/aws/resource_aws_codebuild_source_credential.go
@@ -16,6 +16,10 @@ func resourceAwsCodeBuildSourceCredential() *schema.Resource {
 		Read:   resourceAwsCodeBuildSourceCredentialRead,
 		Delete: resourceAwsCodeBuildSourceCredentialDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_codebuild_source_credential.go
+++ b/aws/resource_aws_codebuild_source_credential.go
@@ -69,7 +69,7 @@ func resourceAwsCodeBuildSourceCredentialCreate(d *schema.ResourceData, meta int
 		Token:      aws.String(d.Get("token").(string)),
 	}
 
-	if attr, ok := d.GetOk("user_name"); ok && attr.(string) != "" && authType == codebuild.AuthTypeBasicAuth {
+	if attr, ok := d.GetOk("user_name"); ok && authType == codebuild.AuthTypeBasicAuth {
 		createOpts.Username = aws.String(attr.(string))
 	}
 

--- a/aws/resource_aws_codebuild_source_credential.go
+++ b/aws/resource_aws_codebuild_source_credential.go
@@ -80,7 +80,7 @@ func resourceAwsCodeBuildSourceCredentialCreate(d *schema.ResourceData, meta int
 
 	d.SetId(aws.StringValue(resp.Arn))
 
-	return nil
+	return resourceAwsCodeBuildSourceCredentialRead(d, meta)
 }
 
 func resourceAwsCodeBuildSourceCredentialRead(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_codebuild_source_credential_test.go
+++ b/aws/resource_aws_codebuild_source_credential_test.go
@@ -1,0 +1,153 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCodeBuildSourceCredential_Basic(t *testing.T) {
+	var sourceCredentialsInfo codebuild.SourceCredentialsInfo
+	token := acctest.RandomWithPrefix("token")
+	resourceName := "aws_codebuild_source_credential.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildSourceCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB", token),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildSourceCredentialExists(resourceName, &sourceCredentialsInfo),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codebuild", regexp.MustCompile(`token/github`)),
+					resource.TestCheckResourceAttr(resourceName, "server_type", "GITHUB"),
+					resource.TestCheckResourceAttr(resourceName, "auth_type", "PERSONAL_ACCESS_TOKEN"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildSourceCredential_Basic("PERSONAL_ACCESS_TOKEN", "GITHUB_ENTERPRISE", token),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildSourceCredentialExists(resourceName, &sourceCredentialsInfo),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codebuild", regexp.MustCompile(`token/github_enterprise`)),
+					resource.TestCheckResourceAttr(resourceName, "server_type", "GITHUB_ENTERPRISE"),
+					resource.TestCheckResourceAttr(resourceName, "auth_type", "PERSONAL_ACCESS_TOKEN"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeBuildSourceCredential_BasicAuth(t *testing.T) {
+	var sourceCredentialsInfo codebuild.SourceCredentialsInfo
+	token := acctest.RandomWithPrefix("token")
+	resourceName := "aws_codebuild_source_credential.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodeBuild(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildSourceCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildSourceCredential_BasicAuth(token, "user1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildSourceCredentialExists(resourceName, &sourceCredentialsInfo),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "codebuild", regexp.MustCompile(`token/bitbucket`)),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "user1"),
+					resource.TestCheckResourceAttr(resourceName, "server_type", "BITBUCKET"),
+					resource.TestCheckResourceAttr(resourceName, "auth_type", "BASIC_AUTH"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildSourceCredential_BasicAuth(token, "user2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildSourceCredentialExists(resourceName, &sourceCredentialsInfo),
+					resource.TestCheckResourceAttr(resourceName, "user_name", "user2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCodeBuildSourceCredentialDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).codebuildconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_codebuild_source_credential" {
+			continue
+		}
+
+		resp, err := conn.ListSourceCredentials(&codebuild.ListSourceCredentialsInput{})
+		if err != nil {
+			return err
+		}
+
+		if len(resp.SourceCredentialsInfos) == 0 {
+			return nil
+		}
+
+		for _, sourceCredentialsInfo := range resp.SourceCredentialsInfos {
+			if rs.Primary.ID == aws.StringValue(sourceCredentialsInfo.Arn) {
+				return fmt.Errorf("Found Source Credential %s", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckAWSCodeBuildSourceCredentialExists(name string, sourceCredential *codebuild.SourceCredentialsInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).codebuildconn
+
+		resp, err := conn.ListSourceCredentials(&codebuild.ListSourceCredentialsInput{})
+		if err != nil {
+			return err
+		}
+
+		if len(resp.SourceCredentialsInfos) == 0 {
+			return fmt.Errorf("Source Credential %s not found", rs.Primary.ID)
+		}
+
+		for _, sourceCredentialsInfo := range resp.SourceCredentialsInfos {
+			if rs.Primary.ID == aws.StringValue(sourceCredentialsInfo.Arn) {
+				*sourceCredential = *sourceCredentialsInfo
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Source Credential %s not found", rs.Primary.ID)
+	}
+}
+
+func testAccAWSCodeBuildSourceCredential_Basic(authType, serverType, token string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_source_credential" "test" {
+  auth_type = "%s"
+  server_type = "%s"
+  token = "%s"
+}
+`, authType, serverType, token)
+}
+
+func testAccAWSCodeBuildSourceCredential_BasicAuth(token, userName string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_source_credential" "test" {
+  auth_type = "BASIC_AUTH"
+  server_type = "BITBUCKET"
+  token = "%s"
+  user_name = "%s"
+}
+`, token, userName)
+}

--- a/aws/resource_aws_codebuild_source_credential_test.go
+++ b/aws/resource_aws_codebuild_source_credential_test.go
@@ -41,6 +41,12 @@ func TestAccAWSCodeBuildSourceCredential_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "PERSONAL_ACCESS_TOKEN"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token", "user_name"},
+			},
 		},
 	})
 }
@@ -71,6 +77,12 @@ func TestAccAWSCodeBuildSourceCredential_BasicAuth(t *testing.T) {
 					testAccCheckAWSCodeBuildSourceCredentialExists(resourceName, &sourceCredentialsInfo),
 					resource.TestCheckResourceAttr(resourceName, "user_name", "user2"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token", "user_name"},
 			},
 		},
 	})

--- a/website/docs/r/codebuild_source_credential.html.markdown
+++ b/website/docs/r/codebuild_source_credential.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "aws"
+page_title: "AWS: aws_codebuild_source_credential"
+sidebar_current: "docs-aws-resource-codebuild-source-credential"
+description: |-
+  Provides a CodeBuild Source Credential resource.
+---
+
+# aws_codebuild_project
+
+Provides a CodeBuild Source Credentials Resource.
+
+## Example Usage
+
+```hcl
+resource "aws_codebuild_source_credential" "example" {
+  auth_type = "PERSONAL_ACCESS_TOKEN"
+  server_type = "GITHUB"
+  token = "example"
+}
+```
+
+### Bitbucket Server Usage
+
+```hcl
+resource "aws_codebuild_source_credential" "example" {
+  auth_type   = "BASIC_AUTH"
+  server_type = "BITBUCKET"
+  token       = "example"
+  user_name   = "test-user"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auth_type` - (Required) The type of authentication used to connect to a GitHub, GitHub Enterprise, or Bitbucket repository. An OAUTH connection is not supported by the API.
+* `server_type` - (Required) The source provider used for this project.
+* `token` - (Required) For `GitHub` or `GitHub Enterprise`, this is the personal access token. For `Bitbucket`, this is the app password.
+* `user_name` - (Optional) The Bitbucket username when the authType is `BASIC_AUTH`. This parameter is not valid for other types of source providers or connections.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ARN of Source Credential.
+* `arn` - The ARN of Source Credential.

--- a/website/docs/r/codebuild_source_credential.html.markdown
+++ b/website/docs/r/codebuild_source_credential.html.markdown
@@ -46,3 +46,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ARN of Source Credential.
 * `arn` - The ARN of Source Credential.
+
+## Import
+
+CodeBuild Source Credential can be imported using the CodeBuild Source Credential arn, e.g.
+
+```
+$ terraform import aws_codebuild_source_credential.example arn:aws:codebuild:us-west-2:123456789:token:github
+```

--- a/website/docs/r/codebuild_source_credential.html.markdown
+++ b/website/docs/r/codebuild_source_credential.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a CodeBuild Source Credential resource.
 ---
 
-# aws_codebuild_project
+# Resource: aws_codebuild_source_credential
 
 Provides a CodeBuild Source Credentials Resource.
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Closes #7025
Closes #7435

Changes proposed in this pull request:

* Add `aws_codebuild_source_credential` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCodeBuildSourceCredential_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCodeBuildSourceCredential_ -timeout 120m
=== RUN   TestAccAWSCodeBuildSourceCredential_Basic
=== PAUSE TestAccAWSCodeBuildSourceCredential_Basic
=== RUN   TestAccAWSCodeBuildSourceCredential_BasicAuth
=== PAUSE TestAccAWSCodeBuildSourceCredential_BasicAuth
=== CONT  TestAccAWSCodeBuildSourceCredential_Basic
=== CONT  TestAccAWSCodeBuildSourceCredential_BasicAuth
--- PASS: TestAccAWSCodeBuildSourceCredential_Basic (49.43s)
--- PASS: TestAccAWSCodeBuildSourceCredential_BasicAuth (49.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	49.623s
```
