### PR TITLE
added local cache type and mode options

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -106,7 +106,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"mode": {
+						"modes": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -442,7 +442,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 			func(diff *schema.ResourceDiff, v interface{}) error {
 				// Plan time validation for cache location
 				cacheType, cacheTypeOk := diff.GetOk("cache.0.type")
-				if !cacheTypeOk || cacheType.(string) == codebuild.CacheTypeNoCache {
+				if !cacheTypeOk || cacheType.(string) == codebuild.CacheTypeNoCache || cacheType.(string) == codebuild.CacheTypeLocal {
 					return nil
 				}
 				if v, ok := diff.GetOk("cache.0.location"); ok && v.(string) != "" {

--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -99,11 +99,17 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								codebuild.CacheTypeNoCache,
 								codebuild.CacheTypeS3,
+								codebuild.CacheTypeLocal,
 							}, false),
 						},
 						"location": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
+						"mode": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
@@ -614,6 +620,13 @@ func expandProjectCache(s []interface{}) *codebuild.ProjectCache {
 		projectCache.Location = aws.String(v.(string))
 	}
 
+	if cacheType := data["type"]; cacheType == codebuild.CacheTypeLocal {
+		if modes, modesOk := data["modes"]; modesOk {
+			modesStrings := modes.([]interface{})
+			projectCache.Modes = expandStringList(modesStrings)
+		}
+	}
+
 	return projectCache
 }
 
@@ -998,6 +1011,7 @@ func flattenAwsCodebuildProjectCache(cache *codebuild.ProjectCache) []interface{
 	values := map[string]interface{}{
 		"location": aws.StringValue(cache.Location),
 		"type":     aws.StringValue(cache.Type),
+		"modes":    aws.StringValueSlice(cache.Modes),
 	}
 
 	return []interface{}{values}

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -216,6 +216,15 @@ func TestAccAWSCodeBuildProject_Cache(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cache.0.type", "NO_CACHE"),
 				),
 			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_LocalCache(rName, "LOCAL_DOCKER_LAYER_CACHE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
+					resource.TestCheckResourceAttr(resourceName, "cache.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache.0.modes.0", "LOCAL_DOCKER_LAYER_CACHE"),
+					resource.TestCheckResourceAttr(resourceName, "cache.0.type", "LOCAL"),
+				),
+			},
 		},
 	})
 }
@@ -1148,6 +1157,35 @@ resource "aws_codebuild_project" "test" {
   }
 }
 `, rName, cacheLocation, cacheType)
+}
+
+func testAccAWSCodeBuildProjectConfig_LocalCache(rName, modeType string) string {
+	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_codebuild_project" "test" {
+  name         = "%s"
+  service_role = "${aws_iam_role.test.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+		type     = "LOCAL"
+		modes		 = ["%s"]
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+  }
+
+  source {
+    type     = "GITHUB"
+    location = "https://github.com/hashicorp/packer.git"
+  }
+}
+`, rName, modeType)
 }
 
 func testAccAWSCodeBuildProjectConfig_Description(rName, description string) string {

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -1171,7 +1171,7 @@ resource "aws_codebuild_project" "test" {
 
   cache {
 		type     = "LOCAL"
-		modes		 = ["%s"]
+		modes    = ["%s"]
   }
 
   environment {

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -140,6 +140,46 @@ resource "aws_codebuild_project" "example" {
     "Environment" = "Test"
   }
 }
+
+resource "aws_codebuild_project" "project-with-cache" {
+  name          = "test-project-cache"
+  description   = "test_codebuild_project_cache"
+  build_timeout = "5"
+  service_role  = "${aws_iam_role.example.arn}"
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type     = "LOCAL"
+    modes    = ["LOCAL_DOCKER_LAYER_CACHE", "LOCAL_SOURCE_CACHE"]
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:1.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+
+    environment_variable {
+      "name"  = "SOME_KEY1"
+      "value" = "SOME_VALUE1"
+    }
+
+
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/mitchellh/packer.git"
+    git_clone_depth = 1
+  }
+
+  tags = {
+    "Environment" = "Test"
+  }
+}
 ```
 
 ## Argument Reference
@@ -173,8 +213,9 @@ The following arguments are supported:
 
 `cache` supports the following:
 
-* `type` - (Optional) The type of storage that will be used for the AWS CodeBuild project cache. Valid values: `NO_CACHE` and `S3`. Defaults to `NO_CACHE`.
+* `type` - (Optional) The type of storage that will be used for the AWS CodeBuild project cache. Valid values: `NO_CACHE`, `LOCAL`, and `S3`. Defaults to `NO_CACHE`.
 * `location` - (Required when cache type is `S3`) The location where the AWS CodeBuild project stores cached resources. For type `S3` the value must be a valid S3 bucket name/prefix.
+* `modes` - (Required when cache type is `LOCAL`) Specifies settings that AWS CodeBuild uses to store and reuse build dependencies. Valid values:  `LOCAL_SOURCE_CACHE`, `LOCAL_DOCKER_LAYER_CACHE`, and `LOCAL_CUSTOM_CACHE`
 
 `environment` supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/7643

Changes proposed in this pull request:

* Add `mode` to `cache` in `aws_codebuild_project`

Output from acceptance testing:

```
 make testacc  TESTARGS='-run=TestAccAWSCodeBuildProject_Cache'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCodeBuildProject_Cache -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCodeBuildProject_Cache
=== PAUSE TestAccAWSCodeBuildProject_Cache
=== CONT  TestAccAWSCodeBuildProject_Cache
--- PASS: TestAccAWSCodeBuildProject_Cache (68.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	68.265s
```
