### PR TITLE
Add aws_quicksight_group resource

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -616,6 +616,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_organizations_organizational_unit":                   resourceAwsOrganizationsOrganizationalUnit(),
 			"aws_placement_group":                                     resourceAwsPlacementGroup(),
 			"aws_proxy_protocol_policy":                               resourceAwsProxyProtocolPolicy(),
+			"aws_quicksight_group":                                    resourceAwsQuickSightGroup(),
 			"aws_ram_principal_association":                           resourceAwsRamPrincipalAssociation(),
 			"aws_ram_resource_association":                            resourceAwsRamResourceAssociation(),
 			"aws_ram_resource_share":                                  resourceAwsRamResourceShare(),

--- a/aws/resource_aws_quicksight_group.go
+++ b/aws/resource_aws_quicksight_group.go
@@ -1,0 +1,187 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+)
+
+func resourceAwsQuickSightGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsQuickSightGroupCreate,
+		Read:   resourceAwsQuickSightGroupRead,
+		Update: resourceAwsQuickSightGroupUpdate,
+		Delete: resourceAwsQuickSightGroupDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"aws_account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "default",
+				ValidateFunc: validation.StringInSlice([]string{
+					"default",
+				}, false),
+			},
+		},
+	}
+}
+
+func resourceAwsQuickSightGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).quicksightconn
+
+	awsAccountID := meta.(*AWSClient).accountid
+	namespace := d.Get("namespace").(string)
+
+	if v, ok := d.GetOk("aws_account_id"); ok {
+		awsAccountID = v.(string)
+	}
+
+	createOpts := &quicksight.CreateGroupInput{
+		AwsAccountId: aws.String(awsAccountID),
+		Namespace:    aws.String(namespace),
+		GroupName:    aws.String(d.Get("group_name").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		createOpts.Description = aws.String(v.(string))
+	}
+
+	resp, err := conn.CreateGroup(createOpts)
+	if err != nil {
+		return fmt.Errorf("Error creating Quick Sight Group: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s", awsAccountID, namespace, aws.StringValue(resp.Group.GroupName)))
+
+	return resourceAwsQuickSightGroupRead(d, meta)
+}
+
+func resourceAwsQuickSightGroupRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).quicksightconn
+
+	awsAccountID, namespace, groupName, err := resourceAwsQuickSightGroupParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	descOpts := &quicksight.DescribeGroupInput{
+		AwsAccountId: aws.String(awsAccountID),
+		Namespace:    aws.String(namespace),
+		GroupName:    aws.String(groupName),
+	}
+
+	resp, err := conn.DescribeGroup(descOpts)
+	if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Quick Sight Group %s is already gone", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error describing Quick Sight Group (%s): %s", d.Id(), err)
+	}
+
+	d.Set("arn", resp.Group.Arn)
+	d.Set("aws_account_id", awsAccountID)
+	d.Set("group_name", resp.Group.GroupName)
+	d.Set("description", resp.Group.Description)
+	d.Set("namespace", namespace)
+
+	return nil
+}
+
+func resourceAwsQuickSightGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).quicksightconn
+
+	awsAccountID, namespace, groupName, err := resourceAwsQuickSightGroupParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	updateOpts := &quicksight.UpdateGroupInput{
+		AwsAccountId: aws.String(awsAccountID),
+		Namespace:    aws.String(namespace),
+		GroupName:    aws.String(groupName),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		updateOpts.Description = aws.String(v.(string))
+	}
+
+	_, err = conn.UpdateGroup(updateOpts)
+	if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] Quick Sight Group %s is already gone", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error updating Quick Sight Group %s: %s", d.Id(), err)
+	}
+
+	return resourceAwsQuickSightGroupRead(d, meta)
+}
+
+func resourceAwsQuickSightGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).quicksightconn
+
+	awsAccountID, namespace, groupName, err := resourceAwsQuickSightGroupParseID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	deleteOpts := &quicksight.DeleteGroupInput{
+		AwsAccountId: aws.String(awsAccountID),
+		Namespace:    aws.String(namespace),
+		GroupName:    aws.String(groupName),
+	}
+
+	if _, err := conn.DeleteGroup(deleteOpts); err != nil {
+		if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Quick Sight Group %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsQuickSightGroupParseID(id string) (string, string, string, error) {
+	parts := strings.SplitN(id, "/", 3)
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("unexpected format of ID (%s), expected AWS_ACCOUNT_ID/NAMESPACE/GROUP_NAME", id)
+	}
+	return parts[0], parts[1], parts[2], nil
+}

--- a/aws/resource_aws_quicksight_group_test.go
+++ b/aws/resource_aws_quicksight_group_test.go
@@ -1,0 +1,235 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/quicksight"
+)
+
+func TestAccAWSQuickSightGroup_basic(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	var group quicksight.Group
+	resourceName := "aws_quicksight_group.default"
+	rName1 := acctest.RandomWithPrefix("tf-acc-test")
+	rName2 := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckQuickSightGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSQuickSightGroupConfig(rName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuickSightGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName1),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "quicksight", fmt.Sprintf("group/default/%s", rName1)),
+				),
+			},
+			{
+				Config: testAccAWSQuickSightGroupConfig(rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuickSightGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName2),
+					testAccCheckResourceAttrRegionalARN(resourceName, "arn", "quicksight", fmt.Sprintf("group/default/%s", rName2)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSQuickSightGroup_withDescription(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	var group quicksight.Group
+	resourceName := "aws_quicksight_group.default"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckQuickSightGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSQuickSightGroupConfigWithDescription(rName, "Description 1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuickSightGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "description", "Description 1"),
+				),
+			},
+			{
+				Config: testAccAWSQuickSightGroupConfigWithDescription(rName, "Description 2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuickSightGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "description", "Description 2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSQuickSightGroup_disappears(t *testing.T) {
+	oldvar := os.Getenv("AWS_DEFAULT_REGION")
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	defer os.Setenv("AWS_DEFAULT_REGION", oldvar)
+
+	var group quicksight.Group
+	resourceName := "aws_quicksight_group.default"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckQuickSightGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSQuickSightGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQuickSightGroupExists(resourceName, &group),
+					testAccCheckQuickSightGroupDisappears(&group),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckQuickSightGroupExists(resourceName string, group *quicksight.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		awsAccountID, namespace, groupName, err := resourceAwsQuickSightGroupParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).quicksightconn
+
+		input := &quicksight.DescribeGroupInput{
+			AwsAccountId: aws.String(awsAccountID),
+			Namespace:    aws.String(namespace),
+			GroupName:    aws.String(groupName),
+		}
+
+		output, err := conn.DescribeGroup(input)
+
+		if err != nil {
+			return err
+		}
+
+		if output == nil || output.Group == nil {
+			return fmt.Errorf("Quick Sight Group (%s) not found", rs.Primary.ID)
+		}
+
+		*group = *output.Group
+
+		return nil
+	}
+}
+
+func testAccCheckQuickSightGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).quicksightconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_quicksight_group" {
+			continue
+		}
+
+		awsAccountID, namespace, groupName, err := resourceAwsQuickSightGroupParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = conn.DescribeGroup(&quicksight.DescribeGroupInput{
+			AwsAccountId: aws.String(awsAccountID),
+			Namespace:    aws.String(namespace),
+			GroupName:    aws.String(groupName),
+		})
+		if isAWSErr(err, quicksight.ErrCodeResourceNotFoundException, "") {
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("Quick Sight Group '%s' was not deleted properly", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+func testAccCheckQuickSightGroupDisappears(v *quicksight.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).quicksightconn
+
+		arn, err := arn.Parse(aws.StringValue(v.Arn))
+		if err != nil {
+			return err
+		}
+
+		parts := strings.SplitN(arn.Resource, "/", 3)
+
+		input := &quicksight.DeleteGroupInput{
+			AwsAccountId: aws.String(arn.AccountID),
+			Namespace:    aws.String(parts[1]),
+			GroupName:    v.GroupName,
+		}
+
+		if _, err := conn.DeleteGroup(input); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccAWSQuickSightGroupConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_quicksight_group" "default" {
+	group_name 		= "%[1]s"
+}
+
+`, rName)
+
+}
+
+func testAccAWSQuickSightGroupConfigWithDescription(rName, description string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_quicksight_group" "default" {
+	aws_account_id 	= "${data.aws_caller_identity.current.account_id}"
+	group_name 		= "%[1]s"
+	description 	= "%[2]s"
+}
+
+`, rName, description)
+
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2134,6 +2134,15 @@
                 </li>
 
                 <li>
+                    <a href="#">QuickSight Resources</a>
+                    <ul class="nav">
+                        <li>
+                        <a href="/docs/providers/aws/r/quicksight_group.html">aws_quicksight_group</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
                     <a href="#">RAM Resources</a>
                     <ul class="nav">
                         <li>

--- a/website/docs/r/quicksight_group.html.markdown
+++ b/website/docs/r/quicksight_group.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: aws_quicksight_group"
+sidebar_current: "docs-aws-resource-quicksight-group"
+description: |-
+  Manages a Resource Quick Sight Group.
+---
+
+# Resource: aws_quicksight_group
+
+Resource for managing Quick Sight Group
+
+## Example Usage
+
+```hcl
+resource "aws_quicksight_group" "example" {
+	group_name = "tf-example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_name` - (Required) A name for the group.
+* `aws_account_id` - (Optional) The ID for the AWS account that the group is in. Currently, you use the ID for the AWS account that contains your Amazon QuickSight account.
+* `description` - (Optional) A description for the group.
+* `namespace` - (Optional) The namespace. Currently, you should set this to `default`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - Amazon Resource Name (ARN) of group
+
+## Import
+
+Quick Sight Group can be imported using the aws account id, namespace and group name separated by `/`.
+
+```
+$ terraform import aws_quicksight_group.example 123456789123/default/tf-example
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8146 

Changes proposed in this pull request:

* Add `aws_quicksight_group` resource

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='-run=TestAccAWSQuickSightGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSQuickSightGroup_ -timeout 120m
=== RUN   TestAccAWSQuickSightGroup_basic
=== PAUSE TestAccAWSQuickSightGroup_basic
=== RUN   TestAccAWSQuickSightGroup_withDescription
=== PAUSE TestAccAWSQuickSightGroup_withDescription
=== RUN   TestAccAWSQuickSightGroup_disappears
=== PAUSE TestAccAWSQuickSightGroup_disappears
=== CONT  TestAccAWSQuickSightGroup_basic
=== CONT  TestAccAWSQuickSightGroup_withDescription
=== CONT  TestAccAWSQuickSightGroup_disappears
--- PASS: TestAccAWSQuickSightGroup_disappears (35.70s)
--- PASS: TestAccAWSQuickSightGroup_withDescription (55.69s)
--- PASS: TestAccAWSQuickSightGroup_basic (56.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	56.694s
```
