### PR TITLE
docs/provider: Sidebar updates for ordering and clarity

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -517,7 +517,7 @@
                 </li>
 
                 <li>
-                    <a href="#">App Autoscaling Resources</a>
+                    <a href="#">Application Autoscaling Resources</a>
                     <ul class="nav">
                       <li>
                         <a href="/docs/providers/aws/r/appautoscaling_policy.html">aws_appautoscaling_policy</a>
@@ -583,6 +583,35 @@
                 </li>
 
                 <li>
+                    <a href="#">Autoscaling Resources</a>
+                    <ul class="nav">
+                        <li>
+                          <a href="/docs/providers/aws/r/autoscaling_attachment.html">aws_autoscaling_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hook</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/autoscaling_policy.html">aws_autoscaling_policy</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/autoscaling_schedule.html">aws_autoscaling_schedule</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
                     <a href="#">Backup Resources</a>
                     <ul class="nav">
                         <li>
@@ -613,19 +642,19 @@
                 </li>
 
                 <li>
-                    <a href="#">Cloud9 Resources</a>
+                    <a href="#">Budgets Resources</a>
                     <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/cloud9_environment_ec2.html">aws_cloud9_environment_ec2</a>
+                            <a href="/docs/providers/aws/r/budgets_budget.html">aws_budgets_budget</a>
                         </li>
                     </ul>
                 </li>
 
                 <li>
-                    <a href="#">Budget Resources</a>
+                    <a href="#">Cloud9 Resources</a>
                     <ul class="nav">
                         <li>
-                            <a href="/docs/providers/aws/r/budgets_budget.html">aws_budgets_budget</a>
+                            <a href="/docs/providers/aws/r/cloud9_environment_ec2.html">aws_cloud9_environment_ec2</a>
                         </li>
                     </ul>
                 </li>
@@ -873,7 +902,7 @@
                 </li>
 
                 <li>
-                    <a href="#">Data Lifecycle Manager Resources</a>
+                    <a href="#">Data Lifecycle Manager (DLM) Resources</a>
                     <ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/dlm_lifecycle_policy.html">aws_dlm_lifecycle_policy</a>
@@ -882,7 +911,7 @@
                 </li>
 
                 <li>
-                    <a href="#">Database Migration Service</a>
+                    <a href="#">Database Migration Service (DMS) Resources</a>
                     <ul class="nav">
 
                         <li>
@@ -1022,7 +1051,7 @@
 
 
                 <li>
-                    <a href="#">DynamoDB Accelerator Resources</a>
+                    <a href="#">DynamoDB Accelerator (DAX) Resources</a>
                     <ul class="nav">
 
                         <li>
@@ -1067,33 +1096,9 @@
                     </ul>
                 </li>
 
-                <li<%= sidebar_current("docs-aws-resource-(ami|app|autoscaling|ebs|elb|elbv2|eip|instance|launch|lb|proxy|snapshot|spot|volume|placement|key-pair|elb_attachment|load-balancer)") %>>
+                <li>
                     <a href="#">EC2 Resources</a>
                     <ul class="nav">
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb.html">aws_alb</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_listener.html">aws_alb_listener</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_alb_listener_certificate</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_listener_rule.html">aws_alb_listener_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_target_group.html">aws_alb_target_group</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_target_group_attachment.html">aws_alb_target_group_attachment</a>
-                        </li>
 
                         <li>
                             <a href="/docs/providers/aws/r/ami.html">aws_ami</a>
@@ -1109,38 +1114,6 @@
 
                         <li>
                             <a href="/docs/providers/aws/r/ami_launch_permission.html">aws_ami_launch_permission</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/autoscaling_attachment.html">aws_autoscaling_attachment</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/autoscaling_group.html">aws_autoscaling_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/autoscaling_lifecycle_hooks.html">aws_autoscaling_lifecycle_hook</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/autoscaling_notification.html">aws_autoscaling_notification</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/autoscaling_policy.html">aws_autoscaling_policy</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/autoscaling_schedule.html">aws_autoscaling_schedule</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/snapshot_create_volume_permission.html">aws_snapshot_create_volume_permission</a>
                         </li>
 
                         <li>
@@ -1204,14 +1177,6 @@
                         </li>
 
                         <li>
-                            <a href="/docs/providers/aws/r/elb.html">aws_elb</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/elb_attachment.html">aws_elb_attachment</a>
-                        </li>
-
-                        <li>
                             <a href="/docs/providers/aws/r/instance.html">aws_instance</a>
                         </li>
 
@@ -1228,30 +1193,11 @@
                         </li>
 
                         <li>
-                            <a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_ssl_negotiation_policy.html">aws_lb_ssl_negotiation_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/load_balancer_backend_server_policy.html">aws_load_balancer_backend_server_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/load_balancer_listener_policy.html">aws_load_balancer_listener_policy</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/load_balancer_policy.html">aws_load_balancer_policy</a>
-                        </li>
-
-                        <li>
                             <a href="/docs/providers/aws/r/placement_group.html">aws_placement_group</a>
                         </li>
+
                         <li>
-                            <a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
+                          <a href="/docs/providers/aws/r/snapshot_create_volume_permission.html">aws_snapshot_create_volume_permission</a>
                         </li>
 
                         <li>
@@ -1273,37 +1219,7 @@
                 </li>
 
                 <li>
-                    <a href="#">Load Balancing Resources</a>
-                    <ul class="nav">
-                        <li>
-                            <a href="/docs/providers/aws/r/lb.html">aws_lb</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_listener.html">aws_lb_listener</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_lb_listener_certificate</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_listener_rule.html">aws_lb_listener_rule</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/lb_target_group.html">aws_lb_target_group</a>
-                        </li>
-
-                        <li>
-                          <a href="/docs/providers/aws/r/lb_target_group_attachment.html">aws_lb_target_group_attachment</a>
-                        </li>
-                    </ul>
-                </li>
-
-
-                <li<%= sidebar_current("docs-aws-resource-(ecs|ecr)") %>>
-                    <a href="#">ECS Resources</a>
+                    <a href="#">ECR Resources</a>
                     <ul class="nav">
 
                         <li>
@@ -1317,6 +1233,14 @@
                         <li>
                             <a href="/docs/providers/aws/r/ecr_repository_policy.html">aws_ecr_repository_policy</a>
                         </li>
+
+                    </ul>
+                </li>
+
+
+                <li>
+                    <a href="#">ECS Resources</a>
+                    <ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
@@ -1332,7 +1256,6 @@
 
                     </ul>
                 </li>
-
 
                 <li>
                     <a href="#">EFS Resources</a>
@@ -1410,7 +1333,77 @@
                 </li>
 
                 <li>
-                    <a href="#">Elastic Map Reduce Resources</a>
+                    <a href="#">Elastic Load Balancing (ELB Classic) Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/app_cookie_stickiness_policy.html">aws_app_cookie_stickiness_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elb.html">aws_elb</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/elb_attachment.html">aws_elb_attachment</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_cookie_stickiness_policy.html">aws_lb_cookie_stickiness_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_ssl_negotiation_policy.html">aws_lb_ssl_negotiation_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/load_balancer_backend_server_policy.html">aws_load_balancer_backend_server_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/load_balancer_listener_policy.html">aws_load_balancer_listener_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/load_balancer_policy.html">aws_load_balancer_policy</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/proxy_protocol_policy.html">aws_proxy_protocol_policy</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Elastic Load Balancing v2 (ALB/NLB) Resources</a>
+                    <ul class="nav">
+                        <li>
+                            <a href="/docs/providers/aws/r/lb.html">aws_lb</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_listener.html">aws_lb_listener</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/lb_listener_certificate.html">aws_lb_listener_certificate</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/lb_listener_rule.html">aws_lb_listener_rule</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/lb_target_group.html">aws_lb_target_group</a>
+                        </li>
+
+                        <li>
+                          <a href="/docs/providers/aws/r/lb_target_group_attachment.html">aws_lb_target_group_attachment</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">Elastic Map Reduce (EMR) Resources</a>
                     <ul class="nav">
                         <li>
                             <a href="/docs/providers/aws/r/emr_cluster.html">aws_emr_cluster</a>
@@ -1881,6 +1874,41 @@
                 </li>
 
                 <li>
+                    <a href="#">Neptune Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_subnet_group.html">aws_neptune_subnet_group</a>
+                        </li>
+
+                         <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster_parameter_group.html">aws_neptune_cluster_parameter_group</a>
+                        </li>
+
+                         <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster.html">aws_neptune_cluster</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster_instance.html">aws_neptune_cluster_instance</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_cluster_snapshot.html">aws_neptune_cluster_snapshot</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/neptune_event_subscription.html">aws_neptune_event_subscription</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
                     <a href="#">OpsWorks Resources</a>
                     <ul class="nav">
 
@@ -2025,7 +2053,7 @@
                     </ul>
                 </li>
 
-                <li<%= sidebar_current("docs-aws-resource-(db|rds)") %>>
+                <li>
                     <a href="#">RDS Resources</a>
                     <ul class="nav">
 
@@ -2083,41 +2111,6 @@
                     </ul>
                 </li>
 
-                 <li>
-                    <a href="#">Neptune Resources</a>
-                    <ul class="nav">
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_parameter_group.html">aws_neptune_parameter_group</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_subnet_group.html">aws_neptune_subnet_group</a>
-                        </li>
-
-                         <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster_parameter_group.html">aws_neptune_cluster_parameter_group</a>
-                        </li>
-
-                         <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster.html">aws_neptune_cluster</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster_instance.html">aws_neptune_cluster_instance</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_cluster_snapshot.html">aws_neptune_cluster_snapshot</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/neptune_event_subscription.html">aws_neptune_event_subscription</a>
-                        </li>
-
-                    </ul>
-                </li>
-
               <li>
                 <a href="#">Redshift Resources</a>
                 <ul class="nav">
@@ -2156,129 +2149,6 @@
                   <li>
                     <a href="/docs/providers/aws/r/resourcegroups_group.html">aws_resourcegroups_group</a>
                   </li>
-                </ul>
-              </li>
-
-              <li>
-                <a href="#">WAF Resources</a>
-                <ul class="nav">
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_geo_match_set.html">aws_waf_geo_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_ipset.html">aws_waf_ipset</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_regex_match_set.html">aws_waf_regex_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_regex_pattern_set.html">aws_waf_regex_pattern_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_rule.html">aws_waf_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_rule_group.html">aws_waf_rule_group</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_size_constraint_set.html">aws_waf_size_constraint_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_sql_injection_match_set.html">aws_waf_sql_injection_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_web_acl.html">aws_waf_web_acl</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/waf_xss_match_set.html">aws_waf_xss_match_set</a>
-                  </li>
-
-                </ul>
-              </li>
-
-              <li>
-                <a href="#">WAF Regional Resources</a>
-                <ul class="nav">
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_geo_match_set.html">aws_wafregional_geo_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_ipset.html">aws_wafregional_ipset</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_regex_match_set.html">aws_wafregional_regex_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_regex_pattern_set.html">aws_wafregional_regex_pattern_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_rule.html">aws_wafregional_rule</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_rule_group.html">aws_wafregional_rule_group</a>
-                  </li>
-
-                   <li>
-                    <a href="/docs/providers/aws/r/wafregional_size_constraint_set.html">aws_wafregional_size_constraint_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_sql_injection_match_set.html">aws_wafregional_sql_injection_match_set</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_web_acl.html">aws_wafregional_web_acl</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_web_acl_association.html">aws_wafregional_web_acl_association</a>
-                  </li>
-
-                  <li>
-                    <a href="/docs/providers/aws/r/wafregional_xss_match_set.html">aws_wafregional_xss_match_set</a>
-                  </li>
-
-                </ul>
-              </li>
-
-              <li>
-                <a href="#">WorkLink Resources</a>
-                <ul class="nav">
-                    <li>
-                        <a href="/docs/providers/aws/r/worklink_fleet.html">aws_worklink_fleet</a>
-                    </li>
                 </ul>
               </li>
 
@@ -2523,22 +2393,6 @@
                 </li>
 
                 <li>
-                    <a href="#">Step Function Resources</a>
-                    <ul class="nav">
-
-                        <li>
-                            <a href="/docs/providers/aws/r/sfn_activity.html">aws_sfn_activity</a>
-                        </li>
-
-                        <li>
-                            <a href="/docs/providers/aws/r/sfn_state_machine.html">aws_sfn_state_machine</a>
-                        </li>
-
-                    </ul>
-                </li>
-
-
-                <li>
                     <a href="#">SimpleDB Resources</a>
                     <ul class="nav">
 
@@ -2572,6 +2426,21 @@
 
                         <li>
                             <a href="/docs/providers/aws/r/sns_topic_subscription.html">aws_sns_topic_subscription</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
+                    <a href="#">SQS Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
+                        </li>
+
+                        <li>
+                            <a href="/docs/providers/aws/r/sqs_queue_policy.html">aws_sqs_queue_policy</a>
                         </li>
 
                     </ul>
@@ -2624,15 +2493,15 @@
                 </li>
 
                 <li>
-                    <a href="#">SQS Resources</a>
+                    <a href="#">Step Function (SFN) Resources</a>
                     <ul class="nav">
 
                         <li>
-                            <a href="/docs/providers/aws/r/sqs_queue.html">aws_sqs_queue</a>
+                            <a href="/docs/providers/aws/r/sfn_activity.html">aws_sfn_activity</a>
                         </li>
 
                         <li>
-                            <a href="/docs/providers/aws/r/sqs_queue_policy.html">aws_sqs_queue_policy</a>
+                            <a href="/docs/providers/aws/r/sfn_state_machine.html">aws_sfn_state_machine</a>
                         </li>
 
                     </ul>
@@ -2702,7 +2571,7 @@
                     </ul>
                 </li>
 
-                <li<%= sidebar_current("docs-aws-resource-(default|customer|egress-only-internet-gateway|flow|internet-gateway|main-route|network|route-|security-group|security-group-attachment|subnet|vpc|vpn)") %>>
+                <li>
                     <a href="#">VPC Resources</a>
                     <ul class="nav">
 
@@ -2768,11 +2637,11 @@
                         <li>
                             <a href="/docs/providers/aws/r/network_interface_attachment.html">aws_network_interface_attachment</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-resource-route|") %>>
+                        <li>
                           <a href="/docs/providers/aws/r/route.html">aws_route</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-aws-resource-route-table|") %>>
+                        <li>
                             <a href="/docs/providers/aws/r/route_table.html">aws_route_table</a>
                         </li>
 
@@ -2870,6 +2739,129 @@
 
                     </ul>
                 </li>
+
+<li>
+                <a href="#">WAF Resources</a>
+                <ul class="nav">
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_byte_match_set.html">aws_waf_byte_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_geo_match_set.html">aws_waf_geo_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_ipset.html">aws_waf_ipset</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_rate_based_rule.html">aws_waf_rate_based_rule</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_regex_match_set.html">aws_waf_regex_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_regex_pattern_set.html">aws_waf_regex_pattern_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_rule.html">aws_waf_rule</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_rule_group.html">aws_waf_rule_group</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_size_constraint_set.html">aws_waf_size_constraint_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_sql_injection_match_set.html">aws_waf_sql_injection_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_web_acl.html">aws_waf_web_acl</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/waf_xss_match_set.html">aws_waf_xss_match_set</a>
+                  </li>
+
+                </ul>
+              </li>
+
+              <li>
+                <a href="#">WAF Regional Resources</a>
+                <ul class="nav">
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_geo_match_set.html">aws_wafregional_geo_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_ipset.html">aws_wafregional_ipset</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_rate_based_rule.html">aws_wafregional_rate_based_rule</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_regex_match_set.html">aws_wafregional_regex_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_regex_pattern_set.html">aws_wafregional_regex_pattern_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_rule.html">aws_wafregional_rule</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_rule_group.html">aws_wafregional_rule_group</a>
+                  </li>
+
+                   <li>
+                    <a href="/docs/providers/aws/r/wafregional_size_constraint_set.html">aws_wafregional_size_constraint_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_sql_injection_match_set.html">aws_wafregional_sql_injection_match_set</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_web_acl.html">aws_wafregional_web_acl</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_web_acl_association.html">aws_wafregional_web_acl_association</a>
+                  </li>
+
+                  <li>
+                    <a href="/docs/providers/aws/r/wafregional_xss_match_set.html">aws_wafregional_xss_match_set</a>
+                  </li>
+
+                </ul>
+              </li>
+
+              <li>
+                <a href="#">WorkLink Resources</a>
+                <ul class="nav">
+                    <li>
+                        <a href="/docs/providers/aws/r/worklink_fleet.html">aws_worklink_fleet</a>
+                    </li>
+                </ul>
+              </li>
 
             </ul>
         </div>


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes:

* Order all service Resources sections
* Remove lingering `sidebar_current` references
* Split EC2 Resources into more appropriate AutoScaling and Elastic Load Balancing (ELB Classic)
* Split ECS Resources into more appropriate ECR and ECS
* Rename Load Balancing to Elastic Load Balancing v2 (ALB/NLB)
* Add common acronyms to some section headers (e.g. DLM, DMS)