### PR TITLE
Corrected ec2_transit_gateway example usage by filter

### DIFF
--- a/website/docs/d/ec2_transit_gateway.html.markdown
+++ b/website/docs/d/ec2_transit_gateway.html.markdown
@@ -17,7 +17,7 @@ Get information on an EC2 Transit Gateway.
 ```hcl
 data "aws_ec2_transit_gateway" "example" {
   filter {
-    name   = "amazon-side-asn"
+    name   = "options.amazon-side-asn"
     values = ["64512"]
   }
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:
* documentation specifies `amazon-side-asn` should be `options.amazon-side-asn`
  * https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-transit-gateways.html#options