### PR TITLE
tests/resource/aws_cloudfront_distribution: Remove extraneous aliases configurations and create aliased us-east-1 provider configuration

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -39,6 +39,11 @@ func init() {
 				*providers = append(*providers, p.(*schema.Provider))
 				return p, nil
 			},
+			"tls": func() (terraform.ResourceProvider, error) {
+				p := tls.Provider()
+				*providers = append(*providers, p.(*schema.Provider))
+				return p, nil
+			},
 		}
 	}
 	testAccProvidersWithTLS = map[string]terraform.ResourceProvider{
@@ -252,6 +257,21 @@ provider "aws" {
   secret_key = %[3]q
 }
 `, os.Getenv("AWS_ALTERNATE_ACCESS_KEY_ID"), os.Getenv("AWS_ALTERNATE_PROFILE"), os.Getenv("AWS_ALTERNATE_SECRET_ACCESS_KEY"))
+}
+
+// Provider configuration hardcoded for us-east-1.
+// This should only be necessary for testing ACM Certificates with CloudFront
+// related infrastucture such as API Gateway Domain Names for EDGE endpoints,
+// CloudFront Distribution Viewer Certificates, and Cognito User Pool Domains.
+// Other valid usage is for services only available in us-east-1 such as the
+// Cost and Usage Reporting and Pricing services.
+func testAccUsEast1RegionProviderConfig() string {
+	return fmt.Sprintf(`
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+`)
 }
 
 func testAccAwsRegionProviderFunc(region string, providers *[]*schema.Provider) func() *schema.Provider {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

On April 8th, 2019, [Amazon CloudFront began validating alternate domain names](https://aws.amazon.com/about-aws/whats-new/2019/04/amazon-cloudfront-enhances-the-security-for-adding-alternate-domain-names-to-a-distribution/) for security reasons. Some of our acceptance testing was extraneously assigning aliases to CloudFront distributions configured with the CloudFront default certificate and began failing as a result of this service update.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSCloudFrontDistribution_S3Origin (95.64s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_cloudfront_distribution.s3_distribution: 1 error occurred:
          * aws_cloudfront_distribution.s3_distribution: error creating CloudFront Distribution: InvalidViewerCertificate: To add an alternate domain name (CNAME) to a CloudFront distribution, you must attach a trusted certificate that validates your authorization to use the domain name. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements

--- FAIL: TestAccAWSCloudFrontDistribution_S3OriginWithTags (95.90s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_cloudfront_distribution.s3_distribution: 1 error occurred:
          * aws_cloudfront_distribution.s3_distribution: error creating CloudFront Distribution: InvalidViewerCertificate: To add an alternate domain name (CNAME) to a CloudFront distribution, you must attach a trusted certificate that validates your authorization to use the domain name. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements

--- FAIL: TestAccAWSCloudFrontDistribution_customOrigin (65.61s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_cloudfront_distribution.custom_distribution: 1 error occurred:
          * aws_cloudfront_distribution.custom_distribution: error creating CloudFront Distribution: InvalidViewerCertificate: To add an alternate domain name (CNAME) to a CloudFront distribution, you must attach a trusted certificate that validates your authorization to use the domain name. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements

--- FAIL: TestAccAWSCloudFrontDistribution_multiOrigin (95.68s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_cloudfront_distribution.multi_origin_distribution: 1 error occurred:
          * aws_cloudfront_distribution.multi_origin_distribution: error creating CloudFront Distribution: InvalidViewerCertificate: To add an alternate domain name (CNAME) to a CloudFront distribution, you must attach a trusted certificate that validates your authorization to use the domain name. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements
```

This change simply removes the `aws_cloudfront_distribution` resource `aliases` configurations, which are not meaningful in these acceptance tests. We also remove the hardcoded `us-east-1` region provider used for ACM certificate handling as it can break other acceptance testing when run concurrently (e.g. locally with `go test -parallel`):

```
--- FAIL: TestAccAWSCloudFrontDistribution_OriginGroups (1247.64s)
    testing.go:599: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Error applying: 2 errors occurred:
          * aws_s3_bucket.s3_bucket_origin (destroy): 1 error occurred:
          * aws_s3_bucket.s3_bucket_origin: error deleting S3 Bucket (mybucket.6479347118024743098): BucketRegionError: incorrect region, the bucket is not in 'us-east-1' region at endpoint ''
          status code: 301, request id: , host id:

          * aws_s3_bucket.s3_backup_bucket_origin (destroy): 1 error occurred:
          * aws_s3_bucket.s3_backup_bucket_origin: error deleting S3 Bucket (mybucket-backup.6479347118024743098): BucketRegionError: incorrect region, the bucket is not in 'us-east-1' region at endpoint ''
          status code: 301, request id: , host id:
```

The aliased `us-east-1` provider configuration will be applied to other test configuration usage later.

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (2.11s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (2.21s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (590.42s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (592.18s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (592.31s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (592.72s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (594.33s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (1187.55s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (1187.67s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (1225.22s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (1225.58s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (1226.33s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (1227.19s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (1229.81s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (1230.36s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (1232.47s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (1232.59s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (1231.23s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (1233.12s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (1234.68s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (1728.08s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1787.54s)
```