### PR TITLE
CodeBuild Webhook FilterGroups

### DIFF
--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -127,7 +127,7 @@ func expandWebhookFilterGroup(d *schema.ResourceData) [][]*codebuild.WebhookFilt
 
 func expandWebhookFilterData(data map[string]interface{}) codebuild.WebhookFilter {
 	filter := codebuild.WebhookFilter{
-		Type: aws.String(data["type"].(string)),
+		Type:                  aws.String(data["type"].(string)),
 		ExcludeMatchedPattern: aws.Bool(data["exclude_matched_pattern"].(bool)),
 	}
 

--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -248,8 +248,8 @@ func resourceAwsCodeBuildWebhookFilterHash(v interface{}) int {
 	m := v.([]map[string]interface{})
 
 	for _, f := range m {
-		buf.WriteString(fmt.Sprintf("%s-", f["type"].(*string)))
-		buf.WriteString(fmt.Sprintf("%s-", f["pattern"].(*string)))
+		buf.WriteString(fmt.Sprintf("%v-", f["type"].(*string)))
+		buf.WriteString(fmt.Sprintf("%v-", f["pattern"].(*string)))
 		buf.WriteString(fmt.Sprintf("%q", f["exclude_matched_pattern"]))
 	}
 

--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -34,7 +34,6 @@ func resourceAwsCodeBuildWebhook() *schema.Resource {
 			"filter_group": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -50,11 +49,12 @@ func resourceAwsCodeBuildWebhook() *schema.Resource {
 						},
 						"exclude_matched_pattern": {
 							Type:     schema.TypeBool,
-							Required: true,
+							Optional: true,
+							Default:  false,
 						},
 						"pattern": {
 							Type:     schema.TypeString,
-							Optional: true,
+							Required: true,
 						},
 					},
 				},

--- a/aws/resource_aws_codebuild_webhook.go
+++ b/aws/resource_aws_codebuild_webhook.go
@@ -175,12 +175,22 @@ func resourceAwsCodeBuildWebhookRead(d *schema.ResourceData, meta interface{}) e
 func resourceAwsCodeBuildWebhookUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).codebuildconn
 
-	_, err := conn.UpdateWebhook(&codebuild.UpdateWebhookInput{
-		ProjectName:  aws.String(d.Id()),
-		BranchFilter: aws.String(d.Get("branch_filter").(string)),
-		FilterGroups: expandWebhookFilterGroup(d),
-		RotateSecret: aws.Bool(false),
-	})
+	var err error
+	filterGroups := expandWebhookFilterGroup(d)
+
+	if len(filterGroups) >= 1 {
+		_, err = conn.UpdateWebhook(&codebuild.UpdateWebhookInput{
+			ProjectName:  aws.String(d.Id()),
+			FilterGroups: filterGroups,
+			RotateSecret: aws.Bool(false),
+		})
+	} else {
+		_, err = conn.UpdateWebhook(&codebuild.UpdateWebhookInput{
+			ProjectName:  aws.String(d.Id()),
+			BranchFilter: aws.String(d.Get("branch_filter").(string)),
+			RotateSecret: aws.Bool(false),
+		})
+	}
 
 	if err != nil {
 		return err

--- a/aws/resource_aws_codebuild_webhook_test.go
+++ b/aws/resource_aws_codebuild_webhook_test.go
@@ -194,13 +194,13 @@ func TestAccAWSCodeBuildWebhook_FilterGroup(t *testing.T) {
 					testAccCheckAWSCodeBuildWebhookFilter(&webhook, [][]*codebuild.WebhookFilter{
 						{
 							{
-								Type:                  aws.String("HEAD_REF"),
-								Pattern:               aws.String("refs/heads/master"),
+								Type:                  aws.String("EVENT"),
+								Pattern:               aws.String("PULL_REQUEST_CREATED"),
 								ExcludeMatchedPattern: aws.Bool(false),
 							},
 							{
-								Type:                  aws.String("EVENT"),
-								Pattern:               aws.String("PULL_REQUEST_CREATED"),
+								Type:                  aws.String("HEAD_REF"),
+								Pattern:               aws.String("refs/heads/master"),
 								ExcludeMatchedPattern: aws.Bool(false),
 							},
 						},

--- a/aws/resource_aws_codebuild_webhook_test.go
+++ b/aws/resource_aws_codebuild_webhook_test.go
@@ -170,19 +170,27 @@ func TestAccAWSCodeBuildWebhook_FilterGroup(t *testing.T) {
 				Config: testAccAWSCodeBuildWebhookConfig_FilterGroup(rName, "EVENT", "PUSH"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildWebhookExists(resourceName, &webhook),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.3033132000.exclude_matched_pattern", "false"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.3033132000.pattern", "PUSH"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.3033132000.type", "EVENT"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.178477371.exclude_matched_pattern", "false"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.178477371.pattern", "refs/heads/master"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.178477371.type", "HEAD_REF"),
 				),
 			},
 			{
 				Config: testAccAWSCodeBuildWebhookConfig_FilterGroup(rName, "EVENT", "PULL_REQUEST_CREATED"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildWebhookExists(resourceName, &webhook),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.2768903781.exclude_matched_pattern", "false"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.2768903781.pattern", "PULL_REQUEST_CREATED"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.2768903781.type", "EVENT"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.178477371.exclude_matched_pattern", "false"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.178477371.pattern", "refs/heads/master"),
+					resource.TestCheckResourceAttr(resourceName, "filter_group.178477371.type", "HEAD_REF"),
 				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"secret"},
 			},
 		},
 	})
@@ -314,6 +322,11 @@ resource "aws_codebuild_webhook" "test" {
 	filter_group {
 		type  = "%s"
 		pattern = "%s"
+	}
+
+	filter_group {
+		type = "HEAD_REF"
+		pattern = "refs/heads/master"
 	}
 }
 `, filterType, filterPattern)

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -23,6 +23,18 @@ When working with [Bitbucket](https://bitbucket.org) and [GitHub](https://github
 ```hcl
 resource "aws_codebuild_webhook" "example" {
   project_name = "${aws_codebuild_project.example.name}"
+  
+  filter_group {
+    filter {
+      type = "EVENT"
+      pattern = "PUSH"
+    }
+
+    filter {
+      type = "HEAD_REF"
+      pattern = "master"
+    }
+  }
 }
 ```
 
@@ -61,6 +73,10 @@ The following arguments are supported:
 * `filter_group` - (Optional) Information about the webhook's trigger. Filter group blocks are documented below.
 
 `filter_group` supports the following:
+
+* `filter` - (Required) A webhook filter for the group. Filter blocks are documented below.
+
+`filter` supports the following:
 
 * `type` - (Required) The webhook filter group's type. Valid values for this parameter are: `EVENT`, `BASE_REF`, `HEAD_REF`, `ACTOR_ACCOUNT_ID`, `FILE_PATH`. At least one filter group must specify `EVENT` as its type.
 * `pattern` - (Required) For a filter that uses `EVENT` type, a comma-separated string that specifies one event: `PUSH`, `PULL_REQUEST_CREATED`, `PULL_REQUEST_UPDATED`, `PULL_REQUEST_REOPENED`. `PULL_REQUEST_REOPENED` works with GitHub & GitHub Enterprise only. For a fitler that uses any of the other filter types, a regular expression.

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -58,6 +58,13 @@ The following arguments are supported:
 
 * `project_name` - (Required) The name of the build project.
 * `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built.
+* `filter_group` - (Optional) Information about the webhook's trigger. Filter group blocks are documented below.
+
+`filter_group` supports the following:
+
+* `type` - (Required) The webhook filter group's type. Valid values for this parameter are: `EVENT`, `BASE_REF`, `HEAD_REF`, `ACTOR_ACCOUNT_ID`, `FILE_PATH`. At least one filter group must specify `EVENT` as its type.
+* `pattern` - (Required) For a filter that uses `EVENT` type, a comma-separated string that specifies one event: `PUSH`, `PULL_REQUEST_CREATED`, `PULL_REQUEST_UPDATED`, `PULL_REQUEST_REOPENED`. `PULL_REQUEST_REOPENED` works with GitHub & GitHub Enterprise only. For a fitler that uses any of the other filter types, a regular expression.
+* `exclude_matched_pattern` - (Optional) If set to `true`, the specified filter does *not* trigger a build. Defaults to `false`.
 
 ## Attributes Reference
 

--- a/website/docs/r/codebuild_webhook.html.markdown
+++ b/website/docs/r/codebuild_webhook.html.markdown
@@ -57,7 +57,7 @@ resource "github_repository_webhook" "example" {
 The following arguments are supported:
 
 * `project_name` - (Required) The name of the build project.
-* `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built.
+* `branch_filter` - (Optional) A regular expression used to determine which branches get built. Default is all branches are built. It is recommended to use `filter_group` over `branch_filter`.
 * `filter_group` - (Optional) Information about the webhook's trigger. Filter group blocks are documented below.
 
 `filter_group` supports the following:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #7503 

Changes proposed in this pull request:

* Add filter_group argument to resource aws_codebuild_webhook

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildWebhook_FilterGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCodeBuildWebhook_FilterGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeBuildWebhook_FilterGroup
=== PAUSE TestAccAWSCodeBuildWebhook_FilterGroup
=== CONT  TestAccAWSCodeBuildWebhook_FilterGroup
--- PASS: TestAccAWSCodeBuildWebhook_FilterGroup (42.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       42.871s
```

ToDo:
- [x] Fix update of existing hook
- [x] Update test
- [x] Update docs
