### PR TITLE
Enabled updates to existing IAM Access Keys

### DIFF
--- a/aws/resource_aws_iam_access_key.go
+++ b/aws/resource_aws_iam_access_key.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/encryption"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsIamAccessKey() *schema.Resource {
@@ -31,6 +32,10 @@ func resourceAwsIamAccessKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					iam.StatusTypeActive,
+					iam.StatusTypeInactive,
+				}, false),
 			},
 			"secret": {
 				Type:       schema.TypeString,

--- a/aws/resource_aws_iam_access_key_test.go
+++ b/aws/resource_aws_iam_access_key_test.go
@@ -28,7 +28,7 @@ func TestAccAWSAccessKey_basic(t *testing.T) {
 				Config: testAccAWSAccessKeyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAccessKeyExists("aws_iam_access_key.a_key", &conf),
-					testAccCheckAWSAccessKeyAttributes(&conf),
+					testAccCheckAWSAccessKeyAttributes(&conf, "Active"),
 					resource.TestCheckResourceAttrSet("aws_iam_access_key.a_key", "secret"),
 				),
 			},
@@ -49,7 +49,7 @@ func TestAccAWSAccessKey_encrypted(t *testing.T) {
 				Config: testAccAWSAccessKeyConfig_encrypted(rName, testPubKey1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAccessKeyExists("aws_iam_access_key.a_key", &conf),
-					testAccCheckAWSAccessKeyAttributes(&conf),
+					testAccCheckAWSAccessKeyAttributes(&conf, "Active"),
 					testDecryptSecretKeyAndTest("aws_iam_access_key.a_key", testPrivKey1),
 					resource.TestCheckNoResourceAttr(
 						"aws_iam_access_key.a_key", "secret"),
@@ -57,6 +57,35 @@ func TestAccAWSAccessKey_encrypted(t *testing.T) {
 						"aws_iam_access_key.a_key", "encrypted_secret"),
 					resource.TestCheckResourceAttrSet(
 						"aws_iam_access_key.a_key", "key_fingerprint"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSAccessKey_inactive(t *testing.T) {
+	var conf iam.AccessKeyMetadata
+	rName := fmt.Sprintf("test-user-%d", acctest.RandInt())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAccessKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAccessKeyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAccessKeyExists("aws_iam_access_key.a_key", &conf),
+					testAccCheckAWSAccessKeyAttributes(&conf, "Active"),
+					resource.TestCheckResourceAttrSet("aws_iam_access_key.a_key", "secret"),
+				),
+			},
+			{
+				Config: testAccAWSAccessKeyConfig_inactive(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAccessKeyExists("aws_iam_access_key.a_key", &conf),
+					testAccCheckAWSAccessKeyAttributes(&conf, "Inactive"),
+					resource.TestCheckResourceAttrSet("aws_iam_access_key.a_key", "secret"),
 				),
 			},
 		},
@@ -127,13 +156,13 @@ func testAccCheckAWSAccessKeyExists(n string, res *iam.AccessKeyMetadata) resour
 	}
 }
 
-func testAccCheckAWSAccessKeyAttributes(accessKeyMetadata *iam.AccessKeyMetadata) resource.TestCheckFunc {
+func testAccCheckAWSAccessKeyAttributes(accessKeyMetadata *iam.AccessKeyMetadata, status string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if !strings.Contains(*accessKeyMetadata.UserName, "test-user") {
 			return fmt.Errorf("Bad username: %s", *accessKeyMetadata.UserName)
 		}
 
-		if *accessKeyMetadata.Status != "Active" {
+		if *accessKeyMetadata.Status != status {
 			return fmt.Errorf("Bad status: %s", *accessKeyMetadata.Status)
 		}
 
@@ -189,6 +218,19 @@ resource "aws_iam_access_key" "a_key" {
 EOF
 }
 `, rName, key)
+}
+
+func testAccAWSAccessKeyConfig_inactive(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_user" "a_user" {
+        name = "%s"
+}
+
+resource "aws_iam_access_key" "a_key" {
+		user   = "${aws_iam_user.a_user.name}"
+		status = "Inactive"
+}
+`, rName)
 }
 
 func TestSesSmtpPasswordFromSecretKey(t *testing.T) {

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -55,7 +55,8 @@ The following arguments are supported:
 * `user` - (Required) The IAM user to associate with this access key.
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a
   keybase username in the form `keybase:some_person_that_exists`.
-* `status` - (Optional) The access key status to apply. Defaults to "Active".
+* `status` - (Optional) The access key status to apply. Defaults to `Active`.
+Valid values are `Active` and `Inactive`.
 
 ## Attributes Reference
 

--- a/website/docs/r/iam_access_key.html.markdown
+++ b/website/docs/r/iam_access_key.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 * `user` - (Required) The IAM user to associate with this access key.
 * `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a
   keybase username in the form `keybase:some_person_that_exists`.
+* `status` - (Optional) The access key status to apply. Defaults to "Active".
 
 ## Attributes Reference
 
@@ -73,5 +74,3 @@ secret from being stored in plain text
 * `ses_smtp_password` - The secret access key converted into an SES SMTP
   password by applying [AWS's documented conversion
   algorithm](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).
-* `status` - "Active" or "Inactive". Keys are initially active, but can be made
-	inactive by other means.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Flag the IAM Access Key status field as optional to support disabling keys via Terraform (e.g. automate key rotation)

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAccessKey_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAccessKey_ -timeout 120m
=== RUN   TestAccAWSAccessKey_basic
=== PAUSE TestAccAWSAccessKey_basic
=== RUN   TestAccAWSAccessKey_encrypted
=== PAUSE TestAccAWSAccessKey_encrypted
=== RUN   TestAccAWSAccessKey_inactive
=== PAUSE TestAccAWSAccessKey_inactive
=== CONT  TestAccAWSAccessKey_basic
=== CONT  TestAccAWSAccessKey_encrypted
=== CONT  TestAccAWSAccessKey_inactive
--- PASS: TestAccAWSAccessKey_encrypted (9.02s)
--- PASS: TestAccAWSAccessKey_basic (9.06s)
--- PASS: TestAccAWSAccessKey_inactive (12.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       12.396s
```