### PR TITLE
resource/aws_launch_configuration: Prevent ResourceInUse errors caused by eventual consistency during deletion

### DIFF
--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -563,19 +563,36 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 
 func resourceAwsLaunchConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
 	autoscalingconn := meta.(*AWSClient).autoscalingconn
+	input := &autoscaling.DeleteLaunchConfigurationInput{
+		LaunchConfigurationName: aws.String(d.Id()),
+	}
 
-	log.Printf("[DEBUG] Launch Configuration destroy: %v", d.Id())
-	_, err := autoscalingconn.DeleteLaunchConfiguration(
-		&autoscaling.DeleteLaunchConfigurationInput{
-			LaunchConfigurationName: aws.String(d.Id()),
-		})
-	if err != nil {
+	log.Printf("[DEBUG] Deleting Autoscaling Launch Configuration: %s", d.Id())
+	// Retry for Autoscaling eventual consistency
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := autoscalingconn.DeleteLaunchConfiguration(input)
+
+		if isAWSErr(err, autoscaling.ErrCodeResourceInUseFault, "") {
+			return resource.RetryableError(err)
+		}
+
 		if isAWSErr(err, "InvalidConfiguration.NotFound", "") {
-			log.Printf("[DEBUG] Launch configuration (%s) not found", d.Id())
 			return nil
 		}
 
-		return err
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
+
+	if isResourceTimeoutError(err) {
+		_, err = autoscalingconn.DeleteLaunchConfiguration(input)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting Autoscaling Launch Configuration (%s): %s", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
Closes #502
Closes #646

Also discovered during acceptance testing, which was no longer present after this change:

```
--- FAIL: TestAccAWSAutoScalingGroup_basic (233.37s)
    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Error applying: 1 error occurred:
          * aws_launch_configuration.foobar (destroy): 1 error occurred:
          * aws_launch_configuration.foobar: ResourceInUse: Cannot delete launch configuration terraform-20190305190002502900000001 because it is attached to AutoScalingGroup terraform-test-xkagj2tcwm
```

It appears the Autoscaling service can display an eventual consistency delay between when an Autoscaling Group requiring a Launch Configuration is deleted and deleting the Launch Configuration immediately after.

Output from acceptance testing:

```
--- PASS: TestAccAWSLaunchConfiguration_importBasic (14.18s)
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (15.10s)
--- PASS: TestAccAWSLaunchConfiguration_ebs_noDevice (16.20s)
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (17.60s)
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (19.82s)
--- PASS: TestAccAWSLaunchConfiguration_userData (26.26s)
--- PASS: TestAccAWSLaunchConfiguration_basic (28.43s)
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (30.24s)
--- PASS: TestAccAWSLaunchConfiguration_updateRootBlockDevice (31.82s)
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (35.39s)
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (37.53s)
```
