### PR TITLE
resource/aws_iam_user_login_profile: Properly read, delete, trigger resource recreation, and require import for existing infrastructure

### DIFF
--- a/aws/resource_aws_iam_user_login_profile.go
+++ b/aws/resource_aws_iam_user_login_profile.go
@@ -7,11 +7,12 @@ import (
 	"log"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/encryption"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -19,28 +20,38 @@ import (
 func resourceAwsIamUserLoginProfile() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsIamUserLoginProfileCreate,
-		Read:   schema.Noop,
-		Update: schema.Noop,
-		Delete: schema.RemoveFromState,
+		Read:   resourceAwsIamUserLoginProfileRead,
+		Delete: resourceAwsIamUserLoginProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				d.Set("encrypted_password", "")
+				d.Set("key_fingerprint", "")
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"user": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"pgp_key": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"password_reset_required": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+				ForceNew: true,
 			},
 			"password_length": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      20,
+				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(5, 128),
 			},
 
@@ -112,41 +123,20 @@ func checkIAMPwdPolicy(pass []byte) bool {
 
 func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
+	username := d.Get("user").(string)
 
 	encryptionKey, err := encryption.RetrieveGPGKey(strings.TrimSpace(d.Get("pgp_key").(string)))
 	if err != nil {
-		return err
+		return fmt.Errorf("error retrieving GPG Key during IAM User Login Profile (%s) creation: %s", username, err)
 	}
 
-	username := d.Get("user").(string)
 	passwordResetRequired := d.Get("password_reset_required").(bool)
 	passwordLength := d.Get("password_length").(int)
-
-	// DEPRECATED: Automatic import will be removed in a future major version update
-	// https://github.com/terraform-providers/terraform-provider-aws/issues/7536
-	_, err = iamconn.GetLoginProfile(&iam.GetLoginProfileInput{
-		UserName: aws.String(username),
-	})
-
-	// If there is already a login profile, bring it under management (to prevent
-	// resource creation diffs) - we will never modify it, but obviously cannot
-	// set the password.
-	if err == nil {
-		d.SetId(username)
-		d.Set("key_fingerprint", "")
-		d.Set("encrypted_password", "")
-		return nil
-	}
-
-	if !isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
-		return fmt.Errorf("Error checking for existing IAM User Login Profile: %s", err)
-	}
-
 	initialPassword := generateIAMPassword(passwordLength)
 
 	fingerprint, encrypted, err := encryption.EncryptValue(encryptionKey, initialPassword, "Password")
 	if err != nil {
-		return err
+		return fmt.Errorf("error encrypting password during IAM User Login Profile (%s) creation: %s", username, err)
 	}
 
 	request := &iam.CreateLoginProfileInput{
@@ -158,20 +148,84 @@ func resourceAwsIamUserLoginProfileCreate(d *schema.ResourceData, meta interface
 	log.Println("[DEBUG] Create IAM User Login Profile request:", request)
 	createResp, err := iamconn.CreateLoginProfile(request)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "EntityAlreadyExists" {
-			// If there is already a login profile, bring it under management (to prevent
-			// resource creation diffs) - we will never modify it, but obviously cannot
-			// set the password.
-			d.SetId(username)
-			d.Set("key_fingerprint", "")
-			d.Set("encrypted_password", "")
-			return nil
-		}
 		return fmt.Errorf("Error creating IAM User Login Profile for %q: %s", username, err)
 	}
 
 	d.SetId(*createResp.LoginProfile.UserName)
 	d.Set("key_fingerprint", fingerprint)
 	d.Set("encrypted_password", encrypted)
+	return nil
+}
+
+func resourceAwsIamUserLoginProfileRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iamconn
+
+	input := &iam.GetLoginProfileInput{
+		UserName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Getting IAM User Login Profile (%s): %s", d.Id(), input)
+	output, err := conn.GetLoginProfile(input)
+
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		log.Printf("[WARN] IAM User Login Profile (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error getting IAM User Login Profile (%s): %s", d.Id(), err)
+	}
+
+	if output == nil || output.LoginProfile == nil {
+		return fmt.Errorf("error getting IAM User Login Profile (%s): empty response", d.Id())
+	}
+
+	d.Set("user", aws.StringValue(output.LoginProfile.UserName))
+
+	return nil
+}
+
+func resourceAwsIamUserLoginProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).iamconn
+
+	input := &iam.DeleteLoginProfileInput{
+		UserName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting IAM User Login Profile (%s): %s", d.Id(), input)
+	// Handle IAM eventual consistency
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteLoginProfile(input)
+
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			return nil
+		}
+
+		// EntityTemporarilyUnmodifiable: Login Profile for User XXX cannot be modified while login profile is being created.
+		if isAWSErr(err, iam.ErrCodeEntityTemporarilyUnmodifiableException, "") {
+			return resource.RetryableError(err)
+		}
+
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	// Handle AWS Go SDK automatic retries
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteLoginProfile(input)
+	}
+
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting IAM User Login Profile (%s): %s", d.Id(), err)
+	}
+
 	return nil
 }

--- a/aws/resource_aws_iam_user_login_profile_test.go
+++ b/aws/resource_aws_iam_user_login_profile_test.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -70,7 +69,24 @@ func TestAccAWSUserLoginProfile_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
 					testDecryptPasswordAndTest("aws_iam_user_login_profile.user", "aws_iam_access_key.user", testPrivKey1),
+					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "encrypted_password"),
+					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "key_fingerprint"),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", "20"),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_reset_required", "true"),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "pgp_key", testPubKey1+"\n"),
 				),
+			},
+			{
+				ResourceName:      "aws_iam_user_login_profile.user",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"encrypted_password",
+					"key_fingerprint",
+					"password_length",
+					"password_reset_required",
+					"pgp_key",
+				},
 			},
 		},
 	})
@@ -92,7 +108,22 @@ func TestAccAWSUserLoginProfile_keybase(t *testing.T) {
 					testAccCheckAWSUserLoginProfileExists("aws_iam_user_login_profile.user", &conf),
 					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "encrypted_password"),
 					resource.TestCheckResourceAttrSet("aws_iam_user_login_profile.user", "key_fingerprint"),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", "20"),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_reset_required", "true"),
+					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "pgp_key", "keybase:terraformacctest\n"),
 				),
+			},
+			{
+				ResourceName:      "aws_iam_user_login_profile.user",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"encrypted_password",
+					"key_fingerprint",
+					"password_length",
+					"password_reset_required",
+					"pgp_key",
+				},
 			},
 		},
 	})
@@ -149,6 +180,18 @@ func TestAccAWSUserLoginProfile_PasswordLength(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_iam_user_login_profile.user", "password_length", "128"),
 				),
 			},
+			{
+				ResourceName:      "aws_iam_user_login_profile.user",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"encrypted_password",
+					"key_fingerprint",
+					"password_length",
+					"password_reset_required",
+					"pgp_key",
+				},
+			},
 		},
 	})
 }
@@ -161,22 +204,15 @@ func testAccCheckAWSUserLoginProfileDestroy(s *terraform.State) error {
 			continue
 		}
 
-		// Try to get user
 		_, err := iamconn.GetLoginProfile(&iam.GetLoginProfileInput{
 			UserName: aws.String(rs.Primary.ID),
 		})
-		if err == nil {
-			return fmt.Errorf("still exists.")
+
+		if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+			continue
 		}
 
-		// Verify the error is what we want
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return err
-		}
-		if ec2err.Code() != "NoSuchEntity" {
-			return err
-		}
+		return fmt.Errorf("IAM User Login Profile (%s) still exists", rs.Primary.ID)
 	}
 
 	return nil

--- a/website/docs/guides/version-2-upgrade.html.md
+++ b/website/docs/guides/version-2-upgrade.html.md
@@ -37,6 +37,7 @@ Upgrade topics:
 - [Resource: aws_ecs_service](#resource-aws_ecs_service)
 - [Resource: aws_efs_file_system](#resource-aws_efs_file_system)
 - [Resource: aws_elasticache_cluster](#resource-aws_elasticache_cluster)
+- [Resource: aws_iam_user_login_profile](#resource-aws_iam_user_login_profile)
 - [Resource: aws_instance](#resource-aws_instance)
 - [Resource: aws_lambda_function](#resource-aws_lambda_function)
 - [Resource: aws_lambda_layer_version](#resource-aws_lambda_layer_version)
@@ -635,6 +636,12 @@ resource "aws_elasticache_cluster" "example" {
   preferred_availability_zones = ["us-west-2a", "us-west-2b"]
 }
 ```
+
+## Resource: aws_iam_user_login_profile
+
+### Import Now Required For Existing Infrastructure
+
+When attempting to bring existing IAM User Login Profiles under Terraform management, `terraform import` is now required. See the [`aws_iam_user_login_profile` resource documentation](https://www.terraform.io/docs/providers/aws/r/iam_user_login_profile.html) for more information.
 
 ## Resource: aws_instance
 

--- a/website/docs/r/iam_user_login_profile.html.markdown
+++ b/website/docs/r/iam_user_login_profile.html.markdown
@@ -3,31 +3,31 @@ layout: "aws"
 page_title: "AWS: aws_iam_user_login_profile"
 sidebar_current: "docs-aws-resource-iam-user-login-profile"
 description: |-
-  Provides an IAM user login profile and encrypts the password.
+  Manages an IAM User Login Profile
 ---
 
 # aws_iam_user_login_profile
 
-Provides one-time creation of a IAM user login profile, and uses PGP to
-encrypt the password for safe transport to the user. PGP keys can be
-obtained from Keybase.
+Manages an IAM User Login Profile with limited support for password creation during Terraform resource creation. Uses PGP to encrypt the password for safe transport to the user. PGP keys can be obtained from Keybase.
+
+-> To reset an IAM User login password via Terraform, you can use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html) or change any of the arguments.
 
 ## Example Usage
 
 ```hcl
-resource "aws_iam_user" "u" {
-  name          = "auser"
+resource "aws_iam_user" "example" {
+  name          = "example"
   path          = "/"
   force_destroy = true
 }
 
-resource "aws_iam_user_login_profile" "u" {
-  user    = "${aws_iam_user.u.name}"
+resource "aws_iam_user_login_profile" "example" {
+  user    = "${aws_iam_user.example.name}"
   pgp_key = "keybase:some_person_that_exists"
 }
 
 output "password" {
-  value = "${aws_iam_user_login_profile.u.encrypted_password}"
+  value = "${aws_iam_user_login_profile.example.encrypted_password}"
 }
 ```
 
@@ -36,24 +36,36 @@ output "password" {
 The following arguments are supported:
 
 * `user` - (Required) The IAM user's name.
-* `pgp_key` - (Required) Either a base-64 encoded PGP public key, or a
-  keybase username in the form `keybase:username`.
-* `password_reset_required` - (Optional, default "true") Whether the
-  user should be forced to reset the generated password on first login.
-* `password_length` - (Optional, default 20) The length of the generated
-  password.
+* `pgp_key` - (Required) Either a base-64 encoded PGP public key, or a keybase username in the form `keybase:username`. Only applies on resource creation. Drift detection is not possible with this argument.
+* `password_length` - (Optional, default 20) The length of the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument.
+* `password_reset_required` - (Optional, default "true") Whether the user should be forced to reset the generated password on resource creation. Only applies on resource creation. Drift detection is not possible with this argument.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `key_fingerprint` - The fingerprint of the PGP key used to encrypt
-  the password
-* `encrypted_password` - The encrypted password, base64 encoded.
+* `key_fingerprint` - The fingerprint of the PGP key used to encrypt the password. Only available if password was handled on Terraform resource creation, not import.
+* `encrypted_password` - The encrypted password, base64 encoded. Only available if password was handled on Terraform resource creation, not import.
 
 ~> **NOTE:** The encrypted password may be decrypted using the command line,
    for example: `terraform output password | base64 --decode | keybase pgp decrypt`.
 
 ## Import
 
-IAM Login Profiles may not be imported.
+IAM User Login Profiles can be imported without password information support via the IAM User name, e.g.
+
+```sh
+$ terraform import aws_iam_user_login_profile.example myusername
+```
+
+Since Terraform has no method to read the PGP or password information during import, use the [Terraform resource `lifecycle` configuration block `ignore_changes` argument](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) to ignore them unless password recreation is desired. e.g.
+
+```hcl
+resource "aws_iam_user_login_profile" "example" {
+  # ... other configuration ...
+
+  lifecycle {
+    ignore_changes = ["password_length", "password_reset_required", "pgp_key"]
+  }
+}
+```


### PR DESCRIPTION
Closes #7536
Closes #3856

Output from acceptance testing:

```
--- PASS: TestAccAWSUserLoginProfile_notAKey (7.29s)
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (7.36s)
--- PASS: TestAccAWSUserLoginProfile_PasswordLength (16.86s)
--- PASS: TestAccAWSUserLoginProfile_keybase (16.93s)
--- PASS: TestAccAWSUserLoginProfile_basic (24.81s)
```
