### PR TITLE
test/resource/aws_kinesis_analytics_application: Adjust test configuration syntax for Terraform 0.12

### DIFF
--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -592,9 +592,9 @@ resource "aws_kinesis_analytics_application" "test" {
 func testAccKinesisAnalyticsApplication_inputsKinesisFirehose(rInt int) string {
 	return fmt.Sprintf(`
 data "aws_iam_policy_document" "trust_firehose" {
-  statement = {
+  statement {
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type = "Service"
       identifiers = ["firehose.amazonaws.com"]
     }
@@ -607,9 +607,9 @@ resource "aws_iam_role" "firehose" {
 }
 
 data "aws_iam_policy_document" "trust_lambda" {
-  statement = {
+  statement {
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type = "Service"
       identifiers = ["lambda.amazonaws.com"]
     }
@@ -636,8 +636,8 @@ resource "aws_lambda_function" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {
   name = "testAcc-%d"
-  destination = "extended_s3" 
-  extended_s3_configuration = {
+  destination = "extended_s3"
+  extended_s3_configuration {
     role_arn = "${aws_iam_role.firehose.arn}"
     bucket_arn = "${aws_s3_bucket.test.arn}"
   }
@@ -646,25 +646,25 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
 resource "aws_kinesis_analytics_application" "test" {
   name = "testAcc-%d"
   code = "testCode\n"
-  inputs = {
+  inputs {
     name_prefix = "test_prefix"
-    kinesis_firehose = {
+    kinesis_firehose {
       resource_arn = "${aws_kinesis_firehose_delivery_stream.test.arn}"
       role_arn = "${aws_iam_role.test.arn}"
     }
-    parallelism = {
+    parallelism {
       count = 1
     }
-    schema = {
-      record_columns = {
+    schema {
+      record_columns {
         mapping = "$.test"
         name = "test"
         sql_type = "VARCHAR(8)"
       }
       record_encoding = "UTF-8"
-      record_format = {
-        mapping_parameters = {
-          csv = {
+      record_format {
+        mapping_parameters {
+          csv {
             record_column_delimiter = ","
             record_row_delimiter = "\n"
           }
@@ -999,9 +999,9 @@ resource "aws_kinesis_analytics_application" "test" {
 func testAccKinesisAnalyticsApplication_prereq(rInt int) string {
 	return fmt.Sprintf(`
 data "aws_iam_policy_document" "trust" {
-  statement = {
+  statement {
     actions = ["sts:AssumeRole"]
-    principals = {
+    principals {
       type = "Service"
       identifiers = ["kinesisanalytics.amazonaws.com"]
     }
@@ -1014,7 +1014,7 @@ resource "aws_iam_role" "test" {
 }
 
 data "aws_iam_policy_document" "test" {
-  statement = {
+  statement {
     actions = ["firehose:*"]
     resources = ["*"]
   }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The acceptance test configurations are now forwards and backwards compatible.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (2.22s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (2.26s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (2.26s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (2.26s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (2.28s)
    testing.go:568: Step 0 error: config is invalid: 6 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "inputs" is not expected here. Did you mean to define a block of type "inputs"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "extended_s3_configuration" is not expected here. Did you mean to define a block of type "extended_s3_configuration"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (2.30s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (2.31s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (2.31s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (2.37s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_outputsAdd (2.40s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (2.40s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (2.41s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- FAIL: TestAccAWSKinesisAnalyticsApplication_inputsAdd (2.41s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:

        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
        - Unsupported argument: An argument named "statement" is not expected here. Did you mean to define a block of type "statement"?
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (10.35s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (15.37s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (35.12s)
```

Output from Terraform 0.11.12 acceptance testing:

```
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (10.58s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (15.21s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (25.47s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (26.30s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (34.71s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (36.11s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (43.11s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (48.36s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (85.62s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (85.64s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (85.68s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (115.98s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (117.21s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (117.35s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (166.24s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (166.53s)
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (10.65s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (15.68s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (24.62s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (29.98s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (42.71s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (42.91s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (43.53s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (52.45s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (86.94s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (87.02s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (87.15s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (107.84s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (109.36s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (121.96s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (170.69s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (170.71s)
```
