### PR TITLE
Add ability to set default version of aws_launch_template

### DIFF
--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -97,6 +97,8 @@ The following arguments are supported:
 * `name` - The name of the launch template. If you leave this blank, Terraform will auto-generate a unique name.
 * `name_prefix` - Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `description` - Description of the launch template.
+* `default_version` - (Optional) The default version of the launch template.
+* `use_latest_version_as_default_version` - (Optional) Whether using the `latest_version` for `default_version`. Defaults to `false`.
 * `block_device_mappings` - Specify volumes to attach to the instance besides the volumes specified by the AMI.
   See [Block Devices](#block-devices) below for details.
 * `capacity_reservation_specification` - Targeting for EC2 capacity reservations. See [Capacity Reservation Specification](#capacity-reservation-specification) below for more details.
@@ -280,7 +282,6 @@ The following attributes are exported along with all argument references:
 
 * `arn` - Amazon Resource Name (ARN) of the launch template.
 * `id` - The ID of the launch template.
-* `default_version` - The default version of the launch template.
 * `latest_version` - The latest version of the launch template.
 
 ## Import


### PR DESCRIPTION
Add flag to catch up default version same as latest version

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #4655

Changes proposed in this pull request:

* Add ability to set default version
* Add `use_latest_version_as_default_version` flag to catch up latest version as default version

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSLaunchTemplate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSLaunchTemplate_ -timeout 120m
=== RUN   TestAccAWSLaunchTemplate_importBasic
=== PAUSE TestAccAWSLaunchTemplate_importBasic
=== RUN   TestAccAWSLaunchTemplate_importData
=== PAUSE TestAccAWSLaunchTemplate_importData
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_description
=== PAUSE TestAccAWSLaunchTemplate_description
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== PAUSE TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== RUN   TestAccAWSLaunchTemplate_licenseSpecification
=== PAUSE TestAccAWSLaunchTemplate_licenseSpecification
=== RUN   TestAccAWSLaunchTemplate_modifyDefaultVersion
=== PAUSE TestAccAWSLaunchTemplate_modifyDefaultVersion
=== RUN   TestAccAWSLaunchTemplate_useLatestVersion
=== PAUSE TestAccAWSLaunchTemplate_useLatestVersion
=== CONT  TestAccAWSLaunchTemplate_importBasic
=== CONT  TestAccAWSLaunchTemplate_networkInterface
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== CONT  TestAccAWSLaunchTemplate_useLatestVersion
=== CONT  TestAccAWSLaunchTemplate_modifyDefaultVersion
=== CONT  TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== CONT  TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_tags
=== CONT  TestAccAWSLaunchTemplate_update
=== CONT  TestAccAWSLaunchTemplate_description
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
=== CONT  TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (33.07s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (34.07s)
=== CONT  TestAccAWSLaunchTemplate_basic
--- PASS: TestAccAWSLaunchTemplate_data (34.73s)
=== CONT  TestAccAWSLaunchTemplate_disappears
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (34.95s)
=== CONT  TestAccAWSLaunchTemplate_importData
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (37.79s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (38.13s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (38.99s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (39.17s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (40.11s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (47.19s)
--- PASS: TestAccAWSLaunchTemplate_description (55.63s)
--- PASS: TestAccAWSLaunchTemplate_disappears (21.63s)
--- PASS: TestAccAWSLaunchTemplate_tags (61.73s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (28.71s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (62.25s)
--- PASS: TestAccAWSLaunchTemplate_basic (28.47s)
--- PASS: TestAccAWSLaunchTemplate_modifyDefaultVersion (63.49s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (66.28s)
--- PASS: TestAccAWSLaunchTemplate_importData (33.70s)
--- PASS: TestAccAWSLaunchTemplate_useLatestVersion (85.79s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (93.07s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (93.17s)
--- PASS: TestAccAWSLaunchTemplate_update (99.80s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (123.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	123.241s
```
