### PR TITLE
resource/aws_kms_alias: Prevent state removal of resource immediately after creation due to eventual consistency

### DIFF
--- a/aws/resource_aws_kms_alias.go
+++ b/aws/resource_aws_kms_alias.go
@@ -182,10 +182,15 @@ func retryFindKmsAliasByName(conn *kms.KMS, name string) (*kms.AliasListEntry, e
 			return resource.NonRetryableError(err)
 		}
 		if resp == nil {
-			return resource.RetryableError(err)
+			return resource.RetryableError(&resource.NotFoundError{})
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		resp, err = findKmsAliasByName(conn, name, nil)
+	}
+
 	return resp, err
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7891
Closes #6560

References:

* https://github.com/terraform-providers/terraform-provider-aws/issues/7873
* https://github.com/hashicorp/terraform/pull/17220

The KMS service has eventual consistency considerations and the `aws_kms_alias` resource immediately tries to read the KMS alias after creation, which may not find the KMS alias. When not able to find the KMS alias, the resource logic returns an empty API object instead of an error. Since a `nil` check was already performed on the error, the error will always be `nil`. Invoking `return resource.RetryableError(nil)`  is equivalent to `return nil`. The resource during its Read performs an error check first which will skip because its `nil`, then assumes the resource has been deleted outside Terraform and triggers recreation.

Here when we cannot find a KMS alias after allowing some time for eventual consistency, we return a resource not found error and ensure we handle any timeouts due to automatic AWS Go SDK retries.

Output from acceptance testing:

```
--- PASS: TestAccAWSKmsAlias_no_name (37.63s)
--- PASS: TestAccAWSKmsAlias_name_prefix (37.80s)
--- PASS: TestAccAWSKmsAlias_multiple (38.38s)
--- PASS: TestAccAWSKmsAlias_importBasic (40.13s)
--- PASS: TestAccAWSKmsAlias_ArnDiffSuppress (43.61s)
--- PASS: TestAccAWSKmsAlias_basic (46.76s)
```
