### PR TITLE
tests/data-source/aws_vpc_endpoint_service: Add us-west-2d Availability Zone to gateway test

### DIFF
--- a/aws/data_source_aws_vpc_endpoint_service_test.go
+++ b/aws/data_source_aws_vpc_endpoint_service_test.go
@@ -28,13 +28,15 @@ func TestAccDataSourceAwsVpcEndpointService_gateway(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.aws_vpc_endpoint_service.s3", "acceptance_required", "false"),
 					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "availability_zones.#", "3"),
+						"data.aws_vpc_endpoint_service.s3", "availability_zones.#", "4"),
 					resource.TestCheckResourceAttr(
 						"data.aws_vpc_endpoint_service.s3", "availability_zones.2487133097", "us-west-2a"),
 					resource.TestCheckResourceAttr(
 						"data.aws_vpc_endpoint_service.s3", "availability_zones.221770259", "us-west-2b"),
 					resource.TestCheckResourceAttr(
 						"data.aws_vpc_endpoint_service.s3", "availability_zones.2050015877", "us-west-2c"),
+					resource.TestCheckResourceAttr(
+						"data.aws_vpc_endpoint_service.s3", "availability_zones.3830732582", "us-west-2d"),
 					resource.TestCheckResourceAttr(
 						"data.aws_vpc_endpoint_service.s3", "private_dns_name", ""),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This is a quick acceptance test fix for the new `us-west-2d` Availability Zone recently added to the region.

Previous output from acceptance testing:

```
--- FAIL: TestAccDataSourceAwsVpcEndpointService_gateway (8.07s)
    testing.go:538: Step 0 error: Check failed: Check 6/12 error: data.aws_vpc_endpoint_service.s3: Attribute 'availability_zones.#' expected "3", got "4"
```

Output from acceptance testing:

```
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (10.45s)
```
