### PR TITLE
tests/service/rds: Add sweepers for aws_rds_cluster and aws_rds_global_cluster resources

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -16,6 +17,88 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_rds_cluster", &resource.Sweeper{
+		Name: "aws_rds_cluster",
+		F:    testSweepRdsClusters,
+		Dependencies: []string{
+			"aws_db_instance",
+		},
+	})
+}
+
+func testSweepRdsClusters(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).rdsconn
+	input := &rds.DescribeDBClustersInput{}
+
+	err = conn.DescribeDBClustersPages(input, func(out *rds.DescribeDBClustersOutput, lastPage bool) bool {
+		for _, cluster := range out.DBClusters {
+			id := aws.StringValue(cluster.DBClusterIdentifier)
+
+			// Automatically remove from global cluster to bypass this error on deletion:
+			// InvalidDBClusterStateFault: This cluster is a part of a global cluster, please remove it from globalcluster first
+			if aws.StringValue(cluster.EngineMode) == "global" {
+				globalCluster, err := rdsDescribeGlobalClusterFromDbClusterARN(conn, aws.StringValue(cluster.DBClusterArn))
+
+				if err != nil {
+					log.Printf("[ERROR] Failure reading RDS Global Cluster information for DB Cluster (%s): %s", id, err)
+				}
+
+				if globalCluster != nil {
+					globalClusterID := aws.StringValue(globalCluster.GlobalClusterIdentifier)
+					input := &rds.RemoveFromGlobalClusterInput{
+						DbClusterIdentifier:     cluster.DBClusterArn,
+						GlobalClusterIdentifier: globalCluster.GlobalClusterIdentifier,
+					}
+
+					log.Printf("[INFO] Removing RDS Cluster (%s) from RDS Global Cluster: %s", id, globalClusterID)
+					_, err = conn.RemoveFromGlobalCluster(input)
+
+					if err != nil {
+						log.Printf("[ERROR] Failure removing RDS Cluster (%s) from RDS Global Cluster (%s): %s", id, globalClusterID, err)
+					}
+				}
+			}
+
+			input := &rds.DeleteDBClusterInput{
+				DBClusterIdentifier: cluster.DBClusterIdentifier,
+				SkipFinalSnapshot:   aws.Bool(true),
+			}
+
+			log.Printf("[INFO] Deleting RDS DB Cluster: %s", id)
+
+			_, err := conn.DeleteDBCluster(input)
+
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete RDS DB Cluster (%s): %s", id, err)
+				continue
+			}
+
+			if err := waitForRDSClusterDeletion(conn, id, 40*time.Minute); err != nil {
+				log.Printf("[ERROR] Failure while waiting for RDS DB Cluster (%s) to be deleted: %s", id, err)
+			}
+		}
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping RDS DB Cluster sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error retrieving RDS DB Clusters: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSRDSCluster_importBasic(t *testing.T) {
 	resourceName := "aws_rds_cluster.default"

--- a/aws/resource_aws_rds_global_cluster_test.go
+++ b/aws/resource_aws_rds_global_cluster_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"log"
 	"regexp"
 	"testing"
 
@@ -12,6 +13,61 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_rds_global_cluster", &resource.Sweeper{
+		Name: "aws_rds_global_cluster",
+		F:    testSweepRdsGlobalClusters,
+		Dependencies: []string{
+			"aws_rds_cluster",
+		},
+	})
+}
+
+func testSweepRdsGlobalClusters(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).rdsconn
+	input := &rds.DescribeGlobalClustersInput{}
+
+	err = conn.DescribeGlobalClustersPages(input, func(out *rds.DescribeGlobalClustersOutput, lastPage bool) bool {
+		for _, globalCluster := range out.GlobalClusters {
+			id := aws.StringValue(globalCluster.GlobalClusterIdentifier)
+			input := &rds.DeleteGlobalClusterInput{
+				GlobalClusterIdentifier: globalCluster.GlobalClusterIdentifier,
+			}
+
+			log.Printf("[INFO] Deleting RDS Global Cluster: %s", id)
+
+			_, err := conn.DeleteGlobalCluster(input)
+
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete RDS Global Cluster (%s): %s", id, err)
+				continue
+			}
+
+			if err := waitForRdsGlobalClusterDeletion(conn, id); err != nil {
+				log.Printf("[ERROR] Failure while waiting for RDS Global Cluster (%s) to be deleted: %s", id, err)
+			}
+		}
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping RDS Global Cluster sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error retrieving RDS Global Clusters: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSRdsGlobalCluster_basic(t *testing.T) {
 	var globalCluster1 rds.GlobalCluster


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Something odd with the RDS API, but okay within this context (as we would want to sweep them anyways) is that the RDS `DescribeDBClusters` call is returning DocDB and Neptune clusters as well. Those services share architecture with RDS, but the cross-service results are a little concerning in general.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSRDSCluster_EngineMode (201.31s)
    testing.go:538: Step 2 error: Error applying: 1 error occurred:
          * aws_rds_cluster.test: 1 error occurred:
          * aws_rds_cluster.test: error creating RDS cluster: DBClusterQuotaExceededFault: DB Cluster quota exceeded
```

Previous output from AWS CLI:

```
$ aws rds describe-db-clusters | jq '.DBClusters | length'
18

$ aws rds describe-global-clusters | jq '.GlobalClusters | length'
3
```

Previous output from AWS console:

![Screen Shot 2019-04-03 at 10 36 11 AM](https://user-images.githubusercontent.com/189114/55490505-dd580500-5601-11e9-9d61-954aa92d31a0.png)

Output from test sweeper:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_rds_global_cluster -timeout 10h
2019/04/03 10:35:57 [DEBUG] Running Sweepers for region (us-west-2):
2019/04/03 10:35:57 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2019/04/03 10:35:57 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
...
2019/04/03 10:36:02 [INFO] Deleting RDS DB Cluster: tf-acc-test-1526833319131111981
...
2019/04/03 10:37:05 [INFO] Removing RDS Cluster (tf-acc-test-2410632546522793153) from RDS Global Cluster: tf-acc-test-2410632546522793153-0
2019/04/03 10:37:06 [ERROR] Failure removing RDS Cluster (tf-acc-test-2410632546522793153) from RDS Global Cluster (tf-acc-test-2410632546522793153-0): InvalidParameterValue: Cluster tf-acc-test-2410632546522793153 is not part of the global cluster tf-acc-test-2410632546522793153-0
  status code: 400, request id: a0ded904-c414-41bc-9f6a-200523b2940e
2019/04/03 10:37:06 [INFO] Deleting RDS DB Cluster: tf-acc-test-2410632546522793153
2019/04/03 10:37:06 [ERROR] Failed to delete RDS DB Cluster (tf-acc-test-2410632546522793153): InvalidDBClusterStateFault: This cluster is a part of a global cluster, please remove it from globalcluster first
  status code: 400, request id: 8a4724fe-e706-47d7-8e1f-be9d0e4f686e
2019/04/03 10:37:06 [INFO] Deleting RDS DB Cluster: tf-acc-test-3909980395311323587
...
2019/04/03 10:38:08 [INFO] Deleting RDS DB Cluster: tf-acc-test-4288293695776479050
...
2019/04/03 10:39:11 [INFO] Removing RDS Cluster (tf-acc-test-4805064940317903012) from RDS Global Cluster: tf-acc-test-4805064940317903012-0
2019/04/03 10:39:12 [ERROR] Failure removing RDS Cluster (tf-acc-test-4805064940317903012) from RDS Global Cluster (tf-acc-test-4805064940317903012-0): InvalidParameterValue: Cluster tf-acc-test-4805064940317903012 is not part of the global cluster tf-acc-test-4805064940317903012-0
  status code: 400, request id: 5bf3275e-69df-45ff-8b52-a74e70b1b21f
2019/04/03 10:39:12 [INFO] Deleting RDS DB Cluster: tf-acc-test-4805064940317903012
2019/04/03 10:39:13 [ERROR] Failed to delete RDS DB Cluster (tf-acc-test-4805064940317903012): InvalidDBClusterStateFault: This cluster is a part of a global cluster, please remove it from globalcluster first
  status code: 400, request id: 77cb6307-e4ca-4816-95d4-5eefb3f5d0bf
2019/04/03 10:39:13 [INFO] Deleting RDS DB Cluster: tf-acc-test-5314371649167369549
...
2019/04/03 10:40:15 [INFO] Deleting RDS DB Cluster: tf-acc-test-5349476957871837832
...
2019/04/03 10:41:17 [INFO] Deleting RDS DB Cluster: tf-acc-test-5394452596108836734
...
2019/04/03 10:42:19 [INFO] Removing RDS Cluster (tf-acc-test-7956788208328737781) from RDS Global Cluster: tf-acc-test-7956788208328737781-0
2019/04/03 10:42:20 [ERROR] Failure removing RDS Cluster (tf-acc-test-7956788208328737781) from RDS Global Cluster (tf-acc-test-7956788208328737781-0): InvalidParameterValue: Cluster tf-acc-test-7956788208328737781 is not part of the global cluster tf-acc-test-7956788208328737781-0
  status code: 400, request id: 4857e55f-b750-463c-abd5-fcce96450661
2019/04/03 10:42:20 [INFO] Deleting RDS DB Cluster: tf-acc-test-7956788208328737781
2019/04/03 10:42:21 [ERROR] Failed to delete RDS DB Cluster (tf-acc-test-7956788208328737781): InvalidDBClusterStateFault: This cluster is a part of a global cluster, please remove it from globalcluster first
  status code: 400, request id: e5cc5a97-0284-471c-8c69-502377bb08e2
2019/04/03 10:42:21 [INFO] Deleting RDS DB Cluster: tf-acc-test-8719996841007642099
...
2019/04/03 10:43:13 [INFO] Deleting RDS DB Cluster: tf-acc-test-961257665305528327
...
2019/04/03 10:44:15 [INFO] Deleting RDS DB Cluster: tf-aurora-cluster-5737855379072096811
...
2019/04/03 10:45:17 [INFO] Deleting RDS DB Cluster: tf-docdb-cluster-7476841011689560422
...
2019/04/03 10:46:19 [INFO] Deleting RDS DB Cluster: tf-neptune-cluster-626075198441789231
...
2019/04/03 10:47:21 [INFO] Deleting RDS DB Cluster: tf-neptune-cluster-8276669143195818294
...
2019/04/03 10:48:23 [INFO] Deleting RDS DB Cluster: tf-neptune-cluster-9007600982936424647
...
2019/04/03 10:49:25 [INFO] Deleting RDS DB Cluster: tf-neptune-cluster-967845058134043825
...
2019/04/03 10:50:29 [INFO] Deleting RDS Global Cluster: tf-acc-test-2410632546522793153-0
2019/04/03 10:50:30 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-2410632546522793153-0): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-2410632546522793153-0 is not empty
  status code: 400, request id: 7affa377-34fe-4e07-8dd7-938d675d3ee0
2019/04/03 10:50:30 [INFO] Deleting RDS Global Cluster: tf-acc-test-4805064940317903012-0
2019/04/03 10:50:31 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-4805064940317903012-0): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-4805064940317903012-0 is not empty
  status code: 400, request id: e2236bbb-a557-45d8-b3e0-35d139f6b1c4
2019/04/03 10:50:31 [INFO] Deleting RDS Global Cluster: tf-acc-test-7956788208328737781-0
2019/04/03 10:50:31 [ERROR] Failed to delete RDS Global Cluster (tf-acc-test-7956788208328737781-0): InvalidGlobalClusterStateFault: Global Cluster arn:aws:rds::187416307283:global-cluster:tf-acc-test-7956788208328737781-0 is not empty
  status code: 400, request id: 9501d85f-0bd0-4087-91a4-d19820d65fe3
2019/04/03 10:50:31 Sweeper Tests ran:
  - aws_rds_global_cluster
  - aws_db_instance
  - aws_rds_cluster
ok    github.com/terraform-providers/terraform-provider-aws/aws 876.339s
```

Output from AWS console:

![Screen Shot 2019-04-03 at 10 47 35 AM](https://user-images.githubusercontent.com/189114/55490531-e9dc5d80-5601-11e9-885f-3d13eafbd9b5.png)

Output from test sweeper after fixing the `RemoveFromGlobalCluster` parameter from `cluster.DBClusterIdentifier` to `cluster.DBClusterArn`:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_rds_global_cluster -timeout 10h
2019/04/03 11:07:41 [DEBUG] Running Sweepers for region (us-west-2):
2019/04/03 11:07:41 [DEBUG] Sweeper (aws_rds_global_cluster) has dependency (aws_rds_cluster), running..
2019/04/03 11:07:41 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
...
2019/04/03 11:07:44 [INFO] Removing RDS Cluster (tf-acc-test-2410632546522793153) from RDS Global Cluster: tf-acc-test-2410632546522793153-0
2019/04/03 11:07:46 [INFO] Deleting RDS DB Cluster: tf-acc-test-2410632546522793153
...
2019/04/03 11:08:48 [INFO] Removing RDS Cluster (tf-acc-test-4805064940317903012) from RDS Global Cluster: tf-acc-test-4805064940317903012-0
2019/04/03 11:08:50 [INFO] Deleting RDS DB Cluster: tf-acc-test-4805064940317903012
...
2019/04/03 11:09:52 [INFO] Removing RDS Cluster (tf-acc-test-7956788208328737781) from RDS Global Cluster: tf-acc-test-7956788208328737781-0
2019/04/03 11:09:54 [INFO] Deleting RDS DB Cluster: tf-acc-test-7956788208328737781
...
2019/04/03 11:10:57 [INFO] Deleting RDS Global Cluster: tf-acc-test-2410632546522793153-0
...
2019/04/03 11:11:00 [INFO] Deleting RDS Global Cluster: tf-acc-test-4805064940317903012-0
...
2019/04/03 11:11:02 [INFO] Deleting RDS Global Cluster: tf-acc-test-7956788208328737781-0
...
2019/04/03 11:11:04 Sweeper Tests ran:
  - aws_db_instance
  - aws_rds_cluster
  - aws_rds_global_cluster
ok    github.com/terraform-providers/terraform-provider-aws/aws 204.629s
```

Output from AWS CLI:

```
$ aws rds describe-db-clusters | jq '.DBClusters | length'
0

$ aws rds describe-global-clusters | jq '.GlobalClusters | length'
0
```

Output from AWS console:

![Screen Shot 2019-04-03 at 11 13 17 AM](https://user-images.githubusercontent.com/189114/55490559-f365c580-5601-11e9-91c8-d5bee3d194df.png)
