### PR TITLE
resource/aws_redshift_cluster: Remove deprecated arguments and properly read logging into Terraform state

### DIFF
--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -33,6 +33,14 @@ func suppressEquivalentTypeStringBoolean(k, old, new string, d *schema.ResourceD
 	return false
 }
 
+// suppressMissingOptionalConfigurationBlock handles configuration block attributes in the following scenario:
+//  * The resource schema includes an optional configuration block with defaults
+//  * The API response includes those defaults to refresh into the Terraform state
+//  * The operator's configuration omits the optional configuration block
+func suppressMissingOptionalConfigurationBlock(k, old, new string, d *schema.ResourceData) bool {
+	return old == "1" && new == "0"
+}
+
 // Suppresses minor version changes to the db_instance engine_version attribute
 func suppressAwsDbEngineVersionDiffs(k, old, new string, d *schema.ResourceData) bool {
 	// First check if the old/new values are nil.

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -241,12 +241,10 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			},
 
 			"logging": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return old == "1" && new == "0"
-				},
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enable": {

--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -244,6 +244,9 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "1" && new == "0"
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enable": {
@@ -267,27 +270,24 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			},
 
 			"enable_logging": {
-				Type:          schema.TypeBool,
-				Optional:      true,
-				Computed:      true,
-				Deprecated:    "Use enable in the 'logging' block instead",
-				ConflictsWith: []string{"logging"},
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				Removed:  "Use `logging` configuration block `enable` argument instead",
 			},
 
 			"bucket_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				Deprecated:    "Use bucket_name in the 'logging' block instead",
-				ConflictsWith: []string{"logging"},
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Removed:  "Use `logging` configuration block `bucket_name` argument instead",
 			},
 
 			"s3_key_prefix": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				Deprecated:    "Use s3_key_prefix in the 'logging' block instead",
-				ConflictsWith: []string{"logging"},
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Removed:  "Use `logging` configuration block `s3_key_prefix` argument instead",
 			},
 
 			"snapshot_identifier": {
@@ -499,13 +499,9 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	logging, ok := d.GetOk("logging.0.enable")
-	_, deprecatedOk := d.GetOk("enable_logging")
-	if (ok && logging.(bool)) || deprecatedOk {
-		loggingErr := enableRedshiftClusterLogging(d, conn)
-		if loggingErr != nil {
-			log.Printf("[ERROR] Error Enabling Logging on Redshift Cluster: %s", err)
-			return loggingErr
+	if logging, ok := d.GetOk("logging.0.enable"); ok && logging.(bool) {
+		if err := enableRedshiftClusterLogging(d, conn); err != nil {
+			return fmt.Errorf("error enabling Redshift Cluster (%s) logging: %s", d.Id(), err)
 		}
 	}
 
@@ -614,12 +610,9 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("snapshot_copy", flattenRedshiftSnapshotCopy(rsc.ClusterSnapshotCopyStatus))
 
-	// TODO: Deprecated fields - remove in next major version
-	d.Set("bucket_name", loggingStatus.BucketName)
-	d.Set("enable_logging", loggingStatus.LoggingEnabled)
-	d.Set("s3_key_prefix", loggingStatus.S3KeyPrefix)
-
-	d.Set("logging", flattenRedshiftLogging(loggingStatus))
+	if err := d.Set("logging", flattenRedshiftLogging(loggingStatus)); err != nil {
+		return fmt.Errorf("error setting logging: %s", err)
+	}
 
 	return nil
 }
@@ -811,22 +804,6 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 				return err
 			}
 		}
-	} else if d.HasChange("enable_logging") || d.HasChange("bucket_name") || d.HasChange("s3_key_prefix") {
-		if enableLogging, ok := d.GetOk("enable_logging"); ok && enableLogging.(bool) {
-			log.Printf("[INFO] Enabling Logging for Redshift Cluster %q", d.Id())
-			err := enableRedshiftClusterLogging(d, conn)
-			if err != nil {
-				return err
-			}
-		} else {
-			log.Printf("[INFO] Disabling Logging for Redshift Cluster %q", d.Id())
-			_, err := conn.DisableLogging(&redshift.DisableLoggingInput{
-				ClusterIdentifier: aws.String(d.Id()),
-			})
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	d.Partial(false)
@@ -835,36 +812,23 @@ func resourceAwsRedshiftClusterUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func enableRedshiftClusterLogging(d *schema.ResourceData, conn *redshift.Redshift) error {
-	var bucketName, v interface{}
-	var deprecatedOk, ok bool
-	bucketName, deprecatedOk = d.GetOk("bucket_name")
-	v, ok = d.GetOk("logging.0.bucket_name")
-	if ok {
-		bucketName = v
-	}
-	if !ok && !deprecatedOk {
+	bucketNameRaw, ok := d.GetOk("logging.0.bucket_name")
+
+	if !ok {
 		return fmt.Errorf("bucket_name must be set when enabling logging for Redshift Clusters")
 	}
 
 	params := &redshift.EnableLoggingInput{
 		ClusterIdentifier: aws.String(d.Id()),
-		BucketName:        aws.String(bucketName.(string)),
+		BucketName:        aws.String(bucketNameRaw.(string)),
 	}
 
-	var s3KeyPrefix interface{}
-	s3KeyPrefix, deprecatedOk = d.GetOk("s3_key_prefix")
-	v, ok = d.GetOk("logging.0.s3_key_prefix")
-	if ok {
-		s3KeyPrefix = v
-	}
-	if ok || deprecatedOk {
-		params.S3KeyPrefix = aws.String(s3KeyPrefix.(string))
+	if v, ok := d.GetOk("logging.0.s3_key_prefix"); ok {
+		params.S3KeyPrefix = aws.String(v.(string))
 	}
 
-	_, loggingErr := conn.EnableLogging(params)
-	if loggingErr != nil {
-		log.Printf("[ERROR] Error Enabling Logging on Redshift Cluster: %s", loggingErr)
-		return loggingErr
+	if _, err := conn.EnableLogging(params); err != nil {
+		return fmt.Errorf("error enabling Redshift Cluster (%s) logging: %s", d.Id(), err)
 	}
 	return nil
 }

--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -223,38 +223,6 @@ func TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled(t *testing.T) {
 	})
 }
 
-func TestAccAWSRedshiftCluster_loggingEnabledDeprecated(t *testing.T) {
-	var v redshift.Cluster
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSRedshiftClusterConfig_loggingEnabledDeprecated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "enable_logging", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "bucket_name", fmt.Sprintf("tf-redshift-logging-%d", rInt)),
-				),
-			},
-
-			{
-				Config: testAccAWSRedshiftClusterConfig_loggingDisabledDeprecated(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
-					resource.TestCheckResourceAttr(
-						"aws_redshift_cluster.default", "enable_logging", "false"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSRedshiftCluster_loggingEnabled(t *testing.T) {
 	var v redshift.Cluster
 	rInt := acctest.RandInt()
@@ -1119,72 +1087,6 @@ resource "aws_redshift_cluster" "default" {
   skip_final_snapshot = true
 }
 `, rInt)
-}
-
-func testAccAWSRedshiftClusterConfig_loggingDisabledDeprecated(rInt int) string {
-	return fmt.Sprintf(`
-	resource "aws_redshift_cluster" "default" {
-		cluster_identifier = "tf-redshift-cluster-%d"
-		availability_zone = "us-west-2a"
-		database_name = "mydb"
-		master_username = "foo_test"
-		master_password = "Mustbe8characters"
-		node_type = "dc1.large"
-		automated_snapshot_retention_period = 0
-		allow_version_upgrade = false
-		enable_logging = false
-		skip_final_snapshot = true
-	}`, rInt)
-}
-
-func testAccAWSRedshiftClusterConfig_loggingEnabledDeprecated(rInt int) string {
-	return fmt.Sprintf(`
-data "aws_redshift_service_account" "main" {}
-
- resource "aws_s3_bucket" "bucket" {
-	 bucket = "tf-redshift-logging-%d"
-	 force_destroy = true
-	 policy = <<EOF
-{
- "Version": "2008-10-17",
- "Statement": [
-	 {
-		 "Sid": "Stmt1376526643067",
-		 "Effect": "Allow",
-		 "Principal": {
-			 "AWS": "${data.aws_redshift_service_account.main.arn}"
-		 },
-		 "Action": "s3:PutObject",
-		 "Resource": "arn:aws:s3:::tf-redshift-logging-%d/*"
-	 },
-	 {
-		 "Sid": "Stmt137652664067",
-		 "Effect": "Allow",
-		 "Principal": {
-			 "AWS": "${data.aws_redshift_service_account.main.arn}"
-		 },
-		 "Action": "s3:GetBucketAcl",
-		 "Resource": "arn:aws:s3:::tf-redshift-logging-%d"
-	 }
- ]
-}
-EOF
- }
-
-
- resource "aws_redshift_cluster" "default" {
-	 cluster_identifier = "tf-redshift-cluster-%d"
-	 availability_zone = "us-west-2a"
-	 database_name = "mydb"
-	 master_username = "foo_test"
-	 master_password = "Mustbe8characters"
-	 node_type = "dc1.large"
-	 automated_snapshot_retention_period = 0
-	 allow_version_upgrade = false
-	 enable_logging = true
-	 bucket_name = "${aws_s3_bucket.bucket.bucket}"
-	 skip_final_snapshot = true
- }`, rInt, rInt, rInt, rInt)
 }
 
 func testAccAWSRedshiftClusterConfig_loggingDisabled(rInt int) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -3916,7 +3916,7 @@ func flattenRedshiftLogging(ls *redshift.LoggingStatus) []interface{} {
 	}
 
 	cfg := make(map[string]interface{})
-	cfg["enabled"] = *ls.LoggingEnabled
+	cfg["enable"] = aws.BoolValue(ls.LoggingEnabled)
 	if ls.BucketName != nil {
 		cfg["bucket_name"] = *ls.BucketName
 	}

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -78,7 +78,7 @@ string.
 #### `logging`
 
 * `enable` - (Required) Enables logging information such as queries and connection attempts, for the specified Amazon Redshift cluster.
-* `bucket_name` - (Optional, required when `enable_logging` is `true`) The name of an existing S3 bucket where the log files are to be stored. Must be in the same region as the cluster and the cluster must have read bucket and put object permissions.
+* `bucket_name` - (Optional, required when `enable` is `true`) The name of an existing S3 bucket where the log files are to be stored. Must be in the same region as the cluster and the cluster must have read bucket and put object permissions.
 For more information on the permissions required for the bucket, please read the AWS [documentation](http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging)
 * `s3_key_prefix` - (Optional) The prefix applied to the log file names.
 


### PR DESCRIPTION
Closes #7692

Output from acceptance testing:

```
--- PASS: TestAccAWSRedshiftCluster_tags (595.02s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (611.53s)
--- PASS: TestAccAWSRedshiftCluster_importBasic (615.23s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (618.40s)
--- PASS: TestAccAWSRedshiftCluster_basic (639.65s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (655.96s)
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (662.38s)
--- PASS: TestAccAWSRedshiftCluster_iamRoles (777.06s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (833.19s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (936.89s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (1223.07s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (1282.65s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (2297.59s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (2431.63s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (2439.15s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (2648.48s)
```
