### PR TITLE
resource/aws_route_table: Set SchemaConfigModeAttr on route configuration block attributes

### DIFF
--- a/aws/resource_aws_route_table.go
+++ b/aws/resource_aws_route_table.go
@@ -42,9 +42,10 @@ func resourceAwsRouteTable() *schema.Resource {
 			},
 
 			"route": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Optional: true,
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cidr_block": {

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -56,7 +56,7 @@ resource "aws_route_table" "r" {
 The following arguments are supported:
 
 * `vpc_id` - (Required) The VPC ID.
-* `route` - (Optional) A list of route objects. Their keys are documented below.
+* `route` - (Optional) A list of route objects. Their keys are documented below. This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `propagating_vgws` - (Optional) A list of virtual gateways for propagation.
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References:

* https://github.com/hashicorp/terraform/issues/20505
* https://github.com/hashicorp/terraform/pull/20626

In Terraform 0.12, behaviors with configuration blocks are more explicit to allow configuration language improvements and remove ambiguities that required various undocumented workarounds in Terraform 0.11 and prior. As a consequence, configuration blocks that are marked `Optional: true` and `Computed: true` will no longer support explicitly zero-ing out the configuration without special implementation.

The `ConfigMode` schema parameter on the configuration block attribute allows the schema to override certain behaviors. In particular, setting `ConfigMode: schema.SchemaConfigModeAttr` will allow practitioners to continue setting the configuration block attribute to an empty list (in the semantic sense, e.g. `attr = []`), keeping this prior behavior in Terraform 0.12. This parameter does not have any effect with Terraform 0.11. This solution may be temporary or revisited in the future.

Previous output from Terraform 0.11:

```
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (66.53s)
```

Previous output from Terraform 0.12:

```
--- FAIL: TestAccAWSRouteTable_Route_ConfigMode (36.11s)
    testing.go:568: Step 2 error: config is invalid: Unsupported argument: An argument named "route" is not expected here. Did you mean to define a block of type "route"?
```

Output from Terraform 0.11:

```
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (67.27s)
```

Output from Terraform 0.12:

```
--- PASS: TestAccAWSRouteTable_Route_ConfigMode (69.03s)
```