### PR TITLE
7605 cloudwatch metric filters need to be serial

### DIFF
--- a/aws/resource_aws_cloudwatch_log_metric_filter.go
+++ b/aws/resource_aws_cloudwatch_log_metric_filter.go
@@ -95,6 +95,12 @@ func resourceAwsCloudWatchLogMetricFilterUpdate(d *schema.ResourceData, meta int
 	o := transformations[0].(map[string]interface{})
 	input.MetricTransformations = expandCloudWatchLogMetricTransformations(o)
 
+	// Creating multiple filters on the same log group can sometimes cause
+	// clashes, so use a mutex here (and on deletion) to serialise actions on
+	// log groups.
+	mutex_key := fmt.Sprintf(`log-group-%s`, d.Get(`log_group_name`))
+	awsMutexKV.Lock(mutex_key)
+	defer awsMutexKV.Unlock(mutex_key)
 	log.Printf("[DEBUG] Creating/Updating CloudWatch Log Metric Filter: %s", input)
 	_, err := conn.PutMetricFilter(&input)
 	if err != nil {
@@ -180,6 +186,12 @@ func resourceAwsCloudWatchLogMetricFilterDelete(d *schema.ResourceData, meta int
 		FilterName:   aws.String(d.Get("name").(string)),
 		LogGroupName: aws.String(d.Get("log_group_name").(string)),
 	}
+	// Creating multiple filters on the same log group can sometimes cause
+	// clashes, so use a mutex here (and on creation) to serialise actions on
+	// log groups.
+	mutex_key := fmt.Sprintf(`log-group-%s`, d.Get(`log_group_name`))
+	awsMutexKV.Lock(mutex_key)
+	defer awsMutexKV.Unlock(mutex_key)
 	log.Printf("[INFO] Deleting CloudWatch Log Metric Filter: %s", d.Id())
 	_, err := conn.DeleteMetricFilter(&input)
 	if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7605

Changes proposed in this pull request:

* Creation/deletion of multiple Cloudwatch Log Metric Filters on any individual Cloudwatch Log Group is performed serially.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchLogMetricFilter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudWatchLogMetricFilter_basic -timeout 120m
=== RUN   TestAccAWSCloudWatchLogMetricFilter_basic
=== PAUSE TestAccAWSCloudWatchLogMetricFilter_basic
=== CONT  TestAccAWSCloudWatchLogMetricFilter_basic
--- PASS: TestAccAWSCloudWatchLogMetricFilter_basic (50.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.269s
```
