### PR TITLE
Reflect actual argument names for aws_backup_selection in docs

### DIFF
--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -14,14 +14,14 @@ Manages selection conditions for AWS Backup plan resources.
 
 ```hcl
 resource "aws_backup_selection" "example" {
-  plan_id  = "${aws_backup_plan.example.id}"
+  plan_id      = "${aws_backup_plan.example.id}"
 
-  name     = "tf_example_backup_selection"
-  iam_role = "arn:aws:iam::123456789012:role/service-role/AWSBackupDefaultServiceRole"
+  name         = "tf_example_backup_selection"
+  iam_role_arn = "arn:aws:iam::123456789012:role/service-role/AWSBackupDefaultServiceRole"
 
-  tag {
-    type = "STRINGEQUALS"
-    key = "foo"
+  selection_tag {
+    type  = "STRINGEQUALS"
+    key   = "foo"
     value = "bar"
   }
 
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The display name of a resource selection document.
 * `plan_id` - (Required) The backup plan ID to be associated with the selection of resources.
-* `iam_role` - (Required) The ARN of the IAM role that AWS Backup uses to authenticate when restoring the target resource.
+* `iam_role_arn` - (Required) The ARN of the IAM role that AWS Backup uses to authenticate when restoring the target resource.
 * `selection_tag` - (Optional) Tag-based conditions used to specify a set of resources to assign to a backup plan.
 * `resources` - (Optional) An array of strings that either contain Amazon Resource Names (ARNs) or match patterns of resources to assign to a backup plan..
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Complements #7382

Documentation for aws_backup_selection is not updated resulting in following error, while trying create the resource:

```
Error: aws_backup_selection.efs_backup: "iam_role_arn": required field is not set
Error: aws_backup_selection.efs_backup: : invalid or unknown key: iam_role
Error: aws_backup_selection.efs_backup: : invalid or unknown key: tag
```

I've updated the documentation to reflect proper arguments names