### PR TITLE
tests/resource/aws_ssm_document: Add missing owners argument and fix deprecation in automation test

### DIFF
--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -589,6 +589,8 @@ func testAccAWSSSMDocumentTypeAutomationConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_ami" "ssm_ami" {
 	most_recent = true
+	owners      = ["099720109477"] # Canonical
+
 	filter {
 		name = "name"
 		values = ["*hvm-ssd/ubuntu-trusty-14.04*"]
@@ -597,7 +599,7 @@ data "aws_ami" "ssm_ami" {
 
 resource "aws_iam_instance_profile" "ssm_profile" {
   name = "ssm_profile-%s"
-  roles = ["${aws_iam_role.ssm_role.name}"]
+  role = "${aws_iam_role.ssm_role.name}"
 }
 
 resource "aws_iam_role" "ssm_role" {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSSSMDocument_automation (0.83s)
    testing.go:538: Step 0 error: config is invalid: 2 problems:

        - aws_iam_instance_profile.ssm_profile: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
        - data.aws_ami.ssm_ami: "owners": required field is not set
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMDocument_automation (20.54s)
```
