### PR TITLE
resource/batch_compute_environment: Support LaunchTemplate

### DIFF
--- a/aws/resource_aws_batch_compute_environment.go
+++ b/aws/resource_aws_batch_compute_environment.go
@@ -64,6 +64,30 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"launch_template": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"launch_template_id": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_name"},
+									},
+									"launch_template_name": {
+										Type:          schema.TypeString,
+										Optional:      true,
+										ConflictsWith: []string{"compute_resources.0.launch_template.0.launch_template_id"},
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
 						"max_vcpus": {
 							Type:     schema.TypeInt,
 							Required: true,
@@ -215,6 +239,20 @@ func resourceAwsBatchComputeEnvironmentCreate(d *schema.ResourceData, meta inter
 		if v, ok := computeResource["tags"]; ok {
 			input.ComputeResources.Tags = tagsFromMapGeneric(v.(map[string]interface{}))
 		}
+
+		if raw, ok := computeResource["launch_template"]; ok && len(raw.([]interface{})) > 0 {
+			input.ComputeResources.LaunchTemplate = &batch.LaunchTemplateSpecification{}
+			launchTemplate := raw.([]interface{})[0].(map[string]interface{})
+			if v, ok := launchTemplate["launch_template_id"]; ok {
+				input.ComputeResources.LaunchTemplate.LaunchTemplateId = aws.String(v.(string))
+			}
+			if v, ok := launchTemplate["launch_template_name"]; ok {
+				input.ComputeResources.LaunchTemplate.LaunchTemplateName = aws.String(v.(string))
+			}
+			if v, ok := launchTemplate["version"]; ok {
+				input.ComputeResources.LaunchTemplate.Version = aws.String(v.(string))
+			}
+		}
 	}
 
 	log.Printf("[DEBUG] Create compute environment %s.\n", input)
@@ -297,6 +335,14 @@ func flattenBatchComputeResources(computeResource *batch.ComputeResource) []map[
 	m["subnets"] = schema.NewSet(schema.HashString, flattenStringList(computeResource.Subnets))
 	m["tags"] = tagsToMapGeneric(computeResource.Tags)
 	m["type"] = aws.StringValue(computeResource.Type)
+
+	if launchTemplate := computeResource.LaunchTemplate; launchTemplate != nil {
+		lt := make(map[string]interface{})
+		lt["launch_template_id"] = aws.StringValue(launchTemplate.LaunchTemplateId)
+		lt["launch_template_name"] = aws.StringValue(launchTemplate.LaunchTemplateName)
+		lt["version"] = aws.StringValue(launchTemplate.Version)
+		m["launch_template"] = []map[string]interface{}{lt}
+	}
 
 	result = append(result, m)
 	return result

--- a/website/docs/r/batch_compute_environment.html.markdown
+++ b/website/docs/r/batch_compute_environment.html.markdown
@@ -131,6 +131,7 @@ resource "aws_batch_compute_environment" "sample" {
 * `image_id` - (Optional) The Amazon Machine Image (AMI) ID used for instances launched in the compute environment.
 * `instance_role` - (Required) The Amazon ECS instance role applied to Amazon EC2 instances in a compute environment.
 * `instance_type` - (Required) A list of instance types that may be launched.
+* `launch_template` - (Optional) The launch template to use for your compute resources. See details below.
 * `max_vcpus` - (Required) The maximum number of EC2 vCPUs that an environment can reach.
 * `min_vcpus` - (Required) The minimum number of EC2 vCPUs that an environment should maintain.
 * `security_group_ids` - (Required) A list of EC2 security group that are associated with instances launched in the compute environment.
@@ -138,6 +139,14 @@ resource "aws_batch_compute_environment" "sample" {
 * `subnets` - (Required) A list of VPC subnets into which the compute resources are launched.
 * `tags` - (Optional) Key-value pair tags to be applied to resources that are launched in the compute environment.
 * `type` - (Required) The type of compute environment. Valid items are `EC2` or `SPOT`.
+
+### launch_template
+
+`launch_template` supports the following:
+
+* `launch_template_id` - (Optional) ID of the launch template. You must specify either the launch template ID or launch template name in the request, but not both.
+* `launch_template_name` - (Optional) Name of the launch template.
+* `version` - (Optional) The version number of the launch template. Default: The default version of the launch template.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #6454

Changes proposed in this pull request:

* `aws_batch_compute_environment` supports LaunchTemplate

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSBatchComputeEnvironment_launchTemplate'
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSBatchComputeEnvironment_launchTemplate -timeout 120m
=== RUN   TestAccAWSBatchComputeEnvironment_launchTemplate
=== PAUSE TestAccAWSBatchComputeEnvironment_launchTemplate
=== CONT  TestAccAWSBatchComputeEnvironment_launchTemplate
--- PASS: TestAccAWSBatchComputeEnvironment_launchTemplate (82.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	82.120s
```
