### PR TITLE
Fix order of s3_key_prefix

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -137,7 +137,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the trail.
 * `s3_bucket_name` - (Required) Specifies the name of the S3 bucket designated for publishing log files.
-* `s3_key_prefix` - (Optional) Specifies the S3 key prefix that precedes
+* `s3_key_prefix` - (Optional) Specifies the S3 key prefix that follows
     the name of the bucket you have designated for log file delivery.
 * `cloud_watch_logs_role_arn` - (Optional) Specifies the role for the CloudWatch Logs
     endpoint to assume to write to a user’s log group.


### PR DESCRIPTION
The `s3_key_prefix` precedes the content of the bucket, but does not precede the bucket itself.
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->