### PR TITLE
tests/resource/aws_cloudwatch_event_target: Implement sweeper

### DIFF
--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -17,6 +17,9 @@ func init() {
 	resource.AddTestSweepers("aws_cloudwatch_event_rule", &resource.Sweeper{
 		Name: "aws_cloudwatch_event_rule",
 		F:    testSweepCloudWatchEventRules,
+		Dependencies: []string{
+			"aws_cloudwatch_event_target",
+		},
 	})
 }
 

--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -2,14 +2,91 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_cloudwatch_event_target", &resource.Sweeper{
+		Name: "aws_cloudwatch_event_target",
+		F:    testSweepCloudWatchEventTargets,
+	})
+}
+
+func testSweepCloudWatchEventTargets(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).cloudwatcheventsconn
+
+	input := &events.ListRulesInput{}
+
+	for {
+		output, err := conn.ListRules(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping CloudWatch Event Target sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving CloudWatch Event Targets: %s", err)
+		}
+
+		for _, rule := range output.Rules {
+			listTargetsByRuleInput := &events.ListTargetsByRuleInput{
+				Limit: aws.Int64(100), // Set limit to allowed maximum to prevent API throttling
+				Rule:  rule.Name,
+			}
+			ruleName := aws.StringValue(rule.Name)
+
+			for {
+				listTargetsByRuleOutput, err := conn.ListTargetsByRule(listTargetsByRuleInput)
+
+				if err != nil {
+					return fmt.Errorf("Error retrieving CloudWatch Event Targets: %s", err)
+				}
+
+				for _, target := range listTargetsByRuleOutput.Targets {
+					removeTargetsInput := &events.RemoveTargetsInput{
+						Ids:  []*string{target.Id},
+						Rule: rule.Name,
+					}
+					targetID := aws.StringValue(target.Id)
+
+					log.Printf("[INFO] Deleting CloudWatch Event Rule (%s) Target: %s", ruleName, targetID)
+					_, err := conn.RemoveTargets(removeTargetsInput)
+
+					if err != nil {
+						return fmt.Errorf("Error deleting CloudWatch Event Rule (%s) Target %s: %s", ruleName, targetID, err)
+					}
+				}
+
+				if aws.StringValue(listTargetsByRuleOutput.NextToken) == "" {
+					break
+				}
+
+				listTargetsByRuleInput.NextToken = listTargetsByRuleOutput.NextToken
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 	var target events.Target


### PR DESCRIPTION
Previously, sweeping `aws_cloudwatch_event_rule` could fail due to target dependencies:

```
[21:03:05][Step 2/4] 2019/02/21 21:03:05 [DEBUG] [aws-sdk-go] DEBUG: Validate Response events/DeleteRule failed, not retrying, error ValidationException: Rule can't be deleted since it has targets.
[21:03:05][Step 2/4] 	status code: 400, request id: 154ca74b-361c-11e9-a50b-c5f44c58b324
[21:03:05][Step 2/4] 2019/02/21 21:03:05 [ERR] error running (aws_cloudwatch_event_rule): Error deleting CloudWatch Event Rule codepipeline-tfacct-latest-739439-rule: ValidationException: Rule can't be deleted since it has targets.
[21:03:05][Step 2/4] 	status code: 400, request id: 154ca74b-361c-11e9-a50b-c5f44c58b324
[21:03:05][Step 2/4] FAIL	github.com/terraform-providers/terraform-provider-aws/aws	324.890s
```

Now we appropriately remove targets first:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_cloudwatch_event_rule -timeout 10h
...
2019/02/21 20:40:58 [INFO] Deleting CloudWatch Event Rule (codepipeline-tfacct-latest-739439-rule) Target: codepipeline-bflad-testing
...
2019/02/21 20:40:59 [INFO] Deleting CloudWatch Event Rule codepipeline-tfacct-latest-739439-rule
2019/02/21 20:41:00 Sweeper Tests ran:
	- aws_cloudwatch_event_target
	- aws_cloudwatch_event_rule
ok  	github.com/terraform-providers/terraform-provider-aws/aws	6.014s
```
