### PR TITLE
resource/aws_autoscaling_group: Temporarily disable ValidateFunc for Mixed Instances Policy allocation strategy

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -107,9 +107,10 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Default:  "prioritized",
-										ValidateFunc: validation.StringInSlice([]string{
-											"prioritized",
-										}, false),
+										// Reference: https://github.com/hashicorp/terraform/issues/18027
+										// ValidateFunc: validation.StringInSlice([]string{
+										// 	"prioritized",
+										// }, false),
 									},
 									"on_demand_base_capacity": {
 										Type:         schema.TypeInt,
@@ -126,9 +127,10 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 										Default:  "lowest-price",
-										ValidateFunc: validation.StringInSlice([]string{
-											"lowest-price",
-										}, false),
+										// Reference: https://github.com/hashicorp/terraform/issues/18027
+										// ValidateFunc: validation.StringInSlice([]string{
+										// 	"lowest-price",
+										// }, false),
 									},
 									"spot_instance_pools": {
 										Type:         schema.TypeInt,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

```
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (113.98s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (345.50s)
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (52.22s)
--- PASS: TestAccAWSAutoScalingGroup_basic (367.73s)
--- PASS: TestAccAWSAutoScalingGroup_classicVpcZoneIdentifier (42.77s)
--- PASS: TestAccAWSAutoScalingGroup_emptyAvailabilityZones (52.13s)
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (193.69s)
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (234.93s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate (47.23s)
--- PASS: TestAccAWSAutoScalingGroup_LaunchTemplate_IAMInstanceProfile (52.54s)
--- PASS: TestAccAWSAutoScalingGroup_launchTemplate_update (108.56s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy (55.62s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandAllocationStrategy (50.51s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandBaseCapacity (73.60s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_OnDemandPercentageAboveBaseCapacity (80.82s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotAllocationStrategy (49.38s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotInstancePools (83.90s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_InstancesDistribution_SpotMaxPrice (148.61s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_LaunchTemplateName (74.23s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_LaunchTemplateSpecification_Version (178.65s)
--- PASS: TestAccAWSAutoScalingGroup_MixedInstancesPolicy_LaunchTemplate_Override_InstanceType (79.11s)
--- PASS: TestAccAWSAutoScalingGroup_namePrefix (55.81s)
--- PASS: TestAccAWSAutoScalingGroup_serviceLinkedRoleARN (75.65s)
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (264.75s)
--- PASS: TestAccAWSAutoScalingGroup_tags (243.86s)
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (115.67s)
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (76.76s)
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (447.50s)
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (189.36s)
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (174.11s)
```
