### PR TITLE
resource/aws_s3_bucket: Prevent empty replication_configuration rules filter crash

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -1931,7 +1931,7 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 			rcRule.SourceSelectionCriteria = ruleSsc
 		}
 
-		if f, ok := rr["filter"].([]interface{}); ok && len(f) > 0 {
+		if f, ok := rr["filter"].([]interface{}); ok && len(f) > 0 && f[0] != nil {
 			// XML schema V2.
 			rcRule.Priority = aws.Int64(int64(rr["priority"].(int)))
 			rcRule.Filter = &s3.ReplicationRuleFilter{}

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -53,7 +53,17 @@ func testSweepS3BucketObjects(region string) error {
 	for _, bucket := range output.Buckets {
 		bucketName := aws.StringValue(bucket.Name)
 
-		if !strings.HasPrefix(bucketName, "tf-acc") && !strings.HasPrefix(bucketName, "tf-object-test") && !strings.HasPrefix(bucketName, "tf-test") {
+		hasPrefix := false
+		prefixes := []string{"mybucket.", "mylogs.", "tf-acc", "tf-object-test", "tf-test"}
+
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(bucketName, prefix) {
+				hasPrefix = true
+				break
+			}
+		}
+
+		if !hasPrefix {
 			log.Printf("[INFO] Skipping S3 Bucket: %s", bucketName)
 			continue
 		}

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -59,7 +59,17 @@ func testSweepS3Buckets(region string) error {
 	for _, bucket := range output.Buckets {
 		name := aws.StringValue(bucket.Name)
 
-		if !strings.HasPrefix(name, "tf-acc") && !strings.HasPrefix(name, "tf-object-test") && !strings.HasPrefix(name, "tf-test") {
+		hasPrefix := false
+		prefixes := []string{"mybucket.", "mylogs.", "tf-acc", "tf-object-test", "tf-test"}
+
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(name, prefix) {
+				hasPrefix = true
+				break
+			}
+		}
+
+		if !hasPrefix {
 			log.Printf("[INFO] Skipping S3 Bucket: %s", name)
 			continue
 		}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7427
Closes #6600

Changes proposed in this pull request (see commit messages for full details):

* resource/aws_s3_bucket: Prevent empty replication_configuration rules filter crash. This is a best effort fix given this may be caused by a manual console update and we do not have a replicating Terraform configuration. The previous code was missing a `nil` check before type assertion.
* tests/resource/aws_s3_bucket: Prevent CheckDestroy errors due to eventual consistency. Previously, errors could be returned since bucket deletion may take a few seconds to propagate.
* tests/service/s3: Add mybucket and mylogs prefixes to sweeping. These two test bucket name prefixes were piling up. We are still keeping the prefix based checks with S3 Bucket names to allow internal users to migrate off their existing buckets.

Output from acceptance testing:

```
--- PASS: TestAccAWSS3Bucket_shouldFailNotFound (17.44s)
--- PASS: TestAccAWSS3Bucket_Cors_EmptyOrigin (29.29s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenAES256IsUsed (29.94s)
--- PASS: TestAccAWSS3Bucket_Cors_Delete (31.64s)
--- PASS: TestAccAWSS3Bucket_importBasic (33.49s)
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (41.70s)
--- PASS: TestAccAWSS3Bucket_Logging (47.80s)
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (52.04s)
--- PASS: TestAccAWSS3Bucket_disableDefaultEncryption_whenDefaultEncryptionIsEnabled (52.96s)
--- PASS: TestAccAWSS3Bucket_Cors_Update (53.36s)
--- PASS: TestAccAWSS3Bucket_objectLock (53.81s)
--- PASS: TestAccAWSS3Bucket_enableDefaultEncryption_whenTypical (58.86s)
--- PASS: TestAccAWSS3Bucket_WebsiteRoutingRules (48.75s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (70.75s)
--- PASS: TestAccAWSS3Bucket_Policy (70.96s)
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutPrefix (72.03s)
--- PASS: TestAccAWSS3Bucket_Versioning (72.13s)
--- PASS: TestAccAWSS3Bucket_Lifecycle (73.01s)
--- PASS: TestAccAWSS3Bucket_RequestPayer (47.45s)
--- PASS: TestAccAWSS3Bucket_basic (24.91s)
--- PASS: TestAccAWSS3Bucket_namePrefix (24.41s)
--- PASS: TestAccAWSS3Bucket_region (31.70s)
--- PASS: TestAccAWSS3Bucket_generatedName (26.78s)
--- PASS: TestAccAWSS3Bucket_acceleration (49.96s)
--- PASS: TestAccAWSS3Bucket_importWithPolicy (35.90s)
--- PASS: TestAccAWSS3Bucket_UpdateAcl (48.55s)
--- PASS: TestAccAWSS3Bucket_WebsiteRedirect (70.34s)
--- PASS: TestAccAWSS3Bucket_Website_Simple (70.38s)
--- PASS: TestAccAWSS3Bucket_ReplicationConfiguration_Rule_Destination_AccessControlTranslation (148.13s)
--- PASS: TestAccAWSS3Bucket_ReplicationSchemaV2 (216.56s)
--- PASS: TestAccAWSS3Bucket_Replication (225.08s)
```
