### PR TITLE
resource/aws_security_group: Set SchemaConfigModeAttr on egress and ingress configuration block attributes

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -71,9 +71,10 @@ func resourceAwsSecurityGroup() *schema.Resource {
 			},
 
 			"ingress": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {
@@ -140,9 +141,10 @@ func resourceAwsSecurityGroup() *schema.Resource {
 			},
 
 			"egress": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -86,8 +86,10 @@ assign a random, unique name
   to classify your security groups in a way that can be updated, use `tags`.
 * `ingress` - (Optional) Can be specified multiple times for each
    ingress rule. Each ingress block supports fields documented below.
+   This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 * `egress` - (Optional, VPC only) Can be specified multiple times for each
       egress rule. Each egress block supports fields documented below.
+      This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 * `revoke_rules_on_delete` - (Optional) Instruct Terraform to revoke all of the
 Security Groups attached ingress and egress rules before deleting the rule
 itself. This is normally not needed, however certain AWS services such as


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References:

* https://github.com/hashicorp/terraform/issues/20505
* https://github.com/hashicorp/terraform/pull/20626

In Terraform 0.12, behaviors with configuration blocks are more explicit to allow configuration language improvements and remove ambiguities that required various undocumented workarounds in Terraform 0.11 and prior. As a consequence, configuration blocks that are marked `Optional: true` and `Computed: true` will no longer support explicitly zero-ing out the configuration without special implementation.

The `ConfigMode` schema parameter on the configuration block attribute allows the schema to override certain behaviors. In particular, setting `ConfigMode: schema.SchemaConfigModeAttr` will allow practitioners to continue setting the configuration block attribute to an empty list (in the semantic sense, e.g. `attr = []`), keeping this prior behavior in Terraform 0.12. This parameter does not have any effect with Terraform 0.11. This solution may be temporary or revisited in the future.

Previous output from Terraform 0.11:

```
--- PASS: TestAccAWSSecurityGroup_Egress_ConfigMode (50.28s)
--- PASS: TestAccAWSSecurityGroup_Ingress_ConfigMode (49.85s)
```

Previous output from Terraform 0.12:

```
--- FAIL: TestAccAWSSecurityGroup_Egress_ConfigMode (31.74s)
    testing.go:568: Step 2 error: config is invalid: Unsupported argument: An argument named "egress" is not expected here. Did you mean to define a block of type "egress"?

--- FAIL: TestAccAWSSecurityGroup_Ingress_ConfigMode (31.94s)
    testing.go:568: Step 2 error: config is invalid: Unsupported argument: An argument named "ingress" is not expected here. Did you mean to define a block of type "ingress"?
```

Output from Terraform 0.11:

```
--- PASS: TestAccAWSSecurityGroup_Egress_ConfigMode (52.27s)
--- PASS: TestAccAWSSecurityGroup_Ingress_ConfigMode (53.55s)
```

Output from Terraform 0.12:

```
--- PASS: TestAccAWSSecurityGroup_Egress_ConfigMode (57.20s)
--- PASS: TestAccAWSSecurityGroup_Ingress_ConfigMode (55.80s)
```