### PR TITLE
R/aws backup selection

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -326,6 +326,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_autoscaling_policy":                           resourceAwsAutoscalingPolicy(),
 			"aws_autoscaling_schedule":                         resourceAwsAutoscalingSchedule(),
 			"aws_backup_plan":                                  resourceAwsBackupPlan(),
+			"aws_backup_selection":                             resourceAwsBackupSelection(),
 			"aws_backup_vault":                                 resourceAwsBackupVault(),
 			"aws_budgets_budget":                               resourceAwsBudgetsBudget(),
 			"aws_cloud9_environment_ec2":                       resourceAwsCloud9EnvironmentEc2(),

--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -201,7 +201,7 @@ func testAccCheckAwsBackupPlanDestroy(s *terraform.State) error {
 
 		if err == nil {
 			if *resp.BackupPlanId == rs.Primary.ID {
-				return fmt.Errorf("Plane '%s' was not deleted properly", rs.Primary.ID)
+				return fmt.Errorf("Plan '%s' was not deleted properly", rs.Primary.ID)
 			}
 		}
 	}

--- a/aws/resource_aws_backup_selection.go
+++ b/aws/resource_aws_backup_selection.go
@@ -1,0 +1,181 @@
+package aws
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsBackupSelection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsBackupSelectionCreate,
+		Read:   resourceAwsBackupSelectionRead,
+		Update: nil,
+		Delete: resourceAwsBackupSelectionDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Second),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"backup_plan_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"iam_role_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resources": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Set: schema.HashString,
+			},
+			"tag_condition": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"test": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+							Default:  "STRINGEQUALS",
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"variable": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsBackupSelectionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	input := &backup.CreateBackupSelectionInput{
+		BackupPlanId: aws.String(d.Get("backup_plan_id").(string)),
+		BackupSelection: &backup.Selection{
+			IamRoleArn:    aws.String(d.Get("iam_role_arn").(string)),
+			SelectionName: aws.String(d.Get("name").(string)),
+		},
+	}
+
+	if v, ok := d.GetOk("resources"); ok {
+		input.BackupSelection.SetResources(expandStringSet(v.(*schema.Set)))
+	}
+
+	if v, ok := d.GetOk("tag_condition"); ok {
+		input.BackupSelection.SetListOfTags(expandTagConditionSet(v.(*schema.Set)))
+	}
+
+	resp, err := retryOnAwsCode("InvalidParameterValueException", func() (interface{}, error) {
+		return conn.CreateBackupSelection(input)
+	})
+	if err != nil {
+		return err
+	}
+
+	output := resp.(*backup.CreateBackupSelectionOutput)
+
+	d.SetId(*output.BackupPlanId + "/" + *output.SelectionId)
+
+	return resourceAwsBackupSelectionRead(d, meta)
+}
+
+func resourceAwsBackupSelectionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	ids := strings.Split(d.Id(), "/")
+	backupPlanId, selectionId := ids[0], ids[1]
+
+	input := &backup.GetBackupSelectionInput{
+		BackupPlanId: aws.String(backupPlanId),
+		SelectionId:  aws.String(selectionId),
+	}
+
+	resp, err := conn.GetBackupSelection(input)
+	if err != nil {
+		return err
+	}
+
+	d.Set("backup_plan_id", *resp.BackupPlanId)
+
+	resources := make([]string, 0, len(resp.BackupSelection.Resources))
+	for _, resource := range resp.BackupSelection.Resources {
+		resources = append(resources, aws.StringValue(resource))
+	}
+	d.Set("resources", resources)
+
+	tagConditions := make([]map[string]string, 0, len(resp.BackupSelection.ListOfTags))
+	for _, condition := range resp.BackupSelection.ListOfTags {
+		tagConditions = append(tagConditions, map[string]string{
+			"test":     aws.StringValue(condition.ConditionType),
+			"variable": aws.StringValue(condition.ConditionKey),
+			"value":    aws.StringValue(condition.ConditionValue),
+		})
+	}
+	d.Set("tag_condition", tagConditions)
+
+	return nil
+}
+
+func resourceAwsBackupSelectionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).backupconn
+
+	ids := strings.Split(d.Id(), "/")
+	backupPlanId, selectionId := ids[0], ids[1]
+
+	input := &backup.DeleteBackupSelectionInput{
+		BackupPlanId: aws.String(backupPlanId),
+		SelectionId:  aws.String(selectionId),
+	}
+
+	_, err := conn.DeleteBackupSelection(input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandTagConditionSet(v *schema.Set) []*backup.Condition {
+	conditionList := v.List()
+	conditions := make([]*backup.Condition, 0, len(conditionList))
+
+	for _, c := range conditionList {
+		sourceMap := c.(map[string]interface{})
+		condition := &backup.Condition{
+			ConditionType:  aws.String(sourceMap["test"].(string)),
+			ConditionKey:   aws.String(sourceMap["variable"].(string)),
+			ConditionValue: aws.String(sourceMap["value"].(string)),
+		}
+		conditions = append(conditions, condition)
+	}
+
+	return conditions
+}

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -1,0 +1,271 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/backup"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsBackupSelection_basic(t *testing.T) {
+	var selection backup.Selection
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsBackupSelectionConfig_create(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupSelectionExists("aws_backup_selection.tftest", &selection),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "name", fmt.Sprintf("tftest-%d", rInt)),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "resources.#", "2"),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "tag_condition.#", "2"),
+				),
+			},
+			{
+				Config: testAccAwsBackupSelectionConfig_update(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupSelectionExists("aws_backup_selection.tftest", &selection),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "name", fmt.Sprintf("tftest-%d", rInt)),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "resources.#", "3"),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "tag_condition.#", "3"),
+				),
+			},
+			{
+				Config: testAccAwsBackupSelectionConfig_tagsonly(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupSelectionExists("aws_backup_selection.tftest", &selection),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "name", fmt.Sprintf("tftest-%d", rInt)),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "resources.#", "0"),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "tag_condition.#", "3"),
+				),
+			},
+			{
+				Config: testAccAwsBackupSelectionConfig_resourcesonly(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupSelectionExists("aws_backup_selection.tftest", &selection),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "name", fmt.Sprintf("tftest-%d", rInt)),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "resources.#", "3"),
+					resource.TestCheckResourceAttr("aws_backup_selection.tftest", "tag_condition.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsBackupSelectionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).backupconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_backup_selection" {
+			continue
+		}
+
+		ids := strings.Split(rs.Primary.ID, "/")
+		backupPlanId, selectionId := ids[0], ids[1]
+
+		input := &backup.GetBackupSelectionInput{
+			BackupPlanId: aws.String(backupPlanId),
+			SelectionId:  aws.String(selectionId),
+		}
+
+		resp, err := conn.GetBackupSelection(input)
+
+		if err == nil {
+			if *resp.SelectionId == rs.Primary.ID {
+				return fmt.Errorf("Backup selection '%s' from plan '%s' was not deleted properly", rs.Primary.ID, rs.Primary.Attributes["backup_plan_id"])
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAwsBackupSelectionExists(n string, selection *backup.Selection) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Backup selection not found: %s", n)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).backupconn
+
+		ids := strings.Split(rs.Primary.ID, "/")
+		backupPlanId, selectionId := ids[0], ids[1]
+
+		input := &backup.GetBackupSelectionInput{
+			BackupPlanId: aws.String(backupPlanId),
+			SelectionId:  aws.String(selectionId),
+		}
+
+		resp, err := conn.GetBackupSelection(input)
+		if err != nil {
+			return err
+		}
+
+		*selection = *resp.BackupSelection
+
+		return nil
+	}
+}
+
+func testAccAwsBackupSelectionConfig_deps(rInt int) string {
+	return fmt.Sprintf(`
+locals {
+  rand_int = "%d"
+}
+
+resource "aws_backup_vault" "tftest" {
+  name = "tftest-${local.rand_int}"
+}
+
+resource "aws_backup_plan" "tftest" {
+  name = "tftest-${local.rand_int}"
+
+  rule {
+    rule_name         = "tftest-${local.rand_int}"
+    target_vault_name = "${aws_backup_vault.tftest.name}"
+    schedule          = "cron(0 0 31 12 ? 2099)"
+  }
+}
+
+data "aws_iam_policy_document" "tftest_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "tftest" {
+  name               = "tftest-${local.rand_int}"
+  assume_role_policy = "${data.aws_iam_policy_document.tftest_assume.json}"
+}
+
+data "aws_iam_policy_document" "tftest" {
+  statement {
+    actions   = ["tag:GetResources"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "tftest" {
+  role   = "${aws_iam_role.tftest.name}"
+  policy = "${data.aws_iam_policy_document.tftest.json}"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+`, rInt)
+}
+
+func testAccAwsBackupSelectionConfig_create(rInt int) string {
+	return testAccAwsBackupSelectionConfig_deps(rInt) + `
+resource "aws_backup_selection" "tftest" {
+  name           = "tftest-${local.rand_int}"
+  backup_plan_id = "${aws_backup_plan.tftest.id}"
+  iam_role_arn   = "${aws_iam_role.tftest.arn}"
+
+  resources = [
+    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/vol-1234",
+    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/vol-2345",
+  ]
+
+  tag_condition {
+    test     = "STRINGEQUALS"
+    variable = "ec2:ResourceTag/tftest"
+    value    = "tftest"
+  }
+
+  tag_condition {
+    variable = "ec2:ResourceTag/tftest2"
+    value    = "tftest2"
+  }
+}
+`
+}
+
+func testAccAwsBackupSelectionConfig_update(rInt int) string {
+	return testAccAwsBackupSelectionConfig_deps(rInt) + `
+resource "aws_backup_selection" "tftest" {
+  name           = "tftest-${local.rand_int}"
+  backup_plan_id = "${aws_backup_plan.tftest.id}"
+  iam_role_arn   = "${aws_iam_role.tftest.arn}"
+
+  resources = [
+    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/vol-1234",
+    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/vol-2345",
+	"arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:tftest",
+  ]
+
+  tag_condition {
+    test     = "STRINGEQUALS"
+    variable = "ec2:ResourceTag/tftest"
+    value    = "tftest"
+  }
+
+  tag_condition {
+    variable = "ec2:ResourceTag/tftest2"
+    value    = "tftest2-update"
+  }
+
+  tag_condition {
+	variable = "ec2:ResourceTag/tftest2"
+	value    = "tftest2"
+  }
+}
+`
+}
+
+func testAccAwsBackupSelectionConfig_tagsonly(rInt int) string {
+	return testAccAwsBackupSelectionConfig_deps(rInt) + `
+resource "aws_backup_selection" "tftest" {
+  name           = "tftest-${local.rand_int}"
+  backup_plan_id = "${aws_backup_plan.tftest.id}"
+  iam_role_arn   = "${aws_iam_role.tftest.arn}"
+
+  tag_condition {
+    test     = "STRINGEQUALS"
+    variable = "ec2:ResourceTag/tftest"
+    value    = "tftest"
+  }
+
+  tag_condition {
+    variable = "ec2:ResourceTag/tftest2"
+    value    = "tftest2-update"
+  }
+
+  tag_condition {
+	variable = "ec2:ResourceTag/tftest2"
+	value    = "tftest2"
+  }
+}
+`
+}
+
+func testAccAwsBackupSelectionConfig_resourcesonly(rInt int) string {
+	return testAccAwsBackupSelectionConfig_deps(rInt) + `
+resource "aws_backup_selection" "tftest" {
+  name           = "tftest-${local.rand_int}"
+  backup_plan_id = "${aws_backup_plan.tftest.id}"
+  iam_role_arn   = "${aws_iam_role.tftest.arn}"
+
+  resources = [
+    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/vol-1234",
+    "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/vol-2345",
+	"arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:tftest",
+  ]
+}
+`
+}

--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -17,10 +17,10 @@ resource "aws_backup_plan" "example" {
   name = "tf_example_backup_plan"
 
   rule {
-    rule_name           = "tf_example_backup_rule"
-      target_vault_name = "${aws_backup_vault.test.name}"
-      schedule          = "cron(0 12 * * ? *)"
-    }
+    rule_name         = "tf_example_backup_rule"
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+  }
 }
 ```
 
@@ -54,4 +54,4 @@ For **lifecycle** the following attributes are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN of the backup plan.
-* `version` - Unique, randomly generated, Unicode, UTF-8 encoded string that serves as the version ID of the backup plan. 
+* `version` - Unique, randomly generated, Unicode, UTF-8 encoded string that serves as the version ID of the backup plan.

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "aws"
+page_title: "AWS: aws_backup_selection"
+sidebar_current: "docs-aws-resource-backup-selection"
+description: |-
+  Provides an AWS Backup selection resource.
+---
+
+# aws_backup_selection
+
+Provides an AWS Backup selection to identify resources that are backed up by an AWS Backup plan.
+
+## Example Usage
+
+```hcl
+resource "aws_backup_selection" "example" {
+  name           = "tf_example_backup_selection"
+  backup_plan_id = "${aws_backup_plan.example.id}"
+  iam_role_arn   = "${aws_iam_role.example.arn}"
+
+  resources = [
+    "${aws_ebs_volume.example.arn}",
+    "${aws_efs_file_system.example.arn}",
+  ]
+
+  tag_condition {
+    test     = "STRINGEQUALS"
+    variable = "ec2:ResourceTag/backup"
+    value    = "true"
+  }
+
+  tag_condition {
+    test     = "STRINGEQUALS"
+    variable = "ec2:ResourceTag/environment"
+    value    = "production"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The display name of the backup selection.
+* `backup_plan_id` - (Required) Id of the backup plan to associate the backup resources with.
+* `iam_role_arn` - (Required) ARN of the role to use for backups and restores.
+* `resources` - (Optional) List of resource ARNs to include in the backup selection.
+* `tag_condition` - (Optional) A tag condition to include in the backup selection.  Multiple tag_condition blocks may be specified.
+
+### Tag Condition Arguments
+For **rule** the following attributes are supported:
+
+* `test` - (Optional) The operator that's applied to this condition.  Currently the only valid value is "STRINGEQUALS" which is also the default.
+* `variable` - (Required) - The variable to match against.  Must be a tag key.
+* `value` - (Required) - The value to match against.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7166 - should be the last resource required to close

Changes proposed in this pull request:

* Add resource `aws_backup_selection`

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsBackupSelection'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsBackupSelection -timeout 120m
=== RUN   TestAccAwsBackupSelection_basic
=== PAUSE TestAccAwsBackupSelection_basic
=== CONT  TestAccAwsBackupSelection_basic
--- PASS: TestAccAwsBackupSelection_basic (65.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       67.521s
```

Possibly controversial things:
* API packages almost everything into a single BackupSelection block which I flattened into the main resource.
* Adopted the IAM condition test/variable/value style for tag_condition so they're consistent, but would be an easy fix to convert to the API's native type/key/value if desired.