### PR TITLE
Bug - Fix regex for aws_transfer_user

### DIFF
--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -147,6 +147,11 @@ func TestAccAWSTransferUserName_validation(t *testing.T) {
 				Config:      testAccAWSTransferUserName_validation("-abcdef"),
 				ExpectError: regexp.MustCompile(`"user_name" cannot begin with a hyphen`),
 			},
+			{
+				Config:             testAccAWSTransferUserName_validation("valid_username"),
+				ExpectNonEmptyPlan: true,
+				PlanOnly:           true,
+			},
 		},
 	})
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -117,15 +117,19 @@ func validateTransferServerID(v interface{}, k string) (ws []string, errors []er
 
 func validateTransferUserName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-
 	// https://docs.aws.amazon.com/transfer/latest/userguide/API_CreateUser.html
-	pattern := `^[a-z0-9]{3,32}$`
-	if !regexp.MustCompile(pattern).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"%q isn't a valid transfer user name (only lowercase alphanumeric characters are allowed): %q",
-			k, value))
+	if regexp.MustCompile(`[^0-9a-zA-Z_-]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q can only contain alphanumeric characters, underscores, and hyphens", k))
 	}
-
+	if len(value) < 3 {
+		errors = append(errors, fmt.Errorf("%q must be at least 3 characters", k))
+	}
+	if len(value) > 32 {
+		errors = append(errors, fmt.Errorf("%q cannot be more than 32 characters", k))
+	}
+	if regexp.MustCompile(`^-`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q cannot begin with a hyphen", k))
+	}
 	return
 }
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -118,17 +118,8 @@ func validateTransferServerID(v interface{}, k string) (ws []string, errors []er
 func validateTransferUserName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	// https://docs.aws.amazon.com/transfer/latest/userguide/API_CreateUser.html
-	if regexp.MustCompile(`[^0-9a-zA-Z_-]`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q can only contain alphanumeric characters, underscores, and hyphens", k))
-	}
-	if len(value) < 3 {
-		errors = append(errors, fmt.Errorf("%q must be at least 3 characters", k))
-	}
-	if len(value) > 32 {
-		errors = append(errors, fmt.Errorf("%q cannot be more than 32 characters", k))
-	}
-	if regexp.MustCompile(`^-`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q cannot begin with a hyphen", k))
+	if !regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]{2,31}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("Invalid %q: must be between 3 and 32 alphanumeric or special characters hyphen and underscore. However, %q cannot begin with a hyphen", k, k))
 	}
 	return
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8065

Changes proposed in this pull request:

* Allow uppercase, hyphens, and underscores in validation regex
* Add condition for user_name beginning with a hyphen
* Split user_name length validation to separate conditionals

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSTransferUserName_validation'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSTransferUserName_validation -timeout 120m
=== RUN   TestAccAWSTransferUserName_validation
=== PAUSE TestAccAWSTransferUserName_validation
=== CONT  TestAccAWSTransferUserName_validation
--- PASS: TestAccAWSTransferUserName_validation (4.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	4.466s

...
```
