### PR TITLE
Add length validation for s3 bucket and bucket_prefix

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -39,12 +39,14 @@ func resourceAwsS3Bucket() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"bucket_prefix"},
+				ValidateFunc:  validation.StringLenBetween(3, 63),
 			},
 			"bucket_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"bucket"},
+				ValidateFunc:  validation.StringLenBetween(0, 63-resource.UniqueIDSuffixLength),
 			},
 
 			"bucket_domain_name": {


### PR DESCRIPTION
Changes proposed in this pull request:

* Add length validation for `bucket` and `bucket_prefix` of resource `aws_s3_bucket`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSS3Bucket_namePrefix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3Bucket_namePrefix -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSS3Bucket_namePrefix
=== PAUSE TestAccAWSS3Bucket_namePrefix
=== CONT  TestAccAWSS3Bucket_namePrefix
--- PASS: TestAccAWSS3Bucket_namePrefix (48.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	48.170s
...
```
