### PR TITLE
resource/aws_s3_bucket_object: Use Terraform 0.11.12 and later compatible file hashing function in documentation and testing

### DIFF
--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -854,7 +854,7 @@ resource "aws_s3_bucket_object" "object" {
   bucket = "${aws_s3_bucket.object_bucket_3.bucket}"
   key = "updateable-key"
   source = "%s"
-  etag = "${md5(file("%s"))}"
+  etag = "${filemd5("%s")}"
 }
 `, randInt, bucketVersioning, source, source)
 }

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -19,7 +19,10 @@ resource "aws_s3_bucket_object" "object" {
   bucket = "your_bucket_name"
   key    = "new_object_key"
   source = "path/to/file"
-  etag   = "${md5(file("path/to/file"))}"
+  # The filemd5() function is available in Terraform 0.11.12 and later
+  # For Terraform 0.11.11 and earlier, use the md5() function and the file() function:
+  # etag = "${md5(file("path/to/file"))}"
+  etag = "${filemd5("path/to/file")}"
 }
 ```
 
@@ -96,7 +99,7 @@ The following arguments are supported:
 * `website_redirect` - (Optional) Specifies a target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
 * `storage_class` - (Optional) Specifies the desired [Storage Class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)
 for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", "`ONEZONE_IA`", "`INTELLIGENT_TIERING`", "`GLACIER`", or "`STANDARD_IA`". Defaults to "`STANDARD`".
-* `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`.
+* `etag` - (Optional) Used to trigger updates. The only meaningful value is `${filemd5("path/to/file")}` (Terraform 0.11.12 or later) or `${md5(file("path/to/file"))}` (Terraform 0.11.11 or earlier).
 This attribute is not compatible with KMS encryption, `kms_key_id` or `server_side_encryption = "aws:kms"`.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".
 * `kms_key_id` - (Optional) Specifies the AWS KMS Key ARN to use for object encryption.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The updated file hashing function is forwards compatible with Terraform 0.12, which does not allow the use of the `file()` function with binary file content.

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSS3BucketObject_updates (45.21s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSS3BucketObject_updates (46.42s)
```
