### PR TITLE
Vpc endpoint suppress policy diff

### DIFF
--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -46,10 +46,10 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.ValidateJsonString,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -50,6 +50,7 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.ValidateJsonString,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 				StateFunc: func(v interface{}) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

* Suppresses policy diff for vpc endpoint policy when old and new policy is structurally equivalent
  * Lack of this feature is considered a bug on our side, since a change is occurring despite both old and new policy being logically equivalent. We're using PTFE, so we require the upstream change for Terraform runs to be kosher.
