### PR TITLE
Fix crawler to use update instead of create

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -251,6 +251,51 @@ func createCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.Creat
 	return crawlerInput, nil
 }
 
+func updateCrawlerInput(crawlerName string, d *schema.ResourceData) (*glue.UpdateCrawlerInput, error) {
+	crawlerTargets, err := expandGlueCrawlerTargets(d)
+	if err != nil {
+		return nil, err
+	}
+	crawlerInput := &glue.UpdateCrawlerInput{
+		Name:         aws.String(crawlerName),
+		DatabaseName: aws.String(d.Get("database_name").(string)),
+		Role:         aws.String(d.Get("role").(string)),
+		Targets:      crawlerTargets,
+	}
+	if description, ok := d.GetOk("description"); ok {
+		crawlerInput.Description = aws.String(description.(string))
+	}
+	if schedule, ok := d.GetOk("schedule"); ok {
+		crawlerInput.Schedule = aws.String(schedule.(string))
+	}
+	if classifiers, ok := d.GetOk("classifiers"); ok {
+		crawlerInput.Classifiers = expandStringList(classifiers.([]interface{}))
+	}
+
+	crawlerInput.SchemaChangePolicy = expandGlueSchemaChangePolicy(d.Get("schema_change_policy").([]interface{}))
+
+	if tablePrefix, ok := d.GetOk("table_prefix"); ok {
+		crawlerInput.TablePrefix = aws.String(tablePrefix.(string))
+	}
+	if configuration, ok := d.GetOk("configuration"); ok {
+		crawlerInput.Configuration = aws.String(configuration.(string))
+	}
+
+	if v, ok := d.GetOk("configuration"); ok {
+		configuration, err := structure.NormalizeJsonString(v)
+		if err != nil {
+			return nil, fmt.Errorf("Configuration contains an invalid JSON: %v", err)
+		}
+		crawlerInput.Configuration = aws.String(configuration)
+	}
+
+	if securityConfiguration, ok := d.GetOk("security_configuration"); ok {
+		crawlerInput.CrawlerSecurityConfiguration = aws.String(securityConfiguration.(string))
+	}
+
+	return crawlerInput, nil
+}
+
 func expandGlueSchemaChangePolicy(v []interface{}) *glue.SchemaChangePolicy {
 	if len(v) == 0 {
 		return nil
@@ -362,15 +407,14 @@ func resourceAwsGlueCrawlerUpdate(d *schema.ResourceData, meta interface{}) erro
 	glueConn := meta.(*AWSClient).glueconn
 	name := d.Get("name").(string)
 
-	crawlerInput, err := createCrawlerInput(name, d)
+	updateCrawlerInput, err := updateCrawlerInput(name, d)
 	if err != nil {
 		return err
 	}
-	updateCrawlerInput := glue.UpdateCrawlerInput(*crawlerInput)
 
 	// Retry for IAM eventual consistency
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		_, err := glueConn.UpdateCrawler(&updateCrawlerInput)
+		_, err := glueConn.UpdateCrawler(updateCrawlerInput)
 		if err != nil {
 			if isAWSErr(err, glue.ErrCodeInvalidInputException, "Service is unable to assume role") {
 				return resource.RetryableError(err)


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7661

Changes proposed in this pull request:

* `r/aws_glue_crawler` was not building due to using create input where update input should be used.

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAWSGlueCrawler_DynamodbTarget'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGlueCrawler_DynamodbTarget -timeout 120m
go: downloading github.com/terraform-providers/terraform-provider-template v1.0.0
go: downloading github.com/pquerna/otp v0.0.0-20180813144649-be78767b3e39
go: downloading github.com/terraform-providers/terraform-provider-tls v1.2.0
go: downloading github.com/boombuler/barcode v0.0.0-20180809052337-34fff276c74e
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSGlueCrawler_DynamodbTarget
=== PAUSE TestAccAWSGlueCrawler_DynamodbTarget
=== CONT  TestAccAWSGlueCrawler_DynamodbTarget
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (20.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	20.139s
```