### PR TITLE
resource/aws_ram_resource_share: Add arn attribute

### DIFF
--- a/aws/resource_aws_ram_resource_share.go
+++ b/aws/resource_aws_ram_resource_share.go
@@ -29,6 +29,11 @@ func resourceAwsRamResourceShare() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -113,6 +118,7 @@ func resourceAwsRamResourceShareRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
+	d.Set("arn", resourceShare.ResourceShareArn)
 	d.Set("name", resourceShare.Name)
 	d.Set("allow_external_principals", resourceShare.AllowExternalPrincipals)
 

--- a/aws/resource_aws_ram_resource_share_test.go
+++ b/aws/resource_aws_ram_resource_share_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -26,6 +27,7 @@ func TestAccAwsRamResourceShare_basic(t *testing.T) {
 				Config: testAccAwsRamResourceShareConfigName(shareName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsRamResourceShareExists(resourceName, &resourceShare),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "ram", regexp.MustCompile(`resource-share/.+`)),
 					resource.TestCheckResourceAttr(resourceName, "allow_external_principals", "false"),
 					resource.TestCheckResourceAttr(resourceName, "name", shareName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),

--- a/website/docs/r/ram_principal_association.markdown
+++ b/website/docs/r/ram_principal_association.markdown
@@ -24,7 +24,7 @@ resource "aws_ram_resource_share" "example" {
 
 resource "aws_ram_principal_association" "example" {
   principal          = "111111111111"
-  resource_share_arn = "${aws_ram_resource_share.example.id}"
+  resource_share_arn = "${aws_ram_resource_share.example.arn}"
 }
 ```
 
@@ -33,7 +33,7 @@ resource "aws_ram_principal_association" "example" {
 ```hcl
 resource "aws_ram_principal_association" "example" {
   principal          = "${aws_organizations_organization.example.id}"
-  resource_share_arn = "${aws_ram_resource_share.example.id}"
+  resource_share_arn = "${aws_ram_resource_share.example.arn}"
 }
 ```
 

--- a/website/docs/r/ram_resource_association.html.markdown
+++ b/website/docs/r/ram_resource_association.html.markdown
@@ -17,7 +17,7 @@ Manages a Resource Access Manager (RAM) Resource Association.
 ```hcl
 resource "aws_ram_resource_association" "example" {
   resource_arn       = "${aws_subnet.example.arn}"
-  resource_share_arn = "${aws_ram_resource_share.example.id}"
+  resource_share_arn = "${aws_ram_resource_share.example.arn}"
 }
 ```
 

--- a/website/docs/r/ram_resource_share.markdown
+++ b/website/docs/r/ram_resource_share.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - The Amazon Resource Name (ARN) of the resource share.
 * `id` - The Amazon Resource Name (ARN) of the resource share.
 
 ## Import


### PR DESCRIPTION
While the ARN was already present in the `id` attribute, most resources that have an ARN follow the pattern of having an `arn` attribute.

Output from acceptance testing:

```
--- PASS: TestAccAwsRamResourceShare_basic (9.85s)
--- PASS: TestAccAwsRamResourceShare_Name (15.21s)
--- PASS: TestAccAwsRamResourceShare_AllowExternalPrincipals (15.60s)
--- PASS: TestAccAwsRamResourceShare_Tags (22.71s)
```
