### PR TITLE
tests/data-source/aws_acmpca_certificate_authority: Add new permanent_deletion_time_in_days = 7 argument to test resources and handle additional error for non-existent testing

### DIFF
--- a/aws/data_source_aws_acmpca_certificate_authority_test.go
+++ b/aws/data_source_aws_acmpca_certificate_authority_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceAwsAcmpcaCertificateAuthority_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceAwsAcmpcaCertificateAuthorityConfig_NonExistent,
-				ExpectError: regexp.MustCompile(`ResourceNotFoundException`),
+				ExpectError: regexp.MustCompile(`(AccessDeniedException|ResourceNotFoundException)`),
 			},
 			{
 				Config: testAccDataSourceAwsAcmpcaCertificateAuthorityConfig_ARN,
@@ -43,6 +43,8 @@ func TestAccDataSourceAwsAcmpcaCertificateAuthority_Basic(t *testing.T) {
 
 const testAccDataSourceAwsAcmpcaCertificateAuthorityConfig_ARN = `
 resource "aws_acmpca_certificate_authority" "wrong" {
+  permanent_deletion_time_in_days = 7
+
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
     signing_algorithm = "SHA512WITHRSA"
@@ -54,6 +56,8 @@ resource "aws_acmpca_certificate_authority" "wrong" {
 }
 
 resource "aws_acmpca_certificate_authority" "test" {
+  permanent_deletion_time_in_days = 7
+
   certificate_authority_configuration {
     key_algorithm     = "RSA_4096"
     signing_algorithm = "SHA512WITHRSA"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

At a certain point, ACM-PCA started returning a `AccessDeniedException` instead of a `ResourceNotFoundException` when referencing a non-existing certificate authority, likely since the testing uses a fake ARN that is "another" AWS account. We cover both errors in case the error ever changes back.

Previous acceptance testing output:

```
--- FAIL: TestAccDataSourceAwsAcmpcaCertificateAuthority_Basic (3.45s)
    testing.go:531: Step 0, expected error:

        Error refreshing: 1 error occurred:
        	* data.aws_acmpca_certificate_authority.test: 1 error occurred:
        	* data.aws_acmpca_certificate_authority.test: data.aws_acmpca_certificate_authority.test: error reading ACMPCA Certificate Authority: AccessDeniedException: User: arn:aws:iam::--OMITTED--:user/teamcity is not authorized to perform: acm-pca:DescribeCertificateAuthority on resource: arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/tf-acc-test-does-not-exist
```

ACM-PCA defaults to 30 day deletion window, which is unnecessary in our acceptance testing. Add the new `permanent_deletion_time_in_days` argument from (https://github.com/terraform-providers/terraform-provider-aws/pull/7366) to help prevent `LimitExceededException` in our testing account. This is a virtual attribute so it is not valid to add to the `Check` functions.

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsAcmpcaCertificateAuthority_Basic (19.09s)
```
