### PR TITLE
resource/aws_vpc_endpoint_service: Implement sweeper

### DIFF
--- a/aws/resource_aws_lb_test.go
+++ b/aws/resource_aws_lb_test.go
@@ -20,6 +20,7 @@ func init() {
 		F:    testSweepLBs,
 		Dependencies: []string{
 			"aws_api_gateway_vpc_link",
+			"aws_vpc_endpoint_service",
 		},
 	})
 }


### PR DESCRIPTION
Previous failure from `aws_subnet` test sweeper:

```
[05:18:56][Step 2/5] 2019/03/04 05:18:56 [ERR] error running (aws_vpc): Error deleting Subnet (subnet-0ce186d56574c271c): DependencyViolation: The subnet 'subnet-0ce186d56574c271c' has dependencies and cannot be deleted.
```

Was being caused by Network Load Balancers associated with VPC Endpoint Services, which the service must be deleted before the NLB:

```
Load balancer 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/tf-acc-test-4564889123438821822/36fbdd033af863b4' cannot be deleted because it is currently associated with another service
```

Output from `aws_subnet` test sweeper:

```
go test ./aws -v -sweep=us-east-1 -sweep-run=aws_subnet -timeout 10h
...
2019/03/04 08:38:48 [INFO] Deleting EC2 VPC Endpoint Service: vpce-svc-0c8fc937a4091b723
2019/03/04 08:38:48 [DEBUG] Waiting for state to become: [Deleted]
2019/03/04 08:38:53 [INFO] Deleting EC2 VPC Endpoint Service: vpce-svc-0895ac7ddaf6ff304
2019/03/04 08:38:54 [DEBUG] Waiting for state to become: [Deleted]
...
2019/03/04 08:39:00 [INFO] Deleting LB: tf-acc-test-4564889123438821822
2019/03/04 08:39:00 [INFO] Deleting LB: tf-acc-test-5369435394751153257
...
2019/03/04 08:39:47 Sweeper Tests ran:
  - aws_spot_fleet_request
  - aws_batch_job_queue
  - aws_eks_cluster
  - aws_elasticache_replication_group
  - aws_elasticsearch_domain
  - aws_api_gateway_vpc_link
  - aws_mq_broker
  - aws_route53_resolver_endpoint
  - aws_autoscaling_group
  - aws_directory_service_directory
  - aws_ec2_transit_gateway_vpc_attachment
  - aws_lambda_function
  - aws_vpc_endpoint_service
  - aws_network_interface
  - aws_redshift_cluster
  - aws_elasticache_cluster
  - aws_vpc_endpoint
  - aws_subnet
  - aws_batch_compute_environment
  - aws_beanstalk_environment
  - aws_db_instance
  - aws_elb
  - aws_emr_cluster
  - aws_lb
  - aws_instance
ok    github.com/terraform-providers/terraform-provider-aws/aws 74.915s
```

Output from acceptance testing:

```
--- PASS: TestAccAWSVpcEndpointService_removed (257.56s)
--- PASS: TestAccAWSVpcEndpointService_importBasic (264.51s)
--- PASS: TestAccAWSVpcEndpointService_basic (482.55s)
```
