### PR TITLE
tests/provider: Skip additional sweeper errors for AWS GovCloud (US) support

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -345,5 +345,13 @@ func testSweepSkipSweepError(err error) bool {
 	if isAWSErr(err, "AccessDeniedException", "") {
 		return true
 	}
+	// Example: BadRequestException: vpc link not supported for region us-gov-west-1
+	if isAWSErr(err, "BadRequestException", "not supported") {
+		return true
+	}
+	// Example: InvalidAction: The action DescribeTransitGatewayAttachments is not valid for this web service
+	if isAWSErr(err, "InvalidAction", "is not valid") {
+		return true
+	}
 	return false
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Skips test sweeper errors like the following in AWS GovCloud (US):

```
2019/03/18 18:57:34 [ERR] error running (aws_api_gateway_vpc_link): Error retrieving API Gateway VPC Links: BadRequestException: vpc link not supported for region us-gov-west-1

2019/03/18 21:07:39 [ERR] error running (aws_ec2_transit_gateway): error retrieving EC2 Transit Gateway VPC Attachments: InvalidAction: The action DescribeTransitGatewayAttachments is not valid for this web service.
```

Output from test sweepers in AWS GovCloud (US):

```
2019/03/18 21:14:28 Sweeper Tests ran:
  - aws_vpc_endpoint_service
  - aws_autoscaling_group
  - aws_directory_service_directory
  - aws_waf_regex_match_set
  - aws_lambda_function
  - aws_ecs_cluster
  - aws_vpn_gateway
  - aws_cognito_user_pool
  - aws_db_option_group
  - aws_config_configuration_recorder
  - aws_config_delivery_channel
  - aws_datasync_agent
  - aws_elasticache_replication_group
  - aws_emr_cluster
  - aws_s3_bucket_object
  - aws_network_acl
  - aws_ec2_transit_gateway
  - aws_kms_key
  - aws_mq_broker
  - aws_redshift_cluster
  - aws_beanstalk_application
  - aws_ebs_volume
  - aws_gamelift_game_session_queue
  - aws_iam_server_certificate
  - aws_launch_configuration
  - aws_vpc_endpoint
  - aws_lb
  - aws_spot_fleet_request
  - aws_appmesh_mesh
  - aws_security_group
  - aws_dx_gateway
  - aws_cloudfront_distribution
  - aws_cloudwatch_event_permission
  - aws_s3_bucket
  - aws_glue_crawler
  - aws_instance
  - aws_gamelift_build
  - aws_licensemanager_license_configuration
  - aws_ec2_capacity_reservation
  - aws_lb_target_group
  - aws_appmesh_virtual_router
  - aws_secretsmanager_secret
  - aws_lightsail_static_ip
  - aws_waf_rule_group
  - aws_route53_resolver_endpoint
  - aws_vpc
  - aws_wafregional_regex_match_set
  - aws_sagemaker_model
  - aws_wafregional_rule_group
  - aws_key_pair
  - aws_datasync_location_efs
  - aws_glue_classifier
  - aws_api_gateway_vpc_link
  - aws_beanstalk_environment
  - aws_eks_cluster
  - aws_subnet
  - aws_datasync_location_nfs
  - aws_datasync_location_s3
  - aws_cloudwatch_event_rule
  - aws_iam_role
  - aws_elasticache_security_group
  - aws_nat_gateway
  - aws_batch_job_queue
  - aws_ec2_transit_gateway_vpc_attachment
  - aws_route_table
  - aws_cloudwatch_event_target
  - aws_dax_cluster
  - aws_elb
  - aws_gamelift_fleet
  - aws_glue_connection
  - aws_config_configuration_aggregator
  - aws_config_aggregate_authorization
  - aws_api_gateway_rest_api
  - aws_internet_gateway
  - aws_iam_user
  - aws_lambda_layer
  - aws_gamelift_alias
  - aws_iam_service_linked_role
  - aws_elasticache_cluster
  - aws_storagegateway_gateway
  - aws_dynamodb_table
  - aws_batch_compute_environment
  - aws_elasticsearch_domain
  - aws_network_interface
  - aws_ecs_service
  - aws_dx_gateway_association
  - aws_datasync_task
  - aws_glue_trigger
  - aws_kinesis_firehose_delivery_stream
  - aws_glue_job
  - aws_db_instance
  - aws_appsync_graphql_api
  - aws_appmesh_route
  - aws_acmpca_certificate_authority
  - aws_glue_security_configuration
ok    github.com/terraform-providers/terraform-provider-aws/aws 160.159s
```