### PR TITLE
tests/resource/aws_lambda_alias: Use Terraform 0.11.12 and later compatible file hashing function

### DIFF
--- a/aws/resource_aws_lambda_alias_test.go
+++ b/aws/resource_aws_lambda_alias_test.go
@@ -269,7 +269,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
   runtime          = "nodejs8.10"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambdatest.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambdatest.zip")}"
   publish          = "true"
 }
 
@@ -336,7 +336,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.example"
   runtime          = "nodejs8.10"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambdatest_modified.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambdatest_modified.zip")}"
   publish          = "true"
 }
 
@@ -345,7 +345,8 @@ resource "aws_lambda_alias" "lambda_alias_test" {
   description      = "a sample description"
   function_name    = "${aws_lambda_function.lambda_function_test_create.arn}"
   function_version = "1"
-  routing_config   = {
+
+  routing_config {
     additional_version_weights = {
       "2" = 0.5
     }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLambdaAlias_basic (1.78s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSLambdaAlias_nameupdate (1.79s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSLambdaAlias_routingconfig (1.79s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.

--- FAIL: TestAccAWSLambdaAlias_routingconfig (24.51s)
    testing.go:568: Step 1 error: config is invalid: Unsupported argument: An argument named "routing_config" is not expected here. Did you mean to define a block of type "routing_config"?
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSLambdaAlias_basic (19.97s)
--- PASS: TestAccAWSLambdaAlias_nameupdate (29.19s)
--- PASS: TestAccAWSLambdaAlias_routingconfig (38.83s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSLambdaAlias_basic (34.62s)
--- PASS: TestAccAWSLambdaAlias_nameupdate (39.36s)
--- PASS: TestAccAWSLambdaAlias_routingconfig (49.33s)
```
