### PR TITLE
Docs: Change datasource to data_source in argument refernce to match actual argument

### DIFF
--- a/website/docs/r/appsync_resolver.html.markdown
+++ b/website/docs/r/appsync_resolver.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 * `api_id` - (Required) The API ID for the GraphQL API.
 * `type` - (Required) The type name from the schema defined in the GraphQL API.
 * `field` - (Required) The field name from the schema defined in the GraphQL API.
-* `datasource` - (Required) The DataSource name.
+* `data_source` - (Required) The DataSource name.
 * `request_template` - (Required) The request mapping template for this resolver.
 * `response_template` - (Required) The response mapping template for this resolver.
 


### PR DESCRIPTION
See: https://github.com/terraform-providers/terraform-provider-aws/blob/2cb743b/aws/resource_aws_appsync_resolver.go#L40