### PR TITLE
New Resource: aws_kms_external_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ ENHANCEMENTS:
 * provider: Support custom endpoint for `ses` [GH-7986]
 * provider: Support custom endpoints for `firehose` and `redshift` [GH-8007]
 * resource/aws_api_gateway_deployment: Allow `stage_name` argument to be optional [GH-6459]
+* resource/aws_appautoscaling_policy: Support resource import [GH-8032]
+* resource/aws_appautoscaling_target: Support resource import [GH-8032]
 * resource/aws_appmesh_route: Support resource import [GH-7858]
 * resource/aws_appmesh_virtual_node: Support resource import [GH-7858]
 * resource/aws_appmesh_virtual_router: Support resource import [GH-7858]

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -526,6 +526,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kinesis_stream":                               resourceAwsKinesisStream(),
 			"aws_kinesis_analytics_application":                resourceAwsKinesisAnalyticsApplication(),
 			"aws_kms_alias":                                    resourceAwsKmsAlias(),
+			"aws_kms_external_key":                             resourceAwsKmsExternalKey(),
 			"aws_kms_grant":                                    resourceAwsKmsGrant(),
 			"aws_kms_key":                                      resourceAwsKmsKey(),
 			"aws_lambda_function":                              resourceAwsLambdaFunction(),

--- a/aws/resource_aws_kms_external_key_test.go
+++ b/aws/resource_aws_kms_external_key_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -13,121 +14,363 @@ import (
 )
 
 func TestAccAWSKmsExternalKey_basic(t *testing.T) {
-	var keyBefore, keyAfter kms.KeyMetadata
+	var key1 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsExternalKey,
+				Config: testAccAWSKmsExternalKeyConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.foo", &keyBefore),
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "kms", regexp.MustCompile(`key/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "deletion_window_in_days", "30"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "expiration_model", ""),
+					resource.TestCheckNoResourceAttr(resourceName, "key_material_base64"),
+					resource.TestCheckResourceAttr(resourceName, "key_state", "PendingImport"),
+					resource.TestCheckResourceAttr(resourceName, "key_usage", "ENCRYPT_DECRYPT"),
+					resource.TestMatchResourceAttr(resourceName, "policy", regexp.MustCompile(`Enable IAM User Permissions`)),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "valid_to", ""),
 				),
 			},
 			{
-				Config: testAccAWSKmsExternalKey_removedPolicy,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.foo", &keyAfter),
-				),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
 			},
 		},
 	})
 }
 
 func TestAccAWSKmsExternalKey_disappears(t *testing.T) {
-	var key kms.KeyMetadata
+	var key1 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsExternalKey,
+				Config: testAccAWSKmsExternalKeyConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.foo", &key),
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					testAccCheckAWSKmsExternalKeyDisappears(&key1),
 				),
-			},
-			{
-				Config:             testAccAWSKmsExternalKey_other_region,
-				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
 }
 
-func TestAccAWSKmsExternalKey_policy(t *testing.T) {
-	var key kms.KeyMetadata
-	expectedPolicyText := `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Sid":"Enable IAM User Permissions","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:*","Resource":"*"}]}`
+func TestAccAWSKmsExternalKey_DeletionWindowInDays(t *testing.T) {
+	var key1, key2 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsExternalKey,
+				Config: testAccAWSKmsExternalKeyConfigDeletionWindowInDays(8),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.foo", &key),
-					testAccCheckAWSKmsExternalKeyHasPolicy("aws_kms_external_key.foo", expectedPolicyText),
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					resource.TestCheckResourceAttr(resourceName, "deletion_window_in_days", "8"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigDeletionWindowInDays(7),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key2),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key1, &key2),
+					resource.TestCheckResourceAttr(resourceName, "deletion_window_in_days", "7"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSKmsExternalKey_isEnabled_isAlwaysFalseWhenKeyStateIsPendingImport(t *testing.T) {
+func TestAccAWSKmsExternalKey_Description(t *testing.T) {
+	var key1, key2 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsExternalKeyConfigDescription("description1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					resource.TestCheckResourceAttr(resourceName, "description", "description1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigDescription("description2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key2),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key1, &key2),
+					resource.TestCheckResourceAttr(resourceName, "description", "description2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsExternalKey_Enabled(t *testing.T) {
 	var key1, key2, key3 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsExternalKey_bar_removedPolicy,
+				Config: testAccAWSKmsExternalKeyConfigEnabled(false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.bar", &key1),
-					resource.TestCheckResourceAttr("aws_kms_external_key.bar", "is_enabled", "false"),
-					testAccCheckAWSKmsExternalKeyIsEnabled(&key1, false),
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 			{
-				Config: testAccAWSKmsExternalKey_disabled,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigEnabled(true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.bar", &key2),
-					resource.TestCheckResourceAttr("aws_kms_external_key.bar", "is_enabled", "false"),
-					testAccCheckAWSKmsExternalKeyIsEnabled(&key2, false),
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key2),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key1, &key2),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 				),
 			},
 			{
-				Config: testAccAWSKmsExternalKey_enabled,
+				Config: testAccAWSKmsExternalKeyConfigEnabled(false),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.bar", &key3),
-					resource.TestCheckResourceAttr("aws_kms_external_key.bar", "is_enabled", "false"),
-					testAccCheckAWSKmsExternalKeyIsEnabled(&key3, false),
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key3),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key2, &key3),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSKmsExternalKey_tags(t *testing.T) {
-	var keyBefore kms.KeyMetadata
+func TestAccAWSKmsExternalKey_KeyMaterialBase64(t *testing.T) {
+	var key1, key2 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSKmsExternalKey_tags,
+				// ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
+				Config: testAccAWSKmsExternalKeyConfigKeyMaterialBase64("Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSKmsExternalKeyExists("aws_kms_external_key.foo", &keyBefore),
-					resource.TestCheckResourceAttr("aws_kms_external_key.foo", "tags.%", "2"),
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					resource.TestCheckResourceAttr(resourceName, "key_material_base64", "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
+			{
+				// ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
+				Config: testAccAWSKmsExternalKeyConfigKeyMaterialBase64("O1zsg06cKRCsZnoT5oizMlwHEtnk0HoOmBLkFtwh2Vw="),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key2),
+					testAccCheckAWSKmsExternalKeyRecreated(&key1, &key2),
+					resource.TestCheckResourceAttr(resourceName, "key_material_base64", "O1zsg06cKRCsZnoT5oizMlwHEtnk0HoOmBLkFtwh2Vw="),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsExternalKey_Policy(t *testing.T) {
+	var key1, key2 kms.KeyMetadata
+	policy1 := `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Sid":"Enable IAM User Permissions 1","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:*","Resource":"*"}]}`
+	policy2 := `{"Version":"2012-10-17","Id":"kms-tf-1","Statement":[{"Sid":"Enable IAM User Permissions 2","Effect":"Allow","Principal":{"AWS":"*"},"Action":"kms:*","Resource":"*"}]}`
+	resourceName := "aws_kms_external_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsExternalKeyConfigPolicy(policy1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					testAccCheckAWSKmsExternalKeyHasPolicy(resourceName, policy1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigPolicy(policy2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key2),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key1, &key2),
+					testAccCheckAWSKmsExternalKeyHasPolicy(resourceName, policy2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsExternalKey_Tags(t *testing.T) {
+	var key1, key2, key3 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsExternalKeyConfigTags1("value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigTags2("value1updated", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key2),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key1, &key2),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigTags1("value1updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key3),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key2, &key3),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSKmsExternalKey_ValidTo(t *testing.T) {
+	var key1, key2, key3, key4 kms.KeyMetadata
+	resourceName := "aws_kms_external_key.test"
+	validTo1 := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+	validTo2 := time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsExternalKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSKmsExternalKeyConfigValidTo(validTo1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key1),
+					resource.TestCheckResourceAttr(resourceName, "expiration_model", "KEY_MATERIAL_EXPIRES"),
+					resource.TestCheckResourceAttr(resourceName, "valid_to", validTo1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deletion_window_in_days",
+					"key_material_base64",
+				},
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigEnabled(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key2),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key1, &key2),
+					resource.TestCheckResourceAttr(resourceName, "expiration_model", "KEY_MATERIAL_DOES_NOT_EXPIRE"),
+					resource.TestCheckResourceAttr(resourceName, "valid_to", ""),
+				),
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigValidTo(validTo1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key3),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key2, &key3),
+					resource.TestCheckResourceAttr(resourceName, "expiration_model", "KEY_MATERIAL_EXPIRES"),
+					resource.TestCheckResourceAttr(resourceName, "valid_to", validTo1),
+				),
+			},
+			{
+				Config: testAccAWSKmsExternalKeyConfigValidTo(validTo2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSKmsExternalKeyExists(resourceName, &key4),
+					testAccCheckAWSKmsExternalKeyNotRecreated(&key3, &key4),
+					resource.TestCheckResourceAttr(resourceName, "expiration_model", "KEY_MATERIAL_EXPIRES"),
+					resource.TestCheckResourceAttr(resourceName, "valid_to", validTo2),
 				),
 			},
 		},
@@ -186,8 +429,8 @@ func testAccCheckAWSKmsExternalKeyDestroy(s *terraform.State) error {
 			return err
 		}
 
-		if *out.KeyMetadata.KeyState == "PendingDeletion" {
-			return nil
+		if aws.StringValue(out.KeyMetadata.KeyState) == kms.KeyStatePendingDeletion {
+			continue
 		}
 
 		return fmt.Errorf("KMS key still exists:\n%#v", out.KeyMetadata)
@@ -225,97 +468,129 @@ func testAccCheckAWSKmsExternalKeyExists(name string, key *kms.KeyMetadata) reso
 	}
 }
 
-func testAccCheckAWSKmsExternalKeyIsEnabled(key *kms.KeyMetadata, isEnabled bool) resource.TestCheckFunc {
+func testAccCheckAWSKmsExternalKeyDisappears(key *kms.KeyMetadata) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if *key.Enabled != isEnabled {
-			return fmt.Errorf("Expected key %q to have is_enabled=%t, given %t",
-				*key.Arn, isEnabled, *key.Enabled)
+		conn := testAccProvider.Meta().(*AWSClient).kmsconn
+
+		input := &kms.ScheduleKeyDeletionInput{
+			KeyId:               key.KeyId,
+			PendingWindowInDays: aws.Int64(int64(7)),
+		}
+
+		_, err := conn.ScheduleKeyDeletion(input)
+
+		if err != nil {
+			return err
+		}
+
+		return waitForKmsKeyScheduleDeletion(conn, aws.StringValue(key.KeyId))
+	}
+}
+
+func testAccCheckAWSKmsExternalKeyNotRecreated(i, j *kms.KeyMetadata) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreationDate) != aws.TimeValue(j.CreationDate) {
+			return fmt.Errorf("KMS External Key recreated")
 		}
 
 		return nil
 	}
 }
 
-var kmsExternalTimestamp = time.Now().Format(time.RFC1123)
-var testAccAWSKmsExternalKey = fmt.Sprintf(`
-resource "aws_kms_external_key" "foo" {
-    description = "Terraform acc test %s"
-    deletion_window_in_days = 7
-    policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "kms-tf-1",
-  "Statement": [
-    {
-      "Sid": "Enable IAM User Permissions",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "kms:*",
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-}`, kmsExternalTimestamp)
+func testAccCheckAWSKmsExternalKeyRecreated(i, j *kms.KeyMetadata) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.TimeValue(i.CreationDate) == aws.TimeValue(j.CreationDate) {
+			return fmt.Errorf("KMS External Key not recreated")
+		}
 
-var testAccAWSKmsExternalKey_other_region = fmt.Sprintf(`
-provider "aws" { 
-	region = "us-east-1"
-}
-resource "aws_kms_external_key" "foo" {
-    description = "Terraform acc test %s"
-    deletion_window_in_days = 7
-    policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "kms-tf-1",
-  "Statement": [
-    {
-      "Sid": "Enable IAM User Permissions",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "*"
-      },
-      "Action": "kms:*",
-      "Resource": "*"
-    }
-  ]
-}
-POLICY
-}`, kmsExternalTimestamp)
-
-var testAccAWSKmsExternalKey_removedPolicy = fmt.Sprintf(`
-resource "aws_kms_external_key" "foo" {
-    description = "Terraform acc test %s"
-    deletion_window_in_days = 7
-}`, kmsExternalTimestamp)
-
-var testAccAWSKmsExternalKey_bar_removedPolicy = fmt.Sprintf(`
-resource "aws_kms_external_key" "bar" {
-    description = "Terraform acc test is_enabled %s"
-    deletion_window_in_days = 7
-}`, kmsExternalTimestamp)
-
-var testAccAWSKmsExternalKey_disabled = fmt.Sprintf(`
-resource "aws_kms_external_key" "bar" {
-    description = "Terraform acc test is_enabled %s"
-    deletion_window_in_days = 7
-    is_enabled = false
-}`, kmsExternalTimestamp)
-var testAccAWSKmsExternalKey_enabled = fmt.Sprintf(`
-resource "aws_kms_external_key" "bar" {
-    description = "Terraform acc test is_enabled %s"
-    deletion_window_in_days = 7
-    is_enabled = true
-}`, kmsExternalTimestamp)
-
-var testAccAWSKmsExternalKey_tags = fmt.Sprintf(`
-resource "aws_kms_external_key" "foo" {
-    description = "Terraform acc test %s"
-	tags {
-		Key1 = "Value One"
-		Description = "Very interesting"
+		return nil
 	}
-}`, kmsExternalTimestamp)
+}
+
+func testAccAWSKmsExternalKeyConfig() string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {}
+`)
+}
+
+func testAccAWSKmsExternalKeyConfigDeletionWindowInDays(deletionWindowInDays int) string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {
+  deletion_window_in_days = %[1]d
+}
+`, deletionWindowInDays)
+}
+
+func testAccAWSKmsExternalKeyConfigDescription(description string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+`, description)
+}
+
+func testAccAWSKmsExternalKeyConfigEnabled(enabled bool) string {
+	return fmt.Sprintf(`
+# ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
+resource "aws_kms_external_key" "test" {
+  deletion_window_in_days = 7
+  enabled                 = %[1]t
+  key_material_base64     = "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="
+}
+`, enabled)
+}
+
+func testAccAWSKmsExternalKeyConfigKeyMaterialBase64(keyMaterialBase64 string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {
+  deletion_window_in_days = 7
+  key_material_base64     = %[1]q
+}
+`, keyMaterialBase64)
+}
+
+func testAccAWSKmsExternalKeyConfigPolicy(policy string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {
+  deletion_window_in_days = 7
+  policy                  = <<POLICY
+%[1]s
+POLICY
+}
+`, policy)
+}
+
+func testAccAWSKmsExternalKeyConfigTags1(value1 string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {
+  deletion_window_in_days = 7
+  tags                    = {
+    key1 = %[1]q
+  }
+}
+`, value1)
+}
+
+func testAccAWSKmsExternalKeyConfigTags2(value1, value2 string) string {
+	return fmt.Sprintf(`
+resource "aws_kms_external_key" "test" {
+  deletion_window_in_days = 7
+  tags                    = {
+    key1 = %[1]q
+    key2 = %[2]q
+  }
+}
+`, value1, value2)
+}
+
+func testAccAWSKmsExternalKeyConfigValidTo(validTo string) string {
+	return fmt.Sprintf(`
+# ACCEPTANCE TESTING ONLY -- NEVER EXPOSE YOUR KEY MATERIAL
+resource "aws_kms_external_key" "test" {
+  deletion_window_in_days = 7
+  key_material_base64     = "Wblj06fduthWggmsT0cLVoIMOkeLbc2kVfMud77i/JY="
+  valid_to                = %[1]q
+}
+`, validTo)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -1730,16 +1730,16 @@
                     <a href="/docs/providers/aws/r/kms_alias.html">aws_kms_alias</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-aws-resource-kms-external-key") %>>
+                    <a href="/docs/providers/aws/r/kms_external_key.html">aws_kms_external_key</a>
+                  </li>
+
                   <li<%= sidebar_current("docs-aws-resource-kms-grant") %>>
                     <a href="/docs/providers/aws/r/kms_grant.html">aws_kms_grant</a>
                   </li>
 
                   <li<%= sidebar_current("docs-aws-resource-kms-key") %>>
                     <a href="/docs/providers/aws/r/kms_key.html">aws_kms_key</a>
-                  </li>
-
-                  <li<%= sidebar_current("docs-aws-resource-kms-external-key") %>>
-                    <a href="/docs/providers/aws/r/kms_external_key.html">aws_kms_external_key</a>
                   </li>
 
                 </ul>

--- a/website/docs/r/kms_external_key.html.markdown
+++ b/website/docs/r/kms_external_key.html.markdown
@@ -1,24 +1,22 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_kms_key"
-sidebar_current: "docs-aws-resource-kms-key"
+page_title: "AWS: aws_kms_external_key"
+sidebar_current: "docs-aws-resource-kms-external-key"
 description: |-
-  Provides a KMS customer master key that uses external key data
+  Manages a KMS Customer Master Key that uses external key material
 ---
 
-# aws\_kms\_key
+# aws_kms_external_key
 
-Provides a KMS customer master key that uses external key data
+Manages a KMS Customer Master Key that uses external key material. To instead manage a KMS Customer Master Key where AWS automatically generates and potentially rotates key material, see the [`aws_kms_key` resource](/docs/providers/aws/r/kms_key.html).
 
-~> **NOTE:** By default, AWS KMS creates key material for you when you create a customer master key (CMK). To instead import your own key material, you need to create a CMK with no key material, which is what this resource does. Currently importing the key material is not implemented in Terraform, and should be done as documented in the [AWS importing key material guide](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-
+~> **Note:** All arguments including the key material will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 ## Example Usage
 
 ```hcl
-resource "aws_kms_external_key" "a" {
+resource "aws_kms_external_key" "example" {
   description = "KMS EXTERNAL for AMI encryption"
-  deletion_window_in_days = 10
 }
 ```
 
@@ -26,26 +24,27 @@ resource "aws_kms_external_key" "a" {
 
 The following arguments are supported:
 
-* `description` - (Optional) The description of the key as viewed in AWS console.
-* `key_usage` - (Optional) Specifies the intended use of the key.
-  Defaults to ENCRYPT/DECRYPT, and only symmetric encryption and decryption are supported.
-* `policy` - (Optional) A valid policy JSON document.
-* `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted
-  after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days.
-* `is_enabled` - (Optional) Specifies whether the key is enabled. this option is always false while `key_state` is `PendingImport`. Defaults to true.
-* `tags` - (Optional) A mapping of tags to assign to the object.
+* `deletion_window_in_days` - (Optional) Duration in days after which the key is deleted after destruction of the resource. Must be between `7` and `30` days. Defaults to `30`.
+* `description` - (Optional) Description of the key.
+* `enabled` - (Optional) Specifies whether the key is enabled. Keys pending import can only be `false`. Imported keys default to `true` unless expired.
+* `key_material_base64` - (Optional) Base64 encoded 256-bit symmetric encryption key material to import. The CMK is permanently associated with this key material. The same key material can be reimported, but you cannot import different key material.
+* `policy` - (Optional) A key policy JSON document. If you do not provide a key policy, AWS KMS attaches a default key policy to the CMK.
+* `tags` - (Optional) A key-value map of tags to assign to the key.
+* `valid_to` - (Optional) Time at which the imported key material expires. When the key material expires, AWS KMS deletes the key material and the CMK becomes unusable. If not specified, key material does not expire. Valid values: [RFC3339 time string](https://tools.ietf.org/html/rfc3339#section-5.8) (`YYYY-MM-DDTHH:MM:SSZ`)
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the key.
-* `key_id` - The globally unique identifier for the key.
+* `expiration_model` - Whether the key material expires. Empty when pending key material import, otherwise `KEY_MATERIAL_EXPIRES` or `KEY_MATERIAL_DOES_NOT_EXPIRE`.
+* `id` - The unique identifier for the key.
 * `key_state` - The state of the CMK.
+* `key_usage` - The cryptographic operations for which you can use the CMK.
 
 ## Import
 
-KMS Keys can be imported using the `id`, e.g.
+KMS External Keys can be imported using the `id`, e.g.
 
 ```
 $ terraform import aws_kms_external_key.a arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References:

* Closes #1126
* Builds on #1127 and #7730
* https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html

Finishes implementation of new `aws_kms_external_key` resource with key material import support.

Output from acceptance testing:

```
--- PASS: TestAccAWSKmsExternalKey_basic (34.74s)
--- PASS: TestAccAWSKmsExternalKey_DeletionWindowInDays (41.80s)
--- PASS: TestAccAWSKmsExternalKey_Description (41.70s)
--- PASS: TestAccAWSKmsExternalKey_disappears (31.06s)
--- PASS: TestAccAWSKmsExternalKey_Enabled (313.67s)
--- PASS: TestAccAWSKmsExternalKey_KeyMaterialBase64 (136.90s)
--- PASS: TestAccAWSKmsExternalKey_Policy (42.64s)
--- PASS: TestAccAWSKmsExternalKey_Tags (51.01s)
--- PASS: TestAccAWSKmsExternalKey_ValidTo (291.29s)
```
