### PR TITLE
Doc update: aws_codecommit_repository does not support default_branch

### DIFF
--- a/website/docs/r/codecommit_repository.html.markdown
+++ b/website/docs/r/codecommit_repository.html.markdown
@@ -29,7 +29,6 @@ The following arguments are supported:
 
 * `repository_name` - (Required) The name for the repository. This needs to be less than 100 characters.
 * `description` - (Optional) The description of the repository. This needs to be less than 1000 characters
-* `default_branch` - (Optional) The default branch of the repository. The branch specified here needs to exist.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The website docs list 'default_branch' as an attribute of aws_codecommit_repository, but this attribute is not in the current code.

```
module.codecommit.output.default_branch: Resource
'aws_codecommit_repository.repo' does not have attribute 
'default_branch' for variable 'aws_codecommit_repository.repo.default_branch'
```

See also: https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/data_source_aws_codecommit_repository.go

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
