### PR TITLE
✨ Add bucket_regional_domain_name to aws_s3_bucket Data Source

### DIFF
--- a/aws/data_source_aws_s3_bucket.go
+++ b/aws/data_source_aws_s3_bucket.go
@@ -27,6 +27,10 @@ func dataSourceAwsS3Bucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"bucket_regional_domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"hosted_zone_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/aws/data_source_aws_s3_bucket.go
+++ b/aws/data_source_aws_s3_bucket.go
@@ -73,7 +73,17 @@ func dataSourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("bucket_domain_name", bucketDomainName(bucket))
 
 	err = bucketLocation(d, bucket, conn)
-	return err
+	if err != nil {
+		return fmt.Errorf("error getting S3 Bucket location: %s", err)
+	}
+
+	regionalDomainName, err := BucketRegionalDomainName(bucket, d.Get("region").(string))
+	if err != nil {
+		return err
+	}
+	d.Set("bucket_regional_domain_name", regionalDomainName)
+
+	return nil
 }
 
 func bucketLocation(d *schema.ResourceData, bucket string, conn *s3.S3) error {

--- a/website/docs/d/s3_bucket.html.markdown
+++ b/website/docs/d/s3_bucket.html.markdown
@@ -66,6 +66,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The name of the bucket.
 * `arn` - The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 * `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
+* `bucket_regional_domain_name` - The bucket region-specific domain name. The bucket domain name including the region name, please refer [here](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent [redirect issues](https://forums.aws.amazon.com/thread.jspa?threadID=216814) from CloudFront to S3 Origin URL.
 * `hosted_zone_id` - The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 * `region` - The AWS region this bucket resides in.
 * `website_endpoint` - The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.


### PR DESCRIPTION
Hi again 👋 

Thanks again for your work! 👏 

This PR allows you to get `bucket_regional_domain_name` using a bucket **data source**.
I have updated the documentation accordingly.

Fix #7764