### PR TITLE
New Data Source: aws_ec2_transit_gateway_vpn_attachment

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEc2TransitGatewayVpnAttachment() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEc2TransitGatewayVpnAttachmentRead,
+
+		Schema: map[string]*schema.Schema{
+			"tags": tagsSchemaComputed(),
+			"transit_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vpn_connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEc2TransitGatewayVpnAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	input := &ec2.DescribeTransitGatewayAttachmentsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("resource-id"),
+				Values: []*string{aws.String(d.Get("vpn_connection_id").(string))},
+			},
+			{
+				Name:   aws.String("resource-type"),
+				Values: []*string{aws.String(ec2.TransitGatewayAttachmentResourceTypeVpn)},
+			},
+			{
+				Name:   aws.String("transit-gateway-id"),
+				Values: []*string{aws.String(d.Get("transit_gateway_id").(string))},
+			},
+		},
+	}
+
+	log.Printf("[DEBUG] Reading EC2 Transit Gateway VPN Attachments: %s", input)
+	output, err := conn.DescribeTransitGatewayAttachments(input)
+
+	if err != nil {
+		return fmt.Errorf("error reading EC2 Transit Gateway VPN Attachment: %s", err)
+	}
+
+	if output == nil || len(output.TransitGatewayAttachments) == 0 || output.TransitGatewayAttachments[0] == nil {
+		return errors.New("error reading EC2 Transit Gateway VPN Attachment: no results found")
+	}
+
+	if len(output.TransitGatewayAttachments) > 1 {
+		return errors.New("error reading EC2 Transit Gateway VPN Attachment: multiple results found, try adjusting search criteria")
+	}
+
+	transitGatewayAttachment := output.TransitGatewayAttachments[0]
+
+	if err := d.Set("tags", tagsToMap(transitGatewayAttachment.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
+
+	d.Set("transit_gateway_id", aws.StringValue(transitGatewayAttachment.TransitGatewayId))
+	d.Set("vpn_connection_id", aws.StringValue(transitGatewayAttachment.ResourceId))
+
+	d.SetId(aws.StringValue(transitGatewayAttachment.TransitGatewayAttachmentId))
+
+	return nil
+}

--- a/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpn_attachment_test.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId(t *testing.T) {
+	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	dataSourceName := "data.aws_ec2_transit_gateway_vpn_attachment.test"
+	transitGatewayResourceName := "aws_ec2_transit_gateway.test"
+	vpnConnectionResourceName := "aws_vpn_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAWSEc2TransitGateway(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEc2TransitGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAndVpnConnectionId(rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "transit_gateway_id", transitGatewayResourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vpn_connection_id", vpnConnectionResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSEc2TransitGatewayVpnAttachmentDataSourceConfigTransitGatewayIdAndVpnConnectionId(rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_ec2_transit_gateway" "test" {}
+
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = %[1]d
+  ip_address = "178.0.0.1"
+  type       = "ipsec.1"
+
+  tags = {
+    Name = "tf-acc-test-ec2-vpn-connection-transit-gateway-id"
+  }
+}
+
+resource "aws_vpn_connection" "test" {
+  customer_gateway_id = "${aws_customer_gateway.test.id}"
+  transit_gateway_id  = "${aws_ec2_transit_gateway.test.id}"
+  type                = "${aws_customer_gateway.test.type}"
+}
+
+data "aws_ec2_transit_gateway_vpn_attachment" "test" {
+  transit_gateway_id = "${aws_ec2_transit_gateway.test.id}"
+  vpn_connection_id  = "${aws_vpn_connection.test.id}"
+}
+`, rBgpAsn)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -182,6 +182,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ec2_transit_gateway":                dataSourceAwsEc2TransitGateway(),
 			"aws_ec2_transit_gateway_route_table":    dataSourceAwsEc2TransitGatewayRouteTable(),
 			"aws_ec2_transit_gateway_vpc_attachment": dataSourceAwsEc2TransitGatewayVpcAttachment(),
+			"aws_ec2_transit_gateway_vpn_attachment": dataSourceAwsEc2TransitGatewayVpnAttachment(),
 			"aws_ecr_repository":                     dataSourceAwsEcrRepository(),
 			"aws_ecs_cluster":                        dataSourceAwsEcsCluster(),
 			"aws_ecs_container_definition":           dataSourceAwsEcsContainerDefinition(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -152,6 +152,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ec2-transit-gateway-vpc-attachment") %>>
                           <a href="/docs/providers/aws/d/ec2_transit_gateway_vpc_attachment.html">aws_ec2_transit_gateway_vpc_attachment</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-ec2-transit-gateway-vpn-attachment") %>>
+                          <a href="/docs/providers/aws/d/ec2_transit_gateway_vpn_attachment.html">aws_ec2_transit_gateway_vpn_attachment</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-ecr-repository") %>>
                           <a href="/docs/providers/aws/d/ecr_repository.html">aws_ecr_repository</a>
                         </li>

--- a/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpn_attachment.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ec2_transit_gateway_vpn_attachment"
+sidebar_current: "docs-aws-datasource-ec2-transit-gateway-vpn-attachment"
+description: |-
+  Get information on an EC2 Transit Gateway VPN Attachment
+---
+
+# Data Source: aws_ec2_transit_gateway_vpn_attachment
+
+Get information on an EC2 Transit Gateway VPN Attachment.
+
+## Example Usage
+
+### By Transit Gateway and VPN Connection Identifiers
+
+```hcl
+data "aws_ec2_transit_gateway_vpn_attachment" "example" {
+  transit_gateway_id = "${aws_ec2_transit_gateway.example.id}"
+  vpn_connection_id  = "${aws_vpn_connection.example.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `transit_gateway_id` - (Required) Identifier of the EC2 Transit Gateway.
+* `vpn_connection_id` - (Required) Identifier of the EC2 VPN Connection.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - EC2 Transit Gateway VPN Attachment identifier
+* `tags` - Key-value tags for the EC2 Transit Gateway VPN Attachment


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/6884

This is a bare minimum implementation to help operators retrieve a VPN Attachment ID using the Transit Gateway ID and VPN Connection ID. It can be further enhanced in the future.

Output from acceptance testing:

```
--- PASS: TestAccAWSEc2TransitGatewayVpnAttachmentDataSource_TransitGatewayIdAndVpnConnectionId (462.11s)
```
