### PR TITLE
resource/aws_api_gateway_method_response: Remove deprecated response_parameters_in_json argument

### DIFF
--- a/website/docs/r/api_gateway_method_response.html.markdown
+++ b/website/docs/r/api_gateway_method_response.html.markdown
@@ -58,7 +58,6 @@ The following arguments are supported:
 * `response_parameters` - (Optional) A map of response parameters that can be sent to the caller.
    For example: `response_parameters = { "method.response.header.X-Some-Header" = true }`
    would define that the header `X-Some-Header` can be provided on the response.
-* `response_parameters_in_json` - **Deprecated**, use `response_parameters` instead.
 
 ## Import
 


### PR DESCRIPTION
Closes #7681

Changes:

* Remove deprecated `response_parameters_in_json` argument
* Remove extraneous `resource.Retry()` usage in resource deletion

Output from acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayMethodResponse_basic (24.21s)
```
