### PR TITLE
update ecs_service max grace period to 2147483647

### DIFF
--- a/aws/resource_aws_ecs_service.go
+++ b/aws/resource_aws_ecs_service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -62,7 +63,7 @@ func resourceAwsEcsService() *schema.Resource {
 			"health_check_grace_period_seconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 7200),
+				ValidateFunc: validation.IntBetween(0, math.MaxInt32),
 			},
 
 			"launch_type": {

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -343,6 +343,14 @@ func TestAccAWSEcsService_healthCheckGracePeriodSeconds(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check_grace_period_seconds", "600"),
 				),
 			},
+			{
+				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
+					roleName, policyName, lbName, svcName, math.MaxInt32),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists(resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "health_check_grace_period_seconds", "2147483647"),
+				),
+			},
 		},
 	})
 }

--- a/aws/resource_aws_ecs_service_test.go
+++ b/aws/resource_aws_ecs_service_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"math"
 	"regexp"
 	"testing"
 	"time"
@@ -323,7 +324,7 @@ func TestAccAWSEcsService_healthCheckGracePeriodSeconds(t *testing.T) {
 			},
 			{
 				Config: testAccAWSEcsService_healthCheckGracePeriodSeconds(vpcNameTag, clusterName, tdName,
-					roleName, policyName, lbName, svcName, 7201),
+					roleName, policyName, lbName, svcName, math.MaxInt32+1),
 				ExpectError: regexp.MustCompile(`expected health_check_grace_period_seconds to be in the range`),
 			},
 			{

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -90,7 +90,7 @@ The following arguments are supported:
 * `enable_ecs_managed_tags` - (Optional) Specifies whether to enable Amazon ECS managed tags for the tasks within the service.
 * `propagate_tags` - (Optional) Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`.
 * `ordered_placement_strategy` - (Optional) Service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. The maximum number of `ordered_placement_strategy` blocks is `5`. Defined below.
-* `health_check_grace_period_seconds` - (Optional) Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers.
+* `health_check_grace_period_seconds` - (Optional) Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers.
 * `load_balancer` - (Optional) A load balancer block. Load balancers documented below.
 * `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of
 `placement_constraints` is `10`. Defined below.


### PR DESCRIPTION

Changes proposed in this pull request:

* ECS now supports a maximum healthCheckGracePeriodSeconds of 2,147,483,647 (the max value of a 32-bit signed int)

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEcsService_healthCheckGracePeriodS_healthCheckGracePeriodS_healthCheckGracePeriodSeconds'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEcsService_healthCheckGracePeriodSeconds -timeout 120m
=== RUN   TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== PAUSE TestAccAWSEcsService_healthCheckGracePeriodSeconds
=== CONT  TestAccAWSEcsService_healthCheckGracePeriodSeconds
--- PASS: TestAccAWSEcsService_healthCheckGracePeriodSeconds (382.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       382.300s
```
