### PR TITLE
Add support Private Link setting for AWS Tranfer for SFTP Service

### DIFF
--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -67,12 +67,18 @@ resource "aws_transfer_server" "foo" {
 
 The following arguments are supported:
 
+* `endpoint_details` - (Optional) The virtual private cloud (VPC) endpoint settings that you want to configure for your SFTP server. Fields documented below.
+* `endpoint_type` - (Optional) The type of endpoint that you want your SFTP server connect to. If you connect to a `VPC_ENDPOINT`, your SFTP server isn't accessible over the public internet. If you want to connect your SFTP server via public internet, set `PUBLIC`.
 * `invocation_role` - (Optional) Amazon Resource Name (ARN) of the IAM role used to authenticate the user account with an `identity_provider_type` of `API_GATEWAY`.
 * `url` - (Optional) - URL of the service endpoint used to authenticate users with an `identity_provider_type` of `API_GATEWAY`.
 * `identity_provider_type` - (Optional) The mode of authentication enabled for this service. The default value is `SERVICE_MANAGED`, which allows you to store and access SFTP user credentials within the service. `API_GATEWAY` indicates that user authentication requires a call to an API Gateway endpoint URL provided by you to integrate an identity provider of your choice.
 * `logging_role` - (Optional) Amazon Resource Name (ARN) of an IAM role that allows the service to write your SFTP users’ activity to your Amazon CloudWatch logs for monitoring and auditing purposes.
 * `force_destroy` - (Optional) A boolean that indicates all users associated with the server should be deleted so that the Server can be destroyed without error. The default value is `false`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+**endpoint_details** requires the following:
+
+* `vpc_endpoint_id` - (Required) The ID of the VPC endpoint.
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8105 

Changes proposed in this pull request:

* Add Private Link Support for AWS Transfer service.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSTransferServer_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSTransferServer_ -timeout 120m
=== RUN   TestAccAWSTransferServer_basic
=== PAUSE TestAccAWSTransferServer_basic
=== RUN   TestAccAWSTransferServer_apigateway
=== PAUSE TestAccAWSTransferServer_apigateway
=== RUN   TestAccAWSTransferServer_disappears
=== PAUSE TestAccAWSTransferServer_disappears
=== RUN   TestAccAWSTransferServer_forcedestroy
=== PAUSE TestAccAWSTransferServer_forcedestroy
=== RUN   TestAccAWSTransferServer_vpcEndpointId
=== PAUSE TestAccAWSTransferServer_vpcEndpointId
=== CONT  TestAccAWSTransferServer_basic
=== CONT  TestAccAWSTransferServer_forcedestroy
=== CONT  TestAccAWSTransferServer_vpcEndpointId
=== CONT  TestAccAWSTransferServer_disappears
=== CONT  TestAccAWSTransferServer_apigateway
--- PASS: TestAccAWSTransferServer_disappears (24.45s)
--- PASS: TestAccAWSTransferServer_forcedestroy (40.59s)
--- PASS: TestAccAWSTransferServer_apigateway (41.64s)
--- PASS: TestAccAWSTransferServer_basic (58.41s)
--- PASS: TestAccAWSTransferServer_vpcEndpointId (80.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	80.376s
```
