### PR TITLE
Add aws_s3_bucket_policy data source

### DIFF
--- a/aws/data_source_aws_s3_bucket_policy.go
+++ b/aws/data_source_aws_s3_bucket_policy.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsS3BucketPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsS3BucketPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3conn
+
+	bucket := d.Get("bucket").(string)
+
+	input := &s3.GetBucketPolicyInput{
+		Bucket: aws.String(bucket),
+	}
+
+	log.Printf("[DEBUG] Reading S3 bucket policy: %s", input)
+	result, err := conn.GetBucketPolicy(input)
+
+	if err != nil {
+		return fmt.Errorf("Failed getting S3 bucket policy: %s Bucket: %q", err, bucket)
+	}
+
+	d.SetId(bucket)
+	d.Set("policy", *result.Policy)
+
+	return err
+}

--- a/aws/data_source_aws_s3_bucket_policy_test.go
+++ b/aws/data_source_aws_s3_bucket_policy_test.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceS3BucketPolicy(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+	partition := testAccGetPartition()
+
+	policy := fmt.Sprintf(`{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Sid": "",
+		"Effect": "Allow",
+		"Principal": {"AWS":"*"},
+		"Action": "s3:*",
+		"Resource": ["arn:%s:s3:::%s/*","arn:%s:s3:::%s"]
+	}]
+}`, partition, name, partition, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDataSourceS3BucketPolicyConfig(name, policy),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists("data.aws_s3_bucket_policy.bucket"),
+					testAccCheckAWSS3BucketHasPolicy("data.aws_s3_bucket_policy.bucket", policy),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSDataSourceS3BucketPolicyConfig(bucketName string, bucketPolicy string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "bucket" {
+	bucket = "%s"
+	tags = {
+		TestName = "TestAccAWSDataSourceS3BucketPolicy"
+	}
+}
+
+resource "aws_s3_bucket_policy" "bucket" {
+	bucket = "${aws_s3_bucket.bucket.id}"
+	policy = <<POLICY
+%s
+POLICY
+}
+
+data "aws_s3_bucket_policy" "bucket" {
+	bucket = "${aws_s3_bucket_policy.bucket.bucket}"
+}
+`, bucketName, bucketPolicy)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -244,6 +244,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route53_zone":                       dataSourceAwsRoute53Zone(),
 			"aws_s3_bucket":                          dataSourceAwsS3Bucket(),
 			"aws_s3_bucket_object":                   dataSourceAwsS3BucketObject(),
+			"aws_s3_bucket_policy":                   dataSourceAwsS3BucketPolicy(),
 			"aws_secretsmanager_secret":              dataSourceAwsSecretsManagerSecret(),
 			"aws_secretsmanager_secret_version":      dataSourceAwsSecretsManagerSecretVersion(),
 			"aws_sns_topic":                          dataSourceAwsSnsTopic(),

--- a/website/docs/d/s3_bucket_policy.html.markdown
+++ b/website/docs/d/s3_bucket_policy.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_policy"
+sidebar_current: "docs-aws-datasource-s3-bucket-policy"
+description: |-
+  Provides details about a specific S3 bucket policy
+---
+
+# Data Source: aws_s3_bucket_policy
+
+Provides details about a specific S3 bucket policy.
+
+## Example Usage
+
+### Merge bucket policy statements
+
+```hcl
+data "aws_s3_bucket" "example" {
+  bucket = "bucket.test.com"
+}
+
+data "aws_s3_bucket_policy" "example" {
+  bucket = "${data.aws_s3_bucket.example.id}"
+}
+
+data "aws_iam_policy_document" "example" {
+
+  # use the bucket policy as the source
+  source_json = "${data.aws_s3_bucket_policy.example.policy}"
+
+  # overwrite any statements in the source policy which have matching statement IDs (sid)
+  statement {
+    sid = "ExampleStatement"
+    actions   = ["s3:GetObject"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["1234567890"]
+    }
+  }
+}
+
+# update the bucket policy with the merged policy document
+resource "aws_s3_bucket_policy" "example" {
+  bucket = "${data.aws_s3_bucket.example.id}"
+  policy = "${data.aws_iam_policy_document.example.json}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `bucket` - (Required) The name of the bucket
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `policy` - The policy for the bucket


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Helps with, or otherwise fixes:

#409
#6334

Changes proposed in this pull request:

* Add a data source for S3 bucket policies

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceS3BucketPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run TestAccDataSourceS3BucketPolicy -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccDataSourceS3BucketPolicy
=== PAUSE TestAccDataSourceS3BucketPolicy
=== CONT  TestAccDataSourceS3BucketPolicy
--- PASS: TestAccDataSourceS3BucketPolicy (35.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	35.438s
```

Additional notes:

When combined with the `source_json` or `override_json` attributes on the `aws_iam_policy_document` data source, support can now be provided for "merging" bucket policy documents. See markdown document for an example.