### PR TITLE
Do not send cold_storage_after or delete_after if not present in configuration

### DIFF
--- a/aws/resource_aws_backup_plan.go
+++ b/aws/resource_aws_backup_plan.go
@@ -297,10 +297,10 @@ func expandBackupPlanRules(l []interface{}) []*backup.RuleInput {
 			if len(lifecycleRaw) == 1 {
 				lifecycle = lifecycleRaw[0].(map[string]interface{})
 				lcValues := &backup.Lifecycle{}
-				if lifecycle["delete_after"] != nil {
+				if lifecycle["delete_after"] != 0 {
 					lcValues.DeleteAfterDays = aws.Int64(int64(lifecycle["delete_after"].(int)))
 				}
-				if lifecycle["cold_storage_after"] != nil {
+				if lifecycle["cold_storage_after"] != 0 {
 					lcValues.MoveToColdStorageAfterDays = aws.Int64(int64(lifecycle["cold_storage_after"].(int)))
 				}
 				rule.Lifecycle = lcValues


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8151

Before:

```
aws_backup_plan.example: Creating...
  arn:                                            "" => "<computed>"
  name:                                           "" => "tf_example_backup_plan"
  rule.#:                                         "" => "1"
  rule.3014963017.completion_window:              "" => "180"
  rule.3014963017.lifecycle.#:                    "" => "1"
  rule.3014963017.lifecycle.0.cold_storage_after: "" => ""
  rule.3014963017.lifecycle.0.delete_after:       "" => "7"
  rule.3014963017.rule_name:                      "" => "tf_example_backup_rule"
  rule.3014963017.schedule:                       "" => "cron(0 12 * * ? *)"
  rule.3014963017.start_window:                   "" => "60"
  rule.3014963017.target_vault_name:              "" => "Default"
  version:                                        "" => "<computed>"

Error: Error applying plan:

1 error(s) occurred:

* aws_backup_plan.example: 1 error(s) occurred:

* aws_backup_plan.example: error creating Backup Plan: InvalidParameterValueException: Error in rule tf_example_backup_rule : Invalid lifecycle. DeleteAfterDays cannot be less than 90 days apart from MoveToColdStorageAfterDays
	status code: 400, request id: 61315cde-a397-4ce2-963f-02d6e295b327
```

After:

```
aws_backup_plan.example: Creating...
  arn:                                            "" => "<computed>"
  name:                                           "" => "tf_example_backup_plan"
  rule.#:                                         "" => "1"
  rule.3014963017.completion_window:              "" => "180"
  rule.3014963017.lifecycle.#:                    "" => "1"
  rule.3014963017.lifecycle.0.cold_storage_after: "" => ""
  rule.3014963017.lifecycle.0.delete_after:       "" => "7"
  rule.3014963017.rule_name:                      "" => "tf_example_backup_rule"
  rule.3014963017.schedule:                       "" => "cron(0 12 * * ? *)"
  rule.3014963017.start_window:                   "" => "60"
  rule.3014963017.target_vault_name:              "" => "Default"
  version:                                        "" => "<computed>"
aws_backup_plan.example: Creation complete after 1s (ID: 29a35cb5-9bfc-4e41-aff3-a3e25d75fc5f)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsBackupPlan_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsBackupPlan_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsBackupPlan_basic
=== PAUSE TestAccAwsBackupPlan_basic
=== RUN   TestAccAwsBackupPlan_withTags
=== PAUSE TestAccAwsBackupPlan_withTags
=== RUN   TestAccAwsBackupPlan_withRules
=== PAUSE TestAccAwsBackupPlan_withRules
=== RUN   TestAccAwsBackupPlan_withRuleRemove
=== PAUSE TestAccAwsBackupPlan_withRuleRemove
=== RUN   TestAccAwsBackupPlan_withRuleAdd
=== PAUSE TestAccAwsBackupPlan_withRuleAdd
=== RUN   TestAccAwsBackupPlan_withLifecycle
=== PAUSE TestAccAwsBackupPlan_withLifecycle
=== RUN   TestAccAwsBackupPlan_disappears
=== PAUSE TestAccAwsBackupPlan_disappears
=== CONT  TestAccAwsBackupPlan_basic
=== CONT  TestAccAwsBackupPlan_disappears
=== CONT  TestAccAwsBackupPlan_withRuleRemove
=== CONT  TestAccAwsBackupPlan_withLifecycle
=== CONT  TestAccAwsBackupPlan_withRuleAdd
=== CONT  TestAccAwsBackupPlan_withRules
=== CONT  TestAccAwsBackupPlan_withTags
--- PASS: TestAccAwsBackupPlan_disappears (32.81s)
--- PASS: TestAccAwsBackupPlan_withRules (35.40s)
--- PASS: TestAccAwsBackupPlan_basic (35.54s)
--- PASS: TestAccAwsBackupPlan_withLifecycle (36.20s)
--- PASS: TestAccAwsBackupPlan_withRuleRemove (60.55s)
--- PASS: TestAccAwsBackupPlan_withRuleAdd (63.40s)
--- PASS: TestAccAwsBackupPlan_withTags (91.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	92.543s


...
```
