### PR TITLE
resource/aws_codebuild_webhook: Only pass BranchFilter if non-empty

### DIFF
--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,12 +50,20 @@ func resourceAwsCodeBuildWebhook() *schema.Resource {
 func resourceAwsCodeBuildWebhookCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codebuildconn
 
-	resp, err := conn.CreateWebhook(&codebuild.CreateWebhookInput{
+	input := &codebuild.CreateWebhookInput{
 		ProjectName:  aws.String(d.Get("project_name").(string)),
-		BranchFilter: aws.String(d.Get("branch_filter").(string)),
-	})
+	}
+
+	// The CodeBuild API requires this to be non-empty if defined
+	if v, ok := d.GetOk("branch_filter"); ok {
+		input.BranchFilter = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating CodeBuild Webhook: %s", input)
+	resp, err := conn.CreateWebhook(input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating CodeBuild Webhook: %s", err)
 	}
 
 	// Secret is only returned on create, so capture it at the start


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7839 

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSCodeBuildWebhook_GitHub (21.97s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_codebuild_webhook.test: 1 error occurred:
        	* aws_codebuild_webhook.test: ValidationException: 1 validation error detected: Value '' at 'newProjectVersion.webhook.branches' failed to satisfy constraint: Member must have length greater than or equal to 1
        	status code: 400, request id: 83a906d9-404e-11e9-8a1d-0b0585cc888f

--- FAIL: TestAccAWSCodeBuildWebhook_Bitbucket (22.71s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_codebuild_webhook.test: 1 error occurred:
        	* aws_codebuild_webhook.test: ValidationException: 1 validation error detected: Value '' at 'newProjectVersion.webhook.branches' failed to satisfy constraint: Member must have length greater than or equal to 1
        	status code: 400, request id: 84099d6c-404e-11e9-8a1d-0b0585cc888f

--- PASS: TestAccAWSCodeBuildWebhook_BranchFilter (39.49s)
--- PASS: TestAccAWSCodeBuildWebhook_GitHubEnterprise (39.88s)
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeBuildWebhook_GitHub (31.61s)
--- PASS: TestAccAWSCodeBuildWebhook_Bitbucket (34.35s)
--- PASS: TestAccAWSCodeBuildWebhook_BranchFilter (39.12s)
--- PASS: TestAccAWSCodeBuildWebhook_GitHubEnterprise (40.69s)
```
