### PR TITLE
resource/aws_autoscaling_group: Configure mixed_instances_policy instance_distribution on_demand_base_capacity and spot_max_price argument zero values

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -1259,7 +1259,7 @@ func expandAutoScalingInstancesDistribution(l []interface{}) *autoscaling.Instan
 		instancesDistribution.OnDemandAllocationStrategy = aws.String(v.(string))
 	}
 
-	if v, ok := m["on_demand_base_capacity"]; ok && v.(int) != 0 {
+	if v, ok := m["on_demand_base_capacity"]; ok {
 		instancesDistribution.OnDemandBaseCapacity = aws.Int64(int64(v.(int)))
 	}
 
@@ -1275,7 +1275,7 @@ func expandAutoScalingInstancesDistribution(l []interface{}) *autoscaling.Instan
 		instancesDistribution.SpotInstancePools = aws.Int64(int64(v.(int)))
 	}
 
-	if v, ok := m["spot_max_price"]; ok && v.(string) != "" {
+	if v, ok := m["spot_max_price"]; ok {
 		instancesDistribution.SpotMaxPrice = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -1128,6 +1128,15 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDem
 					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_base_capacity", "2"),
 				),
 			},
+			{
+				Config: testAccAWSAutoScalingGroupConfig_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAutoScalingGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.instances_distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.instances_distribution.0.on_demand_base_capacity", "0"),
+				),
+			},
 		},
 	})
 }
@@ -1285,6 +1294,15 @@ func TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotM
 					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.instances_distribution.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.instances_distribution.0.spot_max_price", "0.51"),
+				),
+			},
+			{
+				Config: testAccAWSAutoScalingGroupConfig_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAutoScalingGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.instances_distribution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.instances_distribution.0.spot_max_price", ""),
 				),
 			},
 		},


### PR DESCRIPTION
Closes #7368

Additional References:

* https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html
* https://github.com/aws/aws-sdk-go/releases/tag/v1.17.5

The `mixed_instances_policy` configuration block `instance_distribution` configuration block `on_demand_base_capacity` argument was erroneously omitted from the API requests when configured to 0. This has been fixed.

The `mixed_instances_policy` configuration block `instance_distribution` configuration block `spot_max_price` argument now allows unconfiguring the value via an empty string as of AWS Go SDK 1.17.5. This has been added and verified.

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (208.32s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (380.94s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (57.41s)
--- PASS: TestAccAWSAutoScalingGroup_basic (277.63s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (79.47s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (58.64s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (172.07s)
--- PASS: TestAccAWSAutoScalingGroup_importBasic (237.78s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (694.88s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (44.01s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (52.89s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (142.34s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (80.87s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (83.04s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (113.14s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (80.93s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (141.63s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (114.38s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (76.59s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (49.45s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (80.60s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (78.31s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (56.71s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (82.65s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (211.74s)
--- PASS: TestAccAWSAutoScalingGroup_tags (347.60s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (75.88s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (77.10s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (383.31s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (55.06s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (142.28s)
```
