### PR TITLE
Fix indentation in cloudwatch_metric_alarm documentation

### DIFF
--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "foobar" {
   alarm_name                = "terraform-test-foobar%d"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
-	threshold                 = "10"
+  threshold                 = "10"
   alarm_description         = "Request error rate has exceeded 10%"
   insufficient_data_actions = []
 	metric_query {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Fix Indentation in `website/docs/r/cloudwatch_metric_alarm.html.markdown`
