### PR TITLE
Add encryption support to aws_instance.root_block_device

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1573,7 +1573,10 @@ func readBlockDeviceMappingsFromConfig(
 			ebs := &ec2.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
 				Encrypted:           aws.Bool(bd["encrypted"].(bool)),
-				KmsKeyId:            aws.String(bd["kms_key_id"].(string)),
+			}
+
+			if v, ok := bd["kms_key_id"].(int); ok && v != 0 {
+				ebs.KmsKeyId = aws.String(bd["kms_key_id"].(string))
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -432,6 +432,13 @@ func resourceAwsInstance() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"encrypted": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+
 						"iops": {
 							Type:             schema.TypeInt,
 							Optional:         true,
@@ -1321,15 +1328,15 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 		if vol.Iops != nil {
 			bd["iops"] = *vol.Iops
 		}
+		if vol.Encrypted != nil {
+			bd["encrypted"] = *vol.Encrypted
+		}
 
 		if blockDeviceIsRoot(instanceBd, instance) {
 			blockDevices["root"] = bd
 		} else {
 			if instanceBd.DeviceName != nil {
 				bd["device_name"] = *instanceBd.DeviceName
-			}
-			if vol.Encrypted != nil {
-				bd["encrypted"] = *vol.Encrypted
 			}
 			if vol.SnapshotId != nil {
 				bd["snapshot_id"] = *vol.SnapshotId
@@ -1363,7 +1370,7 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 
 	// For a bad image, we just return nil so we don't block a refresh
 	if len(res.Images) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("No images found for AMI %s", ami)
 	}
 
 	image := res.Images[0]
@@ -1371,7 +1378,7 @@ func fetchRootDeviceName(ami string, conn *ec2.EC2) (*string, error) {
 
 	// Instance store backed AMIs do not provide a root device name.
 	if *image.RootDeviceType == ec2.DeviceTypeInstanceStore {
-		return nil, nil
+		return nil, fmt.Errorf("Instance store backed AMIs do not provide a root device name - Use an EBS AMI")
 	}
 
 	// Some AMIs have a RootDeviceName like "/dev/sda1" that does not appear as a
@@ -1546,6 +1553,7 @@ func readBlockDeviceMappingsFromConfig(
 			bd := v.(map[string]interface{})
 			ebs := &ec2.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
+				Encrypted:           aws.Bool(bd["encrypted"].(bool)),
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
@@ -1568,20 +1576,15 @@ func readBlockDeviceMappingsFromConfig(
 				log.Print("[WARN] IOPs is only valid for storate type io1 for EBS Volumes")
 			}
 
-			if dn, err := fetchRootDeviceName(d.Get("ami").(string), conn); err == nil {
-				if dn == nil {
-					return nil, fmt.Errorf(
-						"Expected 1 AMI for ID: %s, got none",
-						d.Get("ami").(string))
-				}
-
-				blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
-					DeviceName: dn,
-					Ebs:        ebs,
-				})
-			} else {
-				return nil, err
+			dn, err := fetchRootDeviceName(d.Get("ami").(string), conn)
+			if err != nil {
+				return nil, fmt.Errorf("Expected 1 AMI for ID: %s (%s)", d.Get("ami").(string), err)
 			}
+
+			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{
+				DeviceName: dn,
+				Ebs:        ebs,
+			})
 		}
 	}
 

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -336,6 +336,12 @@ func resourceAwsInstance() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
 						"iops": {
 							Type:             schema.TypeInt,
 							Optional:         true,
@@ -436,6 +442,12 @@ func resourceAwsInstance() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
+							ForceNew: true,
+						},
+
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 							ForceNew: true,
 						},
 
@@ -1331,6 +1343,9 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 		if vol.Encrypted != nil {
 			bd["encrypted"] = *vol.Encrypted
 		}
+		if vol.KmsKeyId != nil {
+			bd["kms_key_id"] = *vol.KmsKeyId
+		}
 
 		if blockDeviceIsRoot(instanceBd, instance) {
 			blockDevices["root"] = bd
@@ -1498,6 +1513,10 @@ func readBlockDeviceMappingsFromConfig(
 				ebs.Encrypted = aws.Bool(v)
 			}
 
+			if v, ok := bd["kms_key_id"].(string); ok && v != "" {
+				ebs.KmsKeyId = aws.String(v)
+			}
+
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
 				ebs.VolumeSize = aws.Int64(int64(v))
 			}
@@ -1554,6 +1573,7 @@ func readBlockDeviceMappingsFromConfig(
 			ebs := &ec2.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
 				Encrypted:           aws.Bool(bd["encrypted"].(bool)),
+				KmsKeyId:            aws.String(bd["kms_key_id"].(string)),
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -120,10 +120,7 @@ func TestFetchRootDevice(t *testing.T) {
 				data := r.Data.(*ec2.DescribeImagesOutput)
 				data.Images = tc.images
 			})
-			name, err := fetchRootDeviceName("ami-123", conn)
-			if err != nil {
-				t.Errorf("Error fetching device name: %s", err)
-			}
+			name, _ := fetchRootDeviceName("ami-123", conn)
 			if tc.name != aws.StringValue(name) {
 				t.Errorf("Expected name %s, got %s", tc.name, aws.StringValue(name))
 			}

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -2451,11 +2451,30 @@ resource "aws_instance" "foo" {
 `
 
 const testAccInstanceConfigBlockDevices = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-instance-source-dest-enable"
+  }
+}
+
+resource "aws_subnet" "foo" {
+  cidr_block        = "10.1.1.0/24"
+  vpc_id            = "${aws_vpc.foo.id}"
+  availability_zone = "us-west-2a"
+
+  tags {
+    Name = "tf-acc-instance-source-dest-enable"
+  }
+}
+
 resource "aws_kms_key" "foo" {}
 
 resource "aws_instance" "foo" {
 	# us-west-2
-	ami = "ami-55a7ea65"
+	ami       = "ami-55a7ea65"
+    subnet_id = "${aws_subnet.foo.id}"
 
 	# In order to attach an encrypted volume to an instance you need to have an
 	# m3.medium or larger. See "Supported Instance Types" in:

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -131,6 +131,8 @@ The `root_block_device` mapping supports the following:
   using that type
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
+* `encrypted` - (Optional) Enable volume encryption. (Default: `false`).
+* `kms_key_id` - (Optional) The KMS key to use when encrypting the volume.
 
 Modifying any of the `root_block_device` settings requires resource
 replacement.
@@ -150,6 +152,7 @@ Each `ebs_block_device` supports the following:
 * `encrypted` - (Optional) Enables [EBS
   encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
   on the volume (Default: `false`). Cannot be used with `snapshot_id`.
+* `kms_key_id` - (Optional) The KMS key to use when encrypting the volume.
 
 Modifying any `ebs_block_device` currently requires resource replacement.
 


### PR DESCRIPTION
Fixes #6246

Changes proposed in this pull request:

* Adds `encrypted` and `kms_key_id` to the `root_block_device` attribute in `aws_instance`.
* Adds `kms_key_id` support to `ebs_block_device` as well.

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSInstance_encryptedRootVolume -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInstance_encryptedRootVolume
=== PAUSE TestAccAWSInstance_encryptedRootVolume
=== CONT  TestAccAWSInstance_encryptedRootVolume
--- PASS: TestAccAWSInstance_encryptedRootVolume (182.84s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	184.157s
```

And...

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSInstance_blockDevices -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInstance_blockDevices
=== PAUSE TestAccAWSInstance_blockDevices
=== CONT  TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (125.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	126.646s
```