### PR TITLE
Address linting issue

### DIFF
--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -51,7 +51,7 @@ func resourceAwsCodeBuildWebhookCreate(d *schema.ResourceData, meta interface{})
 	conn := meta.(*AWSClient).codebuildconn
 
 	input := &codebuild.CreateWebhookInput{
-		ProjectName:  aws.String(d.Get("project_name").(string)),
+		ProjectName: aws.String(d.Get("project_name").(string)),
 	}
 
 	// The CodeBuild API requires this to be non-empty if defined


### PR DESCRIPTION
resource/aws_codebuild_webhook: Run go fmt on source code

Output from `make lint` before change:
```
> make lint
==> Checking source code against linters...
aws/resource_aws_codebuild_webhook.go:54: File is not `gofmt`-ed with `-s` (gofmt)
                ProjectName:  aws.String(d.Get("project_name").(string)),
CGNUmakefile:34: recipe for target 'lint' failed
```


Output from `make lint` after change:
```
> make lint
==> Checking source code against linters...
```