### PR TITLE
tests/resource/aws_sns_topic_subscription: Use Terraform 0.11.12 and later compatible file hashing function

### DIFF
--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -572,7 +572,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = "tf-acc-test-sns-%d"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "main.confirm_subscription"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambda_confirm_sns.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambda_confirm_sns.zip")}"
   runtime          = "python3.6"
 }
 
@@ -696,7 +696,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = "tf-acc-test-sns-%d"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "main.confirm_subscription"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambda_confirm_sns.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambda_confirm_sns.zip")}"
   runtime          = "python3.6"
 }
 
@@ -755,7 +755,7 @@ resource "aws_api_gateway_authorizer" "test" {
 
 resource "aws_lambda_function" "authorizer" {
   filename         = "test-fixtures/lambda_basic_authorizer.zip"
-  source_code_hash = "${base64sha256(file("test-fixtures/lambda_basic_authorizer.zip"))}"
+  source_code_hash = "${filebase64sha256("test-fixtures/lambda_basic_authorizer.zip")}"
   function_name    = "tf-acc-test-authorizer-%d"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "main.authenticate"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (1.84s)
    testing.go:568: Step 0 error: config is invalid: Error in function call: Call to function "file" failed: contents of test-fixtures/lambda_confirm_sns.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
--- FAIL: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (1.84s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Error in function call: Call to function "file" failed: contents of test-fixtures/lambda_confirm_sns.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
        - Error in function call: Call to function "file" failed: contents of test-fixtures/lambda_basic_authorizer.zip are not valid UTF-8; to read arbitrary bytes, use the filebase64 function instead.
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (43.36s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (64.80s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (43.75s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (80.95s)
```
