### PR TITLE
data-source/aws_instance: Add get_user_data argument and user_data_base64 attribute

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -112,7 +112,16 @@ func dataSourceAwsInstance() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"get_user_data": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"user_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_data_base64": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -423,8 +432,11 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 		if err != nil {
 			return err
 		}
-		if attr.UserData.Value != nil {
-			d.Set("user_data", userDataHashSum(*attr.UserData.Value))
+		if attr != nil && attr.UserData != nil && attr.UserData.Value != nil {
+			d.Set("user_data", userDataHashSum(aws.StringValue(attr.UserData.Value)))
+			if d.Get("get_user_data").(bool) {
+				d.Set("user_data_base64", aws.StringValue(attr.UserData.Value))
+			}
 		}
 	}
 	{

--- a/aws/data_source_aws_instance_test.go
+++ b/aws/data_source_aws_instance_test.go
@@ -22,6 +22,7 @@ func TestAccAWSInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "tags.%", "1"),
 					resource.TestCheckResourceAttr("data.aws_instance.web-instance", "instance_type", "m1.small"),
 					resource.TestMatchResourceAttr("data.aws_instance.web-instance", "arn", regexp.MustCompile(`^arn:[^:]+:ec2:[^:]+:\d{12}:instance/i-.+`)),
+					resource.TestCheckNoResourceAttr("data.aws_instance.web-instance", "user_data_base64"),
 				),
 			},
 		},
@@ -279,6 +280,38 @@ func TestAccAWSInstanceDataSource_getPasswordData_falseToTrue(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_instance.foo", "get_password_data", "true"),
 					resource.TestCheckResourceAttrSet("data.aws_instance.foo", "password_data"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstanceDataSource_GetUserData(t *testing.T) {
+	dataSourceName := "data.aws_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceDataSourceConfigGetUserData(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "get_user_data", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "user_data_base64", "IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo="),
+				),
+			},
+			{
+				Config: testAccInstanceDataSourceConfigGetUserData(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "get_user_data", "false"),
+					resource.TestCheckNoResourceAttr(dataSourceName, "user_data_base64"),
+				),
+			},
+			{
+				Config: testAccInstanceDataSourceConfigGetUserData(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "get_user_data", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "user_data_base64", "IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo="),
 				),
 			},
 		},
@@ -673,6 +706,57 @@ func testAccInstanceDataSourceConfig_getPasswordData(val bool, rInt int) string 
 		get_password_data = %t
 	}
 	`, rInt, val)
+}
+
+func testAccInstanceDataSourceConfigGetUserData(getUserData bool) string {
+	return fmt.Sprintf(`
+data "aws_ami" "amzn-ami-minimal-hvm-ebs" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["amzn-ami-minimal-hvm-*"]
+  }
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "172.16.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-instance-datasource-get-user-data"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "172.16.0.0/24"
+  vpc_id     = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-instance-datasource-get-user-data"
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = "${data.aws_ami.amzn-ami-minimal-hvm-ebs.id}"
+  instance_type = "t2.micro"
+  subnet_id     = "${aws_subnet.test.id}"
+  user_data     = <<EUD
+#!/bin/bash
+
+echo "hello world"
+EUD
+}
+
+data "aws_instance" "test" {
+  get_user_data = %t
+  instance_id   = "${aws_instance.test.id}"
+}
+`, getUserData)
 }
 
 const testAccInstanceDataSourceConfig_creditSpecification = `

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -42,6 +42,8 @@ several valid keys, for a full reference, check out
 
 * `get_password_data` - (Optional) If true, wait for password data to become available and retrieve it. Useful for getting the administrator password for instances running Microsoft Windows. The password data is exported to the `password_data` attribute. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
 
+* `get_user_data` - (Optional) Retrieve Base64 encoded User Data contents into the `user_data_base64` attribute. A SHA-1 hash of the User Data contents will always be present in the `user_data` attribute. Defaults to `false`.
+
 ~> **NOTE:** At least one of `filter`, `instance_tags`, or `instance_id` must be specified.
 
 ~> **NOTE:** If anything other than a single match is returned by the search,
@@ -99,7 +101,8 @@ interpolation.
 * `security_groups` - The associated security groups.
 * `source_dest_check` - Whether the network interface performs source/destination checking (Boolean).
 * `subnet_id` - The VPC subnet ID.
-* `user_data` - The User Data supplied to the Instance.
+* `user_data` - SHA-1 hash of User Data supplied to the Instance.
+* `user_data_base64` - Base64 encoded contents of User Data supplied to the Instance. Valid UTF-8 contents can be decoded with the [`base64decode` function](/docs/configuration/functions/base64decode.html). This attribute is only exported if `get_user_data` is true.
 * `tags` - A mapping of tags assigned to the Instance.
 * `tenancy` - The tenancy of the instance: `dedicated`, `default`, `host`.
 * `host_id` - The Id of the dedicated host the instance will be assigned to.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #5927

As contents may be large and not necessarily safe for the Terraform state, which requires valid UTF-8, we allow retrieving the Base64 contents of EC2 Instance user data into the `user_data_base64` attribute when a new `get_user_data` argument is set to `true`. The SHA-1 hash of the EC2 Instance user data will continue to be set in the `user_data` attribute regardless of the `get_user_data` argument.

Output from acceptance testing:

```
--- PASS: TestAccAWSInstanceDataSource_basic (149.59s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (158.67s)
```
