### PR TITLE
resource/aws_autoscaling_group: Ensure most attributes are correctly set in Terraform state during read

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -644,37 +644,51 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	d.Set("availability_zones", flattenStringList(g.AvailabilityZones))
-	d.Set("default_cooldown", g.DefaultCooldown)
+	if err := d.Set("availability_zones", flattenStringList(g.AvailabilityZones)); err != nil {
+		return fmt.Errorf("error setting availability_zones: %s", err)
+	}
+
 	d.Set("arn", g.AutoScalingGroupARN)
+	d.Set("default_cooldown", g.DefaultCooldown)
 	d.Set("desired_capacity", g.DesiredCapacity)
+
+	d.Set("enabled_metrics", nil)
+	d.Set("metrics_granularity", "1Minute")
+	if g.EnabledMetrics != nil {
+		if err := d.Set("enabled_metrics", flattenAsgEnabledMetrics(g.EnabledMetrics)); err != nil {
+			return fmt.Errorf("error setting enabled_metrics: %s", err)
+		}
+		d.Set("metrics_granularity", g.EnabledMetrics[0].Granularity)
+	}
+
 	d.Set("health_check_grace_period", g.HealthCheckGracePeriod)
 	d.Set("health_check_type", g.HealthCheckType)
-	d.Set("load_balancers", flattenStringList(g.LoadBalancerNames))
+
+	if err := d.Set("load_balancers", flattenStringList(g.LoadBalancerNames)); err != nil {
+		return fmt.Errorf("error setting load_balancers: %s", err)
+	}
 
 	d.Set("launch_configuration", g.LaunchConfigurationName)
 
-	if g.LaunchTemplate != nil {
-		d.Set("launch_template", flattenLaunchTemplateSpecification(g.LaunchTemplate))
-	} else {
-		d.Set("launch_template", nil)
+	if err := d.Set("launch_template", flattenLaunchTemplateSpecification(g.LaunchTemplate)); err != nil {
+		return fmt.Errorf("error setting launch_template: %s", err)
 	}
+
+	d.Set("max_size", g.MaxSize)
+	d.Set("min_size", g.MinSize)
 
 	if err := d.Set("mixed_instances_policy", flattenAutoScalingMixedInstancesPolicy(g.MixedInstancesPolicy)); err != nil {
 		return fmt.Errorf("error setting mixed_instances_policy: %s", err)
 	}
 
-	if err := d.Set("suspended_processes", flattenAsgSuspendedProcesses(g.SuspendedProcesses)); err != nil {
-		log.Printf("[WARN] Error setting suspended_processes for %q: %s", d.Id(), err)
-	}
-	if err := d.Set("target_group_arns", flattenStringList(g.TargetGroupARNs)); err != nil {
-		log.Printf("[ERR] Error setting target groups: %s", err)
-	}
-	d.Set("min_size", g.MinSize)
-	d.Set("max_size", g.MaxSize)
-	d.Set("placement_group", g.PlacementGroup)
 	d.Set("name", g.AutoScalingGroupName)
+	d.Set("placement_group", g.PlacementGroup)
+	d.Set("protect_from_scale_in", g.NewInstancesProtectedFromScaleIn)
 	d.Set("service_linked_role_arn", g.ServiceLinkedRoleARN)
+
+	if err := d.Set("suspended_processes", flattenAsgSuspendedProcesses(g.SuspendedProcesses)); err != nil {
+		return fmt.Errorf("error setting suspended_processes: %s", err)
+	}
 
 	var tagList, tagsList []*autoscaling.TagDescription
 	var tagOk, tagsOk bool
@@ -718,31 +732,27 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("tag", autoscalingTagDescriptionsToSlice(g.Tags))
 	}
 
-	if len(*g.VPCZoneIdentifier) > 0 {
-		d.Set("vpc_zone_identifier", strings.Split(*g.VPCZoneIdentifier, ","))
-	} else {
-		d.Set("vpc_zone_identifier", []string{})
+	if err := d.Set("target_group_arns", flattenStringList(g.TargetGroupARNs)); err != nil {
+		return fmt.Errorf("error setting target_group_arns: %s", err)
 	}
-
-	d.Set("protect_from_scale_in", g.NewInstancesProtectedFromScaleIn)
 
 	// If no termination polices are explicitly configured and the upstream state
 	// is only using the "Default" policy, clear the state to make it consistent
 	// with the default AWS create API behavior.
 	_, ok := d.GetOk("termination_policies")
-	if !ok && len(g.TerminationPolicies) == 1 && *g.TerminationPolicies[0] == "Default" {
+	if !ok && len(g.TerminationPolicies) == 1 && aws.StringValue(g.TerminationPolicies[0]) == "Default" {
 		d.Set("termination_policies", []interface{}{})
 	} else {
-		d.Set("termination_policies", flattenStringList(g.TerminationPolicies))
+		if err := d.Set("termination_policies", flattenStringList(g.TerminationPolicies)); err != nil {
+			return fmt.Errorf("error setting termination_policies: %s", err)
+		}
 	}
 
-	if g.EnabledMetrics != nil {
-		if err := d.Set("enabled_metrics", flattenAsgEnabledMetrics(g.EnabledMetrics)); err != nil {
-			log.Printf("[WARN] Error setting metrics for (%s): %s", d.Id(), err)
+	d.Set("vpc_zone_identifier", []string{})
+	if len(aws.StringValue(g.VPCZoneIdentifier)) > 0 {
+		if err := d.Set("vpc_zone_identifier", strings.Split(aws.StringValue(g.VPCZoneIdentifier), ",")); err != nil {
+			return fmt.Errorf("error setting vpc_zone_identifier: %s", err)
 		}
-		d.Set("metrics_granularity", g.EnabledMetrics[0].Granularity)
-	} else {
-		d.Set("enabled_metrics", nil)
 	}
 
 	return nil

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -79,8 +79,10 @@ func testSweepAutoscalingGroups(region string) error {
 	return nil
 }
 
-func TestAccAWSAutoScalingGroup_importBasic(t *testing.T) {
-	resourceName := "aws_autoscaling_group.bar"
+func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
+	var group autoscaling.Group
+	var lc autoscaling.LaunchConfiguration
+
 	randName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -89,66 +91,55 @@ func TestAccAWSAutoScalingGroup_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAutoScalingGroupImport(randName),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"force_delete", "metrics_granularity", "wait_for_capacity_timeout"},
-			},
-		},
-	})
-}
-
-func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
-	var group autoscaling.Group
-	var lc autoscaling.LaunchConfiguration
-
-	randName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   "aws_autoscaling_group.bar",
-		IDRefreshIgnore: []string{"force_delete", "metrics_granularity", "wait_for_capacity_timeout"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSAutoScalingGroupDestroy,
-		Steps: []resource.TestStep{
-			{
 				Config: testAccAWSAutoScalingGroupConfig(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
 					testAccCheckAWSAutoScalingGroupHealthyCapacity(&group, 2),
 					testAccCheckAWSAutoScalingGroupAttributes(&group, randName),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "availability_zones.2487133097", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "name", randName),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "max_size", "5"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "min_size", "2"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "health_check_grace_period", "300"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "health_check_type", "ELB"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "desired_capacity", "4"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "force_delete", "true"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "termination_policies.0", "OldestInstance"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "termination_policies.1", "ClosestToNextInstanceHour"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "protect_from_scale_in", "false"),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "enabled_metrics.#", "0"),
+					testAccMatchResourceAttrRegionalARN("aws_autoscaling_group.bar", "arn", "autoscaling", regexp.MustCompile(`autoScalingGroup:.+`)),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "availability_zones.2487133097", "us-west-2a"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "default_cooldown", "300"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "desired_capacity", "4"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "enabled_metrics.#", "0"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "force_delete", "true"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "health_check_grace_period", "300"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "health_check_type", "ELB"),
+					resource.TestCheckNoResourceAttr("aws_autoscaling_group.bar", "initial_lifecycle_hook.#"),
+					resource.TestCheckResourceAttrPair("aws_autoscaling_group.bar", "launch_configuration", "aws_launch_configuration.foobar", "name"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "launch_template.#", "0"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "load_balancers.#", "0"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "max_size", "5"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "metrics_granularity", "1Minute"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "min_size", "2"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "mixed_instances_policy.#", "0"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "name", randName),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "placement_group", ""),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "protect_from_scale_in", "false"),
+					testAccCheckResourceAttrGlobalARN("aws_autoscaling_group.bar", "service_linked_role_arn", "iam", "role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "suspended_processes.#", "0"),
+					resource.TestCheckNoResourceAttr("aws_autoscaling_group.bar", "tag.#"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "tags.#", "3"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "target_group_arns.#", "0"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "termination_policies.#", "2"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "termination_policies.0", "OldestInstance"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "termination_policies.1", "ClosestToNextInstanceHour"),
+					resource.TestCheckResourceAttr("aws_autoscaling_group.bar", "vpc_zone_identifier.#", "0"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoScalingGroupConfigUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
@@ -196,6 +187,20 @@ func TestAccAWSAutoScalingGroup_namePrefix(t *testing.T) {
 						"aws_autoscaling_group.test", "arn"),
 				),
 			},
+			{
+				ResourceName:      "aws_autoscaling_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 		},
 	})
 }
@@ -217,6 +222,20 @@ func TestAccAWSAutoScalingGroup_autoGeneratedName(t *testing.T) {
 						"aws_autoscaling_group.bar", "arn"),
 				),
 			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 		},
 	})
 }
@@ -234,7 +253,20 @@ func TestAccAWSAutoScalingGroup_terminationPolicies(t *testing.T) {
 						"aws_autoscaling_group.bar", "termination_policies.#", "0"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoScalingGroupConfig_terminationPoliciesUpdate,
 				Check: resource.ComposeTestCheckFunc(
@@ -244,7 +276,20 @@ func TestAccAWSAutoScalingGroup_terminationPolicies(t *testing.T) {
 						"aws_autoscaling_group.bar", "termination_policies.0", "OldestInstance"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoScalingGroupConfig_terminationPoliciesExplicitDefault,
 				Check: resource.ComposeTestCheckFunc(
@@ -254,7 +299,6 @@ func TestAccAWSAutoScalingGroup_terminationPolicies(t *testing.T) {
 						"aws_autoscaling_group.bar", "termination_policies.0", "Default"),
 				),
 			},
-
 			{
 				Config: testAccAWSAutoScalingGroupConfig_terminationPoliciesEmpty,
 				Check: resource.ComposeTestCheckFunc(
@@ -294,7 +338,20 @@ func TestAccAWSAutoScalingGroup_tags(t *testing.T) {
 					}),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoScalingGroupConfigUpdate(randName),
 				Check: resource.ComposeTestCheckFunc(
@@ -338,7 +395,20 @@ func TestAccAWSAutoScalingGroup_VpcUpdates(t *testing.T) {
 						"aws_autoscaling_group.bar", "vpc_zone_identifier.#", "0"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoScalingGroupConfigWithVPCIdent,
 				Check: resource.ComposeTestCheckFunc(
@@ -371,6 +441,20 @@ func TestAccAWSAutoScalingGroup_WithLoadBalancer(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupAttributesLoadBalancer(&group),
 				),
 			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 		},
 	})
 }
@@ -391,6 +475,20 @@ func TestAccAWSAutoScalingGroup_withPlacementGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_autoscaling_group.bar", "placement_group", randName),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
 			},
 		},
 	})
@@ -413,7 +511,20 @@ func TestAccAWSAutoScalingGroup_enablingMetrics(t *testing.T) {
 						"aws_autoscaling_group.bar", "enabled_metrics"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoscalingMetricsCollectionConfig_updatingMetricsCollected,
 				Check: resource.ComposeTestCheckFunc(
@@ -452,6 +563,20 @@ func TestAccAWSAutoScalingGroup_suspendingProcesses(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
+			{
 				Config: testAccAWSAutoScalingGroupConfigWithSuspendedProcessesUpdated(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
@@ -479,7 +604,20 @@ func TestAccAWSAutoScalingGroup_withMetrics(t *testing.T) {
 						"aws_autoscaling_group.bar", "enabled_metrics.#", "7"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoscalingMetricsCollectionConfig_updatingMetricsCollected,
 				Check: resource.ComposeTestCheckFunc(
@@ -507,6 +645,20 @@ func TestAccAWSAutoScalingGroup_serviceLinkedRoleARN(t *testing.T) {
 					resource.TestCheckResourceAttrSet(
 						"aws_autoscaling_group.bar", "service_linked_role_arn"),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
 			},
 		},
 	})
@@ -565,7 +717,20 @@ func TestAccAWSAutoScalingGroup_ALB_TargetGroups(t *testing.T) {
 						"aws_autoscaling_group.bar", "target_group_arns.#", "2"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_post,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -586,11 +751,9 @@ func TestAccAWSAutoScalingGroup_initialLifecycleHook(t *testing.T) {
 	randName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:        func() { testAccPreCheck(t) },
-		IDRefreshName:   "aws_autoscaling_group.bar",
-		IDRefreshIgnore: []string{"force_delete", "metrics_granularity", "wait_for_capacity_timeout"},
-		Providers:       testAccProviders,
-		CheckDestroy:    testAccCheckAWSAutoScalingGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAutoScalingGroupWithHookConfig(randName),
@@ -606,6 +769,20 @@ func TestAccAWSAutoScalingGroup_initialLifecycleHook(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupInitialLifecycleHookExists(
 						"aws_autoscaling_group.bar", "initial_lifecycle_hook.391359060.name"),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
 			},
 		},
 	})
@@ -629,6 +806,20 @@ func TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity(t *testing.T) {
 					testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &tg),
 					testAccCheckAWSALBTargetGroupHealthy(&tg),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
 			},
 		},
 	})
@@ -880,10 +1071,9 @@ func TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier(t *testing.T) {
 	var group autoscaling.Group
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_autoscaling_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSAutoScalingGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAutoScalingGroupConfig_classicVpcZoneIdentifier,
@@ -891,6 +1081,20 @@ func TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.test", &group),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.test", "vpc_zone_identifier.#", "0"),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
 			},
 		},
 	})
@@ -900,10 +1104,9 @@ func TestAccAWSAutoScalingGroup_emptyAvailabilityZones(t *testing.T) {
 	var group autoscaling.Group
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_autoscaling_group.test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSAutoScalingGroupDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAutoScalingGroupConfig_emptyAvailabilityZones,
@@ -911,6 +1114,20 @@ func TestAccAWSAutoScalingGroup_emptyAvailabilityZones(t *testing.T) {
 					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.test", &group),
 					resource.TestCheckResourceAttr("aws_autoscaling_group.test", "availability_zones.#", "1"),
 				),
+			},
+			{
+				ResourceName:      "aws_autoscaling_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
 			},
 		},
 	})
@@ -932,6 +1149,20 @@ func TestAccAWSAutoScalingGroup_launchTemplate(t *testing.T) {
 						"aws_autoscaling_group.bar", "launch_template.0.id"),
 				),
 			},
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 		},
 	})
 }
@@ -952,7 +1183,20 @@ func TestAccAWSAutoScalingGroup_launchTemplate_update(t *testing.T) {
 						"aws_autoscaling_group.bar", "launch_template.0.name"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_autoscaling_group.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 			{
 				Config: testAccAWSAutoScalingGroupConfig_withLaunchTemplate_toLaunchConfig,
 				Check: resource.ComposeTestCheckFunc(
@@ -1016,6 +1260,20 @@ func TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile(t *testing.T) 
 					testAccCheckAWSAutoScalingGroupExists(resourceName, &group),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_delete",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
+					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
+				},
+			},
 		},
 	})
 }
@@ -1049,8 +1307,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 		},
@@ -1082,8 +1344,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDem
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 		},
@@ -1115,8 +1381,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDem
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 			{
@@ -1157,8 +1427,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDem
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 			{
@@ -1199,8 +1473,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotA
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 		},
@@ -1232,8 +1510,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotI
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 			{
@@ -1274,8 +1556,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotM
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 			{
@@ -1317,8 +1603,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTempla
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 		},
@@ -1351,8 +1641,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTempla
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 			{
@@ -1396,8 +1690,12 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_Ins
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"force_delete",
-					"metrics_granularity",
+					"initial_lifecycle_hook",
+					"name_prefix",
+					"tag",
+					"tags",
 					"wait_for_capacity_timeout",
+					"wait_for_elb_capacity",
 				},
 			},
 			{
@@ -1656,61 +1954,6 @@ resource "aws_autoscaling_group" "bar" {
   ]
 }
 `, name)
-}
-
-func testAccAWSAutoScalingGroupImport(name string) string {
-	return fmt.Sprintf(`
-data "aws_ami" "test_ami" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-hvm-*-x86_64-gp2"]
-  }
-}
-
-resource "aws_launch_configuration" "foobar" {
-  image_id = "${data.aws_ami.test_ami.id}"
-  instance_type = "t2.micro"
-}
-
-resource "aws_placement_group" "test" {
-  name = "asg_pg_%s"
-  strategy = "cluster"
-}
-
-resource "aws_autoscaling_group" "bar" {
-  availability_zones = ["us-west-2a"]
-  name = "%s"
-  max_size = 5
-  min_size = 2
-  health_check_type = "ELB"
-  desired_capacity = 4
-  force_delete = true
-  termination_policies = ["OldestInstance","ClosestToNextInstanceHour"]
-
-  launch_configuration = "${aws_launch_configuration.foobar.name}"
-
-  tag {
-    key = "FromTags1"
-    value = "value1"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "FromTags2"
-    value = "value2"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "FromTags3"
-    value = "value3"
-    propagate_at_launch = true
-  }
-}
-`, name, name)
 }
 
 const testAccAWSAutoScalingGroupConfigWithLoadBalancer = `

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4583,6 +4583,10 @@ func expandLaunchTemplateSpecification(specs []interface{}) (*autoscaling.Launch
 }
 
 func flattenLaunchTemplateSpecification(lt *autoscaling.LaunchTemplateSpecification) []map[string]interface{} {
+	if lt == nil {
+		return []map[string]interface{}{}
+	}
+
 	attrs := map[string]interface{}{}
 	result := make([]map[string]interface{}, 0)
 


### PR DESCRIPTION
Closes #2412

The exceptions of the `initial_lifecycle_hook`, `tag`, `tags` attributes will require additional work.

Changes:

* Alphabetically sort attribute `d.Set()` calls
* Ensure all non-scalar attribute `d.Set()` calls properly return error instead of logging
* Ensure all acceptance tests include `ImportState` and `ImportStateVerify` testing
* Ensure basic acceptance test covers all attributes

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (143.09s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (335.77s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (49.22s)
--- PASS: TestAccAWSAutoScalingGroup_basic (295.87s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (51.32s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (98.48s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (268.25s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (362.24s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (44.77s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (52.78s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (110.01s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (43.08s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (52.82s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (80.06s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (165.03s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (86.05s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (83.17s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (135.70s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (81.37s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (51.38s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (83.30s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (46.53s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (77.93s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (464.71s)
--- PASS: TestAccAWSAutoScalingGroup_tags (295.92s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (82.24s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (113.48s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (453.24s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (92.72s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (147.26s)
```
