### PR TITLE
Added support for EKS control plane logging

### DIFF
--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -403,7 +403,7 @@ func expandEksLoggingTypes(logTypes []interface{}) *eks.Logging {
 	disabledTypes := []*string{}
 	for _, defaultType := range defaultLoggingTypes {
 		logType := defaultType
-		if _, ok := sliceContainsString(logTypes, logType); ok == false {
+		if _, ok := sliceContainsString(logTypes, logType); !ok {
 			disabledTypes = append(disabledTypes, &logType)
 		}
 	}

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,6 +140,44 @@ func TestAccAWSEksCluster_Version(t *testing.T) {
 					testAccCheckAWSEksClusterExists(resourceName, &cluster2),
 					testAccCheckAWSEksClusterNotRecreated(&cluster1, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, "version", "1.11"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEksCluster_Logging(t *testing.T) {
+	var cluster1, cluster2 eks.Cluster
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "aws_eks_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEksClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEksClusterConfig_Logging(rName, []string{"api"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "logging.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logging.0", "api"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSEksClusterConfig_Logging(rName, []string{"api", "audit"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEksClusterExists(resourceName, &cluster2),
+					testAccCheckAWSEksClusterNotRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, "logging.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "logging.0", "api"),
+					resource.TestCheckResourceAttr(resourceName, "logging.1", "audit"),
 				),
 			},
 		},
@@ -432,6 +471,24 @@ resource "aws_eks_cluster" "test" {
   depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
 }
 `, testAccAWSEksClusterConfig_Base(rName), rName, version)
+}
+
+func testAccAWSEksClusterConfig_Logging(rName string, logTypes []string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_eks_cluster" "test" {
+  name     = "%s"
+  role_arn = "${aws_iam_role.test.arn}"
+  logging  = ["%v"]
+
+  vpc_config {
+    subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]
+  }
+
+  depends_on = ["aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy", "aws_iam_role_policy_attachment.test-AmazonEKSServicePolicy"]
+}
+`, testAccAWSEksClusterConfig_Base(rName), rName, strings.Join(logTypes, "\", \""))
 }
 
 func testAccAWSEksClusterConfig_VpcConfig_SecurityGroupIds(rName string) string {

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -161,8 +161,8 @@ func TestAccAWSEksCluster_Logging(t *testing.T) {
 				Config: testAccAWSEksClusterConfig_Logging(rName, []string{"api"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksClusterExists(resourceName, &cluster1),
-					resource.TestCheckResourceAttr(resourceName, "logging.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "logging.0", "api"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cluster_log_types.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cluster_log_types.0", "api"),
 				),
 			},
 			{
@@ -175,9 +175,9 @@ func TestAccAWSEksCluster_Logging(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEksClusterExists(resourceName, &cluster2),
 					testAccCheckAWSEksClusterNotRecreated(&cluster1, &cluster2),
-					resource.TestCheckResourceAttr(resourceName, "logging.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "logging.0", "api"),
-					resource.TestCheckResourceAttr(resourceName, "logging.1", "audit"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cluster_log_types.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cluster_log_types.0", "api"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cluster_log_types.1", "audit"),
 				),
 			},
 		},
@@ -480,7 +480,7 @@ func testAccAWSEksClusterConfig_Logging(rName string, logTypes []string) string 
 resource "aws_eks_cluster" "test" {
   name     = "%s"
   role_arn = "${aws_iam_role.test.arn}"
-  logging  = ["%v"]
+  enabled_cluster_log_types  = ["%v"]
 
   vpc_config {
     subnet_ids = ["${aws_subnet.test.*.id[0]}", "${aws_subnet.test.*.id[1]}"]

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -20,6 +20,8 @@ resource "aws_eks_cluster" "example" {
   vpc_config {
     subnet_ids = ["${aws_subnet.example1.id}", "${aws_subnet.example2.id}"]
   }
+
+  enabled_cluster_log_types = ["api", "audit"]
 }
 
 output "endpoint" {
@@ -39,6 +41,8 @@ The following arguments are supported:
 * `role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
 * `vpc_config` - (Required) Nested argument for the VPC associated with your cluster. Amazon EKS VPC resources have specific requirements to work properly with Kubernetes. For more information, see [Cluster VPC Considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and [Cluster Security Group Considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) in the Amazon EKS User Guide. Configuration detailed below.
 * `version` – (Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except those automatically triggered by EKS. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by EKS.
+* `enabled_cluster_log_types` - (Optional) A list of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging
+](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
 
 ### vpc_config
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8204

Changes proposed in this pull request:

* Add the ability to enable or disable the various logging for an EKS control plane

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEksCluster_Logging'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEksCluster_Logging -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEksCluster_Logging
=== PAUSE TestAccAWSEksCluster_Logging
=== CONT  TestAccAWSEksCluster_Logging
--- PASS: TestAccAWSEksCluster_Logging (1314.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1315.972s

```
