### PR TITLE
resource/aws_guardduty_detector: Clarify finding_publishing_frequency usage for member accounts

### DIFF
--- a/aws/resource_aws_guardduty_detector.go
+++ b/aws/resource_aws_guardduty_detector.go
@@ -30,10 +30,12 @@ func resourceAwsGuardDutyDetector() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			// finding_publishing_frequency is marked as Computed:true since
+			// GuardDuty member accounts inherit setting from master account
 			"finding_publishing_frequency": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "SIX_HOURS",
+				Computed: true,
 			},
 		},
 	}
@@ -43,8 +45,11 @@ func resourceAwsGuardDutyDetectorCreate(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).guarddutyconn
 
 	input := guardduty.CreateDetectorInput{
-		Enable:                     aws.Bool(d.Get("enable").(bool)),
-		FindingPublishingFrequency: aws.String(d.Get("finding_publishing_frequency").(string)),
+		Enable: aws.Bool(d.Get("enable").(bool)),
+	}
+
+	if v, ok := d.GetOk("finding_publishing_frequency"); ok {
+		input.FindingPublishingFrequency = aws.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] Creating GuardDuty Detector: %s", input)

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -17,7 +17,6 @@ Provides a resource to manage a GuardDuty detector.
 ```hcl
 resource "aws_guardduty_detector" "MyDetector" {
   enable = true
-  finding_publishing_frequency = "SIX_HOURS"
 }
 ```
 
@@ -26,7 +25,7 @@ resource "aws_guardduty_detector" "MyDetector" {
 The following arguments are supported:
 
 * `enable` - (Optional) Enable monitoring and feedback reporting. Setting to `false` is equivalent to "suspending" GuardDuty. Defaults to `true`.
-* `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. Valid values: `FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS`. Default: `SIX_HOURS`. See [AWS Documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency) for more information.
+* `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. Cannot be modified for GuardDuty member accounts. Must be configured to enable drift detection in GuardDuty master accounts. Valid values: `FIFTEEN_MINUTES`, `ONE_HOUR`, `SIX_HOURS`. Default: `SIX_HOURS` for GuardDuty master account or matches GuardDuty master account if GuardDuty member account. See [AWS Documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency) for more information.
 
 ## Attributes Reference
 

--- a/website/docs/r/guardduty_detector.html.markdown
+++ b/website/docs/r/guardduty_detector.html.markdown
@@ -25,7 +25,7 @@ resource "aws_guardduty_detector" "MyDetector" {
 The following arguments are supported:
 
 * `enable` - (Optional) Enable monitoring and feedback reporting. Setting to `false` is equivalent to "suspending" GuardDuty. Defaults to `true`.
-* `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. Cannot be modified for GuardDuty member accounts. Must be configured to enable drift detection in GuardDuty master accounts. Valid values: `FIFTEEN_MINUTES`, `ONE_HOUR`, `SIX_HOURS`. Default: `SIX_HOURS` for GuardDuty master account or matches GuardDuty master account if GuardDuty member account. See [AWS Documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency) for more information.
+* `finding_publishing_frequency` - (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to `SIX_HOURS`. For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and master accounts: `FIFTEEN_MINUTES`, `ONE_HOUR`, `SIX_HOURS`. See [AWS Documentation](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency) for more information.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Closes #7781

Output from acceptance testing:

```
    --- PASS: TestAccAWSGuardDuty/Detector (36.21s)
        --- PASS: TestAccAWSGuardDuty/Detector/basic (25.70s)
        --- PASS: TestAccAWSGuardDuty/Detector/import (10.50s)
```
