### PR TITLE
AWS DB Instance validate rds password characters and length #7956

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -52,9 +52,10 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"password": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				Sensitive: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validateRdsPassword,
 			},
 
 			"deletion_protection": {
@@ -467,6 +468,36 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			}
 		}
 		d.Set("identifier", identifier)
+	}
+
+	if attr, ok := d.GetOk("password"); ok {
+		var engine = d.Get("engine").(string)
+		if strings.Contains(strings.ToLower(engine), "mariadb") {
+			if !regexp.MustCompile(`^[^@"/]{8,41}$`).MatchString(attr.(string)) {
+				return fmt.Errorf(`The password parameter should be only 8 to 41 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+			}
+		} else if strings.Contains(strings.ToLower(engine), "mysql") {
+			if !regexp.MustCompile(`^[^@"/]{8,41}$`).MatchString(attr.(string)) {
+				return fmt.Errorf(`The password parameter should be only 8 to 41 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+			}
+		} else if strings.Contains(strings.ToLower(engine), "oracle") {
+			if !regexp.MustCompile(`^[^@"/]{8,30}$`).MatchString(attr.(string)) {
+				return fmt.Errorf(`The password parameter should be only 8 to 30 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+			}
+		} else if strings.Contains(strings.ToLower(engine), "postgres") {
+			if !regexp.MustCompile(`^[^@"/]{8,128}$`).MatchString(attr.(string)) {
+				return fmt.Errorf(`The password parameter should be only 8 to 128 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+			}
+		} else if strings.Contains(strings.ToLower(engine), "sqlserver") {
+			if !regexp.MustCompile(`^[^@"/]{8,128}$`).MatchString(attr.(string)) {
+				return fmt.Errorf(`The password parameter should be only 8 to 128 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("replicate_source_db"); ok {
@@ -1384,6 +1415,35 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		requestUpdate = true
 	}
 	if d.HasChange("password") {
+		if attr, ok := d.GetOk("password"); ok {
+			var engine = d.Get("engine").(string)
+			if strings.Contains(strings.ToLower(engine), "mariadb") {
+				if !regexp.MustCompile(`^[^@"/]{8,41}$`).MatchString(attr.(string)) {
+					return fmt.Errorf(`The password parameter should be only 8 to 41 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+				}
+			} else if strings.Contains(strings.ToLower(engine), "mysql") {
+				if !regexp.MustCompile(`^[^@"/]{8,41}$`).MatchString(attr.(string)) {
+					return fmt.Errorf(`The password parameter should be only 8 to 41 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+				}
+			} else if strings.Contains(strings.ToLower(engine), "oracle") {
+				if !regexp.MustCompile(`^[^@"/]{8,30}$`).MatchString(attr.(string)) {
+					return fmt.Errorf(`The password parameter should be only 8 to 30 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+				}
+			} else if strings.Contains(strings.ToLower(engine), "postgres") {
+				if !regexp.MustCompile(`^[^@"/]{8,128}$`).MatchString(attr.(string)) {
+					return fmt.Errorf(`The password parameter should be only 8 to 128 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+				}
+			} else if strings.Contains(strings.ToLower(engine), "sqlserver") {
+				if !regexp.MustCompile(`^[^@"/]{8,128}$`).MatchString(attr.(string)) {
+					return fmt.Errorf(`The password parameter should be only 8 to 128 alphanumeric
+characters or symbols (excluding @, \", and /) allowed in %s engine`, engine)
+				}
+			}
+		}
 		d.SetPartial("password")
 		req.MasterUserPassword = aws.String(d.Get("password").(string))
 		requestUpdate = true

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -2404,3 +2404,12 @@ func validateRoute53ResolverName(v interface{}, k string) (ws []string, errors [
 
 	return
 }
+
+func validateRdsPassword(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[^@"/]{8,128}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only 8 to 128 alphanumeric characters or symbols (excluding @, \", and /) allowed in %q", k))
+	}
+	return
+}

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -3136,3 +3136,43 @@ func TestValidateRoute53ResolverName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateRdsPassword(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "this-is-valid!#%()^",
+			ErrCount: 0,
+		},
+		{
+			Value:    randomString(7),
+			ErrCount: 1,
+		},
+		{
+			Value:    "this-is-not-valid\"",
+			ErrCount: 1,
+		},
+		{
+			Value:    "this-is-not-valid@",
+			ErrCount: 1,
+		},
+		{
+			Value:    "this-is-not-valid/",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(129),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateRdsPassword(tc.Value, "aws_db_instance")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the RDS Password to trigger a validation error")
+		}
+	}
+}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7956 

Changes proposed in this pull request:

* Validate db password on create and modify instance.
