### PR TITLE
tests/resource/aws_api_gateway_method: Use Terraform 0.11.12 and later compatible file hashing function

### DIFF
--- a/aws/resource_aws_api_gateway_method_test.go
+++ b/aws/resource_aws_api_gateway_method_test.go
@@ -380,7 +380,7 @@ EOF
 
 resource "aws_lambda_function" "authorizer" {
   filename = "test-fixtures/lambdatest.zip"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
   function_name = "tf_acc_api_gateway_authorizer_%d"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSAPIGatewayMethod_customauthorizer (1.85s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (48.68s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSAPIGatewayMethod_customauthorizer (35.74s)
```
