### PR TITLE
data-source/aws_iam_role: Remove deprecated attributes

### DIFF
--- a/aws/data_source_aws_iam_role.go
+++ b/aws/data_source_aws_iam_role.go
@@ -20,9 +20,9 @@ func dataSourceAwsIAMRole() *schema.Resource {
 				Computed: true,
 			},
 			"assume_role_policy_document": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Use `assume_role_policy` instead",
+				Type:     schema.TypeString,
+				Computed: true,
+				Removed:  "Use `assume_role_policy` instead",
 			},
 			"assume_role_policy": {
 				Type:     schema.TypeString,
@@ -37,9 +37,9 @@ func dataSourceAwsIAMRole() *schema.Resource {
 				Computed: true,
 			},
 			"role_id": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Use `unique_id` instead",
+				Type:     schema.TypeString,
+				Computed: true,
+				Removed:  "Use `unique_id` instead",
 			},
 			"unique_id": {
 				Type:     schema.TypeString,
@@ -50,13 +50,13 @@ func dataSourceAwsIAMRole() *schema.Resource {
 				Computed: true,
 			},
 			"role_name": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Deprecated: "Use `name` instead",
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `name` instead",
 			},
 			"name": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 			"create_date": {
 				Type:     schema.TypeString,
@@ -72,34 +72,20 @@ func dataSourceAwsIAMRole() *schema.Resource {
 
 func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
-
-	name, hasName := d.GetOk("name")
-	roleName, hasRoleName := d.GetOk("role_name")
-
-	if !hasName && !hasRoleName {
-		return fmt.Errorf("`%s` must be set", "name")
-	}
-
-	var id string
-	if hasName {
-		id = name.(string)
-	} else if hasRoleName {
-		id = roleName.(string)
-	}
-	d.SetId(id)
+	name := d.Get("name").(string)
 
 	input := &iam.GetRoleInput{
-		RoleName: aws.String(d.Id()),
+		RoleName: aws.String(name),
 	}
 
 	output, err := iamconn.GetRole(input)
 	if err != nil {
-		return fmt.Errorf("Error reading IAM Role %s: %s", d.Id(), err)
+		return fmt.Errorf("error reading IAM Role (%s): %s", name, err)
 	}
 
 	d.Set("arn", output.Role.Arn)
 	if err := d.Set("create_date", output.Role.CreateDate.Format(time.RFC3339)); err != nil {
-		return err
+		return fmt.Errorf("error setting create_date: %s", err)
 	}
 	d.Set("description", output.Role.Description)
 	d.Set("max_session_duration", output.Role.MaxSessionDuration)
@@ -113,15 +99,13 @@ func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	assumRolePolicy, err := url.QueryUnescape(aws.StringValue(output.Role.AssumeRolePolicyDocument))
 	if err != nil {
-		return err
+		return fmt.Errorf("error parsing assume role policy document: %s", err)
 	}
 	if err := d.Set("assume_role_policy", assumRolePolicy); err != nil {
-		return err
+		return fmt.Errorf("error setting assume_role_policy: %s", err)
 	}
 
-	// Keep backward compatibility with previous attributes
-	d.Set("role_id", output.Role.RoleId)
-	d.Set("assume_role_policy_document", assumRolePolicy)
+	d.SetId(name)
 
 	return nil
 }

--- a/aws/data_source_aws_iam_role_test.go
+++ b/aws/data_source_aws_iam_role_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -10,7 +9,9 @@ import (
 )
 
 func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
-	roleName := fmt.Sprintf("test-role-%s", acctest.RandString(10))
+	roleName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_iam_role.test"
+	resourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -18,15 +19,15 @@ func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsIAMRoleConfig(roleName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "unique_id"),
-					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "assume_role_policy"),
-					resource.TestCheckResourceAttr("data.aws_iam_role.test", "path", "/testpath/"),
-					resource.TestCheckResourceAttr("data.aws_iam_role.test", "permissions_boundary", ""),
-					resource.TestCheckResourceAttr("data.aws_iam_role.test", "name", roleName),
-					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "create_date"),
-					resource.TestMatchResourceAttr("data.aws_iam_role.test", "arn",
-						regexp.MustCompile(`^arn:[\w-]+:([a-zA-Z0-9\-])+:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12})?:(.*)$`)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "assume_role_policy", resourceName, "assume_role_policy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "create_date", resourceName, "create_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "max_session_duration", resourceName, "max_session_duration"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "path", resourceName, "path"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "unique_id", resourceName, "unique_id"),
 				),
 			},
 		},
@@ -35,8 +36,8 @@ func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
 
 func testAccAwsIAMRoleConfig(roleName string) string {
 	return fmt.Sprintf(`
-resource "aws_iam_role" "test_role" {
-  name = "%s"
+resource "aws_iam_role" "test" {
+  name = %[1]q
 
   assume_role_policy = <<EOF
 {
@@ -58,7 +59,7 @@ EOF
 }
 
 data "aws_iam_role" "test" {
-  name = "${aws_iam_role.test_role.name}"
+  name = "${aws_iam_role.test.name}"
 }
 `, roleName)
 }

--- a/website/docs/d/iam_role.html.markdown
+++ b/website/docs/d/iam_role.html.markdown
@@ -29,6 +29,9 @@ data "aws_iam_role" "example" {
 * `id` - The friendly IAM role name to match.
 * `arn` - The Amazon Resource Name (ARN) specifying the role.
 * `assume_role_policy` - The policy document associated with the role.
+* `create_date` - Creation date of the role in RFC 3339 format.
+* `description` - Description for the role.
+* `max_session_duration` - Maximum session duration.
 * `path` - The path to the role.
 * `permissions_boundary` - The ARN of the policy that is used to set the permissions boundary for the role.
 * `unique_id` - The stable and unique string identifying the role.


### PR DESCRIPTION
Closes #7675

Changes:

* Remove deprecated `assume_role_policy_document` attribute
* Remove deprecated `role_id` attribute
* Remove deprecated `role_name` argument
* Change `name` from optional to required
* Return context for all errors
* Document missing attributes

Output from acceptance testing:

```
--- PASS: TestAccAWSDataSourceIAMRole_basic (10.60s)
```
