### PR TITLE
resource/aws_api_gateway_authorizer: Use Terraform 0.11.12 and later compatible file hashing function in documentation and testing

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer_test.go
+++ b/aws/resource_aws_api_gateway_authorizer_test.go
@@ -400,7 +400,7 @@ EOF
 
 resource "aws_lambda_function" "authorizer" {
   filename = "test-fixtures/lambdatest.zip"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
   function_name = "%s"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"

--- a/website/docs/r/api_gateway_authorizer.html.markdown
+++ b/website/docs/r/api_gateway_authorizer.html.markdown
@@ -85,10 +85,13 @@ EOF
 
 resource "aws_lambda_function" "authorizer" {
   filename         = "lambda-function.zip"
-  source_code_hash = "${base64sha256(file("lambda-function.zip"))}"
   function_name    = "api_gateway_authorizer"
   role             = "${aws_iam_role.lambda.arn}"
   handler          = "exports.example"
+  # The filebase64sha256() function is available in Terraform 0.11.12 and later
+  # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
+  # source_code_hash = "${base64sha256(file("lambda-function.zip"))}"
+  source_code_hash = "${filebase64sha256("lambda-function.zip")}"
 }
 ```
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSAPIGatewayAuthorizer_switchAuthType (1.83s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSAPIGatewayAuthorizer_basic (1.83s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSAPIGatewayAuthorizer_authTypeValidation (1.83s)
    testing.go:561: Step 0, expected error:

        config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.

        To match:

        authorizer_uri must be set non-empty when authorizer type is TOKEN
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayAuthorizer_cognito (21.46s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (40.97s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_authTypeValidation (47.06s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthType (77.30s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayAuthorizer_cognito (21.97s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_basic (55.51s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_switchAuthType (97.25s)
--- PASS: TestAccAWSAPIGatewayAuthorizer_authTypeValidation (127.83s)
```
