### PR TITLE
resource/aws_route53_zone: Remove deprecated vpc_id and vpc_region arguments

### DIFF
--- a/aws/data_source_aws_route53_zone_test.go
+++ b/aws/data_source_aws_route53_zone_test.go
@@ -85,8 +85,10 @@ func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
 
 	resource "aws_route53_zone" "test_private" {
 		name = "test.acc-%d."
-		vpc_id = "${aws_vpc.test.id}"
-	tags = {
+		vpc {
+			vpc_id = "${aws_vpc.test.id}"
+		}
+		tags = {
 			Environment = "dev-%d"
 		}
 	}

--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -41,12 +41,10 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			},
 
 			"vpc": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				// Deprecated: Remove Computed: true in next major version of the provider
-				Computed:      true,
+				Type:          schema.TypeSet,
+				Optional:      true,
 				MinItems:      1,
-				ConflictsWith: []string{"delegation_set_id", "vpc_id", "vpc_region"},
+				ConflictsWith: []string{"delegation_set_id"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"vpc_id": {
@@ -65,21 +63,19 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			},
 
 			"vpc_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      true,
-				ConflictsWith: []string{"delegation_set_id", "vpc"},
-				Deprecated:    "use 'vpc' attribute instead",
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Removed:  "use 'vpc' configuration block instead",
 			},
 
 			"vpc_region": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      true,
-				ConflictsWith: []string{"delegation_set_id", "vpc"},
-				Deprecated:    "use 'vpc' attribute instead",
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Removed:  "use 'vpc' configuration block instead",
 			},
 
 			"zone_id": {
@@ -91,7 +87,7 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"vpc_id"},
+				ConflictsWith: []string{"vpc"},
 			},
 
 			"name_servers": {
@@ -131,20 +127,6 @@ func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) erro
 	// however we need to associate the remaining after creation.
 
 	var vpcs []*route53.VPC = expandRoute53VPCs(d.Get("vpc").(*schema.Set).List(), region)
-
-	// Backwards compatibility
-	if vpcID, ok := d.GetOk("vpc_id"); ok {
-		vpc := &route53.VPC{
-			VPCId:     aws.String(vpcID.(string)),
-			VPCRegion: aws.String(region),
-		}
-
-		if vpcRegion, ok := d.GetOk("vpc_region"); ok {
-			vpc.VPCRegion = aws.String(vpcRegion.(string))
-		}
-
-		vpcs = []*route53.VPC{vpc}
-	}
 
 	if len(vpcs) > 0 {
 		input.VPC = vpcs[0]
@@ -236,30 +218,6 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 	sort.Strings(nameServers)
 	if err := d.Set("name_servers", nameServers); err != nil {
 		return fmt.Errorf("error setting name_servers: %s", err)
-	}
-
-	// Backwards compatibility: only set vpc_id/vpc_region if either is true:
-	//  * Previously configured
-	//  * Only one VPC association
-	existingVpcID := d.Get("vpc_id").(string)
-
-	// Detect drift in configuration
-	d.Set("vpc_id", "")
-	d.Set("vpc_region", "")
-
-	if len(output.VPCs) == 1 && output.VPCs[0] != nil {
-		d.Set("vpc_id", output.VPCs[0].VPCId)
-		d.Set("vpc_region", output.VPCs[0].VPCRegion)
-	} else if len(output.VPCs) > 1 {
-		for _, vpc := range output.VPCs {
-			if vpc == nil {
-				continue
-			}
-			if aws.StringValue(vpc.VPCId) == existingVpcID {
-				d.Set("vpc_id", vpc.VPCId)
-				d.Set("vpc_region", vpc.VPCRegion)
-			}
-		}
 	}
 
 	if err := d.Set("vpc", flattenRoute53VPCs(output.VPCs)); err != nil {

--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -142,7 +142,12 @@ resource "aws_vpc" "bar" {
 
 resource "aws_route53_zone" "foo" {
 	name = "foo.com"
-	vpc_id = "${aws_vpc.foo.id}"
+	vpc {
+		vpc_id = "${aws_vpc.foo.id}"
+	}
+	lifecycle {
+		ignore_changes = ["vpc"]
+	}
 }
 
 resource "aws_route53_zone_association" "foobar" {
@@ -185,8 +190,13 @@ resource "aws_vpc" "bar" {
 resource "aws_route53_zone" "foo" {
 	provider = "aws.west"
 	name = "foo.com"
-	vpc_id = "${aws_vpc.foo.id}"
-	vpc_region = "us-west-2"
+	vpc {
+		vpc_id     = "${aws_vpc.foo.id}"
+		vpc_region = "us-west-2"
+	}
+	lifecycle {
+		ignore_changes = ["vpc"]
+	}
 }
 
 resource "aws_route53_zone_association" "foobar" {

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -385,77 +385,6 @@ func TestAccAWSRoute53Zone_VPC_Updates(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53Zone_VPCID(t *testing.T) {
-	var zone route53.GetHostedZoneOutput
-
-	rString := acctest.RandString(8)
-	resourceName := "aws_route53_zone.test"
-	vpcResourceName := "aws_vpc.test"
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRoute53ZoneDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoute53ZoneConfigVPCID(zoneName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists(resourceName, &zone),
-					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
-					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName, &zone),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
-			},
-		},
-	})
-}
-
-func TestAccAWSRoute53Zone_VPCRegion(t *testing.T) {
-	var zone route53.GetHostedZoneOutput
-
-	rString := acctest.RandString(8)
-	resourceName := "aws_route53_zone.test"
-	vpcResourceName := "aws_vpc.test"
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
-
-	// record the initialized providers so that we can use them to
-	// check for the instances in each region
-	var providers []*schema.Provider
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckRoute53ZoneDestroyWithProvider, &providers),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRoute53ZoneConfigVPCRegion(zoneName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExistsWithProvider(resourceName, &zone,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", vpcResourceName, "id"),
-					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName, &zone),
-				),
-			},
-			{
-				// Config must be provided for aliased provider
-				Config:                  testAccRoute53ZoneConfigVPCRegion(zoneName),
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
-			},
-		},
-	})
-}
-
 func testAccCheckRoute53ZoneDestroy(s *terraform.State) error {
 	return testAccCheckRoute53ZoneDestroyWithProvider(s, testAccProvider)
 }
@@ -703,55 +632,6 @@ resource "aws_route53_zone" "test" {
   }
 }
 `, zoneName, tag1Key, tag1Value, tag2Key, tag2Value)
-}
-
-func testAccRoute53ZoneConfigVPCID(zoneName string) string {
-	return fmt.Sprintf(`
-resource "aws_vpc" "test" {
-  cidr_block = "172.29.0.0/24"
-
-  tags = {
-    Name = "terraform-testacc-route53-zone-private"
-  }
-}
-
-resource "aws_route53_zone" "test" {
-  name   = "%s."
-  vpc_id = "${aws_vpc.test.id}"
-}
-`, zoneName)
-}
-
-func testAccRoute53ZoneConfigVPCRegion(zoneName string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  alias  = "west"
-  region = "us-west-2"
-}
-
-provider "aws" {
-  alias  = "east"
-  region = "us-east-1"
-}
-
-resource "aws_vpc" "test" {
-  provider = "aws.east"
-
-  cidr_block = "172.29.0.0/24"
-
-  tags = {
-    Name = "terraform-testacc-route53-zone-private-region"
-  }
-}
-
-resource "aws_route53_zone" "test" {
-  provider = "aws.west"
-
-  name       = "%s."
-  vpc_id     = "${aws_vpc.test.id}"
-  vpc_region = "us-east-1"
-}
-`, zoneName)
 }
 
 func testAccRoute53ZoneConfigVPCSingle(rName, zoneName string) string {

--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -76,12 +76,10 @@ The following arguments are supported:
 
 * `name` - (Required) This is the name of the hosted zone.
 * `comment` - (Optional) A comment for the hosted zone. Defaults to 'Managed by Terraform'.
-* `delegation_set_id` - (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with `vpc` and `vpc_id` as delegation sets can only be used for public zones.
+* `delegation_set_id` - (Optional) The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with `vpc` as delegation sets can only be used for public zones.
 * `force_destroy` - (Optional) Whether to destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone.
 * `tags` - (Optional) A mapping of tags to assign to the zone.
-* `vpc` - (Optional) Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with `delegation_set_id`, `vpc_id`, and `vpc_region` in this resource and any [`aws_route53_zone_association` resource](/docs/providers/aws/r/route53_zone_association.html) specifying the same zone ID. Detailed below.
-* `vpc_id` - (Optional, **DEPRECATED**) Use `vpc` instead. The VPC to associate with a private hosted zone. Specifying `vpc_id` will create a private hosted zone. Conflicts with `delegation_set_id` as delegation sets can only be used for public zones and `vpc`.
-* `vpc_region` - (Optional, **DEPRECATED**) Use `vpc` instead. The VPC's region. Defaults to the region of the AWS provider.
+* `vpc` - (Optional) Configuration block(s) specifying VPC(s) to associate with a private hosted zone. Conflicts with the `delegation_set_id` argument in this resource and any [`aws_route53_zone_association` resource](/docs/providers/aws/r/route53_zone_association.html) specifying the same zone ID. Detailed below.
 
 ### vpc Argument Reference
 
@@ -95,7 +93,6 @@ In addition to all arguments above, the following attributes are exported:
 * `zone_id` - The Hosted Zone ID. This can be referenced by zone records.
 * `name_servers` - A list of name servers in associated (or default) delegation set.
   Find more about delegation sets in [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-reusable-delegation-sets.html).
-
 
 ## Import
 


### PR DESCRIPTION
Closes #7693

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53Zone_basic (46.72s)
--- PASS: TestAccAWSRoute53Zone_Comment (65.30s)
--- PASS: TestAccAWSRoute53Zone_DelegationSetID (53.41s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy (184.65s)
--- PASS: TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod (184.40s)
--- PASS: TestAccAWSRoute53Zone_multiple (61.31s)
--- PASS: TestAccAWSRoute53Zone_Tags (62.64s)
--- PASS: TestAccAWSRoute53Zone_VPC_Multiple (102.63s)
--- PASS: TestAccAWSRoute53Zone_VPC_Single (57.30s)
--- PASS: TestAccAWSRoute53Zone_VPC_Updates (176.68s)
--- PASS: TestAccAWSRoute53ZoneAssociation_basic (97.35s)
--- PASS: TestAccAWSRoute53ZoneAssociation_region (121.29s)
--- PASS: TestAccDataSourceAwsRoute53Zone (79.95s)
```
