### PR TITLE
resource/aws_iam_role_policy_attachment: Prevent NoSuchEntity errors from race conditions

### DIFF
--- a/aws/resource_aws_iam_role_policy_attachment.go
+++ b/aws/resource_aws_iam_role_policy_attachment.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -54,43 +53,28 @@ func resourceAwsIamRolePolicyAttachmentCreate(d *schema.ResourceData, meta inter
 func resourceAwsIamRolePolicyAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).iamconn
 	role := d.Get("role").(string)
-	arn := d.Get("policy_arn").(string)
+	policyARN := d.Get("policy_arn").(string)
 
-	_, err := conn.GetRole(&iam.GetRoleInput{
-		RoleName: aws.String(role),
-	})
+	hasPolicyAttachment, err := iamRoleHasPolicyARNAttachment(conn, role, policyARN)
 
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NoSuchEntity" {
-				log.Printf("[WARN] No such entity found for Policy Attachment (%s)", role)
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
-
-	args := iam.ListAttachedRolePoliciesInput{
-		RoleName: aws.String(role),
-	}
-	var policy string
-	err = conn.ListAttachedRolePoliciesPages(&args, func(page *iam.ListAttachedRolePoliciesOutput, lastPage bool) bool {
-		for _, p := range page.AttachedPolicies {
-			if *p.PolicyArn == arn {
-				policy = *p.PolicyArn
-			}
-		}
-
-		return policy == ""
-	})
-	if err != nil {
-		return err
-	}
-	if policy == "" {
-		log.Printf("[WARN] No such policy found for Role Policy Attachment (%s)", role)
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		log.Printf("[WARN] IAM Role (%s) not found, removing from state", role)
 		d.SetId("")
+		return nil
 	}
+
+	if err != nil {
+		return fmt.Errorf("error finding IAM Role (%s) Policy Attachment (%s): %s", role, policyARN, err)
+	}
+
+	if !hasPolicyAttachment {
+		log.Printf("[WARN] IAM Role (%s) Policy Attachment (%s) not found, removing from state", role, policyARN)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("policy_arn", policyARN)
+	d.Set("role", role)
 
 	return nil
 }
@@ -101,6 +85,11 @@ func resourceAwsIamRolePolicyAttachmentDelete(d *schema.ResourceData, meta inter
 	arn := d.Get("policy_arn").(string)
 
 	err := detachPolicyFromRole(conn, role, arn)
+
+	if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error removing policy %s from IAM Role %s: %v", arn, role, err)
 	}
@@ -137,4 +126,24 @@ func detachPolicyFromRole(conn *iam.IAM, role string, arn string) error {
 		PolicyArn: aws.String(arn),
 	})
 	return err
+}
+
+func iamRoleHasPolicyARNAttachment(conn *iam.IAM, role string, policyARN string) (bool, error) {
+	hasPolicyAttachment := false
+	input := &iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(role),
+	}
+
+	err := conn.ListAttachedRolePoliciesPages(input, func(page *iam.ListAttachedRolePoliciesOutput, lastPage bool) bool {
+		for _, p := range page.AttachedPolicies {
+			if aws.StringValue(p.PolicyArn) == policyARN {
+				hasPolicyAttachment = true
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return hasPolicyAttachment, err
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Ensure we catch the `NoSuchEntity` error in the Read and Delete logic to prevent this error during race conditions as we know how to appropriately handle it in both cases. We also ensure the acceptance testing is correctly verifying the removal of IAM Role Policy Attachments.

Output from acceptance testing:

```
--- PASS: TestAccAWSRolePolicyAttachment_disappears (10.62s)
--- PASS: TestAccAWSRolePolicyAttachment_disappears_Role (10.70s)
--- PASS: TestAccAWSRolePolicyAttachment_basic (16.23s)
```