### PR TITLE
Formatting fixes for backup_plan and backup_vault examples

### DIFF
--- a/website/docs/r/backup_plan.html.markdown
+++ b/website/docs/r/backup_plan.html.markdown
@@ -17,10 +17,10 @@ resource "aws_backup_plan" "example" {
   name = "tf_example_backup_plan"
 
   rule {
-    rule_name           = "tf_example_backup_rule"
-      target_vault_name = "${aws_backup_vault.test.name}"
-      schedule          = "cron(0 12 * * ? *)"
-    }
+    rule_name         = "tf_example_backup_rule"
+    target_vault_name = "${aws_backup_vault.test.name}"
+    schedule          = "cron(0 12 * * ? *)"
+  }
 }
 ```
 

--- a/website/docs/r/backup_vault.html.markdown
+++ b/website/docs/r/backup_vault.html.markdown
@@ -14,8 +14,8 @@ Provides an AWS Backup vault resource.
 
 ```hcl
 resource "aws_backup_vault" "example" {
-	name = "example_backup_vault"
-	kms_key_arn = "${aws_kms_key.example.arn}"
+  name        = "example_backup_vault"
+  kms_key_arn = "${aws_kms_key.example.arn}"
 }
 ```
 


### PR DESCRIPTION
Trivial fix to align aws_backup documentation resource examples

Fixes #7207 #7350