### PR TITLE
resource/aws_cloudfront_distribution: Add wait_for_deployment argument

### DIFF
--- a/aws/import_aws_cloudfront_distribution.go
+++ b/aws/import_aws_cloudfront_distribution.go
@@ -10,6 +10,7 @@ func resourceAwsCloudFrontDistributionImport(d *schema.ResourceData, meta interf
 	// This is a non API attribute
 	// We are merely setting this to the same value as the Default setting in the schema
 	d.Set("retain_on_delete", false)
+	d.Set("wait_for_deployment", true)
 
 	conn := meta.(*AWSClient).cloudfrontconn
 	id := d.Id()

--- a/aws/resource_aws_cloudfront_distribution_migrate.go
+++ b/aws/resource_aws_cloudfront_distribution_migrate.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsCloudFrontDistributionMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found CloudFront Distribution state v0; migrating to v1")
+		return migrateCloudFrontDistributionStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateCloudFrontDistributionStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty CloudFront Distribution state; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	// Add wait_for_deployment virtual attribute with Default
+	is.Attributes["wait_for_deployment"] = "true"
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/aws/resource_aws_cloudfront_distribution_migrate_test.go
+++ b/aws/resource_aws_cloudfront_distribution_migrate_test.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAwsCloudFrontDistributionMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"wait_for_deployment": "",
+			},
+			Expected: map[string]string{
+				"wait_for_deployment": "true",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "some_id",
+			Attributes: tc.Attributes,
+		}
+
+		tfResource := resourceAwsCloudFrontDistribution()
+
+		if tfResource.MigrateState == nil {
+			t.Fatalf("bad: %s, err: missing MigrateState function in resource", tn)
+		}
+
+		is, err := tfResource.MigrateState(tc.StateVersion, is, tc.Meta)
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}

--- a/aws/resource_aws_cloudfront_distribution_migrate_test.go
+++ b/aws/resource_aws_cloudfront_distribution_migrate_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestAwsCloudFrontDistributionMigrateState(t *testing.T) {
-	cases := map[string]struct {
+	testCases := map[string]struct {
 		StateVersion int
 		Attributes   map[string]string
 		Expected     map[string]string
 		Meta         interface{}
 	}{
-		"v0_1": {
+		"v0_to_v1": {
 			StateVersion: 0,
 			Attributes: map[string]string{
 				"wait_for_deployment": "",
@@ -24,28 +24,28 @@ func TestAwsCloudFrontDistributionMigrateState(t *testing.T) {
 		},
 	}
 
-	for tn, tc := range cases {
-		is := &terraform.InstanceState{
+	for testName, testCase := range testCases {
+		instanceState := &terraform.InstanceState{
 			ID:         "some_id",
-			Attributes: tc.Attributes,
+			Attributes: testCase.Attributes,
 		}
 
 		tfResource := resourceAwsCloudFrontDistribution()
 
 		if tfResource.MigrateState == nil {
-			t.Fatalf("bad: %s, err: missing MigrateState function in resource", tn)
+			t.Fatalf("bad: %s, err: missing MigrateState function in resource", testName)
 		}
 
-		is, err := tfResource.MigrateState(tc.StateVersion, is, tc.Meta)
+		instanceState, err := tfResource.MigrateState(testCase.StateVersion, instanceState, testCase.Meta)
 		if err != nil {
-			t.Fatalf("bad: %s, err: %#v", tn, err)
+			t.Fatalf("bad: %s, err: %#v", testName, err)
 		}
 
-		for k, v := range tc.Expected {
-			if is.Attributes[k] != v {
+		for key, expectedValue := range testCase.Expected {
+			if instanceState.Attributes[key] != expectedValue {
 				t.Fatalf(
 					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
-					tn, k, v, k, is.Attributes[k], is.Attributes)
+					testName, key, expectedValue, key, instanceState.Attributes[key], instanceState.Attributes)
 			}
 		}
 	}

--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -123,10 +123,13 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_cloudfront_distribution.s3_distribution",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      "aws_cloudfront_distribution.s3_distribution",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -156,10 +159,13 @@ func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_cloudfront_distribution.s3_distribution",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      "aws_cloudfront_distribution.s3_distribution",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 			{
 				Config: postConfig,
@@ -194,10 +200,13 @@ func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_cloudfront_distribution.custom_distribution",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      "aws_cloudfront_distribution.custom_distribution",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -226,10 +235,13 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -261,10 +273,13 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -362,13 +377,17 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "viewer_certificate.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "viewer_certificate.0.cloudfront_default_certificate", "true"),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", "true"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -394,10 +413,13 @@ func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_cloudfront_distribution.http_1_1",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      "aws_cloudfront_distribution.http_1_1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -419,10 +441,13 @@ func TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_cloudfront_distribution.is_ipv6_enabled",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      "aws_cloudfront_distribution.is_ipv6_enabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -442,10 +467,13 @@ func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) 
 				),
 			},
 			{
-				ResourceName:            "aws_cloudfront_distribution.no_custom_error_responses",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      "aws_cloudfront_distribution.no_custom_error_responses",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -468,10 +496,13 @@ func TestAccAWSCloudFrontDistribution_Enabled(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 			{
 				Config: testAccAWSCloudFrontDistributionConfigEnabled(true, false),
@@ -535,10 +566,13 @@ func TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn(t *tes
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
 			},
 		},
 	})
@@ -562,10 +596,60 @@ func TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_Confli
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudFrontDistribution_WaitForDeployment(t *testing.T) {
+	var distribution cloudfront.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFrontDistributionConfigWaitForDeployment(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+					testAccCheckCloudFrontDistributionStatusInProgress(&distribution),
+					testAccCheckCloudFrontDistributionWaitForDeployment(&distribution),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"retain_on_delete",
+					"wait_for_deployment",
+				},
+			},
+			{
+				Config: testAccAWSCloudFrontDistributionConfigWaitForDeployment(true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+					testAccCheckCloudFrontDistributionStatusInProgress(&distribution),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", "false"),
+				),
+			},
+			{
+				Config: testAccAWSCloudFrontDistributionConfigWaitForDeployment(false, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFrontDistributionExists(resourceName, &distribution),
+					testAccCheckCloudFrontDistributionStatusDeployed(&distribution),
+					resource.TestCheckResourceAttr(resourceName, "wait_for_deployment", "true"),
+				),
 			},
 		},
 	})
@@ -650,6 +734,34 @@ func testAccCheckCloudFrontDistributionExistsAPIOnly(distribution *cloudfront.Di
 		}
 
 		*distribution = *output.Distribution
+
+		return nil
+	}
+}
+
+func testAccCheckCloudFrontDistributionStatusDeployed(distribution *cloudfront.Distribution) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if distribution == nil {
+			return fmt.Errorf("CloudFront Distribution empty")
+		}
+
+		if aws.StringValue(distribution.Status) != "Deployed" {
+			return fmt.Errorf("CloudFront Distribution (%s) status not Deployed: %s", aws.StringValue(distribution.Id), aws.StringValue(distribution.Status))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckCloudFrontDistributionStatusInProgress(distribution *cloudfront.Distribution) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if distribution == nil {
+			return fmt.Errorf("CloudFront Distribution empty")
+		}
+
+		if aws.StringValue(distribution.Status) != "InProgress" {
+			return fmt.Errorf("CloudFront Distribution (%s) status not InProgress: %s", aws.StringValue(distribution.Id), aws.StringValue(distribution.Status))
+		}
 
 		return nil
 	}
@@ -1688,4 +1800,50 @@ resource "aws_cloudfront_distribution" "test" {
   }
 }
 `, retainOnDelete)
+}
+
+func testAccAWSCloudFrontDistributionConfigWaitForDeployment(enabled, waitForDeployment bool) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_distribution" "test" {
+  enabled             = %[1]t
+  wait_for_deployment = %[2]t
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`, enabled, waitForDeployment)
 }

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -255,9 +255,9 @@ of several sub-resources - these resources are laid out below.
     deleting it when destroying the resource through Terraform. If this is set,
     the distribution needs to be deleted manually afterwards. Default: `false`.
 
-  * `wait_for_deployment` (Optional) - By default, the resource will wait
-    for creation and updates to fully deploy. Setting this to `false`
-    will skip waiting for deployments to complete. Default: `true`.
+  * `wait_for_deployment` (Optional) - If enabled, the resource will wait for
+    the distribution status to change from `InProgress` to `Deployed`. Setting
+    this to`false` will skip the process. Default: `true`.
 
 #### Cache Behavior Arguments
 

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -255,6 +255,10 @@ of several sub-resources - these resources are laid out below.
     deleting it when destroying the resource through Terraform. If this is set,
     the distribution needs to be deleted manually afterwards. Default: `false`.
 
+  * `wait_for_deployment` (Optional) - By default, the resource will wait
+    for creation and updates to fully deploy. Setting this to `false`
+    will skip waiting for deployments to complete. Default: `true`.
+
 #### Cache Behavior Arguments
 
   * `allowed_methods` (Required) - Controls which HTTP methods CloudFront


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8073

Since we are adding a virtual attribute with a `Default`, we must include a schema state migration to prevent the `"" => "true"` difference on upgrade.

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.25s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.30s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (571.01s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (1263.05s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (1265.06s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (1265.34s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1267.09s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (1267.68s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (1268.95s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (1271.12s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (1271.30s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1271.50s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (1272.82s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (1275.16s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (1275.81s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (1372.94s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1782.07s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (1782.38s)
```