### PR TITLE
Feature/add importer for asg scheduled action

### DIFF
--- a/aws/resource_aws_autoscaling_schedule_test.go
+++ b/aws/resource_aws_autoscaling_schedule_test.go
@@ -19,29 +19,8 @@ func TestAccAWSAutoscalingSchedule_basic(t *testing.T) {
 	start := testAccAWSAutoscalingScheduleValidStart(t)
 	end := testAccAWSAutoscalingScheduleValidEnd(t)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSAutoscalingScheduleDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSAutoscalingScheduleConfig(rName, start, end),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSAutoscalingSchedule_basicImport(t *testing.T) {
-	var schedule autoscaling.ScheduledUpdateGroupAction
-	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
-	start := testAccAWSAutoscalingScheduleValidStart(t)
-	end := testAccAWSAutoscalingScheduleValidEnd(t)
-
 	scheduledActionName := "foobar"
-	resourceName := "aws_autoscaling_schedule.foobar"
+	resourceName := fmt.Sprintf("aws_autoscaling_schedule.%s", scheduledActionName)
 	importInput := fmt.Sprintf("%s/%s", rName, scheduledActionName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -52,24 +31,21 @@ func TestAccAWSAutoscalingSchedule_basicImport(t *testing.T) {
 			{
 				Config: testAccAWSAutoscalingScheduleConfig(rName, start, end),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
+					testAccCheckScalingScheduleExists(resourceName, &schedule),
 				),
 			},
-			// Test existent resource import
 			{
 				ResourceName:      resourceName,
 				ImportStateId:     importInput,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Test non-existent resource import
 			{
 				ResourceName:      resourceName,
 				ImportStateId:     fmt.Sprintf("%s/nonexistent", rName),
 				ImportState:       true,
 				ImportStateVerify: false,
-				ExpectError: regexp.MustCompile(
-					`(Please verify the ID is correct|You cannot import non-existent resources using Terraform import)`),
+				ExpectError:       regexp.MustCompile(`(Cannot import non-existent remote object)`),
 			},
 		},
 	})
@@ -114,6 +90,11 @@ func TestAccAWSAutoscalingSchedule_recurrence(t *testing.T) {
 	var schedule autoscaling.ScheduledUpdateGroupAction
 
 	rName := fmt.Sprintf("tf-test-%d", acctest.RandInt())
+
+	scheduledActionName := "foobar"
+	resourceName := fmt.Sprintf("aws_autoscaling_schedule.%s", scheduledActionName)
+	importInput := fmt.Sprintf("%s/%s", rName, scheduledActionName)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -122,9 +103,15 @@ func TestAccAWSAutoscalingSchedule_recurrence(t *testing.T) {
 			{
 				Config: testAccAWSAutoscalingScheduleConfig_recurrence(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
-					resource.TestCheckResourceAttr("aws_autoscaling_schedule.foobar", "recurrence", "0 8 * * *"),
+					testAccCheckScalingScheduleExists(resourceName, &schedule),
+					resource.TestCheckResourceAttr(resourceName, "recurrence", "0 8 * * *"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     importInput,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -137,6 +124,10 @@ func TestAccAWSAutoscalingSchedule_zeroValues(t *testing.T) {
 	start := testAccAWSAutoscalingScheduleValidStart(t)
 	end := testAccAWSAutoscalingScheduleValidEnd(t)
 
+	scheduledActionName := "foobar"
+	resourceName := fmt.Sprintf("aws_autoscaling_schedule.%s", scheduledActionName)
+	importInput := fmt.Sprintf("%s/%s", rName, scheduledActionName)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -145,8 +136,14 @@ func TestAccAWSAutoscalingSchedule_zeroValues(t *testing.T) {
 			{
 				Config: testAccAWSAutoscalingScheduleConfig_zeroValues(rName, start, end),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
+					testAccCheckScalingScheduleExists(resourceName, &schedule),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     importInput,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -159,6 +156,10 @@ func TestAccAWSAutoscalingSchedule_negativeOne(t *testing.T) {
 	start := testAccAWSAutoscalingScheduleValidStart(t)
 	end := testAccAWSAutoscalingScheduleValidEnd(t)
 
+	scheduledActionName := "foobar"
+	resourceName := fmt.Sprintf("aws_autoscaling_schedule.%s", scheduledActionName)
+	importInput := fmt.Sprintf("%s/%s", rName, scheduledActionName)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -167,10 +168,16 @@ func TestAccAWSAutoscalingSchedule_negativeOne(t *testing.T) {
 			{
 				Config: testAccAWSAutoscalingScheduleConfig_negativeOne(rName, start, end),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalingScheduleExists("aws_autoscaling_schedule.foobar", &schedule),
+					testAccCheckScalingScheduleExists(resourceName, &schedule),
 					testAccCheckScalingScheduleHasNoDesiredCapacity(&schedule),
-					resource.TestCheckResourceAttr("aws_autoscaling_schedule.foobar", "desired_capacity", "-1"),
+					resource.TestCheckResourceAttr(resourceName, "desired_capacity", "-1"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     importInput,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/appautoscaling_scheduled_action.html.markdown
+++ b/website/docs/r/appautoscaling_scheduled_action.html.markdown
@@ -87,3 +87,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the scheduled action.
+
+## Import
+
+AutoScaling ScheduledAction can be imported using the `auto-scaling-group-name` and `scheduled-action-name`, e.g.
+
+```
+$ terraform import aws_autoscaling_schedule.resource-name auto-scaling-group-name/scheduled-action-name
+```

--- a/website/docs/r/appautoscaling_scheduled_action.html.markdown
+++ b/website/docs/r/appautoscaling_scheduled_action.html.markdown
@@ -87,11 +87,3 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the scheduled action.
-
-## Import
-
-AutoScaling ScheduledAction can be imported using the `auto-scaling-group-name` and `scheduled-action-name`, e.g.
-
-```
-$ terraform import aws_autoscaling_schedule.resource-name auto-scaling-group-name/scheduled-action-name
-```

--- a/website/docs/r/autoscaling_schedule.html.markdown
+++ b/website/docs/r/autoscaling_schedule.html.markdown
@@ -56,3 +56,11 @@ Set to -1 if you don't want to change the maximum size at the scheduled time.
 
 ## Attribute Reference
 * `arn` - The ARN assigned by AWS to the autoscaling schedule.
+
+## Import
+
+AutoScaling ScheduledAction can be imported using the `auto-scaling-group-name` and `scheduled-action-name`, e.g.
+
+```
+$ terraform import aws_autoscaling_schedule.resource-name auto-scaling-group-name/scheduled-action-name
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #5617

Changes proposed in this pull request:

* App the importer for autoscaling group scheduled action

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAutoscalingSchedule_basicImport'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAutoscalingSchedule_basicImport -timeout 120m
=== RUN   TestAccAWSAutoscalingSchedule_basicImport
=== PAUSE TestAccAWSAutoscalingSchedule_basicImport
=== CONT  TestAccAWSAutoscalingSchedule_basicImport
--- PASS: TestAccAWSAutoscalingSchedule_basicImport (272.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       272.703s
...
```
