### PR TITLE
resource/aws_autoscaling_policy: Remove deprecated min_adjustment_step argument

### DIFF
--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -72,10 +72,9 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"min_adjustment_step": {
-				Type:          schema.TypeInt,
-				Optional:      true,
-				Deprecated:    "Use min_adjustment_magnitude instead, otherwise you may see a perpetual diff on this resource.",
-				ConflictsWith: []string{"min_adjustment_magnitude"},
+				Type:     schema.TypeInt,
+				Optional: true,
+				Removed:  "Use `min_adjustment_magnitude` argument instead",
 			},
 			"scaling_adjustment": {
 				Type:          schema.TypeInt,
@@ -228,9 +227,6 @@ func resourceAwsAutoscalingPolicyRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("policy_type", p.PolicyType)
 	if p.MinAdjustmentMagnitude != nil {
 		d.Set("min_adjustment_magnitude", p.MinAdjustmentMagnitude)
-		d.Set("min_adjustment_step", 0)
-	} else {
-		d.Set("min_adjustment_step", p.MinAdjustmentStep)
 	}
 	d.Set("arn", p.PolicyARN)
 	d.Set("name", p.PolicyName)
@@ -344,11 +340,8 @@ func getAwsAutoscalingPutScalingPolicyInput(d *schema.ResourceData) (autoscaling
 	}
 
 	// MinAdjustmentMagnitude is supported if the policy type is SimpleScaling or StepScaling.
-	// MinAdjustmentStep is available for backward compatibility. Use MinAdjustmentMagnitude instead.
 	if v, ok := d.GetOkExists("min_adjustment_magnitude"); ok && v.(int) != 0 && (policyType == "SimpleScaling" || policyType == "StepScaling") {
 		params.MinAdjustmentMagnitude = aws.Int64(int64(v.(int)))
-	} else if v, ok := d.GetOkExists("min_adjustment_step"); ok && v.(int) != 0 && (policyType == "SimpleScaling" || policyType == "StepScaling") {
-		params.MinAdjustmentStep = aws.Int64(int64(v.(int)))
 	}
 
 	// This parameter is required if the policy type is SimpleScaling and not supported otherwise.

--- a/aws/resource_aws_autoscaling_policy_test.go
+++ b/aws/resource_aws_autoscaling_policy_test.go
@@ -155,37 +155,6 @@ func testAccCheckScalingPolicyDisappears(conf *autoscaling.ScalingPolicy) resour
 	}
 }
 
-func TestAccAWSAutoscalingPolicy_upgrade(t *testing.T) {
-	var policy autoscaling.ScalingPolicy
-
-	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAutoscalingPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAutoscalingPolicyConfig_upgrade_614(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
-					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_step", "0"),
-					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_magnitude", "1"),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-			{
-				Config: testAccAWSAutoscalingPolicyConfig_upgrade_615(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalingPolicyExists("aws_autoscaling_policy.foobar_simple", &policy),
-					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_step", "0"),
-					resource.TestCheckResourceAttr("aws_autoscaling_policy.foobar_simple", "min_adjustment_magnitude", "1"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment(t *testing.T) {
 	var policy autoscaling.ScalingPolicy
 
@@ -485,34 +454,6 @@ resource "aws_autoscaling_policy" "foobar_target_tracking" {
   }
 }
 `, name, name, name)
-}
-
-func testAccAWSAutoscalingPolicyConfig_upgrade_614(name string) string {
-	return testAccAWSAutoscalingPolicyConfig_base(name) + fmt.Sprintf(`
-resource "aws_autoscaling_policy" "foobar_simple" {
-  name                   = "%s-foobar_simple"
-  adjustment_type        = "PercentChangeInCapacity"
-  cooldown               = 300
-  policy_type            = "SimpleScaling"
-  scaling_adjustment     = 2
-  min_adjustment_step    = 1
-  autoscaling_group_name = "${aws_autoscaling_group.test.name}"
-}
-`, name)
-}
-
-func testAccAWSAutoscalingPolicyConfig_upgrade_615(name string) string {
-	return testAccAWSAutoscalingPolicyConfig_base(name) + fmt.Sprintf(`
-resource "aws_autoscaling_policy" "foobar_simple" {
-  name                     = "%s-foobar_simple"
-  adjustment_type          = "PercentChangeInCapacity"
-  cooldown                 = 300
-  policy_type              = "SimpleScaling"
-  scaling_adjustment       = 2
-  min_adjustment_magnitude = 1
-  autoscaling_group_name   = "${aws_autoscaling_group.test.name}"
-}
-`, name)
 }
 
 func testAccAWSAutoscalingPolicyConfig_SimpleScalingStepAdjustment(name string) string {

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -147,11 +147,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the dimension.
 * `value` - (Required) The value of the dimension.
 
-The following arguments are supported for backwards compatibility but should not be used:
-
-* `min_adjustment_step` - (Optional) Use `min_adjustment_magnitude` instead.
-
 ## Attribute Reference
+
 * `arn` - The ARN assigned by AWS to the scaling policy.
 * `name` - The scaling policy's name.
 * `autoscaling_group_name` - The scaling policy's assigned autoscaling group.


### PR DESCRIPTION
Closes #7683

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoscalingPolicy_SimpleScalingStepAdjustment (41.47s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Predefined (44.11s)
--- PASS: TestAccAWSAutoscalingPolicy_TargetTrack_Custom (49.26s)
--- PASS: TestAccAWSAutoscalingPolicy_zerovalue (78.43s)
--- PASS: TestAccAWSAutoscalingPolicy_disappears (82.36s)
--- PASS: TestAccAWSAutoscalingPolicy_basic (83.38s)
```
