### PR TITLE
resource/aws_ssm_patch_baseline: Support resource import

### DIFF
--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -35,6 +35,9 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 		Read:   resourceAwsSsmPatchBaselineRead,
 		Update: resourceAwsSsmPatchBaselineUpdate,
 		Delete: resourceAwsSsmPatchBaselineDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -36,6 +36,11 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_ssm_patch_baseline.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccAWSSSMPatchBaselineBasicConfigUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMPatchBaselineExists("aws_ssm_patch_baseline.foo", &after),
@@ -85,7 +90,7 @@ func TestAccAWSSSMPatchBaseline_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAWSSSMPatchBaselineWithOperatingSystem(t *testing.T) {
+func TestAccAWSSSMPatchBaseline_OperatingSystem(t *testing.T) {
 	var before, after ssm.PatchBaselineIdentity
 	name := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
@@ -110,6 +115,11 @@ func TestAccAWSSSMPatchBaselineWithOperatingSystem(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "operating_system", "AMAZON_LINUX"),
 				),
+			},
+			{
+				ResourceName:      "aws_ssm_patch_baseline.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSSSMPatchBaselineConfigWithOperatingSystemUpdated(name),

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -106,3 +106,11 @@ The `approval_rule` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the patch baseline.
+
+## Import
+
+SSM Patch Baselines can be imported by their baseline ID, e.g.
+
+```
+$ terraform import aws_ssm_patch_baseline.example pb-12345678
+```


### PR DESCRIPTION
Closes #7816

Also fixes operating system acceptance test name to follow current project consistency with a separating underscore.

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMPatchBaseline_disappears (9.14s)
--- PASS: TestAccAWSSSMPatchBaseline_OperatingSystem (18.84s)
--- PASS: TestAccAWSSSMPatchBaseline_basic (18.98s)
```
