### PR TITLE
docs/resource/aws_api_gateway_domain_name: Additional clarification of ACM vs IAM certificate usage

### DIFF
--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -8,7 +8,8 @@ description: |-
 
 # aws_api_gateway_domain_name
 
-Registers a custom domain name for use with AWS API Gateway.
+Registers a custom domain name for use with AWS API Gateway. Additional information about this functionality
+can be found in the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html).
 
 This resource just establishes ownership of and the TLS settings for
 a particular domain name. An API can be attached to a particular path
@@ -26,12 +27,12 @@ a distribution can be created if needed. In either case, it is necessary to crea
 given domain name which is an alias (either Route53 alias or traditional CNAME) to the regional domain name exported in
 the `regional_domain_name` attribute.
 
+~> **Note:** API Gateway requires the usage of AWS Certificate Manager (ACM) certificates instead of Identity and Access Management (IAM) certificates in regions that support ACM. Regions that support ACM can be found in the [Regions and Endpoints Documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#acm_region). To import an existing private key and certificate into ACM or request an ACM certificate, see the [`aws_acm_certificate` resource](/docs/providers/aws/r/acm_certificate.html).
+
 ~> **Note:** All arguments including the private key will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 ## Example Usage
-
--> For information about regions that support AWS Certificate Manager (ACM), see the [Regions and Endpoints Documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#acm_region).
 
 ### Edge Optimized (ACM Certificate)
 
@@ -56,7 +57,7 @@ resource "aws_route53_record" "example" {
 }
 ```
 
-### Edge Optimized (Uploaded Certificate)
+### Edge Optimized (IAM Certificate)
 
 ```hcl
 resource "aws_api_gateway_domain_name" "example" {
@@ -111,7 +112,7 @@ resource "aws_route53_record" "example" {
 }
 ```
 
-### Regional (Uploaded Certificate)
+### Regional (IAM Certificate)
 
 ```hcl
 resource "aws_api_gateway_domain_name" "example" {

--- a/website/docs/r/api_gateway_domain_name.html.markdown
+++ b/website/docs/r/api_gateway_domain_name.html.markdown
@@ -27,7 +27,7 @@ a distribution can be created if needed. In either case, it is necessary to crea
 given domain name which is an alias (either Route53 alias or traditional CNAME) to the regional domain name exported in
 the `regional_domain_name` attribute.
 
-~> **Note:** API Gateway requires the usage of AWS Certificate Manager (ACM) certificates instead of Identity and Access Management (IAM) certificates in regions that support ACM. Regions that support ACM can be found in the [Regions and Endpoints Documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#acm_region). To import an existing private key and certificate into ACM or request an ACM certificate, see the [`aws_acm_certificate` resource](/docs/providers/aws/r/acm_certificate.html).
+~> **Note:** API Gateway requires the use of AWS Certificate Manager (ACM) certificates instead of Identity and Access Management (IAM) certificates in regions that support ACM. Regions that support ACM can be found in the [Regions and Endpoints Documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#acm_region). To import an existing private key and certificate into ACM or request an ACM certificate, see the [`aws_acm_certificate` resource](/docs/providers/aws/r/acm_certificate.html).
 
 ~> **Note:** All arguments including the private key will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #6936
Closes #6635

References:

* https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html

Previously, the Terraform AWS Provider did not support importing/uploading certificates into ACM. With this newer functionality, we can authoritatively point operators to the `aws_acm_certificate` resource.

We also try to clarify that ACM certificates should be used instead of directly uploading certificates (IAM) where ACM is supported.

Output from acceptance testing: N/A -- documentation change
