### PR TITLE
Refactor Lambda environment variable handling

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -217,18 +217,8 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Computed: true,
 			},
 			"environment": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeMap,
 				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"variables": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
 			},
 			"tracing_config": {
 				Type:     schema.TypeList,
@@ -364,14 +354,8 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if v, ok := d.GetOk("environment"); ok {
-		environments := v.([]interface{})
-		environment, ok := environments[0].(map[string]interface{})
-		if !ok {
-			return errors.New("At least one field is expected inside environment")
-		}
-
-		if environmentVariables, ok := environment["variables"]; ok {
-			variables := readEnvironmentVariables(environmentVariables.(map[string]interface{}))
+		if environment, ok := v.(map[string]interface{}); ok {
+			variables := readEnvironmentVariables(environment)
 
 			params.Environment = &lambda.Environment{
 				Variables: aws.StringMap(variables),
@@ -731,14 +715,8 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	if d.HasChange("environment") {
 		if v, ok := d.GetOk("environment"); ok {
-			environments := v.([]interface{})
-			environment, ok := environments[0].(map[string]interface{})
-			if !ok {
-				return errors.New("At least one field is expected inside environment")
-			}
-
-			if environmentVariables, ok := environment["variables"]; ok {
-				variables := readEnvironmentVariables(environmentVariables.(map[string]interface{}))
+			if environment, ok := v.(map[string]interface{}); ok {
+				variables := readEnvironmentVariables(environment)
 
 				configReq.Environment = &lambda.Environment{
 					Variables: aws.StringMap(variables),

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -46,9 +46,7 @@ resource "aws_lambda_function" "test_lambda" {
   runtime          = "nodejs8.10"
 
   environment {
-    variables = {
-      foo = "bar"
-    }
+    foo = "bar"
   }
 }
 ```
@@ -140,7 +138,7 @@ large files efficiently.
 * `reserved_concurrent_executions` - (Optional) The amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency][9]
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `vpc_config` - (Optional) Provide this to allow your function to access your VPC. Fields documented below. See [Lambda in VPC][7]
-* `environment` - (Optional) The Lambda environment's configuration settings. Fields documented below.
+* `environment` - (Optional) A mapping of environment variables to supply to the Lambda function.
 * `kms_key_arn` - (Optional) The ARN for the KMS encryption key.
 * `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `${base64sha256(file("file.zip"))}`, where "file.zip" is the local filename of the lambda function source archive.
 * `tags` - (Optional) A mapping of tags to assign to the object.
@@ -166,10 +164,6 @@ large files efficiently.
 * `security_group_ids` - (Required) A list of security group IDs associated with the Lambda function.
 
 ~> **NOTE:** if both `subnet_ids` and `security_group_ids` are empty then vpc_config is considered to be empty or unset.
-
-For **environment** the following attributes are supported:
-
-* `variables` - (Optional) A map that defines environment variables for the Lambda function.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This change refactors the `environment` parameter to accept a map of key/value pairs corresponding to environment variable name/values.

Previously, `environment` was a configuration block with one mandatory key, `variables`, which itself was a map of environment variable name/values. This set up, besides being somewhat redundant, also caused some problems for users attempting to pass empty maps to `variables` (see issues #1272 and #1110).

This refactor resolves the core problem in the issues mentioned above whereby users are unable to pass an empty map of variable to the lambda resource; setting `environment` to an empty map will create no environment variables as expected.

However, this change is not backwards compatible with the previous form of `environment`. I'm submitting this as a minimal fix, but I am open to suggestions; perhaps creating a new `environment_variables` parameter and depracating the `environment` parameter would be a preferable approach?  

Fixes #1272 and #1110