### PR TITLE
website: Update links to built-in functions

### DIFF
--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -22,7 +22,7 @@ data "aws_ssm_parameter" "foo" {
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 
-~> **Note:** The data source is currently following the behavior of the [SSM API](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#Parameter) to return a string value, regardless of parameter type. For type `StringList`, we can use [split()](https://www.terraform.io/docs/configuration/interpolation.html#split-delim-string-) built-in function to get values in a list. Example: `split(",", data.aws_ssm_parameter.subnets.value)`
+~> **Note:** The data source is currently following the behavior of the [SSM API](https://docs.aws.amazon.com/sdk-for-go/api/service/ssm/#Parameter) to return a string value, regardless of parameter type. For type `StringList`, we can use the built-in [split()](https://www.terraform.io/docs/configuration/functions/split.html) function to get values in a list. Example: `split(",", data.aws_ssm_parameter.subnets.value)`
 
 
 ## Argument Reference

--- a/website/docs/guides/iam-policy-documents.html.md
+++ b/website/docs/guides/iam-policy-documents.html.md
@@ -108,7 +108,7 @@ resource "aws_iam_policy" "example" {
 
 ### file() Interpolation Function
 
-To decouple the IAM policy JSON from the Terraform configuration, Terraform has a built-in [`file()` interpolation function](/docs/configuration/interpolation.html#file-path-), which can read the contents of a local file into the configuration. Interpolation is _not_ available when using the `file()` function by itself.
+To decouple the IAM policy JSON from the Terraform configuration, Terraform has a built-in [`file()` function](https://www.terraform.io/docs/configuration/functions/file.html), which can read the contents of a local file into the configuration.
 
 For example, creating a file called `policy.json` with the contents:
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

**Reason for docs update:** In the 0.12 language docs, the built-in functions moved to their own pages! 

**Relevant docs version:** The 0.12 docs are live now, and this link works today. The old link currently redirects to a legible place in the 0.11 language docs, but that won't be "current" for much longer. It's also creating some noise due to broken links in the Travis builds for website PRs. 