### PR TITLE
Fix letter case on aws_dms_endpoint.mongodb_settings

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -138,17 +138,17 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 						"auth_type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "PASSWORD",
+							Default:  "password",
 						},
 						"auth_mechanism": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "DEFAULT",
+							Default:  "default",
 						},
 						"nesting_level": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  "NONE",
+							Default:  "none",
 						},
 						"extract_doc_id": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
AWS DMS automatically lowercases the MongoDB settings values. When Terraform runs, it'll change the settings to uppercase, only to have AWS set them to lowercase. Then, next time, Terraform will notice this change, and try again. This means that, if we set the values as uppercase, the state will never converge. This change fixes that.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
