### PR TITLE
tests/resource/aws_swf_domain: Add environment variable PreCheck

### DIFF
--- a/aws/resource_aws_swf_domain_test.go
+++ b/aws/resource_aws_swf_domain_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -12,6 +13,15 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func testAccPreCheckSwfDomainTestingEnabled(t *testing.T) {
+	if os.Getenv("SWF_DOMAIN_TESTING_ENABLED") == "" {
+		t.Skip(
+			"Environment variable SWF_DOMAIN_TESTING_ENABLED is not set. " +
+				"SWF limits domains per region and the API does not support " +
+				"deletions. Set the environment variable to any value to enable.")
+	}
+}
+
 func TestAccAWSSwfDomain_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_swf_domain.test"
@@ -19,6 +29,7 @@ func TestAccAWSSwfDomain_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckSwfDomainTestingEnabled(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSwfDomainDestroy,
@@ -46,6 +57,7 @@ func TestAccAWSSwfDomain_NamePrefix(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckSwfDomainTestingEnabled(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSwfDomainDestroy,
@@ -73,6 +85,7 @@ func TestAccAWSSwfDomain_GeneratedName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckSwfDomainTestingEnabled(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSwfDomainDestroy,
@@ -99,6 +112,7 @@ func TestAccAWSSwfDomain_Description(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckSwfDomainTestingEnabled(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSwfDomainDestroy,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

SWF imposes limits on the number of SWF Domains without providing a method to delete Domains after deprecation. The daily acceptance testing will repeatedly exhaust this limit and cause perpetual errors like the below:

```
--- FAIL: TestAccAWSSwfDomain_basic (2.17s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
        	* aws_swf_domain.test: 1 error occurred:
        	* aws_swf_domain.test: LimitExceededFault: Limit on maximum number of domains per account reached
```

We allow the use of an environment variable to gate these tests with anticipation that they will only be run as necessary during development work. Semi-arbitrarily named `SWF_DOMAIN_TESTING_ENABLED` to be similar to other `ACM_*`, `API_GATEWAY_*`, `GUARDDUTY_*` environment variables used for other acceptance tests.

Output from acceptance testing:

```
--- SKIP: TestAccAWSSwfDomain_basic (1.78s)
    resource_aws_swf_domain_test.go:18: Environment variable SWF_DOMAIN_TESTING_ENABLED is not set. SWF limits domains per region and the API does not support deletions. Set the environment variable to any value to enable.
--- SKIP: TestAccAWSSwfDomain_GeneratedName (1.79s)
    resource_aws_swf_domain_test.go:18: Environment variable SWF_DOMAIN_TESTING_ENABLED is not set. SWF limits domains per region and the API does not support deletions. Set the environment variable to any value to enable.
--- SKIP: TestAccAWSSwfDomain_NamePrefix (1.80s)
    resource_aws_swf_domain_test.go:18: Environment variable SWF_DOMAIN_TESTING_ENABLED is not set. SWF limits domains per region and the API does not support deletions. Set the environment variable to any value to enable.
--- SKIP: TestAccAWSSwfDomain_Description (1.80s)
    resource_aws_swf_domain_test.go:18: Environment variable SWF_DOMAIN_TESTING_ENABLED is not set. SWF limits domains per region and the API does not support deletions. Set the environment variable to any value to enable.
```