### PR TITLE
resource/aws_route53_zone_association: Support resource import and recreate resource on all updates

### DIFF
--- a/aws/resource_aws_route53_zone_association_test.go
+++ b/aws/resource_aws_route53_zone_association_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
 func TestAccAWSRoute53ZoneAssociation_basic(t *testing.T) {
-	var zone route53.HostedZone
+	var vpc route53.VPC
+	resourceName := "aws_route53_zone_association.foobar"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,15 +25,93 @@ func TestAccAWSRoute53ZoneAssociation_basic(t *testing.T) {
 			{
 				Config: testAccRoute53ZoneAssociationConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneAssociationExists("aws_route53_zone_association.foobar", &zone),
+					testAccCheckRoute53ZoneAssociationExists(resourceName, &vpc),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ZoneAssociation_disappears(t *testing.T) {
+	var vpc route53.VPC
+	var zone route53.GetHostedZoneOutput
+	resourceName := "aws_route53_zone_association.foobar"
+	route53ZoneResourceName := "aws_route53_zone.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(route53ZoneResourceName, &zone),
+					testAccCheckRoute53ZoneAssociationExists(resourceName, &vpc),
+					testAccCheckRoute53ZoneAssociationDisappears(&zone, &vpc),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ZoneAssociation_disappears_VPC(t *testing.T) {
+	var ec2Vpc ec2.Vpc
+	var route53Vpc route53.VPC
+	resourceName := "aws_route53_zone_association.foobar"
+	vpcResourceName := "aws_vpc.bar"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneAssociationExists(resourceName, &route53Vpc),
+					testAccCheckVpcExists(vpcResourceName, &ec2Vpc),
+					testAccCheckVpcDisappears(&ec2Vpc),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53ZoneAssociation_disappears_Zone(t *testing.T) {
+	var vpc route53.VPC
+	var zone route53.GetHostedZoneOutput
+	resourceName := "aws_route53_zone_association.foobar"
+	route53ZoneResourceName := "aws_route53_zone.foo"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(route53ZoneResourceName, &zone),
+					testAccCheckRoute53ZoneAssociationExists(resourceName, &vpc),
+					testAccCheckRoute53ZoneDisappears(&zone),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
 func TestAccAWSRoute53ZoneAssociation_region(t *testing.T) {
-	var zone route53.HostedZone
+	var vpc route53.VPC
+	resourceName := "aws_route53_zone_association.foobar"
 
 	// record the initialized providers so that we can use them to
 	// check for the instances in each region
@@ -45,9 +125,15 @@ func TestAccAWSRoute53ZoneAssociation_region(t *testing.T) {
 			{
 				Config: testAccRoute53ZoneAssociationRegionConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneAssociationExistsWithProvider("aws_route53_zone_association.foobar", &zone,
+					testAccCheckRoute53ZoneAssociationExistsWithProvider(resourceName, &vpc,
 						testAccAwsRegionProviderFunc("us-west-2", &providers)),
 				),
+			},
+			{
+				Config:            testAccRoute53ZoneAssociationRegionConfig,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -64,29 +150,34 @@ func testAccCheckRoute53ZoneAssociationDestroyWithProvider(s *terraform.State, p
 			continue
 		}
 
-		zone_id, vpc_id := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
+		zoneID, vpcID, err := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
 
-		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone_id)})
 		if err != nil {
-			exists := false
-			for _, vpc := range resp.VPCs {
-				if vpc_id == *vpc.VPCId {
-					exists = true
-				}
-			}
-			if exists {
-				return fmt.Errorf("VPC: %v is still associated to HostedZone: %v", vpc_id, zone_id)
-			}
+			return err
+		}
+
+		vpc, err := route53GetZoneAssociation(conn, zoneID, vpcID)
+
+		if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if vpc != nil {
+			return fmt.Errorf("Route 53 Hosted Zone (%s) Association (%s) still exists", zoneID, vpcID)
 		}
 	}
 	return nil
 }
 
-func testAccCheckRoute53ZoneAssociationExists(n string, zone *route53.HostedZone) resource.TestCheckFunc {
-	return testAccCheckRoute53ZoneAssociationExistsWithProvider(n, zone, func() *schema.Provider { return testAccProvider })
+func testAccCheckRoute53ZoneAssociationExists(n string, vpc *route53.VPC) resource.TestCheckFunc {
+	return testAccCheckRoute53ZoneAssociationExistsWithProvider(n, vpc, func() *schema.Provider { return testAccProvider })
 }
 
-func testAccCheckRoute53ZoneAssociationExistsWithProvider(n string, zone *route53.HostedZone, providerF func() *schema.Provider) resource.TestCheckFunc {
+func testAccCheckRoute53ZoneAssociationExistsWithProvider(n string, vpc *route53.VPC, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -97,27 +188,44 @@ func testAccCheckRoute53ZoneAssociationExistsWithProvider(n string, zone *route5
 			return fmt.Errorf("No zone association ID is set")
 		}
 
-		zone_id, vpc_id := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
+		zoneID, vpcID, err := resourceAwsRoute53ZoneAssociationParseId(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
 
 		provider := providerF()
 		conn := provider.Meta().(*AWSClient).r53conn
-		resp, err := conn.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zone_id)})
+
+		associationVPC, err := route53GetZoneAssociation(conn, zoneID, vpcID)
+
 		if err != nil {
-			return fmt.Errorf("Hosted zone err: %v", err)
+			return err
 		}
 
-		exists := false
-		for _, vpc := range resp.VPCs {
-			if vpc_id == *vpc.VPCId {
-				exists = true
-			}
-		}
-		if !exists {
-			return fmt.Errorf("Hosted zone association not found")
+		if associationVPC == nil {
+			return fmt.Errorf("Route 53 Hosted Zone (%s) Association (%s) not found", zoneID, vpcID)
 		}
 
-		*zone = *resp.HostedZone
+		*vpc = *associationVPC
+
 		return nil
+	}
+}
+
+func testAccCheckRoute53ZoneAssociationDisappears(zone *route53.GetHostedZoneOutput, vpc *route53.VPC) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).r53conn
+
+		input := &route53.DisassociateVPCFromHostedZoneInput{
+			HostedZoneId: zone.HostedZone.Id,
+			VPC:          vpc,
+			Comment:      aws.String("Managed by Terraform"),
+		}
+
+		_, err := conn.DisassociateVPCFromHostedZone(input)
+
+		return err
 	}
 }
 

--- a/website/docs/r/route53_zone_association.html.markdown
+++ b/website/docs/r/route53_zone_association.html.markdown
@@ -68,3 +68,11 @@ In addition to all arguments above, the following attributes are exported:
 * `zone_id` - The ID of the hosted zone for the association.
 * `vpc_id` - The ID of the VPC for the association.
 * `vpc_region` - The region in which the VPC identified by `vpc_id` was created.
+
+## Import
+
+Route 53 Hosted Zone Associations can be imported via the Hosted Zone ID and VPC ID, separated by a colon (`:`), e.g.
+
+```
+$ terraform import aws_route53_zone_association.example Z123456ABCDEFG:vpc-12345678
+```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7964
Closes #2832

Changes proposed in this pull request:

* tests/resource/aws_vpc: Add acceptance testing to verify Terraform resource recreation after external deletion
* tests/resource/aws_route53_zone: Add acceptance testing to verify Terraform resource recreation after external deletion
* resource/aws_route53_zone_association: Support resource import and recreate resource on all updates

Previously the resource implemented an `Update` function that did not perform any updates. All attributes were switched to `ForceNew: true` and the `Update` function removed.

The new `TestAccAWSRoute53ZoneAssociation_disappears_VPC` acceptance test explicitly verified #2832 by showing DESTROY/CREATE on the resource for properly referenced VPC that was externally deleted from Terraform.

```
DESTROY/CREATE: aws_route53_zone_association.foobar
  vpc_id:     "vpc-0760bf69d6ba598c6" => "<computed>" (forces new resource)
  vpc_region: "us-west-2" => "<computed>"
  zone_id:    "Z3FP49IAL6M01X" => "Z3FP49IAL6M01X"
CREATE: aws_vpc.bar
  arn:                              "" => "<computed>"
  assign_generated_ipv6_cidr_block: "" => "false"
  cidr_block:                       "" => "10.7.0.0/16" (forces new resource)
  default_network_acl_id:           "" => "<computed>"
  default_route_table_id:           "" => "<computed>"
  default_security_group_id:        "" => "<computed>"
  dhcp_options_id:                  "" => "<computed>"
  enable_classiclink:               "" => "<computed>"
  enable_classiclink_dns_support:   "" => "<computed>"
  enable_dns_hostnames:             "" => "true"
  enable_dns_support:               "" => "true"
  instance_tenancy:                 "" => "default" (forces new resource)
  ipv6_association_id:              "" => "<computed>"
  ipv6_cidr_block:                  "" => "<computed>"
  main_route_table_id:              "" => "<computed>"
  owner_id:                         "" => "<computed>"
  tags.%:                           "" => "1"
  tags.Name:                        "" => "terraform-testacc-route53-zone-association-bar"
```

Output from acceptance testing:

```
--- PASS: TestAccAWSVpc_disappears (13.48s)

--- PASS: TestAccAWSRoute53Zone_disappears (40.98s)

--- PASS: TestAccAWSRoute53ZoneAssociation_basic (114.23s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears (131.71s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_VPC (115.04s)
--- PASS: TestAccAWSRoute53ZoneAssociation_disappears_Zone (123.63s)
--- PASS: TestAccAWSRoute53ZoneAssociation_region (115.49s)
```
