### PR TITLE
Feature/add support for deprecate aws ssm maintenance window task

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/validation"
@@ -91,9 +93,10 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			},
 
 			"logging_info": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
+				Type:       schema.TypeList,
+				MaxItems:   1,
+				Optional:   true,
+				Deprecated: "use 'task_invocation_parameters' argument instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"s3_bucket_name": {
@@ -113,8 +116,9 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			},
 
 			"task_parameters": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Deprecated: "use 'task_invocation_parameters' argument instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -125,6 +129,189 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 							Type:     schema.TypeList,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+
+			"task_invocation_parameters": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"task_parameters", "logging_info"},
+				MaxItems:      1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"automation_parameters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"document_version": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringMatch(regexp.MustCompile("([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)"), "see https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_MaintenanceWindowAutomationParameters.html"),
+									},
+									"parameters": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"values": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"lambda_parameters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"client_context": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(1, 8000),
+									},
+
+									"payload": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringLenBetween(0, 4096),
+									},
+
+									"qualifier": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(1, 128),
+									},
+								},
+							},
+						},
+
+						"run_command_parameters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"comment": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"document_hash": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"document_hash_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											ssm.DocumentHashTypeSha256,
+											ssm.DocumentHashTypeSha1,
+										}, false),
+									},
+
+									"notification_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"notification_arn": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+
+												"notification_events": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+
+												"notification_type": {
+													Type:     schema.TypeString,
+													Optional: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														ssm.NotificationTypeCommand,
+														ssm.NotificationTypeInvocation,
+													}, false),
+												},
+											},
+										},
+									},
+
+									"output_s3_bucket": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"output_s3_key_prefix": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"parameters": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"values": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+
+									"service_role_arn": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+
+									"timeout_seconds": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+
+						"step_functions_parameters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"input": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringLenBetween(0, 4096),
+									},
+
+									"name": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringLenBetween(1, 80),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -186,6 +373,264 @@ func flattenAwsSsmTaskParameters(taskParameters map[string]*ssm.MaintenanceWindo
 	return result
 }
 
+func expandAwsSsmTaskInvocationParameters(config []interface{}) *ssm.MaintenanceWindowTaskInvocationParameters {
+	params := &ssm.MaintenanceWindowTaskInvocationParameters{}
+	for _, v := range config {
+		paramConfig := v.(map[string]interface{})
+		if attr, ok := paramConfig["automation_parameters"]; ok && len(attr.([]interface{})) > 0 {
+			params.Automation = expandAwsSsmTaskInvocationAutomationParameters(attr.([]interface{}))
+		}
+		if attr, ok := paramConfig["lambda_parameters"]; ok && len(attr.([]interface{})) > 0 {
+			params.Lambda = expandAwsSsmTaskInvocationLambdaParameters(attr.([]interface{}))
+		}
+		if attr, ok := paramConfig["run_command_parameters"]; ok && len(attr.([]interface{})) > 0 {
+			params.RunCommand = expandAwsSsmTaskInvocationRunCommandParameters(attr.([]interface{}))
+		}
+		if attr, ok := paramConfig["step_functions_parameters"]; ok && len(attr.([]interface{})) > 0 {
+			params.StepFunctions = expandAwsSsmTaskInvocationStepFunctionsParameters(attr.([]interface{}))
+		}
+	}
+	return params
+}
+
+func flattenAwsSsmTaskInvocationParameters(parameters *ssm.MaintenanceWindowTaskInvocationParameters) []interface{} {
+	result := make(map[string]interface{})
+	if parameters.Automation != nil {
+		result["automation_parameters"] = flattenAwsSsmTaskInvocationAutomationParameters(parameters.Automation)
+	}
+
+	if parameters.Lambda != nil {
+		result["lambda_parameters"] = flattenAwsSsmTaskInvocationLambdaParameters(parameters.Lambda)
+	}
+
+	if parameters.RunCommand != nil {
+		result["run_command_parameters"] = flattenAwsSsmTaskInvocationRunCommandParameters(parameters.RunCommand)
+	}
+
+	if parameters.StepFunctions != nil {
+		result["step_functions_parameters"] = flattenAwsSsmTaskInvocationStepFunctionsParameters(parameters.StepFunctions)
+	}
+
+	return []interface{}{result}
+}
+
+func expandAwsSsmTaskInvocationAutomationParameters(config []interface{}) *ssm.MaintenanceWindowAutomationParameters {
+	params := &ssm.MaintenanceWindowAutomationParameters{}
+	configParam := config[0].(map[string]interface{})
+	if attr, ok := configParam["document_version"]; ok && len(attr.(string)) != 0 {
+		params.DocumentVersion = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["parameters"]; ok && len(attr.([]interface{})) > 0 {
+		params.Parameters = expandAwsSsmTaskInvocationCommonParameters(attr.([]interface{}))
+	}
+
+	return params
+}
+
+func flattenAwsSsmTaskInvocationAutomationParameters(parameters *ssm.MaintenanceWindowAutomationParameters) []interface{} {
+	result := make(map[string]interface{})
+
+	if parameters.DocumentVersion != nil {
+		result["document_version"] = aws.StringValue(parameters.DocumentVersion)
+	}
+	if parameters.Parameters != nil {
+		result["parameters"] = flattenAwsSsmTaskInvocationCommonParameters(parameters.Parameters)
+	}
+
+	return []interface{}{result}
+}
+
+func expandAwsSsmTaskInvocationLambdaParameters(config []interface{}) *ssm.MaintenanceWindowLambdaParameters {
+	params := &ssm.MaintenanceWindowLambdaParameters{}
+	configParam := config[0].(map[string]interface{})
+	if attr, ok := configParam["client_context"]; ok && len(attr.(string)) != 0 {
+		params.ClientContext = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["payload"]; ok && len(attr.(string)) != 0 {
+		params.Payload = []byte(attr.(string))
+	}
+	if attr, ok := configParam["qualifier"]; ok && len(attr.(string)) != 0 {
+		params.Qualifier = aws.String(attr.(string))
+	}
+	return params
+}
+
+func flattenAwsSsmTaskInvocationLambdaParameters(parameters *ssm.MaintenanceWindowLambdaParameters) []interface{} {
+	result := make(map[string]interface{})
+
+	if parameters.ClientContext != nil {
+		result["client_context"] = aws.StringValue(parameters.ClientContext)
+	}
+	if parameters.Payload != nil {
+		result["payload"] = string(parameters.Payload)
+	}
+	if parameters.Qualifier != nil {
+		result["qualifier"] = aws.StringValue(parameters.Qualifier)
+	}
+	return []interface{}{result}
+}
+
+func expandAwsSsmTaskInvocationRunCommandParameters(config []interface{}) *ssm.MaintenanceWindowRunCommandParameters {
+	params := &ssm.MaintenanceWindowRunCommandParameters{}
+	configParam := config[0].(map[string]interface{})
+	if attr, ok := configParam["comment"]; ok && len(attr.(string)) != 0 {
+		params.Comment = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["document_hash"]; ok && len(attr.(string)) != 0 {
+		params.DocumentHash = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["document_hash_type"]; ok && len(attr.(string)) != 0 {
+		params.DocumentHashType = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["notification_config"]; ok && len(attr.([]interface{})) > 0 {
+		params.NotificationConfig = expandAwsSsmTaskInvocationRunCommandParametersNotificationConfig(attr.([]interface{}))
+	}
+	if attr, ok := configParam["output_s3_bucket"]; ok && len(attr.(string)) != 0 {
+		params.OutputS3BucketName = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["output_s3_key_prefix"]; ok && len(attr.(string)) != 0 {
+		params.OutputS3KeyPrefix = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["parameters"]; ok && len(attr.([]interface{})) > 0 {
+		params.Parameters = expandAwsSsmTaskInvocationCommonParameters(attr.([]interface{}))
+	}
+	if attr, ok := configParam["service_role_arn"]; ok && len(attr.(string)) != 0 {
+		params.ServiceRoleArn = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["timeout_seconds"]; ok && attr.(int) != 0 {
+		params.TimeoutSeconds = aws.Int64(int64(attr.(int)))
+	}
+	return params
+}
+
+func flattenAwsSsmTaskInvocationRunCommandParameters(parameters *ssm.MaintenanceWindowRunCommandParameters) []interface{} {
+	result := make(map[string]interface{})
+
+	if parameters.Comment != nil {
+		result["comment"] = aws.StringValue(parameters.Comment)
+	}
+	if parameters.DocumentHash != nil {
+		result["document_hash"] = aws.StringValue(parameters.DocumentHash)
+	}
+	if parameters.DocumentHashType != nil {
+		result["document_hash_type"] = aws.StringValue(parameters.DocumentHashType)
+	}
+	if parameters.NotificationConfig != nil {
+		result["notification_config"] = flattenAwsSsmTaskInvocationRunCommandParametersNotificationConfig(parameters.NotificationConfig)
+	}
+	if parameters.OutputS3BucketName != nil {
+		result["output_s3_bucket"] = aws.StringValue(parameters.OutputS3BucketName)
+	}
+	if parameters.OutputS3KeyPrefix != nil {
+		result["output_s3_key_prefix"] = aws.StringValue(parameters.OutputS3KeyPrefix)
+	}
+	if parameters.Parameters != nil {
+		result["parameters"] = flattenAwsSsmTaskInvocationCommonParameters(parameters.Parameters)
+	}
+	if parameters.ServiceRoleArn != nil {
+		result["service_role_arn"] = aws.StringValue(parameters.ServiceRoleArn)
+	}
+	if parameters.TimeoutSeconds != nil {
+		result["timeout_seconds"] = aws.Int64Value(parameters.TimeoutSeconds)
+	}
+
+	return []interface{}{result}
+}
+
+func expandAwsSsmTaskInvocationStepFunctionsParameters(config []interface{}) *ssm.MaintenanceWindowStepFunctionsParameters {
+	params := &ssm.MaintenanceWindowStepFunctionsParameters{}
+	configParam := config[0].(map[string]interface{})
+
+	if attr, ok := configParam["input"]; ok && len(attr.(string)) != 0 {
+		params.Input = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["name"]; ok && len(attr.(string)) != 0 {
+		params.Name = aws.String(attr.(string))
+	}
+
+	return params
+}
+
+func flattenAwsSsmTaskInvocationStepFunctionsParameters(parameters *ssm.MaintenanceWindowStepFunctionsParameters) []interface{} {
+	result := make(map[string]interface{})
+
+	if parameters.Input != nil {
+		result["input"] = aws.StringValue(parameters.Input)
+	}
+	if parameters.Name != nil {
+		result["name"] = aws.StringValue(parameters.Name)
+	}
+	return []interface{}{result}
+}
+
+func expandAwsSsmTaskInvocationRunCommandParametersNotificationConfig(config []interface{}) *ssm.NotificationConfig {
+	params := &ssm.NotificationConfig{}
+	configParam := config[0].(map[string]interface{})
+
+	if attr, ok := configParam["notification_arn"]; ok && len(attr.(string)) != 0 {
+		params.NotificationArn = aws.String(attr.(string))
+	}
+	if attr, ok := configParam["notification_events"]; ok && len(attr.([]interface{})) > 0 {
+		params.NotificationEvents = expandStringList(attr.([]interface{}))
+	}
+	if attr, ok := configParam["notification_type"]; ok && len(attr.(string)) != 0 {
+		params.NotificationType = aws.String(attr.(string))
+	}
+
+	return params
+}
+
+func flattenAwsSsmTaskInvocationRunCommandParametersNotificationConfig(config *ssm.NotificationConfig) []interface{} {
+	result := make(map[string]interface{})
+
+	if config.NotificationArn != nil {
+		result["notification_arn"] = aws.StringValue(config.NotificationArn)
+	}
+	if config.NotificationEvents != nil {
+		result["notification_events"] = flattenStringList(config.NotificationEvents)
+	}
+	if config.NotificationType != nil {
+		result["notification_type"] = aws.StringValue(config.NotificationType)
+	}
+
+	return []interface{}{result}
+}
+
+func expandAwsSsmTaskInvocationCommonParameters(config []interface{}) map[string][]*string {
+	params := make(map[string][]*string)
+
+	for _, v := range config {
+		paramConfig := v.(map[string]interface{})
+		params[paramConfig["name"].(string)] = expandStringList(paramConfig["values"].([]interface{}))
+	}
+
+	return params
+}
+
+func flattenAwsSsmTaskInvocationCommonParameters(parameters map[string][]*string) []interface{} {
+	result := make([]interface{}, 0, len(parameters))
+
+	keys := make([]string, 0, len(parameters))
+	for k := range parameters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		values := make([]string, 0)
+		for _, value := range parameters[key] {
+			values = append(values, aws.StringValue(value))
+		}
+		params := map[string]interface{}{
+			"name":   key,
+			"values": values,
+		}
+		result = append(result, params)
+	}
+
+	return result
+}
+
 func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
@@ -219,6 +664,10 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("task_parameters"); ok {
 		params.TaskParameters = expandAwsSsmTaskParameters(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("task_invocation_parameters"); ok {
+		params.TaskInvocationParameters = expandAwsSsmTaskInvocationParameters(v.([]interface{}))
 	}
 
 	resp, err := ssmconn.RegisterTaskWithMaintenanceWindow(params)
@@ -271,6 +720,12 @@ func resourceAwsSsmMaintenanceWindowTaskRead(d *schema.ResourceData, meta interf
 		}
 	}
 
+	if resp.TaskInvocationParameters != nil {
+		if err := d.Set("task_invocation_parameters", flattenAwsSsmTaskInvocationParameters(resp.TaskInvocationParameters)); err != nil {
+			return fmt.Errorf("Error setting task_invocation_parameters error: %#v", err)
+		}
+	}
+
 	if err := d.Set("targets", flattenAwsSsmTargets(resp.Targets)); err != nil {
 		return fmt.Errorf("Error setting targets error: %#v", err)
 	}
@@ -311,6 +766,10 @@ func resourceAwsSsmMaintenanceWindowTaskUpdate(d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("task_parameters"); ok {
 		params.TaskParameters = expandAwsSsmTaskParameters(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("task_invocation_parameters"); ok {
+		params.TaskInvocationParameters = expandAwsSsmTaskInvocationParameters(v.([]interface{}))
 	}
 
 	_, err := ssmconn.UpdateMaintenanceWindowTask(params)

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/validation"
 
@@ -17,6 +18,9 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 		Read:   resourceAwsSsmMaintenanceWindowTaskRead,
 		Update: resourceAwsSsmMaintenanceWindowTaskUpdate,
 		Delete: resourceAwsSsmMaintenanceWindowTaskDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsSsmMaintenanceWindowTaskImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"window_id": {
@@ -342,4 +346,19 @@ func resourceAwsSsmMaintenanceWindowTaskDelete(d *schema.ResourceData, meta inte
 	}
 
 	return nil
+}
+
+func resourceAwsSsmMaintenanceWindowTaskImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.SplitN(d.Id(), "/", 2)
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <window-id>/<window-task-id>", d.Id())
+	}
+
+	windowID := idParts[0]
+	windowTaskID := idParts[1]
+
+	d.Set("window_id", windowID)
+	d.SetId(windowTaskID)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -383,16 +383,16 @@ func expandAwsSsmTaskInvocationParameters(config []interface{}) *ssm.Maintenance
 	params := &ssm.MaintenanceWindowTaskInvocationParameters{}
 	for _, v := range config {
 		paramConfig := v.(map[string]interface{})
-		if attr, ok := paramConfig["automation_parameters"]; ok && len(attr.([]interface{})) > 0 {
+		if attr, ok := paramConfig["automation_parameters"]; ok && len(attr.([]interface{})) > 0 && attr.([]interface{})[0] != nil {
 			params.Automation = expandAwsSsmTaskInvocationAutomationParameters(attr.([]interface{}))
 		}
-		if attr, ok := paramConfig["lambda_parameters"]; ok && len(attr.([]interface{})) > 0 {
+		if attr, ok := paramConfig["lambda_parameters"]; ok && len(attr.([]interface{})) > 0 && attr.([]interface{})[0] != nil {
 			params.Lambda = expandAwsSsmTaskInvocationLambdaParameters(attr.([]interface{}))
 		}
-		if attr, ok := paramConfig["run_command_parameters"]; ok && len(attr.([]interface{})) > 0 {
+		if attr, ok := paramConfig["run_command_parameters"]; ok && len(attr.([]interface{})) > 0 && attr.([]interface{})[0] != nil {
 			params.RunCommand = expandAwsSsmTaskInvocationRunCommandParameters(attr.([]interface{}))
 		}
-		if attr, ok := paramConfig["step_functions_parameters"]; ok && len(attr.([]interface{})) > 0 {
+		if attr, ok := paramConfig["step_functions_parameters"]; ok && len(attr.([]interface{})) > 0 && attr.([]interface{})[0] != nil {
 			params.StepFunctions = expandAwsSsmTaskInvocationStepFunctionsParameters(attr.([]interface{}))
 		}
 	}

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -93,10 +93,11 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			},
 
 			"logging_info": {
-				Type:       schema.TypeList,
-				MaxItems:   1,
-				Optional:   true,
-				Deprecated: "use 'task_invocation_parameters' argument instead",
+				Type:          schema.TypeList,
+				MaxItems:      1,
+				Optional:      true,
+				ConflictsWith: []string{"task_invocation_parameters"},
+				Deprecated:    "use 'task_invocation_parameters' argument instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"s3_bucket_name": {
@@ -116,9 +117,10 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 			},
 
 			"task_parameters": {
-				Type:       schema.TypeList,
-				Optional:   true,
-				Deprecated: "use 'task_invocation_parameters' argument instead",
+				Type:          schema.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"task_invocation_parameters"},
+				Deprecated:    "use 'task_invocation_parameters' argument instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/aws/resource_aws_ssm_maintenance_window_task.go
@@ -146,6 +146,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 						"automation_parameters": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"document_version": {
@@ -177,6 +178,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 						"lambda_parameters": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"client_context": {
@@ -204,6 +206,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 						"run_command_parameters": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"comment": {
@@ -298,6 +301,7 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 						"step_functions_parameters": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"input": {

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -559,11 +559,11 @@ resource "aws_ssm_maintenance_window_task" "target" {
   task_invocation_parameters {
     automation_parameters {
       document_version = "%[2]s"
-      parameters {
+      parameter {
         name = "InstanceId"
         values = ["${aws_instance.foo.id}"]
       }
-      parameters {
+      parameter {
         name = "NoReboot"
         values = ["false"]
       }
@@ -646,11 +646,11 @@ resource "aws_ssm_maintenance_window_task" "target" {
   task_invocation_parameters {
     automation_parameters {
       document_version = "%[2]s"
-      parameters {
+      parameter {
         name = "InstanceId"
         values = ["${aws_instance.foo.id}"]
       }
-      parameters {
+      parameter {
         name = "NoReboot"
         values = ["false"]
       }
@@ -823,7 +823,7 @@ resource "aws_ssm_maintenance_window_task" "target" {
       document_hash_type  = "Sha256"
       service_role_arn    = "${aws_iam_role.ssm_role.arn}"
       timeout_seconds     = %[3]d
-      parameters {
+      parameter {
         name = "commands"
         values = ["date"]
       }
@@ -912,7 +912,7 @@ resource "aws_ssm_maintenance_window_task" "target" {
       timeout_seconds      = %[3]d
       output_s3_bucket     = "${aws_s3_bucket.foo.id}"
       output_s3_key_prefix = "foo"
-      parameters {
+      parameter {
         name = "commands"
         values = ["date"]
       }

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -291,20 +291,20 @@ func testAccAWSSSMMaintenanceWindowTaskImportStateIdFunc(resourceName string) re
 func testAccAWSSSMMaintenanceWindowTaskBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_maintenance_window" "foo" {
-  name     = "maintenance-window-%s"
+  name  = "maintenance-window-%s"
   schedule = "cron(0 16 ? * TUE *)"
   duration = 3
   cutoff   = 1
 }
 
 resource "aws_ssm_maintenance_window_task" "target" {
-  window_id        = "${aws_ssm_maintenance_window.foo.id}"
-  task_type        = "RUN_COMMAND"
-  task_arn         = "AWS-RunShellScript"
-  priority         = 1
+  window_id   = "${aws_ssm_maintenance_window.foo.id}"
+  task_type   = "RUN_COMMAND"
+  task_arn    = "AWS-RunShellScript"
+  priority    = 1
   service_role_arn = "${aws_iam_role.ssm_role.arn}"
   max_concurrency  = "2"
-  max_errors       = "1"
+  max_errors  = "1"
 
   targets {
     key    = "InstanceIds"
@@ -330,14 +330,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+      "Service": "events.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
     ]
 }
 POLICY
@@ -364,22 +364,22 @@ EOF
 func testAccAWSSSMMaintenanceWindowTaskBasicConfigUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_maintenance_window" "foo" {
-  name     = "maintenance-window-%s"
+  name  = "maintenance-window-%s"
   schedule = "cron(0 16 ? * TUE *)"
   duration = 3
   cutoff   = 1
 }
 
 resource "aws_ssm_maintenance_window_task" "target" {
-  window_id        = "${aws_ssm_maintenance_window.foo.id}"
-  task_type        = "RUN_COMMAND"
-  task_arn         = "AWS-RunShellScript"
-  priority         = 1
-  name             = "TestMaintenanceWindowTask"
-  description      = "This resource is for test purpose only"
+  window_id   = "${aws_ssm_maintenance_window.foo.id}"
+  task_type   = "RUN_COMMAND"
+  task_arn    = "AWS-RunShellScript"
+  priority    = 1
+  name      = "TestMaintenanceWindowTask"
+  description    = "This resource is for test purpose only"
   service_role_arn = "${aws_iam_role.ssm_role.arn}"
   max_concurrency  = "2"
-  max_errors       = "1"
+  max_errors  = "1"
 
   targets {
     key    = "InstanceIds"
@@ -405,14 +405,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+      "Service": "events.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
     ]
 }
 POLICY
@@ -458,17 +458,17 @@ resource "aws_ssm_maintenance_window_task" "target" {
     values = ["${aws_instance.foo.id}"]
   }
   task_invocation_parameters {
-		automation_parameters {
-			document_version = "%[2]s"
-			parameters {
-				name = "InstanceId"
-				values = ["${aws_instance.foo.id}"]
-			}
-			parameters {
-				name = "NoReboot"
-				values = ["false"]
-			}
-		}
+    automation_parameters {
+      document_version = "%[2]s"
+      parameters {
+        name = "InstanceId"
+        values = ["${aws_instance.foo.id}"]
+      }
+      parameters {
+        name = "NoReboot"
+        values = ["false"]
+      }
+    }
   }
 }
 
@@ -485,14 +485,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+      "Service": "events.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
     ]
 }
 POLICY
@@ -520,9 +520,9 @@ EOF
 func testAccAWSSSMMaintenanceWindowTaskAutomationConfigUpdate(rName, version string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "foo" {
-		bucket = "tf-s3-%[1]s"
-		acl = "private"
-		force_destroy = true
+    bucket = "tf-s3-%[1]s"
+    acl = "private"
+    force_destroy = true
 }
 
 resource "aws_ssm_maintenance_window" "foo" {
@@ -545,17 +545,17 @@ resource "aws_ssm_maintenance_window_task" "target" {
     values = ["${aws_instance.foo.id}"]
   }
   task_invocation_parameters {
-		automation_parameters {
-			document_version = "%[2]s"
-			parameters {
-				name = "InstanceId"
-				values = ["${aws_instance.foo.id}"]
-			}
-			parameters {
-				name = "NoReboot"
-				values = ["false"]
-			}
-		}
+    automation_parameters {
+      document_version = "%[2]s"
+      parameters {
+        name = "InstanceId"
+        values = ["${aws_instance.foo.id}"]
+      }
+      parameters {
+        name = "NoReboot"
+        values = ["false"]
+      }
+    }
   }
 }
 
@@ -572,14 +572,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+      "Service": "events.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
     ]
 }
 POLICY
@@ -626,10 +626,10 @@ resource "aws_ssm_maintenance_window_task" "target" {
     values = ["${aws_instance.foo.id}"]
   }
   task_invocation_parameters {
-		lambda_parameters {
-			client_context = "${base64encode(data.template_file.client_context.rendered)}"
-			payload = "${data.template_file.payload.rendered}"
-		}
+    lambda_parameters {
+      client_context = "${base64encode(data.template_file.client_context.rendered)}"
+      payload = "${data.template_file.payload.rendered}"
+    }
   }
 }
 
@@ -646,14 +646,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+      "Service": "events.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
     ]
 }
 POLICY
@@ -678,9 +678,9 @@ EOF
 data "template_file" "client_context" {
   template = <<EOF
 {
-	"key1": "value1",
-	"key2": "value2",
-	"key3": "value3"
+  "key1": "value1",
+  "key2": "value2",
+  "key3": "value3"
 }
 EOF
 }
@@ -688,7 +688,7 @@ EOF
 data "template_file" "payload" {
   template = <<EOF
 {
-	"number": %[2]d
+  "number": %[2]d
 }
 EOF
 }
@@ -718,17 +718,17 @@ resource "aws_ssm_maintenance_window_task" "target" {
     values = ["${aws_instance.foo.id}"]
   }
   task_invocation_parameters {
-		run_command_parameters {
-			comment 						= "%[2]s"
-			document_hash 			= "${sha256("COMMAND")}"
-			document_hash_type 	= "Sha256"
-			service_role_arn 		= "${aws_iam_role.ssm_role.arn}"
-			timeout_seconds			= %[3]d
-			parameters {
-				name = "commands"
-				values = ["date"]
-			}
-		}
+    run_command_parameters {
+      comment             = "%[2]s"
+      document_hash       = "${sha256("COMMAND")}"
+      document_hash_type  = "Sha256"
+      service_role_arn    = "${aws_iam_role.ssm_role.arn}"
+      timeout_seconds     = %[3]d
+      parameters {
+        name = "commands"
+        values = ["date"]
+      }
+    }
   }
 }
 
@@ -745,14 +745,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+      "Service": "events.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
     ]
 }
 POLICY
@@ -780,9 +780,9 @@ EOF
 func testAccAWSSSMMaintenanceWindowTaskRunCommandConfigUpdate(rName, comment string, timeoutSeconds int) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "foo" {
-		bucket = "tf-s3-%[1]s"
-		acl = "private"
-		force_destroy = true
+    bucket = "tf-s3-%[1]s"
+    acl = "private"
+    force_destroy = true
 }
 
 resource "aws_ssm_maintenance_window" "foo" {
@@ -805,19 +805,19 @@ resource "aws_ssm_maintenance_window_task" "target" {
     values = ["${aws_instance.foo.id}"]
   }
   task_invocation_parameters {
-		run_command_parameters {
-			comment 							= "%[2]s"
-			document_hash 				= "${sha256("COMMAND")}"
-			document_hash_type 		= "Sha256"
-			service_role_arn 			= "${aws_iam_role.ssm_role.arn}"
-			timeout_seconds				= %[3]d
-			output_s3_bucket			= "${aws_s3_bucket.foo.id}"
-			output_s3_key_prefix	= "foo"
-			parameters {
-				name = "commands"
-				values = ["date"]
-			}
-		}
+    run_command_parameters {
+    comment                = "%[2]s"
+      document_hash        = "${sha256("COMMAND")}"
+      document_hash_type   = "Sha256"
+      service_role_arn     = "${aws_iam_role.ssm_role.arn}"
+      timeout_seconds      = %[3]d
+      output_s3_bucket     = "${aws_s3_bucket.foo.id}"
+      output_s3_key_prefix = "foo"
+      parameters {
+        name = "commands"
+        values = ["date"]
+      }
+    }
   }
 }
 
@@ -834,14 +834,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+      "Service": "events.amazonaws.com"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
     ]
 }
 POLICY
@@ -888,10 +888,10 @@ resource "aws_ssm_maintenance_window_task" "target" {
     values = ["${aws_instance.foo.id}"]
   }
   task_invocation_parameters {
-		step_functions_parameters {
-			input = "${data.template_file.input.rendered}"
-			name = "tf-step-function-%[1]s"
-		}
+    step_functions_parameters {
+      input = "${data.template_file.input.rendered}"
+      name = "tf-step-function-%[1]s"
+    }
   }
 }
 
@@ -908,14 +908,14 @@ resource "aws_iam_role" "ssm_role" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "events.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
+     {
+       "Action": "sts:AssumeRole",
+       "Principal": {
+         "Service": "events.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+     }
     ]
 }
 POLICY
@@ -940,9 +940,9 @@ EOF
 data "template_file" "input" {
   template = <<EOF
 {
-	"key1": "value1",
-	"key2": "value2",
-	"key3": "value3"
+  "key1": "value1",
+  "key2": "value2",
+  "key3": "value3"
 }
 EOF
 }

--- a/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -73,6 +73,139 @@ func TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters(t *testing.T) {
+	var task ssm.MaintenanceWindowTask
+	resourceName := "aws_ssm_maintenance_window_task.target"
+
+	name := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowTaskAutomationConfig(name, "$DEFAULT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
+					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.automation_parameters.0.document_version", "$DEFAULT"),
+				),
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowTaskAutomationConfigUpdate(name, "$LATEST"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
+					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.automation_parameters.0.document_version", "$LATEST"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTaskImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters(t *testing.T) {
+	var task ssm.MaintenanceWindowTask
+	resourceName := "aws_ssm_maintenance_window_task.target"
+	rString := acctest.RandString(8)
+	rInt := acctest.RandInt()
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_tags_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_tags_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_tags_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_tags_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowTaskLambdaConfig(funcName, policyName, roleName, sgName, rString, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTaskImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters(t *testing.T) {
+	var task ssm.MaintenanceWindowTask
+	resourceName := "aws_ssm_maintenance_window_task.target"
+	serviceRoleResourceName := "aws_iam_role.ssm_role"
+	s3BucketResourceName := "aws_s3_bucket.foo"
+
+	name := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowTaskRunCommandConfig(name, "test comment", 30),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
+					resource.TestCheckResourceAttrPair(resourceName, "service_role_arn", serviceRoleResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "task_invocation_parameters.0.run_command_parameters.0.service_role_arn", serviceRoleResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.run_command_parameters.0.comment", "test comment"),
+					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.run_command_parameters.0.timeout_seconds", "30"),
+				),
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowTaskRunCommandConfigUpdate(name, "test comment update", 60),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
+					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.run_command_parameters.0.comment", "test comment update"),
+					resource.TestCheckResourceAttr(resourceName, "task_invocation_parameters.0.run_command_parameters.0.timeout_seconds", "60"),
+					resource.TestCheckResourceAttrPair(resourceName, "task_invocation_parameters.0.run_command_parameters.0.output_s3_bucket", s3BucketResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTaskImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters(t *testing.T) {
+	var task ssm.MaintenanceWindowTask
+	resourceName := "aws_ssm_maintenance_window_task.target"
+	rString := acctest.RandString(8)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTaskDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowTaskStepFunctionConfig(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowTaskExists(resourceName, &task),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSSSMMaintenanceWindowTaskImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsSsmWindowsTaskRecreated(t *testing.T,
 	before, after *ssm.MaintenanceWindowTask) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -301,4 +434,518 @@ resource "aws_iam_role_policy" "bar" {
 EOF
 }
 `, rName, rName, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowTaskAutomationConfig(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "foo" {
+  name = "maintenance-window-%[1]s"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff = 1
+}
+
+resource "aws_ssm_maintenance_window_task" "target" {
+  window_id = "${aws_ssm_maintenance_window.foo.id}"
+  task_type = "AUTOMATION"
+  task_arn = "AWS-CreateImage"
+  priority = 1
+  service_role_arn = "${aws_iam_role.ssm_role.arn}"
+  max_concurrency = "2"
+  max_errors = "1"
+  targets {
+    key = "InstanceIds"
+    values = ["${aws_instance.foo.id}"]
+  }
+  task_invocation_parameters {
+		automation_parameters {
+			document_version = "%[2]s"
+			parameters {
+				name = "InstanceId"
+				values = ["${aws_instance.foo.id}"]
+			}
+			parameters {
+				name = "NoReboot"
+				values = ["false"]
+			}
+		}
+  }
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-4fccb37f"
+
+  instance_type = "m1.small"
+}
+
+resource "aws_iam_role" "ssm_role" {
+  name = "ssm-role-%[1]s"
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "events.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "bar" {
+  name = "ssm_role_policy_%[1]s"
+  role = "${aws_iam_role.ssm_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "ssm:*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+`, rName, version)
+}
+
+func testAccAWSSSMMaintenanceWindowTaskAutomationConfigUpdate(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "foo" {
+		bucket = "tf-s3-%[1]s"
+		acl = "private"
+		force_destroy = true
+}
+
+resource "aws_ssm_maintenance_window" "foo" {
+  name = "maintenance-window-%[1]s"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff = 1
+}
+
+resource "aws_ssm_maintenance_window_task" "target" {
+  window_id = "${aws_ssm_maintenance_window.foo.id}"
+  task_type = "AUTOMATION"
+  task_arn = "AWS-CreateImage"
+  priority = 1
+  service_role_arn = "${aws_iam_role.ssm_role.arn}"
+  max_concurrency = "2"
+  max_errors = "1"
+  targets {
+    key = "InstanceIds"
+    values = ["${aws_instance.foo.id}"]
+  }
+  task_invocation_parameters {
+		automation_parameters {
+			document_version = "%[2]s"
+			parameters {
+				name = "InstanceId"
+				values = ["${aws_instance.foo.id}"]
+			}
+			parameters {
+				name = "NoReboot"
+				values = ["false"]
+			}
+		}
+  }
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-4fccb37f"
+
+  instance_type = "m1.small"
+}
+
+resource "aws_iam_role" "ssm_role" {
+  name = "ssm-role-%[1]s"
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "events.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "bar" {
+  name = "ssm_role_policy_%[1]s"
+  role = "${aws_iam_role.ssm_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "ssm:*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+`, rName, version)
+}
+
+func testAccAWSSSMMaintenanceWindowTaskLambdaConfig(funcName, policyName, roleName, sgName, rName string, rInt int) string {
+	return fmt.Sprintf(testAccAWSLambdaConfigBasic(funcName, policyName, roleName, sgName)+`
+resource "aws_ssm_maintenance_window" "foo" {
+  name = "maintenance-window-%[1]s"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff = 1
+}
+
+resource "aws_ssm_maintenance_window_task" "target" {
+  window_id = "${aws_ssm_maintenance_window.foo.id}"
+  task_type = "LAMBDA"
+  task_arn = "${aws_lambda_function.lambda_function_test.arn}"
+  priority = 1
+  service_role_arn = "${aws_iam_role.ssm_role.arn}"
+  max_concurrency = "2"
+  max_errors = "1"
+  targets {
+    key = "InstanceIds"
+    values = ["${aws_instance.foo.id}"]
+  }
+  task_invocation_parameters {
+		lambda_parameters {
+			client_context = "${base64encode(data.template_file.client_context.rendered)}"
+			payload = "${data.template_file.payload.rendered}"
+		}
+  }
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-4fccb37f"
+
+  instance_type = "m1.small"
+}
+
+resource "aws_iam_role" "ssm_role" {
+  name = "ssm-role-%[1]s"
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "events.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "bar" {
+  name = "ssm_role_policy_%[1]s"
+  role = "${aws_iam_role.ssm_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "ssm:*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+data "template_file" "client_context" {
+  template = <<EOF
+{
+	"key1": "value1",
+	"key2": "value2",
+	"key3": "value3"
+}
+EOF
+}
+
+data "template_file" "payload" {
+  template = <<EOF
+{
+	"number": %[2]d
+}
+EOF
+}
+
+`, rName, rInt)
+}
+
+func testAccAWSSSMMaintenanceWindowTaskRunCommandConfig(rName, comment string, timeoutSeconds int) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "foo" {
+  name = "maintenance-window-%[1]s"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff = 1
+}
+
+resource "aws_ssm_maintenance_window_task" "target" {
+  window_id = "${aws_ssm_maintenance_window.foo.id}"
+  task_type = "RUN_COMMAND"
+  task_arn = "AWS-RunShellScript"
+  priority = 1
+  service_role_arn = "${aws_iam_role.ssm_role.arn}"
+  max_concurrency = "2"
+  max_errors = "1"
+  targets {
+    key = "InstanceIds"
+    values = ["${aws_instance.foo.id}"]
+  }
+  task_invocation_parameters {
+		run_command_parameters {
+			comment 						= "%[2]s"
+			document_hash 			= "${sha256("COMMAND")}"
+			document_hash_type 	= "Sha256"
+			service_role_arn 		= "${aws_iam_role.ssm_role.arn}"
+			timeout_seconds			= %[3]d
+			parameters {
+				name = "commands"
+				values = ["date"]
+			}
+		}
+  }
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-4fccb37f"
+
+  instance_type = "m1.small"
+}
+
+resource "aws_iam_role" "ssm_role" {
+  name = "ssm-role-%[1]s"
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "events.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "bar" {
+  name = "ssm_role_policy_%[1]s"
+  role = "${aws_iam_role.ssm_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "ssm:*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+`, rName, comment, timeoutSeconds)
+}
+
+func testAccAWSSSMMaintenanceWindowTaskRunCommandConfigUpdate(rName, comment string, timeoutSeconds int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "foo" {
+		bucket = "tf-s3-%[1]s"
+		acl = "private"
+		force_destroy = true
+}
+
+resource "aws_ssm_maintenance_window" "foo" {
+  name = "maintenance-window-%[1]s"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff = 1
+}
+
+resource "aws_ssm_maintenance_window_task" "target" {
+  window_id = "${aws_ssm_maintenance_window.foo.id}"
+  task_type = "RUN_COMMAND"
+  task_arn = "AWS-RunShellScript"
+  priority = 1
+  service_role_arn = "${aws_iam_role.ssm_role.arn}"
+  max_concurrency = "2"
+  max_errors = "1"
+  targets {
+    key = "InstanceIds"
+    values = ["${aws_instance.foo.id}"]
+  }
+  task_invocation_parameters {
+		run_command_parameters {
+			comment 							= "%[2]s"
+			document_hash 				= "${sha256("COMMAND")}"
+			document_hash_type 		= "Sha256"
+			service_role_arn 			= "${aws_iam_role.ssm_role.arn}"
+			timeout_seconds				= %[3]d
+			output_s3_bucket			= "${aws_s3_bucket.foo.id}"
+			output_s3_key_prefix	= "foo"
+			parameters {
+				name = "commands"
+				values = ["date"]
+			}
+		}
+  }
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-4fccb37f"
+
+  instance_type = "m1.small"
+}
+
+resource "aws_iam_role" "ssm_role" {
+  name = "ssm-role-%[1]s"
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "events.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "bar" {
+  name = "ssm_role_policy_%[1]s"
+  role = "${aws_iam_role.ssm_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "ssm:*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+`, rName, comment, timeoutSeconds)
+}
+
+func testAccAWSSSMMaintenanceWindowTaskStepFunctionConfig(rName string) string {
+	return fmt.Sprintf(testAccAWSSfnActivityBasicConfig(rName)+`
+resource "aws_ssm_maintenance_window" "foo" {
+  name = "maintenance-window-%[1]s"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff = 1
+}
+
+resource "aws_ssm_maintenance_window_task" "target" {
+  window_id = "${aws_ssm_maintenance_window.foo.id}"
+  task_type = "STEP_FUNCTIONS"
+  task_arn = "${aws_sfn_activity.foo.id}"
+  priority = 1
+  service_role_arn = "${aws_iam_role.ssm_role.arn}"
+  max_concurrency = "2"
+  max_errors = "1"
+  targets {
+    key = "InstanceIds"
+    values = ["${aws_instance.foo.id}"]
+  }
+  task_invocation_parameters {
+		step_functions_parameters {
+			input = "${data.template_file.input.rendered}"
+			name = "tf-step-function-%[1]s"
+		}
+  }
+}
+
+resource "aws_instance" "foo" {
+  ami = "ami-4fccb37f"
+
+  instance_type = "m1.small"
+}
+
+resource "aws_iam_role" "ssm_role" {
+  name = "ssm-role-%[1]s"
+
+  assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "events.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "bar" {
+  name = "ssm_role_policy_%[1]s"
+  role = "${aws_iam_role.ssm_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "ssm:*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+
+data "template_file" "input" {
+  template = <<EOF
+{
+	"key1": "value1",
+	"key2": "value2",
+	"key3": "value3"
+}
+EOF
+}
+
+`, rName)
 }

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -82,3 +82,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the maintenance window task.
+
+## Import
+
+AWS Maintenance Window Task can be imported using the `window_id` and `window_task_id` separated by `/`.
+
+```sh
+$ terraform import aws_ssm_maintenance_window_task.task <window_id>/<window_task_id>
+```

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -63,8 +63,9 @@ The following arguments are supported:
 * `description` - (Optional) The description of the maintenance window task.
 * `targets` - (Required) The targets (either instances or window target ids). Instances are specified using Key=InstanceIds,Values=instanceid1,instanceid2. Window target ids are specified using Key=WindowTargetIds,Values=window target id1, window target id2.
 * `priority` - (Optional) The priority of the task in the Maintenance Window, the lower the number the higher the priority. Tasks in a Maintenance Window are scheduled in priority order with tasks that have the same priority scheduled in parallel.
-* `logging_info` - (Optional) A structure containing information about an Amazon S3 bucket to write instance-level logs to. Documented below.
-* `task_parameters` - (Optional) A structure containing information about parameters required by the particular `task_arn`. Documented below.
+* `logging_info` - (Optional,**Deprecated**) A structure containing information about an Amazon S3 bucket to write instance-level logs to. Documented below.
+* `task_parameters` - (Optional,**Deprecated**) A structure containing information about parameters required by the particular `task_arn`. Documented below.
+* `task_invocation_parameters` - (Optional) The parameters for task execution.
 
 `logging_info` supports the following:
 
@@ -76,6 +77,54 @@ The following arguments are supported:
 
 * `name` - (Required)
 * `values` - (Required)
+
+`task_invocation_parameters` supports the following:
+
+This argument is conflict with `task_parameters` and `logging_info`.
+
+* `automation_parameters` - (Optional) The parameters for an AUTOMATION task type. Documented below.
+* `lambda_parameters` - (Optional) The parameters for a LAMBDA task type. Documented below.
+* `run_command_parameters` - (Optional) The parameters for a RUN_COMMAND task type. Documented below.
+* `step_functions_parameters` - (Optional)
+
+`automation_parameters` supports the following:
+
+* `document_version` - (Optional) The version of an Automation document to use during task execution.
+* `parameters` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
+
+`lambda_parameters` supports the following:
+
+* `client_context` - (Optional) Pass client-specific information to the Lambda function that you are invoking.
+* `payload` - (Optional) JSON to provide to your Lambda function as input.
+* `qualifier` - (Optional) Specify a Lambda function version or alias name.
+
+`run_command_parameters` supports the following:
+
+* `comment` - (Optional) Information about the command(s) to execute.
+* `document_hash` - (Optional) The SHA-256 or SHA-1 hash created by the system when the document was created. SHA-1 hashes have been deprecated.
+* `document_hash_type` - (Optional) SHA-256 or SHA-1. SHA-1 hashes have been deprecated.
+* `notification_config` - (Optional) Configurations for sending notifications about command status changes on a per-instance basis. Documented below.
+* `output_s3_bucket` - (Optional) The name of the Amazon S3 bucket.
+* `output_s3_key_prefix` - (Optional) The Amazon S3 bucket subfolder.
+* `parameters` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
+* `service_role_arn` - (Optional) The IAM service role to assume during task execution.
+* `timeout_seconds` - (Optional) If this time is reached and the command has not already started executing, it doesn't run.
+
+`step_functions_parameters` supports the following:
+
+* `input` - (Optional) The inputs for the STEP_FUNCTION task.
+* `name` - (Optional) The name of the STEP_FUNCTION task.
+
+`notification_config` supports the following:
+
+* `notification_arn` - (Optional) An Amazon Resource Name (ARN) for a Simple Notification Service (SNS) topic. Run Command pushes notifications about command status changes to this topic.
+* `notification_events` - (Optional) The different events for which you can receive notifications.
+* `notification_type` - (Optional) Command: Receive notification when the status of a command changes. Invocation: For commands sent to multiple instances, receive notification on a per-instance basis when the status of a command changes.
+
+`parameters` supports the following:
+
+* `name` - (Required) The parameter name.
+* `values` - (Required) The array of strings.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -63,9 +63,9 @@ The following arguments are supported:
 * `description` - (Optional) The description of the maintenance window task.
 * `targets` - (Required) The targets (either instances or window target ids). Instances are specified using Key=InstanceIds,Values=instanceid1,instanceid2. Window target ids are specified using Key=WindowTargetIds,Values=window target id1, window target id2.
 * `priority` - (Optional) The priority of the task in the Maintenance Window, the lower the number the higher the priority. Tasks in a Maintenance Window are scheduled in priority order with tasks that have the same priority scheduled in parallel.
-* `logging_info` - (Optional,**Deprecated**) A structure containing information about an Amazon S3 bucket to write instance-level logs to. Documented below.
-* `task_parameters` - (Optional,**Deprecated**) A structure containing information about parameters required by the particular `task_arn`. Documented below.
-* `task_invocation_parameters` - (Optional) The parameters for task execution.
+* `logging_info` - (Optional, **Deprecated**) A structure containing information about an Amazon S3 bucket to write instance-level logs to. Use `task_invocation_parameters` configuration block `run_command_parameters` configuration block `output_s3_*` arguments instead. Conflicts with `task_invocation_parameters`. Documented below.
+* `task_parameters` - (Optional, **Deprecated**) A structure containing information about parameters required by the particular `task_arn`. Use `parameter` configuration blocks under the `task_invocation_parameters` configuration block instead. Conflicts with `task_invocation_parameters`. Documented below.
+* `task_invocation_parameters` - (Optional) The parameters for task execution. This argument is conflict with `task_parameters` and `logging_info`.
 
 `logging_info` supports the following:
 
@@ -80,12 +80,10 @@ The following arguments are supported:
 
 `task_invocation_parameters` supports the following:
 
-This argument is conflict with `task_parameters` and `logging_info`.
-
 * `automation_parameters` - (Optional) The parameters for an AUTOMATION task type. Documented below.
 * `lambda_parameters` - (Optional) The parameters for a LAMBDA task type. Documented below.
 * `run_command_parameters` - (Optional) The parameters for a RUN_COMMAND task type. Documented below.
-* `step_functions_parameters` - (Optional)
+* `step_functions_parameters` - (Optional) The parameters for a STEP_FUNCTIONS task type. Documented below.
 
 `automation_parameters` supports the following:
 

--- a/website/docs/r/ssm_maintenance_window_task.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_task.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 `automation_parameters` supports the following:
 
 * `document_version` - (Optional) The version of an Automation document to use during task execution.
-* `parameters` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
+* `parameter` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
 
 `lambda_parameters` supports the following:
 
@@ -104,7 +104,7 @@ The following arguments are supported:
 * `notification_config` - (Optional) Configurations for sending notifications about command status changes on a per-instance basis. Documented below.
 * `output_s3_bucket` - (Optional) The name of the Amazon S3 bucket.
 * `output_s3_key_prefix` - (Optional) The Amazon S3 bucket subfolder.
-* `parameters` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
+* `parameter` - (Optional) The parameters for the RUN_COMMAND task execution. Documented below.
 * `service_role_arn` - (Optional) The IAM service role to assume during task execution.
 * `timeout_seconds` - (Optional) If this time is reached and the command has not already started executing, it doesn't run.
 
@@ -119,7 +119,7 @@ The following arguments are supported:
 * `notification_events` - (Optional) The different events for which you can receive notifications.
 * `notification_type` - (Optional) Command: Receive notification when the status of a command changes. Invocation: For commands sent to multiple instances, receive notification on a per-instance basis when the status of a command changes.
 
-`parameters` supports the following:
+`parameter` supports the following:
 
 * `name` - (Required) The parameter name.
 * `values` - (Required) The array of strings.


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Closes #7870 
Closes #7746 
Closes #7154
Closes #6431
Closes #5045 

Reference #5700
Reference #4408
Reference #3218

Changes proposed in this pull request:

* [x] Fix to use `GetMaintenanceWindowTask` method when read resource
* [x] Add Support Update resource
* [x] Fix to not return error when resource is already deleted
* [x] Add support import exist resource
* [x] Add attribute `task_invocation_parameters`
* [x] Add deprecated message for `logging_info` and `task_parameters`
* [x] Add test case for `automation_parameters`
* [x] Add test case for `lambda_parameters`
* [x] Add test case for `run_command_parameters`
* [x] Add test case for `step_functions_parameters` 
* [x] Update document

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMMaintenanceWindowTask_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSSSMMaintenanceWindowTask_ -timeout 120m
=== RUN   TestAccAWSSSMMaintenanceWindowTask_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== RUN   TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters
=== CONT  TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationLambdaParameters (147.07s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationStepFunctionParameters (163.38s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationAutomationParameters (169.52s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (173.94s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_TaskInvocationRunCommandParameters (204.06s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (232.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	232.506s
```
