### PR TITLE
Update data_source_aws_db_instance.go

### DIFF
--- a/aws/data_source_aws_db_instance.go
+++ b/aws/data_source_aws_db_instance.go
@@ -241,6 +241,7 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("db_instance_arn", dbInstance.DBInstanceArn)
 	d.Set("db_instance_class", dbInstance.DBInstanceClass)
 	d.Set("db_name", dbInstance.DBName)
+	d.Set("resource_id", dbInstance.DbiResourceId)
 
 	var parameterGroups []string
 	for _, v := range dbInstance.DBParameterGroups {


### PR DESCRIPTION
missed resource id...

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* expose the db resource id in the rds db instance  data source

note I need to expose resource id for referring to db resources in IAM policies.
