### PR TITLE
Fix small typo in aws_route_table doc page

### DIFF
--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 One of the following destination arguments must be supplied:
 
 * `cidr_block` - (Required) The CIDR block of the route.
-* `ipv6_cidr_block` - Optional) The Ipv6 CIDR block of the route
+* `ipv6_cidr_block` - (Optional) The Ipv6 CIDR block of the route
 
 One of the following target arguments must be supplied:
 


### PR DESCRIPTION
Changes proposed in this pull request:

  - [x] Fixing a subtle type in documentation for `aws_route_table` resource
