### PR TITLE
resource/aws_ecr_repository_policy: Update policy in state on read

### DIFF
--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -99,6 +99,7 @@ func resourceAwsEcrRepositoryPolicyRead(d *schema.ResourceData, meta interface{}
 
 	d.SetId(*repositoryPolicy.RepositoryName)
 	d.Set("registry_id", repositoryPolicy.RegistryId)
+	d.Set("policy", repositoryPolicy.PolicyText)
 
 	return nil
 }

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -25,8 +25,8 @@ func resourceAwsEcrRepositoryPolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
 				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 			},
 			"registry_id": {

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -27,6 +27,7 @@ func resourceAwsEcrRepositoryPolicy() *schema.Resource {
 			"policy": {
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 			},
 			"registry_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Description
Whilst using terraform to manage ECR repositories and their policies, I noticed that changing the policy directly in the AWS Console didn't cause my `terraform plan` to show any changes required. Running `terraform refresh` with debugging turned on showed that the modified version of the policy was being returned by the AWS API, but doing a subsequent `terraform state pull` and inspecting the state showed that the policy in the state hadn't been updated.

Changes proposed in this pull request:
 * In `aws_ecr_repository_policy`, update the `policy` property on the schema when pulling the policy from the AWS API.
 * In `aws_ecr_repository_policy`, suppress diffs between equivalent policies via the JSON diff suppressor