### PR TITLE
New Datasource: aws_transfer_server

### DIFF
--- a/aws/data_source_aws_transfer_server.go
+++ b/aws/data_source_aws_transfer_server.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/transfer"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsTransferServer() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsTransferServerRead,
+		Schema: map[string]*schema.Schema{
+			"server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"invocation_role": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"identity_provider_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"logging_role": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsTransferServerRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).transferconn
+
+	serverID := d.Get("server_id").(string)
+	input := &transfer.DescribeServerInput{
+		ServerId: aws.String(serverID),
+	}
+
+	log.Printf("[DEBUG] Describe Transfer Server Option: %#v", input)
+
+	resp, err := conn.DescribeServer(input)
+	if err != nil {
+		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
+			log.Printf("[ERROR] Transfer Server (%s) not found", serverID)
+			return nil
+		}
+		return err
+	}
+
+	endpoint := fmt.Sprintf("%s.server.transfer.%s.amazonaws.com", serverID, meta.(*AWSClient).region)
+
+	d.SetId(serverID)
+	d.Set("arn", resp.Server.Arn)
+	d.Set("endpoint", endpoint)
+	if resp.Server.IdentityProviderDetails != nil {
+		d.Set("invocation_role", aws.StringValue(resp.Server.IdentityProviderDetails.InvocationRole))
+		d.Set("url", aws.StringValue(resp.Server.IdentityProviderDetails.Url))
+	}
+	d.Set("identity_provider_type", resp.Server.IdentityProviderType)
+	d.Set("logging_role", resp.Server.LoggingRole)
+
+	return nil
+}

--- a/aws/data_source_aws_transfer_server.go
+++ b/aws/data_source_aws_transfer_server.go
@@ -28,22 +28,18 @@ func dataSourceAwsTransferServer() *schema.Resource {
 			"invocation_role": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			},
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			},
 			"identity_provider_type": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			},
 			"logging_role": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Optional: true,
 			},
 		},
 	}
@@ -61,11 +57,7 @@ func dataSourceAwsTransferServerRead(d *schema.ResourceData, meta interface{}) e
 
 	resp, err := conn.DescribeServer(input)
 	if err != nil {
-		if isAWSErr(err, transfer.ErrCodeResourceNotFoundException, "") {
-			log.Printf("[ERROR] Transfer Server (%s) not found", serverID)
-			return nil
-		}
-		return err
+		return fmt.Errorf("error describing Transfer Server (%s): %s", serverID, err)
 	}
 
 	endpoint := fmt.Sprintf("%s.server.transfer.%s.amazonaws.com", serverID, meta.(*AWSClient).region)

--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -20,7 +20,10 @@ func TestAccDataSourceAwsTransferServer_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsTransferServerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "endpoint", resourceName, "endpoint"),
+					resource.TestCheckResourceAttrPair(datasourceName, "identity_provider_type", resourceName, "identity_provider_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "logging_role", resourceName, "logging_role"),
 				),
 			},
 		},
@@ -39,7 +42,10 @@ func TestAccDataSourceAwsTransferServer_service_managed(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsTransferServerConfig_service_managed(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "endpoint", resourceName, "endpoint"),
+					resource.TestCheckResourceAttrPair(datasourceName, "identity_provider_type", resourceName, "identity_provider_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "logging_role", resourceName, "logging_role"),
 				),
 			},
 		},
@@ -58,7 +64,12 @@ func TestAccDataSourceAwsTransferServer_apigateway(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsTransferServerConfig_apigateway(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName),
+					resource.TestCheckResourceAttrPair(datasourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "endpoint", resourceName, "endpoint"),
+					resource.TestCheckResourceAttrPair(datasourceName, "identity_provider_type", resourceName, "identity_provider_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "invocation_role", resourceName, "invocation_role"),
+					resource.TestCheckResourceAttrPair(datasourceName, "logging_role", resourceName, "logging_role"),
+					resource.TestCheckResourceAttrPair(datasourceName, "url", resourceName, "url"),
 				),
 			},
 		},

--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceAwsTransferServer_basic(t *testing.T) {
@@ -74,42 +73,6 @@ func TestAccDataSourceAwsTransferServer_apigateway(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[datasourceName]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", datasourceName)
-		}
-
-		transferServerRs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", resourceName)
-		}
-
-		attrNames := []string{
-			"arn",
-			"endpoint",
-			"invocation_role",
-			"url",
-			"identity_provider_type",
-			"logging_role",
-		}
-
-		for _, attrName := range attrNames {
-			if rs.Primary.Attributes[attrName] != transferServerRs.Primary.Attributes[attrName] {
-				return fmt.Errorf(
-					"%s is %s; want %s",
-					attrName,
-					rs.Primary.Attributes[attrName],
-					transferServerRs.Primary.Attributes[attrName],
-				)
-			}
-		}
-
-		return nil
-	}
 }
 
 const testAccDataSourceAwsTransferServerConfig_basic = `

--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -1,0 +1,272 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsTransferServer_basic(t *testing.T) {
+	resourceName := "aws_transfer_server.test"
+	datasourceName := "data.aws_transfer_server.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsTransferServerConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsTransferServer_service_managed(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_transfer_server.test"
+	datasourceName := "data.aws_transfer_server.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsTransferServerConfig_service_managed(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsTransferServer_apigateway(t *testing.T) {
+	rName := acctest.RandString(5)
+	resourceName := "aws_transfer_server.test"
+	datasourceName := "data.aws_transfer_server.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsTransferServerConfig_apigateway(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsTransferServerCheck(datasourceName, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[datasourceName]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", datasourceName)
+		}
+
+		transferServerRs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", resourceName)
+		}
+
+		attrNames := []string{
+			"arn",
+			"endpoint",
+			"invocation_role",
+			"url",
+			"identity_provider_type",
+			"logging_role",
+		}
+
+		for _, attrName := range attrNames {
+			if rs.Primary.Attributes[attrName] != transferServerRs.Primary.Attributes[attrName] {
+				return fmt.Errorf(
+					"%s is %s; want %s",
+					attrName,
+					rs.Primary.Attributes[attrName],
+					transferServerRs.Primary.Attributes[attrName],
+				)
+			}
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsTransferServerConfig_basic = `
+resource "aws_transfer_server" "test" {}
+
+data "aws_transfer_server" "test" {
+  server_id = "${aws_transfer_server.test.id}"
+}
+`
+
+func testAccDataSourceAwsTransferServerConfig_service_managed(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+	name = "tf-test-transfer-server-iam-role-%s"
+
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Effect": "Allow",
+		"Principal": {
+			"Service": "transfer.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+	name = "tf-test-transfer-server-iam-policy-%s"
+	role = "${aws_iam_role.test.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Sid": "AllowFullAccesstoCloudWatchLogs",
+		"Effect": "Allow",
+		"Action": [
+			"logs:*"
+		],
+		"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+resource "aws_transfer_server" "test" {
+  identity_provider_type = "SERVICE_MANAGED"
+  logging_role = "${aws_iam_role.test.arn}"
+}
+
+data "aws_transfer_server" "test" {
+  server_id = "${aws_transfer_server.test.id}"
+}
+`, rName, rName)
+}
+
+func testAccDataSourceAwsTransferServerConfig_apigateway(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+	name = "test"
+}
+
+resource "aws_api_gateway_resource" "test" {
+	rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+	parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+	path_part = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+	rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+	resource_id = "${aws_api_gateway_resource.test.id}"
+	http_method = "GET"
+	authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "error" {
+	rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+	resource_id = "${aws_api_gateway_resource.test.id}"
+	http_method = "${aws_api_gateway_method.test.http_method}"
+	status_code = "400"
+}
+
+resource "aws_api_gateway_integration" "test" {
+	rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+	resource_id = "${aws_api_gateway_resource.test.id}"
+	http_method = "${aws_api_gateway_method.test.http_method}"
+
+	type = "HTTP"
+	uri = "https://www.google.de"
+	integration_http_method = "GET"
+}
+
+resource "aws_api_gateway_integration_response" "test" {
+	rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+	resource_id = "${aws_api_gateway_resource.test.id}"
+	http_method = "${aws_api_gateway_integration.test.http_method}"
+	status_code = "${aws_api_gateway_method_response.error.status_code}"
+}
+
+resource "aws_api_gateway_deployment" "test" {
+	depends_on = ["aws_api_gateway_integration.test"]
+
+	rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+	stage_name = "test"
+	description = "%s"
+	stage_description = "%s"
+
+
+  variables = {
+    "a" = "2"
+  }
+}
+
+
+resource "aws_iam_role" "test" {
+	name = "tf-test-transfer-server-iam-role-for-apigateway-%s"
+
+	assume_role_policy = <<EOF
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Effect": "Allow",
+		"Principal": {
+			"Service": "transfer.amazonaws.com"
+		},
+		"Action": "sts:AssumeRole"
+		}
+	]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test" {
+	name = "tf-test-transfer-server-iam-policy-%s"
+	role = "${aws_iam_role.test.id}"
+	policy = <<POLICY
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Sid": "AllowFullAccesstoCloudWatchLogs",
+		"Effect": "Allow",
+		"Action": [
+			"logs:*"
+		],
+		"Resource": "*"
+		}
+	]
+}
+POLICY
+}
+
+resource "aws_transfer_server" "test" {
+	identity_provider_type	= "API_GATEWAY"
+	url 				   	= "https://${aws_api_gateway_rest_api.test.id}.execute-api.us-west-2.amazonaws.com${aws_api_gateway_resource.test.path}"
+	invocation_role 	   	= "${aws_iam_role.test.arn}"
+	logging_role 		   	= "${aws_iam_role.test.arn}"
+}
+
+data "aws_transfer_server" "test" {
+  server_id = "${aws_transfer_server.test.id}"
+}
+`, rName, rName, rName, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -253,6 +253,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_storagegateway_local_disk":          dataSourceAwsStorageGatewayLocalDisk(),
 			"aws_subnet":                             dataSourceAwsSubnet(),
 			"aws_subnet_ids":                         dataSourceAwsSubnetIDs(),
+			"aws_transfer_server":                    dataSourceAwsTransferServer(),
 			"aws_vpcs":                               dataSourceAwsVpcs(),
 			"aws_security_group":                     dataSourceAwsSecurityGroup(),
 			"aws_security_groups":                    dataSourceAwsSecurityGroups(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -381,6 +381,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-subnet-ids") %>>
                             <a href="/docs/providers/aws/d/subnet_ids.html">aws_subnet_ids</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-transfer-server") %>>
+                            <a href="/docs/providers/aws/d/transfer_server.html">aws_transfer_server</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-vpc-x") %>>
                             <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
                         </li>

--- a/website/docs/d/transfer_server.html.markdown
+++ b/website/docs/d/transfer_server.html.markdown
@@ -26,9 +26,9 @@ data "aws_transfer_server" "example" {
 ## Attributes Reference
 
 * `arn` - Amazon Resource Name (ARN) of Transfer Server
-* `id`  - The Server ID of the Transfer Server (e.g. `s-12345678`)
 * `endpoint` - The endpoint of the Transfer Server (e.g. `s-12345678.server.transfer.REGION.amazonaws.com`)
-* `invocation_role` - Amazon Resource Name (ARN) of the IAM role used to authenticate the user account with an `identity_provider_type` of `API_GATEWAY`.
-* `url` - URL of the service endpoint used to authenticate users with an `identity_provider_type` of `API_GATEWAY`.
+* `id`  - The Server ID of the Transfer Server (e.g. `s-12345678`)
 * `identity_provider_type` - The mode of authentication enabled for this service. The default value is `SERVICE_MANAGED`, which allows you to store and access SFTP user credentials within the service. `API_GATEWAY` indicates that user authentication requires a call to an API Gateway endpoint URL provided by you to integrate an identity provider of your choice.
+* `invocation_role` - Amazon Resource Name (ARN) of the IAM role used to authenticate the user account with an `identity_provider_type` of `API_GATEWAY`.
 * `logging_role` - Amazon Resource Name (ARN) of an IAM role that allows the service to write your SFTP users’ activity to your Amazon CloudWatch logs for monitoring and auditing purposes.
+* `url` - URL of the service endpoint used to authenticate users with an `identity_provider_type` of `API_GATEWAY`.

--- a/website/docs/d/transfer_server.html.markdown
+++ b/website/docs/d/transfer_server.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "aws"
+page_title: "AWS: aws_transfer_server"
+sidebar_current: "docs-aws-datasource-transfer-server"
+description: |-
+  Get information on an AWS Transfer Server resource
+---
+
+# Data Source: aws_transfer_server
+
+Use this data source to get the ARN of an AWS Transfer Server for use in other
+resources.
+
+## Example Usage
+
+```hcl
+data "aws_transfer_server" "example" {
+  server_id = "s-1234567"
+}
+```
+
+## Argument Reference
+
+* `server_id` - (Required) ID for an SFTP server.
+
+## Attributes Reference
+
+* `arn` - Amazon Resource Name (ARN) of Transfer Server
+* `id`  - The Server ID of the Transfer Server (e.g. `s-12345678`)
+* `endpoint` - The endpoint of the Transfer Server (e.g. `s-12345678.server.transfer.REGION.amazonaws.com`)
+* `invocation_role` - Amazon Resource Name (ARN) of the IAM role used to authenticate the user account with an `identity_provider_type` of `API_GATEWAY`.
+* `url` - URL of the service endpoint used to authenticate users with an `identity_provider_type` of `API_GATEWAY`.
+* `identity_provider_type` - The mode of authentication enabled for this service. The default value is `SERVICE_MANAGED`, which allows you to store and access SFTP user credentials within the service. `API_GATEWAY` indicates that user authentication requires a call to an API Gateway endpoint URL provided by you to integrate an identity provider of your choice.
+* `logging_role` - Amazon Resource Name (ARN) of an IAM role that allows the service to write your SFTP users’ activity to your Amazon CloudWatch logs for monitoring and auditing purposes.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7976

Changes proposed in this pull request:

* Data source: `aws_transfer_server`

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsTransferServer_'
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAwsTransferServer_ -timeout 120m
=== RUN   TestAccDataSourceAwsTransferServer_basic
=== PAUSE TestAccDataSourceAwsTransferServer_basic
=== RUN   TestAccDataSourceAwsTransferServer_service_managed
=== PAUSE TestAccDataSourceAwsTransferServer_service_managed
=== RUN   TestAccDataSourceAwsTransferServer_apigateway
=== PAUSE TestAccDataSourceAwsTransferServer_apigateway
=== CONT  TestAccDataSourceAwsTransferServer_basic
=== CONT  TestAccDataSourceAwsTransferServer_service_managed
=== CONT  TestAccDataSourceAwsTransferServer_apigateway
--- PASS: TestAccDataSourceAwsTransferServer_basic (52.01s)
--- PASS: TestAccDataSourceAwsTransferServer_service_managed (54.28s)
--- PASS: TestAccDataSourceAwsTransferServer_apigateway (65.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	65.333s
```
