### PR TITLE
Correct documentation for backup_retention_period and db_subnet_group_name

### DIFF
--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -72,7 +72,7 @@ will be applied automatically to the DB instance during the maintenance window.
 Defaults to true.
 * `availability_zone` - (Optional) The AZ for the RDS instance.
 * `backup_retention_period` - (Optional) The days to retain backups for. Must be
-between `0` and `35`. When creating a Read Replica the value must be greater than `0`. [See Read Replica][1].
+between `0` and `35`. Must be greater than `0` if the database is used as a source for a Read Replica. [See Read Replica][1].
 * `backup_window` - (Optional) The daily time range (in UTC) during which
 automated backups are created if they are enabled. Example: "09:46-10:16". Must
 not overlap with `maintenance_window`.
@@ -85,7 +85,7 @@ for more information.
 * `db_subnet_group_name` - (Optional) Name of [DB subnet group](/docs/providers/aws/r/db_subnet_group.html). DB instance will
 be created in the VPC associated with the DB subnet group. If unspecified, will
 be created in the `default` VPC, or in EC2 Classic, if available. When working
-with read replicas, it needs to be specified only if the source database
+with read replicas, it should be specified only if the source database
 specifies an instance in another AWS Region. See [DBSubnetGroupName in API
 action CreateDBInstanceReadReplica](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html)
 for additional read replica contraints.


### PR DESCRIPTION
## What

The documentation for `backup_retention_period` is incorrect as the source database should have a greater than 0 value, not the read replica. It was accidentally changed here: https://github.com/terraform-providers/terraform-provider-aws/commit/16424ce60b9edfc44454823d3b0a6f763a007379

Also I clarify for the db_subnet_group_name that `it should be specified only if the source database specifies an instance in another AWS Region`, as if you set it and the source database is in the same region then the AWS API returns an error.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

