### PR TITLE
Feature/fix aws directory service directory creation step

### DIFF
--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -215,6 +215,7 @@ func createDirectoryConnector(dsconn *directoryservice.DirectoryService, d *sche
 	input := directoryservice.ConnectDirectoryInput{
 		Name:     aws.String(d.Get("name").(string)),
 		Password: aws.String(d.Get("password").(string)),
+		Tags:     tagsFromMapDS(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -249,6 +250,7 @@ func createSimpleDirectoryService(dsconn *directoryservice.DirectoryService, d *
 	input := directoryservice.CreateDirectoryInput{
 		Name:     aws.String(d.Get("name").(string)),
 		Password: aws.String(d.Get("password").(string)),
+		Tags:     tagsFromMapDS(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("description"); ok {
@@ -283,6 +285,7 @@ func createActiveDirectoryService(dsconn *directoryservice.DirectoryService, d *
 	input := directoryservice.CreateMicrosoftADInput{
 		Name:     aws.String(d.Get("name").(string)),
 		Password: aws.String(d.Get("password").(string)),
+		Tags:     tagsFromMapDS(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -174,6 +174,26 @@ func TestAccAWSDirectoryServiceDirectory_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
 					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.project", "test"),
+				),
+			},
+			{
+				Config: testAccDirectoryServiceDirectoryUpdateTagsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.%", "3"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.project", "test2"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.fizz", "buzz"),
+				),
+			},
+			{
+				Config: testAccDirectoryServiceDirectoryRemoveTagsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_directory_service_directory.bar", "tags.foo", "bar"),
 				),
 			},
 		},
@@ -440,6 +460,90 @@ resource "aws_directory_service_directory" "bar" {
 	tags = {
 		foo = "bar"
 		project = "test"
+	}
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+	tags = {
+		Name = "terraform-testacc-directory-service-directory-tags"
+	}
+}
+
+resource "aws_subnet" "foo" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-west-2a"
+  cidr_block = "10.0.1.0/24"
+  tags = {
+    Name = "tf-acc-directory-service-directory-tags-foo"
+  }
+}
+resource "aws_subnet" "bar" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-west-2b"
+  cidr_block = "10.0.2.0/24"
+  tags = {
+    Name = "tf-acc-directory-service-directory-tags-bar"
+  }
+}
+`
+
+const testAccDirectoryServiceDirectoryUpdateTagsConfig = `
+resource "aws_directory_service_directory" "bar" {
+  name = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  size = "Small"
+
+  vpc_settings {
+    vpc_id = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  }
+
+	tags = {
+		foo = "bar"
+		project = "test2"
+		fizz = "buzz"
+	}
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+	tags = {
+		Name = "terraform-testacc-directory-service-directory-tags"
+	}
+}
+
+resource "aws_subnet" "foo" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-west-2a"
+  cidr_block = "10.0.1.0/24"
+  tags = {
+    Name = "tf-acc-directory-service-directory-tags-foo"
+  }
+}
+resource "aws_subnet" "bar" {
+  vpc_id = "${aws_vpc.main.id}"
+  availability_zone = "us-west-2b"
+  cidr_block = "10.0.2.0/24"
+  tags = {
+    Name = "tf-acc-directory-service-directory-tags-bar"
+  }
+}
+`
+
+const testAccDirectoryServiceDirectoryRemoveTagsConfig = `
+resource "aws_directory_service_directory" "bar" {
+  name = "corp.notexample.com"
+  password = "SuperSecretPassw0rd"
+  size = "Small"
+
+  vpc_settings {
+    vpc_id = "${aws_vpc.main.id}"
+    subnet_ids = ["${aws_subnet.foo.id}", "${aws_subnet.bar.id}"]
+  }
+
+	tags = {
+		foo = "bar"
 	}
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7672 

Changes proposed in this pull request:

* Add Tags setting in creation request.
* Remove `resourceAwsDirectoryServiceDirectoryUpdate` calling from Create step.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDirectoryServiceDirectory_ -timeout 120m
=== RUN   TestAccAWSDirectoryServiceDirectory_importBasic
=== PAUSE TestAccAWSDirectoryServiceDirectory_importBasic
=== RUN   TestAccAWSDirectoryServiceDirectory_basic
=== PAUSE TestAccAWSDirectoryServiceDirectory_basic
=== RUN   TestAccAWSDirectoryServiceDirectory_tags
=== PAUSE TestAccAWSDirectoryServiceDirectory_tags
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoft
=== PAUSE TestAccAWSDirectoryServiceDirectory_microsoft
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoftStandard
=== PAUSE TestAccAWSDirectoryServiceDirectory_microsoftStandard
=== RUN   TestAccAWSDirectoryServiceDirectory_connector
=== PAUSE TestAccAWSDirectoryServiceDirectory_connector
=== RUN   TestAccAWSDirectoryServiceDirectory_withAliasAndSso
=== PAUSE TestAccAWSDirectoryServiceDirectory_withAliasAndSso
=== CONT  TestAccAWSDirectoryServiceDirectory_importBasic
=== CONT  TestAccAWSDirectoryServiceDirectory_microsoftStandard
=== CONT  TestAccAWSDirectoryServiceDirectory_withAliasAndSso
=== CONT  TestAccAWSDirectoryServiceDirectory_tags
=== CONT  TestAccAWSDirectoryServiceDirectory_microsoft
=== CONT  TestAccAWSDirectoryServiceDirectory_basic
=== CONT  TestAccAWSDirectoryServiceDirectory_connector
--- FAIL: TestAccAWSDirectoryServiceDirectory_basic (13.53s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpc.main: 1 error occurred:
        	* aws_vpc.main: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
        	status code: 400, request id: 3309e6bb-c298-4ae9-9056-e3616ca61f97




    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Check failed: Default error in Service Directory Test

        State: <no state>
--- FAIL: TestAccAWSDirectoryServiceDirectory_microsoftStandard (13.64s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpc.main: 1 error occurred:
        	* aws_vpc.main: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
        	status code: 400, request id: ed8b751b-2b54-4384-bc4c-317d13d7275a




    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Check failed: Default error in Service Directory Test

        State: <no state>
--- PASS: TestAccAWSDirectoryServiceDirectory_importBasic (665.52s)
--- PASS: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (701.98s)
--- PASS: TestAccAWSDirectoryServiceDirectory_tags (725.32s)
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (1266.15s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (1744.61s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	1744.686s
make: *** [testacc] Error 1
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDirectoryServiceDirectory_basic -timeout 120m
=== RUN   TestAccAWSDirectoryServiceDirectory_basic
=== PAUSE TestAccAWSDirectoryServiceDirectory_basic
=== CONT  TestAccAWSDirectoryServiceDirectory_basic
--- PASS: TestAccAWSDirectoryServiceDirectory_basic (568.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	568.129s
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_microsoftStandard'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSDirectoryServiceDirectory_microsoftStandard -timeout 120m
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoftStandard
=== PAUSE TestAccAWSDirectoryServiceDirectory_microsoftStandard
=== CONT  TestAccAWSDirectoryServiceDirectory_microsoftStandard
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoftStandard (1882.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1882.653s
```
