### PR TITLE
SetNewCompute ipv6 attrs in vpc when added

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -508,6 +508,11 @@ func resourceAwsVpcCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error
 		}
 	}
 
+	if diff.HasChange("assign_generated_ipv6_cidr_block") {
+		diff.SetNewComputed("ipv6_cidr_block")
+		diff.SetNewComputed("ipv6_association_id")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If `assign_generated_ipv6_block` changes in a vpc, the diff has to reflect
that the ipv6 attrs are going to change.

As is often the case, `diffs didn't match during apply` (soon to be `Provider produced inconsistent final plan`) errors are caused by an upstream dependency. Here, a resource referencing the generated `ipv6_cidr_block` will get the incorrect value if it changes during apply. 

Fixes #6710


```
$ TF_ACC=1 go test -v -run TestAccAWSVpc_AssignGeneratedIpv6CidrBlockFromFalse
=== RUN   TestAccAWSVpc_AssignGeneratedIpv6CidrBlockFromFalse
=== PAUSE TestAccAWSVpc_AssignGeneratedIpv6CidrBlockFromFalse
=== CONT  TestAccAWSVpc_AssignGeneratedIpv6CidrBlockFromFalse
--- PASS: TestAccAWSVpc_AssignGeneratedIpv6CidrBlockFromFalse (50.95s)
PASS
```
