### PR TITLE
resource/aws_ram_principal_association: Organizations principals should be ARNs not IDs

### DIFF
--- a/aws/resource_aws_ram_principal_association.go
+++ b/aws/resource_aws_ram_principal_association.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsRamPrincipalAssociation() *schema.Resource {
@@ -36,6 +37,10 @@ func resourceAwsRamPrincipalAssociation() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.Any(
+					validateAwsAccountId,
+					validateArn,
+				),
 			},
 		},
 	}

--- a/website/docs/r/ram_principal_association.markdown
+++ b/website/docs/r/ram_principal_association.markdown
@@ -32,7 +32,7 @@ resource "aws_ram_principal_association" "example" {
 
 ```hcl
 resource "aws_ram_principal_association" "example" {
-  principal          = "${aws_organizations_organization.example.id}"
+  principal          = "${aws_organizations_organization.example.arn}"
   resource_share_arn = "${aws_ram_resource_share.example.arn}"
 }
 ```
@@ -41,7 +41,7 @@ resource "aws_ram_principal_association" "example" {
 
 The following arguments are supported:
 
-* `principal` - (Required) The principal to associate with the resource share. Possible values are an AWS account ID, an AWS Organizations Organization ID, or an AWS Organizations Organization Unit ID.
+* `principal` - (Required) The principal to associate with the resource share. Possible values are an AWS account ID, an AWS Organizations Organization ARN, or an AWS Organizations Organization Unit ARN.
 * `resource_share_arn` - (Required) The Amazon Resource Name (ARN) of the resource share.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7632

Output from acceptance testing:

```
--- PASS: TestAccAwsRamPrincipalAssociation_disappears (14.65s)
--- PASS: TestAccAwsRamPrincipalAssociation_basic (16.24s)
```