### PR TITLE
service/ec2: Only call DescribeInstanceCreditSpecifications for T2 and T3 Instance Families

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -862,11 +862,18 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
-	{
+
+	// AWS Standard will return InstanceCreditSpecification.NotSupported errors for EC2 Instance IDs outside T2 and T3 instance types
+	// Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8055
+	if strings.HasPrefix(aws.StringValue(instance.InstanceType), "t2") || strings.HasPrefix(aws.StringValue(instance.InstanceType), "t3") {
 		creditSpecifications, err := getCreditSpecifications(conn, d.Id())
+
+		// Ignore UnsupportedOperation errors for AWS China and GovCloud (US)
+		// Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/4362
 		if err != nil && !isAWSErr(err, "UnsupportedOperation", "") {
-			return err
+			return fmt.Errorf("error getting EC2 Instance (%s) Credit Specifications: %s", d.Id(), err)
 		}
+
 		if err := d.Set("credit_specification", creditSpecifications); err != nil {
 			return fmt.Errorf("error setting credit_specification: %s", err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References:

* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceCreditSpecifications.html
* #8055

Changes proposed in this pull request:

* data-source/aws_instance: Only call `DescribeInstanceCreditSpecifications` for T2 and T3 instance families
* resource/aws_instance: Only call `DescribeInstanceCreditSpecifications` for T2 and T3 instance families

Output from acceptance testing:

```
--- PASS: TestAccAWSInstanceDataSource_AzUserData (151.20s)
--- PASS: TestAccAWSInstanceDataSource_basic (97.18s)
--- PASS: TestAccAWSInstanceDataSource_blockDevices (101.25s)
--- PASS: TestAccAWSInstanceDataSource_creditSpecification (112.21s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_falseToTrue (150.08s)
--- PASS: TestAccAWSInstanceDataSource_getPasswordData_trueToFalse (179.42s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData (168.45s)
--- PASS: TestAccAWSInstanceDataSource_GetUserData_NoUserData (168.54s)
--- PASS: TestAccAWSInstanceDataSource_gp2IopsDevice (92.01s)
--- PASS: TestAccAWSInstanceDataSource_keyPair (78.48s)
--- PASS: TestAccAWSInstanceDataSource_PlacementGroup (98.86s)
--- PASS: TestAccAWSInstanceDataSource_privateIP (112.85s)
--- PASS: TestAccAWSInstanceDataSource_rootInstanceStore (86.97s)
--- PASS: TestAccAWSInstanceDataSource_SecurityGroups (260.40s)
--- PASS: TestAccAWSInstanceDataSource_tags (225.46s)
--- PASS: TestAccAWSInstanceDataSource_VPC (106.89s)
--- PASS: TestAccAWSInstanceDataSource_VPCSecurityGroups (99.98s)

--- PASS: TestAccAWSInstance_addSecondaryInterface (108.36s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (218.89s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (194.32s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (72.25s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (72.16s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (194.73s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (62.19s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (185.44s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (61.96s)
--- PASS: TestAccAWSInstance_basic (288.86s)
--- PASS: TestAccAWSInstance_blockDevices (79.90s)
--- PASS: TestAccAWSInstance_changeInstanceType (328.07s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (142.59s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (89.38s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (495.86s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (79.81s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (473.06s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (74.04s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (103.67s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (124.66s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (98.03s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (297.32s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (104.16s)
--- PASS: TestAccAWSInstance_disableApiTermination (227.39s)
--- PASS: TestAccAWSInstance_disappears (289.98s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (283.69s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (187.53s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (136.23s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (180.84s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (73.56s)
--- PASS: TestAccAWSInstance_importBasic (196.90s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgId (184.12s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgName (194.95s)
--- PASS: TestAccAWSInstance_importInEc2Classic (214.50s)
--- PASS: TestAccAWSInstance_instanceProfileChange (143.52s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (80.26s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (106.20s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (10.18s)
--- PASS: TestAccAWSInstance_keyPairCheck (80.63s)
--- PASS: TestAccAWSInstance_multipleRegions (249.95s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (118.76s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (76.21s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (185.11s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (180.51s)
--- PASS: TestAccAWSInstance_placementGroup (93.35s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (73.40s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (64.21s)
--- PASS: TestAccAWSInstance_privateIP (182.71s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (173.54s)
--- PASS: TestAccAWSInstance_rootInstanceStore (78.60s)
--- PASS: TestAccAWSInstance_sourceDestCheck (247.82s)
--- PASS: TestAccAWSInstance_tags (204.28s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (82.70s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (79.17s)
--- PASS: TestAccAWSInstance_userDataBase64 (112.51s)
--- PASS: TestAccAWSInstance_volumeTags (96.54s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (112.38s)
--- PASS: TestAccAWSInstance_vpc (98.94s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (121.70s)
```
