### PR TITLE
resource/aws_route53_record: Switch allow_overwrite default from true to false

### DIFF
--- a/aws/resource_aws_route53_record.go
+++ b/aws/resource_aws_route53_record.go
@@ -235,9 +235,10 @@ func resourceAwsRoute53Record() *schema.Resource {
 			},
 
 			"allow_overwrite": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "The next major version of the Terraform AWS Provider will require importing existing records",
 			},
 		},
 	}

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -650,7 +650,7 @@ resource, with in-line routes, to the state.
 
 ### allow_overwrite Default Value Change
 
-The resource now requires existing Route 53 Records to be imported into the Terraform state for management unless the `allow_overwrite` argument is enabled. The `allow_overwrite` flag is considered deprecated for removal in the next major version of the Terraform AWS Provider (version 3.0.0).
+The resource now requires existing Route 53 Records to be imported into the Terraform state for management unless the `allow_overwrite` argument is enabled. The `allow_overwrite` flag is considered deprecated for removal in a future major version of the Terraform AWS Provider.
 
 For example, if the `www.example.com` Route 53 Record in the `example.com` Route 53 Hosted Zone existed previously and this new Terraform configuration was introduced:
 

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -24,6 +24,7 @@ Upgrade topics:
 - [Data Source: aws_ami_ids](#data-source-aws_ami_ids)
 - [Data Source: aws_iam_role](#data-source-aws_iam_role)
 - [Data Source: aws_kms_secret](#data-source-aws_kms_secret)
+- [Data Source: aws_lambda_function](#data-source-aws_lambda_function)
 - [Data Source: aws_region](#data-source-aws_region)
 - [Resource: aws_api_gateway_api_key](#resource-aws_api_gateway_api_key)
 - [Resource: aws_api_gateway_integration](#resource-aws_api_gateway_integration)
@@ -44,6 +45,7 @@ Upgrade topics:
 - [Resource: aws_network_acl](#resource-aws_network_acl)
 - [Resource: aws_redshift_cluster](#resource-aws_redshift_cluster)
 - [Resource: aws_route_table](#resource-aws_route_table)
+- [Resource: aws_route53_record](#resource-aws_route53_record)
 - [Resource: aws_route53_zone](#resource-aws_route53_zone)
 - [Resource: aws_wafregional_byte_match_set](#resource-aws_wafregional_byte_match_set)
 
@@ -643,6 +645,31 @@ resource "aws_redshift_cluster" "example" {
 Previously, importing this resource resulted in an `aws_route` resource for each route, in
 addition to the `aws_route_table`, in the Terraform state. Support for importing `aws_route` resources has been added and importing this resource only adds the `aws_route_table` 
 resource, with in-line routes, to the state.
+
+## Resource: aws_route53_record
+
+### allow_overwrite Default Value Change
+
+The resource now requires existing Route 53 Records to be imported into the Terraform state for management unless the `allow_overwrite` argument is enabled. The `allow_overwrite` flag is considered deprecated for removal in the next major version of the Terraform AWS Provider (version 3.0.0).
+
+For example, if the `www.example.com` Route 53 Record in the `example.com` Route 53 Hosted Zone existed previously and this new Terraform configuration was introduced:
+
+```hcl
+resource "aws_route53_record" "www" {
+  # ... other configuration ...
+  name = "www.example.com"
+}
+```
+
+During resource creation in version 1.X and prior, it would silently perform an `UPSERT` changeset to the existing Route 53 Record and not report back an error. In version 2.0.0 of the Terraform AWS Provider, the resource now performs a `CREATE` changeset, which will error for existing Route 53 Records.
+
+The `allow_overwrite` argument provides a temporary workaround to keep the old behavior, but existing workflows should be updated to perform a `terraform import` command like the following instead:
+
+```console
+$ terraform import aws_route53_record.www ZONEID_www.example.com_TYPE
+```
+
+More information can be found in the [`aws_route53_record` resource documentation](https://www.terraform.io/docs/providers/aws/r/route53_record.html#import).
 
 ## Resource: aws_route53_zone
 

--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 * `latency_routing_policy` - (Optional) A block indicating a routing policy based on the latency between the requestor and an AWS region. Conflicts with any other routing policy. Documented below.
 * `weighted_routing_policy` - (Optional) A block indicating a weighted routing policy. Conflicts with any other routing policy. Documented below.
 * `multivalue_answer_routing_policy` - (Optional) Set to `true` to indicate a multivalue answer routing policy. Conflicts with any other routing policy.
-* `allow_overwrite` - (Optional) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not prevent other resources within Terraform or manual Route53 changes from overwriting this record. `true` by default.
+* `allow_overwrite` - (Optional, **DEPRECATED**) Allow creation of this record in Terraform to overwrite an existing record, if any. This does not affect the ability to update the record in Terraform and does not prevent other resources within Terraform or manual Route 53 changes outside Terraform from overwriting this record. `false` by default. The next major version of the Terraform AWS Provider will always require importing existing Route 53 Records.
 
 Exactly one of `records` or `alias` must be specified: this determines whether it's an alias record.
 


### PR DESCRIPTION
Closes #3895
Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/2926

Previously, the `aws_route53_record` resource did not follow standard Terraform conventions of requiring existing infrastructure to be imported into Terraform's state for management, which meant operators could unexpectedly affect that existing infrastructure. In version 1.10.0, we introduced the `allow_overwrite` argument so operators could opt into the upcoming import requirement and force the Terraform resource during resource creation to error if it attempted to create a Route53 record that previously existed.

Here we make the breaking change to switch the default resource behavior to error on creation for existing records. Operators can opt out of the new behavior by setting `allow_overwrite = true`, but it is marked as deprecated for removal in the next major version and will display the deprecation warning when used to signal that workflows should be adjusted if necessary.

Output from acceptance testing:

```
--- PASS: TestAccAWSRoute53Record_Alias_Elb (319.83s)
--- PASS: TestAccAWSRoute53Record_Alias_S3 (123.47s)
--- PASS: TestAccAWSRoute53Record_Alias_Uppercase (184.67s)
--- PASS: TestAccAWSRoute53Record_Alias_VpcEndpoint (450.17s)
--- PASS: TestAccAWSRoute53Record_AliasChange (157.29s)
--- PASS: TestAccAWSRoute53Record_allowOverwrite (365.48s)
--- PASS: TestAccAWSRoute53Record_basic (130.53s)
--- PASS: TestAccAWSRoute53Record_basic_fqdn (146.30s)
--- PASS: TestAccAWSRoute53Record_caaSupport (177.87s)
--- PASS: TestAccAWSRoute53Record_disappears (107.58s)
--- PASS: TestAccAWSRoute53Record_disappears_MultipleRecords (247.77s)
--- PASS: TestAccAWSRoute53Record_empty (115.48s)
--- PASS: TestAccAWSRoute53Record_failover (204.75s)
--- PASS: TestAccAWSRoute53Record_generatesSuffix (180.48s)
--- PASS: TestAccAWSRoute53Record_geolocation_basic (196.58s)
--- PASS: TestAccAWSRoute53Record_importBasic (174.28s)
--- PASS: TestAccAWSRoute53Record_importUnderscored (114.40s)
--- PASS: TestAccAWSRoute53Record_latency_basic (173.99s)
--- PASS: TestAccAWSRoute53Record_longTXTrecord (114.97s)
--- PASS: TestAccAWSRoute53Record_multivalue_answer_basic (197.09s)
--- PASS: TestAccAWSRoute53Record_SetIdentifierChange (206.47s)
--- PASS: TestAccAWSRoute53Record_spfSupport (152.57s)
--- PASS: TestAccAWSRoute53Record_txtSupport (170.00s)
--- PASS: TestAccAWSRoute53Record_TypeChange (220.81s)
--- PASS: TestAccAWSRoute53Record_weighted_alias (278.61s)
--- PASS: TestAccAWSRoute53Record_weighted_basic (112.68s)
--- PASS: TestAccAWSRoute53Record_wildcard (216.04s)
```
