### PR TITLE
resource/aws_lb_target_group: Add lambda_multi_value_headers_enabled argument

### DIFF
--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -49,6 +49,11 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				Computed: true,
 			},
 
+			"lambda_multi_value_headers_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"slow_start": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 * `vpc_id` - (Optional, Forces new resource) The identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.
+* `lambda_multi_value_headers_enabled` - (Optional) Boolean whether the request and response headers exchanged between the load balancer and the Lambda function include arrays of values or strings. Only applies when `target_type` is `lambda`.
 * `proxy_protocol_v2` - (Optional) Boolean to enable / disable support for proxy protocol v2 on Network Load Balancers. See [doc](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) for more information.
 * `stickiness` - (Optional) A Stickiness block. Stickiness blocks are documented below. `stickiness` is only valid if used with Load Balancers of type `Application`
 * `health_check` - (Optional) A Health Check block. Health Check blocks are documented below.


### PR DESCRIPTION
Closes #7637

Output from acceptance testing:

```
--- PASS: TestAccAWSALBTargetGroup_lambda (13.37s)
--- PASS: TestAccAWSALBTargetGroup_missingPortProtocolVpc (17.64s)
--- PASS: TestAccAWSALBTargetGroup_namePrefix (23.80s)
--- PASS: TestAccAWSALBTargetGroup_generatedName (24.12s)
--- PASS: TestAccAWSALBTargetGroup_basic (24.63s)
--- PASS: TestAccAWSALBTargetGroup_lambdaMultiValueHeadersEnabled (30.06s)
--- PASS: TestAccAWSALBTargetGroup_setAndUpdateSlowStart (39.47s)
--- PASS: TestAccAWSALBTargetGroup_tags (40.23s)
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (41.56s)
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (41.67s)
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (43.88s)
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (46.08s)
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (52.34s)
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (55.45s)
```
