### PR TITLE
[Elasticsearch] Implement specifying availability zone count ...

### DIFF
--- a/aws/resource_aws_elasticsearch_domain.go
+++ b/aws/resource_aws_elasticsearch_domain.go
@@ -194,6 +194,10 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"zone_awareness_count": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1202,11 +1202,13 @@ func expandESClusterConfig(m map[string]interface{}) *elasticsearch.Elasticsearc
 	}
 
 	if v, ok := m["zone_awareness_enabled"]; ok {
-		config.ZoneAwarenessEnabled = aws.Bool(v.(bool))
-	}
-
-	if v, ok := m["zone_awareness_count"]; ok {
-		config.ZoneAwarenessConfig = &elasticsearch.ZoneAwarenessConfig{AvailabilityZoneCount: aws.Int64(int64(v.(int)))}
+		isEnabled := v.(bool)
+		config.ZoneAwarenessEnabled = aws.Bool(isEnabled)
+		if isEnabled {
+			if v, ok := m["zone_awareness_count"]; ok {
+				config.ZoneAwarenessConfig = &elasticsearch.ZoneAwarenessConfig{AvailabilityZoneCount: aws.Int64(int64(v.(int)))}
+			}
+		}
 	}
 
 	return &config

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1206,7 +1206,7 @@ func expandESClusterConfig(m map[string]interface{}) *elasticsearch.Elasticsearc
 	}
 
 	if v, ok := m["zone_awareness_count"]; ok {
-		config.ZoneAwarenessConfig.AvailabilityZoneCount = aws.Int64(v.(int64))
+		config.ZoneAwarenessConfig = &elasticsearch.ZoneAwarenessConfig{AvailabilityZoneCount: aws.Int64(int64(v.(int)))}
 	}
 
 	return &config

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1233,10 +1233,9 @@ func flattenESClusterConfig(c *elasticsearch.ElasticsearchClusterConfig) []map[s
 	if c.ZoneAwarenessEnabled != nil {
 		m["zone_awareness_enabled"] = *c.ZoneAwarenessEnabled
 	}
-	if c.ZoneAwarenessConfig.AvailabilityZoneCount != nil {
+	if c.ZoneAwarenessConfig != nil && c.ZoneAwarenessConfig.AvailabilityZoneCount != nil {
 		m["zone_awareness_count"] = *c.ZoneAwarenessConfig.AvailabilityZoneCount
 	}
-
 	return []map[string]interface{}{m}
 }
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -1205,6 +1205,10 @@ func expandESClusterConfig(m map[string]interface{}) *elasticsearch.Elasticsearc
 		config.ZoneAwarenessEnabled = aws.Bool(v.(bool))
 	}
 
+	if v, ok := m["zone_awareness_count"]; ok {
+		config.ZoneAwarenessConfig.AvailabilityZoneCount = aws.Int64(v.(int64))
+	}
+
 	return &config
 }
 
@@ -1228,6 +1232,9 @@ func flattenESClusterConfig(c *elasticsearch.ElasticsearchClusterConfig) []map[s
 	}
 	if c.ZoneAwarenessEnabled != nil {
 		m["zone_awareness_enabled"] = *c.ZoneAwarenessEnabled
+	}
+	if c.ZoneAwarenessConfig.AvailabilityZoneCount != nil {
+		m["zone_awareness_count"] = *c.ZoneAwarenessConfig.AvailabilityZoneCount
 	}
 
 	return []map[string]interface{}{m}


### PR DESCRIPTION
... when zone awareness is enabled

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Fixes #7504 

Changes proposed in this pull request:

* add parameter in `cluster_config`: `zone_awareness_count`
  * parameter is mapped to `config.ZoneAwarenessConfig.AvailabilityZoneCount` as `int64`
* add acceptance test case `TestAccAWSElasticSearchDomain_ZoneAwarenessWith3AZ`
  * creates 3 t2.micro.elasticsearch nodes across 3 az's with zone awareness to test this PR

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSElasticSearchDomain_ZoneAwarenessWith3AZ'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticSearchDomain_ZoneAwarenessWith3AZ -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSElasticSearchDomain_ZoneAwarenessWith3AZ
=== PAUSE TestAccAWSElasticSearchDomain_ZoneAwarenessWith3AZ
=== CONT  TestAccAWSElasticSearchDomain_ZoneAwarenessWith3AZ
--- PASS: TestAccAWSElasticSearchDomain_ZoneAwarenessWith3AZ (772.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       797.900s
  
```

Implemented my own tests for this. It's based off of `TestAccAWSElasticSearchDomain_basic` and simply uses `cluster_config` to deploy 3 nodes across 3 AZ's.