### PR TITLE
WIP add partition_count argument to aws_placement_group

### DIFF
--- a/aws/resource_aws_placement_group_test.go
+++ b/aws/resource_aws_placement_group_test.go
@@ -86,11 +86,48 @@ func testAccCheckAWSPlacementGroupExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func TestAccAWSPlacementGroup_partition(t *testing.T) {
+	resourceName := "aws_placement_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPlacementGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPlacementGroupConfig_partition(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPlacementGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "strategy", "partition"),
+					resource.TestCheckResourceAttr(resourceName, "partition_count", "7"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccAWSPlacementGroupConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %q
   strategy = "cluster"
+}
+`, rName)
+}
+
+func testAccAWSPlacementGroupConfig_partition(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_placement_group" "test" {
+  name            = %q
+  strategy        = "partition"
+  partition_count = 7
 }
 `, rName)
 }

--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the placement group.
 * `strategy` - (Required) The placement strategy.
+* `partition_count` - (Optional) The number of partitions. Valid only when Strategy is set to partition.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Sorry, I haven't raise a issue about this topic.
AWS added partition placement group feature which uses partition_count argument, so I added partiton_count argument to set the number.

Changes proposed in this pull request:

* Added partition_count argument to aws_placement_group

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSPlacementGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSPlacementGroup -timeout 120m
=== RUN   TestAccAWSPlacementGroup_basic
=== PAUSE TestAccAWSPlacementGroup_basic
=== RUN   TestAccAWSPlacementGroup_partition
=== PAUSE TestAccAWSPlacementGroup_partition
=== CONT  TestAccAWSPlacementGroup_basic
=== CONT  TestAccAWSPlacementGroup_partition
--- PASS: TestAccAWSPlacementGroup_partition (7.83s)
--- PASS: TestAccAWSPlacementGroup_basic (8.20s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	8.218s
```

And bellows are sample partition placement group which acctest has created.
```
$ aws ec2 describe-placement-groups
{
    "PlacementGroups": [
        {
            "GroupName": "tf-acc-test-7259013876622124670",
            "State": "available",
            "Strategy": "partition",
            "PartitionCount": 7
        }
    ]
}
```