### PR TITLE
provider: Return error instead of logging on AWS Account ID lookup failure during initialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/protobuf v0.0.0-20171113180720-1e59b77b52bf // indirect
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/hashicorp/aws-sdk-go-base v0.2.0
+	github.com/hashicorp/aws-sdk-go-base v0.3.0
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/go-getter v0.0.0-20180327010114-90bb99a48d86 // indirect
 	github.com/hashicorp/go-hclog v0.0.0-20171005151751-ca137eb4b438 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pO
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
-github.com/hashicorp/aws-sdk-go-base v0.2.0 h1:5bjZnWCvQg9Im5CHZr9t90IaFC4uvVlMl2fTh23IoCk=
-github.com/hashicorp/aws-sdk-go-base v0.2.0/go.mod h1:ZIWACGGi0N7a4DZbf15yuE1JQORmWLtBcVM6F5SXNFU=
+github.com/hashicorp/aws-sdk-go-base v0.3.0 h1:CPWKWCuOwpIFNsy8FUI9IT2QI7mGwgVPc4hrXW9I4L4=
+github.com/hashicorp/aws-sdk-go-base v0.3.0/go.mod h1:ZIWACGGi0N7a4DZbf15yuE1JQORmWLtBcVM6F5SXNFU=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=

--- a/vendor/github.com/hashicorp/aws-sdk-go-base/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/aws-sdk-go-base/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.0 (February 26, 2019)
+
+BUG FIXES
+
+* session: Return error instead of logging with AWS Account ID lookup failure [GH-3]
+
 # v0.2.0 (February 20, 2019)
 
 ENHANCEMENTS

--- a/vendor/github.com/hashicorp/aws-sdk-go-base/session.go
+++ b/vendor/github.com/hashicorp/aws-sdk-go-base/session.go
@@ -185,13 +185,10 @@ func GetSessionWithAccountIDAndPartition(c *Config) (*session.Session, string, s
 			return sess, accountID, partition, nil
 		}
 
-		// DEPRECATED: Next major version of the provider should return the error instead of logging
-		//             if skip_request_account_id is not enabled.
-		log.Printf("[WARN] %s", fmt.Sprintf(
+		return nil, "", "", fmt.Errorf(
 			"AWS account ID not previously found and failed retrieving via all available methods. "+
-				"This will return an error in the next major version of the AWS provider. "+
 				"See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for workaround and implications. "+
-				"Errors: %s", err))
+				"Errors: %s", err)
 	}
 
 	var partition string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -189,7 +189,7 @@ github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/snappy
 # github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
 github.com/google/gofuzz
-# github.com/hashicorp/aws-sdk-go-base v0.2.0
+# github.com/hashicorp/aws-sdk-go-base v0.3.0
 github.com/hashicorp/aws-sdk-go-base
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap


### PR DESCRIPTION
Closes #7674
Additional reference: https://github.com/terraform-providers/terraform-provider-aws/pull/5795

Updated via:

```
$ go get github.com/hashicorp/aws-sdk-go-base@v0.3.0
$ go mod tidy
$ go mod vendor
```
