### PR TITLE
tests/provider: Update to Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: go
 go:
-- "1.11.x"
+- "1.12.x"
 env:
   GOFLAGS=-mod=vendor
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.10+
-- [Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
 
 Building The Provider
 ---------------------
@@ -37,7 +37,7 @@ If you're building the provider, follow the instructions to [install it as a plu
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 

--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -230,6 +231,16 @@ type CloudWatchEventPermissionPolicyDoc struct {
 	Statements []CloudWatchEventPermissionPolicyStatement `json:"Statement"`
 }
 
+// String returns the string representation
+func (d CloudWatchEventPermissionPolicyDoc) String() string {
+	return awsutil.Prettify(d)
+}
+
+// GoString returns the string representation
+func (d CloudWatchEventPermissionPolicyDoc) GoString() string {
+	return d.String()
+}
+
 // CloudWatchEventPermissionPolicyStatement represents the Statement attribute of CloudWatchEventPermissionPolicyDoc
 // See also: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html
 type CloudWatchEventPermissionPolicyStatement struct {
@@ -241,12 +252,32 @@ type CloudWatchEventPermissionPolicyStatement struct {
 	Resource  string
 }
 
+// String returns the string representation
+func (s CloudWatchEventPermissionPolicyStatement) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s CloudWatchEventPermissionPolicyStatement) GoString() string {
+	return s.String()
+}
+
 // CloudWatchEventPermissionPolicyStatementCondition represents the Condition attribute of CloudWatchEventPermissionPolicyStatement
 // See also: https://docs.aws.amazon.com/AmazonCloudWatchEvents/latest/APIReference/API_DescribeEventBus.html
 type CloudWatchEventPermissionPolicyStatementCondition struct {
 	Key   string
 	Type  string
 	Value string
+}
+
+// String returns the string representation
+func (c CloudWatchEventPermissionPolicyStatementCondition) String() string {
+	return awsutil.Prettify(c)
+}
+
+// GoString returns the string representation
+func (c CloudWatchEventPermissionPolicyStatementCondition) GoString() string {
+	return c.String()
 }
 
 func (condition *CloudWatchEventPermissionPolicyStatementCondition) UnmarshalJSON(b []byte) error {
@@ -275,7 +306,7 @@ func (condition *CloudWatchEventPermissionPolicyStatementCondition) UnmarshalJSO
 func findCloudWatchEventPermissionPolicyStatementByID(policy *CloudWatchEventPermissionPolicyDoc, id string) (
 	*CloudWatchEventPermissionPolicyStatement, error) {
 
-	log.Printf("[DEBUG] Received %d statements in CloudWatch Events permission policy: %s", len(policy.Statements), policy.Statements)
+	log.Printf("[DEBUG] Finding statement (%s) in CloudWatch Events permission policy: %s", id, policy)
 	for _, statement := range policy.Statements {
 		if statement.Sid == id {
 			return &statement, nil
@@ -285,7 +316,7 @@ func findCloudWatchEventPermissionPolicyStatementByID(policy *CloudWatchEventPer
 	return nil, &resource.NotFoundError{
 		LastRequest:  id,
 		LastResponse: policy,
-		Message:      fmt.Sprintf("Failed to find statement %q in CloudWatch Events permission policy:\n%s", id, policy.Statements),
+		Message:      fmt.Sprintf("Failed to find statement (%s) in CloudWatch Events permission policy: %s", id, policy),
 	}
 }
 


### PR DESCRIPTION
Also fixes build failure after upgrade:

```
aws/resource_aws_cloudwatch_event_permission.go:278:2: Printf format %s has arg policy.Statements of wrong type []github.com/terraform-providers/terraform-provider-aws/aws.CloudWatchEventPermissionPolicyStatement
aws/resource_aws_cloudwatch_event_permission.go:288:17: Sprintf format %s has arg policy.Statements of wrong type []github.com/terraform-providers/terraform-provider-aws/aws.CloudWatchEventPermissionPolicyStatement
```
