### PR TITLE
Set aws_eip.allocation_id on read

### DIFF
--- a/aws/resource_aws_eip.go
+++ b/aws/resource_aws_eip.go
@@ -223,6 +223,7 @@ func resourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("private_ip", address.PrivateIpAddress)
 	d.Set("public_ip", address.PublicIp)
 	d.Set("public_ipv4_pool", address.PublicIpv4Pool)
+	d.Set("allocation_id", d.Id())
 
 	// On import (domain never set, which it must've been if we created),
 	// set the 'vpc' attribute depending on if we're in a VPC.

--- a/website/docs/r/eip.html.markdown
+++ b/website/docs/r/eip.html.markdown
@@ -116,6 +116,7 @@ more information.
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Contains the EIP allocation ID.
+* `association_id` - Contains the EIP allocation ID.
 * `private_ip` - Contains the private IP address (if in VPC).
 * `associate_with_private_ip` - Contains the user specified private IP address
 (if in VPC).


### PR DESCRIPTION
`allocation_id` in the schema for `aws_eip` is marked as `Computed`, but never set to a value. It is also undocumented, and is likely legacy, since it would duplicate the `id` attribute.

The two options to fix this are:

- Set it at read and document it (the approach taken here), or
- Remove it from the schema, which would be a breaking change, although not one necessarily with meaningful impact since the value has not been set at least since the providers were broken out in to their own repositories