### PR TITLE
resource/aws_wafregional_byte_match_set: Remove deprecated byte_match_tuple configuration block

### DIFF
--- a/aws/resource_aws_wafregional_rate_based_rule_test.go
+++ b/aws/resource_aws_wafregional_rate_based_rule_test.go
@@ -399,7 +399,7 @@ resource "aws_wafregional_ipset" "ipset" {
 
 resource "aws_wafregional_byte_match_set" "set" {
   name = "%s"
-  byte_match_tuple {
+  byte_match_tuples {
     text_transformation   = "NONE"
     target_string         = "badrefer1"
     positional_constraint = "CONTAINS"

--- a/website/docs/r/wafregional_byte_match_set.html.markdown
+++ b/website/docs/r/wafregional_byte_match_set.html.markdown
@@ -34,7 +34,6 @@ resource "aws_wafregional_byte_match_set" "byte_set" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the ByteMatchSet.
-* `byte_match_tuple` - **Deprecated**, use `byte_match_tuples` instead.
 * `byte_match_tuples` - (Optional)Settings for the ByteMatchSet, such as the bytes (typically a string that corresponds with ASCII characters) that you want AWS WAF to search for in web requests. ByteMatchTuple documented below.
 
 


### PR DESCRIPTION
Closes #7694

Output from acceptance testing:

```
--- PASS: TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples (16.84s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_disappears (21.55s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_basic (24.30s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples (29.25s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeNameForceNew (34.32s)
```
