### PR TITLE
website/docs/r/emr_cluster: Update documentation for bid_price

### DIFF
--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -126,7 +126,7 @@ EOF
       "Properties": {}
     }
   ]
-EOF  
+EOF
   service_role        = "${aws_iam_role.iam_emr_service_role.arn}"
 }
 ```
@@ -266,7 +266,7 @@ Attributes for each task instance group in the cluster
 * `instance_type` - (Required) The EC2 instance type for all instances in the instance group
 * `instance_count` - (Optional) Target number of instances for the instance group
 * `name` - (Optional) Friendly name given to the instance group
-* `bid_price` - (Optional) If set, the bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance, and will implicitly create a Spot request. Leave this blank to use On-Demand Instances. `bid_price` can not be set for the `MASTER` instance group, since that group must always be On-Demand
+* `bid_price` - (Optional) If set, the bid price for each EC2 instance in the instance group, expressed in USD. By setting this attribute, the instance group is being declared as a Spot Instance, and will implicitly create a Spot request. Leave this blank to use On-Demand Instances.
 * `ebs_config` - (Optional) A list of attributes for the EBS volumes attached to each instance in the instance group. Each `ebs_config` defined will result in additional EBS volumes being attached to _each_ instance in the instance group. Defined below
 * `autoscaling_policy` - (Optional) The autoscaling policy document. This is a JSON formatted string. See [EMR Auto Scaling](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-automatic-scaling.html)
 


### PR DESCRIPTION
Closes: #8153

The attribute bid_price is allowed for the Master instance group since a
master node can be either a spot instance or an onDemand instance.