### PR TITLE
resource/aws_network_acl: Remove deprecated subnet_id argument

### DIFF
--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -36,20 +36,18 @@ func resourceAwsNetworkAcl() *schema.Resource {
 				Computed: false,
 			},
 			"subnet_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Computed:      false,
-				ConflictsWith: []string{"subnet_ids"},
-				Deprecated:    "Attribute subnet_id is deprecated on network_acl resources. Use subnet_ids instead",
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: false,
+				Removed:  "Use `subnet_ids` argument instead",
 			},
 			"subnet_ids": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"subnet_id"},
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				Set:           schema.HashString,
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 			"ingress": {
 				Type:     schema.TypeSet,
@@ -266,23 +264,6 @@ func resourceAwsNetworkAclUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if d.HasChange("subnet_id") {
-		//associate new subnet with the acl.
-		_, n := d.GetChange("subnet_id")
-		newSubnet := n.(string)
-		association, err := findNetworkAclAssociation(newSubnet, conn)
-		if err != nil {
-			return fmt.Errorf("Failed to update acl %s with subnet %s: %s", d.Id(), newSubnet, err)
-		}
-		_, err = conn.ReplaceNetworkAclAssociation(&ec2.ReplaceNetworkAclAssociationInput{
-			AssociationId: association.NetworkAclAssociationId,
-			NetworkAclId:  aws.String(d.Id()),
-		})
-		if err != nil {
-			return err
-		}
-	}
-
 	if d.HasChange("subnet_ids") {
 		o, n := d.GetChange("subnet_ids")
 		if o == nil {
@@ -471,14 +452,7 @@ func resourceAwsNetworkAclDelete(d *schema.ResourceData, meta interface{}) error
 				// In case of dependency violation, we remove the association between subnet and network acl.
 				// This means the subnet is attached to default acl of vpc.
 				var associations []*ec2.NetworkAclAssociation
-				if v, ok := d.GetOk("subnet_id"); ok {
-
-					a, err := findNetworkAclAssociation(v.(string), conn)
-					if err != nil {
-						return resource.NonRetryableError(err)
-					}
-					associations = append(associations, a)
-				} else if v, ok := d.GetOk("subnet_ids"); ok {
+				if v, ok := d.GetOk("subnet_ids"); ok {
 					ids := v.(*schema.Set).List()
 					for _, i := range ids {
 						a, err := findNetworkAclAssociation(i.(string), conn)

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -53,8 +53,6 @@ The following arguments are supported:
 
 * `vpc_id` - (Required) The ID of the associated VPC.
 * `subnet_ids` - (Optional) A list of Subnet IDs to apply the ACL to
-* `subnet_id` - (Optional, Deprecated) The ID of the associated Subnet. This
-attribute is deprecated, please use the `subnet_ids` attribute instead
 * `ingress` - (Optional) Specifies an ingress rule. Parameters defined below.
 * `egress` - (Optional) Specifies an egress rule. Parameters defined below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
Closes #7691

Output from acceptance testing:

```
--- PASS: TestAccAWSNetworkAcl_CaseSensitivityNoChanges (33.81s)
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (27.16s)
--- PASS: TestAccAWSNetworkAcl_espProtocol (24.53s)
--- PASS: TestAccAWSNetworkAcl_importBasic (28.49s)
--- PASS: TestAccAWSNetworkAcl_ipv6ICMPRules (24.71s)
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (33.13s)
--- PASS: TestAccAWSNetworkAcl_ipv6VpcRules (25.34s)
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (27.24s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (33.85s)
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (47.15s)
--- PASS: TestAccAWSNetworkAcl_SubnetChange (47.51s)
--- PASS: TestAccAWSNetworkAcl_Subnets (55.61s)
```
