### PR TITLE
Add attribute constraints requirement to Cognito User Pool documentation

### DIFF
--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -89,6 +89,8 @@ The following arguments are supported:
 
 #### Schema Attributes
 
+~> **NOTE:** When defining an `attribute_data_type` of `String` or `Number`, the respective attribute constraints configuration block (e.g `string_attribute_constraints` or `number_attribute_contraints`) is required to prevent recreation of the Terraform resource. This requirement is true for both standard (e.g. name, email) and custom schema attributes.
+
   * `attribute_data_type` (Required) - The attribute data type. Must be one of `Boolean`, `Number`, `String`, `DateTime`.
   * `developer_only_attribute` (Optional) - Specifies whether the attribute type is developer only.
   * `mutable` (Optional) - Specifies whether the attribute can be changed once it has been created.


### PR DESCRIPTION
Closes #7502

There is a known issue with the `aws_cognito_user_pool` resource that causes a recreation if schema attributes of type `String` or `Number` are used without an attribute constraints configuration block. This change does not fix the issue, but updates the documentation for the resource with a note indicating the requirements to prevent future invocations of the said issue.