### PR TITLE
resource/aws_api_gateway_method: Remove deprecated request_parameters_in_json argument

### DIFF
--- a/website/docs/r/api_gateway_method.html.markdown
+++ b/website/docs/r/api_gateway_method.html.markdown
@@ -87,7 +87,6 @@ The following arguments are supported:
 * `request_validator_id` - (Optional) The ID of a `aws_api_gateway_request_validator`
 * `request_parameters` - (Optional) A map of request query string parameters and headers that should be passed to the integration.
   For example: `request_parameters = {"method.request.header.X-Some-Header" = true "method.request.querystring.some-query-param" = true}` would define that the header `X-Some-Header` and the query string `some-query-param` must be provided in the request
-* `request_parameters_in_json` - **Deprecated**, use `request_parameters` instead.
 
 ## Import
 


### PR DESCRIPTION
Closes #7680

Changes:

* Remove deprecated `request_parameters_in_json` argument
* Remove extraneous `resource.Retry()` wrapping in resource deletion

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayMethod_customrequestvalidator (17.26s)
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (53.66s)
--- PASS: TestAccAWSAPIGatewayMethod_cognitoauthorizer (104.21s)
--- PASS: TestAccAWSAPIGatewayMethod_basic (125.96s)
```
