### PR TITLE
Rename instance_interruption_behaviour

### DIFF
--- a/aws/resource_aws_ec2_fleet.go
+++ b/aws/resource_aws_ec2_fleet.go
@@ -175,11 +175,11 @@ func resourceAwsEc2Fleet() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							Default:  ec2.SpotInstanceInterruptionBehaviorTerminate,
+							Default:  ec2.InstanceInterruptionBehaviorTerminate,
 							ValidateFunc: validation.StringInSlice([]string{
-								ec2.SpotInstanceInterruptionBehaviorHibernate,
-								ec2.SpotInstanceInterruptionBehaviorStop,
-								ec2.SpotInstanceInterruptionBehaviorTerminate,
+								ec2.InstanceInterruptionBehaviorHibernate,
+								ec2.InstanceInterruptionBehaviorStop,
+								ec2.InstanceInterruptionBehaviorTerminate,
 							}, false),
 						},
 						"instance_pools_to_use_count": {

--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -271,6 +271,11 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 									"instance_interruption_behavior": {
 										Type:     schema.TypeString,
 										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											ec2.InstanceInterruptionBehaviorHibernate,
+											ec2.InstanceInterruptionBehaviorStop,
+											ec2.InstanceInterruptionBehaviorTerminate,
+										}, false),
 									},
 									"max_price": {
 										Type:     schema.TypeString,

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -297,11 +297,21 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 				Default:  "Default",
 				ForceNew: false,
 			},
+			"instance_interruption_behavior": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  ec2.InstanceInterruptionBehaviorTerminate,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.InstanceInterruptionBehaviorHibernate,
+					ec2.InstanceInterruptionBehaviorStop,
+					ec2.InstanceInterruptionBehaviorTerminate,
+				}, false),
+				ForceNew: true,
+			},
 			"instance_interruption_behaviour": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "terminate",
-				ForceNew: true,
+				Removed:  "Use `instance_interruption_behavior` instead.",
 			},
 			"spot_price": {
 				Type:     schema.TypeString,
@@ -615,7 +625,7 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		ClientToken:                      aws.String(resource.UniqueId()),
 		TerminateInstancesWithExpiration: aws.Bool(d.Get("terminate_instances_with_expiration").(bool)),
 		ReplaceUnhealthyInstances:        aws.Bool(d.Get("replace_unhealthy_instances").(bool)),
-		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behaviour").(string)),
+		InstanceInterruptionBehavior:     aws.String(d.Get("instance_interruption_behavior").(string)),
 		Type:                             aws.String(d.Get("fleet_type").(string)),
 	}
 
@@ -930,7 +940,7 @@ func resourceAwsSpotFleetRequestRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("replace_unhealthy_instances", config.ReplaceUnhealthyInstances)
-	d.Set("instance_interruption_behaviour", config.InstanceInterruptionBehavior)
+	d.Set("instance_interruption_behavior", config.InstanceInterruptionBehavior)
 	d.Set("fleet_type", config.Type)
 	d.Set("launch_specification", launchSpecsToSet(config.LaunchSpecifications, conn))
 

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -101,7 +101,7 @@ func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "instance_interruption_behaviour", "stop"),
+						"aws_spot_fleet_request.foo", "instance_interruption_behavior", "stop"),
 				),
 			},
 		},
@@ -872,7 +872,7 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
-    instance_interruption_behaviour = "stop"
+    instance_interruption_behavior = "stop"
     wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
@@ -1060,7 +1060,7 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
-    instance_interruption_behaviour = "stop"
+    instance_interruption_behavior = "stop"
     wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -79,16 +79,21 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			}
-			s["instance_interruption_behaviour"] = &schema.Schema{
+			s["instance_interruption_behavior"] = &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  ec2.InstanceInterruptionBehaviorTerminate,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					ec2.InstanceInterruptionBehaviorTerminate,
-					ec2.InstanceInterruptionBehaviorStop,
 					ec2.InstanceInterruptionBehaviorHibernate,
+					ec2.InstanceInterruptionBehaviorStop,
+					ec2.InstanceInterruptionBehaviorTerminate,
 				}, false),
+			}
+			s["instance_interruption_behaviour"] = &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `instance_interruption_behavior` instead.",
 			}
 			s["valid_from"] = &schema.Schema{
 				Type:         schema.TypeString,
@@ -120,7 +125,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	spotOpts := &ec2.RequestSpotInstancesInput{
 		SpotPrice:                    aws.String(d.Get("spot_price").(string)),
 		Type:                         aws.String(d.Get("spot_type").(string)),
-		InstanceInterruptionBehavior: aws.String(d.Get("instance_interruption_behaviour").(string)),
+		InstanceInterruptionBehavior: aws.String(d.Get("instance_interruption_behavior").(string)),
 
 		// Though the AWS API supports creating spot instance requests for multiple
 		// instances, for TF purposes we fix this to one instance per request.
@@ -168,7 +173,7 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 	}
 
 	// Placement GroupName can only be specified when instanceInterruptionBehavior is not set or set to 'terminate'
-	if v, exists := d.GetOkExists("instance_interruption_behaviour"); v.(string) == ec2.InstanceInterruptionBehaviorTerminate || !exists {
+	if v, exists := d.GetOkExists("instance_interruption_behavior"); v.(string) == ec2.InstanceInterruptionBehaviorTerminate || !exists {
 		spotOpts.LaunchSpecification.Placement = instanceOpts.SpotPlacement
 	}
 
@@ -275,7 +280,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 	d.Set("launch_group", request.LaunchGroup)
 	d.Set("block_duration_minutes", request.BlockDurationMinutes)
 	d.Set("tags", tagsToMap(request.Tags))
-	d.Set("instance_interruption_behaviour", request.InstanceInterruptionBehavior)
+	d.Set("instance_interruption_behavior", request.InstanceInterruptionBehavior)
 	d.Set("valid_from", aws.TimeValue(request.ValidFrom).Format(time.RFC3339))
 	d.Set("valid_until", aws.TimeValue(request.ValidUntil).Format(time.RFC3339))
 

--- a/aws/resource_aws_spot_instance_request_test.go
+++ b/aws/resource_aws_spot_instance_request_test.go
@@ -34,7 +34,7 @@ func TestAccAWSSpotInstanceRequest_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_instance_request.foo", "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "instance_interruption_behaviour", "terminate"),
+						"aws_spot_instance_request.foo", "instance_interruption_behavior", "terminate"),
 				),
 			},
 		},
@@ -497,7 +497,7 @@ func TestAccAWSSpotInstanceRequestInterruptStop(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_instance_request.foo", "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "instance_interruption_behaviour", "stop"),
+						"aws_spot_instance_request.foo", "instance_interruption_behavior", "stop"),
 				),
 			},
 		},
@@ -522,7 +522,7 @@ func TestAccAWSSpotInstanceRequestInterruptHibernate(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_instance_request.foo", "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_instance_request.foo", "instance_interruption_behaviour", "hibernate"),
+						"aws_spot_instance_request.foo", "instance_interruption_behavior", "hibernate"),
 				),
 			},
 		},
@@ -794,6 +794,6 @@ func testAccAWSSpotInstanceRequestInterruptConfig(interruption_behavior string) 
 		// and verify termination behavior
 		wait_for_fulfillment = true
 
-		instance_interruption_behaviour = "%s"
+		instance_interruption_behavior = "%s"
 	}`, interruption_behavior)
 }

--- a/website/docs/r/cloudfront_origin_access_identity.html.markdown
+++ b/website/docs/r/cloudfront_origin_access_identity.html.markdown
@@ -66,7 +66,7 @@ s3_origin_config {
 Note that the AWS API may translate the `s3_canonical_user_id` `CanonicalUser`
 principal into an `AWS` IAM ARN principal when supplied in an
 [`aws_s3_bucket`][4] bucket policy, causing spurious diffs in Terraform. If
-you see this behaviour, use the `iam_arn` instead:
+you see this behavior, use the `iam_arn` instead:
 
 ```hcl
 data "aws_iam_policy_document" "s3_policy" {

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -169,7 +169,7 @@ is ignored and you should instead declare `kms_key_id` with a valid ARN. The
 default is `false` if not specified.
 * `storage_type` - (Optional) One of "standard" (magnetic), "gp2" (general
 purpose SSD), or "io1" (provisioned IOPS SSD). The default is "io1" if `iops` is
-specified, "standard" if not. Note that this behaviour is different from the AWS
+specified, "standard" if not. Note that this behavior is different from the AWS
 web console, where the default is "gp2".
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `timezone` - (Optional) Time zone of the DB instance. `timezone` is currently

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -218,7 +218,7 @@ The `instance_market_options` block supports the following:
 The `spot_options` block supports the following:
 
 * `block_duration_minutes` - The required duration in minutes. This value must be a multiple of 60.
-* `instance_interruption_behavior` - The behavior when a Spot Instance is interrupted. Can be `hibernate`,
+* `instance_interruption_behavior` - The behavior when a Spot instance is interrupted. Can be `hibernate`,
   `stop`, or `terminate`. (Default: `terminate`).
 * `max_price` - The maximum hourly price you're willing to pay for the Spot Instances.
 * `spot_instance_type` - The Spot Instance request type. Can be `one-time`, or `persistent`.

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -45,7 +45,7 @@ resource "aws_spot_fleet_request" "cheap_compute" {
       volume_type = "gp2"
     }
 
-  tags = {
+    tags = {
       Name = "spot-fleet-example"
     }
   }
@@ -120,9 +120,8 @@ across different markets and instance types.
   request is decreased below the current size of the Spot fleet.
 * `terminate_instances_with_expiration` - Indicates whether running Spot
   instances should be terminated when the Spot fleet request expires.
-* `instance_interruption_behaviour` - (Optional) Indicates whether a Spot
-  instance stops or terminates when it is interrupted. Default is
-  `terminate`.
+* `instance_interruption_behavior` - (Optional) The behavior when a Spot instance is interrupted. Can be `hibernate`,
+  `stop`, or `terminate`. (Default: `terminate`).
 * `fleet_type` - (Optional) The type of fleet request. Indicates whether the Spot Fleet only requests the target
   capacity or also attempts to maintain it. Default is `maintain`.
 * `valid_until` - (Optional) The end date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request. Defaults to 24 hours.

--- a/website/docs/r/spot_instance_request.html.markdown
+++ b/website/docs/r/spot_instance_request.html.markdown
@@ -63,7 +63,8 @@ Spot Instance Requests support all the same arguments as
 * `block_duration_minutes` - (Optional) The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360).
   The duration period starts as soon as your Spot instance receives its instance ID. At the end of the duration period, Amazon EC2 marks the Spot instance for termination and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates.
   Note that you can't specify an Availability Zone group or a launch group if you specify a duration.
-* `instance_interruption_behaviour` - (Optional) Indicates whether a Spot instance stops or terminates when it is interrupted. Default is `terminate` as this is the current AWS behaviour.
+* `instance_interruption_behavior` - (Optional) The behavior when a Spot instance is interrupted. Can be `hibernate`,
+  `stop`, or `terminate`. (Default: `terminate`).
 * `valid_until` - (Optional) The end date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request. The default end date is 7 days from the current date.
 * `valid_from` - (Optional) The start date and time of the request, in UTC [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.8) format(for example, YYYY-MM-DDTHH:MM:SSZ). The default is to start fulfilling the request immediately.
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
A bit to my disappointment, v2.0.0 was released without https://github.com/terraform-providers/terraform-provider-aws/issues/7006 being fixed. So I decided to give it a go.

Initially I tried to deprecate it cleanly using `Deprecated` and `DiffSuppressFunc`, and it kinda worked, but there were some edge cases that I didn't like a lot. For example, my plan would print both attributes because I still had `Default` in there.

Example:
```
  + aws_spot_instance_request.cheap_worker
      id:                              <computed>
      ami:                             "ami-005bdb005fb00e791"
      arn:                             <computed>
      associate_public_ip_address:     <computed>
      availability_zone:               <computed>
      host_id:                         <computed>
      instance_interruption_behavior:  "terminate"
      instance_interruption_behaviour: "stop"
      instance_state:                  <computed>
      instance_type:                   "t1.micro"
```

This didn't look very great to me.

Anyway, I decided to just remove the old attribute instead. Maybe it can still be sneaked in a v2.1.0 release. I think this attribute is not that commonly used, and I hope that not everyone updates to v2.0.0 too quickly so we still have a little bit of time to break things.

I also added some minor things. Validation in `aws_launch_template`, sorted the validation lists, and for whatever reason there's both `ec2.InstanceInterruptionBehavior*` and `ec2.SpotInstanceInterruptionBehavior*` with no clear reasoning so I updated everything to use the constants without `Spot` in the name.

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/7006.

Let me know what you think!