### PR TITLE
Support import for aws_appautoscaling_policy and aws_appautoscaling_target

### DIFF
--- a/aws/resource_aws_appautoscaling_policy_test.go
+++ b/aws/resource_aws_appautoscaling_policy_test.go
@@ -39,6 +39,12 @@ func TestAccAWSAppautoScalingPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "step_scaling_policy_configuration.0.step_adjustment.207530251.metric_interval_upper_bound", ""),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingPolicyImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -117,6 +123,18 @@ func TestAccAWSAppautoScalingPolicy_scaleOutAndIn(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.foobar_in", "scalable_dimension", "ecs:service:DesiredCount"),
 				),
 			},
+			{
+				ResourceName:      "aws_appautoscaling_policy.foobar_out",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingPolicyImportStateIdFunc("aws_appautoscaling_policy.foobar_out"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_appautoscaling_policy.foobar_in",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingPolicyImportStateIdFunc("aws_appautoscaling_policy.foobar_in"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -139,6 +157,12 @@ func TestAccAWSAppautoScalingPolicy_spotFleetRequest(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.test", "service_namespace", "ec2"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.test", "scalable_dimension", "ec2:spot-fleet-request:TargetCapacity"),
 				),
+			},
+			{
+				ResourceName:      "aws_appautoscaling_policy.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingPolicyImportStateIdFunc("aws_appautoscaling_policy.test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -164,6 +188,12 @@ func TestAccAWSAppautoScalingPolicy_dynamoDb(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.dynamo_test", "service_namespace", "dynamodb"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.dynamo_test", "scalable_dimension", "dynamodb:table:WriteCapacityUnits"),
 				),
+			},
+			{
+				ResourceName:      "aws_appautoscaling_policy.dynamo_test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingPolicyImportStateIdFunc("aws_appautoscaling_policy.dynamo_test"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -229,6 +259,18 @@ func TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.write", "service_namespace", "dynamodb"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_policy.write", "scalable_dimension", "dynamodb:table:WriteCapacityUnits"),
 				),
+			},
+			{
+				ResourceName:      "aws_appautoscaling_policy.read",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingPolicyImportStateIdFunc("aws_appautoscaling_policy.read"),
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "aws_appautoscaling_policy.write",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingPolicyImportStateIdFunc("aws_appautoscaling_policy.write"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -891,4 +933,21 @@ resource "aws_cloudwatch_metric_alarm" "test" {
   }
 }
 `, rName)
+}
+
+func testAccAWSAppautoscalingPolicyImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := fmt.Sprintf("%s/%s/%s/%s",
+			rs.Primary.Attributes["service_namespace"],
+			rs.Primary.Attributes["resource_id"],
+			rs.Primary.Attributes["scalable_dimension"],
+			rs.Primary.Attributes["name"])
+
+		return id, nil
+	}
 }

--- a/aws/resource_aws_appautoscaling_target_test.go
+++ b/aws/resource_aws_appautoscaling_target_test.go
@@ -43,6 +43,12 @@ func TestAccAWSAppautoScalingTarget_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "max_capacity", "8"),
 				),
 			},
+			{
+				ResourceName:      "aws_appautoscaling_target.bar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingTargetImportStateIdFunc("aws_appautoscaling_target.bar"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -64,6 +70,12 @@ func TestAccAWSAppautoScalingTarget_spotFleetRequest(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.test", "scalable_dimension", "ec2:spot-fleet-request:TargetCapacity"),
 				),
 			},
+			{
+				ResourceName:      "aws_appautoscaling_target.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingTargetImportStateIdFunc("aws_appautoscaling_target.test"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -84,6 +96,12 @@ func TestAccAWSAppautoScalingTarget_emrCluster(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "service_namespace", "elasticmapreduce"),
 					resource.TestCheckResourceAttr("aws_appautoscaling_target.bar", "scalable_dimension", "elasticmapreduce:instancegroup:InstanceCount"),
 				),
+			},
+			{
+				ResourceName:      "aws_appautoscaling_target.bar",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSAppautoscalingTargetImportStateIdFunc("aws_appautoscaling_target.bar"),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -709,4 +727,19 @@ resource "aws_appautoscaling_target" "read" {
   max_capacity = 15
 }
 `, tableName)
+}
+
+func testAccAWSAppautoscalingTargetImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := fmt.Sprintf("%s/%s/%s",
+			rs.Primary.Attributes["service_namespace"],
+			rs.Primary.Attributes["resource_id"],
+			rs.Primary.Attributes["scalable_dimension"])
+		return id, nil
+	}
 }

--- a/website/docs/r/appautoscaling_policy.html.markdown
+++ b/website/docs/r/appautoscaling_policy.html.markdown
@@ -193,3 +193,11 @@ resource "aws_appautoscaling_policy" "ecs_policy" {
 * `arn` - The ARN assigned by AWS to the scaling policy.
 * `name` - The scaling policy's name.
 * `policy_type` - The scaling policy's type.
+
+## Import
+
+Application AutoScaling Policy can be imported using the `service-namespace` , `resource-id`, `scalable-dimension` and `policy-name` separated by `/`.
+
+```
+$ terraform import aws_appautoscaling_policy.test-policy service-namespace/resource-id/scalable-dimension/policy-name
+```

--- a/website/docs/r/appautoscaling_target.html.markdown
+++ b/website/docs/r/appautoscaling_target.html.markdown
@@ -74,3 +74,11 @@ The following arguments are supported:
 AutoScaling to modify your scalable target on your behalf.
 * `scalable_dimension` - (Required) The scalable dimension of the scalable target. Documentation can be found in the `ScalableDimension` parameter at: [AWS Application Auto Scaling API Reference](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
 * `service_namespace` - (Required) The AWS service namespace of the scalable target. Documentation can be found in the `ServiceNamespace` parameter at: [AWS Application Auto Scaling API Reference](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html#API_RegisterScalableTarget_RequestParameters)
+
+## Import
+
+Application AutoScaling Target can be imported using the `service-namespace` , `resource-id` and `scalable-dimension` separated by `/`.
+
+```
+$ terraform import aws_appautoscaling_target.test-target service-namespace/resource-id/scalable-dimension
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Support import for aws_appautoscaling_policy
* Support import for aws_appautoscaling_target

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppautoScalingPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppautoScalingPolicy -timeout 120m
=== RUN   TestAccAWSAppautoScalingPolicy_basic
=== PAUSE TestAccAWSAppautoScalingPolicy_basic
=== RUN   TestAccAWSAppautoScalingPolicy_disappears
=== PAUSE TestAccAWSAppautoScalingPolicy_disappears
=== RUN   TestAccAWSAppautoScalingPolicy_scaleOutAndIn
=== PAUSE TestAccAWSAppautoScalingPolicy_scaleOutAndIn
=== RUN   TestAccAWSAppautoScalingPolicy_spotFleetRequest
=== PAUSE TestAccAWSAppautoScalingPolicy_spotFleetRequest
=== RUN   TestAccAWSAppautoScalingPolicy_dynamoDb
=== PAUSE TestAccAWSAppautoScalingPolicy_dynamoDb
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName
=== PAUSE TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName
=== RUN   TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource
=== PAUSE TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource
=== RUN   TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew
=== PAUSE TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew
=== CONT  TestAccAWSAppautoScalingPolicy_basic
=== CONT  TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew
=== CONT  TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource
=== CONT  TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName
=== CONT  TestAccAWSAppautoScalingPolicy_dynamoDb
=== CONT  TestAccAWSAppautoScalingPolicy_spotFleetRequest
=== CONT  TestAccAWSAppautoScalingPolicy_scaleOutAndIn
=== CONT  TestAccAWSAppautoScalingPolicy_disappears
--- PASS: TestAccAWSAppautoScalingPolicy_disappears (41.66s)
--- PASS: TestAccAWSAppautoScalingPolicy_scaleOutAndIn (52.17s)
--- PASS: TestAccAWSAppautoScalingPolicy_basic (52.72s)
--- PASS: TestAccAWSAppautoScalingPolicy_ResourceId_ForceNew (86.29s)
--- PASS: TestAccAWSAppautoScalingPolicy_spotFleetRequest (86.67s)
--- PASS: TestAccAWSAppautoScalingPolicy_dynamoDb (141.87s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameName (141.93s)
--- PASS: TestAccAWSAppautoScalingPolicy_multiplePoliciesSameResource (145.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       145.646s
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppautoScalingTarget'      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppautoScalingTarget -timeout 120m
=== RUN   TestAccAWSAppautoScalingTarget_basic
=== PAUSE TestAccAWSAppautoScalingTarget_basic
=== RUN   TestAccAWSAppautoScalingTarget_spotFleetRequest
=== PAUSE TestAccAWSAppautoScalingTarget_spotFleetRequest
=== RUN   TestAccAWSAppautoScalingTarget_emrCluster
=== PAUSE TestAccAWSAppautoScalingTarget_emrCluster
=== RUN   TestAccAWSAppautoScalingTarget_multipleTargets
=== PAUSE TestAccAWSAppautoScalingTarget_multipleTargets
=== RUN   TestAccAWSAppautoScalingTarget_optionalRoleArn
=== PAUSE TestAccAWSAppautoScalingTarget_optionalRoleArn
=== CONT  TestAccAWSAppautoScalingTarget_basic
=== CONT  TestAccAWSAppautoScalingTarget_spotFleetRequest
=== CONT  TestAccAWSAppautoScalingTarget_emrCluster
=== CONT  TestAccAWSAppautoScalingTarget_multipleTargets
=== CONT  TestAccAWSAppautoScalingTarget_optionalRoleArn
--- PASS: TestAccAWSAppautoScalingTarget_basic (79.44s)
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (90.14s)
--- PASS: TestAccAWSAppautoScalingTarget_optionalRoleArn (135.78s)
--- PASS: TestAccAWSAppautoScalingTarget_multipleTargets (137.16s)
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (550.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       550.081s
```