### PR TITLE
website: Link to docs for "attribute-as-blocks mode"

### DIFF
--- a/website/docs/r/default_route_table.html.markdown
+++ b/website/docs/r/default_route_table.html.markdown
@@ -62,6 +62,7 @@ The following arguments are supported:
 
 * `default_route_table_id` - (Required) The ID of the Default Routing Table.
 * `route` - (Optional) A list of route objects. Their keys are documented below.
+  This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `propagating_vgws` - (Optional) A list of virtual gateways for propagation.
 

--- a/website/docs/r/network_acl.html.markdown
+++ b/website/docs/r/network_acl.html.markdown
@@ -54,7 +54,9 @@ The following arguments are supported:
 * `vpc_id` - (Required) The ID of the associated VPC.
 * `subnet_ids` - (Optional) A list of Subnet IDs to apply the ACL to
 * `ingress` - (Optional) Specifies an ingress rule. Parameters defined below.
+  This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 * `egress` - (Optional) Specifies an egress rule. Parameters defined below.
+  This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 Both `egress` and `ingress` support the following keys:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

----

Some initial testing and discussion about the attribute-as-blocks processing mode revealed that there are some caveats with it that become apparent in more complex cases. With that in mind, here we link to [a documentation page explaining those caveats](https://www.terraform.io/docs/configuration/attr-as-blocks.html) to minimize the chance that users will be surprised by them, and can use the examples on that page to understand the meaning of the various configuration permutations supported by these attributes.

This is a catchup PR to add it to the docs for three attributes we already updated for this mode in previous PRs. Ideally we should add similar links to the docs for other attributes we'll update in subsequent PRs.
