### PR TITLE
resource/aws_vpn_connection: Add transit_gateway_attachment_id attribute

### DIFF
--- a/aws/resource_aws_vpn_connection_test.go
+++ b/aws/resource_aws_vpn_connection_test.go
@@ -51,6 +51,7 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 				Config: testAccAwsVpnConnectionConfig(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAwsVpnConnectionExists("aws_vpn_connection.foo", &vpn),
+					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "transit_gateway_attachment_id", ""),
 				),
 			},
 			{
@@ -66,10 +67,14 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 func TestAccAWSVpnConnection_TransitGatewayID(t *testing.T) {
 	var vpn ec2.VpnConnection
 	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
 	resourceName := "aws_vpn_connection.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAwsVpnConnectionDestroy,
 		Steps: []resource.TestStep{
@@ -77,6 +82,8 @@ func TestAccAWSVpnConnection_TransitGatewayID(t *testing.T) {
 				Config: testAccAwsVpnConnectionConfigTransitGatewayID(rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAwsVpnConnectionExists(resourceName, &vpn),
+					resource.TestMatchResourceAttr(resourceName, "transit_gateway_attachment_id", regexp.MustCompile(`tgw-attach-.+`)),
+					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
 				),
 			},
 		},

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -93,6 +93,7 @@ In addition to all arguments above, the following attributes are exported:
 * `customer_gateway_id` - The ID of the customer gateway to which the connection is attached.
 * `static_routes_only` - Whether the VPN connection uses static routes exclusively.
 * `tags` - Tags applied to the connection.
+* `transit_gateway_attachment_id` - When associated with an EC2 Transit Gateway (`transit_gateway_id` argument), the attachment ID.
 * `tunnel1_address` - The public IP address of the first VPN tunnel.
 * `tunnel1_cgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side).
 * `tunnel1_vgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (VPN Gateway Side).


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/6884

Only performs lookup when the VPN Connection has an associated Transit Gateway ID. I tried unsuccessfully to use a EC2 Transit Gateway shared via Resource Access Manager (RAM) in EC2 VPN Connection creation and it always returned the below error even after waiting for greater than 10 minutes and in the web console manually as well:

```
InvalidTransitGatewayID.NotFound: The transitGateway ID 'tgw-XXXXXXXXX' does not exist
```

This broken acceptance testing is omitted from this change request as it may not be functionality actually supported by EC2. If there is a working configuration with shared Transit Gateways, we may need to lean on additional feedback after this implementation to smooth over those issues.

Output from acceptance testing:

```
--- PASS: TestAccAWSVpnConnection_basic (617.58s)
--- PASS: TestAccAWSVpnConnection_disappears (426.58s)
--- PASS: TestAccAWSVpnConnection_importBasic (238.20s)
--- PASS: TestAccAWSVpnConnection_TransitGatewayID (439.63s)
--- PASS: TestAccAWSVpnConnection_tunnelOptions (269.52s)
--- PASS: TestAccAWSVpnConnection_withoutStaticRoutes (195.55s)
```