### PR TITLE
Add engine_version to modify option at restore from snapshot step

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -813,6 +813,11 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.Engine = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("engine_version"); ok {
+			modifyDbInstanceInput.EngineVersion = aws.String(attr.(string))
+			requiresModifyDbInstance = true
+		}
+
 		if attr, ok := d.GetOk("iam_database_authentication_enabled"); ok {
 			opts.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
 		}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7723 

Changes proposed in this pull request:

* Add setting `engine_version` to modify options when creating from snapshot restore

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion -timeout 120m
=== RUN   TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== PAUSE TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
=== CONT  TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1929.94s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1930.005s
```
