### PR TITLE
AWS EC2 partition number support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## placement_groups
+
+Implements `placement_partition_number` on top of ysfj's partition_count
+enhancement (https://github.com/david-cako/terraform-provider-aws/commit/9d4a689d8d55ccf11bc6691b9ab95bd38e8dfd2d)
+
 ## 1.60.0 (Unreleased)
 
 ENHANCEMENTS:

--- a/aws/resource_aws_instance_test.go
+++ b/aws/resource_aws_instance_test.go
@@ -767,7 +767,7 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 func TestAccAWSInstance_placementGroup(t *testing.T) {
 	var v ec2.Instance
 	rStr := acctest.RandString(5)
-	rInt := acctest.RandIntRange(1, 3)
+	rInt := 3
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -2580,7 +2580,8 @@ resource "aws_vpc" "foo" {
 }
 
 resource "aws_subnet" "foo" {
-  cidr_block = "10.1.1.0/24"
+	cidr_block = "10.1.1.0/24"
+	availability_zone = "us-west-2a"
   vpc_id = "${aws_vpc.foo.id}"
   tags = {
   	Name = "tf-acc-instance-placement-group"
@@ -2596,8 +2597,8 @@ resource "aws_placement_group" "foo" {
 # Limitations: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups
 resource "aws_instance" "foo" {
   # us-west-2
-  ami = "ami-55a7ea65"
-  instance_type = "c3.large"
+  ami = "ami-01e24be29428c15b2"
+  instance_type = "t2.micro"
   subnet_id = "${aws_subnet.foo.id}"
   associate_public_ip_address = true
 	placement_group = "${aws_placement_group.foo.name}"

--- a/aws/resource_aws_placement_group_test.go
+++ b/aws/resource_aws_placement_group_test.go
@@ -86,11 +86,48 @@ func testAccCheckAWSPlacementGroupExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func TestAccAWSPlacementGroup_partition(t *testing.T) {
+	resourceName := "aws_placement_group.test"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPlacementGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSPlacementGroupConfig_partition(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPlacementGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "strategy", "partition"),
+					resource.TestCheckResourceAttr(resourceName, "partition_count", "7"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccAWSPlacementGroupConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_placement_group" "test" {
   name     = %q
   strategy = "cluster"
+}
+`, rName)
+}
+
+func testAccAWSPlacementGroupConfig_partition(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_placement_group" "test" {
+  name            = %q
+  strategy        = "partition"
+  partition_count = 7
 }
 `, rName)
 }

--- a/website/docs/r/placement_group.html.markdown
+++ b/website/docs/r/placement_group.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the placement group.
 * `strategy` - (Required) The placement strategy.
+* `partition_count` - (Optional) The number of partitions. Valid only when Strategy is set to partition.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Allow specifying `placement_partition_number` for AWS EC2 instances.
* Includes @ys56's implementation of `partition_count` for `aws_placement_group`
* Fixes `TestAccAWSInstance_placementGroup` (was not in functional state in forked commit -- instance no longer available and AMI incompatible)

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSInstance_placementGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.11.5 test ./... -v -parallel 20 -run=TestAccAWSInstance_placementGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSInstance_placementGroup
=== PAUSE TestAccAWSInstance_placementGroup
=== CONT  TestAccAWSInstance_placementGroup
--- PASS: TestAccAWSInstance_placementGroup (141.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       142.236s

...
```
