### PR TITLE
Add Data Source Elasticsearch Domain

### DIFF
--- a/aws/data_source_aws_elasticsearch_domain.go
+++ b/aws/data_source_aws_elasticsearch_domain.go
@@ -1,0 +1,344 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+func dataSourceAwsElasticSearchDomain() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsElasticSearchDomainRead,
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access_policies": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"advanced_options": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kibana_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ebs_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ebs_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"iops": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"volume_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"volume_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"encrypt_at_rest": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"node_to_node_encryption": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dedicated_master_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"dedicated_master_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"dedicated_master_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"zone_awareness_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"snapshot_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"automated_snapshot_start_hour": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"vpc_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"availability_zones": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"security_group_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"subnet_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"log_publishing_options": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"log_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cloudwatch_log_group_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"elasticsearch_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cognito_options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"user_pool_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"identity_pool_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"role_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).esconn
+
+	domainName := d.Get("domain_name").(string)
+
+	out, err := conn.DescribeElasticsearchDomain(&elasticsearch.DescribeElasticsearchDomainInput{
+		DomainName: aws.String(domainName),
+	})
+	if err != nil {
+		return fmt.Errorf("Error describing elastic search domain(%s): %s", domainName, err)
+	}
+
+	log.Printf("[DEBUG] Received ElasticSearch domain: %s", out)
+
+	ds := out.DomainStatus
+
+	d.SetId(aws.StringValue(ds.ARN))
+	d.Set("domain_id", ds.DomainId)
+	d.Set("domain_name", ds.DomainName)
+	d.Set("elasticsearch_version", ds.ElasticsearchVersion)
+
+	if ds.AccessPolicies != nil && aws.StringValue(ds.AccessPolicies) != "" {
+		policies, err := structure.NormalizeJsonString(aws.StringValue(ds.AccessPolicies))
+		if err != nil {
+			return fmt.Errorf("access policies contain an invalid JSON: %s", err)
+		}
+		d.Set("access_policies", policies)
+	}
+	err = d.Set("advanced_options", pointersMapToStringList(ds.AdvancedOptions))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("ebs_options", flattenESEBSOptions(ds.EBSOptions))
+	if err != nil {
+		return err
+	}
+	err = d.Set("encrypt_at_rest", flattenESEncryptAtRestOptions(ds.EncryptionAtRestOptions))
+	if err != nil {
+		return err
+	}
+	err = d.Set("cluster_config", flattenESClusterConfig(ds.ElasticsearchClusterConfig))
+	if err != nil {
+		return err
+	}
+	err = d.Set("cognito_options", flattenESCognitoOptions(ds.CognitoOptions))
+	if err != nil {
+		return err
+	}
+	err = d.Set("node_to_node_encryption", flattenESNodeToNodeEncryptionOptions(ds.NodeToNodeEncryptionOptions))
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("snapshot_options", flattenESSnapshotOptions(ds.SnapshotOptions)); err != nil {
+		return fmt.Errorf("error setting snapshot_options: %s", err)
+	}
+
+	if ds.VPCOptions != nil {
+		err = d.Set("vpc_options", flattenESVPCDerivedInfo(ds.VPCOptions))
+		if err != nil {
+			return err
+		}
+		endpoints := pointersMapToStringList(ds.Endpoints)
+		err = d.Set("endpoint", endpoints["vpc"])
+		if err != nil {
+			return err
+		}
+		d.Set("kibana_endpoint", getKibanaEndpoint(d))
+		if ds.Endpoint != nil {
+			return fmt.Errorf("%q: Elasticsearch domain in VPC expected to have null Endpoint value", d.Id())
+		}
+	} else {
+		if ds.Endpoint != nil {
+			d.Set("endpoint", aws.StringValue(ds.Endpoint))
+			d.Set("kibana_endpoint", getKibanaEndpoint(d))
+		}
+		if ds.Endpoints != nil {
+			return fmt.Errorf("%q: Elasticsearch domain not in VPC expected to have null Endpoints value", d.Id())
+		}
+	}
+
+	if ds.LogPublishingOptions != nil {
+		m := make([]map[string]interface{}, 0)
+		for k, val := range ds.LogPublishingOptions {
+			mm := map[string]interface{}{}
+			mm["log_type"] = k
+			if val.CloudWatchLogsLogGroupArn != nil {
+				mm["cloudwatch_log_group_arn"] = aws.StringValue(val.CloudWatchLogsLogGroupArn)
+			}
+			mm["enabled"] = aws.BoolValue(val.Enabled)
+			m = append(m, mm)
+		}
+		d.Set("log_publishing_options", m)
+	}
+
+	d.Set("arn", ds.ARN)
+
+	listOut, err := conn.ListTags(&elasticsearch.ListTagsInput{
+		ARN: ds.ARN,
+	})
+
+	if err != nil {
+		return err
+	}
+	var est []*elasticsearch.Tag
+	if len(listOut.TagList) > 0 {
+		est = listOut.TagList
+	}
+
+	d.Set("tags", tagsToMapElasticsearchService(est))
+
+	return nil
+}

--- a/aws/data_source_aws_elasticsearch_domain_test.go
+++ b/aws/data_source_aws_elasticsearch_domain_test.go
@@ -1,0 +1,215 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	elasticsearch "github.com/aws/aws-sdk-go/service/elasticsearchservice"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAWSElasticSearchDomain_basic(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+	resourceName := "aws_elasticsearch_domain.example"
+	dataSourceName := "data.aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceESDomainConfig(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "elasticsearch_version", resourceName, "elasticsearch_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "domain_id", resourceName, "domain_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "endpoint", resourceName, "endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "kibana_endpoint", resourceName, "kibana_endpoint"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ebs_options.0.ebs_enabled", resourceName, "ebs_options.0.ebs_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ebs_options.0.iops", resourceName, "ebs_options.0.iops"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ebs_options.0.volume_size", resourceName, "ebs_options.0.volume_size"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ebs_options.0.volume_type", resourceName, "ebs_options.0.volume_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSElasticSearchDomain_withDedicatedMaster(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+	resourceName := "aws_elasticsearch_domain.example"
+	dataSourceName := "data.aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceESDomainConfigWithDedicatedClusterMaster(ri, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_config.0.instance_type", resourceName, "cluster_config.0.instance_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_config.0.instance_count", resourceName, "cluster_config.0.instance_count"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_config.0.dedicated_master_enabled", resourceName, "cluster_config.0.dedicated_master_enabled"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_config.0.dedicated_master_count", resourceName, "cluster_config.0.dedicated_master_count"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cluster_config.0.dedicated_master_type", resourceName, "cluster_config.0.dedicated_master_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSElasticSearchDomain_withPolicy(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+	resourceName := "aws_elasticsearch_domain.example"
+	dataSourceName := "data.aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceESDomainConfigWithPolicy(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "access_policies", resourceName, "access_policies"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSElasticSearchDomain_withEncryptAtRestDefaultKey(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+	resourceName := "aws_elasticsearch_domain.example"
+	dataSourceName := "data.aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceESDomainConfigWithEncryptAtRestDefaultKey(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encrypt_at_rest.0.enabled", resourceName, "encrypt_at_rest.0.enabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSElasticSearchDomain_withNodeToNodeEncryption(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+	resourceName := "aws_elasticsearch_domain.example"
+	dataSourceName := "data.aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceESDomainConfigWithNodeToNodeEncryption(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "node_to_node_encryption.0.enabled", resourceName, "node_to_node_encryption.0.enabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSElasticSearchDomain_complex(t *testing.T) {
+	var domain elasticsearch.ElasticsearchDomainStatus
+	ri := acctest.RandInt()
+	resourceName := "aws_elasticsearch_domain.example"
+	dataSourceName := "data.aws_elasticsearch_domain.example"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckESDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceESDomainConfigComplex(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "snapshot_options.0.automated_snapshot_start_hour", resourceName, "snapshot_options.0.automated_snapshot_start_hour"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.bar", resourceName, "tags.bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceESDomainConfig(randInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_elasticsearch_domain" "example" {
+	domain_name = "${aws_elasticsearch_domain.example.domain_name}"
+}
+`, testAccESDomainConfig(randInt))
+}
+
+func testAccDataSourceESDomainConfigWithDedicatedClusterMaster(randInt int, enabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_elasticsearch_domain" "example" {
+	domain_name = "${aws_elasticsearch_domain.example.domain_name}"
+}
+`, testAccESDomainConfig_WithDedicatedClusterMaster(randInt, enabled))
+}
+
+func testAccDataSourceESDomainConfigWithPolicy(randInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_elasticsearch_domain" "example" {
+	domain_name = "${aws_elasticsearch_domain.example.domain_name}"
+}
+`, testAccESDomainConfigWithPolicy(randInt, randInt))
+}
+
+func testAccDataSourceESDomainConfigWithEncryptAtRestDefaultKey(randInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_elasticsearch_domain" "example" {
+	domain_name = "${aws_elasticsearch_domain.example.domain_name}"
+}
+`, testAccESDomainConfigWithEncryptAtRestDefaultKey(randInt))
+}
+
+func testAccDataSourceESDomainConfigWithNodeToNodeEncryption(randInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_elasticsearch_domain" "example" {
+	domain_name = "${aws_elasticsearch_domain.example.domain_name}"
+}
+`, testAccESDomainConfigwithNodeToNodeEncryption(randInt))
+}
+
+func testAccDataSourceESDomainConfigComplex(randInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "aws_elasticsearch_domain" "example" {
+	domain_name = "${aws_elasticsearch_domain.example.domain_name}"
+}
+`, testAccESDomainConfig_complex(randInt))
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -194,6 +194,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elastic_beanstalk_hosted_zone":      dataSourceAwsElasticBeanstalkHostedZone(),
 			"aws_elastic_beanstalk_solution_stack":   dataSourceAwsElasticBeanstalkSolutionStack(),
 			"aws_elasticache_cluster":                dataSourceAwsElastiCacheCluster(),
+			"aws_elasticsearch_domain":               dataSourceAwsElasticSearchDomain(),
 			"aws_elb":                                dataSourceAwsElb(),
 			"aws_elasticache_replication_group":      dataSourceAwsElasticacheReplicationGroup(),
 			"aws_elb_hosted_zone_id":                 dataSourceAwsElbHostedZoneId(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -207,6 +207,9 @@
                             <a href="/docs/providers/aws/d/elasticache_replication_group.html">aws_elasticache_replication_group</a>
                         </li>
                         <li>
+                            <a href="/docs/providers/aws/d/elasticsearch_domain.html">aws_elasticsearch_domain</a>
+                        </li>
+                        <li>
                             <a href="/docs/providers/aws/d/elb.html">aws_elb</a>
                         </li>
                         <li>

--- a/website/docs/d/elasticsearch_domain.html.markdown
+++ b/website/docs/d/elasticsearch_domain.html.markdown
@@ -1,0 +1,111 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elasticsearch_domain"
+sidebar_current: "docs-aws-datasource-elasticsearch-domain"
+description: |-
+  Get information on an AWS Elasticsearch Domain resource.
+---
+
+# Data Source: aws_elasticsearch_domain
+
+Use this data source to get information about an AWS Elasticsearch Domain.
+
+## Example Usage
+
+```hcl
+data "aws_elasticsearch_domain" "bar" {
+  domain_name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` – (Required) Name of the domain.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the domain.
+* `domain_id` - Unique identifier for the domain.
+* `domain_name` - The name of the Elasticsearch domain.
+* `endpoint` - Domain-specific endpoint used to submit index, search, and data upload requests.
+* `kibana_endpoint` - Domain-specific endpoint for kibana without https scheme.
+* `vpc_options.0.availability_zones` - If the domain was created inside a VPC, the names of the availability zones the configured `subnet_ids` were created inside.
+* `vpc_options.0.vpc_id` - If the domain was created inside a VPC, the ID of the VPC.
+* `access_policies` - IAM policy document specifying the access policies for the domain
+* `advanced_options` - Key-value string pairs to specify advanced configuration options.
+   Note that the values for these configuration options must be strings (wrapped in quotes) or they
+   may be wrong and cause a perpetual diff, causing Terraform to want to recreate your Elasticsearch
+   domain on every apply.
+* `ebs_options` - EBS related options, may be required based on chosen [instance size](https://aws.amazon.com/elasticsearch-service/pricing/). See below.
+* `encrypt_at_rest` - Encrypt at rest options. Only available for [certain instance types](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-instance-types.html). See below.
+* `node_to_node_encryption` - Node-to-node encryption options. See below.
+* `cluster_config` - Cluster configuration of the domain, see below.
+* `snapshot_options` - Snapshot related options, see below.
+* `vpc_options` - VPC related options, see below. Adding or removing this configuration forces a new resource ([documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html#es-vpc-limitations)).
+* `log_publishing_options` - Options for publishing slow logs to CloudWatch Logs.
+* `elasticsearch_version` - The version of Elasticsearch to deploy. Defaults to `1.5`
+* `tags` - A mapping of tags to assign to the resource
+
+**ebs_options** the following attributes are exported:
+
+* `ebs_enabled` - Whether EBS volumes are attached to data nodes in the domain
+* `volume_type` - The type of EBS volumes attached to data nodes.
+* `volume_size` - The size of EBS volumes attached to data nodes (in GB).
+**Required** if `ebs_enabled` is set to `true`.
+* `iops` - The baseline input/output (I/O) performance of EBS volumes
+	attached to data nodes. Applicable only for the Provisioned IOPS EBS volume type.
+
+**encrypt_at_rest** the following attributes are exported:
+
+* `enabled` - Whether to enable encryption at rest. If the `encrypt_at_rest` block is not provided then this defaults to `false`.
+* `kms_key_id` - The KMS key id to encrypt the Elasticsearch domain with. If not specified then it defaults to using the `aws/es` service KMS key.
+
+**cluster_config** the following attributes are exported:
+
+* `instance_type` - Instance type of data nodes in the cluster.
+* `instance_count` - Number of instances in the cluster.
+* `dedicated_master_enabled` - Indicates whether dedicated master nodes are enabled for the cluster.
+* `dedicated_master_type` - Instance type of the dedicated master nodes in the cluster.
+* `dedicated_master_count` - Number of dedicated master nodes in the cluster
+* `zone_awareness_enabled` - Indicates whether zone awareness is enabled.
+
+**node_to_node_encryption** the following attributes are exported:
+
+* `enabled` - Whether to enable node-to-node encryption. If the `node_to_node_encryption` block is not provided then this defaults to `false`.
+
+**vpc_options** the following attributes are exported:
+
+AWS documentation: [VPC Support for Amazon Elasticsearch Service Domains](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-vpc.html)
+
+**Note** you must have created the service linked role for the Elasticsearch service to use the `vpc_options`.
+If you need to create the service linked role at the same time as the Elasticsearch domain then you must use `depends_on` to make sure that the role is created before the Elasticsearch domain.
+See the [VPC based ES domain example](#vpc-based-es) above.
+
+* `security_group_ids` - List of VPC Security Group IDs to be applied to the Elasticsearch domain endpoints. If omitted, the default Security Group for the VPC will be used.
+* `subnet_ids` - List of VPC Subnet IDs for the Elasticsearch domain endpoints to be created in.
+
+Security Groups and Subnets referenced in these attributes must all be within the same VPC; this determines what VPC the endpoints are created in.
+
+**snapshot_options** the following attributes are exported:
+
+* `automated_snapshot_start_hour` - Hour during which the service takes an automated daily
+	snapshot of the indices in the domain.
+
+**log_publishing_options** the following attributes are exported:
+
+* `log_type` - A type of Elasticsearch log. Valid values: INDEX_SLOW_LOGS, SEARCH_SLOW_LOGS, ES_APPLICATION_LOGS
+* `cloudwatch_log_group_arn` - ARN of the Cloudwatch log group to which log needs to be published.
+* `enabled` - Specifies whether given log publishing option is enabled or not.
+
+**cognito_options** the following attributes are exported:
+
+AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-cognito-auth.html)
+
+* `enabled` - Specifies whether Amazon Cognito authentication with Kibana is enabled or not
+* `user_pool_id` - ID of the Cognito User Pool to use
+* `identity_pool_id` - ID of the Cognito Identity Pool to use
+* `role_arn` - ARN of the IAM role that has the AmazonESCognitoAccess policy attached


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7899 

Changes proposed in this pull request:

- [x] Add `aws_elasticsearch_domain` data source
- [x] Add `aws_elasticsearch_domain` data source acceptance test
- [x] Add `aws_elasticsearch_domain` data source document

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAWSElasticSearchDomain_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAWSElasticSearchDomain_ -timeout 120m
=== RUN   TestAccDataSourceAWSElasticSearchDomain_basic
=== PAUSE TestAccDataSourceAWSElasticSearchDomain_basic
=== RUN   TestAccDataSourceAWSElasticSearchDomain_withDedicatedMaster
=== PAUSE TestAccDataSourceAWSElasticSearchDomain_withDedicatedMaster
=== RUN   TestAccDataSourceAWSElasticSearchDomain_withPolicy
=== PAUSE TestAccDataSourceAWSElasticSearchDomain_withPolicy
=== RUN   TestAccDataSourceAWSElasticSearchDomain_withEncryptAtRestDefaultKey
=== PAUSE TestAccDataSourceAWSElasticSearchDomain_withEncryptAtRestDefaultKey
=== RUN   TestAccDataSourceAWSElasticSearchDomain_withNodeToNodeEncryption
=== PAUSE TestAccDataSourceAWSElasticSearchDomain_withNodeToNodeEncryption
=== RUN   TestAccDataSourceAWSElasticSearchDomain_complex
=== PAUSE TestAccDataSourceAWSElasticSearchDomain_complex
=== CONT  TestAccDataSourceAWSElasticSearchDomain_basic
=== CONT  TestAccDataSourceAWSElasticSearchDomain_withNodeToNodeEncryption
=== CONT  TestAccDataSourceAWSElasticSearchDomain_withPolicy
=== CONT  TestAccDataSourceAWSElasticSearchDomain_complex
=== CONT  TestAccDataSourceAWSElasticSearchDomain_withDedicatedMaster
=== CONT  TestAccDataSourceAWSElasticSearchDomain_withEncryptAtRestDefaultKey
--- PASS: TestAccDataSourceAWSElasticSearchDomain_withEncryptAtRestDefaultKey (780.75s)
--- PASS: TestAccDataSourceAWSElasticSearchDomain_basic (843.03s)
--- PASS: TestAccDataSourceAWSElasticSearchDomain_withPolicy (883.27s)
--- PASS: TestAccDataSourceAWSElasticSearchDomain_withNodeToNodeEncryption (903.07s)
--- PASS: TestAccDataSourceAWSElasticSearchDomain_complex (919.82s)
--- PASS: TestAccDataSourceAWSElasticSearchDomain_withDedicatedMaster (969.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	969.368s
```
