### PR TITLE
Remove 0.0.0.0/0 from examples

### DIFF
--- a/website/docs/r/default_network_acl.html.markdown
+++ b/website/docs/r/default_network_acl.html.markdown
@@ -51,7 +51,7 @@ resource "aws_default_network_acl" "default" {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = "0.0.0.0/0"
+    cidr_block = # set a CIDR block here
     from_port  = 0
     to_port    = 0
   }
@@ -84,7 +84,7 @@ resource "aws_default_network_acl" "default" {
     protocol   = -1
     rule_no    = 100
     action     = "allow"
-    cidr_block = "0.0.0.0/0"
+    cidr_block = # set a CIDR block here
     from_port  = 0
     to_port    = 0
   }

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -396,16 +396,19 @@ EOF
   service_role = "${aws_iam_role.iam_emr_service_role.arn}"
 }
 
-resource "aws_security_group" "allow_all" {
-  name        = "allow_all"
-  description = "Allow all inbound traffic"
+resource "aws_security_group" "allow_access" {
+  name        = "allow_access"
+  description = "Allow inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
   ingress {
+    # these ports should be locked down
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+
+    # we do not recommend opening your cluster to 0.0.0.0/0
+    cidr_blocks = # add your IP address here
   }
 
   egress {

--- a/website/docs/r/network_acl_rule.html.markdown
+++ b/website/docs/r/network_acl_rule.html.markdown
@@ -29,7 +29,8 @@ resource "aws_network_acl_rule" "bar" {
   egress         = false
   protocol       = "tcp"
   rule_action    = "allow"
-  cidr_block     = "0.0.0.0/0"
+  # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
+  cidr_block = # add a CIDR block here
   from_port      = 22
   to_port        = 22
 }

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -24,16 +24,19 @@ a conflict of rule settings and will overwrite rules.
 Basic usage
 
 ```hcl
-resource "aws_security_group" "allow_all" {
-  name        = "allow_all"
-  description = "Allow all inbound traffic"
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
   vpc_id      = "${aws_vpc.main.id}"
 
   ingress {
-    from_port   = 0
-    to_port     = 0
+    # TLS (change to whatever ports you need)
+    from_port   = 443
+    to_port     = 443
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    # Please restrict your ingress to only necessary IPs and ports.
+    # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
+    cidr_blocks = # add a CIDR block here
   }
 
   egress {
@@ -49,15 +52,18 @@ resource "aws_security_group" "allow_all" {
 Basic usage with tags:
 
 ```hcl
-resource "aws_security_group" "allow_all" {
-  name        = "allow_all"
-  description = "Allow all inbound traffic"
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
 
   ingress {
-    from_port   = 0
-    to_port     = 65535
+    # TLS (change to whatever ports you need)
+    from_port   = 443
+    to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    # Please restrict your ingress to only necessary IPs and ports.
+    # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
+    cidr_blocks = # add your IP address here
   }
 
   tags = {

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -32,7 +32,8 @@ resource "aws_security_group_rule" "allow_all" {
   from_port       = 0
   to_port         = 65535
   protocol        = "tcp"
-  cidr_blocks     = ["0.0.0.0/0"]
+  # Opening to 0.0.0.0/0 can lead to security vulnerabilities.
+  cidr_blocks = # add a CIDR block here
   prefix_list_ids = ["pl-12c4e678"]
 
   security_group_id = "sg-123456"


### PR DESCRIPTION
Removes `0.0.0.0/0` from docs and examples in `ingress`. Force people to make a more secure choice for their ingress CIDR blocks.