### PR TITLE
resource/aws_api_gateway_integration: Remove deprecated request_parameters_in_json argument

### DIFF
--- a/aws/resource_aws_api_gateway_integration.go
+++ b/aws/resource_aws_api_gateway_integration.go
@@ -1,17 +1,14 @@
 package aws
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -112,17 +109,15 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 			},
 
 			"request_parameters": {
-				Type:          schema.TypeMap,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Optional:      true,
-				ConflictsWith: []string{"request_parameters_in_json"},
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
 			},
 
 			"request_parameters_in_json": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"request_parameters"},
-				Deprecated:    "Use field request_parameters instead",
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `request_parameters` argument instead",
 			},
 
 			"content_handling": {
@@ -199,12 +194,6 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 	if kv, ok := d.GetOk("request_parameters"); ok {
 		for k, v := range kv.(map[string]interface{}) {
 			parameters[k] = v.(string)
-		}
-	}
-
-	if v, ok := d.GetOk("request_parameters_in_json"); ok {
-		if err := json.Unmarshal([]byte(v.(string)), &parameters); err != nil {
-			return fmt.Errorf("Error unmarshaling request_parameters_in_json: %s", err)
 		}
 	}
 
@@ -302,15 +291,9 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 	d.Set("integration_http_method", integration.HttpMethod)
 	d.Set("passthrough_behavior", integration.PassthroughBehavior)
 
-	// KNOWN ISSUE: This next d.Set() is broken as it should be a JSON string of the map,
-	//              however leaving as-is since this attribute has been deprecated
-	//              for a very long time and will be removed soon in the next major release.
-	//              Not worth the effort of fixing, acceptance testing, and potential JSON equivalence bugs.
-	if _, ok := d.GetOk("request_parameters_in_json"); ok {
-		d.Set("request_parameters_in_json", aws.StringValueMap(integration.RequestParameters))
+	if err := d.Set("request_parameters", aws.StringValueMap(integration.RequestParameters)); err != nil {
+		return fmt.Errorf("error setting request_parameters: %s", err)
 	}
-
-	d.Set("request_parameters", aws.StringValueMap(integration.RequestParameters))
 
 	// We need to explicitly convert key = nil values into key = "", which aws.StringValueMap() removes
 	requestTemplateMap := make(map[string]string)
@@ -509,25 +492,19 @@ func resourceAwsApiGatewayIntegrationDelete(d *schema.ResourceData, meta interfa
 	conn := meta.(*AWSClient).apigateway
 	log.Printf("[DEBUG] Deleting API Gateway Integration: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteIntegration(&apigateway.DeleteIntegrationInput{
-			HttpMethod: aws.String(d.Get("http_method").(string)),
-			ResourceId: aws.String(d.Get("resource_id").(string)),
-			RestApiId:  aws.String(d.Get("rest_api_id").(string)),
-		})
-		if err == nil {
-			return nil
-		}
-
-		apigatewayErr, ok := err.(awserr.Error)
-		if apigatewayErr.Code() == "NotFoundException" {
-			return nil
-		}
-
-		if !ok {
-			return resource.NonRetryableError(err)
-		}
-
-		return resource.NonRetryableError(err)
+	_, err := conn.DeleteIntegration(&apigateway.DeleteIntegrationInput{
+		HttpMethod: aws.String(d.Get("http_method").(string)),
+		ResourceId: aws.String(d.Get("resource_id").(string)),
+		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
 	})
+
+	if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting API Gateway Integration (%s): %s", d.Id(), err)
+	}
+
+	return nil
 }

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -223,7 +223,6 @@ The following arguments are supported:
 * `passthrough_behavior` - (Optional) The integration passthrough behavior (`WHEN_NO_MATCH`, `WHEN_NO_TEMPLATES`, `NEVER`).  **Required** if `request_templates` is used.
 * `cache_key_parameters` - (Optional) A list of cache key parameters for the integration.
 * `cache_namespace` - (Optional) The integration's cache namespace.
-* `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
 * `content_handling` - (Optional) Specifies how to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the passthroughBehaviors is configured to support payload pass-through.
 * `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
 


### PR DESCRIPTION
Closes #7678

Changes:

* Remove deprecated `request_parameters_in_json` argument
* Remove extraneous `resource.Retry()` usage during resource deletion
* Return any error from setting `request_parameters` in Terraform state

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayIntegration_cache_key_parameters (13.95s)
--- PASS: TestAccAWSAPIGatewayIntegration_basic (44.82s)
--- PASS: TestAccAWSAPIGatewayIntegration_contentHandling (79.71s)
--- PASS: TestAccAWSAPIGatewayIntegration_integrationType (703.80s)
```
