### PR TITLE
resource/aws_batch_compute_environment: Remove deprecated ecc_cluster_arn attribute

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -122,9 +122,9 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 				Computed: true,
 			},
 			"ecc_cluster_arn": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "Use ecs_cluster_arn instead",
+				Type:     schema.TypeString,
+				Computed: true,
+				Removed:  "Use `ecs_cluster_arn` attribute instead",
 			},
 			"ecs_cluster_arn": {
 				Type:     schema.TypeString,
@@ -273,7 +273,6 @@ func resourceAwsBatchComputeEnvironmentRead(d *schema.ResourceData, meta interfa
 	}
 
 	d.Set("arn", computeEnvironment.ComputeEnvironmentArn)
-	d.Set("ecc_cluster_arn", computeEnvironment.EcsClusterArn)
 	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
 	d.Set("status", computeEnvironment.Status)
 	d.Set("status_reason", computeEnvironment.StatusReason)


### PR DESCRIPTION
Closes #7684

Output from acceptance testing:

```
--- PASS: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (19.65s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (20.93s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (32.65s)
--- PASS: TestAccAWSBatchComputeEnvironment_createUnmanaged (41.09s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2 (43.16s)
--- PASS: TestAccAWSBatchComputeEnvironment_createEc2WithTags (47.57s)
--- PASS: TestAccAWSBatchComputeEnvironment_createSpot (49.41s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (62.80s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateState (65.42s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (80.69s)
--- PASS: TestAccAWSBatchComputeEnvironment_updateInstanceType (87.94s)
```
