### PR TITLE
resource/aws_emr_cluster: Set SchemaConfigModeAttr on step configuration block attribute

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -352,10 +352,11 @@ func resourceAwsEMRCluster() *schema.Resource {
 				},
 			},
 			"step": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"action_on_failure": {
@@ -370,10 +371,11 @@ func resourceAwsEMRCluster() *schema.Resource {
 							}, false),
 						},
 						"hadoop_jar_step": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Required: true,
-							ForceNew: true,
+							Type:       schema.TypeList,
+							MaxItems:   1,
+							Required:   true,
+							ForceNew:   true,
+							ConfigMode: schema.SchemaConfigModeAttr,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"args": {

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -217,7 +217,7 @@ EOF
 
 * `visible_to_all_users` - (Optional) Whether the job flow is visible to all IAM users of the AWS account associated with the job flow. Default `true`
 * `autoscaling_role` - (Optional) An IAM role for automatic scaling policies. The IAM role provides permissions that the automatic scaling feature requires to launch and terminate EC2 instances in an instance group.
-* `step` - (Optional) List of steps to run when creating the cluster. Defined below. It is highly recommended to utilize the [lifecycle configuration block](/docs/configuration/resources.html) with `ignore_changes` if other steps are being managed outside of Terraform.
+* `step` - (Optional) List of steps to run when creating the cluster. Defined below. It is highly recommended to utilize the [lifecycle configuration block](/docs/configuration/resources.html) with `ignore_changes` if other steps are being managed outside of Terraform. This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 * `tags` - (Optional) list of tags to apply to the EMR Cluster
 
 ## ec2_attributes


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References:

* https://github.com/hashicorp/terraform/issues/20505
* https://github.com/hashicorp/terraform/pull/20626

In Terraform 0.12, behaviors with configuration blocks are more explicit to allow configuration language improvements and remove ambiguities that required various undocumented workarounds in Terraform 0.11 and prior. As a consequence, configuration blocks that are marked `Optional: true` and `Computed: true` will no longer support explicitly zero-ing out the configuration without special implementation.

The `ConfigMode` schema parameter on the configuration block attribute allows the schema to override certain behaviors. In particular, setting `ConfigMode: schema.SchemaConfigModeAttr` will allow practitioners to continue setting the configuration block attribute to an empty list (in the semantic sense, e.g. `attr = []`), keeping this prior behavior in Terraform 0.12. This parameter does not have any effect with Terraform 0.11. This solution may be temporary or revisited in the future.

Previous output from Terraform 0.11:

```
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (828.01s)
```

Previous output from Terraform 0.12:

```
--- FAIL: TestAccAWSEMRCluster_Step_ConfigMode (390.69s)
    testing.go:568: Step 4 error: config is invalid: Unsupported argument: An argument named "step" is not expected here. Did you mean to define a block of type "step"?
```

Output from Terraform 0.11:

```
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (764.03s)
```

Output from Terraform 0.12:

```
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (833.49s)
```
