### PR TITLE
Bugfix: allow updates to metric_query on aws_cloudwatch_metric_alarm

### DIFF
--- a/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -422,8 +422,12 @@ func getAwsCloudWatchPutMetricAlarmInput(d *schema.ResourceData) cloudwatch.PutM
 	if v := d.Get("metric_query"); v != nil {
 		for _, v := range v.(*schema.Set).List() {
 			metricQueryResource := v.(map[string]interface{})
+			id := metricQueryResource["id"].(string)
+			if id == "" {
+				continue
+			}
 			metricQuery := cloudwatch.MetricDataQuery{
-				Id: aws.String(metricQueryResource["id"].(string)),
+				Id: aws.String(id),
 			}
 			if v, ok := metricQueryResource["expression"]; ok && v.(string) != "" {
 				metricQuery.Expression = aws.String(v.(string))

--- a/aws/resource_aws_cloudwatch_metric_alarm_test.go
+++ b/aws/resource_aws_cloudwatch_metric_alarm_test.go
@@ -264,6 +264,20 @@ func TestAccAWSCloudWatchMetricAlarm_expression(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAWSCloudWatchMetricAlarmConfigWithExpression(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
+					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_query.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSCloudWatchMetricAlarmConfigWithExpressionWithQueryUpdated(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchMetricAlarmExists("aws_cloudwatch_metric_alarm.foobar", &alarm),
+					resource.TestCheckResourceAttr("aws_cloudwatch_metric_alarm.foobar", "metric_query.#", "2"),
+				),
+			},
+			{
 				ResourceName:      "aws_cloudwatch_metric_alarm.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -568,6 +582,37 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
 			namespace   = "AWS/EC2"
 			period      = "120"
 			stat        = "Average"
+			unit        = "Count"
+			dimensions = {
+				InstanceId = "i-abc123"
+			}
+		}
+	}
+}`, rInt)
+}
+
+func testAccAWSCloudWatchMetricAlarmConfigWithExpressionWithQueryUpdated(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "foobar" {
+  alarm_name                = "terraform-test-foobar%d"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+	threshold                 = "80"
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+	metric_query {
+		id = "e1"
+		expression = "m1"
+		label = "cat"
+		return_data = "true"
+	}
+	metric_query {
+		id = "m1"
+		metric {
+			metric_name = "CPUUtilization"
+			namespace   = "AWS/EC2"
+			period      = "120"
+			stat        = "Maximum"
 			unit        = "Count"
 			dimensions = {
 				InstanceId = "i-abc123"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7593 

Changes proposed in this pull request:

* allow updates to metric_query on aws_cloudwatch_metric_alarm

Output from acceptance testing:

```
aws-vault exec sand-superuser -- make testacc TESTARGS="-run TestAccAWSCloudWatchMetricAlarm"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run TestAccAWSCloudWatchMetricAlarm -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchMetricAlarm_basic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_basic
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== RUN   TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== PAUSE TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== RUN   TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== PAUSE TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
=== RUN   TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== PAUSE TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== RUN   TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== PAUSE TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== RUN   TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== RUN   TestAccAWSCloudWatchMetricAlarm_expression
=== PAUSE TestAccAWSCloudWatchMetricAlarm_expression
=== RUN   TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== PAUSE TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== CONT  TestAccAWSCloudWatchMetricAlarm_basic
=== CONT  TestAccAWSCloudWatchMetricAlarm_treatMissingData
=== CONT  TestAccAWSCloudWatchMetricAlarm_missingStatistic
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic
=== CONT  TestAccAWSCloudWatchMetricAlarm_extendedStatistic
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction
=== CONT  TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles
=== CONT  TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate
=== CONT  TestAccAWSCloudWatchMetricAlarm_expression
=== CONT  TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm
--- PASS: TestAccAWSCloudWatchMetricAlarm_missingStatistic (10.63s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_extendedStatistic (33.01s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_datapointsToAlarm (33.07s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_basic (37.68s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SWFAction (41.93s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_SNSTopic (42.46s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_treatMissingData (55.71s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_evaluateLowSampleCountPercentiles (56.70s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_expression (113.50s)
--- PASS: TestAccAWSCloudWatchMetricAlarm_AlarmActions_EC2Automate (360.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       360.108s
```

Please see https://github.com/terraform-providers/terraform-provider-aws/pull/8085/commits/ad064a698983b24d76ab1e45d3793b6eda0ea4ba for the output of the failing test prior to this patch.