### PR TITLE
resource/aws_ecs_service: Ensure placement_strategy removal in version 2.0.0 does not force recreation

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -210,39 +210,23 @@ func resourceAwsEcsService() *schema.Resource {
 			"placement_strategy": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
 				MaxItems: 5,
 				Removed:  "Use `ordered_placement_strategy` configuration block(s) instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:     schema.TypeString,
-							ForceNew: true,
 							Required: true,
 						},
 						"field": {
 							Type:     schema.TypeString,
-							ForceNew: true,
 							Optional: true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								return strings.EqualFold(old, new)
 							},
 						},
 					},
-				},
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-					m := v.(map[string]interface{})
-					buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
-					if m["field"] != nil {
-						field := m["field"].(string)
-						if field == "host" {
-							buf.WriteString("instanceId-")
-						} else {
-							buf.WriteString(fmt.Sprintf("%s-", field))
-						}
-					}
-					return hashcode.String(buf.String())
 				},
 			},
 			"ordered_placement_strategy": {


### PR DESCRIPTION
Closes #7787

Verified outside the acceptance testing framework as this type of testing is not well supported nor easy to implement for a one-time fix. Theoretically, this can also be prevented with a resource state migration, but that also seems heavy handed for a one-time fix and the extraneous information left in the state should not hurt anything. Lessons learned here will be added to the Terraform Provider development documentation.

Given this version 1.6.0 configuration:

```hcl
provider "aws" {
  region  = "us-east-2"
  version = "1.6.0"
}

resource "aws_ecs_cluster" "test" {
  name = "bflad-testing"
}

resource "aws_ecs_task_definition" "test" {
  family                = "test"
  container_definitions = <<DEFINITION
[
  {
    "cpu": 128,
    "essential": true,
    "image": "busybox:latest",
    "memory": 128,
    "name": "busybox"
  }
]
DEFINITION
}

resource "aws_ecs_service" "test" {
  cluster = "${aws_ecs_cluster.test.id}"
  desired_count = 0
  name = "bflad-testing"
  task_definition = "${aws_ecs_task_definition.test.arn}"

  placement_strategy {
    field = "memory"
    type = "binpack"
  }

  placement_strategy {
    field = "attribute:ecs.availability-zone"
    type = "spread"
  }
}
```

And attempting to upgrade the configuration to version 2.0.0 like the below:

```hcl
provider "aws" {
  region  = "us-east-2"
  version = "2.0.0"
}

resource "aws_ecs_cluster" "test" {
  name = "bflad-testing"
}

resource "aws_ecs_task_definition" "test" {
  family                = "test"
  container_definitions = <<DEFINITION
[
  {
    "cpu": 128,
    "essential": true,
    "image": "busybox:latest",
    "memory": 128,
    "name": "busybox"
  }
]
DEFINITION
}

resource "aws_ecs_service" "test" {
  cluster = "${aws_ecs_cluster.test.id}"
  desired_count = 0
  name = "bflad-testing"
  task_definition = "${aws_ecs_task_definition.test.arn}"

  ordered_placement_strategy {
    field = "memory"
    type = "binpack"
  }

  ordered_placement_strategy {
    field = "attribute:ecs.availability-zone"
    type = "spread"
  }
}
```

Would yield the following:

```console
$ terraform plan
...
Terraform will perform the following actions:

-/+ aws_ecs_service.test (new resource required)
...
      ordered_placement_strategy.#:        "2" => "2"
      ordered_placement_strategy.0.field:  "memory" => "memory"
      ordered_placement_strategy.0.type:   "binpack" => "binpack"
      ordered_placement_strategy.1.field:  "attribute:ecs.availability-zone" => "attribute:ecs.availability-zone"
      ordered_placement_strategy.1.type:   "spread" => "spread"
      placement_strategy.#:                "2" => "0" (forces new resource)
      placement_strategy.2224589570.field: "memory" => "" (forces new resource)
      placement_strategy.2224589570.type:  "binpack" => "" (forces new resource)
      placement_strategy.3619322362.field: "attribute:ecs.availability-zone" => "" (forces new resource)
      placement_strategy.3619322362.type:  "spread" => "" (forces new resource)
...

Plan: 1 to add, 0 to change, 1 to destroy.
```

These changes here yield the expected no-operation change:

```console
$ cp ~/go/bin/terraform-provider-aws .terraform/plugins/darwin_amd64/terraform-provider-aws_v2.0.0_x4; terraform init # Overwrite with locally built binary with this change
...
$ terraform plan
...
No changes. Infrastructure is up-to-date.
```