### PR TITLE
Add new intervals to dlm

### DIFF
--- a/aws/resource_aws_dlm_lifecycle_policy.go
+++ b/aws/resource_aws_dlm_lifecycle_policy.go
@@ -66,6 +66,11 @@ func resourceAwsDlmLifecyclePolicy() *schema.Resource {
 													Type:     schema.TypeInt,
 													Required: true,
 													ValidateFunc: validateIntegerInSlice([]int{
+														2,
+														3,
+														4,
+														6,
+														8,
 														12,
 														24,
 													}),


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7749

Changes proposed in this pull request:

* Add new intervals for AWS DLM
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDlmLifecyclePolicy_Basic' && $ make testacc TESTARGS='-run=TestAccAWSDlmLifecyclePolicy_Full'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDlmLifecyclePolicy_Basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDlmLifecyclePolicy_Basic
=== PAUSE TestAccAWSDlmLifecyclePolicy_Basic
=== CONT  TestAccAWSDlmLifecyclePolicy_Basic
--- PASS: TestAccAWSDlmLifecyclePolicy_Basic (37.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       56.064s
...
```
