### PR TITLE
New Resources: aws_cloudformation_stack_set and aws_cloudformation_stack_set_instance

### DIFF
--- a/aws/diff_suppress_funcs.go
+++ b/aws/diff_suppress_funcs.go
@@ -107,6 +107,24 @@ func suppressAutoscalingGroupAvailabilityZoneDiffs(k, old, new string, d *schema
 	return false
 }
 
+func suppressCloudFormationTemplateBodyDiffs(k, old, new string, d *schema.ResourceData) bool {
+	normalizedOld, err := normalizeCloudFormationTemplate(old)
+
+	if err != nil {
+		log.Printf("[WARN] Unable to normalize Terraform state CloudFormation template body: %s", err)
+		return false
+	}
+
+	normalizedNew, err := normalizeCloudFormationTemplate(new)
+
+	if err != nil {
+		log.Printf("[WARN] Unable to normalize Terraform configuration CloudFormation template body: %s", err)
+		return false
+	}
+
+	return normalizedOld == normalizedNew
+}
+
 func suppressRoute53ZoneNameWithTrailingDot(k, old, new string, d *schema.ResourceData) bool {
 	// "." is different from "".
 	if old == "." || new == "." {

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -330,6 +330,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_budgets_budget":                               resourceAwsBudgetsBudget(),
 			"aws_cloud9_environment_ec2":                       resourceAwsCloud9EnvironmentEc2(),
 			"aws_cloudformation_stack":                         resourceAwsCloudFormationStack(),
+			"aws_cloudformation_stack_set":                     resourceAwsCloudFormationStackSet(),
 			"aws_cloudfront_distribution":                      resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":            resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_public_key":                        resourceAwsCloudFrontPublicKey(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -331,6 +331,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloud9_environment_ec2":                       resourceAwsCloud9EnvironmentEc2(),
 			"aws_cloudformation_stack":                         resourceAwsCloudFormationStack(),
 			"aws_cloudformation_stack_set":                     resourceAwsCloudFormationStackSet(),
+			"aws_cloudformation_stack_set_instance":            resourceAwsCloudFormationStackSetInstance(),
 			"aws_cloudfront_distribution":                      resourceAwsCloudFrontDistribution(),
 			"aws_cloudfront_origin_access_identity":            resourceAwsCloudFrontOriginAccessIdentity(),
 			"aws_cloudfront_public_key":                        resourceAwsCloudFrontPublicKey(),

--- a/aws/resource_aws_cloudformation_stack_set.go
+++ b/aws/resource_aws_cloudformation_stack_set.go
@@ -1,0 +1,262 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsCloudFormationStackSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudFormationStackSetCreate,
+		Read:   resourceAwsCloudFormationStackSetRead,
+		Update: resourceAwsCloudFormationStackSetUpdate,
+		Delete: resourceAwsCloudFormationStackSetDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"administration_role_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateArn,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"capabilities": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						cloudformation.CapabilityCapabilityAutoExpand,
+						cloudformation.CapabilityCapabilityIam,
+						cloudformation.CapabilityCapabilityNamedIam,
+					}, false),
+				},
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 1024),
+			},
+			"execution_role_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "AWSCloudFormationStackSetExecutionRole",
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 128),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9-]+$`), "must contain only alphanumeric and hyphen characters"),
+				),
+			},
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"stack_set_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"template_body": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ConflictsWith:    []string{"template_url"},
+				DiffSuppressFunc: suppressCloudFormationTemplateBodyDiffs,
+				ValidateFunc:     validateCloudFormationTemplate,
+			},
+			"template_url": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"template_body"},
+			},
+		},
+	}
+}
+
+func resourceAwsCloudFormationStackSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+	name := d.Get("name").(string)
+
+	input := &cloudformation.CreateStackSetInput{
+		AdministrationRoleARN: aws.String(d.Get("administration_role_arn").(string)),
+		ClientRequestToken:    aws.String(resource.UniqueId()),
+		ExecutionRoleName:     aws.String(d.Get("execution_role_name").(string)),
+		StackSetName:          aws.String(name),
+	}
+
+	if v, ok := d.GetOk("capabilities"); ok {
+		input.Capabilities = expandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = expandCloudFormationTags(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("template_body"); ok {
+		input.TemplateBody = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("template_url"); ok {
+		input.TemplateURL = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating CloudFormation Stack Set: %s", input)
+	_, err := conn.CreateStackSet(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating CloudFormation Stack Set: %s", err)
+	}
+
+	d.SetId(name)
+
+	return resourceAwsCloudFormationStackSetRead(d, meta)
+}
+
+func resourceAwsCloudFormationStackSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+
+	input := &cloudformation.DescribeStackSetInput{
+		StackSetName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Reading CloudFormation Stack Set: %s", d.Id())
+	output, err := conn.DescribeStackSet(input)
+
+	if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
+		log.Printf("[WARN] CloudFormation Stack Set (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading CloudFormation Stack Set (%s): %s", d.Id(), err)
+	}
+
+	if output == nil || output.StackSet == nil {
+		return fmt.Errorf("error reading CloudFormation Stack Set (%s): empty response", d.Id())
+	}
+
+	stackSet := output.StackSet
+
+	d.Set("administration_role_arn", stackSet.AdministrationRoleARN)
+	d.Set("arn", stackSet.StackSetARN)
+
+	if err := d.Set("capabilities", aws.StringValueSlice(stackSet.Capabilities)); err != nil {
+		return fmt.Errorf("error setting capabilities: %s", err)
+	}
+
+	d.Set("description", stackSet.Description)
+	d.Set("execution_role_name", stackSet.ExecutionRoleName)
+	d.Set("name", stackSet.StackSetName)
+
+	if err := d.Set("parameters", flattenAllCloudFormationParameters(stackSet.Parameters)); err != nil {
+		return fmt.Errorf("error setting parameters: %s", err)
+	}
+
+	d.Set("stack_set_id", stackSet.StackSetId)
+
+	if err := d.Set("tags", flattenCloudFormationTags(stackSet.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	d.Set("template_body", stackSet.TemplateBody)
+
+	return nil
+}
+
+func resourceAwsCloudFormationStackSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+
+	input := &cloudformation.UpdateStackSetInput{
+		AdministrationRoleARN: aws.String(d.Get("administration_role_arn").(string)),
+		ExecutionRoleName:     aws.String(d.Get("execution_role_name").(string)),
+		OperationId:           aws.String(resource.UniqueId()),
+		StackSetName:          aws.String(d.Id()),
+		Tags:                  []*cloudformation.Tag{},
+		TemplateBody:          aws.String(d.Get("template_body").(string)),
+	}
+
+	if v, ok := d.GetOk("capabilities"); ok {
+		input.Capabilities = expandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		input.Parameters = expandCloudFormationParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = expandCloudFormationTags(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("template_url"); ok {
+		// ValidationError: Exactly one of TemplateBody or TemplateUrl must be specified
+		// TemplateBody is always present when TemplateUrl is used so remove TemplateBody if TemplateUrl is set
+		input.TemplateBody = nil
+		input.TemplateURL = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Updating CloudFormation Stack Set: %s", input)
+	_, err := conn.UpdateStackSet(input)
+
+	if err != nil {
+		return fmt.Errorf("error updating CloudFormation Stack Set (%s): %s", d.Id(), err)
+	}
+
+	return resourceAwsCloudFormationStackSetRead(d, meta)
+}
+
+func resourceAwsCloudFormationStackSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+
+	input := &cloudformation.DeleteStackSetInput{
+		StackSetName: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting CloudFormation Stack Set: %s", d.Id())
+	_, err := conn.DeleteStackSet(input)
+
+	if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting CloudFormation Stack Set (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}

--- a/aws/resource_aws_cloudformation_stack_set_instance.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance.go
@@ -1,0 +1,323 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsCloudFormationStackSetInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCloudFormationStackSetInstanceCreate,
+		Read:   resourceAwsCloudFormationStackSetInstanceRead,
+		Update: resourceAwsCloudFormationStackSetInstanceUpdate,
+		Delete: resourceAwsCloudFormationStackSetInstanceDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsAccountId,
+			},
+			"parameter_overrides": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"retain_stack": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"stack_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stack_set_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func resourceAwsCloudFormationStackSetInstanceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+
+	accountID := meta.(*AWSClient).accountid
+	if v, ok := d.GetOk("account_id"); ok {
+		accountID = v.(string)
+	}
+
+	region := meta.(*AWSClient).region
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+	}
+
+	stackSetName := d.Get("stack_set_name").(string)
+
+	input := &cloudformation.CreateStackInstancesInput{
+		Accounts:     aws.StringSlice([]string{accountID}),
+		OperationId:  aws.String(resource.UniqueId()),
+		Regions:      aws.StringSlice([]string{region}),
+		StackSetName: aws.String(stackSetName),
+	}
+
+	if v, ok := d.GetOk("parameter_overrides"); ok {
+		input.ParameterOverrides = expandCloudFormationParameters(v.(map[string]interface{}))
+	}
+
+	log.Printf("[DEBUG] Creating CloudFormation Stack Set Instance: %s", input)
+	output, err := conn.CreateStackInstances(input)
+
+	if err != nil {
+		return fmt.Errorf("error creating CloudFormation Stack Set Instance: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s,%s,%s", stackSetName, accountID, region))
+
+	if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) creation: %s", d.Id(), err)
+	}
+
+	return resourceAwsCloudFormationStackSetInstanceRead(d, meta)
+}
+
+func resourceAwsCloudFormationStackSetInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+
+	stackSetName, accountID, region, err := resourceAwsCloudFormationStackSetInstanceParseId(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	input := &cloudformation.DescribeStackInstanceInput{
+		StackInstanceAccount: aws.String(accountID),
+		StackInstanceRegion:  aws.String(region),
+		StackSetName:         aws.String(stackSetName),
+	}
+
+	log.Printf("[DEBUG] Reading CloudFormation Stack Set Instance: %s", d.Id())
+	output, err := conn.DescribeStackInstance(input)
+
+	if isAWSErr(err, cloudformation.ErrCodeStackInstanceNotFoundException, "") {
+		log.Printf("[WARN] CloudFormation Stack Set Instance (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
+		log.Printf("[WARN] CloudFormation Stack Set (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error reading CloudFormation Stack Set Instance (%s): %s", d.Id(), err)
+	}
+
+	if output == nil || output.StackInstance == nil {
+		return fmt.Errorf("error reading CloudFormation Stack Set Instance (%s): empty response", d.Id())
+	}
+
+	stackInstance := output.StackInstance
+
+	d.Set("account_id", stackInstance.Account)
+
+	if err := d.Set("parameter_overrides", flattenAllCloudFormationParameters(stackInstance.ParameterOverrides)); err != nil {
+		return fmt.Errorf("error setting parameters: %s", err)
+	}
+
+	d.Set("region", stackInstance.Region)
+	d.Set("stack_id", stackInstance.StackId)
+	d.Set("stack_set_name", stackSetName)
+
+	return nil
+}
+
+func resourceAwsCloudFormationStackSetInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+
+	if d.HasChange("parameter_overrides") {
+		stackSetName, accountID, region, err := resourceAwsCloudFormationStackSetInstanceParseId(d.Id())
+
+		if err != nil {
+			return err
+		}
+
+		input := &cloudformation.UpdateStackInstancesInput{
+			Accounts:           aws.StringSlice([]string{accountID}),
+			OperationId:        aws.String(resource.UniqueId()),
+			ParameterOverrides: []*cloudformation.Parameter{},
+			Regions:            aws.StringSlice([]string{region}),
+			StackSetName:       aws.String(stackSetName),
+		}
+
+		if v, ok := d.GetOk("parameter_overrides"); ok {
+			input.ParameterOverrides = expandCloudFormationParameters(v.(map[string]interface{}))
+		}
+
+		log.Printf("[DEBUG] Updating CloudFormation Stack Set Instance: %s", input)
+		output, err := conn.UpdateStackInstances(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating CloudFormation Stack Set Instance (%s): %s", d.Id(), err)
+		}
+
+		if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) update: %s", d.Id(), err)
+		}
+	}
+
+	return resourceAwsCloudFormationStackSetInstanceRead(d, meta)
+}
+
+func resourceAwsCloudFormationStackSetInstanceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+
+	stackSetName, accountID, region, err := resourceAwsCloudFormationStackSetInstanceParseId(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	input := &cloudformation.DeleteStackInstancesInput{
+		Accounts:     aws.StringSlice([]string{accountID}),
+		OperationId:  aws.String(resource.UniqueId()),
+		Regions:      aws.StringSlice([]string{region}),
+		RetainStacks: aws.Bool(d.Get("retain_stack").(bool)),
+		StackSetName: aws.String(stackSetName),
+	}
+
+	log.Printf("[DEBUG] Deleting CloudFormation Stack Set Instance: %s", d.Id())
+	output, err := conn.DeleteStackInstances(input)
+
+	if isAWSErr(err, cloudformation.ErrCodeStackInstanceNotFoundException, "") {
+		return nil
+	}
+
+	if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error deleting CloudFormation Stack Set Instance (%s): %s", d.Id(), err)
+	}
+
+	if err := waitForCloudFormationStackSetOperation(conn, stackSetName, aws.StringValue(output.OperationId), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("error waiting for CloudFormation Stack Set Instance (%s) deletion: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsCloudFormationStackSetInstanceParseId(id string) (string, string, string, error) {
+	idFormatErr := fmt.Errorf("unexpected format of ID (%s), expected NAME,ACCOUNT,REGION", id)
+
+	parts := strings.SplitN(id, ",", 3)
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", idFormatErr
+	}
+
+	return parts[0], parts[1], parts[2], nil
+}
+
+func refreshCloudformationStackSetOperation(conn *cloudformation.CloudFormation, stackSetName, operationID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &cloudformation.DescribeStackSetOperationInput{
+			OperationId:  aws.String(operationID),
+			StackSetName: aws.String(stackSetName),
+		}
+
+		output, err := conn.DescribeStackSetOperation(input)
+
+		if isAWSErr(err, cloudformation.ErrCodeOperationNotFoundException, "") {
+			return nil, cloudformation.StackSetOperationStatusRunning, nil
+		}
+
+		if err != nil {
+			return nil, cloudformation.StackSetOperationStatusFailed, err
+		}
+
+		if output == nil || output.StackSetOperation == nil {
+			return nil, cloudformation.StackSetOperationStatusRunning, nil
+		}
+
+		if aws.StringValue(output.StackSetOperation.Status) == cloudformation.StackSetOperationStatusFailed {
+			allResults := make([]string, 0)
+			listOperationResultsInput := &cloudformation.ListStackSetOperationResultsInput{
+				OperationId:  aws.String(operationID),
+				StackSetName: aws.String(stackSetName),
+			}
+
+			for {
+				listOperationResultsOutput, err := conn.ListStackSetOperationResults(listOperationResultsInput)
+
+				if err != nil {
+					return output.StackSetOperation, cloudformation.StackSetOperationStatusFailed, fmt.Errorf("error listing Operation (%s) errors: %s", operationID, err)
+				}
+
+				if listOperationResultsOutput == nil {
+					continue
+				}
+
+				for _, summary := range listOperationResultsOutput.Summaries {
+					allResults = append(allResults, fmt.Sprintf("Account (%s) Region (%s) Status (%s) Status Reason: %s", aws.StringValue(summary.Account), aws.StringValue(summary.Region), aws.StringValue(summary.Status), aws.StringValue(summary.StatusReason)))
+				}
+
+				if aws.StringValue(listOperationResultsOutput.NextToken) == "" {
+					break
+				}
+
+				listOperationResultsInput.NextToken = listOperationResultsOutput.NextToken
+			}
+
+			return output.StackSetOperation, cloudformation.StackSetOperationStatusFailed, fmt.Errorf("Operation (%s) Results:\n%s", operationID, strings.Join(allResults, "\n"))
+		}
+
+		return output.StackSetOperation, aws.StringValue(output.StackSetOperation.Status), nil
+	}
+}
+
+func waitForCloudFormationStackSetOperation(conn *cloudformation.CloudFormation, stackSetName, operationID string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{cloudformation.StackSetOperationStatusRunning},
+		Target:  []string{cloudformation.StackSetOperationStatusSucceeded},
+		Refresh: refreshCloudformationStackSetOperation(conn, stackSetName, operationID),
+		Timeout: timeout,
+		Delay:   5 * time.Second,
+	}
+
+	log.Printf("[DEBUG] Waiting for CloudFormation Stack Set (%s) operation: %s", stackSetName, operationID)
+	_, err := stateConf.WaitForState()
+
+	return err
+}

--- a/aws/resource_aws_cloudformation_stack_set_instance_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_instance_test.go
@@ -1,0 +1,456 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCloudFormationStackSetInstance_basic(t *testing.T) {
+	var stackInstance1 cloudformation.StackInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cloudformationStackSetResourceName := "aws_cloudformation_stack_set.test"
+	resourceName := "aws_cloudformation_stack_set_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance1),
+					testAccCheckResourceAttrAccountID(resourceName, "account_id"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "region", testAccGetRegion()),
+					resource.TestCheckResourceAttr(resourceName, "retain_stack", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "stack_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "stack_set_name", cloudformationStackSetResourceName, "name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_stack",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSetInstance_disappears(t *testing.T) {
+	var stackInstance1 cloudformation.StackInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance1),
+					testAccCheckCloudFormationStackSetInstanceDisappears(&stackInstance1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSetInstance_disappears_StackSet(t *testing.T) {
+	var stackInstance1 cloudformation.StackInstance
+	var stackSet1 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	cloudformationStackSetResourceName := "aws_cloudformation_stack_set.test"
+	resourceName := "aws_cloudformation_stack_set_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(cloudformationStackSetResourceName, &stackSet1),
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance1),
+					testAccCheckCloudFormationStackSetInstanceDisappears(&stackInstance1),
+					testAccCheckCloudFormationStackSetDisappears(&stackSet1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSetInstance_ParameterOverrides(t *testing.T) {
+	var stackInstance1, stackInstance2, stackInstance3, stackInstance4 cloudformation.StackInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfigParameterOverrides1(rName, "overridevalue1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance1),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.Parameter1", "overridevalue1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_stack",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfigParameterOverrides2(rName, "overridevalue1updated", "overridevalue2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance2),
+					testAccCheckCloudFormationStackSetInstanceNotRecreated(&stackInstance1, &stackInstance2),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.Parameter1", "overridevalue1updated"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.Parameter2", "overridevalue2"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfigParameterOverrides1(rName, "overridevalue1updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance3),
+					testAccCheckCloudFormationStackSetInstanceNotRecreated(&stackInstance2, &stackInstance3),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.Parameter1", "overridevalue1updated"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance4),
+					testAccCheckCloudFormationStackSetInstanceNotRecreated(&stackInstance3, &stackInstance4),
+					resource.TestCheckResourceAttr(resourceName, "parameter_overrides.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAWSCloudFrontDistribution_RetainStack verifies retain_stack = true
+// This acceptance test performs the following steps:
+//  * Trigger a Terraform destroy of the resource, which should only remove the instance from the stack set
+//  * Check it still exists outside Terraform
+//  * Destroy for real outside Terraform
+func TestAccAWSCloudFormationStackSetInstance_RetainStack(t *testing.T) {
+	var stack1 cloudformation.Stack
+	var stackInstance1, stackInstance2, stackInstance3 cloudformation.StackInstance
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set_instance.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfigRetainStack(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance1),
+					resource.TestCheckResourceAttr(resourceName, "retain_stack", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_stack",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfigRetainStack(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance2),
+					testAccCheckCloudFormationStackSetInstanceNotRecreated(&stackInstance1, &stackInstance2),
+					resource.TestCheckResourceAttr(resourceName, "retain_stack", "false"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetInstanceConfigRetainStack(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceExists(resourceName, &stackInstance3),
+					testAccCheckCloudFormationStackSetInstanceNotRecreated(&stackInstance2, &stackInstance3),
+					resource.TestCheckResourceAttr(resourceName, "retain_stack", "true"),
+				),
+			},
+			{
+				Config:  testAccAWSCloudFormationStackSetInstanceConfigRetainStack(rName, true),
+				Destroy: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetInstanceStackExists(&stackInstance3, &stack1),
+					testAccCheckCloudFormationStackDisappears(&stack1),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudFormationStackSetInstanceExists(resourceName string, stackInstance *cloudformation.StackInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+		stackSetName, accountID, region, err := resourceAwsCloudFormationStackSetInstanceParseId(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		input := &cloudformation.DescribeStackInstanceInput{
+			StackInstanceAccount: aws.String(accountID),
+			StackInstanceRegion:  aws.String(region),
+			StackSetName:         aws.String(stackSetName),
+		}
+
+		output, err := conn.DescribeStackInstance(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.StackInstance == nil {
+			return fmt.Errorf("CloudFormation Stack Set Instance (%s) not found", rs.Primary.ID)
+		}
+
+		*stackInstance = *output.StackInstance
+
+		return nil
+	}
+}
+
+func testAccCheckCloudFormationStackSetInstanceStackExists(stackInstance *cloudformation.StackInstance, stack *cloudformation.Stack) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+		input := &cloudformation.DescribeStacksInput{
+			StackName: stackInstance.StackId,
+		}
+
+		output, err := conn.DescribeStacks(input)
+
+		if err != nil {
+			return err
+		}
+
+		if len(output.Stacks) == 0 || output.Stacks[0] == nil {
+			return fmt.Errorf("CloudFormation Stack (%s) not found", aws.StringValue(stackInstance.StackId))
+		}
+
+		*stack = *output.Stacks[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCloudFormationStackSetInstanceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudformation_stack_set_instance" {
+			continue
+		}
+
+		stackSetName, accountID, region, err := resourceAwsCloudFormationStackSetInstanceParseId(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		input := &cloudformation.DescribeStackInstanceInput{
+			StackInstanceAccount: aws.String(accountID),
+			StackInstanceRegion:  aws.String(region),
+			StackSetName:         aws.String(stackSetName),
+		}
+
+		output, err := conn.DescribeStackInstance(input)
+
+		if isAWSErr(err, cloudformation.ErrCodeStackInstanceNotFoundException, "") {
+			return nil
+		}
+
+		if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output != nil && output.StackInstance != nil {
+			return fmt.Errorf("CloudFormation Stack Set Instance (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudFormationStackSetInstanceDisappears(stackInstance *cloudformation.StackInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+		input := &cloudformation.DeleteStackInstancesInput{
+			Accounts:     []*string{stackInstance.Account},
+			Regions:      []*string{stackInstance.Region},
+			RetainStacks: aws.Bool(false),
+			StackSetName: stackInstance.StackSetId,
+		}
+
+		output, err := conn.DeleteStackInstances(input)
+
+		if err != nil {
+			return err
+		}
+
+		return waitForCloudFormationStackSetOperation(conn, aws.StringValue(stackInstance.StackSetId), aws.StringValue(output.OperationId), 10*time.Minute)
+	}
+}
+
+func testAccCheckCloudFormationStackSetInstanceNotRecreated(i, j *cloudformation.StackInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.StackId) != aws.StringValue(j.StackId) {
+			return fmt.Errorf("CloudFormation Stack Set Instance (%s,%s,%s) recreated", aws.StringValue(i.StackSetId), aws.StringValue(i.Account), aws.StringValue(i.Region))
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSCloudFormationStackSetInstanceConfigBase(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "Administration" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = "%[1]s-Administration"
+}
+
+resource "aws_iam_role_policy" "Administration" {
+  policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Resource\":[\"*\"],\"Action\":[\"sts:AssumeRole\"]}]}"
+  role   = "${aws_iam_role.Administration.name}"
+}
+
+resource "aws_iam_role" "Execution" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"${aws_iam_role.Administration.arn}\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = "%[1]s-Execution"
+}
+
+resource "aws_iam_role_policy" "Execution" {
+  policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Resource\":[\"*\"],\"Action\":[\"*\"]}]}"
+  role   = "${aws_iam_role.Execution.name}"
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  depends_on = ["aws_iam_role_policy.Execution"]
+
+  administration_role_arn = "${aws_iam_role.Administration.arn}"
+  execution_role_name     = "${aws_iam_role.Execution.name}"
+  name                    = %[1]q
+  parameters              = {
+    Parameter1 = "stacksetvalue1"
+    Parameter2 = "stacksetvalue2"
+  }
+  template_body           = <<TEMPLATE
+Parameters:
+  Parameter1:
+    Type: String
+  Parameter2:
+    Type: String
+Resources:
+  TestVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+        -
+          Key: Name
+          Value: %[1]q
+Outputs:
+  Parameter1Value:
+    Value: !Ref Parameter1
+  Parameter2Value:
+    Value: !Ref Parameter2
+  Region:
+    Value: !Ref "AWS::Region"
+  TestVpcID:
+    Value: !Ref TestVpc
+TEMPLATE
+}
+`, rName)
+}
+
+func testAccAWSCloudFormationStackSetInstanceConfig(rName string) string {
+	return testAccAWSCloudFormationStackSetInstanceConfigBase(rName) + fmt.Sprintf(`
+resource "aws_cloudformation_stack_set_instance" "test" {
+  depends_on = ["aws_iam_role_policy.Administration", "aws_iam_role_policy.Execution"]
+
+  stack_set_name = "${aws_cloudformation_stack_set.test.name}"
+}
+`)
+}
+
+func testAccAWSCloudFormationStackSetInstanceConfigParameterOverrides1(rName, value1 string) string {
+	return testAccAWSCloudFormationStackSetInstanceConfigBase(rName) + fmt.Sprintf(`
+resource "aws_cloudformation_stack_set_instance" "test" {
+  depends_on = ["aws_iam_role_policy.Administration", "aws_iam_role_policy.Execution"]
+
+  parameter_overrides = {
+    Parameter1 = %[1]q
+  }
+  stack_set_name      = "${aws_cloudformation_stack_set.test.name}"
+}
+`, value1)
+}
+
+func testAccAWSCloudFormationStackSetInstanceConfigParameterOverrides2(rName, value1, value2 string) string {
+	return testAccAWSCloudFormationStackSetInstanceConfigBase(rName) + fmt.Sprintf(`
+resource "aws_cloudformation_stack_set_instance" "test" {
+  depends_on = ["aws_iam_role_policy.Administration", "aws_iam_role_policy.Execution"]
+
+  parameter_overrides = {
+    Parameter1 = %[1]q
+    Parameter2 = %[2]q
+  }
+  stack_set_name      = "${aws_cloudformation_stack_set.test.name}"
+}
+`, value1, value2)
+}
+
+func testAccAWSCloudFormationStackSetInstanceConfigRetainStack(rName string, retainStack bool) string {
+	return testAccAWSCloudFormationStackSetInstanceConfigBase(rName) + fmt.Sprintf(`
+resource "aws_cloudformation_stack_set_instance" "test" {
+  depends_on = ["aws_iam_role_policy.Administration", "aws_iam_role_policy.Execution"]
+
+  retain_stack   = %[1]t
+  stack_set_name = "${aws_cloudformation_stack_set.test.name}"
+}
+`, retainStack)
+}

--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -1,0 +1,1048 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCloudFormationStackSet_basic(t *testing.T) {
+	var stackSet1 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName := "aws_iam_role.test"
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttrPair(resourceName, "administration_role_arn", iamRoleResourceName, "arn"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "cloudformation", regexp.MustCompile(`stackset/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "capabilities.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "execution_role_name", "AWSCloudFormationStackSetExecutionRole"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+					resource.TestMatchResourceAttr(resourceName, "stack_set_id", regexp.MustCompile(fmt.Sprintf("%s:.+", rName))),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "template_body", testAccAWSCloudFormationStackSetTemplateBodyVpc(rName)+"\n"),
+					resource.TestCheckNoResourceAttr(resourceName, "template_url"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_disappears(t *testing.T) {
+	var stackSet1 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					testAccCheckCloudFormationStackSetDisappears(&stackSet1),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_AdministrationRoleArn(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	iamRoleResourceName1 := "aws_iam_role.test1"
+	iamRoleResourceName2 := "aws_iam_role.test2"
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigAdministrationRoleArn1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttrPair(resourceName, "administration_role_arn", iamRoleResourceName1, "arn"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigAdministrationRoleArn2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttrPair(resourceName, "administration_role_arn", iamRoleResourceName2, "arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_Description(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigDescription(rName, "description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigDescription(rName, "description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_ExecutionRoleName(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigExecutionRoleName(rName, "name1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "execution_role_name", "name1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigExecutionRoleName(rName, "name2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "execution_role_name", "name2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_Name(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCloudFormationStackSetConfigName(""),
+				ExpectError: regexp.MustCompile(`expected length`),
+			},
+			{
+				Config:      testAccAWSCloudFormationStackSetConfigName(acctest.RandStringFromCharSet(129, acctest.CharSetAlpha)),
+				ExpectError: regexp.MustCompile(`expected length`),
+			},
+			{
+				Config:      testAccAWSCloudFormationStackSetConfigName("1"),
+				ExpectError: regexp.MustCompile(`must begin with alphabetic character`),
+			},
+			{
+				Config:      testAccAWSCloudFormationStackSetConfigName("a_b"),
+				ExpectError: regexp.MustCompile(`must contain only alphanumeric and hyphen characters`),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigName(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "name", rName1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigName(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_Parameters(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParameters1(rName, "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParameters2(rName, "value1updated", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParameters1(rName, "value1updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "value1updated"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_Parameters_Default(t *testing.T) {
+	t.Skip("this resource does not currently ignore unconfigured CloudFormation template parameters with the Default property")
+	// Additional references:
+	//  * https://github.com/hashicorp/terraform/issues/18863
+
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParametersDefault0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "defaultvalue"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParametersDefault1(rName, "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParametersDefault0(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "defaultvalue"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_Parameters_NoEcho(t *testing.T) {
+	t.Skip("this resource does not currently ignore CloudFormation template parameters with the NoEcho property")
+	// Additional references:
+	//  * https://github.com/terraform-providers/terraform-provider-aws/issues/55
+
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParametersNoEcho1(rName, "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "****"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigParametersNoEcho1(rName, "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.Parameter1", "****"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_Tags(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigTags1(rName, "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigTags2(rName, "value1updated", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigTags1(rName, "value1updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "value1updated"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_TemplateBody(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigTemplateBody(rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName+"1")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttr(resourceName, "template_body", testAccAWSCloudFormationStackSetTemplateBodyVpc(rName+"1")+"\n"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigTemplateBody(rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName+"2")),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttr(resourceName, "template_body", testAccAWSCloudFormationStackSetTemplateBodyVpc(rName+"2")+"\n"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFormationStackSet_TemplateUrl(t *testing.T) {
+	var stackSet1, stackSet2 cloudformation.StackSet
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationStackSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackSetConfigTemplateUrl1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet1),
+					resource.TestCheckResourceAttrSet(resourceName, "template_body"),
+					resource.TestCheckResourceAttrSet(resourceName, "template_url"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_url",
+				},
+			},
+			{
+				Config: testAccAWSCloudFormationStackSetConfigTemplateUrl2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackSetExists(resourceName, &stackSet2),
+					testAccCheckCloudFormationStackSetNotRecreated(&stackSet1, &stackSet2),
+					resource.TestCheckResourceAttrSet(resourceName, "template_body"),
+					resource.TestCheckResourceAttrSet(resourceName, "template_url"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCloudFormationStackSetExists(resourceName string, stackSet *cloudformation.StackSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+		input := &cloudformation.DescribeStackSetInput{
+			StackSetName: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeStackSet(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.StackSet == nil {
+			return fmt.Errorf("CloudFormation Stack Set (%s) not found", rs.Primary.ID)
+		}
+
+		*stackSet = *output.StackSet
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCloudFormationStackSetDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cloudformation_stack_set" {
+			continue
+		}
+
+		input := cloudformation.DescribeStackSetInput{
+			StackSetName: aws.String(rs.Primary.ID),
+		}
+
+		output, err := conn.DescribeStackSet(&input)
+
+		if isAWSErr(err, cloudformation.ErrCodeStackSetNotFoundException, "") {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if output != nil && output.StackSet != nil {
+			return fmt.Errorf("CloudFormation Stack Set (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCloudFormationStackSetDisappears(stackSet *cloudformation.StackSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).cfconn
+
+		input := &cloudformation.DeleteStackSetInput{
+			StackSetName: stackSet.StackSetName,
+		}
+
+		_, err := conn.DeleteStackSet(input)
+
+		return err
+	}
+}
+
+func testAccCheckCloudFormationStackSetNotRecreated(i, j *cloudformation.StackSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.StackSetId) != aws.StringValue(j.StackSetId) {
+			return fmt.Errorf("CloudFormation Stack Set (%s) recreated", aws.StringValue(i.StackSetName))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudFormationStackSetRecreated(i, j *cloudformation.StackSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.StackSetId) == aws.StringValue(j.StackSetId) {
+			return fmt.Errorf("CloudFormation Stack Set (%s) not recreated", aws.StringValue(i.StackSetName))
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSCloudFormationStackSetTemplateBodyParameters1(rName string) string {
+	return fmt.Sprintf(`
+Parameters:
+  Parameter1:
+    Type: String
+Resources:
+  TestVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+        -
+          Key: Name
+          Value: %[1]q
+Outputs:
+  Parameter1Value:
+    Value: !Ref Parameter1
+  Region:
+    Value: !Ref "AWS::Region"
+  TestVpcID:
+    Value: !Ref TestVpc
+`, rName)
+}
+
+func testAccAWSCloudFormationStackSetTemplateBodyParameters2(rName string) string {
+	return fmt.Sprintf(`
+Parameters:
+  Parameter1:
+    Type: String
+  Parameter2:
+    Type: String
+Resources:
+  TestVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+        -
+          Key: Name
+          Value: %[1]q
+Outputs:
+  Parameter1Value:
+    Value: !Ref Parameter1
+  Parameter2Value:
+    Value: !Ref Parameter2
+  Region:
+    Value: !Ref "AWS::Region"
+  TestVpcID:
+    Value: !Ref TestVpc
+`, rName)
+}
+
+func testAccAWSCloudFormationStackSetTemplateBodyParametersDefault1(rName string) string {
+	return fmt.Sprintf(`
+Parameters:
+  Parameter1:
+    Type: String
+    Default: defaultvalue
+Resources:
+  TestVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+        -
+          Key: Name
+          Value: %[1]q
+Outputs:
+  Parameter1Value:
+    Value: !Ref Parameter1
+  Region:
+    Value: !Ref "AWS::Region"
+  TestVpcID:
+    Value: !Ref TestVpc
+`, rName)
+}
+
+func testAccAWSCloudFormationStackSetTemplateBodyParametersNoEcho1(rName string) string {
+	return fmt.Sprintf(`
+Parameters:
+  Parameter1:
+    Type: String
+    NoEcho: true
+Resources:
+  TestVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+        -
+          Key: Name
+          Value: %[1]q
+Outputs:
+  Parameter1Value:
+    Value: !Ref Parameter1
+  Region:
+    Value: !Ref "AWS::Region"
+  TestVpcID:
+    Value: !Ref TestVpc
+`, rName)
+}
+
+func testAccAWSCloudFormationStackSetTemplateBodyVpc(rName string) string {
+	return fmt.Sprintf(`
+Resources:
+  TestVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Tags:
+        -
+          Key: Name
+          Value: %[1]q
+Outputs:
+  Region:
+    Value: !Ref "AWS::Region"
+  TestVpcID:
+    Value: !Ref TestVpc
+`, rName)
+}
+
+func testAccAWSCloudFormationStackSetConfigAdministrationRoleArn1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test1" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = "%[1]s1"
+}
+
+resource "aws_iam_role" "test2" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = "%[1]s2"
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test1.arn}"
+  name                    = %[1]q
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName))
+}
+
+func testAccAWSCloudFormationStackSetConfigAdministrationRoleArn2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test1" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = "%[1]s1"
+}
+
+resource "aws_iam_role" "test2" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = "%[1]s2"
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test2.arn}"
+  name                    = %[1]q
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName))
+}
+
+func testAccAWSCloudFormationStackSetConfigDescription(rName, description string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  description             = %[3]q
+  name                    = %[1]q
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName), description)
+}
+
+func testAccAWSCloudFormationStackSetConfigExecutionRoleName(rName, executionRoleName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  execution_role_name     = %[3]q
+  name                    = %[1]q
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName), executionRoleName)
+}
+
+func testAccAWSCloudFormationStackSetConfigName(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName))
+}
+
+func testAccAWSCloudFormationStackSetConfigParameters1(rName, value1 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  parameters              = {
+    Parameter1 = %[3]q
+  }
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyParameters1(rName), value1)
+}
+
+func testAccAWSCloudFormationStackSetConfigParameters2(rName, value1, value2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  parameters              = {
+    Parameter1 = %[3]q
+    Parameter2 = %[4]q
+  }
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyParameters2(rName), value1, value2)
+}
+
+func testAccAWSCloudFormationStackSetConfigParametersDefault0(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyParametersDefault1(rName))
+}
+
+func testAccAWSCloudFormationStackSetConfigParametersDefault1(rName, value1 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  parameters              = {
+    Parameter1 = %[3]q
+  }
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyParametersDefault1(rName), value1)
+}
+
+func testAccAWSCloudFormationStackSetConfigParametersNoEcho1(rName, value1 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  parameters              = {
+    Parameter1 = %[3]q
+  }
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyParametersNoEcho1(rName), value1)
+}
+
+func testAccAWSCloudFormationStackSetConfigTags1(rName, value1 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  tags                    = {
+    Key1 = %[3]q
+  }
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName), value1)
+}
+
+func testAccAWSCloudFormationStackSetConfigTags2(rName, value1, value2 string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  tags                    = {
+    Key1 = %[3]q
+    Key2 = %[4]q
+  }
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName), value1, value2)
+}
+
+func testAccAWSCloudFormationStackSetConfigTemplateBody(rName, templateBody string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  template_body           = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, templateBody)
+}
+
+func testAccAWSCloudFormationStackSetConfigTemplateUrl1(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+  acl    = "public-read"
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_object" "test" {
+  acl     = "public-read"
+  bucket  = "${aws_s3_bucket.test.bucket}"
+  content = <<CONTENT
+%[2]s
+CONTENT
+  key     = "%[1]s-template1.yml"
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  template_url            = "https://${aws_s3_bucket.test.bucket_regional_domain_name}/${aws_s3_bucket_object.test.key}"
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName+"1"))
+}
+
+func testAccAWSCloudFormationStackSetConfigTemplateUrl2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"cloudformation.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+  name               = %[1]q
+}
+
+resource "aws_s3_bucket" "test" {
+  acl    = "public-read"
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_object" "test" {
+  acl     = "public-read"
+  bucket  = "${aws_s3_bucket.test.bucket}"
+  content = <<CONTENT
+%[2]s
+CONTENT
+  key     = "%[1]s-template2.yml"
+}
+
+resource "aws_cloudformation_stack_set" "test" {
+  administration_role_arn = "${aws_iam_role.test.arn}"
+  name                    = %[1]q
+  template_url            = "https://${aws_s3_bucket.test.bucket_regional_domain_name}/${aws_s3_bucket_object.test.key}"
+}
+`, rName, testAccAWSCloudFormationStackSetTemplateBodyVpc(rName+"2"))
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -621,6 +621,9 @@
                         <li<%= sidebar_current("docs-aws-resource-cloudformation-stack") %>>
                             <a href="/docs/providers/aws/r/cloudformation_stack.html">aws_cloudformation_stack</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-cloudformation-stack-set") %>>
+                            <a href="/docs/providers/aws/r/cloudformation_stack_set.html">aws_cloudformation_stack_set</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -624,6 +624,9 @@
                         <li<%= sidebar_current("docs-aws-resource-cloudformation-stack-set") %>>
                             <a href="/docs/providers/aws/r/cloudformation_stack_set.html">aws_cloudformation_stack_set</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-resource-cloudformation-stack-set-instance") %>>
+                            <a href="/docs/providers/aws/r/cloudformation_stack_set_instance.html">aws_cloudformation_stack_set_instance</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -1,0 +1,112 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudformation_stack_set"
+sidebar_current: "docs-aws-resource-cloudformation-stack-set"
+description: |-
+  Manages a CloudFormation Stack Set.
+---
+
+# aws_cloudformation_stack_set
+
+Manages a CloudFormation Stack Set. Stack Sets allow CloudFormation templates to be easily deployed across multiple accounts and regions via Stack Set Instances ([`aws_cloudformation_stack_set_instance` resource](/docs/providers/aws/r/cloudformation_stack_set_instance.html)). Additional information about Stack Sets can be found in the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).
+
+~> **NOTE:** All template parameters, including those with a `Default`, must be configured or ignored with the `lifecycle` configuration block `ignore_changes` argument.
+
+~> **NOTE:** All `NoEcho` template parameters must be ignored with the `lifecycle` configuration block `ignore_changes` argument.
+
+## Example Usage
+
+```hcl
+data "aws_iam_policy_document" "AWSCloudFormationStackSetAdministrationRole_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      identifiers = ["cloudformation.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "AWSCloudFormationStackSetAdministrationRole" {
+  assume_role_policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetAdministrationRole_assume_role_policy.json}"
+  name               = "AWSCloudFormationStackSetAdministrationRole"
+}
+
+resource "aws_cloudformation_stack_set" "example" {
+  administration_role_arn = "${aws_iam_role.AWSCloudFormationStackSetAdministrationRole.arn}"
+  name                    = "example"
+
+  parameters = {
+    VPCCidr = "10.0.0.0/16"
+  }
+
+  template_body = <<TEMPLATE
+{
+  "Parameters" : {
+    "VPCCidr" : {
+      "Type" : "String",
+      "Default" : "10.0.0.0/16",
+      "Description" : "Enter the CIDR block for the VPC. Default is 10.0.0.0/16."
+    }
+  },
+  "Resources" : {
+    "myVpc": {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : { "Ref" : "VPCCidr" },
+        "Tags" : [
+          {"Key": "Name", "Value": "Primary_CF_VPC"}
+        ]
+      }
+    }
+  }
+}
+TEMPLATE
+}
+
+data "aws_iam_policy_document" "AWSCloudFormationStackSetAdministrationRole_ExecutionPolicy" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    effect    = "Allow"
+    resources = ["arn:aws:iam::*:role/${aws_cloudformation_stack_set.example.execution_role_name}"]
+  }
+}
+
+resource "aws_iam_role_policy" "AWSCloudFormationStackSetAdministrationRole_ExecutionPolicy" {
+  name   = "ExecutionPolicy"
+  policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetAdministrationRole_ExecutionPolicy.json}"
+  role   = "${aws_iam_role.AWSCloudFormationStackSetAdministrationRole.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `administration_role_arn` - (Required) Amazon Resource Number (ARN) of the IAM Role in the administrator account.
+* `name` - (Required) Name of the Stack Set. The name must be unique in the region where you create your Stack Set. The name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and cannot be longer than 128 characters.
+* `capabilities` - (Optional) A list of capabilities. Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, `CAPABILITY_AUTO_EXPAND`.
+* `description` - (Optional) Description of the Stack Set.
+* `execution_role_name` - (Optional) Name of the IAM Role in all target accounts for Stack Set operations. Defaults to `AWSCloudFormationStackSetExecutionRole`.
+* `parameters` - (Optional) Key-value map of input parameters for the Stack Set template. All template parameters, including those with a `Default`, must be configured or ignored with `lifecycle` configuration block `ignore_changes` argument. All `NoEcho` template parameters must be ignored with the `lifecycle` configuration block `ignore_changes` argument.
+* `tags` - (Optional) Key-value map of tags to associate with this Stack Set and the Stacks created from it. AWS CloudFormation also propagates these tags to supported resources that are created in the Stacks. A maximum number of 50 tags can be specified.
+* `template_body` - (Optional) String containing the CloudFormation template body. Maximum size: 51,200 bytes. Conflicts with `template_url`.
+* `template_url` - (Optional) String containing the location of a file containing the CloudFormation template body. The URL must point to a template that is located in an Amazon S3 bucket. Maximum location file size: 460,800 bytes. Conflicts with `template_body`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of the Stack Set.
+* `id` - Name of the Stack Set.
+* `stack_set_id` - Unique identifier of the Stack Set.
+
+## Import
+
+CloudFormation Stack Sets can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_cloudformation_stack.example example
+```

--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -1,0 +1,99 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudformation_stack_set_instance"
+sidebar_current: "docs-aws-resource-cloudformation-stack-set-instance"
+description: |-
+  Manages a CloudFormation Stack Set Instance.
+---
+
+# aws_cloudformation_stack_set_instance
+
+Manages a CloudFormation Stack Set Instance. Instances are managed in the account and region of the Stack Set after the target account permissions have been configured. Additional information about Stack Sets can be found in the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/what-is-cfnstacksets.html).
+
+~> **NOTE:** All target accounts must have an IAM Role created that matches the name of the execution role configured in the Stack Set (the `execution_role_name` argument in the `aws_cloudformation_stack_set` resource) in a trust relationship with the administrative account or administration IAM Role. The execution role must have appropriate permissions to manage resources defined in the template along with those required for Stack Sets to operate. See the [AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html) for more details.
+
+~> **NOTE:** To retain the Stack during Terraform resource destroy, ensure `retain_stack = true` has been successfully applied into the Terraform state first. This must be completed _before_ an apply that would destroy the resource.
+
+## Example Usage
+
+```hcl
+resource "aws_cloudformation_stack_set_instance" "example" {
+  account_id     = "123456789012"
+  region         = "us-east-1"
+  stack_set_name = "${aws_cloudformation_stack_set.example.name}"
+}
+```
+
+### Example IAM Setup in Target Account
+
+```hcl
+data "aws_iam_policy_document" "AWSCloudFormationStackSetExecutionRole_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+
+    principals {
+      identifiers = ["${aws_iam_role.AWSCloudFormationStackSetAdministrationRole.arn}"]
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_iam_role" "AWSCloudFormationStackSetExecutionRole" {
+  assume_role_policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetExecutionRole_assume_role_policy.json}"
+  name               = "AWSCloudFormationStackSetExecutionRole"
+}
+
+# Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs.html
+# Additional IAM permissions necessary depend on the resources defined in the Stack Set template
+data "aws_iam_policy_document" "AWSCloudFormationStackSetExecutionRole_MinimumExecutionPolicy" {
+  statement {
+    actions   = [
+      "cloudformation:*",
+      "s3:*",
+      "sns:*",
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "AWSCloudFormationStackSetExecutionRole_MinimumExecutionPolicy" {
+  name   = "MinimumExecutionPolicy"
+  policy = "${data.aws_iam_policy_document.AWSCloudFormationStackSetExecutionRole_MinimumExecutionPolicy.json}"
+  role   = "${aws_iam_role.AWSCloudFormationStackSetExecutionRole.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `stack_set_name` - (Required) Name of the Stack Set.
+* `account_id` - (Optional) Target AWS Account ID to create a Stack based on the Stack Set. Defaults to current account.
+* `parameter_overrides` - (Optional) Key-value map of input parameters to override from the Stack Set for this Instance.
+* `region` - (Optional) Target AWS Region to create a Stack based on the Stack Set. Defaults to current region.
+* `retain_stack` - (Optional) During Terraform resource destroy, remove Instance from Stack Set while keeping the Stack and its associated resources. Must be enabled in Terraform state _before_ destroy operation to take effect. You cannot reassociate a retained Stack or add an existing, saved Stack to a new Stack Set. Defaults to `false`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Stack Set name, target AWS account ID, and target AWS region separated by commas (`,`)
+* `stack_id` - Stack identifier
+
+## Timeouts
+
+`aws_cloudformation_stack_set_instance` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+* `create` - (Default `30m`) How long to wait for a Stack to be created.
+* `update` - (Default `30m`) How long to wait for a Stack to be updated.
+* `delete` - (Default `30m`) How long to wait for a Stack to be deleted.
+
+## Import
+
+CloudFormation Stack Set Instances can be imported using the Stack Set name, target AWS account ID, and target AWS region separated by commas (`,`) e.g.
+
+```
+$ terraform import aws_cloudformation_stack_set_instance.example example,123456789012,us-east-1
+```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* **New Resource:** `aws_cloudformation_stack_set`
* **New Resource:** `aws_cloudformation_stack_set_instance`
* tests/resource/aws_cloudformation_stack: Ensure resource recreation when deleted outside Terraform

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFormationStack_disappears (69.36s)

--- PASS: TestAccAWSCloudFormationStackSet_basic (15.29s)
--- PASS: TestAccAWSCloudFormationStackSet_disappears (22.90s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateBody (39.15s)
--- PASS: TestAccAWSCloudFormationStackSet_Description (39.37s)
--- PASS: TestAccAWSCloudFormationStackSet_Name (43.84s)
--- PASS: TestAccAWSCloudFormationStackSet_ExecutionRoleName (44.60s)
--- PASS: TestAccAWSCloudFormationStackSet_AdministrationRoleArn (50.43s)
--- PASS: TestAccAWSCloudFormationStackSet_TemplateUrl (62.88s)
--- PASS: TestAccAWSCloudFormationStackSet_Tags (66.14s)
--- PASS: TestAccAWSCloudFormationStackSet_Parameters (69.07s)

--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears (116.33s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_disappears_StackSet (123.01s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_basic (131.07s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_RetainStack (161.53s)
--- PASS: TestAccAWSCloudFormationStackSetInstance_ParameterOverrides (225.51s)
```
