### PR TITLE
resource/aws_instance: Remove deprecated top-level network_interface_id attribute

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -187,7 +187,7 @@ func resourceAwsInstance() *schema.Resource {
 			"network_interface_id": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Removed:  "Use `primary_network_interface_id` instead",
+				Removed:  "Use `primary_network_interface_id` attribute instead",
 			},
 
 			"primary_network_interface_id": {

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -263,7 +263,6 @@ In addition to all arguments above, the following attributes are exported:
   is only available if you've enabled DNS hostnames for your VPC
 * `public_ip` - The public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
 * `ipv6_addresses` - A list of assigned IPv6 addresses, if any
-* `network_interface_id` - The ID of the network interface that was created with the instance.
 * `primary_network_interface_id` - The ID of the instance's primary network interface.
 * `private_dns` - The private DNS name assigned to the instance. Can only be
   used inside the Amazon EC2, and only available if you've enabled DNS hostnames


### PR DESCRIPTION
Closes #7690

Output from acceptance testing:

```
--- PASS: TestAccAWSInstance_addSecondaryInterface (152.51s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (274.60s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (130.37s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (100.05s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (99.71s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (89.49s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (292.12s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (211.33s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (110.19s)
--- PASS: TestAccAWSInstance_basic (240.03s)
--- PASS: TestAccAWSInstance_blockDevices (178.54s)
--- PASS: TestAccAWSInstance_changeInstanceType (332.95s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (99.32s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (104.14s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (359.61s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (216.48s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (367.30s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (69.62s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (233.43s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (307.11s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (308.10s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (302.92s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (92.53s)
--- PASS: TestAccAWSInstance_disableApiTermination (151.40s)
--- PASS: TestAccAWSInstance_disappears (198.32s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (307.42s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (183.41s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (150.51s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (178.25s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (65.03s)
--- PASS: TestAccAWSInstance_importBasic (203.19s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgId (244.09s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgName (115.92s)
--- PASS: TestAccAWSInstance_importInEc2Classic (96.90s)
--- PASS: TestAccAWSInstance_instanceProfileChange (130.56s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (245.32s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (229.85s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.22s)
--- PASS: TestAccAWSInstance_keyPairCheck (184.07s)
--- PASS: TestAccAWSInstance_multipleRegions (239.75s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (70.36s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (84.93s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (69.24s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (171.04s)
--- PASS: TestAccAWSInstance_placementGroup (65.25s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (90.76s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (81.20s)
--- PASS: TestAccAWSInstance_privateIP (89.23s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (170.91s)
--- PASS: TestAccAWSInstance_rootInstanceStore (80.55s)
--- PASS: TestAccAWSInstance_sourceDestCheck (145.37s)
--- PASS: TestAccAWSInstance_tags (108.46s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (114.24s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (115.30s)
--- PASS: TestAccAWSInstance_userDataBase64 (234.15s)
--- PASS: TestAccAWSInstance_volumeTags (97.80s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (109.57s)
--- PASS: TestAccAWSInstance_vpc (233.67s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (119.20s)
```
