### PR TITLE
docs/data-source/aws_kms_secret: Restore placeholder documentation page with migration information

### DIFF
--- a/website/docs/d/kms_secret.html.markdown
+++ b/website/docs/d/kms_secret.html.markdown
@@ -1,0 +1,11 @@
+---
+layout: "aws"
+page_title: "AWS: aws_kms_secret"
+sidebar_current: "docs-aws-datasource-kms-secret-x"
+description: |-
+    Provides secret data encrypted with the KMS service
+---
+
+# Data Source: aws_kms_secret
+
+!> **WARNING:** This data source was removed in version 2.0.0 of the Terraform AWS Provider. You can migrate existing configurations to the [`aws_kms_secrets` data source](/docs/providers/aws/d/kms_secrets.html) following instructions available in the [Version 2 Upgrade Guide](/docs/providers/aws/guides/version-2-upgrade.html#data-source-aws_kms_secret).


### PR DESCRIPTION
This placeholder documentation page will be removed in a future major version of the Terraform AWS Provider.
