### PR TITLE
resource/aws_ecs_service: Remove deprecated placement_strategy configuration block

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -208,12 +208,11 @@ func resourceAwsEcsService() *schema.Resource {
 				},
 			},
 			"placement_strategy": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				ForceNew:      true,
-				MaxItems:      5,
-				ConflictsWith: []string{"ordered_placement_strategy"},
-				Deprecated:    "Use `ordered_placement_strategy` instead",
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 5,
+				Removed:  "Use `ordered_placement_strategy` configuration block(s) instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -247,11 +246,10 @@ func resourceAwsEcsService() *schema.Resource {
 				},
 			},
 			"ordered_placement_strategy": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				ForceNew:      true,
-				MaxItems:      5,
-				ConflictsWith: []string{"placement_strategy"},
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 5,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -430,12 +428,6 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("ordered_placement_strategy"); ok {
 		ps, err := expandPlacementStrategy(v.([]interface{}))
-		if err != nil {
-			return err
-		}
-		input.PlacementStrategy = ps
-	} else {
-		ps, err := expandPlacementStrategyDeprecated(d.Get("placement_strategy").(*schema.Set))
 		if err != nil {
 			return err
 		}
@@ -630,15 +622,10 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("load_balancer", flattenEcsLoadBalancers(service.LoadBalancers))
 	}
 
-	if _, ok := d.GetOk("placement_strategy"); ok {
-		if err := d.Set("placement_strategy", flattenPlacementStrategyDeprecated(service.PlacementStrategy)); err != nil {
-			return fmt.Errorf("error setting placement_strategy: %s", err)
-		}
-	} else {
-		if err := d.Set("ordered_placement_strategy", flattenPlacementStrategy(service.PlacementStrategy)); err != nil {
-			return fmt.Errorf("error setting ordered_placement_strategy: %s", err)
-		}
+	if err := d.Set("ordered_placement_strategy", flattenPlacementStrategy(service.PlacementStrategy)); err != nil {
+		return fmt.Errorf("error setting ordered_placement_strategy: %s", err)
 	}
+
 	if err := d.Set("placement_constraints", flattenServicePlacementConstraints(service.PlacementConstraints)); err != nil {
 		log.Printf("[ERR] Error setting placement_constraints for (%s): %s", d.Id(), err)
 	}
@@ -739,59 +726,12 @@ func flattenServicePlacementConstraints(pcs []*ecs.PlacementConstraint) []map[st
 	return results
 }
 
-func flattenPlacementStrategyDeprecated(pss []*ecs.PlacementStrategy) []map[string]interface{} {
-	if len(pss) == 0 {
-		return nil
-	}
-	results := make([]map[string]interface{}, 0)
-	for _, ps := range pss {
-		c := make(map[string]interface{})
-		c["type"] = *ps.Type
-
-		if ps.Field != nil {
-			c["field"] = *ps.Field
-
-			// for some fields the API requires lowercase for creation but will return uppercase on query
-			if *ps.Field == "MEMORY" || *ps.Field == "CPU" {
-				c["field"] = strings.ToLower(*ps.Field)
-			}
-		}
-
-		results = append(results, c)
-	}
-	return results
-}
-
 func expandPlacementStrategy(s []interface{}) ([]*ecs.PlacementStrategy, error) {
 	if len(s) == 0 {
 		return nil, nil
 	}
 	pss := make([]*ecs.PlacementStrategy, 0)
 	for _, raw := range s {
-		p := raw.(map[string]interface{})
-		t := p["type"].(string)
-		f := p["field"].(string)
-		if err := validateAwsEcsPlacementStrategy(t, f); err != nil {
-			return nil, err
-		}
-		ps := &ecs.PlacementStrategy{
-			Type: aws.String(t),
-		}
-		if f != "" {
-			// Field must be omitted (i.e. not empty string) for random strategy
-			ps.Field = aws.String(f)
-		}
-		pss = append(pss, ps)
-	}
-	return pss, nil
-}
-
-func expandPlacementStrategyDeprecated(s *schema.Set) ([]*ecs.PlacementStrategy, error) {
-	if len(s.List()) == 0 {
-		return nil, nil
-	}
-	pss := make([]*ecs.PlacementStrategy, 0)
-	for _, raw := range s.List() {
 		p := raw.(map[string]interface{})
 		t := p["type"].(string)
 		f := p["field"].(string)

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -1191,7 +1191,7 @@ resource "aws_ecs_service" "mongo" {
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 1
-  placement_strategy {
+  ordered_placement_strategy {
     field = "host"
     type = "spread"
   }

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -89,7 +89,6 @@ The following arguments are supported:
 * `deployment_minimum_healthy_percent` - (Optional) The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
 * `enable_ecs_managed_tags` - (Optional) Specifies whether to enable Amazon ECS managed tags for the tasks within the service.
 * `propagate_tags` - (Optional) Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`.
-* `placement_strategy` - (Optional) **Deprecated**, use `ordered_placement_strategy` instead.
 * `ordered_placement_strategy` - (Optional) Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy` blocks is `5`. Defined below.
 * `health_check_grace_period_seconds` - (Optional) Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers.
 * `load_balancer` - (Optional) A load balancer block. Load balancers documented below.


### PR DESCRIPTION
Closes #7687

Output from acceptance testing:

```
--- PASS: TestAccAWSEcsService_basicImport (41.70s)
--- PASS: TestAccAWSEcsService_disappears (19.59s)
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (280.20s)
--- PASS: TestAccAWSEcsService_ManagedTags (40.17s)
--- PASS: TestAccAWSEcsService_PropagateTags (51.77s)
--- PASS: TestAccAWSEcsService_Tags (52.20s)
--- PASS: TestAccAWSEcsService_withAlb (230.24s)
--- PASS: TestAccAWSEcsService_withARN (45.47s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategy (39.76s)
--- PASS: TestAccAWSEcsService_withDaemonSchedulingStrategySetDeploymentMinimum (11.07s)
--- PASS: TestAccAWSEcsService_withDeploymentController_Type_CodeDeploy (251.33s)
--- PASS: TestAccAWSEcsService_withDeploymentMinimumZeroMaximumOneHundred (21.32s)
--- PASS: TestAccAWSEcsService_withDeploymentValues (14.64s)
--- PASS: TestAccAWSEcsService_withEcsClusterName (39.81s)
--- PASS: TestAccAWSEcsService_withFamilyAndRevision (34.30s)
--- PASS: TestAccAWSEcsService_withIamRole (157.58s)
--- PASS: TestAccAWSEcsService_withLaunchTypeEC2AndNetworkConfiguration (60.52s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargate (105.95s)
--- PASS: TestAccAWSEcsService_withLaunchTypeFargateAndPlatformVersion (116.83s)
--- PASS: TestAccAWSEcsService_withLbChanges (241.52s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints (18.51s)
--- PASS: TestAccAWSEcsService_withPlacementConstraints_emptyExpression (37.03s)
--- PASS: TestAccAWSEcsService_withPlacementStrategy (79.48s)
--- PASS: TestAccAWSEcsService_withRenamedCluster (60.43s)
--- PASS: TestAccAWSEcsService_withReplicaSchedulingStrategy (17.00s)
--- PASS: TestAccAWSEcsService_withServiceRegistries (138.96s)
--- PASS: TestAccAWSEcsService_withServiceRegistries_container (139.06s)
--- PASS: TestAccAWSEcsService_withUnnormalizedPlacementStrategy (21.10s)
```
