### PR TITLE
Add a mention on how Terraform handles existing EBS attachments

### DIFF
--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -65,3 +65,8 @@ means attached.
 [1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html#available-ec2-device-names
 [2]: https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/device_naming.html#available-ec2-device-names
 [3]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-detaching-volume.html
+
+## Import
+`aws_volume_attachment` are syntethic resources created by Terraform which don't exist as an AWS object. Hence, there isn't an ID available to import them.
+
+If you define a `aws_volume_attachment` which references to an EBS that is in fact already attached to the instance, Terraform will not attempt to recreate it but will simply add it to your `tfstate` file as if it was imported. Please note that your `plan` will still show the `aws_volume_attachment` being created.


### PR DESCRIPTION
I used to edit my `tfstate` file manually to import `aws_volume_attachment`. Then I found https://github.com/hashicorp/terraform/pull/11060 which changed Terraform behaviour when an EBS volume is already attached to an instance.

I thought would be a good idea to mention it in the docs.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Add mention on how Terraform handles existing EBS attachments
