### PR TITLE
Correct resource name of aws_eks_cluster

### DIFF
--- a/website/docs/d/eks_cluster_auth.html.markdown
+++ b/website/docs/d/eks_cluster_auth.html.markdown
@@ -28,8 +28,8 @@ data "aws_eks_cluster_auth" "example" {
 }
 
 provider "kubernetes" {
-  host                   = "${data.aws_eks_cluster.cluster.endpoint}"
-  cluster_ca_certificate = "${base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)}"
+  host                   = "${data.aws_eks_cluster.example.endpoint}"
+  cluster_ca_certificate = "${base64decode(data.aws_eks_cluster.example.certificate_authority.0.data)}"
   token                  = "${data.aws_eks_cluster_auth.example.token}"
   load_config_file       = false
 }


### PR DESCRIPTION
Updates the sample from the documentation so that it runs without modifications.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes documentation at https://www.terraform.io/docs/providers/aws/d/eks_cluster_auth.html