### PR TITLE
#7441 redshift resource create/update/delete timeouts

### DIFF
--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -922,6 +922,10 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
   skip_final_snapshot = true
+
+  timeouts {
+	create = "30m"
+  }
 }`, rInt)
 }
 

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -73,6 +73,15 @@ string.
 * `snapshot_copy` - (Optional) Configuration of automatic copy of snapshots from one region to another. Documented below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+### Timeouts
+
+`aws_redshift_cluster` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `75 minutes`) Used for creating Clusters.
+- `update` - (Default `40 minutes`) Used for Cluster Argument changes.
+- `delete` - (Default `40 minutes`) Used for destroying Clusters.
+
 ### Nested Blocks
 
 #### `logging`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

Add timeouts to the `aws_redshift_cluster` resource to address issue linked (#7441).

I followed the suggestion in the issue of making it like https://www.terraform.io/docs/providers/aws/r/db_instance.html#timeouts and the related source code.

It is my first time contributing. I've read all the linked docs on contributing, but please let me know what needs to change. Thanks!

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7441

Changes proposed in this pull request:

* Add Timeout for Redshift Cluster Creation, Update, and Delete
* Updated tests to include changing a timeout
* Updated documentation to reflect changes

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSRedshiftCluster'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRedshiftCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRedshiftCluster_importBasic
=== PAUSE TestAccAWSRedshiftCluster_importBasic
=== RUN   TestAccAWSRedshiftCluster_basic
=== PAUSE TestAccAWSRedshiftCluster_basic
=== RUN   TestAccAWSRedshiftCluster_withFinalSnapshot
=== PAUSE TestAccAWSRedshiftCluster_withFinalSnapshot
=== RUN   TestAccAWSRedshiftCluster_kmsKey
=== PAUSE TestAccAWSRedshiftCluster_kmsKey
=== RUN   TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
=== PAUSE TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
=== RUN   TestAccAWSRedshiftCluster_loggingEnabled
=== PAUSE TestAccAWSRedshiftCluster_loggingEnabled
=== RUN   TestAccAWSRedshiftCluster_snapshotCopy
=== PAUSE TestAccAWSRedshiftCluster_snapshotCopy
=== RUN   TestAccAWSRedshiftCluster_iamRoles
=== PAUSE TestAccAWSRedshiftCluster_iamRoles
=== RUN   TestAccAWSRedshiftCluster_publiclyAccessible
=== PAUSE TestAccAWSRedshiftCluster_publiclyAccessible
=== RUN   TestAccAWSRedshiftCluster_updateNodeCount
=== PAUSE TestAccAWSRedshiftCluster_updateNodeCount
=== RUN   TestAccAWSRedshiftCluster_updateNodeType
=== PAUSE TestAccAWSRedshiftCluster_updateNodeType
=== RUN   TestAccAWSRedshiftCluster_tags
=== PAUSE TestAccAWSRedshiftCluster_tags
=== RUN   TestAccAWSRedshiftCluster_forceNewUsername
=== PAUSE TestAccAWSRedshiftCluster_forceNewUsername
=== RUN   TestAccAWSRedshiftCluster_changeAvailabilityZone
=== PAUSE TestAccAWSRedshiftCluster_changeAvailabilityZone
=== RUN   TestAccAWSRedshiftCluster_changeEncryption1
=== PAUSE TestAccAWSRedshiftCluster_changeEncryption1
=== RUN   TestAccAWSRedshiftCluster_changeEncryption2
=== PAUSE TestAccAWSRedshiftCluster_changeEncryption2
=== CONT  TestAccAWSRedshiftCluster_importBasic
=== CONT  TestAccAWSRedshiftCluster_publiclyAccessible
=== CONT  TestAccAWSRedshiftCluster_updateNodeCount
=== CONT  TestAccAWSRedshiftCluster_changeEncryption2
=== CONT  TestAccAWSRedshiftCluster_changeEncryption1
=== CONT  TestAccAWSRedshiftCluster_changeAvailabilityZone
=== CONT  TestAccAWSRedshiftCluster_forceNewUsername
=== CONT  TestAccAWSRedshiftCluster_tags
=== CONT  TestAccAWSRedshiftCluster_updateNodeType
=== CONT  TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled
=== CONT  TestAccAWSRedshiftCluster_withFinalSnapshot
=== CONT  TestAccAWSRedshiftCluster_iamRoles
=== CONT  TestAccAWSRedshiftCluster_snapshotCopy
=== CONT  TestAccAWSRedshiftCluster_kmsKey
=== CONT  TestAccAWSRedshiftCluster_basic
=== CONT  TestAccAWSRedshiftCluster_loggingEnabled
--- PASS: TestAccAWSRedshiftCluster_tags (609.50s)
--- PASS: TestAccAWSRedshiftCluster_kmsKey (630.01s)
--- PASS: TestAccAWSRedshiftCluster_importBasic (639.67s)
--- PASS: TestAccAWSRedshiftCluster_publiclyAccessible (649.04s)
--- PASS: TestAccAWSRedshiftCluster_snapshotCopy (650.16s)
--- PASS: TestAccAWSRedshiftCluster_basic (650.67s)
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (660.05s)
--- PASS: TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled (711.71s)
--- PASS: TestAccAWSRedshiftCluster_iamRoles (733.98s)
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (889.45s)
--- PASS: TestAccAWSRedshiftCluster_changeAvailabilityZone (1075.75s)
--- PASS: TestAccAWSRedshiftCluster_forceNewUsername (1089.13s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeType (3828.96s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption2 (4028.25s)
--- PASS: TestAccAWSRedshiftCluster_updateNodeCount (4153.38s)
--- PASS: TestAccAWSRedshiftCluster_changeEncryption1 (4364.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       4364.303s
```
