### PR TITLE
resource/aws_network_acl: Set SchemaConfigModeAttr on egress and ingress configuration block attributes

### DIFF
--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -50,10 +50,11 @@ func resourceAwsNetworkAcl() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"ingress": {
-				Type:     schema.TypeSet,
-				Required: false,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Required:   false,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {
@@ -100,10 +101,11 @@ func resourceAwsNetworkAcl() *schema.Resource {
 				Set: resourceAwsNetworkAclEntryHash,
 			},
 			"egress": {
-				Type:     schema.TypeSet,
-				Required: false,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Required:   false,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {

--- a/aws/resource_aws_network_acl_test.go
+++ b/aws/resource_aws_network_acl_test.go
@@ -121,6 +121,110 @@ func TestAccAWSNetworkAcl_importBasic(t *testing.T) {
 	})
 }
 
+func TestAccAWSNetworkAcl_Egress_ConfigMode(t *testing.T) {
+	var networkAcl1, networkAcl2, networkAcl3 ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNetworkAclConfigEgressConfigModeBlocks(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl1),
+					testAccCheckAWSNetworkAclEgressRuleLength(&networkAcl1, 2),
+					resource.TestCheckResourceAttr(resourceName, "egress.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSNetworkAclConfigEgressConfigModeNoBlocks(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl2),
+					testAccCheckAWSNetworkAclEgressRuleLength(&networkAcl2, 2),
+					resource.TestCheckResourceAttr(resourceName, "egress.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSNetworkAclConfigEgressConfigModeZeroed(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl3),
+					testAccCheckAWSNetworkAclEgressRuleLength(&networkAcl3, 0),
+					resource.TestCheckResourceAttr(resourceName, "egress.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSNetworkAcl_Ingress_ConfigMode(t *testing.T) {
+	var networkAcl1, networkAcl2, networkAcl3 ec2.NetworkAcl
+	resourceName := "aws_network_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNetworkAclConfigIngressConfigModeBlocks(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl1),
+					testIngressRuleLength(&networkAcl1, 2),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSNetworkAclConfigIngressConfigModeNoBlocks(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl2),
+					testIngressRuleLength(&networkAcl2, 2),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSNetworkAclConfigIngressConfigModeZeroed(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSNetworkAclExists(resourceName, &networkAcl3),
+					testIngressRuleLength(&networkAcl3, 0),
+					resource.TestCheckResourceAttr(resourceName, "ingress.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 	var networkAcl ec2.NetworkAcl
 
@@ -559,6 +663,23 @@ func testAccCheckAWSNetworkAclExists(n string, networkAcl *ec2.NetworkAcl) resou
 		}
 
 		return fmt.Errorf("Network Acls not found")
+	}
+}
+
+func testAccCheckAWSNetworkAclEgressRuleLength(networkAcl *ec2.NetworkAcl, length int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var entries []*ec2.NetworkAclEntry
+		for _, entry := range networkAcl.Entries {
+			if aws.BoolValue(entry.Egress) {
+				entries = append(entries, entry)
+			}
+		}
+		// There is always a default rule (ALL Traffic ... DENY)
+		// so we have to increase the length by 1
+		if len(entries) != length+1 {
+			return fmt.Errorf("Invalid number of ingress entries found; count = %d", len(entries))
+		}
+		return nil
 	}
 }
 
@@ -1151,3 +1272,149 @@ resource "aws_network_acl" "testesp" {
   }
 }
 `
+
+func testAccAWSNetworkAclConfigEgressConfigModeBlocks() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = {
+    Name = "terraform-testacc-network-acl-egress-computed-attribute-mode"
+  }
+}
+
+resource "aws_network_acl" "test" {
+  tags   = {
+    Name = "terraform-testacc-network-acl-egress-computed-attribute-mode"
+  }
+  vpc_id = "${aws_vpc.test.id}"
+
+  egress {
+    action     = "allow"
+    cidr_block = "${aws_vpc.test.cidr_block}"
+    from_port  = 0
+    protocol   = "tcp"
+    rule_no    = 1
+    to_port    = 0
+  }
+
+  egress {
+    action     = "allow"
+    cidr_block = "${aws_vpc.test.cidr_block}"
+    from_port  = 0
+    protocol   = "udp"
+    rule_no    = 2
+    to_port    = 0
+  }
+}
+`)
+}
+
+func testAccAWSNetworkAclConfigEgressConfigModeNoBlocks() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = {
+    Name = "terraform-testacc-network-acl-egress-computed-attribute-mode"
+  }
+}
+
+resource "aws_network_acl" "test" {
+  tags   = {
+    Name = "terraform-testacc-network-acl-egress-computed-attribute-mode"
+  }
+  vpc_id = "${aws_vpc.test.id}"
+}
+`)
+}
+
+func testAccAWSNetworkAclConfigEgressConfigModeZeroed() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = {
+    Name = "terraform-testacc-network-acl-egress-computed-attribute-mode"
+  }
+}
+
+resource "aws_network_acl" "test" {
+  egress = []
+  tags    = {
+    Name = "terraform-testacc-network-acl-egress-computed-attribute-mode"
+  }
+  vpc_id  = "${aws_vpc.test.id}"
+}
+`)
+}
+
+func testAccAWSNetworkAclConfigIngressConfigModeBlocks() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = {
+    Name = "terraform-testacc-network-acl-ingress-computed-attribute-mode"
+  }
+}
+
+resource "aws_network_acl" "test" {
+  tags   = {
+    Name = "terraform-testacc-network-acl-ingress-computed-attribute-mode"
+  }
+  vpc_id = "${aws_vpc.test.id}"
+
+  ingress {
+    action     = "allow"
+    cidr_block = "${aws_vpc.test.cidr_block}"
+    from_port  = 0
+    protocol   = "tcp"
+    rule_no    = 1
+    to_port    = 0
+  }
+
+  ingress {
+    action     = "allow"
+    cidr_block = "${aws_vpc.test.cidr_block}"
+    from_port  = 0
+    protocol   = "udp"
+    rule_no    = 2
+    to_port    = 0
+  }
+}
+`)
+}
+
+func testAccAWSNetworkAclConfigIngressConfigModeNoBlocks() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = {
+    Name = "terraform-testacc-network-acl-ingress-computed-attribute-mode"
+  }
+}
+
+resource "aws_network_acl" "test" {
+  tags   = {
+    Name = "terraform-testacc-network-acl-ingress-computed-attribute-mode"
+  }
+  vpc_id = "${aws_vpc.test.id}"
+}
+`)
+}
+
+func testAccAWSNetworkAclConfigIngressConfigModeZeroed() string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = {
+    Name = "terraform-testacc-network-acl-ingress-computed-attribute-mode"
+  }
+}
+
+resource "aws_network_acl" "test" {
+  ingress = []
+  tags    = {
+    Name = "terraform-testacc-network-acl-ingress-computed-attribute-mode"
+  }
+  vpc_id  = "${aws_vpc.test.id}"
+}
+`)
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


References:

* https://github.com/hashicorp/terraform/issues/20505
* https://github.com/hashicorp/terraform/pull/20626

In Terraform 0.12, behaviors with configuration blocks are more explicit to allow configuration language improvements and remove ambiguities that required various undocumented workarounds in Terraform 0.11 and prior. As a consequence, configuration blocks that are marked `Optional: true` and `Computed: true` will no longer support explicitly zero-ing out the configuration without special implementation.

The `ConfigMode` schema parameter on the configuration block attribute allows the schema to override certain behaviors. In particular, setting `ConfigMode: schema.SchemaConfigModeAttr` will allow practitioners to continue setting the configuration block attribute to an empty list (in the semantic sense, e.g. `attr = []`), keeping this prior behavior in Terraform 0.12. This parameter does not have any effect with Terraform 0.11. This solution may be temporary or revisited in the future.

Previous output from Terraform 0.11:

```
--- PASS: TestAccAWSNetworkAcl_Egress_ConfigMode (53.47s)
--- PASS: TestAccAWSNetworkAcl_Ingress_ConfigMode (51.81s)
```

Previous output from Terraform 0.12:

```
--- FAIL: TestAccAWSNetworkAcl_Egress_ConfigMode (38.74s)
    testing.go:568: Step 4 error: config is invalid: Unsupported argument: An argument named "egress" is not expected here. Did you mean "ingress"?

--- FAIL: TestAccAWSNetworkAcl_Ingress_ConfigMode (38.89s)
    testing.go:568: Step 4 error: config is invalid: Unsupported argument: An argument named "ingress" is not expected here. Did you mean to define a block of type "ingress"?
```

Output from Terraform 0.11:

```
--- PASS: TestAccAWSNetworkAcl_Egress_ConfigMode (52.88s)
--- PASS: TestAccAWSNetworkAcl_Ingress_ConfigMode (52.70s)
```

Output from Terraform 0.12:

```
--- PASS: TestAccAWSNetworkAcl_Egress_ConfigMode (52.43s)
--- PASS: TestAccAWSNetworkAcl_Ingress_ConfigMode (53.60s)
```