### PR TITLE
Fix id in Data Source Cognito User Pool

### DIFF
--- a/aws/data_source_aws_cognito_user_pools.go
+++ b/aws/data_source_aws_cognito_user_pools.go
@@ -61,7 +61,7 @@ func dataSourceAwsCognitoUserPoolsRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("No cognito user pool found with name: %s", name)
 	}
 
-	d.SetId(name)
+	d.SetId(ids[0])
 	d.Set("ids", ids)
 	d.Set("arns", arns)
 

--- a/aws/data_source_aws_cognito_user_pools_test.go
+++ b/aws/data_source_aws_cognito_user_pools_test.go
@@ -18,6 +18,8 @@ func TestAccDataSourceAwsCognitoUserPools_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsCognitoUserPoolsConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_cognito_user_pools.selected", "name", rName),
+					resource.TestMatchResourceAttr("data.aws_cognito_user_pools.selected", "id", regexp.MustCompile("^us-west-2_[a-zA-Z0-9]{9,}$")),
 					resource.TestCheckResourceAttr("data.aws_cognito_user_pools.selected", "ids.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_cognito_user_pools.selected", "arns.#", "2"),
 				),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Set `data "aws_cognito_user_pools"` key `id` to user pool ID and not name value (which is confusing). Name value is already kept in `name`.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccDataSourceAwsCognitoUserPools_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccDataSourceAwsCognitoUserPools_basic -timeout 120m
=== RUN   TestAccDataSourceAwsCognitoUserPools_basic
=== PAUSE TestAccDataSourceAwsCognitoUserPools_basic
=== CONT  TestAccDataSourceAwsCognitoUserPools_basic
--- PASS: TestAccDataSourceAwsCognitoUserPools_basic (21.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       (cached)
```
