### PR TITLE
tests/resource/aws_neptunce_cluster_instance: Add missing third availability zone from cluster configuration

### DIFF
--- a/aws/resource_aws_neptune_cluster_instance_test.go
+++ b/aws/resource_aws_neptune_cluster_instance_test.go
@@ -285,7 +285,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_neptune_cluster" "default" {
   cluster_identifier 	= "tf-neptune-cluster-test-%d"
-  availability_zones 	= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}"]
+  availability_zones 	= ["${data.aws_availability_zones.available.names[0]}", "${data.aws_availability_zones.available.names[1]}", "${data.aws_availability_zones.available.names[2]}"]
   skip_final_snapshot 	= true
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Similar to RDS, Neptune requires clusters to have three availability zones if manually configured.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSNeptuneClusterInstance_withaz (865.51s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: aws_neptune_cluster.default
...
          availability_zones.#:                 "3" => "2" (forces new resource)
          availability_zones.2050015877:        "us-west-2c" => "" (forces new resource)
          availability_zones.221770259:         "us-west-2b" => "us-west-2b"
          availability_zones.2487133097:        "us-west-2a" => "us-west-2a"
...
```

Output from acceptance testing:

```
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (801.98s)
```