### PR TITLE
Add the ability to encrypt root_block_device in aws_launch_configuration

### DIFF
--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -260,6 +260,13 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"encrypted": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+							ForceNew: true,
+						},
+
 						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -419,6 +426,10 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 			bd := v.(map[string]interface{})
 			ebs := &autoscaling.Ebs{
 				DeleteOnTermination: aws.Bool(bd["delete_on_termination"].(bool)),
+			}
+
+			if v, ok := bd["encrypted"].(bool); ok && v {
+				ebs.Encrypted = aws.Bool(v)
 			}
 
 			if v, ok := bd["volume_size"].(int); ok && v != 0 {
@@ -658,16 +669,17 @@ func readBlockDevicesFromLaunchConfiguration(d *schema.ResourceData, lc *autosca
 		if bdm.Ebs != nil && bdm.Ebs.Iops != nil {
 			bd["iops"] = *bdm.Ebs.Iops
 		}
+		if bdm.Ebs != nil && bdm.Ebs.Encrypted != nil {
+			bd["encrypted"] = *bdm.Ebs.Encrypted
+		}
 
 		if bdm.DeviceName != nil && *bdm.DeviceName == *rootDeviceName {
 			blockDevices["root"] = bd
 		} else {
-			if bdm.Ebs != nil && bdm.Ebs.Encrypted != nil {
-				bd["encrypted"] = *bdm.Ebs.Encrypted
-			}
 			if bdm.DeviceName != nil {
 				bd["device_name"] = *bdm.DeviceName
 			}
+
 			if bdm.VirtualName != nil {
 				bd["virtual_name"] = *bdm.VirtualName
 				blockDevices["ephemeral"] = append(blockDevices["ephemeral"].([]map[string]interface{}), bd)

--- a/aws/resource_aws_launch_configuration_test.go
+++ b/aws/resource_aws_launch_configuration_test.go
@@ -161,6 +161,26 @@ func TestAccAWSLaunchConfiguration_updateRootBlockDevice(t *testing.T) {
 	})
 }
 
+func TestAccAWSLaunchConfiguration_encryptedRootBlockDevice(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationConfigWithEncryptedRootBlockDevice(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.bar", &conf),
+					resource.TestCheckResourceAttr("aws_launch_configuration.bar", "root_block_device.0.encrypted", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLaunchConfiguration_withSpotPrice(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration
 
@@ -494,6 +514,42 @@ resource "aws_launch_configuration" "bar" {
   }
 }
 `, rInt)
+}
+
+func testAccAWSLaunchConfigurationConfigWithEncryptedRootBlockDevice(rInt int) string {
+	return testAccAWSLaunchConfigurationConfig_ami() + fmt.Sprintf(`
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-instance-%d"
+  }
+}
+
+resource "aws_subnet" "foo" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
+  availability_zone = "us-west-2a"
+
+  tags {
+    Name = "terraform-testacc-instance-%d"
+  }
+}
+
+resource "aws_launch_configuration" "bar" {
+  name_prefix = "tf-acc-test-%d"
+  image_id = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t3.nano"
+  user_data = "foobar-user-data"
+  associate_public_ip_address = true
+
+  root_block_device {
+    encrypted   = true
+    volume_type = "gp2"
+    volume_size = 11
+  }
+}
+`, rInt, rInt, rInt)
 }
 
 func testAccAWSLaunchConfigurationConfigWithRootBlockDeviceUpdated(rInt int) string {

--- a/website/docs/r/launch_configuration.html.markdown
+++ b/website/docs/r/launch_configuration.html.markdown
@@ -180,6 +180,7 @@ The `root_block_device` mapping supports the following:
   This must be set with a `volume_type` of `"io1"`.
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
+* `encrypted` - (Optional) Whether the volume should be encrypted or not. (Default: `false`).
 
 Modifying any of the `root_block_device` settings requires resource
 replacement.


### PR DESCRIPTION
Refs #6246
Refs #8624

Changes proposed in this pull request:

* Adds the `encrypted` attribute to the `root_block_device` on `aws_launch_configuration`.

**NOTE:** It appears `KmsKeyId` is [not supported by this API](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_Ebs.html).

Output from acceptance testing:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLaunchConfiguration_encryptedRootBlockDevice -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== PAUSE TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
=== CONT  TestAccAWSLaunchConfiguration_encryptedRootBlockDevice
--- PASS: TestAccAWSLaunchConfiguration_encryptedRootBlockDevice (34.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.220s
```
