### PR TITLE
syncing the timeout with the attachment resource

### DIFF
--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -219,7 +219,7 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"detached", "attaching"},
 		Target:  []string{"attached"},
 		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id()),
-		Timeout: 10 * time.Minute,
+		Timeout: 15 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
We've seen some timeout failures when specifying the `vpc_id` while using this resource. Syncing the timeout for the gateway attachment with the gateway attachment resource @ https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_vpn_gateway_attachment.go#L62

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* Syncing resource timeout with its partner resource

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
