### PR TITLE
Fix aws_s3_bucket_notification without filters

### DIFF
--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -399,6 +399,10 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 
 func flattenNotificationConfigurationFilter(filter *s3.NotificationConfigurationFilter) map[string]interface{} {
 	filterRules := map[string]interface{}{}
+	if filter.Key == nil || filter.Key.FilterRules == nil {
+		return filterRules
+	}
+
 	for _, f := range filter.Key.FilterRules {
 		if strings.ToLower(*f.Name) == s3.FilterRuleNamePrefix {
 			filterRules["filter_prefix"] = *f.Value


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6724

Changes proposed in this pull request:

* Check properties before de-referencing, to prevent nil pointer exception
