### PR TITLE
tests/resource/aws_ec2_client_vpn_endpoint: Add sweeper

### DIFF
--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -155,7 +155,7 @@ func TestAccAwsEc2ClientVpnEndpoint_withLogGroup(t *testing.T) {
 	})
 }
 
-func TestAccAwsEc2ClientVpnEndpoint_withDNervers(t *testing.T) {
+func TestAccAwsEc2ClientVpnEndpoint_withDNSServers(t *testing.T) {
 	rStr := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_ec2_client_vpn_endpoint_test.go
+++ b/aws/resource_aws_ec2_client_vpn_endpoint_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +11,66 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_ec2_client_vpn_endpoint", &resource.Sweeper{
+		Name: "aws_ec2_client_vpn_endpoint",
+		F:    testSweepEc2ClientVpnEndpoints,
+		Dependencies: []string{
+			"aws_directory_service_directory",
+		},
+	})
+}
+
+func testSweepEc2ClientVpnEndpoints(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).ec2conn
+	input := &ec2.DescribeClientVpnEndpointsInput{}
+
+	for {
+		output, err := conn.DescribeClientVpnEndpoints(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Client VPN Endpoint sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error retrieving Client VPN Endpoints: %s", err)
+		}
+
+		for _, clientVpnEndpoint := range output.ClientVpnEndpoints {
+			if clientVpnEndpoint.Status != nil && aws.StringValue(clientVpnEndpoint.Status.Code) == ec2.ClientVpnEndpointStatusCodeDeleted {
+				continue
+			}
+
+			id := aws.StringValue(clientVpnEndpoint.ClientVpnEndpointId)
+			input := &ec2.DeleteClientVpnEndpointInput{
+				ClientVpnEndpointId: clientVpnEndpoint.ClientVpnEndpointId,
+			}
+
+			log.Printf("[INFO] Deleting Client VPN Endpoint: %s", id)
+			_, err := conn.DeleteClientVpnEndpoint(input)
+
+			if err != nil {
+				return fmt.Errorf("error deleting Client VPN Endpoint (%s): %s", id, err)
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAwsEc2ClientVpnEndpoint_basic(t *testing.T) {
 	rStr := acctest.RandString(5)
@@ -94,7 +155,7 @@ func TestAccAwsEc2ClientVpnEndpoint_withLogGroup(t *testing.T) {
 	})
 }
 
-func TestAccAwsEc2ClientVpnEndpoint_withDNSServers(t *testing.T) {
+func TestAccAwsEc2ClientVpnEndpoint_withDNervers(t *testing.T) {
 	rStr := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -25,6 +25,7 @@ func init() {
 			"aws_beanstalk_environment",
 			"aws_db_instance",
 			"aws_directory_service_directory",
+			"aws_ec2_client_vpn_endpoint",
 			"aws_ec2_transit_gateway_vpc_attachment",
 			"aws_eks_cluster",
 			"aws_elasticache_cluster",


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Previous output from acceptance testing:

```
--- FAIL: TestAccAwsEc2ClientVpnEndpoint_basic (5.71s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_ec2_client_vpn_endpoint.test: 1 error occurred:
        	* aws_ec2_client_vpn_endpoint.test: Error creating Client VPN endpoint: ClientVpnEndpointLimitExceeded: Limit exceeded
```

Previously output from AWS CLI:

```console
$ aws ec2 describe-client-vpn-endpoints | jq '.ClientVpnEndpoints | length'
5
```

Output from sweeper:

```console
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_ec2_client_vpn_endpoint -timeout 10h
...
2019/04/02 12:46:28 [INFO] Deleting Client VPN Endpoint: cvpn-endpoint-073bf6cb2791e2d37
2019/04/02 12:46:28 [INFO] Deleting Client VPN Endpoint: cvpn-endpoint-056499587fe3f59c6
2019/04/02 12:46:29 [INFO] Deleting Client VPN Endpoint: cvpn-endpoint-0e92f7d99d531d5ae
2019/04/02 12:46:31 [INFO] Deleting Client VPN Endpoint: cvpn-endpoint-0b4741c9520d69d36
2019/04/02 12:46:31 [INFO] Deleting Client VPN Endpoint: cvpn-endpoint-0c5fadd250f9ca007
2019/04/02 12:46:32 Sweeper Tests ran:
	- aws_ec2_client_vpn_endpoint
	- aws_directory_service_directory
ok  	github.com/terraform-providers/terraform-provider-aws/aws	9.578s
```

Output from AWS CLI:

```console
$ aws ec2 describe-client-vpn-endpoints | jq '.ClientVpnEndpoints | length'
0
```