### PR TITLE
tests/provider: Remove all aws_region current = true configurations

### DIFF
--- a/aws/resource_aws_cloudwatch_log_destination_policy_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_policy_test.go
@@ -103,9 +103,7 @@ resource "aws_kinesis_stream" "test" {
   shard_count = 1
 }
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_iam_policy_document" "role" {
   statement {

--- a/aws/resource_aws_cloudwatch_log_destination_test.go
+++ b/aws/resource_aws_cloudwatch_log_destination_test.go
@@ -103,9 +103,7 @@ resource "aws_kinesis_stream" "test" {
   shard_count = 1
 }
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_iam_policy_document" "role" {
   statement {

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -150,9 +150,7 @@ func testAccCheckAwsDynamoDbGlobalTableExists(name string) resource.TestCheckFun
 
 func testAccDynamoDbGlobalTableConfig_basic(tableName string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 resource "aws_dynamodb_table" "test" {
   hash_key         = "myAttribute"

--- a/aws/resource_aws_iot_topic_rule_test.go
+++ b/aws/resource_aws_iot_topic_rule_test.go
@@ -455,9 +455,7 @@ resource "aws_iot_topic_rule" "rule" {
 
 func testAccAWSIoTTopicRule_elasticsearch(rName string) string {
 	return fmt.Sprintf(testAccAWSIoTTopicRuleRole+`
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 resource "aws_iot_topic_rule" "rule" {
   name        = "test_rule_%[1]s"

--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -137,9 +137,7 @@ func testAccCheckAWSSfnStateMachineDestroy(s *terraform.State) error {
 
 func testAccAWSSfnStateMachineConfig(rName string, rMaxAttempts int) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
   name = "iam_policy_for_lambda_%s"
@@ -256,9 +254,7 @@ EOF
 
 func testAccAWSSfnStateMachineConfigTags1(rName string, tag1Key, tag1Value string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
   name = "iam_policy_for_lambda_%s"
@@ -377,9 +373,7 @@ tags = {
 
 func testAccAWSSfnStateMachineConfigTags2(rName string, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
   name = "iam_policy_for_lambda_%s"


### PR DESCRIPTION
This argument was recently removed.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSCloudwatchLogDestinationPolicy_basic (1.75s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSCloudwatchLogDestinationPolicy_importBasic (1.75s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSCloudwatchLogDestination_importBasic (1.75s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSCloudwatchLogDestination_basic (1.75s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSDynamoDbGlobalTable_import (0.72s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSDynamoDbGlobalTable_basic (0.85s)
    testing.go:538: Step 3 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSIoTTopicRule_elasticsearch (1.84s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (1.52s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
--- FAIL: TestAccAWSSfnStateMachine_Tags (1.52s)
    testing.go:538: Step 0 error: config is invalid: data.aws_region.current: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_importBasic (109.96s)
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_basic (110.55s)
--- PASS: TestAccAWSCloudwatchLogDestination_importBasic (97.04s)
--- PASS: TestAccAWSCloudwatchLogDestination_basic (98.22s)
--- PASS: TestAccAWSDynamoDbGlobalTable_import (283.25s)
--- PASS: TestAccAWSDynamoDbGlobalTable_basic (285.12s)
--- PASS: TestAccAWSIoTTopicRule_elasticsearch (11.31s)
--- PASS: TestAccAWSSfnStateMachine_Tags (55.71s)
```
