### PR TITLE
Add Route 53 Resolver rule and rule association resources

### DIFF
--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -108,5 +108,9 @@ func suppressAutoscalingGroupAvailabilityZoneDiffs(k, old, new string, d *schema
 }
 
 func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.ResourceData) bool {
+	// "." is different from "".
+	if old == "." || new == "." {
+		return old == new
+	}
 	return strings.TrimSuffix(old, ".") == strings.TrimSuffix(new, ".")
 }

--- a/aws/diff_suppress_funcs_test.go
+++ b/aws/diff_suppress_funcs_test.go
@@ -70,3 +70,59 @@ func TestSuppressEquivalentTypeStringBoolean(t *testing.T) {
 		}
 	}
 }
+
+func TestSuppressRoute53ZoneNameWithTrailingDot(t *testing.T) {
+	testCases := []struct {
+		old        string
+		new        string
+		equivalent bool
+	}{
+		{
+			old:        "example.com",
+			new:        "example.com",
+			equivalent: true,
+		},
+		{
+			old:        "example.com.",
+			new:        "example.com.",
+			equivalent: true,
+		},
+		{
+			old:        "example.com.",
+			new:        "example.com",
+			equivalent: true,
+		},
+		{
+			old:        "example.com",
+			new:        "example.com.",
+			equivalent: true,
+		},
+		{
+			old:        ".",
+			new:        "",
+			equivalent: false,
+		},
+		{
+			old:        "",
+			new:        ".",
+			equivalent: false,
+		},
+		{
+			old:        ".",
+			new:        ".",
+			equivalent: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		value := suppressRoute53ZoneNameWithTrailingDot("test_property", tc.old, tc.new, nil)
+
+		if tc.equivalent && !value {
+			t.Fatalf("expected test case %d to be equivalent", i)
+		}
+
+		if !tc.equivalent && value {
+			t.Fatalf("expected test case %d to not be equivalent", i)
+		}
+	}
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -605,6 +605,8 @@ func Provider() terraform.ResourceProvider {
 			"aws_route53_zone":                                 resourceAwsRoute53Zone(),
 			"aws_route53_health_check":                         resourceAwsRoute53HealthCheck(),
 			"aws_route53_resolver_endpoint":                    resourceAwsRoute53ResolverEndpoint(),
+			"aws_route53_resolver_rule_association":            resourceAwsRoute53ResolverRuleAssociation(),
+			"aws_route53_resolver_rule":                        resourceAwsRoute53ResolverRule(),
 			"aws_route":                                        resourceAwsRoute(),
 			"aws_route_table":                                  resourceAwsRouteTable(),
 			"aws_default_route_table":                          resourceAwsDefaultRouteTable(),

--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -79,7 +79,7 @@ func resourceAwsRoute53ResolverEndpoint() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateRoute53ResolverEndpointName,
+				ValidateFunc: validateRoute53ResolverName,
 			},
 
 			"tags": tagsSchema(),

--- a/aws/resource_aws_route53_resolver_endpoint.go
+++ b/aws/resource_aws_route53_resolver_endpoint.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -62,7 +63,7 @@ func resourceAwsRoute53ResolverEndpoint() *schema.Resource {
 						},
 					},
 				},
-				Set: route53ResolverHashIPAddress,
+				Set: route53ResolverEndpointHashIpAddress,
 			},
 
 			"security_group_ids": {
@@ -106,9 +107,9 @@ func resourceAwsRoute53ResolverEndpointCreate(d *schema.ResourceData, meta inter
 	conn := meta.(*AWSClient).route53resolverconn
 
 	req := &route53resolver.CreateResolverEndpointInput{
-		CreatorRequestId: aws.String(resource.PrefixedUniqueId("tf-r53-resolver-")),
+		CreatorRequestId: aws.String(resource.PrefixedUniqueId("tf-r53-resolver-endpoint-")),
 		Direction:        aws.String(d.Get("direction").(string)),
-		IpAddresses:      expandRoute53ResolverIpAddresses(d.Get("ip_address").(*schema.Set)),
+		IpAddresses:      expandRoute53ResolverEndpointIpAddresses(d.Get("ip_address").(*schema.Set)),
 		SecurityGroupIds: expandStringSet(d.Get("security_group_ids").(*schema.Set)),
 	}
 	if v, ok := d.GetOk("name"); ok && v.(string) != "" {
@@ -168,14 +169,14 @@ func resourceAwsRoute53ResolverEndpointRead(d *schema.ResourceData, meta interfa
 			return fmt.Errorf("error getting Route53 Resolver endpoint (%s) IP addresses: %s", d.Id(), err)
 		}
 
-		ipAddresses = append(ipAddresses, flattenRoute53ResolverIpAddresses(resp.IpAddresses)...)
+		ipAddresses = append(ipAddresses, flattenRoute53ResolverEndpointIpAddresses(resp.IpAddresses)...)
 
 		if resp.NextToken == nil {
 			break
 		}
 		req.NextToken = resp.NextToken
 	}
-	if err := d.Set("ip_address", schema.NewSet(route53ResolverHashIPAddress, ipAddresses)); err != nil {
+	if err := d.Set("ip_address", schema.NewSet(route53ResolverEndpointHashIpAddress, ipAddresses)); err != nil {
 		return err
 	}
 
@@ -223,7 +224,7 @@ func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta inter
 		for _, v := range add {
 			_, err := conn.AssociateResolverEndpointIpAddress(&route53resolver.AssociateResolverEndpointIpAddressInput{
 				ResolverEndpointId: aws.String(d.Id()),
-				IpAddress:          expandRoute53ResolverIpAddressUpdate(v),
+				IpAddress:          expandRoute53ResolverEndpointIpAddressUpdate(v),
 			})
 			if err != nil {
 				return fmt.Errorf("error associating Route53 Resolver endpoint (%s) IP address: %s", d.Id(), err)
@@ -240,7 +241,7 @@ func resourceAwsRoute53ResolverEndpointUpdate(d *schema.ResourceData, meta inter
 		for _, v := range del {
 			_, err := conn.DisassociateResolverEndpointIpAddress(&route53resolver.DisassociateResolverEndpointIpAddressInput{
 				ResolverEndpointId: aws.String(d.Id()),
-				IpAddress:          expandRoute53ResolverIpAddressUpdate(v),
+				IpAddress:          expandRoute53ResolverEndpointIpAddressUpdate(v),
 			})
 			if err != nil {
 				return fmt.Errorf("error disassociating Route53 Resolver endpoint (%s) IP address: %s", d.Id(), err)
@@ -273,11 +274,10 @@ func resourceAwsRoute53ResolverEndpointDelete(d *schema.ResourceData, meta inter
 	_, err := conn.DeleteResolverEndpoint(&route53resolver.DeleteResolverEndpointInput{
 		ResolverEndpointId: aws.String(d.Id()),
 	})
+	if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
 	if err != nil {
-		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-			return nil
-		}
-
 		return fmt.Errorf("error deleting Route53 Resolver endpoint (%s): %s", d.Id(), err)
 	}
 
@@ -303,7 +303,11 @@ func route53ResolverEndpointRefresh(conn *route53resolver.Route53Resolver, epId 
 			return nil, "", err
 		}
 
-		return resp.ResolverEndpoint, aws.StringValue(resp.ResolverEndpoint.Status), nil
+		status := aws.StringValue(resp.ResolverEndpoint.Status)
+		if status == route53resolver.ResolverEndpointStatusActionNeeded {
+			return nil, status, errors.New(aws.StringValue(resp.ResolverEndpoint.StatusMessage))
+		}
+		return resp.ResolverEndpoint, status, nil
 	}
 }
 
@@ -323,7 +327,7 @@ func route53ResolverEndpointWaitUntilTargetState(conn *route53resolver.Route53Re
 	return nil
 }
 
-func route53ResolverHashIPAddress(v interface{}) int {
+func route53ResolverEndpointHashIpAddress(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -151,7 +151,7 @@ func testAccCheckRoute53ResolverEndpointDestroy(s *terraform.State) error {
 		})
 		// Verify the error is what we want
 		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-			return nil
+			continue
 		}
 		if err != nil {
 			return err

--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -156,6 +156,7 @@ func testAccCheckRoute53ResolverEndpointDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
+		return fmt.Errorf("Route 53 Resolver endpoint still exists: %s", rs.Primary.ID)
 	}
 
 	return nil
@@ -169,7 +170,7 @@ func testAccCheckRoute53ResolverEndpointExists(n string, ep *route53resolver.Res
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Route 53 Resolver Endpoint ID is set")
+			return fmt.Errorf("No Route 53 Resolver endpoint ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn

--- a/aws/resource_aws_route53_resolver_rule.go
+++ b/aws/resource_aws_route53_resolver_rule.go
@@ -21,10 +21,11 @@ const (
 
 func resourceAwsRoute53ResolverRule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAwsRoute53ResolverRuleCreate,
-		Read:   resourceAwsRoute53ResolverRuleRead,
-		Update: resourceAwsRoute53ResolverRuleUpdate,
-		Delete: resourceAwsRoute53ResolverRuleDelete,
+		Create:        resourceAwsRoute53ResolverRuleCreate,
+		Read:          resourceAwsRoute53ResolverRuleRead,
+		Update:        resourceAwsRoute53ResolverRuleUpdate,
+		Delete:        resourceAwsRoute53ResolverRuleDelete,
+		CustomizeDiff: resourceAwsRoute53ResolverRuleCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -244,6 +245,20 @@ func resourceAwsRoute53ResolverRuleDelete(d *schema.ResourceData, meta interface
 		[]string{route53ResolverRuleStatusDeleted})
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverRuleCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
+	if diff.Id() != "" {
+		if diff.HasChange("resolver_endpoint_id") {
+			if _, n := diff.GetChange("resolver_endpoint_id"); n.(string) == "" {
+				if err := diff.ForceNew("resolver_endpoint_id"); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	return nil

--- a/aws/resource_aws_route53_resolver_rule.go
+++ b/aws/resource_aws_route53_resolver_rule.go
@@ -59,7 +59,7 @@ func resourceAwsRoute53ResolverRule() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateRoute53ResolverRuleName,
+				ValidateFunc: validateRoute53ResolverName,
 			},
 
 			"resolver_endpoint_id": {
@@ -91,6 +91,11 @@ func resourceAwsRoute53ResolverRule() *schema.Resource {
 			"tags": tagsSchema(),
 
 			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"owner_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -159,6 +164,7 @@ func resourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface{}
 	d.Set("arn", rule.Arn)
 	d.Set("domain_name", rule.DomainName)
 	d.Set("name", rule.Name)
+	d.Set("owner_id", rule.OwnerId)
 	d.Set("resolver_endpoint_id", rule.ResolverEndpointId)
 	d.Set("rule_type", rule.RuleType)
 	d.Set("share_status", rule.ShareStatus)

--- a/aws/resource_aws_route53_resolver_rule.go
+++ b/aws/resource_aws_route53_resolver_rule.go
@@ -1,0 +1,317 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+)
+
+const (
+	Route53ResolverRuleStatusCreating = "CREATING"
+	Route53ResolverRuleStatusDeleted  = "DELETED"
+)
+
+func resourceAwsRoute53ResolverRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53ResolverRuleCreate,
+		Read:   resourceAwsRoute53ResolverRuleRead,
+		Update: resourceAwsRoute53ResolverRuleUpdate,
+		Delete: resourceAwsRoute53ResolverRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"domain_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppressRoute53ZoneNameWithTrailingDot,
+				ValidateFunc:     validation.StringLenBetween(1, 256),
+			},
+
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+
+			"resolver_endpoint_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+
+			"rule_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					route53resolver.RuleTypeOptionForward,
+					route53resolver.RuleTypeOptionSystem,
+					route53resolver.RuleTypeOptionRecursive,
+				}, false),
+			},
+
+			"target_ip": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.SingleIP(),
+						},
+						"port": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      53,
+							ValidateFunc: validation.IntBetween(0, 65535),
+						},
+					},
+				},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceAwsRoute53ResolverRuleCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	req := &route53resolver.CreateResolverRuleInput{
+		CreatorRequestId: aws.String(resource.UniqueId()),
+		DomainName:       aws.String(d.Get("domain_name").(string)),
+		RuleType:         aws.String(d.Get("rule_type").(string)),
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		req.Name = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("resolver_endpoint_id"); ok {
+		req.ResolverEndpointId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("target_ip"); ok {
+		req.TargetIps = expandTargetIps(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		req.Tags = tagsFromMapRoute53Resolver(v.(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] Creating Route 53 Resolver rule: %s", req)
+
+	res, err := conn.CreateResolverRule(req)
+	if err != nil {
+		return fmt.Errorf("Error creating Route 53 Resolver rule: %s", err)
+	}
+
+	d.SetId(*res.ResolverRule.Id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{Route53ResolverRuleStatusCreating},
+		Target:  []string{route53resolver.ResolverRuleStatusComplete},
+		Refresh: resourceAwsRoute53ResolverRuleStateRefresh(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Route 53 Resolver rule (%s) to be created: %s", d.Id(), err)
+	}
+
+	return resourceAwsRoute53ResolverRuleRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	req := &route53resolver.GetResolverRuleInput{
+		ResolverRuleId: aws.String(d.Id()),
+	}
+
+	res, err := conn.GetResolverRule(req)
+	if err != nil {
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] No Route 53 Resolver rule by Id (%s) found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Route 53 Resolver rule %s: %s", d.Id(), err)
+	}
+
+	rule := res.ResolverRule
+
+	d.Set("arn", rule.Arn)
+	d.Set("domain_name", rule.DomainName)
+	d.Set("name", rule.Name)
+	d.Set("resolver_endpoint_id", rule.ResolverEndpointId)
+	d.Set("rule_type", rule.RuleType)
+	d.Set("target_ip", flattenTargetIps(rule.TargetIps))
+
+	err = getTagsRoute53Resolver(conn, d, d.Get("arn").(string))
+	if err != nil {
+		return fmt.Errorf("Error reading Route 53 Resolver rule tags %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	d.Partial(true)
+
+	if d.HasChange("name") || d.HasChange("resolver_endpoint_id") || d.HasChange("target_ip") {
+		config := &route53resolver.ResolverRuleConfig{}
+
+		if v, ok := d.GetOk("name"); ok {
+			config.Name = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("resolver_endpoint_id"); ok {
+			config.ResolverEndpointId = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("target_ip"); ok {
+			config.TargetIps = expandTargetIps(v.([]interface{}))
+		}
+
+		req := &route53resolver.UpdateResolverRuleInput{
+			ResolverRuleId: aws.String(d.Id()),
+			Config:         config,
+		}
+
+		_, err := conn.UpdateResolverRule(req)
+		if err != nil {
+			if isAWSErr(err, route53resolver.ErrCodeUnknownResourceException, "") {
+				log.Printf("[WARN] No Route 53 Resolver rule by Id (%s) found, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return fmt.Errorf("Error updating Route 53 Resolver rule %s: %s", d.Id(), err)
+		}
+
+		d.SetPartial("name")
+		d.SetPartial("resolver_endpoint_id")
+		d.SetPartial("target_ip")
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{route53resolver.ResolverRuleStatusUpdating},
+		Target:  []string{route53resolver.ResolverRuleStatusComplete},
+		Refresh: resourceAwsRoute53ResolverRuleStateRefresh(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutUpdate),
+	}
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Route 53 Resolver rule (%s) to be updated: %s", d.Id(), err)
+	}
+
+	if d.HasChange("tags") {
+		err := setTagsRoute53Resolver(conn, d, d.Get("arn").(string))
+		if err != nil {
+			return fmt.Errorf("Error updating Route 53 Resolver rule tags: %s", err)
+		}
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsRoute53ResolverRuleRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	req := &route53resolver.DeleteResolverRuleInput{
+		ResolverRuleId: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteResolverRule(req)
+	if err != nil {
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Route 53 Resolver rule %s: %s", d.Id(), err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{route53resolver.ResolverRuleStatusDeleting},
+		Target:  []string{Route53ResolverRuleStatusDeleted},
+		Refresh: resourceAwsRoute53ResolverRuleStateRefresh(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Route 53 Resolver rule (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverRuleStateRefresh(conn *route53resolver.Route53Resolver, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+
+		req := &route53resolver.GetResolverRuleInput{
+			ResolverRuleId: aws.String(id),
+		}
+
+		res, err := conn.GetResolverRule(req)
+		if err != nil {
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return "", Route53ResolverRuleStatusDeleted, nil
+			}
+			return nil, "", err
+		}
+
+		return res.ResolverRule, aws.StringValue(res.ResolverRule.Status), nil
+	}
+}
+
+func expandTargetIps(tips []interface{}) []*route53resolver.TargetAddress {
+	tas := make([]*route53resolver.TargetAddress, len(tips), len(tips))
+
+	for i, tip := range tips {
+		ta := tip.(map[string]interface{})
+		tas[i] = &route53resolver.TargetAddress{
+			Ip:   aws.String(ta["ip"].(string)),
+			Port: aws.Int64(int64(ta["port"].(int))),
+		}
+	}
+
+	return tas
+}
+
+func flattenTargetIps(tas []*route53resolver.TargetAddress) []interface{} {
+	tips := make([]interface{}, len(tas), len(tas))
+
+	for i, ta := range tas {
+		tips[i] = map[string]interface{}{
+			"ip":   *ta.Ip,
+			"port": *ta.Port,
+		}
+	}
+	return tips
+}

--- a/aws/resource_aws_route53_resolver_rule_association.go
+++ b/aws/resource_aws_route53_resolver_rule_association.go
@@ -57,7 +57,7 @@ func resourceAwsRoute53ResolverRuleAssociation() *schema.Resource {
 }
 
 func resourceAwsRoute53ResolverRuleAssociationCreate(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).r53resolverconn
+	conn := meta.(*AWSClient).route53resolverconn
 
 	req := &route53resolver.AssociateResolverRuleInput{
 		ResolverRuleId: aws.String(d.Get("resolver_rule_id").(string)),
@@ -92,7 +92,7 @@ func resourceAwsRoute53ResolverRuleAssociationCreate(d *schema.ResourceData, met
 }
 
 func resourceAwsRoute53ResolverRuleAssociationRead(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).r53resolverconn
+	conn := meta.(*AWSClient).route53resolverconn
 
 	req := &route53resolver.GetResolverRuleAssociationInput{
 		ResolverRuleAssociationId: aws.String(d.Id()),
@@ -117,7 +117,7 @@ func resourceAwsRoute53ResolverRuleAssociationRead(d *schema.ResourceData, meta 
 }
 
 func resourceAwsRoute53ResolverRuleAssociationDelete(d *schema.ResourceData, meta interface{}) error {
-	conn := meta.(*AWSClient).r53resolverconn
+	conn := meta.(*AWSClient).route53resolverconn
 
 	req := &route53resolver.DisassociateResolverRuleInput{
 		ResolverRuleId: aws.String(d.Get("resolver_rule_id").(string)),

--- a/aws/resource_aws_route53_resolver_rule_association.go
+++ b/aws/resource_aws_route53_resolver_rule_association.go
@@ -1,0 +1,166 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+)
+
+const (
+	Route53ResolverRuleAssociationStatusDeleted = "DELETED"
+)
+
+func resourceAwsRoute53ResolverRuleAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRoute53ResolverRuleAssociationCreate,
+		Read:   resourceAwsRoute53ResolverRuleAssociationRead,
+		Delete: resourceAwsRoute53ResolverRuleAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+
+			"resolver_rule_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+
+			"vpc_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+		},
+	}
+}
+
+func resourceAwsRoute53ResolverRuleAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	req := &route53resolver.AssociateResolverRuleInput{
+		ResolverRuleId: aws.String(d.Get("resolver_rule_id").(string)),
+		VPCId:          aws.String(d.Get("vpc_id").(string)),
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		req.Name = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating Route 53 Resolver rule association: %s", req)
+
+	res, err := conn.AssociateResolverRule(req)
+	if err != nil {
+		return fmt.Errorf("Error creating Route 53 Resolver rule association: %s", err)
+	}
+
+	d.SetId(*res.ResolverRuleAssociation.Id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{route53resolver.ResolverRuleAssociationStatusCreating},
+		Target:  []string{route53resolver.ResolverRuleAssociationStatusComplete},
+		Refresh: resourceAwsRoute53ResolverRuleAssociationStateRefresh(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Route 53 Resolver rule association (%s) to be created: %s", d.Id(), err)
+	}
+
+	return resourceAwsRoute53ResolverRuleAssociationRead(d, meta)
+}
+
+func resourceAwsRoute53ResolverRuleAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	req := &route53resolver.GetResolverRuleAssociationInput{
+		ResolverRuleAssociationId: aws.String(d.Id()),
+	}
+
+	res, err := conn.GetResolverRuleAssociation(req)
+	if err != nil {
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[WARN] No Route 53 Resolver rule association by Id (%s) found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Route 53 Resolver rule association %s: %s", d.Id(), err)
+	}
+
+	assn := res.ResolverRuleAssociation
+
+	d.Set("resolver_rule_id", assn.ResolverRuleId)
+	d.Set("vpc_id", assn.VPCId)
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverRuleAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).r53resolverconn
+
+	req := &route53resolver.DisassociateResolverRuleInput{
+		ResolverRuleId: aws.String(d.Get("resolver_rule_id").(string)),
+		VPCId:          aws.String(d.Get("vpc_id").(string)),
+	}
+
+	_, err := conn.DisassociateResolverRule(req)
+	if err != nil {
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Route 53 Resolver rule association %s: %s", d.Id(), err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{route53resolver.ResolverRuleAssociationStatusDeleting},
+		Target:  []string{Route53ResolverRuleAssociationStatusDeleted},
+		Refresh: resourceAwsRoute53ResolverRuleAssociationStateRefresh(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for Route 53 Resolver rule association (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsRoute53ResolverRuleAssociationStateRefresh(conn *route53resolver.Route53Resolver, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+
+		req := &route53resolver.GetResolverRuleAssociationInput{
+			ResolverRuleAssociationId: aws.String(id),
+		}
+
+		res, err := conn.GetResolverRuleAssociation(req)
+		if err != nil {
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return "", Route53ResolverRuleAssociationStatusDeleted, nil
+			}
+			return nil, "", err
+		}
+
+		return res.ResolverRuleAssociation, aws.StringValue(res.ResolverRuleAssociation.Status), nil
+	}
+}

--- a/aws/resource_aws_route53_resolver_rule_association.go
+++ b/aws/resource_aws_route53_resolver_rule_association.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -64,7 +63,7 @@ func resourceAwsRoute53ResolverRuleAssociationCreate(d *schema.ResourceData, met
 		ResolverRuleId: aws.String(d.Get("resolver_rule_id").(string)),
 		VPCId:          aws.String(d.Get("vpc_id").(string)),
 	}
-	if v, ok := d.GetOk("name"); ok && v.(string) != "" {
+	if v, ok := d.GetOk("name"); ok {
 		req.Name = aws.String(v.(string))
 	}
 
@@ -145,11 +144,11 @@ func route53ResolverRuleAssociationRefresh(conn *route53resolver.Route53Resolver
 			return nil, "", err
 		}
 
-		status := aws.StringValue(resp.ResolverRuleAssociation.Status)
-		if status == route53resolver.ResolverRuleAssociationStatusFailed {
-			return nil, status, errors.New(aws.StringValue(resp.ResolverRuleAssociation.StatusMessage))
+		if statusMessage := aws.StringValue(resp.ResolverRuleAssociation.StatusMessage); statusMessage != "" {
+			log.Printf("[INFO] Route 53 Resolver rule association (%s) status message: %s", assocId, statusMessage)
 		}
-		return resp.ResolverRuleAssociation, status, nil
+
+		return resp.ResolverRuleAssociation, aws.StringValue(resp.ResolverRuleAssociation.Status), nil
 	}
 }
 

--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -36,7 +36,7 @@ func TestAccAWSRoute53ResolverRuleAssociation_basic(t *testing.T) {
 }
 
 func testAccCheckRoute53ResolverRuleAssociationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+	conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route53_resolver_rule_association" {
 			continue
@@ -64,7 +64,7 @@ func testAccCheckRoute53ResolverRuleAssociationDestroy(s *terraform.State) error
 
 func testAccCheckRoute53ResolverRuleAssociationExists(n string, assn *route53resolver.ResolverRuleAssociation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+)
+
+func TestAccAWSRoute53ResolverRuleAssociation_basic(t *testing.T) {
+	var assn route53resolver.ResolverRuleAssociation
+	resourceName := "aws_route53_resolver_rule_association.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverRuleAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverRuleAssociationConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleAssociationExists(resourceName, &assn),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRoute53ResolverRuleAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_resolver_rule_association" {
+			continue
+		}
+
+		req := &route53resolver.GetResolverRuleAssociationInput{
+			ResolverRuleAssociationId: aws.String(rs.Primary.ID),
+		}
+
+		exists := true
+		_, err := conn.GetResolverRuleAssociation(req)
+		if err != nil {
+			if !isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return fmt.Errorf("Error reading Route 53 Resolver rule association: %s", err)
+			}
+			exists = false
+		}
+
+		if exists {
+			return fmt.Errorf("Route 53 Resolver rule association still exists: %s", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckRoute53ResolverRuleAssociationExists(n string, assn *route53resolver.ResolverRuleAssociation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No resolver rule association ID is set")
+		}
+
+		req := &route53resolver.GetResolverRuleAssociationInput{
+			ResolverRuleAssociationId: aws.String(rs.Primary.ID),
+		}
+
+		res, err := conn.GetResolverRuleAssociation(req)
+		if err != nil {
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return fmt.Errorf("Route 53 Resolver rule association not found")
+			}
+			return fmt.Errorf("Error reading Route 53 Resolver rule association: %s", err)
+		}
+
+		*assn = *res.ResolverRuleAssociation
+		return nil
+	}
+}
+
+const testAccRoute53ResolverRuleAssociationConfig_basic = `
+resource "aws_vpc" "example" {
+	cidr_block = "10.6.0.0/16"
+	enable_dns_hostnames = true
+	enable_dns_support = true
+	tags {
+		Name = "terraform-testacc-route53-zone-association-foo"
+	}
+}
+
+resource "aws_route53_resolver_rule" "example" {
+	domain_name          = "example.com"
+	name                 = "example"
+	rule_type            = "SYSTEM"
+}
+
+resource "aws_route53_resolver_rule_association" "example" {
+	resolver_rule_id = "${aws_route53_resolver_rule.example.id}"
+	vpc_id  = "${aws_vpc.example.id}"
+}
+`

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -28,6 +28,7 @@ func TestAccAwsRoute53ResolverRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
 					resource.TestCheckResourceAttr(resourceName, "rule_type", "SYSTEM"),
 					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					testAccCheckResourceAttrAccountID(resourceName, "owner_id"),
 				),
 			},
 			{
@@ -172,7 +173,7 @@ func testAccCheckRoute53ResolverRuleDestroy(s *terraform.State) error {
 		})
 		// Verify the error is what we want
 		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-			return nil
+			continue
 		}
 		if err != nil {
 			return err

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53resolver"
 )
 
-func TestAccAWSRoute53ResolverRule_basic(t *testing.T) {
+func TestAccAwsRoute53ResolverRule_basic(t *testing.T) {
 	var rule route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 
@@ -21,9 +22,12 @@ func TestAccAWSRoute53ResolverRule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ResolverRuleConfig_basic,
+				Config: testAccRoute53ResolverRuleConfig_basicNoTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "SYSTEM"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
 				),
 			},
 			{
@@ -35,7 +39,7 @@ func TestAccAWSRoute53ResolverRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53ResolverRule_updateRule(t *testing.T) {
+func TestAccAwsRoute53ResolverRule_tags(t *testing.T) {
 	var rule route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
 
@@ -45,29 +49,46 @@ func TestAccAWSRoute53ResolverRule_updateRule(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ResolverRuleConfig_basic,
+				Config: testAccRoute53ResolverRuleConfig_basicTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "SYSTEM"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "original"),
 				),
 			},
 			{
-				Config: testAccRoute53ResolverRuleConfig_updateRule,
+				Config: testAccRoute53ResolverRuleConfig_basicTagsChanged,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "SYSTEM"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Usage", "changed"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: testAccRoute53ResolverRuleConfig_basicNoTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "SYSTEM"),
+					resource.TestCheckResourceAttr(resourceName, "share_status", "NOT_SHARED"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
 			},
 		},
 	})
 }
 
-func TestAccAWSRoute53ResolverRule_updateTags(t *testing.T) {
+func TestAccAwsRoute53ResolverRule_updateName(t *testing.T) {
 	var rule route53resolver.ResolverRule
 	resourceName := "aws_route53_resolver_rule.example"
+	name1 := fmt.Sprintf("terraform-testacc-r53-resolver-%d", acctest.RandInt())
+	name2 := fmt.Sprintf("terraform-testacc-r53-resolver-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -75,115 +96,193 @@ func TestAccAWSRoute53ResolverRule_updateTags(t *testing.T) {
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ResolverRuleConfig_basic,
+				Config: testAccRoute53ResolverRuleConfig_basicName(name1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "name", name1),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "SYSTEM"),
 				),
 			},
 			{
-				Config: testAccRoute53ResolverRuleConfig_updateTags,
+				Config: testAccRoute53ResolverRuleConfig_basicName(name2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "name", name2),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "SYSTEM"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsRoute53ResolverRule_forward(t *testing.T) {
+	var rule route53resolver.ResolverRule
+	resourceName := "aws_route53_resolver_rule.example"
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverRuleConfig_forward(rInt, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "FORWARD"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.1379138419.ip", "192.0.2.6"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.1379138419.port", "53"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: testAccRoute53ResolverRuleConfig_forwardChanged(rInt, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "example.com."),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "rule_type", "FORWARD"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.1867764419.ip", "192.0.2.7"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.1867764419.port", "53"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.1677112772.ip", "192.0.2.17"),
+					resource.TestCheckResourceAttr(resourceName, "target_ip.1677112772.port", "54"),
+				),
 			},
 		},
 	})
 }
 
 func testAccCheckRoute53ResolverRuleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+	conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aws_route53_resolver_rule" {
 			continue
 		}
 
-		req := &route53resolver.GetResolverRuleInput{
+		// Try to find the resource
+		_, err := conn.GetResolverRule(&route53resolver.GetResolverRuleInput{
 			ResolverRuleId: aws.String(rs.Primary.ID),
+		})
+		// Verify the error is what we want
+		if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+			return nil
 		}
-
-		exists := true
-		_, err := conn.GetResolverRule(req)
 		if err != nil {
-			if !isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-				return fmt.Errorf("Error reading Route 53 Resolver rule: %s", err)
-			}
-			exists = false
+			return err
 		}
-
-		if exists {
-			return fmt.Errorf("Route 53 Resolver rule still exists: %s", rs.Primary.ID)
-		}
+		return fmt.Errorf("Route 53 Resolver rule still exists: %s", rs.Primary.ID)
 	}
 	return nil
 }
 
 func testAccCheckRoute53ResolverRuleExists(n string, rule *route53resolver.ResolverRule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
-
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No resolver rule ID is set")
+			return fmt.Errorf("No Route 53 Resolver rule ID is set")
 		}
 
-		req := &route53resolver.GetResolverRuleInput{
+		conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+		res, err := conn.GetResolverRule(&route53resolver.GetResolverRuleInput{
 			ResolverRuleId: aws.String(rs.Primary.ID),
-		}
-
-		res, err := conn.GetResolverRule(req)
+		})
 		if err != nil {
-			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
-				return fmt.Errorf("Route 53 Resolver rule not found")
-			}
-			return fmt.Errorf("Error reading Route 53 Resolver rule: %s", err)
+			return err
 		}
 
 		*rule = *res.ResolverRule
+
 		return nil
 	}
 }
 
-const testAccRoute53ResolverRuleConfig_basic = `
+const testAccRoute53ResolverRuleConfig_basicNoTags = `
 resource "aws_route53_resolver_rule" "example" {
-	domain_name          = "example.com"
-	name                 = "example"
-	rule_type            = "SYSTEM"
-
-	tags {
-	  Foo = "Barr"
-	}
-  }
+  domain_name = "example.com"
+  rule_type   = "SYSTEM"
+}
 `
 
-const testAccRoute53ResolverRuleConfig_updateRule = `
+const testAccRoute53ResolverRuleConfig_basicTags = `
 resource "aws_route53_resolver_rule" "example" {
-	domain_name          = "example.com"
-	name                 = "test"
-	rule_type            = "SYSTEM"
+  domain_name = "example.com"
+  rule_type   = "SYSTEM"
 
-	tags {
-	  Foo = "Barr"
-	}
+  tags = {
+    Environment = "production"
+    Usage = "original"
   }
+}
 `
 
-const testAccRoute53ResolverRuleConfig_updateTags = `
+const testAccRoute53ResolverRuleConfig_basicTagsChanged = `
 resource "aws_route53_resolver_rule" "example" {
-	domain_name          = "example.com"
-	name                 = "test"
-	rule_type            = "SYSTEM"
+  domain_name = "example.com"
+  rule_type   = "SYSTEM"
 
-	tags {
-	  Bar = "Foo"
-	}
+  tags = {
+    Usage = "changed"
   }
+}
 `
+
+func testAccRoute53ResolverRuleConfig_basicName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "example" {
+  domain_name = "example.com"
+  rule_type   = "SYSTEM"
+  name        = %q
+}
+`, name)
+}
+
+func testAccRoute53ResolverRuleConfig_forward(rInt int, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_route53_resolver_rule" "example" {
+  domain_name = "example.com"
+  rule_type   = "FORWARD"
+  name        = %q
+
+  resolver_endpoint_id = "${aws_route53_resolver_endpoint.foo.id}"
+
+  target_ip {
+    ip = "192.0.2.6"
+  }
+}
+`, testAccRoute53ResolverEndpointConfig_initial(rInt, "OUTBOUND", name), name)
+}
+
+func testAccRoute53ResolverRuleConfig_forwardChanged(rInt int, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_route53_resolver_rule" "example" {
+  domain_name = "example.com"
+  rule_type   = "FORWARD"
+  name        = %q
+
+  resolver_endpoint_id = "${aws_route53_resolver_endpoint.foo.id}"
+
+  target_ip {
+    ip = "192.0.2.7"
+  }
+  target_ip {
+    ip   = "192.0.2.17"
+    port = 54
+  }
+}
+`, testAccRoute53ResolverEndpointConfig_initial(rInt, "OUTBOUND", name), name)
+}

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -1,0 +1,189 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+)
+
+func TestAccAWSRoute53ResolverRule_basic(t *testing.T) {
+	var rule route53resolver.ResolverRule
+	resourceName := "aws_route53_resolver_rule.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverRuleConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverRule_updateRule(t *testing.T) {
+	var rule route53resolver.ResolverRule
+	resourceName := "aws_route53_resolver_rule.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverRuleConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+				),
+			},
+			{
+				Config: testAccRoute53ResolverRuleConfig_updateRule,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ResolverRule_updateTags(t *testing.T) {
+	var rule route53resolver.ResolverRule
+	resourceName := "aws_route53_resolver_rule.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ResolverRuleConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+				),
+			},
+			{
+				Config: testAccRoute53ResolverRuleConfig_updateTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ResolverRuleExists(resourceName, &rule),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckRoute53ResolverRuleDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_route53_resolver_rule" {
+			continue
+		}
+
+		req := &route53resolver.GetResolverRuleInput{
+			ResolverRuleId: aws.String(rs.Primary.ID),
+		}
+
+		exists := true
+		_, err := conn.GetResolverRule(req)
+		if err != nil {
+			if !isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return fmt.Errorf("Error reading Route 53 Resolver rule: %s", err)
+			}
+			exists = false
+		}
+
+		if exists {
+			return fmt.Errorf("Route 53 Resolver rule still exists: %s", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckRoute53ResolverRuleExists(n string, rule *route53resolver.ResolverRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).r53resolverconn
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No resolver rule ID is set")
+		}
+
+		req := &route53resolver.GetResolverRuleInput{
+			ResolverRuleId: aws.String(rs.Primary.ID),
+		}
+
+		res, err := conn.GetResolverRule(req)
+		if err != nil {
+			if isAWSErr(err, route53resolver.ErrCodeResourceNotFoundException, "") {
+				return fmt.Errorf("Route 53 Resolver rule not found")
+			}
+			return fmt.Errorf("Error reading Route 53 Resolver rule: %s", err)
+		}
+
+		*rule = *res.ResolverRule
+		return nil
+	}
+}
+
+const testAccRoute53ResolverRuleConfig_basic = `
+resource "aws_route53_resolver_rule" "example" {
+	domain_name          = "example.com"
+	name                 = "example"
+	rule_type            = "SYSTEM"
+
+	tags {
+	  Foo = "Barr"
+	}
+  }
+`
+
+const testAccRoute53ResolverRuleConfig_updateRule = `
+resource "aws_route53_resolver_rule" "example" {
+	domain_name          = "example.com"
+	name                 = "test"
+	rule_type            = "SYSTEM"
+
+	tags {
+	  Foo = "Barr"
+	}
+  }
+`
+
+const testAccRoute53ResolverRuleConfig_updateTags = `
+resource "aws_route53_resolver_rule" "example" {
+	domain_name          = "example.com"
+	name                 = "test"
+	rule_type            = "SYSTEM"
+
+	tags {
+	  Bar = "Foo"
+	}
+  }
+`

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -5056,7 +5056,7 @@ func flattenAppmeshRouteSpec(spec *appmesh.RouteSpec) []interface{} {
 	return []interface{}{mSpec}
 }
 
-func expandRoute53ResolverIpAddresses(vIpAddresses *schema.Set) []*route53resolver.IpAddressRequest {
+func expandRoute53ResolverEndpointIpAddresses(vIpAddresses *schema.Set) []*route53resolver.IpAddressRequest {
 	ipAddressRequests := []*route53resolver.IpAddressRequest{}
 
 	for _, vIpAddress := range vIpAddresses.List() {
@@ -5077,7 +5077,7 @@ func expandRoute53ResolverIpAddresses(vIpAddresses *schema.Set) []*route53resolv
 	return ipAddressRequests
 }
 
-func flattenRoute53ResolverIpAddresses(ipAddresses []*route53resolver.IpAddressResponse) []interface{} {
+func flattenRoute53ResolverEndpointIpAddresses(ipAddresses []*route53resolver.IpAddressResponse) []interface{} {
 	if ipAddresses == nil {
 		return []interface{}{}
 	}
@@ -5085,11 +5085,11 @@ func flattenRoute53ResolverIpAddresses(ipAddresses []*route53resolver.IpAddressR
 	vIpAddresses := []interface{}{}
 
 	for _, ipAddress := range ipAddresses {
-		mIpAddress := map[string]interface{}{}
-
-		mIpAddress["subnet_id"] = aws.StringValue(ipAddress.SubnetId)
-		mIpAddress["ip"] = aws.StringValue(ipAddress.Ip)
-		mIpAddress["ip_id"] = aws.StringValue(ipAddress.IpId)
+		mIpAddress := map[string]interface{}{
+			"subnet_id": aws.StringValue(ipAddress.SubnetId),
+			"ip":        aws.StringValue(ipAddress.Ip),
+			"ip_id":     aws.StringValue(ipAddress.IpId),
+		}
 
 		vIpAddresses = append(vIpAddresses, mIpAddress)
 	}
@@ -5097,7 +5097,7 @@ func flattenRoute53ResolverIpAddresses(ipAddresses []*route53resolver.IpAddressR
 	return vIpAddresses
 }
 
-func expandRoute53ResolverIpAddressUpdate(vIpAddress interface{}) *route53resolver.IpAddressUpdate {
+func expandRoute53ResolverEndpointIpAddressUpdate(vIpAddress interface{}) *route53resolver.IpAddressUpdate {
 	ipAddressUpdate := &route53resolver.IpAddressUpdate{}
 
 	mIpAddress := vIpAddress.(map[string]interface{})
@@ -5113,4 +5113,44 @@ func expandRoute53ResolverIpAddressUpdate(vIpAddress interface{}) *route53resolv
 	}
 
 	return ipAddressUpdate
+}
+
+func expandRoute53ResolverRuleTargetIps(vTargetIps *schema.Set) []*route53resolver.TargetAddress {
+	targetAddresses := []*route53resolver.TargetAddress{}
+
+	for _, vTargetIp := range vTargetIps.List() {
+		targetAddress := &route53resolver.TargetAddress{}
+
+		mTargetIp := vTargetIp.(map[string]interface{})
+
+		if vIp, ok := mTargetIp["ip"].(string); ok && vIp != "" {
+			targetAddress.Ip = aws.String(vIp)
+		}
+		if vPort, ok := mTargetIp["port"].(int); ok {
+			targetAddress.Port = aws.Int64(int64(vPort))
+		}
+
+		targetAddresses = append(targetAddresses, targetAddress)
+	}
+
+	return targetAddresses
+}
+
+func flattenRoute53ResolverRuleTargetIps(targetAddresses []*route53resolver.TargetAddress) []interface{} {
+	if targetAddresses == nil {
+		return []interface{}{}
+	}
+
+	vTargetIps := []interface{}{}
+
+	for _, targetAddress := range targetAddresses {
+		mTargetIp := map[string]interface{}{
+			"ip":   aws.StringValue(targetAddress.Ip),
+			"port": int(aws.Int64Value(targetAddress.Port)),
+		}
+
+		vTargetIps = append(vTargetIps, mTargetIp)
+	}
+
+	return vTargetIps
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2382,30 +2382,7 @@ func validateWorklinkFleetName(v interface{}, k string) (ws []string, errors []e
 	return
 }
 
-func validateRoute53ResolverEndpointName(v interface{}, k string) (ws []string, errors []error) {
-	// Type: String
-	// Length Constraints: Maximum length of 64.
-	// Pattern: (?!^[0-9]+$)([a-zA-Z0-9-_' ']+)
-	value := v.(string)
-
-	// re2 doesn't support negative lookaheads so check for single numeric character explicitly.
-	if regexp.MustCompile(`^[0-9]$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be a single digit", k))
-	}
-	if !regexp.MustCompile(`^[a-zA-Z0-9-_' ']+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, '-', '_' and ' ' are allowed in %q", k))
-	}
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be greater than 64 characters", k))
-	}
-
-	return
-}
-
-func validateRoute53ResolverRuleName(v interface{}, k string) (ws []string, errors []error) {
+func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors []error) {
 	// Type: String
 	// Length Constraints: Maximum length of 64.
 	// Pattern: (?!^[0-9]+$)([a-zA-Z0-9-_' ']+)

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2404,3 +2404,26 @@ func validateRoute53ResolverEndpointName(v interface{}, k string) (ws []string, 
 
 	return
 }
+
+func validateRoute53ResolverRuleName(v interface{}, k string) (ws []string, errors []error) {
+	// Type: String
+	// Length Constraints: Maximum length of 64.
+	// Pattern: (?!^[0-9]+$)([a-zA-Z0-9-_' ']+)
+	value := v.(string)
+
+	// re2 doesn't support negative lookaheads so check for single numeric character explicitly.
+	if regexp.MustCompile(`^[0-9]$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be a single digit", k))
+	}
+	if !regexp.MustCompile(`^[a-zA-Z0-9-_' ']+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters, '-', '_' and ' ' are allowed in %q", k))
+	}
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 64 characters", k))
+	}
+
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3128,11 +3128,59 @@ func TestValidateRoute53ResolverEndpointName(t *testing.T) {
 			Value:    "A",
 			ErrCount: 0,
 		},
+		// Empty name not allowed.
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
 	}
 	for _, tc := range cases {
 		_, errors := validateRoute53ResolverEndpointName(tc.Value, "aws_route53_resolver_endpoint")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the AWS Route 53 Resolver Endpoint Name to not trigger a validation error for %q", tc.Value)
+		}
+	}
+}
+
+func TestValidateRoute53ResolverRuleName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing - 123__",
+			ErrCount: 0,
+		},
+		{
+			Value:    randomString(65),
+			ErrCount: 1,
+		},
+		{
+			Value:    "1",
+			ErrCount: 1,
+		},
+		{
+			Value:    "10",
+			ErrCount: 0,
+		},
+		{
+			Value:    "A",
+			ErrCount: 0,
+		},
+		// Empty name not allowed.
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := validateRoute53ResolverRuleName(tc.Value, "aws_route53_resolver_rule")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the AWS Route 53 Resolver Rule Name to not trigger a validation error for %q", tc.Value)
 		}
 	}
 }

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3099,7 +3099,7 @@ func TestValidateSecretManagerSecretNamePrefix(t *testing.T) {
 	}
 }
 
-func TestValidateRoute53ResolverEndpointName(t *testing.T) {
+func TestValidateRoute53ResolverName(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -3128,59 +3128,11 @@ func TestValidateRoute53ResolverEndpointName(t *testing.T) {
 			Value:    "A",
 			ErrCount: 0,
 		},
-		// Empty name not allowed.
-		{
-			Value:    "",
-			ErrCount: 1,
-		},
 	}
 	for _, tc := range cases {
-		_, errors := validateRoute53ResolverEndpointName(tc.Value, "aws_route53_resolver_endpoint")
+		_, errors := validateRoute53ResolverName(tc.Value, "aws_route53_resolver_endpoint")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected the AWS Route 53 Resolver Endpoint Name to not trigger a validation error for %q", tc.Value)
-		}
-	}
-}
-
-func TestValidateRoute53ResolverRuleName(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "testing123!",
-			ErrCount: 1,
-		},
-		{
-			Value:    "testing - 123__",
-			ErrCount: 0,
-		},
-		{
-			Value:    randomString(65),
-			ErrCount: 1,
-		},
-		{
-			Value:    "1",
-			ErrCount: 1,
-		},
-		{
-			Value:    "10",
-			ErrCount: 0,
-		},
-		{
-			Value:    "A",
-			ErrCount: 0,
-		},
-		// Empty name not allowed.
-		{
-			Value:    "",
-			ErrCount: 1,
-		},
-	}
-	for _, tc := range cases {
-		_, errors := validateRoute53ResolverRuleName(tc.Value, "aws_route53_resolver_rule")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AWS Route 53 Resolver Rule Name to not trigger a validation error for %q", tc.Value)
 		}
 	}
 }

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2275,12 +2275,12 @@
                             <a href="/docs/providers/aws/r/route53_resolver_endpoint.html">aws_route53_resolver_endpoint</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule-association") %>>
-                            <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
-                        </li>
-
                         <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule") %>>
                             <a href="/docs/providers/aws/r/route53_resolver_rule.html">aws_route53_resolver_rule</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule-association") %>>
+                            <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
                         </li>
 
                     </ul>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2255,14 +2255,6 @@
                             <a href="/docs/providers/aws/r/route53_record.html">aws_route53_record</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule") %>>
-                            <a href="/docs/providers/aws/r/route53_resolver_rule.html">aws_route53_resolver_rule</a>
-                        </li>
-
-                        # <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule-association") %>>
-                        #     <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
-                        # </li>
-
                         <li<%= sidebar_current("docs-aws-resource-route53-zone") %>>
                             <a href="/docs/providers/aws/r/route53_zone.html">aws_route53_zone</a>
                         </li>
@@ -2281,6 +2273,14 @@
 
                         <li<%= sidebar_current("docs-aws-resource-route53-resolver-endpoint") %>>
                             <a href="/docs/providers/aws/r/route53_resolver_endpoint.html">aws_route53_resolver_endpoint</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule-association") %>>
+                            <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule") %>>
+                            <a href="/docs/providers/aws/r/route53_resolver_rule.html">aws_route53_resolver_rule</a>
                         </li>
 
                     </ul>

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2255,6 +2255,14 @@
                             <a href="/docs/providers/aws/r/route53_record.html">aws_route53_record</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule") %>>
+                            <a href="/docs/providers/aws/r/route53_resolver_rule.html">aws_route53_resolver_rule</a>
+                        </li>
+
+                        # <li<%= sidebar_current("docs-aws-resource-route53-resolver-rule-association") %>>
+                        #     <a href="/docs/providers/aws/r/route53_resolver_rule_association.html">aws_route53_resolver_rule_association</a>
+                        # </li>
+
                         <li<%= sidebar_current("docs-aws-resource-route53-zone") %>>
                             <a href="/docs/providers/aws/r/route53_zone.html">aws_route53_zone</a>
                         </li>

--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_rule"
+sidebar_current: "docs-aws-resource-route53-resolver-rule"
+description: |-
+  Provides a Route53 Resolver rule.
+---
+
+# aws_route53_resolver_rule
+
+Provides a Route53 Resolver rule.
+
+## Example Usage
+
+```hcl
+resource "aws_route53_resolver_rule" "example" {
+  domain_name          = "example.com"
+  name                 = "example"
+  resolver_endpoint_id = "..."
+  rule_type            = "FORWARD"
+
+  target_ip {
+    ip   = "123.45.67.89"
+    port = 1234
+  }
+
+  tags {
+    Foo = "Barr"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) DNS queries for this domain name are forwarded to the IP addresses that are specified using `target_ip`.
+* `name` - (Optional) A friendly name that lets you easily find a rule in the Resolver dashboard in the Route 53 console.
+* `resolver_endpoint_id` (Optional) The ID of the outbound resolver endpoint that you want to use to route DNS queries to the IP addresses that you specify using `target_ip`.
+* `rule_type` - (Required) The rule type. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`.
+* `target_ip` - (Optional) Configuration block(s) indicating the IPs that you want Resolver to forward DNS queries to (documented below).
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `target_ip` object supports the following:
+
+* `ip` - (Required) One IP address that you want to forward DNS queries to. You can specify only IPv4 addresses.
+* `port` - (Optional) The port at `ip` that you want to forward DNS queries to.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the resolver rule.
+* `arn` - The ARN (Amazon Resource Name) for the resolver rule.
+
+## Import
+
+Route53 Resolver rules can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_route53_resolver_rule.example rslvr-rr-0123456789abcdef0
+```

--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -16,12 +16,10 @@ Provides a Route53 Resolver rule.
 resource "aws_route53_resolver_rule" "example" {
   domain_name          = "example.com"
   name                 = "example"
-  resolver_endpoint_id = "..."
   rule_type            = "FORWARD"
 
   target_ip {
     ip   = "123.45.67.89"
-    port = 1234
   }
 
   tags {
@@ -35,16 +33,16 @@ resource "aws_route53_resolver_rule" "example" {
 The following arguments are supported:
 
 * `domain_name` - (Required) DNS queries for this domain name are forwarded to the IP addresses that are specified using `target_ip`.
+* `rule_type` - (Required) The rule type. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`.
 * `name` - (Optional) A friendly name that lets you easily find a rule in the Resolver dashboard in the Route 53 console.
 * `resolver_endpoint_id` (Optional) The ID of the outbound resolver endpoint that you want to use to route DNS queries to the IP addresses that you specify using `target_ip`.
-* `rule_type` - (Required) The rule type. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`.
 * `target_ip` - (Optional) Configuration block(s) indicating the IPs that you want Resolver to forward DNS queries to (documented below).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `target_ip` object supports the following:
 
 * `ip` - (Required) One IP address that you want to forward DNS queries to. You can specify only IPv4 addresses.
-* `port` - (Optional) The port at `ip` that you want to forward DNS queries to.
+* `port` - (Optional) The port at `ip` that you want to forward DNS queries to. Default value is `53`
 
 ## Attributes Reference
 
@@ -52,6 +50,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the resolver rule.
 * `arn` - The ARN (Amazon Resource Name) for the resolver rule.
+* `share_status` - Whether the rules is shared and, if so, whether the current account is sharing the rule with another account, or another account is sharing the rule with the current account.
+Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
 
 ## Import
 

--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -12,18 +12,30 @@ Provides a Route53 Resolver rule.
 
 ## Example Usage
 
+### System rule
+
 ```hcl
-resource "aws_route53_resolver_rule" "example" {
+resource "aws_route53_resolver_rule" "sys" {
+  domain_name = "subdomain.example.com"
+  rule_type   = "SYSTEM"
+}
+```
+
+### Forward rule
+
+```hcl
+resource "aws_route53_resolver_rule" "fwd" {
   domain_name          = "example.com"
   name                 = "example"
   rule_type            = "FORWARD"
+  resolver_endpoint_id = "${aws_route53_resolver_endpoint.foo.id}"
 
   target_ip {
     ip   = "123.45.67.89"
   }
 
   tags {
-    Foo = "Barr"
+    Environment = "Prod"
   }
 }
 ```
@@ -36,7 +48,9 @@ The following arguments are supported:
 * `rule_type` - (Required) The rule type. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`.
 * `name` - (Optional) A friendly name that lets you easily find a rule in the Resolver dashboard in the Route 53 console.
 * `resolver_endpoint_id` (Optional) The ID of the outbound resolver endpoint that you want to use to route DNS queries to the IP addresses that you specify using `target_ip`.
+This argument should only be specified for `FORWARD` type rules.
 * `target_ip` - (Optional) Configuration block(s) indicating the IPs that you want Resolver to forward DNS queries to (documented below).
+This argument should only be specified for `FORWARD` type rules.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `target_ip` object supports the following:
@@ -59,5 +73,5 @@ Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
 Route53 Resolver rules can be imported using the `id`, e.g.
 
 ```
-$ terraform import aws_route53_resolver_rule.example rslvr-rr-0123456789abcdef0
+$ terraform import aws_route53_resolver_rule.sys rslvr-rr-0123456789abcdef0
 ```

--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -50,6 +50,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the resolver rule.
 * `arn` - The ARN (Amazon Resource Name) for the resolver rule.
+* `owner_id` - When a rule is shared with another AWS account, the account ID of the account that the rule is shared with.
 * `share_status` - Whether the rules is shared and, if so, whether the current account is sharing the rule with another account, or another account is sharing the rule with the current account.
 Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
 

--- a/website/docs/r/route53_resolver_rule_association.html.markdown
+++ b/website/docs/r/route53_resolver_rule_association.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_rule_association"
+sidebar_current: "docs-aws-resource-route53-resolver-rule-association"
+description: |-
+  Provides a Route53 Resolver rule association.
+---
+
+# aws_route53_resolver_rule
+
+Provides a Route53 Resolver rule association.
+
+## Example Usage
+
+```hcl
+resource "aws_route53_resolver_rule_association" "example" {
+  resolver_rule_id = "rslvr-rr-0123456789abcdef0"
+  vpc_id = "vpc-01234567"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) A name for the association that you're creating between a resolver rule and a VPC.
+* `resolver_rule_id` - (Required) The ID of the resolver rule that you want to associate with the VPC.
+* `vpc_id` - (Optional) The ID of the VPC that you want to associate the resolver rule with.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the resolver rule association.
+
+## Import
+
+Route53 Resolver rule associations can be imported using the `id`, e.g.
+
+```
+$ terraform import aws_route53_resolver_rule_association.example rslvr-rr-0123456789abcdef0
+```

--- a/website/docs/r/route53_resolver_rule_association.html.markdown
+++ b/website/docs/r/route53_resolver_rule_association.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a Route53 Resolver rule association.
 ---
 
-# aws_route53_resolver_rule
+# aws_route53_resolver_rule_association
 
 Provides a Route53 Resolver rule association.
 
@@ -14,8 +14,8 @@ Provides a Route53 Resolver rule association.
 
 ```hcl
 resource "aws_route53_resolver_rule_association" "example" {
-  resolver_rule_id = "rslvr-rr-0123456789abcdef0"
-  vpc_id = "vpc-01234567"
+  resolver_rule_id = "${aws_route53_resolver_rule.sys.id}"
+  vpc_id           = "${aws_vpc.foo.id}"
 }
 ```
 
@@ -38,5 +38,5 @@ In addition to all arguments above, the following attributes are exported:
 Route53 Resolver rule associations can be imported using the `id`, e.g.
 
 ```
-$ terraform import aws_route53_resolver_rule_association.example rslvr-rr-0123456789abcdef0
+$ terraform import aws_route53_resolver_rule_association.example rslvr-rrassoc-97242eaf88example
 ```

--- a/website/docs/r/route53_resolver_rule_association.html.markdown
+++ b/website/docs/r/route53_resolver_rule_association.html.markdown
@@ -23,9 +23,9 @@ resource "aws_route53_resolver_rule_association" "example" {
 
 The following arguments are supported:
 
-* `name` - (Optional) A name for the association that you're creating between a resolver rule and a VPC.
 * `resolver_rule_id` - (Required) The ID of the resolver rule that you want to associate with the VPC.
-* `vpc_id` - (Optional) The ID of the VPC that you want to associate the resolver rule with.
+* `vpc_id` - (Required) The ID of the VPC that you want to associate the resolver rule with.
+* `name` - (Optional) A name for the association that you're creating between a resolver rule and a VPC.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/6550.
Completes the work started in https://github.com/terraform-providers/terraform-provider-aws/pull/6571.
Finishes the tasks in https://github.com/terraform-providers/terraform-provider-aws/issues/6525.

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsRoute53ResolverRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsRoute53ResolverRule_ -timeout 120m
=== RUN   TestAccAwsRoute53ResolverRule_basic
=== PAUSE TestAccAwsRoute53ResolverRule_basic
=== RUN   TestAccAwsRoute53ResolverRule_tags
=== PAUSE TestAccAwsRoute53ResolverRule_tags
=== RUN   TestAccAwsRoute53ResolverRule_updateName
=== PAUSE TestAccAwsRoute53ResolverRule_updateName
=== RUN   TestAccAwsRoute53ResolverRule_forward
=== PAUSE TestAccAwsRoute53ResolverRule_forward
=== CONT  TestAccAwsRoute53ResolverRule_basic
=== CONT  TestAccAwsRoute53ResolverRule_forward
=== CONT  TestAccAwsRoute53ResolverRule_updateName
=== CONT  TestAccAwsRoute53ResolverRule_tags
--- PASS: TestAccAwsRoute53ResolverRule_basic (36.81s)
--- PASS: TestAccAwsRoute53ResolverRule_updateName (55.63s)
--- PASS: TestAccAwsRoute53ResolverRule_tags (55.91s)
--- PASS: TestAccAwsRoute53ResolverRule_forward (342.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	342.274s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsRoute53ResolverRuleAssociation_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsRoute53ResolverRuleAssociation_ -timeout 120m
=== RUN   TestAccAwsRoute53ResolverRuleAssociation_basic
=== PAUSE TestAccAwsRoute53ResolverRuleAssociation_basic
=== CONT  TestAccAwsRoute53ResolverRuleAssociation_basic
--- PASS: TestAccAwsRoute53ResolverRuleAssociation_basic (230.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	230.625s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsRoute53ResolverEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsRoute53ResolverEndpoint_ -timeout 120m
=== RUN   TestAccAwsRoute53ResolverEndpoint_basicInbound
=== PAUSE TestAccAwsRoute53ResolverEndpoint_basicInbound
=== RUN   TestAccAwsRoute53ResolverEndpoint_updateOutbound
=== PAUSE TestAccAwsRoute53ResolverEndpoint_updateOutbound
=== CONT  TestAccAwsRoute53ResolverEndpoint_basicInbound
=== CONT  TestAccAwsRoute53ResolverEndpoint_updateOutbound
--- PASS: TestAccAwsRoute53ResolverEndpoint_basicInbound (101.06s)
--- PASS: TestAccAwsRoute53ResolverEndpoint_updateOutbound (550.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	550.480s
```
