### PR TITLE
Add arn of the glue crawler

### DIFF
--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -32,6 +32,10 @@ func resourceAwsGlueCrawler() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"database_name": {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -459,6 +463,14 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "glue",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("crawler/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 	d.Set("name", crawlerOutput.Crawler.Name)
 	d.Set("database_name", crawlerOutput.Crawler.DatabaseName)
 	d.Set("role", crawlerOutput.Crawler.Role)

--- a/aws/resource_aws_glue_crawler.go
+++ b/aws/resource_aws_glue_crawler.go
@@ -463,14 +463,14 @@ func resourceAwsGlueCrawlerRead(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	arn := arn.ARN{
+	crawlerARN := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   "glue",
 		Region:    meta.(*AWSClient).region,
 		AccountID: meta.(*AWSClient).accountid,
 		Resource:  fmt.Sprintf("crawler/%s", d.Id()),
 	}.String()
-	d.Set("arn", arn)
+	d.Set("arn", crawlerARN)
 	d.Set("name", crawlerOutput.Crawler.Name)
 	d.Set("database_name", crawlerOutput.Crawler.DatabaseName)
 	d.Set("role", crawlerOutput.Crawler.Role)

--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -73,6 +73,7 @@ func TestAccAWSGlueCrawler_DynamodbTarget(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_DynamodbTarget(rName, "table1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
@@ -94,6 +95,7 @@ func TestAccAWSGlueCrawler_DynamodbTarget(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_DynamodbTarget(rName, "table2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
@@ -134,6 +136,7 @@ func TestAccAWSGlueCrawler_JdbcTarget(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_JdbcTarget(rName, "database-name/%"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
@@ -157,6 +160,7 @@ func TestAccAWSGlueCrawler_JdbcTarget(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_JdbcTarget(rName, "database-name/table-name"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
@@ -199,6 +203,7 @@ func TestAccAWSGlueCrawler_JdbcTarget_Exclusions(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_JdbcTarget_Exclusions2(rName, "exclusion1", "exclusion2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.0", "exclusion1"),
@@ -209,6 +214,7 @@ func TestAccAWSGlueCrawler_JdbcTarget_Exclusions(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_JdbcTarget_Exclusions1(rName, "exclusion1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.0", "exclusion1"),
@@ -237,6 +243,7 @@ func TestAccAWSGlueCrawler_JdbcTarget_Multiple(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_JdbcTarget_Multiple(rName, "database-name/table1", "database-name/table2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.connection_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.#", "0"),
@@ -250,6 +257,7 @@ func TestAccAWSGlueCrawler_JdbcTarget_Multiple(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_JdbcTarget(rName, "database-name/table1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.connection_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.#", "0"),
@@ -261,6 +269,7 @@ func TestAccAWSGlueCrawler_JdbcTarget_Multiple(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.#", "2"),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.connection_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.exclusions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "jdbc_target.0.path", "database-name/table1"),
@@ -292,6 +301,7 @@ func TestAccAWSGlueCrawler_S3Target(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_S3Target(rName, "s3://bucket1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
@@ -314,6 +324,7 @@ func TestAccAWSGlueCrawler_S3Target(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_S3Target(rName, "s3://bucket2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "classifiers.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration", ""),
 					resource.TestCheckResourceAttr(resourceName, "database_name", rName),
@@ -355,6 +366,7 @@ func TestAccAWSGlueCrawler_S3Target_Exclusions(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_S3Target_Exclusions2(rName, "exclusion1", "exclusion2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.exclusions.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.exclusions.0", "exclusion1"),
@@ -365,6 +377,7 @@ func TestAccAWSGlueCrawler_S3Target_Exclusions(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_S3Target_Exclusions1(rName, "exclusion1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.exclusions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.exclusions.0", "exclusion1"),
@@ -393,6 +406,7 @@ func TestAccAWSGlueCrawler_S3Target_Multiple(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_S3Target_Multiple(rName, "s3://bucket1", "s3://bucket2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.exclusions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.path", "s3://bucket1"),
@@ -404,6 +418,7 @@ func TestAccAWSGlueCrawler_S3Target_Multiple(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_S3Target(rName, "s3://bucket1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.exclusions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.path", "s3://bucket1"),
@@ -413,6 +428,7 @@ func TestAccAWSGlueCrawler_S3Target_Multiple(t *testing.T) {
 				Config: testAccGlueCrawlerConfig_S3Target_Multiple(rName, "s3://bucket1", "s3://bucket2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSGlueCrawlerExists(resourceName, &crawler),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "glue", fmt.Sprintf("crawler/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.exclusions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "s3_target.0.path", "s3://bucket1"),

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -238,6 +238,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   - [`aws_elasticache_cluster` data source](/docs/providers/aws/d/elasticache_cluster.html)
   - [`aws_elasticache_cluster` resource](/docs/providers/aws/r/elasticache_cluster.html)
   - [`aws_elb` resource](/docs/providers/aws/r/elb.html)
+  - [`aws_glue_crawler` resource](/docs/providers/aws/r/glue_crawler.html)
   - [`aws_instance` data source](/docs/providers/aws/d/instance.html)
   - [`aws_instance` resource](/docs/providers/aws/r/instance.html)
   - [`aws_launch_template` resource](/docs/providers/aws/r/launch_template.html)

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -100,6 +100,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Crawler name
+* `arn` - The ARN of the crawler 
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7934 

Changes proposed in this pull request:

* Add arn attribute for the glue crawler resource.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSGlueCrawler_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSGlueCrawler_ -timeout 120m
=== RUN   TestAccAWSGlueCrawler_DynamodbTarget
=== PAUSE TestAccAWSGlueCrawler_DynamodbTarget
=== RUN   TestAccAWSGlueCrawler_JdbcTarget
=== PAUSE TestAccAWSGlueCrawler_JdbcTarget
=== RUN   TestAccAWSGlueCrawler_JdbcTarget_Exclusions
=== PAUSE TestAccAWSGlueCrawler_JdbcTarget_Exclusions
=== RUN   TestAccAWSGlueCrawler_JdbcTarget_Multiple
=== PAUSE TestAccAWSGlueCrawler_JdbcTarget_Multiple
=== RUN   TestAccAWSGlueCrawler_S3Target
=== PAUSE TestAccAWSGlueCrawler_S3Target
=== RUN   TestAccAWSGlueCrawler_S3Target_Exclusions
=== PAUSE TestAccAWSGlueCrawler_S3Target_Exclusions
=== RUN   TestAccAWSGlueCrawler_S3Target_Multiple
=== PAUSE TestAccAWSGlueCrawler_S3Target_Multiple
=== RUN   TestAccAWSGlueCrawler_recreates
=== PAUSE TestAccAWSGlueCrawler_recreates
=== RUN   TestAccAWSGlueCrawler_Classifiers
=== PAUSE TestAccAWSGlueCrawler_Classifiers
=== RUN   TestAccAWSGlueCrawler_Configuration
=== PAUSE TestAccAWSGlueCrawler_Configuration
=== RUN   TestAccAWSGlueCrawler_Description
=== PAUSE TestAccAWSGlueCrawler_Description
=== RUN   TestAccAWSGlueCrawler_Role_ARN_NoPath
=== PAUSE TestAccAWSGlueCrawler_Role_ARN_NoPath
=== RUN   TestAccAWSGlueCrawler_Role_ARN_Path
=== PAUSE TestAccAWSGlueCrawler_Role_ARN_Path
=== RUN   TestAccAWSGlueCrawler_Role_Name_Path
=== PAUSE TestAccAWSGlueCrawler_Role_Name_Path
=== RUN   TestAccAWSGlueCrawler_Schedule
=== PAUSE TestAccAWSGlueCrawler_Schedule
=== RUN   TestAccAWSGlueCrawler_SchemaChangePolicy
=== PAUSE TestAccAWSGlueCrawler_SchemaChangePolicy
=== RUN   TestAccAWSGlueCrawler_TablePrefix
=== PAUSE TestAccAWSGlueCrawler_TablePrefix
=== RUN   TestAccAWSGlueCrawler_SecurityConfiguration
=== PAUSE TestAccAWSGlueCrawler_SecurityConfiguration
=== CONT  TestAccAWSGlueCrawler_Schedule
=== CONT  TestAccAWSGlueCrawler_SecurityConfiguration
=== CONT  TestAccAWSGlueCrawler_DynamodbTarget
=== CONT  TestAccAWSGlueCrawler_Role_Name_Path
=== CONT  TestAccAWSGlueCrawler_Role_ARN_Path
=== CONT  TestAccAWSGlueCrawler_Role_ARN_NoPath
=== CONT  TestAccAWSGlueCrawler_Description
=== CONT  TestAccAWSGlueCrawler_Configuration
=== CONT  TestAccAWSGlueCrawler_Classifiers
=== CONT  TestAccAWSGlueCrawler_recreates
=== CONT  TestAccAWSGlueCrawler_S3Target_Multiple
=== CONT  TestAccAWSGlueCrawler_S3Target_Exclusions
=== CONT  TestAccAWSGlueCrawler_S3Target
=== CONT  TestAccAWSGlueCrawler_JdbcTarget_Multiple
=== CONT  TestAccAWSGlueCrawler_JdbcTarget_Exclusions
=== CONT  TestAccAWSGlueCrawler_TablePrefix
=== CONT  TestAccAWSGlueCrawler_JdbcTarget
=== CONT  TestAccAWSGlueCrawler_SchemaChangePolicy
--- PASS: TestAccAWSGlueCrawler_Role_ARN_NoPath (54.94s)
--- PASS: TestAccAWSGlueCrawler_recreates (57.04s)
--- PASS: TestAccAWSGlueCrawler_Role_Name_Path (58.20s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_Path (66.06s)
--- PASS: TestAccAWSGlueCrawler_Configuration (76.62s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (77.19s)
--- PASS: TestAccAWSGlueCrawler_Description (81.93s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (82.54s)
--- PASS: TestAccAWSGlueCrawler_S3Target (85.16s)
--- PASS: TestAccAWSGlueCrawler_SecurityConfiguration (85.33s)
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (91.27s)
--- PASS: TestAccAWSGlueCrawler_TablePrefix (93.95s)
--- PASS: TestAccAWSGlueCrawler_Schedule (94.12s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (94.81s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (104.17s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (108.94s)
--- PASS: TestAccAWSGlueCrawler_Classifiers (113.93s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (116.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	116.966s
```
