### PR TITLE
Rearrange docs to de-emphasize using AWS static credentials

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -38,10 +38,27 @@ The AWS provider offers a flexible means of providing credentials for
 authentication. The following methods are supported, in this order, and
 explained below:
 
+- Static credentials
 - Environment variables
 - Shared credentials file
 - EC2 Role
-- Static credentials
+
+### Static credentials ###
+
+!> WARNING: Hard-coding credentials into any Terraform file is not recommended and risks secret leakage should this file ever be committed to a public source code control system.
+
+Static credentials can be provided by adding an `access_key` and `secret_key`
+in-line in the AWS provider block:
+
+Usage:
+
+```hcl
+provider "aws" {
+  region     = "us-west-2"
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}
+```
 
 ### Environment variables
 
@@ -131,23 +148,6 @@ provider "aws" {
     session_name = "SESSION_NAME"
     external_id  = "EXTERNAL_ID"
   }
-}
-```
-
-### Static credentials ###
-
-!> WARNING: Hard-coding credentials into any Terraform file is not recommended and risks secret leakage should this file ever be committed to a public source code control system.
-
-Static credentials can be provided by adding an `access_key` and `secret_key` in-line in the
-AWS provider block:
-
-Usage:
-
-```hcl
-provider "aws" {
-  region     = "us-west-2"
-  access_key = "anaccesskey"
-  secret_key = "asecretkey"
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -23,12 +23,9 @@ provider "aws" {
   region = "us-east-1"
 }
 
-# Create a web server
-resource "aws_instance" "web" {
-  ami           = "ami-2757f631"
-  instance_type = "t2.micro"
-
-  # ...
+# Create a VPC
+resource "aws_vpc" "example" {
+  cidr_block = "10.0.0.0/16"
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -42,7 +42,9 @@ explained below:
 
 ### Static credentials ###
 
-!> WARNING: Hard-coding credentials into any Terraform file is not recommended and risks secret leakage should this file ever be committed to a public source code control system.
+!> **Warning:** Hard-coding credentials into any Terraform configuration is not
+recommended, and risks secret leakage should this file ever be committed to a
+public version control system.
 
 Static credentials can be provided by adding an `access_key` and `secret_key`
 in-line in the AWS provider block:

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,6 +17,12 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
+# Configure the AWS Provider
+provider "aws" {
+  version = "~> 2.0"
+  region = "us-east-1"
+}
+
 # Create a web server
 resource "aws_instance" "web" {
   ami           = "ami-2757f631"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,15 +17,11 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
-# Configure the AWS Provider
-provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region     = "us-east-1"
-}
-
 # Create a web server
 resource "aws_instance" "web" {
+  ami           = "ami-2757f631"
+  instance_type = "t2.micro"
+
   # ...
 }
 ```
@@ -36,25 +32,10 @@ The AWS provider offers a flexible means of providing credentials for
 authentication. The following methods are supported, in this order, and
 explained below:
 
-- Static credentials
 - Environment variables
 - Shared credentials file
 - EC2 Role
-
-### Static credentials ###
-
-Static credentials can be provided by adding an `access_key` and `secret_key` in-line in the
-AWS provider block:
-
-Usage:
-
-```hcl
-provider "aws" {
-  region     = "us-west-2"
-  access_key = "anaccesskey"
-  secret_key = "asecretkey"
-}
-```
+- Static credentials
 
 ### Environment variables
 
@@ -144,6 +125,23 @@ provider "aws" {
     session_name = "SESSION_NAME"
     external_id  = "EXTERNAL_ID"
   }
+}
+```
+
+### Static credentials ###
+
+!> WARNING: Hard-coding credentials into any Terraform file is not recommended and risks secret leakage should this file ever be committed to a public source code control system.
+
+Static credentials can be provided by adding an `access_key` and `secret_key` in-line in the
+AWS provider block:
+
+Usage:
+
+```hcl
+provider "aws" {
+  region     = "us-west-2"
+  access_key = "anaccesskey"
+  secret_key = "asecretkey"
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,11 +17,15 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
+# Configure the AWS Provider
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "us-east-1"
+}
+
 # Create a web server
 resource "aws_instance" "web" {
-  ami           = "ami-2757f631"
-  instance_type = "t2.micro"
-
   # ...
 }
 ```
@@ -32,10 +36,25 @@ The AWS provider offers a flexible means of providing credentials for
 authentication. The following methods are supported, in this order, and
 explained below:
 
+- Static credentials
 - Environment variables
 - Shared credentials file
 - EC2 Role
-- Static credentials
+
+### Static credentials ###
+
+Static credentials can be provided by adding an `access_key` and `secret_key` in-line in the
+AWS provider block:
+
+Usage:
+
+```hcl
+provider "aws" {
+  region     = "us-west-2"
+  access_key = "anaccesskey"
+  secret_key = "asecretkey"
+}
+```
 
 ### Environment variables
 
@@ -125,23 +144,6 @@ provider "aws" {
     session_name = "SESSION_NAME"
     external_id  = "EXTERNAL_ID"
   }
-}
-```
-
-### Static credentials ###
-
-!> WARNING: Hard-coding credentials into any Terraform file is not recommended and risks secret leakage should this file ever be committed to a public source code control system.
-
-Static credentials can be provided by adding an `access_key` and `secret_key` in-line in the
-AWS provider block:
-
-Usage:
-
-```hcl
-provider "aws" {
-  region     = "us-west-2"
-  access_key = "anaccesskey"
-  secret_key = "asecretkey"
 }
 ```
 


### PR DESCRIPTION
Moves description of static credentials to the bottom of the authentication docs. This will encourage new practitioners to use environment variables, roles, or other authentication methods rather than hard-coding sensitive AWS creds in their Terraform files.

It also adds a warning to the static credentials section in order to educate the practitioner about the risks of hard-coding static credentials.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Moves description of static credentials to the bottom of the authentication docs. This will encourage new practitioners to use environment variables, roles, or other authentication methods rather than hard-coding sensitive AWS creds in their Terraform files.

