### PR TITLE
tests/resource/aws_db_instance: Use Terraform 0.11.12 and later compatible file hashing function

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -2171,7 +2171,7 @@ resource "aws_s3_bucket_object" "xtrabackup_db" {
   bucket = "${aws_s3_bucket.xtrabackup.id}"
   key    = "%s/mysql-5-6-xtrabackup.tar.gz"
   source = "../files/mysql-5-6-xtrabackup.tar.gz"
-  etag   = "${md5(file("../files/mysql-5-6-xtrabackup.tar.gz"))}"
+  etag   = "${filemd5("../files/mysql-5-6-xtrabackup.tar.gz")}"
 }
 
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content. The acceptance testing failure with the incompatible restore will need to be addressed separately as RDS does not give detailed information in the RDS events about why the failure occurs.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSDBInstance_S3Import (1.82s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of ../files/mysql-5-6-xtrabackup.tar.gz are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
```

Output from Terraform 0.11.12 acceptance testing (same test failure as previously):

```
--- FAIL: TestAccAWSDBInstance_S3Import (709.69s)
    testing.go:568: Step 0 error: errors during apply:

        Error: unexpected state 'incompatible-restore', wanted target 'available, storage-optimization'. last error: %!s(<nil>)
```

Output from Terraform 0.12 acceptance testing (same test failure as previously):

```
--- FAIL: TestAccAWSDBInstance_S3Import (708.87s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_db_instance.s3: 1 error occurred:
        	* aws_db_instance.s3: unexpected state 'incompatible-restore', wanted target 'available, storage-optimization'. last error: %!s(<nil>)
```
