### PR TITLE
make aws_glue_connection resource connection_properties argument sensitive

### DIFF
--- a/aws/resource_aws_glue_connection.go
+++ b/aws/resource_aws_glue_connection.go
@@ -29,8 +29,9 @@ func resourceAwsGlueConnection() *schema.Resource {
 				Computed: true,
 			},
 			"connection_properties": {
-				Type:     schema.TypeMap,
-				Required: true,
+				Type:      schema.TypeMap,
+				Required:  true,
+				Sensitive: true,
 			},
 			"connection_type": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Fixes #7318

Changes proposed in this pull request:

* Switch connection_properties argument to sensitive so it does not expose username and password of DB to end users. (useful when running in CI/CD) 

