### PR TITLE
d/aws_lb_target_group: Add missing schema attributes

### DIFF
--- a/aws/data_source_aws_lb_target_group.go
+++ b/aws/data_source_aws_lb_target_group.go
@@ -18,6 +18,7 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
 			"arn_suffix": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -49,13 +50,23 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				Computed: true,
 			},
 
+			"slow_start": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"proxy_protocol_v2": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"lambda_multi_value_headers_enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
 
-			"slow_start": {
-				Type:     schema.TypeInt,
+			"target_type": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 
@@ -87,6 +98,11 @@ func dataSourceAwsLbTargetGroup() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
 						"interval": {
 							Type:     schema.TypeInt,
 							Computed: true,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8209.

Acceptance tests:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAWSALBTargetGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAWSALBTargetGroup_ -timeout 120m
=== RUN   TestAccDataSourceAWSALBTargetGroup_basic
=== PAUSE TestAccDataSourceAWSALBTargetGroup_basic
=== CONT  TestAccDataSourceAWSALBTargetGroup_basic
--- PASS: TestAccDataSourceAWSALBTargetGroup_basic (194.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	194.348s
```

See https://github.com/terraform-providers/terraform-provider-aws/issues/8209#issuecomment-480278168 for how the same test was failing before this PR.