### PR TITLE
Fix staticcheck ST1016

### DIFF
--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -280,7 +280,7 @@ func (c CloudWatchEventPermissionPolicyStatementCondition) GoString() string {
 	return c.String()
 }
 
-func (condition *CloudWatchEventPermissionPolicyStatementCondition) UnmarshalJSON(b []byte) error {
+func (c *CloudWatchEventPermissionPolicyStatementCondition) UnmarshalJSON(b []byte) error {
 	var out CloudWatchEventPermissionPolicyStatementCondition
 
 	// JSON representation: \"Condition\":{\"StringEquals\":{\"aws:PrincipalOrgID\":\"o-0123456789\"}}
@@ -299,7 +299,7 @@ func (condition *CloudWatchEventPermissionPolicyStatementCondition) UnmarshalJSO
 		}
 	}
 
-	*condition = out
+	*c = out
 	return nil
 }
 
@@ -336,15 +336,15 @@ func expandCloudWatchEventsCondition(l []interface{}) *events.Condition {
 	return condition
 }
 
-func flattenCloudWatchEventPermissionPolicyStatementCondition(condition *CloudWatchEventPermissionPolicyStatementCondition) []interface{} {
-	if condition == nil {
+func flattenCloudWatchEventPermissionPolicyStatementCondition(c *CloudWatchEventPermissionPolicyStatementCondition) []interface{} {
+	if c == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"key":   condition.Key,
-		"type":  condition.Type,
-		"value": condition.Value,
+		"key":   c.Key,
+		"type":  c.Type,
+		"value": c.Value,
 	}
 
 	return []interface{}{m}


### PR DESCRIPTION
aws/resource_aws_cloudwatch_event_permission: Fix staticcheck ST1016

Receiver names of the same type should match. This change updates the receiver names to `c` for each of the methods.

Before the update
```
> staticcheck ./aws
aws/resource_aws_cloudwatch_event_permission.go:279:60: methods on the same type should have the same receiver name (seen 2x "c", 1x "condition") (ST1016)
```

After the update
```
> staticcheck ./aws
```