### PR TITLE
Convert text/template Usage to fmt.Sprintf()

### DIFF
--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -1,12 +1,10 @@
 package aws
 
 import (
-	"bytes"
 	"fmt"
 	"reflect"
 	"regexp"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -312,129 +310,115 @@ func testAccAWSBudgetsBudgetConfigDefaults(name string) budgets.Budget {
 }
 
 func testAccAWSBudgetsBudgetConfig_WithAccountID(budgetConfig budgets.Budget, accountID, costFilterKey string) string {
-	t := template.Must(template.New("t1").
-		Parse(`
+	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
+	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+
+	return fmt.Sprintf(`
 resource "aws_budgets_budget" "foo" {
-	account_id = "` + accountID + `"
-	name_prefix = "{{.BudgetName}}"
-	budget_type = "{{.BudgetType}}"
- 	limit_amount = "{{.BudgetLimit.Amount}}"
- 	limit_unit = "{{.BudgetLimit.Unit}}"
-	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
- 	time_unit = "{{.TimeUnit}}"
+	account_id = "%s"
+	name_prefix = "%s"
+	budget_type = "%s"
+	limit_amount = "%s"
+	limit_unit = "%s"
+	time_period_start = "%s" 
+	time_unit = "%s"
 	cost_filters = {
-		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
+		"%s" = "%s"
 	}
 }
-`))
-	var doc bytes.Buffer
-	// TODO: Convert to fmt.Sprintf() (https://github.com/terraform-providers/terraform-provider-aws/issues/7456)
-	if err := t.Execute(&doc, budgetConfig); err != nil {
-		panic(fmt.Sprintf("error executing template: %s", err))
-	}
-	return doc.String()
+
+	`, accountID, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, timePeriodStart, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
 }
 
 func testAccAWSBudgetsBudgetConfig_PrefixDefaults(budgetConfig budgets.Budget, costFilterKey string) string {
-	t := template.Must(template.New("t1").
-		Parse(`
+	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
+	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+
+	return fmt.Sprintf(`
 resource "aws_budgets_budget" "foo" {
-	name_prefix = "{{.BudgetName}}"
-	budget_type = "{{.BudgetType}}"
- 	limit_amount = "{{.BudgetLimit.Amount}}"
- 	limit_unit = "{{.BudgetLimit.Unit}}"
-	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
- 	time_unit = "{{.TimeUnit}}"
+	name_prefix = "%s"
+	budget_type = "%s"
+	limit_amount = "%s"
+	limit_unit = "%s"
+	time_period_start = "%s" 
+	time_unit = "%s"
 	cost_filters = {
-		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
+		"%s" = "%s"
 	}
 }
-`))
-	var doc bytes.Buffer
-	// TODO: Convert to fmt.Sprintf() (https://github.com/terraform-providers/terraform-provider-aws/issues/7456)
-	if err := t.Execute(&doc, budgetConfig); err != nil {
-		panic(fmt.Sprintf("error executing template: %s", err))
-	}
-	return doc.String()
+
+	`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, timePeriodStart, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
 }
 
 func testAccAWSBudgetsBudgetConfig_Prefix(budgetConfig budgets.Budget, costFilterKey string) string {
-	t := template.Must(template.New("t1").
-		Parse(`
+	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
+	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
+	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+
+	return fmt.Sprintf(`
 resource "aws_budgets_budget" "foo" {
-	name_prefix = "{{.BudgetName}}"
-	budget_type = "{{.BudgetType}}"
- 	limit_amount = "{{.BudgetLimit.Amount}}"
- 	limit_unit = "{{.BudgetLimit.Unit}}"
+	name_prefix = "%s"
+	budget_type = "%s"
+	limit_amount = "%s"
+	limit_unit = "%s"
 	cost_types {
-		include_tax = "{{.CostTypes.IncludeTax}}"
-		include_subscription = "{{.CostTypes.IncludeSubscription}}"
-		use_blended = "{{.CostTypes.UseBlended}}"
+		include_tax = "%t"
+		include_subscription = "%t"
+		use_blended = "%t"
 	}
-	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
-	time_period_end = "{{.TimePeriod.End.Format "2006-01-02_15:04"}}"
- 	time_unit = "{{.TimeUnit}}"
+	time_period_start = "%s" 
+	time_period_end = "%s"
+	time_unit = "%s"
 	cost_filters = {
-		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
+		"%s" = "%s"
 	}
-}
-`))
-	var doc bytes.Buffer
-	// TODO: Convert to fmt.Sprintf() (https://github.com/terraform-providers/terraform-provider-aws/issues/7456)
-	if err := t.Execute(&doc, budgetConfig); err != nil {
-		panic(fmt.Sprintf("error executing template: %s", err))
-	}
-	return doc.String()
 }
 
+	`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, *budgetConfig.CostTypes.IncludeTax, *budgetConfig.CostTypes.IncludeSubscription, *budgetConfig.CostTypes.UseBlended, timePeriodStart, timePeriodEnd, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
+}
 func testAccAWSBudgetsBudgetConfig_BasicDefaults(budgetConfig budgets.Budget, costFilterKey string) string {
-	t := template.Must(template.New("t1").
-		Parse(`
+	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
+	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+
+	return fmt.Sprintf(`
 resource "aws_budgets_budget" "foo" {
-	name = "{{.BudgetName}}"
-	budget_type = "{{.BudgetType}}"
- 	limit_amount = "{{.BudgetLimit.Amount}}"
- 	limit_unit = "{{.BudgetLimit.Unit}}"
-	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
- 	time_unit = "{{.TimeUnit}}"
+	name = "%s"
+	budget_type = "%s"
+	limit_amount = "%s"
+	limit_unit = "%s"
+	time_period_start = "%s" 
+	time_unit = "%s"
 	cost_filters = {
-		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
+		"%s" = "%s"
 	}
 }
-`))
-	var doc bytes.Buffer
-	// TODO: Convert to fmt.Sprintf() (https://github.com/terraform-providers/terraform-provider-aws/issues/7456)
-	if err := t.Execute(&doc, budgetConfig); err != nil {
-		panic(fmt.Sprintf("error executing template: %s", err))
-	}
-	return doc.String()
+
+	`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, timePeriodStart, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
 }
 
 func testAccAWSBudgetsBudgetConfig_Basic(budgetConfig budgets.Budget, costFilterKey string) string {
-	t := template.Must(template.New("t1").
-		Parse(`
+	timePeriodStart := budgetConfig.TimePeriod.Start.Format("2006-01-02_15:04")
+	timePeriodEnd := budgetConfig.TimePeriod.End.Format("2006-01-02_15:04")
+	costFilterValue := *budgetConfig.CostFilters[costFilterKey][0]
+
+	return fmt.Sprintf(`
 resource "aws_budgets_budget" "foo" {
-	name = "{{.BudgetName}}"
-	budget_type = "{{.BudgetType}}"
- 	limit_amount = "{{.BudgetLimit.Amount}}"
- 	limit_unit = "{{.BudgetLimit.Unit}}"
+	name = "%s"
+	budget_type = "%s"
+	limit_amount = "%s"
+	limit_unit = "%s"
 	cost_types {
-		include_tax = "{{.CostTypes.IncludeTax}}"
-		include_subscription = "{{.CostTypes.IncludeSubscription}}"
-		use_blended = "{{.CostTypes.UseBlended}}"
+		include_tax = "%t"
+		include_subscription = "%t"
+		use_blended = "%t"
 	}
-	time_period_start = "{{.TimePeriod.Start.Format "2006-01-02_15:04"}}" 
-	time_period_end = "{{.TimePeriod.End.Format "2006-01-02_15:04"}}"
- 	time_unit = "{{.TimeUnit}}"
+	time_period_start = "%s" 
+	time_period_end = "%s"
+	time_unit = "%s"
 	cost_filters = {
-		"` + costFilterKey + `" = "` + *budgetConfig.CostFilters[costFilterKey][0] + `"
+		"%s" = "%s"
 	}
 }
-`))
-	var doc bytes.Buffer
-	// TODO: Convert to fmt.Sprintf() (https://github.com/terraform-providers/terraform-provider-aws/issues/7456)
-	if err := t.Execute(&doc, budgetConfig); err != nil {
-		panic(fmt.Sprintf("error executing template: %s", err))
-	}
-	return doc.String()
+
+	`, *budgetConfig.BudgetName, *budgetConfig.BudgetType, *budgetConfig.BudgetLimit.Amount, *budgetConfig.BudgetLimit.Unit, *budgetConfig.CostTypes.IncludeTax, *budgetConfig.CostTypes.IncludeSubscription, *budgetConfig.CostTypes.UseBlended, timePeriodStart, timePeriodEnd, *budgetConfig.TimeUnit, costFilterKey, costFilterValue)
 }

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -11,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -2021,74 +2019,68 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 func testAccAWSS3MultiBucketConfigWithTags(randInt int) string {
-	t := template.Must(template.New("t1").
-		Parse(`
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket1" {
-	bucket = "tf-test-bucket-1-{{.GUID}}"
+	bucket = "tf-test-bucket-1-%[1]d"
 	acl = "private"
 	force_destroy = true
 	tags = {
-		Name = "tf-test-bucket-1-{{.GUID}}"
-		Environment = "{{.GUID}}"
+		Name = "tf-test-bucket-1-%[1]d"
+		Environment = "%[1]d"
 	}
 }
 
 resource "aws_s3_bucket" "bucket2" {
-	bucket = "tf-test-bucket-2-{{.GUID}}"
+	bucket = "tf-test-bucket-2-%[1]d"
 	acl = "private"
 	force_destroy = true
 	tags = {
-		Name = "tf-test-bucket-2-{{.GUID}}"
-		Environment = "{{.GUID}}"
+		Name = "tf-test-bucket-2-%[1]d"
+		Environment = "%[1]d"
 	}
 }
 
 resource "aws_s3_bucket" "bucket3" {
-	bucket = "tf-test-bucket-3-{{.GUID}}"
+	bucket = "tf-test-bucket-3-%[1]d"
 	acl = "private"
 	force_destroy = true
 	tags = {
-		Name = "tf-test-bucket-3-{{.GUID}}"
-		Environment = "{{.GUID}}"
+		Name = "tf-test-bucket-3-%[1]d"
+		Environment = "%[1]d"
 	}
 }
 
 resource "aws_s3_bucket" "bucket4" {
-	bucket = "tf-test-bucket-4-{{.GUID}}"
+	bucket = "tf-test-bucket-4-%[1]d"
 	acl = "private"
 	force_destroy = true
 	tags = {
-		Name = "tf-test-bucket-4-{{.GUID}}"
-		Environment = "{{.GUID}}"
+		Name = "tf-test-bucket-4-%[1]d"
+		Environment = "%[1]d"
 	}
 }
 
 resource "aws_s3_bucket" "bucket5" {
-	bucket = "tf-test-bucket-5-{{.GUID}}"
+	bucket = "tf-test-bucket-5-%[1]d"
 	acl = "private"
 	force_destroy = true
 	tags = {
-		Name = "tf-test-bucket-5-{{.GUID}}"
-		Environment = "{{.GUID}}"
+		Name = "tf-test-bucket-5-%[1]d"
+		Environment = "%[1]d"
 	}
 }
 
 resource "aws_s3_bucket" "bucket6" {
-	bucket = "tf-test-bucket-6-{{.GUID}}"
+	bucket = "tf-test-bucket-6-%[1]d"
 	acl = "private"
 	force_destroy = true
 	tags = {
-		Name = "tf-test-bucket-6-{{.GUID}}"
-		Environment = "{{.GUID}}"
+		Name = "tf-test-bucket-6-%[1]d"
+		Environment = "%[1]d"
 	}
 }
-`))
-	var doc bytes.Buffer
-	// TODO: Convert to fmt.Sprintf() (https://github.com/terraform-providers/terraform-provider-aws/issues/7456)
-	if err := t.Execute(&doc, struct{ GUID int }{GUID: randInt}); err != nil {
-		panic(fmt.Sprintf("error executing template: %s", err))
-	}
-	return doc.String()
+
+`, randInt)
 }
 
 func testAccAWSS3BucketConfigWithRegion(bucketName, region string) string {


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7456 

Changes proposed in this pull request:

* Convert text/template Usage to fmt.Sprintf in `aws_s3_bucket` resource test
* Convert text/template Usage to fmt.Sprintf in `aws_budgets_budget` resource test

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSS3MultiBucket_withTags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSS3MultiBucket_withTags -timeout 120m
=== RUN   TestAccAWSS3MultiBucket_withTags
=== PAUSE TestAccAWSS3MultiBucket_withTags
=== CONT  TestAccAWSS3MultiBucket_withTags
--- PASS: TestAccAWSS3MultiBucket_withTags (44.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	44.793s
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSBudgetsBudget_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSBudgetsBudget_ -timeout 120m
=== RUN   TestAccAWSBudgetsBudget_basic
=== PAUSE TestAccAWSBudgetsBudget_basic
=== RUN   TestAccAWSBudgetsBudget_prefix
=== PAUSE TestAccAWSBudgetsBudget_prefix
=== CONT  TestAccAWSBudgetsBudget_basic
=== CONT  TestAccAWSBudgetsBudget_prefix
--- PASS: TestAccAWSBudgetsBudget_prefix (35.01s)
--- PASS: TestAccAWSBudgetsBudget_basic (38.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws    38.670s
```