### PR TITLE
resource/aws_elasticache_cluster: Remove deprecated availability_zones argument

### DIFF
--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -41,13 +41,12 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				ForceNew: true,
 			},
 			"availability_zones": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				ForceNew:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Set:           schema.HashString,
-				ConflictsWith: []string{"preferred_availability_zones"},
-				Deprecated:    "Use `preferred_availability_zones` instead",
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				Removed:  "Use `preferred_availability_zones` argument instead",
 			},
 			"az_mode": {
 				Type:     schema.TypeString,
@@ -165,7 +164,6 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				ConflictsWith: []string{
-					"availability_zones",
 					"az_mode",
 					"engine_version",
 					"engine",
@@ -387,12 +385,6 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("preferred_availability_zones"); ok && len(v.([]interface{})) > 0 {
 		req.PreferredAvailabilityZones = expandStringList(v.([]interface{}))
-	} else {
-		preferred_azs := d.Get("availability_zones").(*schema.Set).List()
-		if len(preferred_azs) > 0 {
-			azs := expandStringList(preferred_azs)
-			req.PreferredAvailabilityZones = azs
-		}
 	}
 
 	id, err := createElasticacheCacheCluster(conn, req)

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -637,10 +637,6 @@ func TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes(t *testin
 		CheckDestroy: testAccCheckAWSElasticacheClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSElasticacheClusterConfig_ReplicationGroupID_InvalidAttribute(rName, "availability_zones", "${list(\"us-east-1a\", \"us-east-1c\")}"),
-				ExpectError: regexp.MustCompile(`"replication_group_id": conflicts with availability_zones`),
-			},
-			{
 				Config:      testAccAWSElasticacheClusterConfig_ReplicationGroupID_InvalidAttribute(rName, "az_mode", "single-az"),
 				ExpectError: regexp.MustCompile(`"replication_group_id": conflicts with az_mode`),
 			},

--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -130,8 +130,6 @@ SNS topic to send ElastiCache notifications to. Example:
 
 * `availability_zone` - (Optional) The Availability Zone for the cache cluster. If you want to create cache nodes in multi-az, use `preferred_availability_zones` instead. Default: System chosen Availability Zone.
 
-* `availability_zones` - (*DEPRECATED*, Optional, Memcached only) Use `preferred_availability_zones` instead unless you want to create cache nodes in single-az, then use `availability_zone`. Set of Availability Zones in which the cache nodes will be created.
-
 * `preferred_availability_zones` - (Optional, Memcached only) A list of the Availability Zones in which cache nodes are created. If you are creating your cluster in an Amazon VPC you can only locate nodes in Availability Zones that are associated with the subnets in the selected subnet group. The number of Availability Zones listed must equal the value of `num_cache_nodes`. If you want all the nodes in the same Availability Zone, use `availability_zone` instead, or repeat the Availability Zone multiple times in the list. Default: System chosen Availability Zones. Detecting drift of existing node availability zone is not currently supported. Updating this argument by itself to migrate existing node availability zones is not currently supported and will show a perpetual difference.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource


### PR DESCRIPTION
Closes #7689

Output from acceptance testing:

```
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic (461.78s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic (714.33s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic (572.93s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1220.84s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1467.78s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (743.94s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (924.84s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (991.05s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (789.71s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (983.93s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (984.32s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic (2.75s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (575.89s)
--- PASS: TestAccAWSElasticacheCluster_Port_Ec2Classic (572.71s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic (1174.26s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (2.46s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic (1235.85s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic (1133.99s)
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (547.40s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1342.77s)
--- PASS: TestAccAWSElasticacheCluster_vpc (633.71s)
```
