### PR TITLE
resource/aws_lambda_function: Use Terraform 0.11.12 and later compatible file hashing function in documentation and testing

### DIFF
--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1121,7 +1121,7 @@ func TestAccAWSLambdaFunction_runtimeValidation_noRuntime(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSLambdaConfigNoRuntime(funcName, policyName, roleName, sgName),
-				ExpectError: regexp.MustCompile(`"runtime": required field is not set`),
+				ExpectError: regexp.MustCompile(`("runtime": required field is not set|The argument "runtime" is required)`),
 			},
 		},
 	})
@@ -2287,7 +2287,7 @@ EOF
 }
 resource "aws_lambda_function" "lambda_function_local" {
     filename = "%s"
-    source_code_hash = "${base64sha256(file("%s"))}"
+    source_code_hash = "${filebase64sha256("%s")}"
     function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
@@ -2352,7 +2352,7 @@ resource "aws_s3_bucket_object" "o" {
     bucket = "${aws_s3_bucket.artifacts.bucket}"
     key = "%s"
     source = "%s"
-    etag = "${md5(file("%s"))}"
+    etag = "${filemd5("%s")}"
 }
 resource "aws_iam_role" "iam_for_lambda" {
     name = "%s"
@@ -2395,7 +2395,7 @@ resource "aws_s3_bucket_object" "o" {
     bucket = "${aws_s3_bucket.artifacts.bucket}"
     key = "%s"
     source = "%s"
-    etag = "${md5(file("%s"))}"
+    etag = "${filemd5("%s")}"
 }
 resource "aws_iam_role" "iam_for_lambda" {
 	name = "%s"

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -42,7 +42,10 @@ resource "aws_lambda_function" "test_lambda" {
   function_name    = "lambda_function_name"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "exports.test"
-  source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
+  # The filebase64sha256() function is available in Terraform 0.11.12 and later
+  # For Terraform 0.11.11 and earlier, use the base64sha256() function and the file() function:
+  # source_code_hash = "${base64sha256(file("lambda_function_payload.zip"))}"
+  source_code_hash = "${filebase64sha256("lambda_function_payload.zip")}"
   runtime          = "nodejs8.10"
 
   environment {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content. Also adds Terraform 0.12 compatible `ExpectError` condition for `TestAccAWSLambdaFunction_runtimeValidation_noRuntime`.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (0.64s)
    testing.go:561: Step 0, expected error:

        config is invalid: Missing required argument: The argument "runtime" is required, but no definition was found.

        To match:

        "runtime": required field is not set

--- FAIL: TestAccAWSLambdaFunction_localUpdate (2.02s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/lambda_localUpdate083548067 are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSLambdaFunction_s3Update_unversioned (1.62s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/lambda_s3Update704916359 are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSLambdaFunction_s3Update_basic (0.68s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/lambda_s3Update316607176 are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (1.83s)
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (26.03s)
--- PASS: TestAccAWSLambdaFunction_localUpdate (27.82s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (49.97s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (51.00s)
```

Output from Terraform 0.12 acceptance testing (new failure will need to be addressed separately):

```
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (1.04s)
--- FAIL: TestAccAWSLambdaFunction_localUpdate (33.35s)
    testing.go:568: Step 1 error: Check failed: Check 5/5 error: Expected time attribute data.template_file.last_modified.rendered with value 2019-03-13T03:02:00.589+0000 was not before 2019-03-12T23:02:04-0400
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (35.23s)
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (51.66s)
--- PASS: TestAccAWSLambdaFunction_s3Update_basic (51.78s)
```
