### PR TITLE
docs/resource/aws_s3_bucket_notification: Add note that multiple resource declarations to the same S3 Bucket will generate a perpetual difference

### DIFF
--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -3,12 +3,14 @@ layout: "aws"
 page_title: "AWS: aws_s3_bucket_notification"
 sidebar_current: "docs-aws-resource-s3-bucket-notification"
 description: |-
-  Provides a S3 bucket notification resource.
+  Manages a S3 Bucket Notification Configuration
 ---
 
 # aws_s3_bucket_notification
 
-Provides a S3 bucket notification resource.
+Manages a S3 Bucket Notification Configuration. For additional information, see the [Configuring S3 Event Notifications section in the Amazon S3 Developer Guide](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html).
+
+~> **NOTE:** S3 Buckets only support a single notification configuration. Declaring multiple `aws_s3_bucket_notification` resources to the same S3 Bucket will cause a perpetual difference in configuration.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #5299
Closes #1715
Closes #271

We will keep #501 open with the feature request to support multiple resources with the same S3 Bucket, however as noted there, S3 API limitations may prevent that implementation.
