### PR TITLE
Add update step for change tags for aws_backup_vault resource

### DIFF
--- a/aws/resource_aws_backup_vault_test.go
+++ b/aws/resource_aws_backup_vault_test.go
@@ -72,6 +72,17 @@ func TestAccAwsBackupVault_withTags(t *testing.T) {
 				Config: testAccBackupVaultWithUpdateTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.%", "4"),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.up", "downdown"),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.left", "rightright"),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.fizz", "buzz"),
+				),
+			},
+			{
+				Config: testAccBackupVaultWithRemoveTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
 					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.%", "2"),
 					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.foo", "bar"),
 					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.fizz", "buzz"),
@@ -166,6 +177,21 @@ func testAccBackupVaultWithUpdateTags(randInt int) string {
 resource "aws_backup_vault" "test" {
 	name = "tf_acc_test_backup_vault_%d"
 	
+	tags = {
+		up		= "downdown"
+		left	= "rightright"
+		foo		= "bar"
+		fizz	= "buzz"
+	}
+}
+`, randInt)
+}
+
+func testAccBackupVaultWithRemoveTags(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+	name = "tf_acc_test_backup_vault_%d"
+
 	tags = {
 		foo		= "bar"
 		fizz	= "buzz"

--- a/aws/resource_aws_backup_vault_test.go
+++ b/aws/resource_aws_backup_vault_test.go
@@ -68,6 +68,15 @@ func TestAccAwsBackupVault_withTags(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.left", "right"),
 				),
 			},
+			{
+				Config: testAccBackupVaultWithUpdateTags(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.fizz", "buzz"),
+				),
+			},
 		},
 	})
 }
@@ -147,6 +156,19 @@ resource "aws_backup_vault" "test" {
 	tags = {
 		up		= "down"
 		left	= "right"
+	}
+}
+`, randInt)
+}
+
+func testAccBackupVaultWithUpdateTags(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_backup_vault" "test" {
+	name = "tf_acc_test_backup_vault_%d"
+	
+	tags = {
+		foo		= "bar"
+		fizz	= "buzz"
 	}
 }
 `, randInt)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7801 

Changes proposed in this pull request:

* Add step for update tags

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsBackupVault_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsBackupVault_ -timeout 120m
=== RUN   TestAccAwsBackupVault_basic
=== PAUSE TestAccAwsBackupVault_basic
=== RUN   TestAccAwsBackupVault_withKmsKey
=== PAUSE TestAccAwsBackupVault_withKmsKey
=== RUN   TestAccAwsBackupVault_withTags
=== PAUSE TestAccAwsBackupVault_withTags
=== CONT  TestAccAwsBackupVault_basic
=== CONT  TestAccAwsBackupVault_withTags
=== CONT  TestAccAwsBackupVault_withKmsKey
--- PASS: TestAccAwsBackupVault_basic (31.67s)
--- PASS: TestAccAwsBackupVault_withTags (52.90s)
--- PASS: TestAccAwsBackupVault_withKmsKey (65.63s)
PASS
ok  	github.com/terraform-providers/tmp-terraform-provider-aws/aws	65.699s
```
