### PR TITLE
resource/aws_lambda_layer_version: Use Terraform 0.11.12 and later compatible file hashing function in documentation and testing

### DIFF
--- a/aws/resource_aws_lambda_layer_version_test.go
+++ b/aws/resource_aws_lambda_layer_version_test.go
@@ -330,7 +330,7 @@ func testAccAWSLambdaLayerVersionCreateBeforeDestroy(layerName string, filename 
 resource "aws_lambda_layer_version" "lambda_layer_test" {
   filename         = "%s"
   layer_name       = "%s"
-  source_code_hash = "${base64sha256(file("%s"))}"
+  source_code_hash = "${filebase64sha256("%s")}"
 
   lifecycle {
     create_before_destroy = true

--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -45,7 +45,7 @@ large files efficiently.
 * `compatible_runtimes` - (Optional) A list of [Runtimes][2] this layer is compatible with. Up to 5 runtimes can be specified.
 * `description` - (Optional) Description of what your Lambda Layer does.
 * `license_info` - (Optional) License info for your Lambda Layer. See [License Info][3].
-* `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `${base64sha256(file("file.zip"))}`, where "file.zip" is the local filename of the lambda layer source archive.
+* `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `${filebase64sha256("file.zip")}` (Terraform 0.11.12 or later) or `${base64sha256(file("file.zip"))}` (Terraform 0.11.11 and earlier), where "file.zip" is the local filename of the lambda layer source archive.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSLambdaLayerVersion_update (1.73s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambdatest.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSLambdaLayerVersion_update (26.10s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSLambdaLayerVersion_update (25.75s)
```
