### PR TITLE
resource/ssm_association: Support MaxConcurrency and MaxErrors

### DIFF
--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -38,6 +39,30 @@ func resourceAwsSsmAssociation() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"max_concurrency": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"%q invalid format", k))
+					}
+					return
+				},
+			},
+			"max_errors": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`).MatchString(value) {
+						es = append(es, fmt.Errorf(
+							"%q invalid format", k))
+					}
+					return
+				},
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -41,28 +41,14 @@ func resourceAwsSsmAssociation() *schema.Resource {
 				Computed: true,
 			},
 			"max_concurrency": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`).MatchString(value) {
-						es = append(es, fmt.Errorf(
-							"%q invalid format", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$`), "must be a valid number (e.g. 10) or percentage including the percent sign (e.g. 10%)"),
 			},
 			"max_errors": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`).MatchString(value) {
-						es = append(es, fmt.Errorf(
-							"%q invalid format", k))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$`), "must be a valid number (e.g. 10) or percentage including the percent sign (e.g. 10%)"),
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -170,6 +156,14 @@ func resourceAwsSsmAssociationCreate(d *schema.ResourceData, meta interface{}) e
 		associationInput.ComplianceSeverity = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("max_concurrency"); ok {
+		associationInput.MaxConcurrency = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_errors"); ok {
+		associationInput.MaxErrors = aws.String(v.(string))
+	}
+
 	resp, err := ssmconn.CreateAssociation(associationInput)
 	if err != nil {
 		return fmt.Errorf("Error creating SSM association: %s", err)
@@ -216,6 +210,8 @@ func resourceAwsSsmAssociationRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("schedule_expression", association.ScheduleExpression)
 	d.Set("document_version", association.DocumentVersion)
 	d.Set("compliance_severity", association.ComplianceSeverity)
+	d.Set("max_concurrency", association.MaxConcurrency)
+	d.Set("max_errors", association.MaxErrors)
 
 	if err := d.Set("targets", flattenAwsSsmTargets(association.Targets)); err != nil {
 		return fmt.Errorf("Error setting targets error: %#v", err)
@@ -264,6 +260,14 @@ func resourceAwsSsmAssociationUpdate(d *schema.ResourceData, meta interface{}) e
 
 	if v, ok := d.GetOk("compliance_severity"); ok {
 		associationInput.ComplianceSeverity = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_concurrency"); ok {
+		associationInput.MaxConcurrency = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("max_errors"); ok {
+		associationInput.MaxErrors = aws.String(v.(string))
 	}
 
 	_, err := ssmconn.UpdateAssociation(associationInput)

--- a/aws/resource_aws_ssm_association.go
+++ b/aws/resource_aws_ssm_association.go
@@ -48,7 +48,7 @@ func resourceAwsSsmAssociation() *schema.Resource {
 			"max_errors": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$`), "must be a valid number (e.g. 10) or percentage including the percent sign (e.g. 10%)"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$`), "must be a valid number (e.g. 10) or percentage including the percent sign (e.g. 10%)"),
 			},
 			"name": {
 				Type:     schema.TypeString,

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -36,6 +36,8 @@ The following arguments are supported:
 * `schedule_expression` - (Optional) A cron expression when the association will be applied to the target(s).
 * `targets` - (Optional) A block containing the targets of the SSM association. Targets are documented below. AWS currently supports a maximum of 5 targets.
 * `compliance_severity` - (Optional) The compliance severity for the association. Can be one of the following: `UNSPECIFIED`, `LOW`, `MEDIUM`, `HIGH` or `CRITICAL`
+* `max_concurrency` - (Optional) The maximum number of targets allowed to run the association at the same time. You can specify a number, for example 10, or a percentage of the target set, for example 10%.
+* `max_errors` - (Optional) The number of errors that are allowed before the system stops sending requests to run the association on additional targets. You can specify a number, for example 10, or a percentage of the target set, for example 10%.
 
 Output Location (`output_location`) is an S3 bucket where you want to store the results of this association:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Closes #6258

Changes proposed in this pull request:

* Support `max_concurrency` and `max_errors`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSSMAssociation_rateControl'
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSSSMAssociation_rateControl -timeout 120m
=== RUN   TestAccAWSSSMAssociation_rateControl
=== PAUSE TestAccAWSSSMAssociation_rateControl
=== CONT  TestAccAWSSSMAssociation_rateControl
--- PASS: TestAccAWSSSMAssociation_rateControl (68.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.165s
```
