### PR TITLE
Fix bug in aws_db_instance example

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -38,7 +38,7 @@ about [DB Instance Class Types](https://docs.aws.amazon.com/AmazonRDS/latest/Use
 
 ```hcl
 resource "aws_db_instance" "default" {
-  allocated_storage    = 10
+  allocated_storage    = 20
   storage_type         = "gp2"
   engine               = "mysql"
   engine_version       = "5.7"


### PR DESCRIPTION
According to [this AWS doc](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html):
> General Purpose (SSD) storage (gp2): Must be an integer from **20** to 32768.

As `gp2` is used in the given example, I therefore propose to change the `allocated_storage` from 10 to 20.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

---
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
---


Changes proposed in this pull request:
* Change `allocated_storage` in example from `10` to `20`
