### PR TITLE
Feature/add support resource tags for aws cloudwatch event rule resource

### DIFF
--- a/aws/resource_aws_cloudwatch_event_rule.go
+++ b/aws/resource_aws_cloudwatch_event_rule.go
@@ -168,8 +168,9 @@ func resourceAwsCloudWatchEventRuleRead(d *schema.ResourceData, meta interface{}
 	}
 	log.Printf("[DEBUG] Setting boolean state: %t", boolState)
 	d.Set("is_enabled", boolState)
-	d.Set("tags", saveTagsCloudWatchEvents(conn, d, aws.StringValue(out.Arn)))
-
+	if err := saveTagsCloudWatchEvents(conn, d, aws.StringValue(out.Arn)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
+	}
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_event_rule_test.go
+++ b/aws/resource_aws_cloudwatch_event_rule_test.go
@@ -138,6 +138,7 @@ func TestAccAWSCloudWatchEventRule_prefix(t *testing.T) {
 
 func TestAccAWSCloudWatchEventRule_tags(t *testing.T) {
 	var rule events.DescribeRuleOutput
+	resourceName := "aws_cloudwatch_event_rule.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -147,20 +148,34 @@ func TestAccAWSCloudWatchEventRule_tags(t *testing.T) {
 			{
 				Config: testAccAWSCloudWatchEventRuleConfig_tags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.default", &rule),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.default", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.default", "tags.fizz", "buzz"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.default", "tags.foo", "bar"),
+					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
 				Config: testAccAWSCloudWatchEventRuleConfig_updateTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudWatchEventRuleExists("aws_cloudwatch_event_rule.default", &rule),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.default", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.default", "tags.foo", "bar2"),
-					resource.TestCheckResourceAttr("aws_cloudwatch_event_rule.default", "tags.good", "bad"),
+					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.good", "bad"),
 				),
+			},
+			{
+				Config: testAccAWSCloudWatchEventRuleConfig_removeTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventRuleExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -390,7 +405,7 @@ PATTERN
 
 var testAccAWSCloudWatchEventRuleConfig_tags = `
 resource "aws_cloudwatch_event_rule" "default" {
-    name = "tf-acc-cw-event-rule"
+    name = "tf-acc-cw-event-rule-tags"
 	schedule_expression = "rate(1 hour)"
 	
 	tags = {
@@ -402,12 +417,24 @@ resource "aws_cloudwatch_event_rule" "default" {
 
 var testAccAWSCloudWatchEventRuleConfig_updateTags = `
 resource "aws_cloudwatch_event_rule" "default" {
-    name = "tf-acc-cw-event-rule"
+    name = "tf-acc-cw-event-rule-tags"
 	schedule_expression = "rate(1 hour)"
 	
 	tags = {
+		fizz 	= "buzz"
 		foo		= "bar2"
 		good	= "bad"
+	}
+}
+`
+
+var testAccAWSCloudWatchEventRuleConfig_removeTags = `
+resource "aws_cloudwatch_event_rule" "default" {
+    name = "tf-acc-cw-event-rule-tags"
+	schedule_expression = "rate(1 hour)"
+	
+	tags = {
+		fizz 	= "buzz"
 	}
 }
 `

--- a/aws/tagsCloudWatchEvent.go
+++ b/aws/tagsCloudWatchEvent.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsCloudWatchEvents(conn *events.CloudWatchEvents, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsCloudWatchEvents(tagsFromMapCloudWatchEvents(o), tagsFromMapCloudWatchEvents(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, 0, len(remove))
+			for _, t := range remove {
+				k = append(k, t.Key)
+			}
+			_, err := conn.UntagResource(&events.UntagResourceInput{
+				ResourceARN: aws.String(arn),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&events.TagResourceInput{
+				ResourceARN: aws.String(arn),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsCloudWatchEvents(oldTags, newTags []*events.Tag) ([]*events.Tag, []*events.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*events.Tag
+	for _, t := range oldTags {
+		old, ok := create[*t.Key]
+		if !ok || old != *t.Value {
+			// Delete it!
+			remove = append(remove, t)
+		}
+	}
+
+	return tagsFromMapCloudWatchEvents(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapCloudWatchEvents(m map[string]interface{}) []*events.Tag {
+	var result []*events.Tag
+	for k, v := range m {
+		t := &events.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredCloudWatchEvents(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapCloudWatchEvents(ts []*events.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredCloudWatchEvents(t) {
+			result[*t.Key] = *t.Value
+		}
+	}
+
+	return result
+}
+
+func saveTagsCloudWatchEvents(conn *events.CloudWatchEvents, d *schema.ResourceData, arn string) error {
+	resp, err := conn.ListTagsForResource(&events.ListTagsForResourceInput{
+		ResourceARN: aws.String(arn),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retreiving tags for ARN: %s", arn)
+	}
+
+	var tagList []*events.Tag
+	if len(resp.Tags) > 0 {
+		tagList = resp.Tags
+	}
+
+	return d.Set("tags", tagsToMapCloudWatchEvents(tagList))
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredCloudWatchEvents(t *events.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		r, _ := regexp.MatchString(v, *t.Key)
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsCloudWatchEvent_test.go
+++ b/aws/tagsCloudWatchEvent_test.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
+)
+
+func TestDiffCloudWatchEventTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsCloudWatchEvents(tagsFromMapCloudWatchEvents(tc.Old), tagsFromMapCloudWatchEvents(tc.New))
+		cm := tagsToMapCloudWatchEvents(c)
+		rm := tagsToMapCloudWatchEvents(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+func TestIgnoringTagsCloudWatchEvents(t *testing.T) {
+	var ignoredTags []*events.Tag
+	ignoredTags = append(ignoredTags, &events.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &events.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredCloudWatchEvents(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/cloudwatch_event_rule.html.markdown
+++ b/website/docs/r/cloudwatch_event_rule.html.markdown
@@ -70,6 +70,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the rule.
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) associated with the role that is used for target invocation.
 * `is_enabled` - (Optional) Whether the rule should be enabled (defaults to `true`).
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8047 

Changes proposed in this pull request:

* Add resource tags support
* Add tags attribute for `aws_cloudwatch_event_rule` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventRule_tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudWatchEventRule_tags -timeout 120m
=== RUN   TestAccAWSCloudWatchEventRule_tags
=== PAUSE TestAccAWSCloudWatchEventRule_tags
=== CONT  TestAccAWSCloudWatchEventRule_tags
--- PASS: TestAccAWSCloudWatchEventRule_tags (57.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	57.489s
```
```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventRule_full'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudWatchEventRule_full -timeout 120m
=== RUN   TestAccAWSCloudWatchEventRule_full
=== PAUSE TestAccAWSCloudWatchEventRule_full
=== CONT  TestAccAWSCloudWatchEventRule_full
--- PASS: TestAccAWSCloudWatchEventRule_full (51.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.780s
```