### PR TITLE
Fix api_gateway_authorizer caching ttl in case explicitly set to 0

### DIFF
--- a/aws/resource_aws_api_gateway_authorizer.go
+++ b/aws/resource_aws_api_gateway_authorizer.go
@@ -90,7 +90,7 @@ func resourceAwsApiGatewayAuthorizerCreate(d *schema.ResourceData, meta interfac
 	if v, ok := d.GetOk("authorizer_credentials"); ok {
 		input.AuthorizerCredentials = aws.String(v.(string))
 	}
-	if v, ok := d.GetOk("authorizer_result_ttl_in_seconds"); ok {
+	if v, ok := d.GetOkExists("authorizer_result_ttl_in_seconds"); ok {
 		input.AuthorizerResultTtlInSeconds = aws.Int64(int64(v.(int)))
 	}
 	if v, ok := d.GetOk("identity_validation_expression"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #705 

Changes proposed in this pull request:

The GetOk will compare the value to the default zero value of a type. When the ttl is set to 0, the value matches the default zero value of the type Integer and will be ignored for the api request.

Normally not a problem, but in this case, this results in an authorizer with a cache ttl of null, which defaults to 300s on AWS side. This is also not visible properly in the AWS console, since the value is displayed as "undefined" and the checkbox for caching is not activated. So it looks like the caching is disabled, but the default caching ttl of 300s kicks in and produces unreliable results in the API Gateway behaviour.

So this change uses the GetOkExists function for the parameter validation which will not compare
the value to the type zero value and therefore the resource will now accept an explicitly value of 0 for
the parameter authorizer_result_ttl_in_seconds.