### PR TITLE
Feature/add resource tags for appmesh mesh resource

### DIFF
--- a/aws/resource_aws_appmesh_test.go
+++ b/aws/resource_aws_appmesh_test.go
@@ -9,6 +9,7 @@ func TestAccAWSAppmesh(t *testing.T) {
 		"Mesh": {
 			"basic":        testAccAwsAppmeshMesh_basic,
 			"egressFilter": testAccAwsAppmeshMesh_egressFilter,
+			"tags":         testAccAwsAppmeshMesh_tags,
 		},
 		"Route": {
 			"httpRoute": testAccAwsAppmeshRoute_httpRoute,

--- a/aws/tagsAppmesh.go
+++ b/aws/tagsAppmesh.go
@@ -1,0 +1,128 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsAppmesh(conn *appmesh.AppMesh, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsAppmesh(tagsFromMapAppmesh(o), tagsFromMapAppmesh(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			input := appmesh.UntagResourceInput{
+				ResourceArn: aws.String(arn),
+				TagKeys:     remove,
+			}
+			log.Printf("[DEBUG] Removing Appmesh tags: %s", input)
+			_, err := conn.UntagResource(&input)
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			input := appmesh.TagResourceInput{
+				ResourceArn: aws.String(arn),
+				Tags:        create,
+			}
+			log.Printf("[DEBUG] Adding Appmesh tags: %s", input)
+			_, err := conn.TagResource(&input)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsAppmesh(oldTags, newTags []*appmesh.TagRef) ([]*appmesh.TagRef, []*string) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[*t.Key] = *t.Value
+	}
+
+	// Build the list of what to remove
+	var remove []*string
+	for _, t := range oldTags {
+		if _, ok := create[*t.Key]; !ok {
+			// Delete it!
+			remove = append(remove, t.Key)
+		}
+	}
+
+	return tagsFromMapAppmesh(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapAppmesh(m map[string]interface{}) []*appmesh.TagRef {
+	var result []*appmesh.TagRef
+	for k, v := range m {
+		t := &appmesh.TagRef{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredAppmesh(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapAppmesh(ts []*appmesh.TagRef) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredAppmesh(t) {
+			result[*t.Key] = *t.Value
+		}
+	}
+
+	return result
+}
+
+func saveTagsAppmesh(conn *appmesh.AppMesh, d *schema.ResourceData, arn string) error {
+	resp, err := conn.ListTagsForResource(&appmesh.ListTagsForResourceInput{
+		ResourceArn: aws.String(arn),
+	})
+	if err != nil {
+		return err
+	}
+
+	var dt []*appmesh.TagRef
+	if len(resp.Tags) > 0 {
+		dt = resp.Tags
+	}
+
+	return d.Set("tags", tagsToMapAppmesh(dt))
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredAppmesh(t *appmesh.TagRef) bool {
+	filter := []string{"^aws:", "^appmesh:", "Name"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		r, _ := regexp.MatchString(v, *t.Key)
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsAppmesh_test.go
+++ b/aws/tagsAppmesh_test.go
@@ -14,20 +14,19 @@ func TestDiffAppmeshTags(t *testing.T) {
 		Create   map[string]string
 		Remove   []string
 	}{
-		// Basic add/remove
+		// Add
 		{
 			Old: map[string]interface{}{
 				"foo": "bar",
 			},
 			New: map[string]interface{}{
+				"foo": "bar",
 				"bar": "baz",
 			},
 			Create: map[string]string{
 				"bar": "baz",
 			},
-			Remove: []string{
-				"foo",
-			},
+			Remove: map[string]string{},
 		},
 
 		// Modify
@@ -41,7 +40,42 @@ func TestDiffAppmeshTags(t *testing.T) {
 			Create: map[string]string{
 				"foo": "baz",
 			},
-			Remove: []string{},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
 		},
 	}
 

--- a/aws/tagsAppmesh_test.go
+++ b/aws/tagsAppmesh_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appmesh"
+)
+
+func TestDiffAppmeshTags(t *testing.T) {
+	cases := []struct {
+		Old, New map[string]interface{}
+		Create   map[string]string
+		Remove   []string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: []string{
+				"foo",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: []string{},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsAppmesh(tagsFromMapAppmesh(tc.Old), tagsFromMapAppmesh(tc.New))
+		cm := tagsToMapAppmesh(c)
+		rl := []string{}
+		for _, tagName := range r {
+			rl = append(rl, *tagName)
+		}
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rl, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rl)
+		}
+	}
+}
+
+func TestIgnoringTagsAppmesh(t *testing.T) {
+	var ignoredTags []*appmesh.TagRef
+	ignoredTags = append(ignoredTags, &appmesh.TagRef{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &appmesh.TagRef{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredAppmesh(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/appmesh_mesh.html.markdown
+++ b/website/docs/r/appmesh_mesh.html.markdown
@@ -40,6 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name to use for the service mesh.
 * `spec` - (Optional) The service mesh specification to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `spec` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8101 

Changes proposed in this pull request:

* Add tag resource for appmesh service
* Add tags attribute for `aws_appmesh_mesh` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh/Mesh'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppmesh/Mesh -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/Mesh
=== RUN   TestAccAWSAppmesh/Mesh/tags
=== RUN   TestAccAWSAppmesh/Mesh/basic
--- PASS: TestAccAWSAppmesh (108.16s)
    --- PASS: TestAccAWSAppmesh/Mesh (108.16s)
        --- PASS: TestAccAWSAppmesh/Mesh/tags (77.71s)
        --- PASS: TestAccAWSAppmesh/Mesh/basic (30.45s)
PASS
ok  	github.com/terraform-providers/tmp-terraform-provider-aws/aws	108.233s
```
