### PR TITLE
Recommend specifying glue_catalog_table table_type argument

### DIFF
--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `partition_keys` - (Optional) A list of columns by which the table is partitioned. Only primitive types are supported as partition keys.
 * `view_original_text` - (Optional) If the table is a view, the original text of the view; otherwise null.
 * `view_expanded_text` - (Optional) If the table is a view, the expanded text of the view; otherwise null.
-* `table_type` - (Optional) The type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.).
+* `table_type` - (Optional) The type of this table (EXTERNAL_TABLE, VIRTUAL_VIEW, etc.). While optional, some Athena DDL queries such as `ALTER TABLE` and `SHOW CREATE TABLE` will fail if this argument is empty.
 * `parameters` - (Optional) Properties associated with this table, as a list of key-value pairs.
 
 ##### storage_descriptor


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Without a table_type, some Athena DDL queries fail with an internal exception. This is not documented in the [Glue Table API](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-Table), but I don't see a downside to recommend this here.

To reproduce this issue, apply these resources :
```resource "aws_glue_catalog_database" "example" {
  name = "test_example"
}

resource "aws_glue_catalog_table" "example" {
  name          = "test_table"
  database_name = "${aws_glue_catalog_database.example.name}"
  storage_descriptor {
    location = "s3://example/"
    input_format = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"
    output_format = "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"
    ser_de_info {
      name = "example"
      parameters {
        serialization.format = 1
      }
      serialization_library = "org.apache.hadoop.hive.ql.io.orc.OrcSerde"
    }
  }
}
```

Then in Athena :
```
SHOW CREATE TABLE test_table;
```
Should result in `FAILED: NullPointerException Name is null`