### PR TITLE
tests/resource/aws_s3_bucket_notification: Refactor for concurrency and add Lambda Alias test

### DIFF
--- a/aws/resource_aws_s3_bucket_notification_test.go
+++ b/aws/resource_aws_s3_bucket_notification_test.go
@@ -16,60 +16,38 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
-	rString := acctest.RandString(8)
-
-	topicName := fmt.Sprintf("tf-acc-topic-s3-b-n-import-%s", rString)
-	bucketName := fmt.Sprintf("tf-acc-bucket-n-import-%s", rString)
-	queueName := fmt.Sprintf("tf-acc-queue-s3-b-n-import-%s", rString)
-	roleName := fmt.Sprintf("tf-acc-role-s3-b-n-import-%s", rString)
-	lambdaFuncName := fmt.Sprintf("tf-acc-lambda-func-s3-b-n-import-%s", rString)
-
+func TestAccAWSS3BucketNotification_LambdaFunction(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_s3_bucket_notification.notification"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSS3BucketConfigWithTopicNotification(topicName, bucketName),
+				Config: testAccAWSS3BucketNotificationConfigLambdaFunction(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketLambdaFunctionConfiguration(
+						"aws_s3_bucket.bucket",
+						"notification-lambda",
+						"aws_lambda_function.func",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						&s3.KeyFilter{
+							FilterRules: []*s3.FilterRule{
+								{
+									Name:  aws.String("Prefix"),
+									Value: aws.String("tf-acc-test/"),
+								},
+								{
+									Name:  aws.String("Suffix"),
+									Value: aws.String(".png"),
+								},
+							},
+						},
+					),
+				),
 			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSS3BucketConfigWithQueueNotification(queueName, bucketName),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSS3BucketConfigWithLambdaNotification(roleName, lambdaFuncName, bucketName),
-			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -79,14 +57,9 @@ func TestAccAWSS3BucketNotification_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3BucketNotification_basic(t *testing.T) {
-	rString := acctest.RandString(8)
-
-	topicName := fmt.Sprintf("tf-acc-topic-s3-b-notification-%s", rString)
-	bucketName := fmt.Sprintf("tf-acc-bucket-notification-%s", rString)
-	queueName := fmt.Sprintf("tf-acc-queue-s3-b-notification-%s", rString)
-	roleName := fmt.Sprintf("tf-acc-role-s3-b-notification-%s", rString)
-	lambdaFuncName := fmt.Sprintf("tf-acc-lambda-func-s3-b-notification-%s", rString)
+func TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_notification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -94,7 +67,108 @@ func TestAccAWSS3BucketNotification_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSS3BucketConfigWithTopicNotification(topicName, bucketName),
+				Config: testAccAWSS3BucketNotificationConfigLambdaFunctionLambdaFunctionArnAlias(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketLambdaFunctionConfiguration(
+						"aws_s3_bucket.test",
+						"test",
+						"aws_lambda_alias.test",
+						[]string{"s3:ObjectCreated:*"},
+						nil,
+					),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketNotification_Queue(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_notification.notification"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketNotificationConfigQueue(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketQueueNotification(
+						"aws_s3_bucket.bucket",
+						"notification-sqs",
+						"aws_sqs_queue.queue",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						&s3.KeyFilter{
+							FilterRules: []*s3.FilterRule{
+								{
+									Name:  aws.String("Prefix"),
+									Value: aws.String("tf-acc-test/"),
+								},
+								{
+									Name:  aws.String("Suffix"),
+									Value: aws.String(".mp4"),
+								},
+							},
+						},
+					),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketNotification_Topic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_notification.notification"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketNotificationConfigTopic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketTopicNotification(
+						"aws_s3_bucket.bucket",
+						"notification-sns1",
+						"aws_sns_topic.topic",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						nil,
+					),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketNotification_Topic_Multiple(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_s3_bucket_notification.notification"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketNotificationConfigTopicMultiple(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketTopicNotification(
 						"aws_s3_bucket.bucket",
@@ -131,7 +205,36 @@ func TestAccAWSS3BucketNotification_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSS3BucketConfigWithQueueNotification(queueName, bucketName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSS3BucketNotification_update(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketNotificationConfigTopic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketTopicNotification(
+						"aws_s3_bucket.bucket",
+						"notification-sns1",
+						"aws_sns_topic.topic",
+						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
+						nil,
+					),
+				),
+			},
+			{
+				Config: testAccAWSS3BucketNotificationConfigQueue(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSS3BucketQueueNotification(
 						"aws_s3_bucket.bucket",
@@ -150,56 +253,6 @@ func TestAccAWSS3BucketNotification_basic(t *testing.T) {
 								},
 							},
 						},
-					),
-				),
-			},
-			{
-				Config: testAccAWSS3BucketConfigWithLambdaNotification(roleName, lambdaFuncName, bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketLambdaFunctionConfiguration(
-						"aws_s3_bucket.bucket",
-						"notification-lambda",
-						"aws_lambda_function.func",
-						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
-						&s3.KeyFilter{
-							FilterRules: []*s3.FilterRule{
-								{
-									Name:  aws.String("Prefix"),
-									Value: aws.String("tf-acc-test/"),
-								},
-								{
-									Name:  aws.String("Suffix"),
-									Value: aws.String(".png"),
-								},
-							},
-						},
-					),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSS3BucketNotification_withoutFilter(t *testing.T) {
-	rString := acctest.RandString(8)
-
-	topicName := fmt.Sprintf("tf-acc-topic-s3-b-notification-wo-f-%s", rString)
-	bucketName := fmt.Sprintf("tf-acc-bucket-notification-wo-f-%s", rString)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSS3BucketNotificationDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSS3BucketConfigWithTopicNotificationWithoutFilter(topicName, bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSS3BucketTopicNotification(
-						"aws_s3_bucket.bucket",
-						"notification-sns1",
-						"aws_sns_topic.topic",
-						[]string{"s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"},
-						nil,
 					),
 				),
 			},
@@ -415,12 +468,12 @@ func testAccCheckAWSS3BucketLambdaFunctionConfiguration(n, i, t string, events [
 	}
 }
 
-func testAccAWSS3BucketConfigWithTopicNotification(topicName, bucketName string) string {
+func testAccAWSS3BucketNotificationConfigTopicMultiple(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_sns_topic" "topic" {
-    name = "%s"
+    name = %[1]q
 	policy = <<POLICY
 {
 	"Version":"2012-10-17",
@@ -429,7 +482,7 @@ resource "aws_sns_topic" "topic" {
 		"Effect": "Allow",
 		"Principal": {"AWS":"*"},
 		"Action": "SNS:Publish",
-		"Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%s",
+		"Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
 		"Condition":{
 			"ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
 		}
@@ -439,7 +492,7 @@ POLICY
 }
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = "%s"
+	bucket = %[1]q
 	acl = "public-read"
 }
 
@@ -465,15 +518,15 @@ resource "aws_s3_bucket_notification" "notification" {
 		filter_suffix = ".log"
 	}
 }
-`, topicName, topicName, bucketName)
+`, rName)
 }
 
-func testAccAWSS3BucketConfigWithQueueNotification(queueName, bucketName string) string {
+func testAccAWSS3BucketNotificationConfigQueue(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_sqs_queue" "queue" {
-    name = "%s"
+    name = %[1]q
 	policy = <<POLICY
 {
 	"Version":"2012-10-17",
@@ -481,7 +534,7 @@ resource "aws_sqs_queue" "queue" {
 		"Effect":"Allow",
 		"Principal":"*",
 		"Action":"sqs:SendMessage",
-		"Resource":"arn:${data.aws_partition.current.partition}:sqs:*:*:%s",
+		"Resource":"arn:${data.aws_partition.current.partition}:sqs:*:*:%[1]s",
 		"Condition":{
 			"ArnEquals":{
 				"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"
@@ -493,7 +546,7 @@ POLICY
 }
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = "%s"
+	bucket = %[1]q
 	acl = "public-read"
 }
 
@@ -510,13 +563,13 @@ resource "aws_s3_bucket_notification" "notification" {
 		filter_suffix = ".mp4"
 	}
 }
-`, queueName, queueName, bucketName)
+`, rName)
 }
 
-func testAccAWSS3BucketConfigWithLambdaNotification(roleName, lambdaFuncName, bucketName string) string {
+func testAccAWSS3BucketNotificationConfigLambdaFunction(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "%s"
+    name = %[1]q
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -544,14 +597,14 @@ resource "aws_lambda_permission" "allow_bucket" {
 
 resource "aws_lambda_function" "func" {
     filename = "test-fixtures/lambdatest.zip"
-    function_name = "%s"
+    function_name = %[1]q
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
 		runtime = "nodejs8.10"
 }
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = "%s"
+	bucket = %[1]q
 	acl = "public-read"
 }
 
@@ -568,14 +621,62 @@ resource "aws_s3_bucket_notification" "notification" {
 		filter_suffix = ".png"
 	}
 }
-`, roleName, lambdaFuncName, bucketName)
+`, rName)
 }
 
-func testAccAWSS3BucketConfigWithTopicNotificationWithoutFilter(topicName, bucketName string) string {
+func testAccAWSS3BucketNotificationConfigLambdaFunctionLambdaFunctionArnAlias(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\"}]}"
+  name               = %[1]q
+}
+
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  handler       = "exports.example"
+  role          = "${aws_iam_role.test.arn}"
+  runtime       = "nodejs8.10"
+}
+
+resource "aws_lambda_alias" "test" {
+  function_name    = "${aws_lambda_function.test.arn}"
+  function_version = "$LATEST"
+  name             = "testalias"
+}
+
+resource "aws_lambda_permission" "test" {
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.test.arn}"
+  principal     = "s3.amazonaws.com"
+  qualifier     = "${aws_lambda_alias.test.name}"
+  source_arn    = "${aws_s3_bucket.test.arn}"
+  statement_id  = "AllowExecutionFromS3Bucket"
+}
+
+
+resource "aws_s3_bucket" "test" {
+  acl    = "private"
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_notification" "test" {
+  bucket = "${aws_s3_bucket.test.id}"
+
+  lambda_function {
+    events              = ["s3:ObjectCreated:*"]
+    id                  = "test"
+    lambda_function_arn = "${aws_lambda_alias.test.arn}"
+  }
+}
+`, rName)
+}
+
+func testAccAWSS3BucketNotificationConfigTopic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 resource "aws_sns_topic" "topic" {
-    name = "%s"
+    name = %[1]q
 	policy = <<POLICY
 {
 	"Version":"2012-10-17",
@@ -584,7 +685,7 @@ resource "aws_sns_topic" "topic" {
 		"Effect": "Allow",
 		"Principal": {"AWS":"*"},
 		"Action": "SNS:Publish",
-		"Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%s",
+		"Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
 		"Condition":{
 			"ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
 		}
@@ -594,7 +695,7 @@ POLICY
 }
 
 resource "aws_s3_bucket" "bucket" {
-	bucket = "%s"
+	bucket = %[1]q
 	acl = "public-read"
 }
 
@@ -609,5 +710,5 @@ resource "aws_s3_bucket_notification" "notification" {
 		]
 	}
 }
-`, topicName, topicName, bucketName)
+`, rName)
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: #5930

Changes:

* Replace serialized _importBasic and _basic acceptance tests with parallelized tests
* Add Lambda Alias test
* Simplify randomized naming to single variable

Output from acceptance testing:

```
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction (42.65s)
--- PASS: TestAccAWSS3BucketNotification_LambdaFunction_LambdaFunctionArn_Alias (34.78s)
--- PASS: TestAccAWSS3BucketNotification_Queue (33.96s)
--- PASS: TestAccAWSS3BucketNotification_Topic (34.50s)
--- PASS: TestAccAWSS3BucketNotification_Topic_Multiple (36.83s)
--- PASS: TestAccAWSS3BucketNotification_update (54.90s)
```
