### PR TITLE
Feature/add retry step and timeout options for aws ebs snapshot resource

### DIFF
--- a/aws/resource_aws_ebs_snapshot.go
+++ b/aws/resource_aws_ebs_snapshot.go
@@ -18,6 +18,11 @@ func resourceAwsEbsSnapshot() *schema.Resource {
 		Read:   resourceAwsEbsSnapshotRead,
 		Delete: resourceAwsEbsSnapshotDelete,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(40 * time.Minute),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"volume_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8043 

Changes proposed in this pull request:

* Add retry step for wait for snapshot available
* Add timeouts options for create/delete

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSEBSSnapshot_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEBSSnapshot_ -timeout 120m
=== RUN   TestAccAWSEBSSnapshot_basic
=== PAUSE TestAccAWSEBSSnapshot_basic
=== RUN   TestAccAWSEBSSnapshot_withDescription
=== PAUSE TestAccAWSEBSSnapshot_withDescription
=== RUN   TestAccAWSEBSSnapshot_withKms
=== PAUSE TestAccAWSEBSSnapshot_withKms
=== CONT  TestAccAWSEBSSnapshot_basic
=== CONT  TestAccAWSEBSSnapshot_withKms
=== CONT  TestAccAWSEBSSnapshot_withDescription
--- PASS: TestAccAWSEBSSnapshot_withDescription (50.40s)
--- PASS: TestAccAWSEBSSnapshot_withKms (115.55s)
--- PASS: TestAccAWSEBSSnapshot_basic (135.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	135.635s
```
