### PR TITLE
provider: Remove hardcoded AWS China handling

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -317,11 +317,6 @@ func (c *AWSClient) DynamoDB() *dynamodb.DynamoDB {
 	return c.dynamodbconn
 }
 
-func (c *AWSClient) IsChinaCloud() bool {
-	_, isChinaCloud := endpoints.PartitionForRegion([]endpoints.Partition{endpoints.AwsCnPartition()}, c.region)
-	return isChinaCloud
-}
-
 // Client configures and returns a fully initialized AWSClient
 func (c *Config) Client() (interface{}, error) {
 	// Get the auth and region. This can fail if keys/regions were not

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -556,36 +556,32 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Only 1 of `ipv6_address_count` or `ipv6_addresses` can be specified")
 	}
 
-	restricted := meta.(*AWSClient).IsChinaCloud()
-	if !restricted {
+	tagsSpec := make([]*ec2.TagSpecification, 0)
 
-		tagsSpec := make([]*ec2.TagSpecification, 0)
+	if v, ok := d.GetOk("tags"); ok {
+		tags := tagsFromMap(v.(map[string]interface{}))
 
-		if v, ok := d.GetOk("tags"); ok {
-			tags := tagsFromMap(v.(map[string]interface{}))
-
-			spec := &ec2.TagSpecification{
-				ResourceType: aws.String("instance"),
-				Tags:         tags,
-			}
-
-			tagsSpec = append(tagsSpec, spec)
+		spec := &ec2.TagSpecification{
+			ResourceType: aws.String("instance"),
+			Tags:         tags,
 		}
 
-		if v, ok := d.GetOk("volume_tags"); ok {
-			tags := tagsFromMap(v.(map[string]interface{}))
+		tagsSpec = append(tagsSpec, spec)
+	}
 
-			spec := &ec2.TagSpecification{
-				ResourceType: aws.String("volume"),
-				Tags:         tags,
-			}
+	if v, ok := d.GetOk("volume_tags"); ok {
+		tags := tagsFromMap(v.(map[string]interface{}))
 
-			tagsSpec = append(tagsSpec, spec)
+		spec := &ec2.TagSpecification{
+			ResourceType: aws.String("volume"),
+			Tags:         tags,
 		}
 
-		if len(tagsSpec) > 0 {
-			runOpts.TagSpecifications = tagsSpec
-		}
+		tagsSpec = append(tagsSpec, spec)
+	}
+
+	if len(tagsSpec) > 0 {
+		runOpts.TagSpecifications = tagsSpec
 	}
 
 	// Create the instance
@@ -903,25 +899,18 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	d.Partial(true)
-	restricted := meta.(*AWSClient).IsChinaCloud()
 
-	if d.HasChange("tags") {
-		if !d.IsNewResource() || restricted {
-			if err := setTags(conn, d); err != nil {
-				return err
-			} else {
-				d.SetPartial("tags")
-			}
+	if d.HasChange("tags") && !d.IsNewResource() {
+		if err := setTags(conn, d); err != nil {
+			return err
 		}
+		d.SetPartial("tags")
 	}
-	if d.HasChange("volume_tags") {
-		if !d.IsNewResource() || restricted {
-			if err := setVolumeTags(conn, d); err != nil {
-				return err
-			} else {
-				d.SetPartial("volume_tags")
-			}
+	if d.HasChange("volume_tags") && !d.IsNewResource() {
+		if err := setVolumeTags(conn, d); err != nil {
+			return err
 		}
+		d.SetPartial("volume_tags")
 	}
 
 	if d.HasChange("iam_instance_profile") && !d.IsNewResource() {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -159,8 +159,6 @@ func resourceAwsS3BucketObject() *schema.Resource {
 func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
-	restricted := meta.(*AWSClient).IsChinaCloud()
-
 	var body io.ReadSeeker
 
 	if v, ok := d.GetOk("source"); ok {
@@ -241,10 +239,6 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
-		if restricted {
-			return fmt.Errorf("This region does not allow for tags on S3 objects")
-		}
-
 		// The tag-set must be encoded as URL Query parameters.
 		values := url.Values{}
 		for k, v := range v.(map[string]interface{}) {
@@ -271,8 +265,6 @@ func resourceAwsS3BucketObjectCreate(d *schema.ResourceData, meta interface{}) e
 
 func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
-
-	restricted := meta.(*AWSClient).IsChinaCloud()
 
 	bucket := d.Get("bucket").(string)
 	key := d.Get("key").(string)
@@ -329,10 +321,8 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("storage_class", resp.StorageClass)
 	}
 
-	if !restricted {
-		if err := getTagsS3Object(s3conn, d); err != nil {
-			return fmt.Errorf("error getting S3 object tags (bucket: %s, key: %s): %s", bucket, key, err)
-		}
+	if err := getTagsS3Object(s3conn, d); err != nil {
+		return fmt.Errorf("error getting S3 object tags (bucket: %s, key: %s): %s", bucket, key, err)
 	}
 
 	return nil


### PR DESCRIPTION
The usage of `IsChinaCloud()` (and previously `IsGovCloud()`) represented the first iteration of trying to support the 3 public AWS partitions when they offered differing capabilities due to running different service API versions. While this approach of checking the AWS partition provides an immediate fix for these situations, it does not automatically handle if/when those new capabilities are enabled.

In newer iterations of this handling, we attempt to simply ignore read errors based on specific error messages, like `UnsupportedOperation` and passthrough any create/update errors. See https://github.com/terraform-providers/terraform-provider-aws/pull/3794/files for an example of this.

Here we introduce the potentially breaking change of removing the AWS China protections in the `aws_instance` and `aws_s3_bucket_object` resources to further discourage the usage of this approach. Should any issues arise in AWS China from these removals, we will implement the error-based approach going forward. It is entirely possible that both EC2 Instance tagging on creation and S3 Object tagging is supported now in that partition though given both have been supported in AWS GovCloud for an extended period of time now.
