### PR TITLE
New resource: ram_resource_share_accepter

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -633,6 +633,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ram_principal_association":                           resourceAwsRamPrincipalAssociation(),
 			"aws_ram_resource_association":                            resourceAwsRamResourceAssociation(),
 			"aws_ram_resource_share":                                  resourceAwsRamResourceShare(),
+			"aws_ram_resource_share_accepter":                         resourceAwsRamResourceShareAccepter(),
 			"aws_rds_cluster":                                         resourceAwsRDSCluster(),
 			"aws_rds_cluster_endpoint":                                resourceAwsRDSClusterEndpoint(),
 			"aws_rds_cluster_instance":                                resourceAwsRDSClusterInstance(),

--- a/aws/resource_aws_ram_resource_share_accepter.go
+++ b/aws/resource_aws_ram_resource_share_accepter.go
@@ -193,14 +193,6 @@ func resourceAwsRamResourceShareAccepterRead(d *schema.ResourceData, meta interf
 	return nil
 }
 
-/*
-func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("")
-	log.Printf("[WARN] Will not delete resource share invitation. Terraform will remove this invitation accepter from the state file. However, resources may remain.")
-	return nil
-}
-*/
-
 func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ramconn
 

--- a/aws/resource_aws_ram_resource_share_accepter.go
+++ b/aws/resource_aws_ram_resource_share_accepter.go
@@ -1,0 +1,163 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ram"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsRamResourceShareAccepter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsRamResourceShareAccepterCreate,
+		Read:   resourceAwsRamResourceShareAccepterRead,
+		Delete: resourceAwsRamResourceShareAccepterDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"receiver_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"sender_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"share_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"share_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"client_token": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+		},
+	}
+}
+
+func resourceAwsRamResourceShareAccepterCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ramconn
+
+	requestInput := &ram.AcceptResourceShareInvitationInput{
+		ResourceShareInvitationArn: aws.String(d.Get("arn").(string)),
+	}
+
+	if v, ok := d.GetOk("client_token"); ok {
+		requestInput.ClientToken = aws.String(v.(string))
+	}
+
+	log.Println("[DEBUG] Accept RAM resource share invitation request:", requestInput)
+	requestOutput, err := conn.AcceptResourceShareInvitation(requestInput)
+	if err != nil {
+		return fmt.Errorf("Error accepting RAM resource share invitation: %s", err)
+	}
+
+	d.SetId(aws.StringValue(requestOutput.ResourceShareInvitation.ResourceShareInvitationArn))
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ram.ResourceShareInvitationStatusPending},
+		Target:  []string{ram.ResourceShareInvitationStatusAccepted},
+		Refresh: resourceAwsRamResourceShareAccepterStateRefreshFunc(conn, d.Id()),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for RAM resource share invitation (%s) state: %s", d.Id(), err)
+	}
+
+	return resourceAwsRamResourceShareAccepterRead(d, meta)
+}
+
+func resourceAwsRamResourceShareAccepterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ramconn
+
+	request := &ram.GetResourceShareInvitationsInput{
+		ResourceShareInvitationArns: []*string{aws.String(d.Id())},
+	}
+
+	output, err := conn.GetResourceShareInvitations(request)
+	if err != nil {
+		if isAWSErr(err, ram.ErrCodeUnknownResourceException, "") {
+			log.Printf("[WARN] No RAM resource share invitation by ARN (%s) found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading RAM resource share invitation %s: %s", d.Id(), err)
+	}
+
+	if len(output.ResourceShareInvitations) == 0 {
+		log.Printf("[WARN] No RAM resource share invitation by ARN (%s) found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	invitation := output.ResourceShareInvitations[0]
+
+	d.Set("status", invitation.Status)
+	d.Set("receiver_account_id", invitation.ReceiverAccountId)
+	d.Set("sender_account_id", invitation.SenderAccountId)
+	d.Set("share_arn", invitation.ResourceShareArn)
+	d.Set("share_name", invitation.ResourceShareName)
+
+	return nil
+}
+
+func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Will not delete resource share invitation. Terraform will remove this invitation from the state file. However, resources may remain.")
+	return nil
+}
+
+func resourceAwsRamResourceShareAccepterStateRefreshFunc(conn *ram.RAM, invitationArn string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		request := &ram.GetResourceShareInvitationsInput{
+			ResourceShareInvitationArns: []*string{aws.String(invitationArn)},
+		}
+
+		output, err := conn.GetResourceShareInvitations(request)
+
+		if err != nil {
+			return nil, "Unable to get resource share invitations", err
+		}
+
+		if len(output.ResourceShareInvitations) == 0 {
+			return nil, "Resource share invitation not found", nil
+		}
+
+		invitation := output.ResourceShareInvitations[0]
+
+		return invitation, aws.StringValue(invitation.Status), nil
+	}
+}

--- a/aws/resource_aws_ram_resource_share_accepter.go
+++ b/aws/resource_aws_ram_resource_share_accepter.go
@@ -3,14 +3,15 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ram"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsRamResourceShareAccepter() *schema.Resource {
@@ -19,17 +20,35 @@ func resourceAwsRamResourceShareAccepter() *schema.Resource {
 		Read:   resourceAwsRamResourceShareAccepterRead,
 		Delete: resourceAwsRamResourceShareAccepterDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": {
+			"invitation_arn": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
 				ValidateFunc: validateArn,
+			},
+
+			"share_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validateArn,
+			},
+
+			"share_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"status": {
@@ -47,21 +66,17 @@ func resourceAwsRamResourceShareAccepter() *schema.Resource {
 				Computed: true,
 			},
 
-			"share_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"share_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"client_token": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 64),
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 		},
 	}
@@ -70,21 +85,31 @@ func resourceAwsRamResourceShareAccepter() *schema.Resource {
 func resourceAwsRamResourceShareAccepterCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ramconn
 
-	requestInput := &ram.AcceptResourceShareInvitationInput{
-		ResourceShareInvitationArn: aws.String(d.Get("arn").(string)),
+	in := &ram.AcceptResourceShareInvitationInput{
+		ClientToken: aws.String(resource.UniqueId()),
 	}
 
-	if v, ok := d.GetOk("client_token"); ok {
-		requestInput.ClientToken = aws.String(v.(string))
+	if v, ok := d.GetOk("invitation_arn"); ok {
+		in.ResourceShareInvitationArn = aws.String(v.(string))
+	} else if v, ok := d.GetOk("share_arn"); ok {
+		// need to find invitation arn
+		invitationARN, err := resourceAwsRamResourceShareGetInvitationARN(conn, v.(string))
+		if err != nil {
+			return err
+		}
+
+		in.ResourceShareInvitationArn = aws.String(invitationARN)
+	} else {
+		return fmt.Errorf("Either an invitation ARN or share ARN are required")
 	}
 
-	log.Println("[DEBUG] Accept RAM resource share invitation request:", requestInput)
-	requestOutput, err := conn.AcceptResourceShareInvitation(requestInput)
+	log.Printf("[DEBUG] Accept RAM resource share invitation request: %s", in)
+	out, err := conn.AcceptResourceShareInvitation(in)
 	if err != nil {
 		return fmt.Errorf("Error accepting RAM resource share invitation: %s", err)
 	}
 
-	d.SetId(aws.StringValue(requestOutput.ResourceShareInvitation.ResourceShareInvitationArn))
+	d.SetId(aws.StringValue(out.ResourceShareInvitation.ResourceShareInvitationArn))
 
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{ram.ResourceShareInvitationStatusPending},
@@ -95,7 +120,7 @@ func resourceAwsRamResourceShareAccepterCreate(d *schema.ResourceData, meta inte
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for RAM resource share invitation (%s) state: %s", d.Id(), err)
+		return fmt.Errorf("Error waiting for RAM resource share (%s) state: %s", d.Id(), err)
 	}
 
 	return resourceAwsRamResourceShareAccepterRead(d, meta)
@@ -108,7 +133,7 @@ func resourceAwsRamResourceShareAccepterRead(d *schema.ResourceData, meta interf
 		ResourceShareInvitationArns: []*string{aws.String(d.Id())},
 	}
 
-	output, err := conn.GetResourceShareInvitations(request)
+	out, err := conn.GetResourceShareInvitations(request)
 	if err != nil {
 		if isAWSErr(err, ram.ErrCodeUnknownResourceException, "") {
 			log.Printf("[WARN] No RAM resource share invitation by ARN (%s) found, removing from state", d.Id())
@@ -118,26 +143,139 @@ func resourceAwsRamResourceShareAccepterRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error reading RAM resource share invitation %s: %s", d.Id(), err)
 	}
 
-	if len(output.ResourceShareInvitations) == 0 {
+	if len(out.ResourceShareInvitations) == 0 {
 		log.Printf("[WARN] No RAM resource share invitation by ARN (%s) found, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}
 
-	invitation := output.ResourceShareInvitations[0]
+	invitation := out.ResourceShareInvitations[0]
 
 	d.Set("status", invitation.Status)
 	d.Set("receiver_account_id", invitation.ReceiverAccountId)
 	d.Set("sender_account_id", invitation.SenderAccountId)
 	d.Set("share_arn", invitation.ResourceShareArn)
+	d.Set("invitation_arn", invitation.ResourceShareInvitationArn)
+	d.Set("share_id", resourceAwsRamResourceShareGetIDFromARN(aws.StringValue(invitation.ResourceShareArn)))
 	d.Set("share_name", invitation.ResourceShareName)
+
+	var nextToken string
+	var resourceARNs []*string
+	for {
+		listInput := &ram.ListResourcesInput{
+			MaxResults:        aws.Int64(int64(500)),
+			ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
+			ResourceShareArns: aws.StringSlice([]string{aws.StringValue(invitation.ResourceShareArn)}),
+			Principal:         invitation.SenderAccountId,
+		}
+
+		if nextToken != "" {
+			listInput.NextToken = aws.String(nextToken)
+		}
+		out, err := conn.ListResources(listInput)
+		if err != nil {
+			return fmt.Errorf("could not list share resources: %s", err)
+		}
+		for _, resource := range out.Resources {
+			resourceARNs = append(resourceARNs, resource.Arn)
+		}
+
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = aws.StringValue(out.NextToken)
+	}
+
+	if err := d.Set("resources", flattenStringList(resourceARNs)); err != nil {
+		return fmt.Errorf("unable to set resources: %s", err)
+	}
 
 	return nil
 }
 
+/*
 func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[WARN] Will not delete resource share invitation. Terraform will remove this invitation from the state file. However, resources may remain.")
+	d.SetId("")
+	log.Printf("[WARN] Will not delete resource share invitation. Terraform will remove this invitation accepter from the state file. However, resources may remain.")
 	return nil
+}
+*/
+
+func resourceAwsRamResourceShareAccepterDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ramconn
+
+	v, ok := d.GetOk("share_arn")
+	if !ok {
+		return fmt.Errorf("The share ARN is required to leave a resource share")
+	}
+	shareARN := v.(string)
+
+	v, ok = d.GetOk("receiver_account_id")
+	if !ok {
+		return fmt.Errorf("The receiver account ID is required to leave a resource share")
+	}
+	receiverID := v.(string)
+
+	in := &ram.DisassociateResourceShareInput{
+		ClientToken:      aws.String(resource.UniqueId()),
+		ResourceShareArn: aws.String(shareARN),
+		Principals:       []*string{aws.String(receiverID)},
+	}
+	log.Printf("[DEBUG] Leaving RAM resource share request: %s", in)
+	_, err := conn.DisassociateResourceShare(in)
+	if err != nil {
+		return fmt.Errorf("Error leaving RAM resource share: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{ram.ResourceShareAssociationStatusAssociated},
+		Target:  []string{ram.ResourceShareAssociationStatusDisassociated},
+		Refresh: resourceAwsRamResourceShareStateRefreshFunc(conn, shareARN),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, err := stateConf.WaitForState(); err != nil {
+		if awserr, ok := err.(awserr.Error); ok {
+			switch awserr.Code() {
+			case ram.ErrCodeUnknownResourceException:
+				// what we want
+				d.SetId("")
+				return nil
+			}
+		}
+		return fmt.Errorf("Error waiting for RAM resource share (%s) state: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsRamResourceShareGetInvitationARN(conn *ram.RAM, resourceShareARN string) (string, error) {
+	var nextToken string
+	for {
+		input := &ram.GetResourceShareInvitationsInput{
+			MaxResults:        aws.Int64(int64(500)),
+			ResourceShareArns: aws.StringSlice([]string{resourceShareARN}),
+		}
+		if nextToken != "" {
+			input.NextToken = aws.String(nextToken)
+		}
+		out, err := conn.GetResourceShareInvitations(input)
+		if err != nil {
+			return "", err
+		}
+		for _, invitation := range out.ResourceShareInvitations {
+			if aws.StringValue(invitation.Status) == ram.ResourceShareInvitationStatusPending {
+				return aws.StringValue(invitation.ResourceShareInvitationArn), nil
+			}
+		}
+
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = aws.StringValue(out.NextToken)
+	}
+
+	return "", fmt.Errorf("Unable to find a pending invitation for resource share %s", resourceShareARN)
 }
 
 func resourceAwsRamResourceShareAccepterStateRefreshFunc(conn *ram.RAM, invitationArn string) resource.StateRefreshFunc {
@@ -146,18 +284,22 @@ func resourceAwsRamResourceShareAccepterStateRefreshFunc(conn *ram.RAM, invitati
 			ResourceShareInvitationArns: []*string{aws.String(invitationArn)},
 		}
 
-		output, err := conn.GetResourceShareInvitations(request)
+		out, err := conn.GetResourceShareInvitations(request)
 
 		if err != nil {
 			return nil, "Unable to get resource share invitations", err
 		}
 
-		if len(output.ResourceShareInvitations) == 0 {
+		if len(out.ResourceShareInvitations) == 0 {
 			return nil, "Resource share invitation not found", nil
 		}
 
-		invitation := output.ResourceShareInvitations[0]
+		invitation := out.ResourceShareInvitations[0]
 
 		return invitation, aws.StringValue(invitation.Status), nil
 	}
+}
+
+func resourceAwsRamResourceShareGetIDFromARN(arn string) string {
+	return strings.Replace(arn[strings.LastIndex(arn, ":")+1:], "resource-share/", "rs-", -1)
 }

--- a/aws/resource_aws_ram_resource_share_accepter_test.go
+++ b/aws/resource_aws_ram_resource_share_accepter_test.go
@@ -1,0 +1,128 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ram"
+)
+
+func TestAccAwsRamResourceShareAccepter_basic(t *testing.T) {
+	var providers []*schema.Provider
+	resourceName := "aws_ram_resource_share_accepter.test"
+	shareName := fmt.Sprintf("tf-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsRamResourceShareAccepterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsRamResourceShareAccepterBasic(shareName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsRamResourceShareAccepterExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "share_arn", regexp.MustCompile(`^arn\:aws\:ram\:.*resource-share/.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "invitation_arn", regexp.MustCompile(`^arn\:aws\:ram\:.*resource-share-invitation/.+$`)),
+					resource.TestMatchResourceAttr(resourceName, "share_id", regexp.MustCompile(`^rs-.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "status", ram.ResourceShareInvitationStatusAccepted),
+					resource.TestMatchResourceAttr(resourceName, "receiver_account_id", regexp.MustCompile(`\d{12}`)),
+					resource.TestMatchResourceAttr(resourceName, "sender_account_id", regexp.MustCompile(`\d{12}`)),
+					resource.TestCheckResourceAttr(resourceName, "share_name", shareName),
+					resource.TestCheckResourceAttr(resourceName, "resources.%", "0"),
+				),
+			},
+			{
+				Config:            testAccAwsRamResourceShareAccepterBasic(shareName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsRamResourceShareAccepterDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ramconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ram_resource_share_accepter" {
+			continue
+		}
+
+		request := &ram.GetResourceSharesInput{
+			ResourceShareArns: []*string{aws.String(rs.Primary.Attributes["share_arn"])},
+			ResourceOwner:     aws.String(ram.ResourceOwnerOtherAccounts),
+		}
+
+		resp, err := conn.GetResourceShares(request)
+		if err != nil {
+			if awserr, ok := err.(awserr.Error); ok {
+				switch awserr.Code() {
+				case ram.ErrCodeUnknownResourceException:
+					// good - it's gone
+					return nil
+				}
+			}
+			return fmt.Errorf("Error deleting RAM resource share: %s", err)
+		}
+
+		if len(resp.ResourceShares) == 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("RAM resource share association found, should be destroyed")
+}
+
+func testAccCheckAwsRamResourceShareAccepterExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccAwsRamResourceShareAccepterBasic(shareName string) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+resource "aws_ram_resource_share" "test" {
+  provider = "aws.alternate"
+
+  name                      = %q
+  allow_external_principals = true
+
+  tags = {
+	Name = %q
+  }
+}
+
+resource "aws_ram_principal_association" "test" {
+  provider = "aws.alternate"
+
+  principal          = "${data.aws_caller_identity.receiver.account_id}"
+  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+
+  depends_on = ["data.aws_caller_identity.receiver"]
+}
+
+data "aws_caller_identity" "receiver" {}
+
+resource "aws_ram_resource_share_accepter" "test" {
+  share_arn = "${aws_ram_resource_share.test.arn}"
+
+  depends_on = ["aws_ram_resource_share.test", "aws_ram_principal_association.test"]
+}
+`, shareName, shareName)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -324,6 +324,9 @@
                                 </li>
                             </ul>
                         </li>
+                        <li>
+                        <a href="/docs/providers/aws/r/ram_resource_share_accepter.html">aws_ram_resource_share_accepter</a>
+                        </li>
                     </ul>
                 </li>
                 <li>

--- a/website/docs/r/ram_resource_share_accepter.markdown
+++ b/website/docs/r/ram_resource_share_accepter.markdown
@@ -1,0 +1,80 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ram_resource_share_accepter"
+sidebar_current: "docs-aws-resource-ram-resource-share-accepter"
+description: |-
+  Manages accepting a Resource Access Manager (RAM) Resource Share invitation.
+---
+
+# Resource: aws_ram_resource_share_accepter
+
+Manage accepting a Resource Access Manager (RAM) Resource Share invitation. From a _receiver_ AWS account, accept an invitation to share resources that were shared by a _sender_ AWS account. To create a resource share in the _sender_, see the [`aws_ram_resource_share` resource](/docs/providers/aws/r/ram_resource_share.html).
+
+~> **Note:** You can [`share resources`](https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html) with Organizations, Organizational Units (OUs), AWS accounts, and accounts from outside of your Organization.
+
+## Example Usage
+
+This configuration provides an example of using multiple Terraform AWS providers to configure two different AWS accounts. In the _sender_ account, the configuration creates a `aws_ram_resource_share` and uses a data source in the _receiver_ account to create a `aws_ram_principal_assocation` resource with the _receiver's_ account ID. In the _receiver_ account, the configuration accepts the invitation to share resources with the `aws_ram_resource_share_accepter`.
+
+```hcl
+provider "aws" {
+  profile = "profile2"
+}
+
+provider "aws" {
+  alias   = "alternate"
+  profile = "profile1"
+}
+
+resource "aws_ram_resource_share" "sender_share" {
+  provider = "aws.alternate"
+
+  name                      = "tf-test-resource-share"
+  allow_external_principals = true
+
+  tags = {
+	  Name = "tf-test-resource-share"
+  }
+}
+
+resource "aws_ram_principal_association" "sender_invite" {
+  provider = "aws.alternate"
+
+  principal          = "${data.aws_caller_identity.receiver.account_id}"
+  resource_share_arn = "${aws_ram_resource_share.test.arn}"
+}
+
+data "aws_caller_identity" "receiver" {}
+
+resource "aws_ram_resource_share_accepter" "receiver_accept" {
+  share_arn = "${aws_ram_principal_association.test.resource_share_arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+~> **Note:** One of either `share_arn` or `invitation_arn` is required. Using `share_arn` where multiple resources share invitations exist between the same _sender_ and _receiver_, may result in this resource selecting an unexpected invitation. In that case, use `invitation_arn`.
+
+* `share_arn` - (Optional) The ARN of the resource share.
+* `invitation_arn` - (Optional) The ARN of the resource share invitation.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `share_id` - The ID of the resource share as displayed in the console.
+* `status` - The status of the invitation (e.g., ACCEPTED, REJECTED).
+* `receiver_account_id` - The account ID of the receiver account which accepts the invitation.
+* `sender_account_id` - The account ID of the sender account which extends the invitation.
+* `share_name` - The name of the resource share.
+* `resources` - A list of the resource ARNs shared via the resource share.
+
+## Import
+
+Resource share accepters can be imported using the invitation ARN, e.g.
+
+```
+$ terraform import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767
+```

--- a/website/docs/r/ram_resource_share_accepter.markdown
+++ b/website/docs/r/ram_resource_share_accepter.markdown
@@ -14,7 +14,7 @@ Manage accepting a Resource Access Manager (RAM) Resource Share invitation. From
 
 ## Example Usage
 
-This configuration provides an example of using multiple Terraform AWS providers to configure two different AWS accounts. In the _sender_ account, the configuration creates a `aws_ram_resource_share` and uses a data source in the _receiver_ account to create a `aws_ram_principal_assocation` resource with the _receiver's_ account ID. In the _receiver_ account, the configuration accepts the invitation to share resources with the `aws_ram_resource_share_accepter`.
+This configuration provides an example of using multiple Terraform AWS providers to configure two different AWS accounts. In the _sender_ account, the configuration creates a `aws_ram_resource_share` and uses a data source in the _receiver_ account to create a `aws_ram_principal_association` resource with the _receiver's_ account ID. In the _receiver_ account, the configuration accepts the invitation to share resources with the `aws_ram_resource_share_accepter`.
 
 ```hcl
 provider "aws" {
@@ -55,15 +55,13 @@ resource "aws_ram_resource_share_accepter" "receiver_accept" {
 
 The following arguments are supported:
 
-~> **Note:** One of either `share_arn` or `invitation_arn` is required. Using `share_arn` where multiple resources share invitations exist between the same _sender_ and _receiver_, may result in this resource selecting an unexpected invitation. In that case, use `invitation_arn`.
-
-* `share_arn` - (Optional) The ARN of the resource share.
-* `invitation_arn` - (Optional) The ARN of the resource share invitation.
+* `share_arn` - (Required) The ARN of the resource share.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
+* `invitation_arn` - The ARN of the resource share invitation.
 * `share_id` - The ID of the resource share as displayed in the console.
 * `status` - The status of the invitation (e.g., ACCEPTED, REJECTED).
 * `receiver_account_id` - The account ID of the receiver account which accepts the invitation.
@@ -73,7 +71,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Resource share accepters can be imported using the invitation ARN, e.g.
+Resource share accepters can be imported using the resource share ARN, e.g.
 
 ```
 $ terraform import aws_ram_resource_share_accepter.example arn:aws:ram:us-east-1:123456789012:resource-share/c4b56393-e8d9-89d9-6dc9-883752de4767


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7601 

Changes proposed in this pull request:

* r/ram_resource_share_accepter: New resource allowing accepting AWS resource share invitations.

Output from acceptance testing:

```console
$ make testacc TESTARGS='-run=TestAccAwsRamResourceShareAccepter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsRamResourceShareAccepter_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAwsRamResourceShareAccepter_basic
=== PAUSE TestAccAwsRamResourceShareAccepter_basic
=== CONT  TestAccAwsRamResourceShareAccepter_basic
--- PASS: TestAccAwsRamResourceShareAccepter_basic (34.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	34.071s
```

## Usage
Example usage:
```hcl
resource "aws_ram_resource_share_accepter" "example" {
  arn = "arn:aws:ram:us-east-1:999999999999:resource-share-invitation/49510c94-3f65-5949-a939-98900e9a5765"
}
```

Slightly more complicated example:
```hcl
resource "aws_ram_resource_share" "test" {
  provider = "aws.alternate"

  name                      = "veryfineshare"
  allow_external_principals = true

  tags = {
	Name = "veryfineshare"
  }
}

resource "aws_ram_principal_association" "test" {
  provider = "aws.alternate"

  principal          = "${data.aws_caller_identity.receiver.account_id}"
  resource_share_arn = "${aws_ram_resource_share.test.arn}"

  depends_on = ["data.aws_caller_identity.receiver"]
}

data "aws_caller_identity" "receiver" {}

resource "aws_ram_resource_share_accepter" "test" {
  share_arn = "${aws_ram_resource_share.test.arn}"

  depends_on = ["aws_ram_resource_share.test", "aws_ram_principal_association.test"]
}
```

### Arguments
One of the following is required:
**share_arn** - (Optional) Resource share ARN. 
**invitation_arn** - (Optional) Resource share invitation ARN. 

### Attributes
**status** - Invitation status (e.g., ACCEPTED, REJECTED).
**receiver_account_id** - Account ID of resource share receiver.
**sender_account_id** - Account ID of resource share sender.
**share_name** - Name of the resource share.
**resources** - List of ARNs of shared resources.
