### PR TITLE
tests/resource/aws_cloudwatch_event_target: Use Terraform 0.11.12 and later compatible file hashing function

### DIFF
--- a/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/aws/resource_aws_cloudwatch_event_target_test.go
@@ -872,7 +872,7 @@ EOF
 resource "aws_lambda_function" "lambda" {
 	function_name = "tf_acc_input_transformer"
 	filename = "test-fixtures/lambdatest.zip"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
   role = "${aws_iam_role.iam_for_lambda.arn}"
   handler = "exports.example"
 	runtime = "nodejs8.10"
@@ -890,7 +890,7 @@ resource "aws_cloudwatch_event_target" "test" {
   rule = "${aws_cloudwatch_event_rule.schedule.id}"
 
   input_transformer {
-    input_paths {
+    input_paths = {
       time = "$.time"
     }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSCloudWatchEventTarget_input_transformer (2.18s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.

--- FAIL: TestAccAWSCloudWatchEventTarget_input_transformer (1.81s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "input_paths" are not expected here. Did you mean to define argument "input_paths"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (24.60s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSCloudWatchEventTarget_input_transformer (22.38s)
```
