### PR TITLE
resource/aws_ses_domain_mail_from: Prevent crash with deleted SES Domain Identity

### DIFF
--- a/aws/resource_aws_ses_domain_mail_from.go
+++ b/aws/resource_aws_ses_domain_mail_from.go
@@ -73,20 +73,26 @@ func resourceAwsSesDomainMailFromRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	out, err := conn.GetIdentityMailFromDomainAttributes(readOpts)
+
 	if err != nil {
-		log.Printf("error fetching MAIL FROM domain attributes for %s: %s", domainName, err)
-		return err
+		return fmt.Errorf("error fetching SES MAIL FROM domain attributes for %s: %s", domainName, err)
 	}
 
+	if out == nil {
+		return fmt.Errorf("error fetching SES MAIL FROM domain attributes for %s: empty response", domainName)
+	}
+
+	attributes, ok := out.MailFromDomainAttributes[domainName]
+
+	if !ok {
+		log.Printf("[WARN] SES Domain Identity (%s) not found, removing from state", domainName)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("behavior_on_mx_failure", attributes.BehaviorOnMXFailure)
 	d.Set("domain", domainName)
-
-	if v, ok := out.MailFromDomainAttributes[domainName]; ok {
-		d.Set("behavior_on_mx_failure", v.BehaviorOnMXFailure)
-		d.Set("mail_from_domain", v.MailFromDomain)
-	} else {
-		d.Set("behavior_on_mx_failure", v.BehaviorOnMXFailure)
-		d.Set("mail_from_domain", "")
-	}
+	d.Set("mail_from_domain", attributes.MailFromDomain)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #7862

Output from acceptance testing before code update:

```
=== CONT  TestAccAWSSESDomainMailFrom_disappears_Identity
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3e051ac]

goroutine 415 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsSesDomainMailFromRead(0xc0009825b0, 0x4a444a0, 0xc0004cec00, 0xc0009825b0, 0x0)
	/Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_ses_domain_mail_from.go:87 +0x37c
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSESDomainIdentity_disappears (9.03s)
--- PASS: TestAccAWSSESDomainMailFrom_disappears_Identity (10.38s)
--- PASS: TestAccAWSSESDomainMailFrom_disappears (13.55s)
--- PASS: TestAccAWSSESDomainMailFrom_behaviorOnMxFailure (21.04s)
--- PASS: TestAccAWSSESDomainMailFrom_basic (21.11s)
```
