### PR TITLE
ECR repository tag-on-create

### DIFF
--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -54,6 +54,7 @@ func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 	input := ecr.CreateRepositoryInput{
 		RepositoryName: aws.String(d.Get("name").(string)),
+		Tags:           tagsFromMapECR(d.Get("tags").(map[string]interface{})),
 	}
 
 	log.Printf("[DEBUG] Creating ECR repository: %#v", input)
@@ -67,12 +68,6 @@ func resourceAwsEcrRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] ECR repository created: %q", *repository.RepositoryArn)
 
 	d.SetId(aws.StringValue(repository.RepositoryName))
-	// ARN required for setting any tags.
-	d.Set("arn", repository.RepositoryArn)
-
-	if err := setTagsECR(conn, d); err != nil {
-		return fmt.Errorf("error setting ECR repository tags: %s", err)
-	}
 
 	return resourceAwsEcrRepositoryRead(d, meta)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8195.
Tag ECR repositories on creation to prevent potential IAM permission issues.
Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSEcrRepository_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSEcrRepository_ -timeout 120m
=== RUN   TestAccAWSEcrRepository_basic
=== PAUSE TestAccAWSEcrRepository_basic
=== RUN   TestAccAWSEcrRepository_tags
=== PAUSE TestAccAWSEcrRepository_tags
=== CONT  TestAccAWSEcrRepository_basic
=== CONT  TestAccAWSEcrRepository_tags
--- PASS: TestAccAWSEcrRepository_basic (16.62s)
--- PASS: TestAccAWSEcrRepository_tags (25.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.118s
```