### PR TITLE
Add support tags attribute for resource_aws_media_package_channel

### DIFF
--- a/aws/tagsMediapackage.go
+++ b/aws/tagsMediapackage.go
@@ -1,0 +1,47 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/mediapackage"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func setTagsMediaPackage(conn *mediapackage.MediaPackage, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsGeneric(o, n)
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			keys := make([]*string, 0, len(remove))
+			for k := range remove {
+				keys = append(keys, aws.String(k))
+			}
+
+			_, err := conn.UntagResource(&mediapackage.UntagResourceInput{
+				ResourceArn: aws.String(arn),
+				TagKeys:     keys,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&mediapackage.TagResourceInput{
+				ResourceArn: aws.String(arn),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/website/docs/r/media_package_channel.html.markdown
+++ b/website/docs/r/media_package_channel.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 
 * `channel_id` - (Required) A unique identifier describing the channel
 * `description` - (Optional) A description of the channel
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7813 

Changes proposed in this pull request:

* Add support tags attribute

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSMediaPackageChannel_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSMediaPackageChannel_ -timeout 120m
=== RUN   TestAccAWSMediaPackageChannel_basic
=== PAUSE TestAccAWSMediaPackageChannel_basic
=== RUN   TestAccAWSMediaPackageChannel_description
=== PAUSE TestAccAWSMediaPackageChannel_description
=== RUN   TestAccAWSMediaPackageChannel_tags
=== PAUSE TestAccAWSMediaPackageChannel_tags
=== CONT  TestAccAWSMediaPackageChannel_basic
=== CONT  TestAccAWSMediaPackageChannel_description
=== CONT  TestAccAWSMediaPackageChannel_tags
--- PASS: TestAccAWSMediaPackageChannel_basic (35.25s)
--- PASS: TestAccAWSMediaPackageChannel_description (56.33s)
--- PASS: TestAccAWSMediaPackageChannel_tags (79.10s)
PASS
ok  	github.com/terraform-providers/tmp-terraform-provider-aws/aws	79.216s
```
