### PR TITLE
resource/aws_lambda_layer_version: Swap arn and layer_arn attribute values

### DIFF
--- a/aws/data_source_aws_lambda_function_test.go
+++ b/aws/data_source_aws_lambda_function_test.go
@@ -284,7 +284,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   handler       = "exports.example"
-  layers        = ["${aws_lambda_layer_version.test.layer_arn}"]
+  layers        = ["${aws_lambda_layer_version.test.arn}"]
   role          = "${aws_iam_role.lambda.arn}"
   runtime       = "nodejs8.10"
 }

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1982,7 +1982,7 @@ resource "aws_lambda_function" "lambda_function_test" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs8.10"
-    layers = ["${aws_lambda_layer_version.lambda_function_test.layer_arn}"]
+    layers = ["${aws_lambda_layer_version.lambda_function_test.arn}"]
 }
 `, layerName, funcName)
 }
@@ -2008,8 +2008,8 @@ resource "aws_lambda_function" "lambda_function_test" {
     handler = "exports.example"
     runtime = "nodejs8.10"
     layers = [
-        "${aws_lambda_layer_version.lambda_function_test.layer_arn}",
-        "${aws_lambda_layer_version.lambda_function_test_2.layer_arn}",
+        "${aws_lambda_layer_version.lambda_function_test.arn}",
+        "${aws_lambda_layer_version.lambda_function_test_2.arn}",
     ]
 }
 `, layerName, layer2Name, funcName)

--- a/aws/resource_aws_lambda_layer_version.go
+++ b/aws/resource_aws_lambda_layer_version.go
@@ -196,11 +196,11 @@ func resourceAwsLambdaLayerVersionRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("version", strconv.FormatInt(version, 10)); err != nil {
 		return fmt.Errorf("Error setting lambda layer version: %s", err)
 	}
-	if err := d.Set("arn", layerVersion.LayerArn); err != nil {
-		return fmt.Errorf("Error setting lambda layer arn: %s", err)
+	if err := d.Set("arn", layerVersion.LayerVersionArn); err != nil {
+		return fmt.Errorf("Error setting lambda layer version arn: %s", err)
 	}
-	if err := d.Set("layer_arn", layerVersion.LayerVersionArn); err != nil {
-		return fmt.Errorf("Error setting lambda layer qualified arn: %s", err)
+	if err := d.Set("layer_arn", layerVersion.LayerArn); err != nil {
+		return fmt.Errorf("Error setting lambda layer arn: %s", err)
 	}
 	if err := d.Set("description", layerVersion.Description); err != nil {
 		return fmt.Errorf("Error setting lambda layer description: %s", err)

--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -74,7 +74,16 @@ func TestAccAWSLambdaLayerVersion_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSLambdaLayerVersionBasic(layerName),
-				Check:  testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaLayerVersionExists(resourceName, layerName),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "lambda", fmt.Sprintf("layer:%s:1", layerName)),
+					resource.TestCheckResourceAttr(resourceName, "compatible_runtimes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "layer_name", layerName),
+					resource.TestCheckResourceAttr(resourceName, "license_info", ""),
+					testAccCheckResourceAttrRegionalARN(resourceName, "layer_arn", "lambda", fmt.Sprintf("layer:%s", layerName)),
+					resource.TestCheckResourceAttr(resourceName, "version", "1"),
+				),
 			},
 
 			{

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -55,7 +55,7 @@ resource "aws_lambda_function" "test_lambda" {
 
 ### Lambda Layers
 
-~> **NOTE:** The `aws_lambda_layer_version` attribute values for `arn` and `layer_arn` will be swapped in version 2.0.0 of the Terraform AWS Provider. For version 1.x, use `layer_arn` references. For version 2.x, use `arn` references.
+~> **NOTE:** The `aws_lambda_layer_version` attribute values for `arn` and `layer_arn` were swapped in version 2.0.0 of the Terraform AWS Provider. For version 1.x, use `layer_arn` references. For version 2.x, use `arn` references.
 
 ```hcl
 resource "aws_lambda_layer_version" "example" {
@@ -64,7 +64,7 @@ resource "aws_lambda_layer_version" "example" {
 
 resource "aws_lambda_function" "example" {
   # ... other configuration ...
-  layers = ["${aws_lambda_layer_version.example.layer_arn}"]
+  layers = ["${aws_lambda_layer_version.example.arn}"]
 }
 ```
 

--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -12,8 +12,6 @@ Provides a Lambda Layer Version resource. Lambda Layers allow you to reuse share
 
 For information about Lambda Layers and how to use them, see [AWS Lambda Layers][1]
 
-~> **NOTE:** The attribute values for `arn` and `layer_arn` will be swapped in version 2.0.0 of the Terraform AWS Provider.
-
 ## Example Usage
 
 ```hcl
@@ -51,8 +49,8 @@ large files efficiently.
 
 ## Attributes Reference
 
-* `arn` - The Amazon Resource Name (ARN) identifying your Lambda Layer.
-* `layer_arn` - The Amazon Resource Name (ARN) identifying your specific Lambda Layer version.
+* `arn` - The Amazon Resource Name (ARN) of the Lambda Layer with version.
+* `layer_arn` - The Amazon Resource Name (ARN) of the Lambda Layer without version.
 * `created_date` - The date this resource was created.
 * `source_code_size` - The size in bytes of the function .zip file.
 * `version` - This Lamba Layer version.


### PR DESCRIPTION
Closes #7402

This fixes the currently confusing user experience with the existing attributes.

Output from acceptance testing:

```
--- PASS: TestAccAWSLambdaLayerVersion_basic (13.63s)
--- PASS: TestAccAWSLambdaLayerVersion_description (19.95s)
--- PASS: TestAccAWSLambdaLayerVersion_compatibleRuntimes (24.30s)
--- PASS: TestAccDataSourceAWSLambdaFunction_layers (30.19s)
--- PASS: TestAccAWSLambdaLayerVersion_licenseInfo (31.30s)
--- PASS: TestAccAWSLambdaLayerVersion_s3 (36.71s)
--- PASS: TestAccAWSLambdaLayerVersion_update (36.78s)
--- PASS: TestAccAWSLambdaFunction_Layers (44.14s)
--- PASS: TestAccAWSLambdaFunction_LayersUpdate (63.28s)
```
