### PR TITLE
service/secretsmanager: Handle additional scheduled/marked for deletion error messages

### DIFF
--- a/aws/resource_aws_secretsmanager_secret_version_test.go
+++ b/aws/resource_aws_secretsmanager_secret_version_test.go
@@ -148,7 +148,7 @@ func testAccCheckAwsSecretsManagerSecretVersionDestroy(s *terraform.State) error
 			if isAWSErr(err, secretsmanager.ErrCodeResourceNotFoundException, "") {
 				return nil
 			}
-			if isAWSErr(err, secretsmanager.ErrCodeInvalidRequestException, "You can’t perform this operation on the secret because it was deleted") {
+			if isAWSErr(err, secretsmanager.ErrCodeInvalidRequestException, "was deleted") || isAWSErr(err, secretsmanager.ErrCodeInvalidRequestException, "was marked for deletion") {
 				return nil
 			}
 			return err


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

It seems the Secrets Manager service now delineates the pending deletion state with different error messages. Presumably the old messages could still be returned depending on timing.

Previous output from acceptance testing:

```
--- FAIL: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (6.87s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
          * aws_secretsmanager_secret.test: 1 error occurred:
          * aws_secretsmanager_secret.test: error creating Secrets Manager Secret: InvalidRequestException: You can't create this secret because a secret with this name is already scheduled for deletion.

--- FAIL: TestAccAwsSecretsManagerSecretVersion_Base64Binary (7.05s)
    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: InvalidRequestException: You can’t perform this operation on the secret because it was marked for deletion.

--- FAIL: TestAccAwsSecretsManagerSecretVersion_BasicString (6.82s)
    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: InvalidRequestException: You can’t perform this operation on the secret because it was marked for deletion.

--- FAIL: TestAccAwsSecretsManagerSecretVersion_VersionStages (16.18s)
    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Check failed: InvalidRequestException: You can’t perform this operation on the secret because it was marked for deletion.
```

Output from acceptance testing:

```
--- PASS: TestAccAwsSecretsManagerSecret_policy (10.63s)
--- PASS: TestAccAwsSecretsManagerSecret_Basic (11.18s)
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (11.23s)
--- PASS: TestAccAwsSecretsManagerSecret_Description (19.12s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (33.62s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (45.49s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (46.06s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (48.05s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (50.75s)

--- PASS: TestAccAwsSecretsManagerSecretVersion_BasicString (11.80s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_Base64Binary (11.81s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (25.33s)
```
