### PR TITLE
Add partition_count attribute for aws_placement_group resource

### DIFF
--- a/aws/resource_aws_placement_group_test.go
+++ b/aws/resource_aws_placement_group_test.go
@@ -38,6 +38,33 @@ func TestAccAWSPlacementGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSPlacementGroup_partition(t *testing.T) {
+	resourceName := "aws_placement_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPlacementGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPlacementGroupConfigPartition(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPlacementGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "strategy", "partition"),
+					resource.TestCheckResourceAttr(resourceName, "partition_count", "4"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAWSPlacementGroupDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -91,6 +118,16 @@ func testAccAWSPlacementGroupConfig(rName string) string {
 resource "aws_placement_group" "test" {
   name     = %q
   strategy = "cluster"
+}
+`, rName)
+}
+
+func testAccAWSPlacementGroupConfigPartition(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_placement_group" "test" {
+  name     			= %q
+  strategy 			= "partition"
+  partition_count 	= 4
 }
 `, rName)
 }

--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the placement group.
 * `strategy` - (Required) The placement strategy.
+* `partition_count` - (Optional) The number of partitions. Valid only if strategy is set to `partition`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #7754

Changes proposed in this pull request:

* Add `partition_count` attribute for `aws_placement_group` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSPlacementGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSPlacementGroup_ -timeout 120m
=== RUN   TestAccAWSPlacementGroup_basic
=== PAUSE TestAccAWSPlacementGroup_basic
=== RUN   TestAccAWSPlacementGroup_partition
=== PAUSE TestAccAWSPlacementGroup_partition
=== CONT  TestAccAWSPlacementGroup_basic
=== CONT  TestAccAWSPlacementGroup_partition
--- PASS: TestAccAWSPlacementGroup_partition (30.32s)
--- PASS: TestAccAWSPlacementGroup_basic (30.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	30.933s
```
