### PR TITLE
provider: Fix updated govet composites and nilness checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - gosimple
     - ineffassign
     - misspell
-    - staticcheck
     - structcheck
     - unconvert
     - unused

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,33 @@
-dist: trusty
+dist: xenial
 sudo: required
 services:
   - docker
 language: go
 go:
-- "1.12.x"
-env:
-  GOFLAGS=-mod=vendor
+  - "1.12.x"
+env: GOFLAGS=-mod=vendor
 
 git:
   depth: 1
 
 install:
-# This script is used by the Travis build to install a cookie for
-# go.googlesource.com so rate limits are higher when using `go get` to fetch
-# packages that live there.
-# See: https://github.com/golang/go/issues/12933
-- bash scripts/gogetcookie.sh
-- make tools
+  # This script is used by the Travis build to install a cookie for
+  # go.googlesource.com so rate limits are higher when using `go get` to fetch
+  # packages that live there.
+  # See: https://github.com/golang/go/issues/12933
+  - bash scripts/gogetcookie.sh
+  - make tools
 
 script:
-- make lint
-- make test
-- make website-lint
-- make website-test
+  - make lint
+  - make test
+  - make website-lint
+  - make website-test
 
 branches:
   only:
-  - master
+    - master
 matrix:
   fast_finish: true
   allow_failures:
-  - go: tip
+    - go: tip

--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -11,9 +11,16 @@ import (
 func TestGetSupportedEC2Platforms(t *testing.T) {
 	ec2Endpoints := []*awsbase.MockEndpoint{
 		{
-			Request: &awsbase.MockRequest{"POST", "/", "Action=DescribeAccountAttributes&" +
-				"AttributeName.1=supported-platforms&Version=2016-11-15"},
-			Response: &awsbase.MockResponse{200, test_ec2_describeAccountAttributes_response, "text/xml"},
+			Request: &awsbase.MockRequest{
+				Method: "POST",
+				Uri:    "/",
+				Body:   "Action=DescribeAccountAttributes&AttributeName.1=supported-platforms&Version=2016-11-15",
+			},
+			Response: &awsbase.MockResponse{
+				StatusCode:  200,
+				Body:        test_ec2_describeAccountAttributes_response,
+				ContentType: "text/xml",
+			},
 		},
 	}
 	closeFunc, sess, err := awsbase.GetMockedAwsApiSession("EC2", ec2Endpoints)

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1544,11 +1544,8 @@ func resourceAwsDbInstanceRetrieve(id string, conn *rds.RDS) (*rds.DBInstance, e
 		return nil, fmt.Errorf("Error retrieving DB Instances: %s", err)
 	}
 
-	if len(resp.DBInstances) != 1 ||
-		*resp.DBInstances[0].DBInstanceIdentifier != id {
-		if err != nil {
-			return nil, nil
-		}
+	if len(resp.DBInstances) != 1 || resp.DBInstances[0] == nil || aws.StringValue(resp.DBInstances[0].DBInstanceIdentifier) != id {
+		return nil, nil
 	}
 
 	return resp.DBInstances[0], nil

--- a/aws/resource_aws_docdb_cluster_instance.go
+++ b/aws/resource_aws_docdb_cluster_instance.go
@@ -456,11 +456,8 @@ func resourceAwsDocDBInstanceRetrieve(id string, conn *docdb.DocDB) (*docdb.DBIn
 		return nil, fmt.Errorf("Error retrieving DB Instances: %s", err)
 	}
 
-	if len(resp.DBInstances) != 1 ||
-		*resp.DBInstances[0].DBInstanceIdentifier != id {
-		if err != nil {
-			return nil, nil
-		}
+	if len(resp.DBInstances) != 1 || resp.DBInstances[0] == nil || aws.StringValue(resp.DBInstances[0].DBInstanceIdentifier) != id {
+		return nil, nil
 	}
 
 	return resp.DBInstances[0], nil

--- a/aws/resource_aws_egress_only_internet_gateway.go
+++ b/aws/resource_aws_egress_only_internet_gateway.go
@@ -39,10 +39,6 @@ func resourceAwsEgressOnlyInternetGatewayCreate(d *schema.ResourceData, meta int
 
 	d.SetId(*resp.EgressOnlyInternetGateway.EgressOnlyInternetGatewayId)
 
-	if err != nil {
-		return fmt.Errorf("%s", err)
-	}
-
 	return resourceAwsEgressOnlyInternetGatewayRead(d, meta)
 }
 

--- a/aws/resource_aws_emr_security_configuration_test.go
+++ b/aws/resource_aws_emr_security_configuration_test.go
@@ -58,21 +58,20 @@ func testAccCheckEmrSecurityConfigurationDestroy(s *terraform.State) error {
 		resp, err := conn.DescribeSecurityConfiguration(&emr.DescribeSecurityConfigurationInput{
 			Name: aws.String(rs.Primary.ID),
 		})
-		if err == nil {
-			if resp.Name != nil && *resp.Name == rs.Primary.ID {
-				// assume this means the resource still exists
-				return fmt.Errorf("Error: EMR Security Configuration still exists: %s", *resp.Name)
-			}
+
+		if isAWSErr(err, "InvalidRequestException", "does not exist") {
 			return nil
 		}
 
-		// Verify the error is what we want
 		if err != nil {
-			if isAWSErr(err, "InvalidRequestException", "does not exist") {
-				return nil
-			}
 			return err
 		}
+
+		if resp != nil && aws.StringValue(resp.Name) == rs.Primary.ID {
+			return fmt.Errorf("Error: EMR Security Configuration still exists: %s", aws.StringValue(resp.Name))
+		}
+
+		return nil
 	}
 
 	return nil

--- a/aws/resource_aws_gamelift_game_session_queue_test.go
+++ b/aws/resource_aws_gamelift_game_session_queue_test.go
@@ -31,11 +31,12 @@ func testSweepGameliftGameSessionQueue(region string) error {
 
 	out, err := conn.DescribeGameSessionQueues(&gamelift.DescribeGameSessionQueuesInput{})
 
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping Gamelife Queue sweep for %s: %s", region, err)
+		return nil
+	}
+
 	if err != nil {
-		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping Gamelife Queue sweep for %s: %s", region, err)
-			return nil
-		}
 		return fmt.Errorf("error listing Gamelift Session Queue: %s", err)
 	}
 
@@ -55,14 +56,6 @@ func testSweepGameliftGameSessionQueue(region string) error {
 			return fmt.Errorf("error deleting Gamelift Session Queue (%s): %s",
 				*queue.Name, err)
 		}
-	}
-
-	if err != nil {
-		if testSweepSkipSweepError(err) {
-			log.Printf("[WARN] Skipping Gamelift Session Queue sweep for %s: %s", region, err)
-			return nil
-		}
-		return fmt.Errorf("error listing Gamelift Session Queue: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_organizations_account_test.go
+++ b/aws/resource_aws_organizations_account_test.go
@@ -64,14 +64,15 @@ func testAccCheckAwsOrganizationsAccountDestroy(s *terraform.State) error {
 
 		resp, err := conn.DescribeAccount(params)
 
+		if isAWSErr(err, organizations.ErrCodeAccountNotFoundException, "") {
+			return nil
+		}
+
 		if err != nil {
-			if isAWSErr(err, organizations.ErrCodeAccountNotFoundException, "") {
-				return nil
-			}
 			return err
 		}
 
-		if resp == nil && resp.Account != nil {
+		if resp != nil && resp.Account != nil {
 			return fmt.Errorf("Bad: Account still exists: %q", rs.Primary.ID)
 		}
 	}

--- a/aws/resource_aws_organizations_policy_test.go
+++ b/aws/resource_aws_organizations_policy_test.go
@@ -98,14 +98,15 @@ func testAccCheckAwsOrganizationsPolicyDestroy(s *terraform.State) error {
 
 		resp, err := conn.DescribePolicy(input)
 
+		if isAWSErr(err, organizations.ErrCodePolicyNotFoundException, "") {
+			return nil
+		}
+
 		if err != nil {
-			if isAWSErr(err, organizations.ErrCodePolicyNotFoundException, "") {
-				return nil
-			}
 			return err
 		}
 
-		if resp == nil && resp.Policy != nil {
+		if resp != nil && resp.Policy != nil {
 			return fmt.Errorf("Policy %q still exists", rs.Primary.ID)
 		}
 	}

--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -222,13 +222,9 @@ func testAccAWSVpnConnectionDisappears(connection *ec2.VpnConnection) resource.T
 		_, err := conn.DeleteVpnConnection(&ec2.DeleteVpnConnectionInput{
 			VpnConnectionId: connection.VpnConnectionId,
 		})
+
 		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
+			return err
 		}
 
 		return resource.Retry(40*time.Minute, func() *resource.RetryError {

--- a/aws/resource_aws_vpn_gateway_test.go
+++ b/aws/resource_aws_vpn_gateway_test.go
@@ -374,18 +374,7 @@ func testAccAWSVpnGatewayDisappears(gateway *ec2.VpnGateway) resource.TestCheckF
 			VpcId:        gateway.VpcAttachments[0].VpcId,
 		})
 		if err != nil {
-			ec2err, ok := err.(awserr.Error)
-			if ok {
-				if ec2err.Code() == "InvalidVpnGatewayID.NotFound" {
-					return nil
-				} else if ec2err.Code() == "InvalidVpnGatewayAttachment.NotFound" {
-					return nil
-				}
-			}
-
-			if err != nil {
-				return err
-			}
+			return err
 		}
 
 		opts := &ec2.DeleteVpnGatewayInput{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #7992

Output from acceptance testing (test failures unrelated):

```
--- PASS: TestAccAWSDBInstance_iamAuth (433.73s)
--- PASS: TestAccAWSDBInstance_generatedName (433.85s)
--- PASS: TestAccAWSDBInstance_kmsKey (472.91s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (474.40s)
--- PASS: TestAccAWSDBInstance_basic (504.75s)
--- PASS: TestAccAWSDBInstance_namePrefix (515.35s)
--- PASS: TestAccAWSDBInstance_DeletionProtection (519.84s)
--- PASS: TestAccAWSDBInstance_optionGroup (524.56s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (615.45s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (889.07s)
--- PASS: TestAccAWSDBInstance_subnetGroup (941.03s)
--- FAIL: TestAccAWSDBInstance_S3Import (670.42s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1325.20s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (1335.22s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1397.87s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1427.89s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1467.48s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1505.86s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1597.63s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1620.53s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1070.32s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1230.49s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1306.43s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1788.44s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1331.92s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1041.75s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1516.69s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1562.85s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1655.35s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1422.63s)
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (668.86s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1123.73s)
--- PASS: TestAccAWSDBInstance_portUpdate (532.58s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2112.96s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1260.79s)
--- PASS: TestAccAWSDBInstance_separate_iops_update (698.74s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1337.11s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1322.37s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1211.08s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1406.51s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1190.56s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1130.64s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1703.38s)
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (452.04s)
--- PASS: TestAccAWSDBInstance_ec2Classic (429.38s)
--- PASS: TestAccAWSDBInstance_MinorVersion (462.68s)
--- PASS: TestAccAWSEgressOnlyInternetGateway_basic (9.07s)
--- PASS: TestAccAWSEmrSecurityConfiguration_basic (11.70s)
--- PASS: TestAccAWSEmrSecurityConfiguration_importBasic (15.62s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1223.74s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1232.99s)
--- PASS: TestAccAWSVpnGateway_disappears (22.85s)
--- PASS: TestAccAWSVpnConnection_disappears (159.00s)
--- FAIL: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (560.67s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (700.56s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (745.47s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1935.89s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (766.60s)
--- PASS: TestAccAWSDocDBClusterInstance_namePrefix (649.47s)
--- PASS: TestAccAWSDocDBClusterInstance_generatedName (659.47s)
--- PASS: TestAccAWSDocDBClusterInstance_az (676.29s)
--- PASS: TestAccAWSDocDBClusterInstance_kmsKey (694.98s)
--- PASS: TestAccAWSDocDBClusterInstance_disappears (640.17s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1792.55s)
--- PASS: TestAccAWSDocDBClusterInstance_basic (1339.75s)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (2067.04s)
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (3150.09s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4083.21s)
--- PASS: TestAccAWSDBInstance_MSSQL_Domain (3593.05s)
```
