### PR TITLE
data-source/aws_region: Remove deprecated current attribute

### DIFF
--- a/aws/data_source_aws_region.go
+++ b/aws/data_source_aws_region.go
@@ -20,10 +20,10 @@ func dataSourceAwsRegion() *schema.Resource {
 			},
 
 			"current": {
-				Type:       schema.TypeBool,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "Defaults to current provider region if no other filtering is enabled",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				Removed:  "Defaults to current provider region if no other filtering is enabled",
 			},
 
 			"endpoint": {
@@ -76,7 +76,6 @@ func dataSourceAwsRegionRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(region.ID())
-	d.Set("current", region.ID() == providerRegion)
 
 	regionEndpointEc2, err := region.ResolveEndpoint(endpoints.Ec2ServiceID)
 	if err != nil {

--- a/aws/data_source_aws_region_test.go
+++ b/aws/data_source_aws_region_test.go
@@ -90,7 +90,6 @@ func TestAccDataSourceAwsRegion_basic(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_empty,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", "ec2.us-east-1.amazonaws.com"),
 					resource.TestCheckResourceAttr(resourceName, "name", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceName, "description", "US East (N. Virginia)"),
@@ -122,7 +121,6 @@ func TestAccDataSourceAwsRegion_endpoint(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_endpoint(endpoint1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
 					resource.TestCheckResourceAttr(resourceName, "description", description1),
@@ -132,7 +130,6 @@ func TestAccDataSourceAwsRegion_endpoint(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_endpoint(endpoint2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "false"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
 					resource.TestCheckResourceAttr(resourceName, "description", description2),
@@ -168,7 +165,6 @@ func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_endpointAndName(endpoint1, name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
 					resource.TestCheckResourceAttr(resourceName, "description", description1),
@@ -178,7 +174,6 @@ func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_endpointAndName(endpoint2, name2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "false"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
 					resource.TestCheckResourceAttr(resourceName, "description", description2),
@@ -188,7 +183,6 @@ func TestAccDataSourceAwsRegion_endpointAndName(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_endpointAndName(endpoint1, name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
 					resource.TestCheckResourceAttr(resourceName, "description", description1),
@@ -228,7 +222,6 @@ func TestAccDataSourceAwsRegion_name(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_name(name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "true"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint1),
 					resource.TestCheckResourceAttr(resourceName, "name", name1),
 					resource.TestCheckResourceAttr(resourceName, "description", description1),
@@ -238,7 +231,6 @@ func TestAccDataSourceAwsRegion_name(t *testing.T) {
 				Config: testAccDataSourceAwsRegionConfig_name(name2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRegionCheck(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "current", "false"),
 					resource.TestCheckResourceAttr(resourceName, "endpoint", endpoint2),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
 					resource.TestCheckResourceAttr(resourceName, "description", description2),

--- a/website/docs/d/region.html.markdown
+++ b/website/docs/d/region.html.markdown
@@ -40,9 +40,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `name` - The name of the selected region.
 
-* `current` - `true` if the selected region is the one configured on the
-  provider, or `false` otherwise.
-
 * `endpoint` - The EC2 endpoint for the selected region.
 
 * `description` - The region's description in this format: "Location (Region name)".


### PR DESCRIPTION
Closes #7676

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsRegion_basic (5.53s)
--- PASS: TestAccDataSourceAwsRegion_name (5.83s)
--- PASS: TestAccDataSourceAwsRegion_endpoint (1.98s)
--- PASS: TestAccDataSourceAwsRegion_endpointAndName (3.04s)
```
