### PR TITLE
Add options and fix names for EKS example.

### DIFF
--- a/examples/eks-getting-started/eks-cluster.tf
+++ b/examples/eks-getting-started/eks-cluster.tf
@@ -6,7 +6,7 @@
 #
 
 resource "aws_iam_role" "demo-cluster" {
-  name = "terraform-eks-demo-cluster"
+  name = "${var.cluster-name}-cluster"
 
   assume_role_policy = <<POLICY
 {
@@ -35,7 +35,7 @@ resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSServicePolicy" 
 }
 
 resource "aws_security_group" "demo-cluster" {
-  name        = "terraform-eks-demo-cluster"
+  name        = "${var.cluster-name}-cluster"
   description = "Cluster communication with worker nodes"
   vpc_id      = "${aws_vpc.demo.id}"
 
@@ -47,7 +47,7 @@ resource "aws_security_group" "demo-cluster" {
   }
 
   tags = {
-    Name = "terraform-eks-demo"
+    Name = "${var.cluster-name}"
   }
 }
 

--- a/examples/eks-getting-started/variables.tf
+++ b/examples/eks-getting-started/variables.tf
@@ -6,3 +6,18 @@ variable "cluster-name" {
   default = "terraform-eks-demo"
   type    = "string"
 }
+
+variable "desired-workers" {
+  default = "2"
+  type    = "string"
+}
+
+variable "max-workers" {
+  default = "2"
+  type    = "string"
+}
+
+variable "min-workers" {
+  default = "1"
+  type    = "string"
+}

--- a/examples/eks-getting-started/vpc.tf
+++ b/examples/eks-getting-started/vpc.tf
@@ -11,7 +11,7 @@ resource "aws_vpc" "demo" {
 
   tags = "${
     map(
-      "Name", "terraform-eks-demo-node",
+      "Name", "${var.cluster-name}-node",
       "kubernetes.io/cluster/${var.cluster-name}", "shared",
     )
   }"
@@ -26,7 +26,7 @@ resource "aws_subnet" "demo" {
 
   tags = "${
     map(
-      "Name", "terraform-eks-demo-node",
+      "Name", "${var.cluster-name}-node",
       "kubernetes.io/cluster/${var.cluster-name}", "shared",
     )
   }"
@@ -36,7 +36,7 @@ resource "aws_internet_gateway" "demo" {
   vpc_id = "${aws_vpc.demo.id}"
 
   tags = {
-    Name = "terraform-eks-demo"
+    Name = "${var.cluster-name}"
   }
 }
 


### PR DESCRIPTION
Why:

* It is beneficial to be able to select the size of your autoscaling
  group.
* The names/tags should be built off of the cluster name variable.

This change addresses the need by:

* Add the desired-workers variable
* Add the max-workers variable
* Add the min-workers variable
* Replace static "terraform-eks-demo" values with "${var.cluster-name}"

Side effects:

* The example may not line up anymore with the blog post.


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```