### PR TITLE
Fix production_variants spelling in sagemaker-endpoint-configuration docs

### DIFF
--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -19,7 +19,7 @@ Basic usage:
 resource "aws_sagemaker_endpoint_configuration" "ec" {
     name = "my-endpoint-config"
 
-    production_variant {
+    production_variants {
         variant_name            = "variant-1"
         model_name              = "${aws_sagemaker_model.m.name}"
         initial_instance_count  = 1
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the endpoint configuration. If omitted, Terraform will assign a random, unique name.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-The `production_variant` block supports:
+The `production_variants` block supports:
 
 * `initial_instance_count` - (Required) Initial number of instances used for auto-scaling.
 * `instance_type` (Required) - The type of instance to start.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Fixes spelling of the `production_variants` attribute in  the`sagemaker-endpoint-configuration` website docs. It's incorrectly spelled as `production_variant` in a few places.
