### PR TITLE
tests/resource/aws_batch_compute_environment: Skip disabling already disabled compute environments in sweeper

### DIFF
--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -40,19 +40,23 @@ func testSweepBatchComputeEnvironments(region string) error {
 		return fmt.Errorf("Error retrieving Batch Compute Environments: %s", err)
 	}
 	for _, computeEnvironment := range out.ComputeEnvironments {
-		name := computeEnvironment.ComputeEnvironmentName
+		name := aws.StringValue(computeEnvironment.ComputeEnvironmentName)
 
-		log.Printf("[INFO] Disabling Batch Compute Environment: %s", *name)
-		err := disableBatchComputeEnvironment(*name, 20*time.Minute, conn)
-		if err != nil {
-			log.Printf("[ERROR] Failed to disable Batch Compute Environment %s: %s", *name, err)
-			continue
+		if aws.StringValue(computeEnvironment.State) == batch.CEStateEnabled {
+			log.Printf("[INFO] Disabling Batch Compute Environment: %s", name)
+			err := disableBatchComputeEnvironment(name, 20*time.Minute, conn)
+
+			if err != nil {
+				log.Printf("[ERROR] Failed to disable Batch Compute Environment %s: %s", name, err)
+				continue
+			}
 		}
 
-		log.Printf("[INFO] Deleting Batch Compute Environment: %s", *name)
-		err = deleteBatchComputeEnvironment(*name, 20*time.Minute, conn)
+		log.Printf("[INFO] Deleting Batch Compute Environment: %s", name)
+		err := deleteBatchComputeEnvironment(name, 20*time.Minute, conn)
+
 		if err != nil {
-			log.Printf("[ERROR] Failed to delete Batch Compute Environment %s: %s", *name, err)
+			log.Printf("[ERROR] Failed to delete Batch Compute Environment %s: %s", name, err)
 		}
 	}
 


### PR DESCRIPTION
Previous output from sweeper:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_batch_compute_environment -timeout 10h
...
2019/02/20 21:09:37 [INFO] Disabling Batch Compute Environment: tf_acc_test_8263634293510486727
...
2019/02/20 21:10:44 [ERROR] Failed to disable Batch Compute Environment tf_acc_test_8263634293510486727: unexpected state 'INVALID', wanted target 'VALID'. last error: %!s(<nil>)
...
```

Output from sweeper:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_batch_compute_environment -timeout 10h
...
2019/02/21 09:11:04 [INFO] Deleting Batch Compute Environment: tf_acc_test_8263634293510486727
2019/02/21 09:11:04 [DEBUG] Waiting for state to become: [DELETED]
...
2019/02/21 09:22:37 Sweeper Tests ran:
	- aws_batch_job_queue
	- aws_batch_compute_environment
```
