### PR TITLE
resource/aws_dx_lag: Remove deprecated number_of_connections argument and delete unmanaged connection during resource creation

### DIFF
--- a/aws/resource_aws_dx_lag.go
+++ b/aws/resource_aws_dx_lag.go
@@ -47,8 +47,7 @@ func resourceAwsDxLag() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				Deprecated: "Use aws_dx_connection and aws_dx_connection_association resources instead. " +
-					"Default connections will be removed as part of LAG creation automatically in future versions.",
+				Removed:  "Use `aws_dx_connection` and `aws_dx_connection_association` resources instead",
 			},
 			"force_destroy": {
 				Type:     schema.TypeBool,
@@ -63,30 +62,32 @@ func resourceAwsDxLag() *schema.Resource {
 func resourceAwsDxLagCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
 
-	var noOfConnections int
-	if v, ok := d.GetOk("number_of_connections"); ok {
-		noOfConnections = v.(int)
-	} else {
-		noOfConnections = 1
-	}
-
 	req := &directconnect.CreateLagInput{
 		ConnectionsBandwidth: aws.String(d.Get("connections_bandwidth").(string)),
 		LagName:              aws.String(d.Get("name").(string)),
 		Location:             aws.String(d.Get("location").(string)),
-		NumberOfConnections:  aws.Int64(int64(noOfConnections)),
+		NumberOfConnections:  aws.Int64(int64(1)),
 	}
 
 	log.Printf("[DEBUG] Creating Direct Connect LAG: %#v", req)
 	resp, err := conn.CreateLag(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Direct Connect LAG: %s", err)
 	}
 
-	// TODO: Remove default connection(s) automatically provisioned by AWS
-	// per NumberOfConnections
-
 	d.SetId(aws.StringValue(resp.LagId))
+
+	// Delete unmanaged connection
+	connectionID := aws.StringValue(resp.Connections[0].ConnectionId)
+	deleteConnectionInput := &directconnect.DeleteConnectionInput{
+		ConnectionId: resp.Connections[0].ConnectionId,
+	}
+
+	log.Printf("[DEBUG] Deleting newly created and unmanaged Direct Connect LAG (%s) Connection: %s", d.Id(), connectionID)
+	if _, err := conn.DeleteConnection(deleteConnectionInput); err != nil {
+		return fmt.Errorf("error deleting newly created and unmanaged Direct Connect LAG (%s) Connection (%s): %s", d.Id(), connectionID, err)
+	}
+
 	return resourceAwsDxLagUpdate(d, meta)
 }
 

--- a/website/docs/r/dx_connection_association.html.markdown
+++ b/website/docs/r/dx_connection_association.html.markdown
@@ -23,7 +23,6 @@ resource "aws_dx_lag" "example" {
   name                  = "example"
   connections_bandwidth = "1Gbps"
   location              = "EqSe2"
-  number_of_connections = 1
 }
 
 resource "aws_dx_connection_association" "example" {

--- a/website/docs/r/dx_lag.html.markdown
+++ b/website/docs/r/dx_lag.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # aws_dx_lag
 
-Provides a Direct Connect LAG.
+Provides a Direct Connect LAG. Connections can be added to the LAG via the [`aws_dx_connection`](/docs/providers/aws/r/dx_connection.html) and [`aws_dx_connection_association`](/docs/providers/aws/r/dx_connection_association.html) resources.
+
+~> *NOTE:* When creating a LAG, Direct Connect requires creating a Connection. Terraform will remove this unmanaged connection during resource creation.
 
 ## Example Usage
 
@@ -17,7 +19,6 @@ resource "aws_dx_lag" "hoge" {
   name                  = "tf-dx-lag"
   connections_bandwidth = "1Gbps"
   location              = "EqDC2"
-  number_of_connections = 2
   force_destroy         = true
 }
 ```
@@ -29,7 +30,6 @@ The following arguments are supported:
 * `name` - (Required) The name of the LAG.
 * `connections_bandwidth` - (Required) The bandwidth of the individual physical connections bundled by the LAG. Available values: 1Gbps, 10Gbps. Case sensitive.
 * `location` - (Required) The AWS Direct Connect location in which the LAG should be allocated. See [DescribeLocations](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_DescribeLocations.html) for the list of AWS Direct Connect locations. Use `locationCode`.
-* `number_of_connections` - (**Deprecated**) The number of physical connections initially provisioned and bundled by the LAG. Use `aws_dx_connection` and `aws_dx_connection_association` resources instead. Default connections will be removed as part of LAG creation automatically in future versions.
 * `force_destroy` - (Optional, Default:false) A boolean that indicates all connections associated with the LAG should be deleted so that the LAG can be destroyed without error. These objects are *not* recoverable.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Closes #7686

Output from acceptance testing:

```
--- PASS: TestAccAWSDxLag_importBasic (24.02s)
--- PASS: TestAccAWSDxLag_basic (28.45s)
--- PASS: TestAccAWSDxLag_tags (35.60s)
```
