### PR TITLE
Add err object to return when err is not nil

### DIFF
--- a/aws/tagsCloudWatchEvent.go
+++ b/aws/tagsCloudWatchEvent.go
@@ -106,7 +106,7 @@ func saveTagsCloudWatchEvents(conn *events.CloudWatchEvents, d *schema.ResourceD
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error retreiving tags for ARN: %s", arn)
+		return fmt.Errorf("Error retreiving tags for %s: %s", arn, err)
 	}
 
 	var tagList []*events.Tag


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References: https://github.com/terraform-providers/terraform-provider-aws/pull/8076#issuecomment-478773320

Changes proposed in this pull request:

* Add return `err` object
  * It help for find out why error occured
Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSCloudWatchEventRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudWatchEventRule_ -timeout 120m
=== RUN   TestAccAWSCloudWatchEventRule_importBasic
=== PAUSE TestAccAWSCloudWatchEventRule_importBasic
=== RUN   TestAccAWSCloudWatchEventRule_basic
=== PAUSE TestAccAWSCloudWatchEventRule_basic
=== RUN   TestAccAWSCloudWatchEventRule_prefix
=== PAUSE TestAccAWSCloudWatchEventRule_prefix
=== RUN   TestAccAWSCloudWatchEventRule_tags
=== PAUSE TestAccAWSCloudWatchEventRule_tags
=== RUN   TestAccAWSCloudWatchEventRule_full
=== PAUSE TestAccAWSCloudWatchEventRule_full
=== RUN   TestAccAWSCloudWatchEventRule_enable
=== PAUSE TestAccAWSCloudWatchEventRule_enable
=== CONT  TestAccAWSCloudWatchEventRule_importBasic
=== CONT  TestAccAWSCloudWatchEventRule_full
=== CONT  TestAccAWSCloudWatchEventRule_enable
=== CONT  TestAccAWSCloudWatchEventRule_prefix
=== CONT  TestAccAWSCloudWatchEventRule_tags
=== CONT  TestAccAWSCloudWatchEventRule_basic
--- PASS: TestAccAWSCloudWatchEventRule_prefix (27.46s)
--- PASS: TestAccAWSCloudWatchEventRule_full (29.50s)
--- PASS: TestAccAWSCloudWatchEventRule_importBasic (30.97s)
--- PASS: TestAccAWSCloudWatchEventRule_basic (46.56s)
--- PASS: TestAccAWSCloudWatchEventRule_enable (63.71s)
--- PASS: TestAccAWSCloudWatchEventRule_tags (66.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	66.906s
```
