### PR TITLE
 Add support for Glacier Deep Archive storage class

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -402,6 +402,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 														s3.StorageClassOnezoneIa,
 														s3.StorageClassIntelligentTiering,
 														s3.StorageClassGlacier,
+														s3.StorageClassDeepArchive,
 													}, false),
 												},
 												"replica_kms_key_id": {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -112,6 +112,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 					s3.ObjectStorageClassStandardIa,
 					s3.ObjectStorageClassOnezoneIa,
 					s3.ObjectStorageClassIntelligentTiering,
+					s3.ObjectStorageClassDeepArchive,
 				}, false),
 			},
 

--- a/aws/resource_aws_s3_bucket_object_test.go
+++ b/aws/resource_aws_s3_bucket_object_test.go
@@ -458,6 +458,14 @@ func TestAccAWSS3BucketObject_storageClass(t *testing.T) {
 					testAccCheckAWSS3BucketObjectStorageClass(resourceName, "INTELLIGENT_TIERING"),
 				),
 			},
+			{
+				Config: testAccAWSS3BucketObjectConfig_storageClass(rInt, "DEEP_ARCHIVE"),
+				Check: resource.ComposeTestCheckFunc(
+					// 	Can't GetObject on an object in DEEP_ARCHIVE without restoring it.
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "DEEP_ARCHIVE"),
+					testAccCheckAWSS3BucketObjectStorageClass(resourceName, "DEEP_ARCHIVE"),
+				),
+			},
 		},
 	})
 }

--- a/aws/resource_aws_s3_bucket_test.go
+++ b/aws/resource_aws_s3_bucket_test.go
@@ -913,6 +913,12 @@ func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.962205413.storage_class", "GLACIER"),
 					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.1571523406.date", ""),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.1571523406.days", "210"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.0.transition.1571523406.storage_class", "DEEP_ARCHIVE"),
+					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.id", "id2"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.prefix", "path2/"),
@@ -2473,6 +2479,11 @@ resource "aws_s3_bucket" "bucket" {
 		transition {
 			days = 120
 			storage_class = "GLACIER"
+		}
+
+		transition {
+			days = 210
+			storage_class = "DEEP_ARCHIVE"
 		}
 	}
 	lifecycle_rule {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -903,6 +903,7 @@ func validateS3BucketLifecycleTransitionStorageClass() schema.SchemaValidateFunc
 		s3.TransitionStorageClassStandardIa,
 		s3.TransitionStorageClassOnezoneIa,
 		s3.TransitionStorageClassIntelligentTiering,
+		s3.StorageClassDeepArchive,
 	}, false)
 }
 

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -388,7 +388,7 @@ The `transition` object supports the following
 
 * `date` (Optional) Specifies the date after which you want the corresponding action to take effect.
 * `days` (Optional) Specifies the number of days after object creation when the specific rule action takes effect.
-* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, or `GLACIER`.
+* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, `GLACIER`, or `DEEP_ARCHIVE`.
 
 The `noncurrent_version_expiration` object supports the following
 
@@ -397,7 +397,7 @@ The `noncurrent_version_expiration` object supports the following
 The `noncurrent_version_transition` object supports the following
 
 * `days` (Required) Specifies the number of days an object is noncurrent object versions expire.
-* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the noncurrent versions object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, or `GLACIER`.
+* `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the noncurrent versions object to transition. Can be `ONEZONE_IA`, `STANDARD_IA`, `INTELLIGENT_TIERING`, `GLACIER`, or `DEEP_ARCHIVE`.
 
 The `replication_configuration` object supports the following:
 
@@ -424,7 +424,7 @@ Replication configuration V1 supports filtering based on only the `prefix` attri
 The `destination` object supports the following:
 
 * `bucket` - (Required) The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
-* `storage_class` - (Optional) The class of storage used to store the object. Can be `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, or `GLACIER`.
+* `storage_class` - (Optional) The class of storage used to store the object. Can be `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `GLACIER`, or `DEEP_ARCHIVE`.
 * `replica_kms_key_id` - (Optional) Destination KMS encryption key ARN for SSE-KMS replication. Must be used in conjunction with
   `sse_kms_encrypted_objects` source selection criteria.
 * `access_control_translation` - (Optional) Specifies the overrides to use for object owners on replication. Must be used in conjunction with `account_id` owner override configuration.

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -98,7 +98,7 @@ The following arguments are supported:
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
 * `website_redirect` - (Optional) Specifies a target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
 * `storage_class` - (Optional) Specifies the desired [Storage Class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)
-for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", "`ONEZONE_IA`", "`INTELLIGENT_TIERING`", "`GLACIER`", or "`STANDARD_IA`". Defaults to "`STANDARD`".
+for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", "`ONEZONE_IA`", "`INTELLIGENT_TIERING`", "`GLACIER`", "`DEEP_ARCHIVE`", or "`STANDARD_IA`". Defaults to "`STANDARD`".
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${filemd5("path/to/file")}` (Terraform 0.11.12 or later) or `${md5(file("path/to/file"))}` (Terraform 0.11.11 or earlier).
 This attribute is not compatible with KMS encryption, `kms_key_id` or `server_side_encryption = "aws:kms"`.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".


### PR DESCRIPTION
Fixes #8106

Changes proposed in this pull request:

* Support for DEEP_ARCHIVE s3 storage class

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=^TestAccAWSS3Bucket_Lifecycle$'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=^TestAccAWSS3Bucket_Lifecycle -timeout 120m
=== RUN   TestAccAWSS3Bucket_Lifecycle
=== PAUSE TestAccAWSS3Bucket_Lifecycle
=== RUN   TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== PAUSE TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
=== CONT  TestAccAWSS3Bucket_Lifecycle
=== CONT  TestAccAWSS3Bucket_LifecycleExpireMarkerOnly
--- PASS: TestAccAWSS3Bucket_LifecycleExpireMarkerOnly (103.26s)
--- PASS: TestAccAWSS3Bucket_Lifecycle (155.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       155.122s


$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSS3BucketObject_storageClass'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSS3BucketObject_storageClass -timeout 120m
=== RUN   TestAccAWSS3BucketObject_storageClass
=== PAUSE TestAccAWSS3BucketObject_storageClass
=== CONT  TestAccAWSS3BucketObject_storageClass
--- PASS: TestAccAWSS3BucketObject_storageClass (224.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       224.970s
...
```
