### PR TITLE
resource/aws_s3_bucket: Continue supporting empty string bucket argument

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -39,7 +39,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"bucket_prefix"},
-				ValidateFunc:  validation.StringLenBetween(3, 63),
+				ValidateFunc:  validation.StringLenBetween(0, 63),
 			},
 			"bucket_prefix": {
 				Type:          schema.TypeString,

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -207,6 +207,27 @@ func TestAccAWSS3Bucket_basic(t *testing.T) {
 	})
 }
 
+// Support for common Terraform 0.11 pattern
+// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/7868
+func TestAccAWSS3Bucket_Bucket_EmptyString(t *testing.T) {
+	resourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketConfigBucketEmptyString,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "bucket", regexp.MustCompile("^terraform-")),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3MultiBucket_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
@@ -3091,6 +3112,12 @@ resource "aws_s3_bucket" "arbitrary" {
 }
 `, randInt)
 }
+
+const testAccAWSS3BucketConfigBucketEmptyString = `
+resource "aws_s3_bucket" "test" {
+  bucket = ""
+}
+`
 
 const testAccAWSS3BucketConfig_namePrefix = `
 resource "aws_s3_bucket" "test" {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7868

Output from acceptance testing before code change:

```
--- FAIL: TestAccAWSS3Bucket_Bucket_EmptyString (2.15s)
    testing.go:538: Step 0 error: config is invalid: aws_s3_bucket.test: expected length of bucket to be in the range (3 - 63), got
```

Output from acceptance testing:

```
--- PASS: TestAccAWSS3Bucket_Bucket_EmptyString (26.50s)
```