### PR TITLE
resource/aws_cloudfront_distribution: Adjust TypeSet and TypeList attributes for better difference handling

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -10,8 +10,6 @@ package aws
 import (
 	"bytes"
 	"fmt"
-	"reflect"
-	"sort"
 	"strconv"
 	"time"
 
@@ -26,14 +24,6 @@ import (
 // is used to set the zone_id attribute.
 const cloudFrontRoute53ZoneID = "Z2FDTNDATAQYW2"
 
-// Define Sort interface for []*string so we can ensure the order of
-// geo_restrictions.locations
-type StringPtrSlice []*string
-
-func (p StringPtrSlice) Len() int           { return len(p) }
-func (p StringPtrSlice) Less(i, j int) bool { return *p[i] < *p[j] }
-func (p StringPtrSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
 // Assemble the *cloudfront.DistributionConfig variable. Calls out to various
 // expander functions to convert attributes and sub-attributes to the various
 // complex structures which are necessary to properly build the
@@ -43,33 +33,26 @@ func (p StringPtrSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionConfig {
 	distributionConfig := &cloudfront.DistributionConfig{
 		CacheBehaviors:       expandCacheBehaviors(d.Get("ordered_cache_behavior").([]interface{})),
+		CallerReference:      aws.String(time.Now().Format(time.RFC3339Nano)),
+		Comment:              aws.String(d.Get("comment").(string)),
 		CustomErrorResponses: expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set)),
-		DefaultCacheBehavior: expandDefaultCacheBehavior(d.Get("default_cache_behavior").(*schema.Set).List()[0].(map[string]interface{})),
+		DefaultCacheBehavior: expandCloudFrontDefaultCacheBehavior(d.Get("default_cache_behavior").([]interface{})[0].(map[string]interface{})),
+		DefaultRootObject:    aws.String(d.Get("default_root_object").(string)),
 		Enabled:              aws.Bool(d.Get("enabled").(bool)),
 		IsIPV6Enabled:        aws.Bool(d.Get("is_ipv6_enabled").(bool)),
 		HttpVersion:          aws.String(d.Get("http_version").(string)),
 		Origins:              expandOrigins(d.Get("origin").(*schema.Set)),
 		PriceClass:           aws.String(d.Get("price_class").(string)),
+		WebACLId:             aws.String(d.Get("web_acl_id").(string)),
 	}
 
 	// This sets CallerReference if it's still pending computation (ie: new resource)
-	if v, ok := d.GetOk("caller_reference"); !ok {
-		distributionConfig.CallerReference = aws.String(time.Now().Format(time.RFC3339Nano))
-	} else {
+	if v, ok := d.GetOk("caller_reference"); ok {
 		distributionConfig.CallerReference = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("comment"); ok {
-		distributionConfig.Comment = aws.String(v.(string))
-	} else {
-		distributionConfig.Comment = aws.String("")
-	}
-	if v, ok := d.GetOk("default_root_object"); ok {
-		distributionConfig.DefaultRootObject = aws.String(v.(string))
-	} else {
-		distributionConfig.DefaultRootObject = aws.String("")
-	}
+
 	if v, ok := d.GetOk("logging_config"); ok {
-		distributionConfig.Logging = expandLoggingConfig(v.(*schema.Set).List()[0].(map[string]interface{}))
+		distributionConfig.Logging = expandLoggingConfig(v.([]interface{})[0].(map[string]interface{}))
 	} else {
 		distributionConfig.Logging = expandLoggingConfig(nil)
 	}
@@ -79,15 +62,10 @@ func expandDistributionConfig(d *schema.ResourceData) *cloudfront.DistributionCo
 		distributionConfig.Aliases = expandAliases(schema.NewSet(aliasesHash, []interface{}{}))
 	}
 	if v, ok := d.GetOk("restrictions"); ok {
-		distributionConfig.Restrictions = expandRestrictions(v.(*schema.Set).List()[0].(map[string]interface{}))
+		distributionConfig.Restrictions = expandRestrictions(v.([]interface{})[0].(map[string]interface{}))
 	}
 	if v, ok := d.GetOk("viewer_certificate"); ok {
-		distributionConfig.ViewerCertificate = expandViewerCertificate(v.(*schema.Set).List()[0].(map[string]interface{}))
-	}
-	if v, ok := d.GetOk("web_acl_id"); ok {
-		distributionConfig.WebACLId = aws.String(v.(string))
-	} else {
-		distributionConfig.WebACLId = aws.String("")
+		distributionConfig.ViewerCertificate = expandViewerCertificate(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	return distributionConfig
@@ -149,7 +127,7 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 	if distributionConfig.Logging != nil && *distributionConfig.Logging.Enabled {
 		err = d.Set("logging_config", flattenLoggingConfig(distributionConfig.Logging))
 	} else {
-		err = d.Set("logging_config", schema.NewSet(loggingConfigHash, []interface{}{}))
+		err = d.Set("logging_config", []interface{}{})
 	}
 	if err != nil {
 		return err
@@ -177,72 +155,8 @@ func flattenDistributionConfig(d *schema.ResourceData, distributionConfig *cloud
 	return nil
 }
 
-func expandDefaultCacheBehavior(m map[string]interface{}) *cloudfront.DefaultCacheBehavior {
-	cb := expandCacheBehaviorDeprecated(m)
-	var dcb cloudfront.DefaultCacheBehavior
-
-	simpleCopyStruct(cb, &dcb)
-	return &dcb
-}
-
-func flattenDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior) *schema.Set {
-	var cb cloudfront.CacheBehavior
-
-	simpleCopyStruct(dcb, &cb)
-	m := flattenCacheBehaviorDeprecated(&cb)
-	return schema.NewSet(defaultCacheBehaviorHash, []interface{}{m})
-}
-
-// Assemble the hash for the aws_cloudfront_distribution default_cache_behavior
-// TypeSet attribute.
-func defaultCacheBehaviorHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%t-", m["compress"].(bool)))
-	buf.WriteString(fmt.Sprintf("%s-", m["viewer_protocol_policy"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["target_origin_id"].(string)))
-	buf.WriteString(fmt.Sprintf("%d-", forwardedValuesHash(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{}))))
-	buf.WriteString(fmt.Sprintf("%d-", m["min_ttl"].(int)))
-	if d, ok := m["field_level_encryption_id"]; ok && d.(string) != "" {
-		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
-	}
-	if d, ok := m["trusted_signers"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["max_ttl"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
-	}
-	if d, ok := m["smooth_streaming"]; ok {
-		buf.WriteString(fmt.Sprintf("%t-", d.(bool)))
-	}
-	if d, ok := m["default_ttl"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", d.(int)))
-	}
-	if d, ok := m["allowed_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["cached_methods"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["lambda_function_association"]; ok {
-		var associations []interface{}
-		switch d.(type) {
-		case *schema.Set:
-			associations = d.(*schema.Set).List()
-		default:
-			associations = d.([]interface{})
-		}
-		for _, lfa := range associations {
-			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(lfa.(map[string]interface{}))))
-		}
-	}
-	return hashcode.String(buf.String())
+func flattenDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior) []interface{} {
+	return []interface{}{flattenCloudFrontDefaultCacheBehavior(dcb)}
 }
 
 func expandCacheBehaviors(lst []interface{}) *cloudfront.CacheBehaviors {
@@ -266,54 +180,51 @@ func flattenCacheBehaviors(cbs *cloudfront.CacheBehaviors) []interface{} {
 	return lst
 }
 
-// Deprecated.
-func expandCacheBehaviorDeprecated(m map[string]interface{}) *cloudfront.CacheBehavior {
-	cb := &cloudfront.CacheBehavior{
+func expandCloudFrontDefaultCacheBehavior(m map[string]interface{}) *cloudfront.DefaultCacheBehavior {
+	dcb := &cloudfront.DefaultCacheBehavior{
 		Compress:               aws.Bool(m["compress"].(bool)),
-		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
-		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
-		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
-		ForwardedValues:        expandForwardedValues(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{})),
 		DefaultTTL:             aws.Int64(int64(m["default_ttl"].(int))),
+		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
+		ForwardedValues:        expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{})),
 		MaxTTL:                 aws.Int64(int64(m["max_ttl"].(int))),
 		MinTTL:                 aws.Int64(int64(m["min_ttl"].(int))),
+		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
+		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
 	}
 
 	if v, ok := m["trusted_signers"]; ok {
-		cb.TrustedSigners = expandTrustedSigners(v.([]interface{}))
+		dcb.TrustedSigners = expandTrustedSigners(v.([]interface{}))
 	} else {
-		cb.TrustedSigners = expandTrustedSigners([]interface{}{})
+		dcb.TrustedSigners = expandTrustedSigners([]interface{}{})
 	}
 
 	if v, ok := m["lambda_function_association"]; ok {
-		cb.LambdaFunctionAssociations = expandLambdaFunctionAssociations(v.(*schema.Set).List())
+		dcb.LambdaFunctionAssociations = expandLambdaFunctionAssociations(v.(*schema.Set).List())
 	}
 
 	if v, ok := m["smooth_streaming"]; ok {
-		cb.SmoothStreaming = aws.Bool(v.(bool))
+		dcb.SmoothStreaming = aws.Bool(v.(bool))
 	}
 	if v, ok := m["allowed_methods"]; ok {
-		cb.AllowedMethods = expandAllowedMethodsDeprecated(v.([]interface{}))
+		dcb.AllowedMethods = expandAllowedMethods(v.(*schema.Set))
 	}
 	if v, ok := m["cached_methods"]; ok {
-		cb.AllowedMethods.CachedMethods = expandCachedMethodsDeprecated(v.([]interface{}))
+		dcb.AllowedMethods.CachedMethods = expandCachedMethods(v.(*schema.Set))
 	}
-	if v, ok := m["path_pattern"]; ok {
-		cb.PathPattern = aws.String(v.(string))
-	}
-	return cb
+
+	return dcb
 }
 
 func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 	cb := &cloudfront.CacheBehavior{
 		Compress:               aws.Bool(m["compress"].(bool)),
-		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
-		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
-		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
-		ForwardedValues:        expandForwardedValues(m["forwarded_values"].(*schema.Set).List()[0].(map[string]interface{})),
 		DefaultTTL:             aws.Int64(int64(m["default_ttl"].(int))),
+		FieldLevelEncryptionId: aws.String(m["field_level_encryption_id"].(string)),
+		ForwardedValues:        expandForwardedValues(m["forwarded_values"].([]interface{})[0].(map[string]interface{})),
 		MaxTTL:                 aws.Int64(int64(m["max_ttl"].(int))),
 		MinTTL:                 aws.Int64(int64(m["min_ttl"].(int))),
+		TargetOriginId:         aws.String(m["target_origin_id"].(string)),
+		ViewerProtocolPolicy:   aws.String(m["viewer_protocol_policy"].(string)),
 	}
 
 	if v, ok := m["trusted_signers"]; ok {
@@ -341,40 +252,38 @@ func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 	return cb
 }
 
-func flattenCacheBehaviorDeprecated(cb *cloudfront.CacheBehavior) map[string]interface{} {
-	m := make(map[string]interface{})
+func flattenCloudFrontDefaultCacheBehavior(dcb *cloudfront.DefaultCacheBehavior) map[string]interface{} {
+	m := map[string]interface{}{
+		"compress":                  aws.BoolValue(dcb.Compress),
+		"field_level_encryption_id": aws.StringValue(dcb.FieldLevelEncryptionId),
+		"viewer_protocol_policy":    aws.StringValue(dcb.ViewerProtocolPolicy),
+		"target_origin_id":          aws.StringValue(dcb.TargetOriginId),
+		"forwarded_values":          []interface{}{flattenForwardedValues(dcb.ForwardedValues)},
+		"min_ttl":                   aws.Int64Value(dcb.MinTTL),
+	}
 
-	m["compress"] = *cb.Compress
-	m["field_level_encryption_id"] = aws.StringValue(cb.FieldLevelEncryptionId)
-	m["viewer_protocol_policy"] = *cb.ViewerProtocolPolicy
-	m["target_origin_id"] = *cb.TargetOriginId
-	m["forwarded_values"] = schema.NewSet(forwardedValuesHash, []interface{}{flattenForwardedValues(cb.ForwardedValues)})
-	m["min_ttl"] = int(*cb.MinTTL)
+	if len(dcb.TrustedSigners.Items) > 0 {
+		m["trusted_signers"] = flattenTrustedSigners(dcb.TrustedSigners)
+	}
+	if len(dcb.LambdaFunctionAssociations.Items) > 0 {
+		m["lambda_function_association"] = flattenLambdaFunctionAssociations(dcb.LambdaFunctionAssociations)
+	}
+	if dcb.MaxTTL != nil {
+		m["max_ttl"] = aws.Int64Value(dcb.MaxTTL)
+	}
+	if dcb.SmoothStreaming != nil {
+		m["smooth_streaming"] = aws.BoolValue(dcb.SmoothStreaming)
+	}
+	if dcb.DefaultTTL != nil {
+		m["default_ttl"] = int(aws.Int64Value(dcb.DefaultTTL))
+	}
+	if dcb.AllowedMethods != nil {
+		m["allowed_methods"] = flattenAllowedMethods(dcb.AllowedMethods)
+	}
+	if dcb.AllowedMethods.CachedMethods != nil {
+		m["cached_methods"] = flattenCachedMethods(dcb.AllowedMethods.CachedMethods)
+	}
 
-	if len(cb.TrustedSigners.Items) > 0 {
-		m["trusted_signers"] = flattenTrustedSigners(cb.TrustedSigners)
-	}
-	if len(cb.LambdaFunctionAssociations.Items) > 0 {
-		m["lambda_function_association"] = flattenLambdaFunctionAssociations(cb.LambdaFunctionAssociations)
-	}
-	if cb.MaxTTL != nil {
-		m["max_ttl"] = int(*cb.MaxTTL)
-	}
-	if cb.SmoothStreaming != nil {
-		m["smooth_streaming"] = *cb.SmoothStreaming
-	}
-	if cb.DefaultTTL != nil {
-		m["default_ttl"] = int(*cb.DefaultTTL)
-	}
-	if cb.AllowedMethods != nil {
-		m["allowed_methods"] = flattenAllowedMethodsDeprecated(cb.AllowedMethods)
-	}
-	if cb.AllowedMethods.CachedMethods != nil {
-		m["cached_methods"] = flattenCachedMethodsDeprecated(cb.AllowedMethods.CachedMethods)
-	}
-	if cb.PathPattern != nil {
-		m["path_pattern"] = *cb.PathPattern
-	}
 	return m
 }
 
@@ -385,7 +294,7 @@ func flattenCacheBehavior(cb *cloudfront.CacheBehavior) map[string]interface{} {
 	m["field_level_encryption_id"] = aws.StringValue(cb.FieldLevelEncryptionId)
 	m["viewer_protocol_policy"] = *cb.ViewerProtocolPolicy
 	m["target_origin_id"] = *cb.TargetOriginId
-	m["forwarded_values"] = schema.NewSet(forwardedValuesHash, []interface{}{flattenForwardedValues(cb.ForwardedValues)})
+	m["forwarded_values"] = []interface{}{flattenForwardedValues(cb.ForwardedValues)}
 	m["min_ttl"] = int(*cb.MinTTL)
 
 	if len(cb.TrustedSigners.Items) > 0 {
@@ -497,8 +406,8 @@ func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues
 	fv := &cloudfront.ForwardedValues{
 		QueryString: aws.Bool(m["query_string"].(bool)),
 	}
-	if v, ok := m["cookies"]; ok && v.(*schema.Set).Len() > 0 {
-		fv.Cookies = expandCookiePreference(v.(*schema.Set).List()[0].(map[string]interface{}))
+	if v, ok := m["cookies"]; ok && len(v.([]interface{})) > 0 {
+		fv.Cookies = expandCookiePreference(v.([]interface{})[0].(map[string]interface{}))
 	}
 	if v, ok := m["headers"]; ok {
 		fv.Headers = expandHeaders(v.([]interface{}))
@@ -513,7 +422,7 @@ func flattenForwardedValues(fv *cloudfront.ForwardedValues) map[string]interface
 	m := make(map[string]interface{})
 	m["query_string"] = *fv.QueryString
 	if fv.Cookies != nil {
-		m["cookies"] = schema.NewSet(cookiePreferenceHash, []interface{}{flattenCookiePreference(fv.Cookies)})
+		m["cookies"] = []interface{}{flattenCookiePreference(fv.Cookies)}
 	}
 	if fv.Headers != nil {
 		m["headers"] = flattenHeaders(fv.Headers)
@@ -522,28 +431,6 @@ func flattenForwardedValues(fv *cloudfront.ForwardedValues) map[string]interface
 		m["query_string_cache_keys"] = flattenQueryStringCacheKeys(fv.QueryStringCacheKeys)
 	}
 	return m
-}
-
-// Assemble the hash for the aws_cloudfront_distribution forwarded_values
-// TypeSet attribute.
-func forwardedValuesHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%t-", m["query_string"].(bool)))
-	if d, ok := m["cookies"]; ok && d.(*schema.Set).Len() > 0 {
-		buf.WriteString(fmt.Sprintf("%d-", cookiePreferenceHash(d.(*schema.Set).List()[0].(map[string]interface{}))))
-	}
-	if d, ok := m["headers"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	if d, ok := m["query_string_cache_keys"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	return hashcode.String(buf.String())
 }
 
 func expandHeaders(d []interface{}) *cloudfront.Headers {
@@ -593,20 +480,6 @@ func flattenCookiePreference(cp *cloudfront.CookiePreference) map[string]interfa
 	return m
 }
 
-// Assemble the hash for the aws_cloudfront_distribution cookies
-// TypeSet attribute.
-func cookiePreferenceHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["forward"].(string)))
-	if d, ok := m["whitelisted_names"]; ok {
-		for _, e := range sortInterfaceSlice(d.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
-		}
-	}
-	return hashcode.String(buf.String())
-}
-
 func expandCookieNames(d []interface{}) *cloudfront.CookieNames {
 	return &cloudfront.CookieNames{
 		Quantity: aws.Int64(int64(len(d))),
@@ -635,20 +508,6 @@ func flattenAllowedMethods(am *cloudfront.AllowedMethods) *schema.Set {
 	return nil
 }
 
-func expandAllowedMethodsDeprecated(s []interface{}) *cloudfront.AllowedMethods {
-	return &cloudfront.AllowedMethods{
-		Quantity: aws.Int64(int64(len(s))),
-		Items:    expandStringList(s),
-	}
-}
-
-func flattenAllowedMethodsDeprecated(am *cloudfront.AllowedMethods) []interface{} {
-	if am.Items != nil {
-		return flattenStringList(am.Items)
-	}
-	return []interface{}{}
-}
-
 func expandCachedMethods(s *schema.Set) *cloudfront.CachedMethods {
 	return &cloudfront.CachedMethods{
 		Quantity: aws.Int64(int64(s.Len())),
@@ -661,20 +520,6 @@ func flattenCachedMethods(cm *cloudfront.CachedMethods) *schema.Set {
 		return schema.NewSet(schema.HashString, flattenStringList(cm.Items))
 	}
 	return nil
-}
-
-func expandCachedMethodsDeprecated(s []interface{}) *cloudfront.CachedMethods {
-	return &cloudfront.CachedMethods{
-		Quantity: aws.Int64(int64(len(s))),
-		Items:    expandStringList(s),
-	}
-}
-
-func flattenCachedMethodsDeprecated(cm *cloudfront.CachedMethods) []interface{} {
-	if cm.Items != nil {
-		return flattenStringList(cm.Items)
-	}
-	return []interface{}{}
 }
 
 func expandOrigins(s *schema.Set) *cloudfront.Origins {
@@ -707,7 +552,7 @@ func expandOrigin(m map[string]interface{}) *cloudfront.Origin {
 		origin.CustomHeaders = expandCustomHeaders(v.(*schema.Set))
 	}
 	if v, ok := m["custom_origin_config"]; ok {
-		if s := v.(*schema.Set).List(); len(s) > 0 {
+		if s := v.([]interface{}); len(s) > 0 {
 			origin.CustomOriginConfig = expandCustomOriginConfig(s[0].(map[string]interface{}))
 		}
 	}
@@ -715,7 +560,7 @@ func expandOrigin(m map[string]interface{}) *cloudfront.Origin {
 		origin.OriginPath = aws.String(v.(string))
 	}
 	if v, ok := m["s3_origin_config"]; ok {
-		if s := v.(*schema.Set).List(); len(s) > 0 {
+		if s := v.([]interface{}); len(s) > 0 {
 			origin.S3OriginConfig = expandS3OriginConfig(s[0].(map[string]interface{}))
 		}
 	}
@@ -733,21 +578,19 @@ func expandOrigin(m map[string]interface{}) *cloudfront.Origin {
 
 func flattenOrigin(or *cloudfront.Origin) map[string]interface{} {
 	m := make(map[string]interface{})
-	m["origin_id"] = *or.Id
-	m["domain_name"] = *or.DomainName
+	m["origin_id"] = aws.StringValue(or.Id)
+	m["domain_name"] = aws.StringValue(or.DomainName)
 	if or.CustomHeaders != nil {
 		m["custom_header"] = flattenCustomHeaders(or.CustomHeaders)
 	}
 	if or.CustomOriginConfig != nil {
-		m["custom_origin_config"] = schema.NewSet(customOriginConfigHash, []interface{}{flattenCustomOriginConfig(or.CustomOriginConfig)})
+		m["custom_origin_config"] = []interface{}{flattenCustomOriginConfig(or.CustomOriginConfig)}
 	}
 	if or.OriginPath != nil {
-		m["origin_path"] = *or.OriginPath
+		m["origin_path"] = aws.StringValue(or.OriginPath)
 	}
-	if or.S3OriginConfig != nil {
-		if or.S3OriginConfig.OriginAccessIdentity != nil && *or.S3OriginConfig.OriginAccessIdentity != "" {
-			m["s3_origin_config"] = schema.NewSet(s3OriginConfigHash, []interface{}{flattenS3OriginConfig(or.S3OriginConfig)})
-		}
+	if or.S3OriginConfig != nil && aws.StringValue(or.S3OriginConfig.OriginAccessIdentity) != "" {
+		m["s3_origin_config"] = []interface{}{flattenS3OriginConfig(or.S3OriginConfig)}
 	}
 	return m
 }
@@ -763,7 +606,7 @@ func originHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%d-", customHeadersHash(v.(*schema.Set))))
 	}
 	if v, ok := m["custom_origin_config"]; ok {
-		if s := v.(*schema.Set).List(); len(s) > 0 {
+		if s := v.([]interface{}); len(s) > 0 && s[0] != nil {
 			buf.WriteString(fmt.Sprintf("%d-", customOriginConfigHash((s[0].(map[string]interface{})))))
 		}
 	}
@@ -771,7 +614,7 @@ func originHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 	if v, ok := m["s3_origin_config"]; ok {
-		if s := v.(*schema.Set).List(); len(s) > 0 {
+		if s := v.([]interface{}); len(s) > 0 && s[0] != nil {
 			buf.WriteString(fmt.Sprintf("%d-", s3OriginConfigHash((s[0].(map[string]interface{})))))
 		}
 	}
@@ -839,7 +682,7 @@ func expandCustomOriginConfig(m map[string]interface{}) *cloudfront.CustomOrigin
 		OriginProtocolPolicy:   aws.String(m["origin_protocol_policy"].(string)),
 		HTTPPort:               aws.Int64(int64(m["http_port"].(int))),
 		HTTPSPort:              aws.Int64(int64(m["https_port"].(int))),
-		OriginSslProtocols:     expandCustomOriginConfigSSL(m["origin_ssl_protocols"].([]interface{})),
+		OriginSslProtocols:     expandCustomOriginConfigSSL(m["origin_ssl_protocols"].(*schema.Set).List()),
 		OriginReadTimeout:      aws.Int64(int64(m["origin_read_timeout"].(int))),
 		OriginKeepaliveTimeout: aws.Int64(int64(m["origin_keepalive_timeout"].(int))),
 	}
@@ -869,7 +712,7 @@ func customOriginConfigHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["origin_protocol_policy"].(string)))
 	buf.WriteString(fmt.Sprintf("%d-", m["http_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", m["https_port"].(int)))
-	for _, v := range sortInterfaceSlice(m["origin_ssl_protocols"].([]interface{})) {
+	for _, v := range sortInterfaceSlice(m["origin_ssl_protocols"].(*schema.Set).List()) {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 	buf.WriteString(fmt.Sprintf("%d-", m["origin_keepalive_timeout"].(int)))
@@ -886,8 +729,8 @@ func expandCustomOriginConfigSSL(s []interface{}) *cloudfront.OriginSslProtocols
 	}
 }
 
-func flattenCustomOriginConfigSSL(osp *cloudfront.OriginSslProtocols) []interface{} {
-	return flattenStringList(osp.Items)
+func flattenCustomOriginConfigSSL(osp *cloudfront.OriginSslProtocols) *schema.Set {
+	return schema.NewSet(schema.HashString, flattenStringList(osp.Items))
 }
 
 func expandS3OriginConfig(m map[string]interface{}) *cloudfront.S3OriginConfig {
@@ -1000,23 +843,14 @@ func expandLoggingConfig(m map[string]interface{}) *cloudfront.LoggingConfig {
 	return &lc
 }
 
-func flattenLoggingConfig(lc *cloudfront.LoggingConfig) *schema.Set {
-	m := make(map[string]interface{})
-	m["prefix"] = *lc.Prefix
-	m["bucket"] = *lc.Bucket
-	m["include_cookies"] = *lc.IncludeCookies
-	return schema.NewSet(loggingConfigHash, []interface{}{m})
-}
+func flattenLoggingConfig(lc *cloudfront.LoggingConfig) []interface{} {
+	m := map[string]interface{}{
+		"bucket":          aws.StringValue(lc.Bucket),
+		"include_cookies": aws.BoolValue(lc.IncludeCookies),
+		"prefix":          aws.StringValue(lc.Prefix),
+	}
 
-// Assemble the hash for the aws_cloudfront_distribution logging_config
-// TypeSet attribute.
-func loggingConfigHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["prefix"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["bucket"].(string)))
-	buf.WriteString(fmt.Sprintf("%t-", m["include_cookies"].(bool)))
-	return hashcode.String(buf.String())
+	return []interface{}{m}
 }
 
 func expandAliases(as *schema.Set) *cloudfront.Aliases {
@@ -1046,64 +880,40 @@ func aliasesHash(v interface{}) int {
 
 func expandRestrictions(m map[string]interface{}) *cloudfront.Restrictions {
 	return &cloudfront.Restrictions{
-		GeoRestriction: expandGeoRestriction(m["geo_restriction"].(*schema.Set).List()[0].(map[string]interface{})),
+		GeoRestriction: expandGeoRestriction(m["geo_restriction"].([]interface{})[0].(map[string]interface{})),
 	}
 }
 
-func flattenRestrictions(r *cloudfront.Restrictions) *schema.Set {
-	m := make(map[string]interface{})
-	s := schema.NewSet(geoRestrictionHash, []interface{}{flattenGeoRestriction(r.GeoRestriction)})
-	m["geo_restriction"] = s
-	return schema.NewSet(restrictionsHash, []interface{}{m})
-}
+func flattenRestrictions(r *cloudfront.Restrictions) []interface{} {
+	m := map[string]interface{}{
+		"geo_restriction": []interface{}{flattenGeoRestriction(r.GeoRestriction)},
+	}
 
-// Assemble the hash for the aws_cloudfront_distribution restrictions
-// TypeSet attribute.
-func restrictionsHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%d-", geoRestrictionHash(m["geo_restriction"].(*schema.Set).List()[0].(map[string]interface{}))))
-	return hashcode.String(buf.String())
+	return []interface{}{m}
 }
 
 func expandGeoRestriction(m map[string]interface{}) *cloudfront.GeoRestriction {
-	gr := cloudfront.GeoRestriction{
+	gr := &cloudfront.GeoRestriction{
+		Quantity:        aws.Int64(int64(0)),
 		RestrictionType: aws.String(m["restriction_type"].(string)),
 	}
+
 	if v, ok := m["locations"]; ok {
-		gr.Quantity = aws.Int64(int64(len(v.([]interface{}))))
-		gr.Items = expandStringList(v.([]interface{}))
-		sort.Sort(StringPtrSlice(gr.Items))
-	} else {
-		gr.Quantity = aws.Int64(0)
+		gr.Items = expandStringSet(v.(*schema.Set))
+		gr.Quantity = aws.Int64(int64(v.(*schema.Set).Len()))
 	}
-	return &gr
+
+	return gr
 }
 
 func flattenGeoRestriction(gr *cloudfront.GeoRestriction) map[string]interface{} {
 	m := make(map[string]interface{})
 
-	m["restriction_type"] = *gr.RestrictionType
+	m["restriction_type"] = aws.StringValue(gr.RestrictionType)
 	if gr.Items != nil {
-		sort.Sort(StringPtrSlice(gr.Items))
-		m["locations"] = flattenStringList(gr.Items)
+		m["locations"] = schema.NewSet(schema.HashString, flattenStringList(gr.Items))
 	}
 	return m
-}
-
-// Assemble the hash for the aws_cloudfront_distribution geo_restriction
-// TypeSet attribute.
-func geoRestrictionHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	// All keys added in alphabetical order.
-	buf.WriteString(fmt.Sprintf("%s-", m["restriction_type"].(string)))
-	if v, ok := m["locations"]; ok {
-		for _, w := range sortInterfaceSlice(v.([]interface{})) {
-			buf.WriteString(fmt.Sprintf("%s-", w.(string)))
-		}
-	}
-	return hashcode.String(buf.String())
 }
 
 func expandViewerCertificate(m map[string]interface{}) *cloudfront.ViewerCertificate {
@@ -1123,7 +933,7 @@ func expandViewerCertificate(m map[string]interface{}) *cloudfront.ViewerCertifi
 	return &vc
 }
 
-func flattenViewerCertificate(vc *cloudfront.ViewerCertificate) *schema.Set {
+func flattenViewerCertificate(vc *cloudfront.ViewerCertificate) []interface{} {
 	m := make(map[string]interface{})
 
 	if vc.IAMCertificateId != nil {
@@ -1140,50 +950,7 @@ func flattenViewerCertificate(vc *cloudfront.ViewerCertificate) *schema.Set {
 	if vc.MinimumProtocolVersion != nil {
 		m["minimum_protocol_version"] = *vc.MinimumProtocolVersion
 	}
-	return schema.NewSet(viewerCertificateHash, []interface{}{m})
-}
-
-// Assemble the hash for the aws_cloudfront_distribution viewer_certificate
-// TypeSet attribute.
-func viewerCertificateHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	if v, ok := m["iam_certificate_id"]; ok && v.(string) != "" {
-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["ssl_support_method"].(string)))
-	} else if v, ok := m["acm_certificate_arn"]; ok && v.(string) != "" {
-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["ssl_support_method"].(string)))
-	} else {
-		buf.WriteString(fmt.Sprintf("%t-", m["cloudfront_default_certificate"].(bool)))
-	}
-	// if minimum_protocol_version is not specified and we use cloudfront_default_certificate,
-	// ignore current value of minimum_protocol_version
-	if c, ok := m["cloudfront_default_certificate"]; !(ok && c.(bool)) {
-		if v, ok := m["minimum_protocol_version"]; ok && v.(string) != "" {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-		}
-	}
-	return hashcode.String(buf.String())
-}
-
-// Do a top-level copy of struct fields from one struct to another. Used to
-// copy fields between CacheBehavior and DefaultCacheBehavior structs.
-func simpleCopyStruct(src, dst interface{}) {
-	s := reflect.ValueOf(src).Elem()
-	d := reflect.ValueOf(dst).Elem()
-
-	for i := 0; i < s.NumField(); i++ {
-		if s.Field(i).CanSet() {
-			if s.Field(i).Interface() != nil {
-				for j := 0; j < d.NumField(); j++ {
-					if d.Type().Field(j).Name == s.Type().Field(i).Name {
-						d.Field(j).Set(s.Field(i))
-					}
-				}
-			}
-		}
-	}
+	return []interface{}{m}
 }
 
 // Convert *cloudfront.ActiveTrustedSigners to a flatmap.Map type, which ensures

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -67,14 +67,12 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"forwarded_values": {
 							Type:     schema.TypeSet,
 							Required: true,
-							Set:      forwardedValuesHash,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"cookies": {
 										Type:     schema.TypeSet,
 										Required: true,
-										Set:      cookiePreferenceHash,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -128,7 +126,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									},
 								},
 							},
-							Set: lambdaFunctionAssociationHash,
 						},
 						"max_ttl": {
 							Type:     schema.TypeInt,
@@ -194,16 +191,14 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Optional: true,
 						},
 						"forwarded_values": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
-							Set:      forwardedValuesHash,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"cookies": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Required: true,
-										Set:      cookiePreferenceHash,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -323,19 +318,18 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				},
 			},
 			"default_cache_behavior": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
-				Set:      defaultCacheBehaviorHash,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"cached_methods": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -354,16 +348,14 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Optional: true,
 						},
 						"forwarded_values": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
-							Set:      forwardedValuesHash,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"cookies": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Required: true,
-										Set:      cookiePreferenceHash,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -464,9 +456,8 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"http1.1", "http2"}, false),
 			},
 			"logging_config": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
-				Set:      loggingConfigHash,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -494,11 +485,9 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"custom_origin_config": {
-							Type:          schema.TypeSet,
-							Optional:      true,
-							ConflictsWith: []string{"origin.s3_origin_config"},
-							Set:           customOriginConfigHash,
-							MaxItems:      1,
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"http_port": {
@@ -524,7 +513,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Required: true,
 									},
 									"origin_ssl_protocols": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Required: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
@@ -563,11 +552,9 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							Optional: true,
 						},
 						"s3_origin_config": {
-							Type:          schema.TypeSet,
-							Optional:      true,
-							ConflictsWith: []string{"origin.custom_origin_config"},
-							Set:           s3OriginConfigHash,
-							MaxItems:      1,
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"origin_access_identity": {
@@ -586,21 +573,19 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				Default:  "PriceClass_All",
 			},
 			"restrictions": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
-				Set:      restrictionsHash,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"geo_restriction": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
-							Set:      geoRestrictionHash,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"locations": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Optional: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
@@ -615,26 +600,25 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 				},
 			},
 			"viewer_certificate": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Required: true,
-				Set:      viewerCertificateHash,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"acm_certificate_arn": {
 							Type:          schema.TypeString,
 							Optional:      true,
-							ConflictsWith: []string{"viewer_certificate.cloudfront_default_certificate", "viewer_certificate.iam_certificate_id"},
+							ConflictsWith: []string{"viewer_certificate.0.cloudfront_default_certificate", "viewer_certificate.0.iam_certificate_id"},
 						},
 						"cloudfront_default_certificate": {
 							Type:          schema.TypeBool,
 							Optional:      true,
-							ConflictsWith: []string{"viewer_certificate.acm_certificate_arn", "viewer_certificate.iam_certificate_id"},
+							ConflictsWith: []string{"viewer_certificate.0.acm_certificate_arn", "viewer_certificate.0.iam_certificate_id"},
 						},
 						"iam_certificate_id": {
 							Type:          schema.TypeString,
 							Optional:      true,
-							ConflictsWith: []string{"viewer_certificate.acm_certificate_arn", "viewer_certificate.cloudfront_default_certificate"},
+							ConflictsWith: []string{"viewer_certificate.0.acm_certificate_arn", "viewer_certificate.0.cloudfront_default_certificate"},
 						},
 						"minimum_protocol_version": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -75,29 +75,6 @@ func testSweepCloudFrontDistributions(region string) error {
 	return nil
 }
 
-func TestAccAWSCloudFrontDistribution_importBasic(t *testing.T) {
-	ri := acctest.RandInt()
-	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3Config, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
-
-	resourceName := "aws_cloudfront_distribution.s3_distribution"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testConfig,
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 // TestAccAWSCloudFrontDistribution_S3Origin runs an
 // aws_cloudfront_distribution acceptance test with a single S3 origin.
 //
@@ -123,6 +100,12 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 						"Z2FDTNDATAQYW2",
 					),
 				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_distribution.s3_distribution",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
 			},
 		},
 	})
@@ -151,6 +134,12 @@ func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_cloudfront_distribution.s3_distribution", "tags.account", "main"),
 				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_distribution.s3_distribution",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
 			},
 			{
 				Config: postConfig,
@@ -187,6 +176,12 @@ func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:            "aws_cloudfront_distribution.custom_distribution",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+			},
 		},
 	})
 }
@@ -211,6 +206,12 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ordered_cache_behavior.0.default_ttl", "50"),
 					resource.TestCheckResourceAttr(resourceName, "ordered_cache_behavior.0.path_pattern", "images1/*.jpg"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
 			},
 		},
 	})
@@ -241,9 +242,10 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
 			},
 		},
 	})
@@ -297,33 +299,24 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "arn", regexp.MustCompile(`^arn:[^:]+:cloudfront::[^:]+:distribution/[A-Z0-9]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "custom_error_response.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.#", "7"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.0", "HEAD"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.1", "DELETE"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.2", "POST"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.3", "GET"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.4", "OPTIONS"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.5", "PUT"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.allowed_methods.6", "PATCH"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.cached_methods.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.cached_methods.0", "HEAD"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.cached_methods.1", "GET"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.compress", "false"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.default_ttl", "86400"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.cookies.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.cookies.1870923232.forward", "all"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.cookies.1870923232.whitelisted_names.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.headers.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.query_string", "false"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.forwarded_values.2510654351.query_string_cache_keys.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.lambda_function_association.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.max_ttl", "31536000"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.min_ttl", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.smooth_streaming", "false"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.target_origin_id", "myCustomOrigin"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.trusted_signers.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.2871742778.viewer_protocol_policy", "allow-all"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.allowed_methods.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.cached_methods.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.compress", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.default_ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.cookies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.cookies.0.forward", "all"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.cookies.0.whitelisted_names.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.headers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.query_string", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.forwarded_values.0.query_string_cache_keys.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.lambda_function_association.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.max_ttl", "31536000"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.min_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.smooth_streaming", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.target_origin_id", "myCustomOrigin"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.trusted_signers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_cache_behavior.0.viewer_protocol_policy", "allow-all"),
 					resource.TestMatchResourceAttr(resourceName, "domain_name", regexp.MustCompile(`^[a-z0-9]+\.cloudfront\.net$`)),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestMatchResourceAttr(resourceName, "etag", regexp.MustCompile(`^[A-Z0-9]+$`)),
@@ -334,28 +327,28 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_header.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.http_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.https_port", "443"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_keepalive_timeout", "5"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_protocol_policy", "http-only"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_read_timeout", "30"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.0", "SSLv3"),
-					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.1", "TLSv1"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.http_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_keepalive_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_protocol_policy", "http-only"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_read_timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.custom_origin_config.0.origin_ssl_protocols.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "origin.1857972443.domain_name", "www.example.com"),
 					resource.TestCheckResourceAttr(resourceName, "price_class", "PriceClass_All"),
 					resource.TestCheckResourceAttr(resourceName, "restrictions.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.#", "4"),
-					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.0", "CA"),
-					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.1", "DE"),
-					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.2", "GB"),
-					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.locations.3", "US"),
-					resource.TestCheckResourceAttr(resourceName, "restrictions.811065190.geo_restriction.1303118592.restriction_type", "whitelist"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.geo_restriction.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.geo_restriction.0.locations.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "restrictions.0.geo_restriction.0.restriction_type", "whitelist"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "viewer_certificate.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "viewer_certificate.69840937.cloudfront_default_certificate", "true"),
+					resource.TestCheckResourceAttr(resourceName, "viewer_certificate.0.cloudfront_default_certificate", "true"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
 			},
 		},
 	})
@@ -381,6 +374,12 @@ func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:            "aws_cloudfront_distribution.http_1_1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+			},
 		},
 	})
 }
@@ -401,6 +400,12 @@ func TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig(t *testing.T) {
 						"aws_cloudfront_distribution.is_ipv6_enabled", "is_ipv6_enabled", "true"),
 				),
 			},
+			{
+				ResourceName:            "aws_cloudfront_distribution.is_ipv6_enabled",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+			},
 		},
 	})
 }
@@ -418,6 +423,12 @@ func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) 
 						"aws_cloudfront_distribution.no_custom_error_responses",
 					),
 				),
+			},
+			{
+				ResourceName:            "aws_cloudfront_distribution.no_custom_error_responses",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retain_on_delete"},
 			},
 		},
 	})


### PR DESCRIPTION
Closes #7709
Closes #5526
Closes #4338
Closes #3842
Closes #3766
Closes #3256
Closes #1194
Closes #824
Closes #416

The usage of `TypeSet` for single container block attributes can cause unnecessary problems with Terraform's difference logic and makes plan output unnecessarily more difficult to read. Here we adjust these to `TypeList`.

Converted the following from `Type: schema.TypeSet` and `MaxItems: 1` to `Type: schema.TypeList`:

* `default_cache_behavior` configuration block
* `default_cache_behavior` configuration block `forwarded_values` configuration block
* `default_cache_behavior` configuration block `forwarded_values` configuration block `cookies` configuration block
* `logging_config` configuration block
* `origin` configuration block `custom_origin_config` configuration block
* `origin` configuration block `s3_origin_config` configuration block
* `ordered_cache_behavior` configuration block `forwarded_values` configuration block
* `ordered_cache_behavior` configuration block `forwarded_values` configuration block `cookies` configuration block
* `restrictions` configuration block
* `restrictions` configuration block `geo_restriction` configuration block
* `viewer_certificate` configuration block

The usage of `TypeList` for arguments where ordering does not matter causes unnecessary hassle for operators to match their configuration to the CloudFront API. Here we replace these with `TypeSet` to ignore ordering.

Converted the following from `Type: schema.TypeList` to `Type: schema.TypeSet`:

* `default_cache_behavior` configuration block `allowed_methods` argument
* `default_cache_behavior` configuration block `cached_methods` argument
* `origin` configuration block `custom_origin_config` configuration block `origin_ssl_protocols` argument
* `restrictions` configuration block `geo_restriction` configuration block `locations` argument

This change was verified with a live configuration outside the acceptance testing framework with Terraform 0.11 as effectively a no-op for the most common use case configurations that do not later reference these attributes.

```console
$ terraform apply
...
aws_cloudfront_distribution.test: Creating...
  active_trusted_signers.%:                                                                             "" => "<computed>"
  arn:                                                                                                  "" => "<computed>"
  caller_reference:                                                                                     "" => "<computed>"
  default_cache_behavior.#:                                                                             "0" => "1"
  default_cache_behavior.1848826977.allowed_methods.#:                                                  "0" => "7"
  default_cache_behavior.1848826977.allowed_methods.0:                                                  "" => "DELETE"
  default_cache_behavior.1848826977.allowed_methods.1:                                                  "" => "GET"
  default_cache_behavior.1848826977.allowed_methods.2:                                                  "" => "HEAD"
  default_cache_behavior.1848826977.allowed_methods.3:                                                  "" => "OPTIONS"
  default_cache_behavior.1848826977.allowed_methods.4:                                                  "" => "PATCH"
  default_cache_behavior.1848826977.allowed_methods.5:                                                  "" => "POST"
  default_cache_behavior.1848826977.allowed_methods.6:                                                  "" => "PUT"
  default_cache_behavior.1848826977.cached_methods.#:                                                   "0" => "2"
  default_cache_behavior.1848826977.cached_methods.0:                                                   "" => "GET"
  default_cache_behavior.1848826977.cached_methods.1:                                                   "" => "HEAD"
  default_cache_behavior.1848826977.compress:                                                           "" => "false"
  default_cache_behavior.1848826977.default_ttl:                                                        "" => "100"
  default_cache_behavior.1848826977.field_level_encryption_id:                                          "" => ""
  default_cache_behavior.1848826977.forwarded_values.#:                                                 "0" => "1"
  default_cache_behavior.1848826977.forwarded_values.2510654351.cookies.#:                              "0" => "1"
  default_cache_behavior.1848826977.forwarded_values.2510654351.cookies.1870923232.forward:             "" => "all"
  default_cache_behavior.1848826977.forwarded_values.2510654351.cookies.1870923232.whitelisted_names.#: "0" => "0"
  default_cache_behavior.1848826977.forwarded_values.2510654351.headers.#:                              "0" => "0"
  default_cache_behavior.1848826977.forwarded_values.2510654351.query_string:                           "" => "false"
  default_cache_behavior.1848826977.forwarded_values.2510654351.query_string_cache_keys.#:              "0" => "0"
  default_cache_behavior.1848826977.lambda_function_association.#:                                      "0" => "0"
  default_cache_behavior.1848826977.max_ttl:                                                            "" => "100"
  default_cache_behavior.1848826977.min_ttl:                                                            "" => "100"
  default_cache_behavior.1848826977.smooth_streaming:                                                   "" => "true"
  default_cache_behavior.1848826977.target_origin_id:                                                   "" => "myCustomOrigin"
  default_cache_behavior.1848826977.trusted_signers.#:                                                  "0" => "0"
  default_cache_behavior.1848826977.viewer_protocol_policy:                                             "" => "allow-all"
  domain_name:                                                                                          "" => "<computed>"
  enabled:                                                                                              "" => "true"
  etag:                                                                                                 "" => "<computed>"
  hosted_zone_id:                                                                                       "" => "<computed>"
  http_version:                                                                                         "" => "http2"
  in_progress_validation_batches:                                                                       "" => "<computed>"
  is_ipv6_enabled:                                                                                      "" => "false"
  last_modified_time:                                                                                   "" => "<computed>"
  ordered_cache_behavior.#:                                                                             "0" => "2"
  ordered_cache_behavior.0.allowed_methods.#:                                                           "0" => "7"
  ordered_cache_behavior.0.allowed_methods.1012961568:                                                  "" => "POST"
  ordered_cache_behavior.0.allowed_methods.1040875975:                                                  "" => "GET"
  ordered_cache_behavior.0.allowed_methods.1445840968:                                                  "" => "HEAD"
  ordered_cache_behavior.0.allowed_methods.1741119464:                                                  "" => "PATCH"
  ordered_cache_behavior.0.allowed_methods.348445828:                                                   "" => "DELETE"
  ordered_cache_behavior.0.allowed_methods.3982006612:                                                  "" => "OPTIONS"
  ordered_cache_behavior.0.allowed_methods.4024585617:                                                  "" => "PUT"
  ordered_cache_behavior.0.cached_methods.#:                                                            "0" => "2"
  ordered_cache_behavior.0.cached_methods.1040875975:                                                   "" => "GET"
  ordered_cache_behavior.0.cached_methods.1445840968:                                                   "" => "HEAD"
  ordered_cache_behavior.0.compress:                                                                    "" => "false"
  ordered_cache_behavior.0.default_ttl:                                                                 "" => "50"
  ordered_cache_behavior.0.forwarded_values.#:                                                          "0" => "1"
  ordered_cache_behavior.0.forwarded_values.2555876073.cookies.#:                                       "0" => "1"
  ordered_cache_behavior.0.forwarded_values.2555876073.cookies.2625240281.forward:                      "" => "none"
  ordered_cache_behavior.0.forwarded_values.2555876073.cookies.2625240281.whitelisted_names.#:          "0" => "0"
  ordered_cache_behavior.0.forwarded_values.2555876073.headers.#:                                       "0" => "0"
  ordered_cache_behavior.0.forwarded_values.2555876073.query_string:                                    "" => "true"
  ordered_cache_behavior.0.forwarded_values.2555876073.query_string_cache_keys.#:                       "0" => "0"
  ordered_cache_behavior.0.max_ttl:                                                                     "" => "50"
  ordered_cache_behavior.0.min_ttl:                                                                     "" => "50"
  ordered_cache_behavior.0.path_pattern:                                                                "" => "images1/*.jpg"
  ordered_cache_behavior.0.target_origin_id:                                                            "" => "myCustomOrigin"
  ordered_cache_behavior.0.viewer_protocol_policy:                                                      "" => "allow-all"
  ordered_cache_behavior.1.allowed_methods.#:                                                           "0" => "7"
  ordered_cache_behavior.1.allowed_methods.1012961568:                                                  "" => "POST"
  ordered_cache_behavior.1.allowed_methods.1040875975:                                                  "" => "GET"
  ordered_cache_behavior.1.allowed_methods.1445840968:                                                  "" => "HEAD"
  ordered_cache_behavior.1.allowed_methods.1741119464:                                                  "" => "PATCH"
  ordered_cache_behavior.1.allowed_methods.348445828:                                                   "" => "DELETE"
  ordered_cache_behavior.1.allowed_methods.3982006612:                                                  "" => "OPTIONS"
  ordered_cache_behavior.1.allowed_methods.4024585617:                                                  "" => "PUT"
  ordered_cache_behavior.1.cached_methods.#:                                                            "0" => "2"
  ordered_cache_behavior.1.cached_methods.1040875975:                                                   "" => "GET"
  ordered_cache_behavior.1.cached_methods.1445840968:                                                   "" => "HEAD"
  ordered_cache_behavior.1.compress:                                                                    "" => "false"
  ordered_cache_behavior.1.default_ttl:                                                                 "" => "51"
  ordered_cache_behavior.1.forwarded_values.#:                                                          "0" => "1"
  ordered_cache_behavior.1.forwarded_values.2555876073.cookies.#:                                       "0" => "1"
  ordered_cache_behavior.1.forwarded_values.2555876073.cookies.2625240281.forward:                      "" => "none"
  ordered_cache_behavior.1.forwarded_values.2555876073.cookies.2625240281.whitelisted_names.#:          "0" => "0"
  ordered_cache_behavior.1.forwarded_values.2555876073.headers.#:                                       "0" => "0"
  ordered_cache_behavior.1.forwarded_values.2555876073.query_string:                                    "" => "true"
  ordered_cache_behavior.1.forwarded_values.2555876073.query_string_cache_keys.#:                       "0" => "0"
  ordered_cache_behavior.1.max_ttl:                                                                     "" => "51"
  ordered_cache_behavior.1.min_ttl:                                                                     "" => "51"
  ordered_cache_behavior.1.path_pattern:                                                                "" => "images2/*.jpg"
  ordered_cache_behavior.1.target_origin_id:                                                            "" => "myCustomOrigin"
  ordered_cache_behavior.1.viewer_protocol_policy:                                                      "" => "allow-all"
  origin.#:                                                                                             "0" => "1"
  origin.1857972443.custom_header.#:                                                                    "0" => "0"
  origin.1857972443.custom_origin_config.#:                                                             "0" => "1"
  origin.1857972443.custom_origin_config.3832794885.http_port:                                          "" => "80"
  origin.1857972443.custom_origin_config.3832794885.https_port:                                         "" => "443"
  origin.1857972443.custom_origin_config.3832794885.origin_keepalive_timeout:                           "" => "5"
  origin.1857972443.custom_origin_config.3832794885.origin_protocol_policy:                             "" => "http-only"
  origin.1857972443.custom_origin_config.3832794885.origin_read_timeout:                                "" => "30"
  origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.#:                             "0" => "2"
  origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.0:                             "" => "SSLv3"
  origin.1857972443.custom_origin_config.3832794885.origin_ssl_protocols.1:                             "" => "TLSv1"
  origin.1857972443.domain_name:                                                                        "" => "www.example.com"
  origin.1857972443.origin_id:                                                                          "" => "myCustomOrigin"
  origin.1857972443.origin_path:                                                                        "" => ""
  origin.1857972443.s3_origin_config.#:                                                                 "0" => "0"
  price_class:                                                                                          "" => "PriceClass_All"
  restrictions.#:                                                                                       "0" => "1"
  restrictions.811065190.geo_restriction.#:                                                             "0" => "1"
  restrictions.811065190.geo_restriction.1303118592.locations.#:                                        "0" => "4"
  restrictions.811065190.geo_restriction.1303118592.locations.0:                                        "" => "US"
  restrictions.811065190.geo_restriction.1303118592.locations.1:                                        "" => "CA"
  restrictions.811065190.geo_restriction.1303118592.locations.2:                                        "" => "GB"
  restrictions.811065190.geo_restriction.1303118592.locations.3:                                        "" => "DE"
  restrictions.811065190.geo_restriction.1303118592.restriction_type:                                   "" => "whitelist"
  retain_on_delete:                                                                                     "" => "false"
  status:                                                                                               "" => "<computed>"
  viewer_certificate.#:                                                                                 "0" => "1"
  viewer_certificate.69840937.acm_certificate_arn:                                                      "" => ""
  viewer_certificate.69840937.cloudfront_default_certificate:                                           "" => "true"
  viewer_certificate.69840937.iam_certificate_id:                                                       "" => ""
  viewer_certificate.69840937.minimum_protocol_version:                                                 "" => "TLSv1"
  viewer_certificate.69840937.ssl_support_method:                                                       "" => ""
aws_cloudfront_distribution.test: Creation complete after 0s (ID: E3K1GJF3SSNJRN)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ cp ~/go/bin/terraform-provider-aws .terraform/plugins/darwin_amd64/terraform-provider-aws_v1.60.0_x4; terraform init # this binary is an updated Terraform AWS Provider built with these changes

$ terraform apply # Here we see no state migration required
aws_cloudfront_distribution.test: Refreshing state... (ID: E3K1GJF3SSNJRN)

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

$ terraform state show aws_cloudfront_distribution.test # Here we see a successful state refresh with the new layout
id                                                                        = E3K1GJF3SSNJRN
active_trusted_signers.%                                                  = 2
active_trusted_signers.enabled                                            = false
active_trusted_signers.items.#                                            = 0
aliases.#                                                                 = 0
arn                                                                       = arn:aws:cloudfront::187416307283:distribution/E3K1GJF3SSNJRN
caller_reference                                                          = 2019-02-25T14:51:42.674464-05:00
custom_error_response.#                                                   = 0
default_cache_behavior.#                                                  = 1
default_cache_behavior.0.allowed_methods.#                                = 7
default_cache_behavior.0.allowed_methods.1012961568                       = POST
default_cache_behavior.0.allowed_methods.1040875975                       = GET
default_cache_behavior.0.allowed_methods.1445840968                       = HEAD
default_cache_behavior.0.allowed_methods.1741119464                       = PATCH
default_cache_behavior.0.allowed_methods.348445828                        = DELETE
default_cache_behavior.0.allowed_methods.3982006612                       = OPTIONS
default_cache_behavior.0.allowed_methods.4024585617                       = PUT
default_cache_behavior.0.cached_methods.#                                 = 2
default_cache_behavior.0.cached_methods.1040875975                        = GET
default_cache_behavior.0.cached_methods.1445840968                        = HEAD
default_cache_behavior.0.compress                                         = false
default_cache_behavior.0.default_ttl                                      = 100
default_cache_behavior.0.field_level_encryption_id                        =
default_cache_behavior.0.forwarded_values.#                               = 1
default_cache_behavior.0.forwarded_values.0.cookies.#                     = 1
default_cache_behavior.0.forwarded_values.0.cookies.0.forward             = all
default_cache_behavior.0.forwarded_values.0.cookies.0.whitelisted_names.# = 0
default_cache_behavior.0.forwarded_values.0.headers.#                     = 0
default_cache_behavior.0.forwarded_values.0.query_string                  = false
default_cache_behavior.0.forwarded_values.0.query_string_cache_keys.#     = 0
default_cache_behavior.0.lambda_function_association.#                    = 0
default_cache_behavior.0.max_ttl                                          = 100
default_cache_behavior.0.min_ttl                                          = 100
default_cache_behavior.0.smooth_streaming                                 = true
default_cache_behavior.0.target_origin_id                                 = myCustomOrigin
default_cache_behavior.0.trusted_signers.#                                = 0
default_cache_behavior.0.viewer_protocol_policy                           = allow-all
default_root_object                                                       =
domain_name                                                               = dot6h04nf0cmx.cloudfront.net
enabled                                                                   = true
etag                                                                      = E33ZADXZHBHVXT
hosted_zone_id                                                            = Z2FDTNDATAQYW2
http_version                                                              = http2
in_progress_validation_batches                                            = 0
is_ipv6_enabled                                                           = false
last_modified_time                                                        = 2019-02-26 02:22:40.558 +0000 UTC
logging_config.#                                                          = 0
ordered_cache_behavior.#                                                  = 2
ordered_cache_behavior.0.allowed_methods.#                                = 7
ordered_cache_behavior.0.allowed_methods.1012961568                       = POST
ordered_cache_behavior.0.allowed_methods.1040875975                       = GET
ordered_cache_behavior.0.allowed_methods.1445840968                       = HEAD
ordered_cache_behavior.0.allowed_methods.1741119464                       = PATCH
ordered_cache_behavior.0.allowed_methods.348445828                        = DELETE
ordered_cache_behavior.0.allowed_methods.3982006612                       = OPTIONS
ordered_cache_behavior.0.allowed_methods.4024585617                       = PUT
ordered_cache_behavior.0.cached_methods.#                                 = 2
ordered_cache_behavior.0.cached_methods.1040875975                        = GET
ordered_cache_behavior.0.cached_methods.1445840968                        = HEAD
ordered_cache_behavior.0.compress                                         = false
ordered_cache_behavior.0.default_ttl                                      = 50
ordered_cache_behavior.0.field_level_encryption_id                        =
ordered_cache_behavior.0.forwarded_values.#                               = 1
ordered_cache_behavior.0.forwarded_values.0.cookies.#                     = 1
ordered_cache_behavior.0.forwarded_values.0.cookies.0.forward             = none
ordered_cache_behavior.0.forwarded_values.0.cookies.0.whitelisted_names.# = 0
ordered_cache_behavior.0.forwarded_values.0.headers.#                     = 0
ordered_cache_behavior.0.forwarded_values.0.query_string                  = true
ordered_cache_behavior.0.forwarded_values.0.query_string_cache_keys.#     = 0
ordered_cache_behavior.0.lambda_function_association.#                    = 0
ordered_cache_behavior.0.max_ttl                                          = 50
ordered_cache_behavior.0.min_ttl                                          = 50
ordered_cache_behavior.0.path_pattern                                     = images1/*.jpg
ordered_cache_behavior.0.smooth_streaming                                 = false
ordered_cache_behavior.0.target_origin_id                                 = myCustomOrigin
ordered_cache_behavior.0.trusted_signers.#                                = 0
ordered_cache_behavior.0.viewer_protocol_policy                           = allow-all
ordered_cache_behavior.1.allowed_methods.#                                = 7
ordered_cache_behavior.1.allowed_methods.1012961568                       = POST
ordered_cache_behavior.1.allowed_methods.1040875975                       = GET
ordered_cache_behavior.1.allowed_methods.1445840968                       = HEAD
ordered_cache_behavior.1.allowed_methods.1741119464                       = PATCH
ordered_cache_behavior.1.allowed_methods.348445828                        = DELETE
ordered_cache_behavior.1.allowed_methods.3982006612                       = OPTIONS
ordered_cache_behavior.1.allowed_methods.4024585617                       = PUT
ordered_cache_behavior.1.cached_methods.#                                 = 2
ordered_cache_behavior.1.cached_methods.1040875975                        = GET
ordered_cache_behavior.1.cached_methods.1445840968                        = HEAD
ordered_cache_behavior.1.compress                                         = false
ordered_cache_behavior.1.default_ttl                                      = 51
ordered_cache_behavior.1.field_level_encryption_id                        =
ordered_cache_behavior.1.forwarded_values.#                               = 1
ordered_cache_behavior.1.forwarded_values.0.cookies.#                     = 1
ordered_cache_behavior.1.forwarded_values.0.cookies.0.forward             = none
ordered_cache_behavior.1.forwarded_values.0.cookies.0.whitelisted_names.# = 0
ordered_cache_behavior.1.forwarded_values.0.headers.#                     = 0
ordered_cache_behavior.1.forwarded_values.0.query_string                  = true
ordered_cache_behavior.1.forwarded_values.0.query_string_cache_keys.#     = 0
ordered_cache_behavior.1.lambda_function_association.#                    = 0
ordered_cache_behavior.1.max_ttl                                          = 51
ordered_cache_behavior.1.min_ttl                                          = 51
ordered_cache_behavior.1.path_pattern                                     = images2/*.jpg
ordered_cache_behavior.1.smooth_streaming                                 = false
ordered_cache_behavior.1.target_origin_id                                 = myCustomOrigin
ordered_cache_behavior.1.trusted_signers.#                                = 0
ordered_cache_behavior.1.viewer_protocol_policy                           = allow-all
origin.#                                                                  = 1
origin.1857972443.custom_header.#                                         = 0
origin.1857972443.custom_origin_config.#                                  = 1
origin.1857972443.custom_origin_config.0.http_port                        = 80
origin.1857972443.custom_origin_config.0.https_port                       = 443
origin.1857972443.custom_origin_config.0.origin_keepalive_timeout         = 5
origin.1857972443.custom_origin_config.0.origin_protocol_policy           = http-only
origin.1857972443.custom_origin_config.0.origin_read_timeout              = 30
origin.1857972443.custom_origin_config.0.origin_ssl_protocols.#           = 2
origin.1857972443.custom_origin_config.0.origin_ssl_protocols.1162609714  = TLSv1
origin.1857972443.custom_origin_config.0.origin_ssl_protocols.2159350162  = SSLv3
origin.1857972443.domain_name                                             = www.example.com
origin.1857972443.origin_id                                               = myCustomOrigin
origin.1857972443.origin_path                                             =
origin.1857972443.s3_origin_config.#                                      = 0
price_class                                                               = PriceClass_All
restrictions.#                                                            = 1
restrictions.0.geo_restriction.#                                          = 1
restrictions.0.geo_restriction.0.locations.#                              = 4
restrictions.0.geo_restriction.0.locations.3034033770                     = DE
restrictions.0.geo_restriction.0.locations.3047936762                     = US
restrictions.0.geo_restriction.0.locations.3589570027                     = CA
restrictions.0.geo_restriction.0.locations.4191192820                     = GB
restrictions.0.geo_restriction.0.restriction_type                         = whitelist
retain_on_delete                                                          = false
status                                                                    = Deployed
tags.%                                                                    = 0
viewer_certificate.#                                                      = 1
viewer_certificate.0.acm_certificate_arn                                  =
viewer_certificate.0.cloudfront_default_certificate                       = true
viewer_certificate.0.iam_certificate_id                                   =
viewer_certificate.0.minimum_protocol_version                             = TLSv1
viewer_certificate.0.ssl_support_method                                   =
web_acl_id                                                                =
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.04s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.12s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (1082.43s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (1082.47s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (1083.16s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (1083.56s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1084.20s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (1089.11s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (1090.38s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1092.54s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1093.67s)
```
