### PR TITLE
Update ram_resource_association.html.markdown

### DIFF
--- a/website/docs/r/ram_resource_association.html.markdown
+++ b/website/docs/r/ram_resource_association.html.markdown
@@ -17,7 +17,7 @@ Manages a Resource Access Manager (RAM) Resource Association.
 ```hcl
 resource "aws_ram_resource_association" "example" {
   resource_arn       = "${aws_subnet.example.arn}"
-  resource_share_arn = "${aws_ram_resource_share.example.arn}"
+  resource_share_arn = "${aws_ram_resource_share.example.id}"
 }
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
Currently the documentation points to use aws_ram_resource_share.example.arn which is incorrect. The output of the aws_ram_resource_share.example is id which contains the ARN value.