### PR TITLE
Fixes #8173

### DIFF
--- a/aws/resource_aws_glue_catalog_table.go
+++ b/aws/resource_aws_glue_catalog_table.go
@@ -16,7 +16,6 @@ func resourceAwsGlueCatalogTable() *schema.Resource {
 		Read:   resourceAwsGlueCatalogTableRead,
 		Update: resourceAwsGlueCatalogTableUpdate,
 		Delete: resourceAwsGlueCatalogTableDelete,
-		Exists: resourceAwsGlueCatalogTableExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -337,33 +336,6 @@ func resourceAwsGlueCatalogTableDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error deleting Glue Catalog Table: %s", err.Error())
 	}
 	return nil
-}
-
-func resourceAwsGlueCatalogTableExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	glueconn := meta.(*AWSClient).glueconn
-	catalogID, dbName, name, tableIdErr := readAwsGlueTableID(d.Id())
-	if tableIdErr != nil {
-		return false, tableIdErr
-	}
-
-	log.Printf("[DEBUG] Glue Catalog Table: %s:%s:%s", catalogID, dbName, name)
-
-	input := &glue.GetTableInput{
-		CatalogId:    aws.String(catalogID),
-		DatabaseName: aws.String(dbName),
-		Name:         aws.String(name),
-	}
-
-	_, err := glueconn.GetTable(input)
-
-	if err != nil {
-		if isAWSErr(err, glue.ErrCodeEntityNotFoundException, "") {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }
 
 func expandGlueTableInput(d *schema.ResourceData) *glue.TableInput {

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -12,6 +12,41 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAWSGlueCatalogTable_recreates(t *testing.T) {
+	resourceName := "aws_glue_catalog_table.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGlueTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlueCatalogTable_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlueCatalogTableExists(resourceName),
+				),
+			},
+			{
+				PreConfig: func() {
+					conn := testAccProvider.Meta().(*AWSClient).glueconn
+					input := &glue.DeleteTableInput{
+						Name:         aws.String(fmt.Sprintf("my_test_catalog_table_%d", rInt)),
+						DatabaseName: aws.String(fmt.Sprintf("my_test_catalog_database_%d", rInt)),
+					}
+					_, err := conn.DeleteTable(input)
+					if err != nil {
+						t.Fatalf("error deleting Glue Catalog Table: %s", err)
+					}
+				},
+				Config:             testAccGlueCatalogTable_basic(rInt),
+				ExpectNonEmptyPlan: true,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
 func TestAccAWSGlueCatalogTable_importBasic(t *testing.T) {
 	resourceName := "aws_glue_catalog_table.test"
 	rInt := acctest.RandInt()

--- a/aws/resource_aws_glue_catalog_table_test.go
+++ b/aws/resource_aws_glue_catalog_table_test.go
@@ -16,7 +16,7 @@ func TestAccAWSGlueCatalogTable_recreates(t *testing.T) {
 	resourceName := "aws_glue_catalog_table.test"
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGlueTableDestroy,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8173 

Changes proposed in this pull request:

* Recreate an aws_glue_catalog_table if it's been deleted manually outside of Terraform

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSGlueCatalogTable_recreates'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSGlueCatalogTable_recreates -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSGlueCatalogTable_recreates
--- PASS: TestAccAWSGlueCatalogTable_recreates (29.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       29.063s

```
