### PR TITLE
tests/resource/aws_codebuild_project: Provide S3 source type testing a real bucket and object

### DIFF
--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -637,7 +637,6 @@ func TestAccAWSCodeBuildProject_Source_Type_S3(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_Source_Type_S3(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
-					resource.TestCheckResourceAttr(resourceName, "source.2751363124.type", "S3"),
 				),
 			},
 		},
@@ -1609,8 +1608,18 @@ resource "aws_codebuild_project" "test" {
 
 func testAccAWSCodeBuildProjectConfig_Source_Type_S3(rName string) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_object" "test" {
+  bucket  = "${aws_s3_bucket.test.bucket}"
+  content = "test"
+  key     = "test.txt"
+}
+
 resource "aws_codebuild_project" "test" {
-  name         = %q
+  name         = %[1]q
   service_role = "${aws_iam_role.test.arn}"
 
   artifacts {
@@ -1624,7 +1633,7 @@ resource "aws_codebuild_project" "test" {
   }
 
   source {
-    location = "bucket-name/object-name.zip"
+    location = "${aws_s3_bucket.test.bucket}/${aws_s3_bucket_object.test.key}"
     type     = "S3"
   }
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSCodeBuildProject_Source_Type_S3 (24.04s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_codebuild_project.test: 1 error occurred:
          * aws_codebuild_project.test: Error creating CodeBuild project: InvalidInputException: All access has been disabled to bucket bucket-name/object-name.zip
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (37.46s)
```