### PR TITLE
Docs: Change role resource reference in policy

### DIFF
--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -18,7 +18,7 @@ interface, subnet, or VPC. Logs are sent to a CloudWatch Log Group or a S3 Bucke
 ```hcl
 resource "aws_flow_log" "example" {
   iam_role_arn    = "${aws_iam_role.example.arn}"
-  log_destination = "${aws_cloudwatch_log_group.example.arn}"
+  log_destination = "${aws_cloudwatch_log_group.test_role.arn}"
   traffic_type    = "ALL"
   vpc_id          = "${aws_vpc.example.id}"
 }

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -49,7 +49,7 @@ EOF
 
 resource "aws_iam_role_policy" "example" {
   name = "example"
-  role = "${aws_iam_role.example.id}"
+  role = "${aws_iam_role.test_role.id}"
 
   policy = <<EOF
 {


### PR DESCRIPTION
In the `aws_iam_role_policy` resource, the role attribute points to iam role resource called 'example', which is actually called 'test_role'

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
