### PR TITLE
Add Import Support for aws_cloudwatch_log_subscription_filter

### DIFF
--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -21,6 +21,9 @@ func resourceAwsCloudwatchLogSubscriptionFilter() *schema.Resource {
 		Read:   resourceAwsCloudwatchLogSubscriptionFilterRead,
 		Update: resourceAwsCloudwatchLogSubscriptionFilterUpdate,
 		Delete: resourceAwsCloudwatchLogSubscriptionFilterDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsCloudwatchLogSubscriptionFilterImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -154,8 +157,13 @@ func resourceAwsCloudwatchLogSubscriptionFilterRead(d *schema.ResourceData, meta
 	}
 
 	for _, subscriptionFilter := range resp.SubscriptionFilters {
-		if *subscriptionFilter.LogGroupName == log_group_name {
+		if aws.StringValue(subscriptionFilter.LogGroupName) == log_group_name {
 			d.SetId(cloudwatchLogsSubscriptionFilterId(log_group_name))
+			d.Set("destination_arn", aws.StringValue(subscriptionFilter.DestinationArn))
+			d.Set("distribution", aws.StringValue(subscriptionFilter.Distribution))
+			d.Set("filter_pattern", aws.StringValue(subscriptionFilter.FilterPattern))
+			d.Set("log_group_name", aws.StringValue(subscriptionFilter.LogGroupName))
+			d.Set("role_arn", aws.StringValue(subscriptionFilter.RoleArn))
 			return nil // OK, matching subscription filter found
 		}
 	}
@@ -185,6 +193,22 @@ func resourceAwsCloudwatchLogSubscriptionFilterDelete(d *schema.ResourceData, me
 	}
 
 	return nil
+}
+
+func resourceAwsCloudwatchLogSubscriptionFilterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.Split(d.Id(), "|")
+	if len(idParts) < 2 {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <log-group-name>/<filter-name-prefix>", d.Id())
+	}
+
+	logGroupName := idParts[0]
+	filterNamePrefix := idParts[1]
+
+	d.Set("log_group_name", logGroupName)
+	d.Set("name", filterNamePrefix)
+	d.SetId(cloudwatchLogsSubscriptionFilterId(filterNamePrefix))
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func cloudwatchLogsSubscriptionFilterId(log_group_name string) string {

--- a/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -35,6 +35,12 @@ func TestAccAWSCloudwatchLogSubscriptionFilter_basic(t *testing.T) {
 						"aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", "distribution", "Random"),
 				),
 			},
+			{
+				ResourceName:      "aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter",
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSCloudwatchLogSubscriptionFilterImportStateIDFunc("aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter"),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -168,6 +174,21 @@ func testAccCheckAwsCloudwatchLogSubscriptionFilterExists(n string, filter *clou
 		}
 
 		return nil
+	}
+}
+
+func testAccAWSCloudwatchLogSubscriptionFilterImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		logGroupName := rs.Primary.Attributes["log_group_name"]
+		filterNamePrefix := rs.Primary.Attributes["name"]
+		stateID := fmt.Sprintf("%s|%s", logGroupName, filterNamePrefix)
+
+		return stateID, nil
 	}
 }
 

--- a/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_subscription_filter.html.markdown
@@ -37,3 +37,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 No extra attributes are exported.
+
+## Import
+
+CloudWatch Logs subscription filter can be imported using the log group name and subscription filter name separated by `|`.
+
+```
+$ terraform import aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter /aws/lambda/example_lambda_name|test_lambdafunction_logfilter
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8147

Changes proposed in this pull request:

* add import support for `aws_cloudwatch_log_subscription_filter` resource

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudwatchLogSubscriptionFilter_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudwatchLogSubscriptionFilter_ -timeout 120m
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== PAUSE TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_disappears
=== PAUSE TestAccAWSCloudwatchLogSubscriptionFilter_disappears
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup
=== PAUSE TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup
=== CONT  TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== CONT  TestAccAWSCloudwatchLogSubscriptionFilter_disappears
=== CONT  TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_disappears (48.92s)
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup (49.19s)
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_basic (53.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	53.347s
```
