### PR TITLE
service/ec2: Automatically retry EC2 CreateVpnConnection and CreateVpnGateway requests for concurrency errors

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -500,6 +500,20 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	})
 
+	client.ec2conn.Handlers.Retry.PushBack(func(r *request.Request) {
+		if r.Operation.Name == "CreateVpnConnection" {
+			if isAWSErr(r.Error, "VpnConnectionLimitExceeded", "maximum number of mutating objects has been reached") {
+				r.Retryable = aws.Bool(true)
+			}
+		}
+
+		if r.Operation.Name == "CreateVpnGateway" {
+			if isAWSErr(r.Error, "VpnGatewayLimitExceeded", "maximum number of mutating objects has been reached") {
+				r.Retryable = aws.Bool(true)
+			}
+		}
+	})
+
 	client.kinesisconn.Handlers.Retry.PushBack(func(r *request.Request) {
 		if r.Operation.Name == "CreateStream" {
 			if isAWSErr(r.Error, kinesis.ErrCodeLimitExceededException, "simultaneously be in CREATING or DELETING") {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSVpnGateway_basic (5.90s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_gateway.foo: 1 error occurred:
        	* aws_vpn_gateway.foo: Error creating VPN gateway: VpnGatewayLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVpnGateway_importBasic (6.14s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_gateway.foo: 1 error occurred:
        	* aws_vpn_gateway.foo: Error creating VPN gateway: VpnGatewayLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVpnGateway_tags (5.29s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_gateway.foo: 1 error occurred:
        	* aws_vpn_gateway.foo: Error creating VPN gateway: VpnGatewayLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVpnGatewayAttachment_deleted (6.00s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_gateway.test: 1 error occurred:
        	* aws_vpn_gateway.test: Error creating VPN gateway: VpnGatewayLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVPNGatewayRoutePropagation_basic (6.64s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_gateway.foo: 1 error occurred:
        	* aws_vpn_gateway.foo: Error creating VPN gateway: VpnGatewayLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVpnConnection_basic (14.67s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_connection.foo: 1 error occurred:
        	* aws_vpn_connection.foo: Error creating vpn connection: VpnConnectionLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVpnConnection_disappears (14.49s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_gateway.vpn_gateway: 1 error occurred:
        	* aws_vpn_gateway.vpn_gateway: Error creating VPN gateway: VpnGatewayLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVpnConnection_tunnelOptions (15.47s)
    testing.go:538: Step 14 error: Error applying: 1 error occurred:
        	* aws_vpn_connection.foo: 1 error occurred:
        	* aws_vpn_connection.foo: Error creating vpn connection: VpnConnectionLimitExceeded: The maximum number of mutating objects has been reached.

--- FAIL: TestAccAWSVpnConnection_withoutStaticRoutes (14.51s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_vpn_connection.foo: 1 error occurred:
        	* aws_vpn_connection.foo: Error creating vpn connection: VpnConnectionLimitExceeded: The maximum number of mutating objects has been reached.
```

With this new handling added, we can see successful retrying of the requests after this error in the debug logging, e.g.

```
2019/04/02 16:53:39 [DEBUG] [aws-sdk-go] DEBUG: Retrying Request ec2/CreateVpnGateway, attempt 1
```

Output from acceptance testing:

```
# Concurrently
--- PASS: TestAccAWSVpnGateway_disappears (70.16s)
--- PASS: TestAccAWSVpnGatewayAttachment_basic (71.99s)
--- PASS: TestAccAWSVpnGatewayAttachment_deleted (82.35s)
--- PASS: TestAccAWSVpnGateway_delete (88.05s)
--- PASS: TestAccAWSVpnGateway_importBasic (88.90s)
--- PASS: TestAccAWSVPNGatewayRoutePropagation_basic (90.45s)
--- PASS: TestAccAWSVpnGateway_tags (94.23s)
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (111.57s)
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (111.61s)
--- PASS: TestAccAWSVpnGateway_basic (149.61s)
--- PASS: TestAccAWSVpnGateway_reattach (177.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	178.133s

# Concurrently
--- PASS: TestAccAWSVpnConnection_withoutStaticRoutes (192.33s)
--- PASS: TestAccAWSVpnConnection_importBasic (212.25s)
--- PASS: TestAccAWSVpnConnectionRoute_basic (254.94s)
--- PASS: TestAccAWSVpnConnection_disappears (279.78s)
--- PASS: TestAccAWSVpnConnection_basic (504.96s)
--- PASS: TestAccAWSVpnConnection_TransitGatewayID (575.86s)
--- PASS: TestAccAWSVpnConnection_tunnelOptions (582.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	583.190s
```
