### PR TITLE
docs/resource/aws_api_gateway_integration: Use Terraform 0.11.12 and later compatible file hashing function

### DIFF
--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -107,7 +107,10 @@ resource "aws_lambda_function" "lambda" {
   role             = "${aws_iam_role.role.arn}"
   handler          = "lambda.lambda_handler"
   runtime          = "python2.7"
-  source_code_hash = "${base64sha256(file("lambda.zip"))}"
+  # The filebase64sha256() function is available in Terraform 0.11.12 and later
+  # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
+  # source_code_hash = "${base64sha256(file("lambda.zip"))}"
+  source_code_hash = "${filebase64sha256("lambda.zip")}"
 }
 
 # IAM


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Output from acceptance testing: N/A
