### PR TITLE
tests/service/wafregional: Add test sweepers for Rate-Based Rules, Rules, and Web ACLs

### DIFF
--- a/aws/resource_aws_wafregional_rule_test.go
+++ b/aws/resource_aws_wafregional_rule_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,6 +13,108 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_wafregional_rule", &resource.Sweeper{
+		Name: "aws_wafregional_rule",
+		F:    testSweepWafRegionalRules,
+		Dependencies: []string{
+			"aws_wafregional_web_acl",
+		},
+	})
+}
+
+func testSweepWafRegionalRules(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).wafregionalconn
+
+	input := &waf.ListRulesInput{}
+
+	for {
+		output, err := conn.ListRules(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping WAF Regional Rule sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing WAF Regional Rules: %s", err)
+		}
+
+		for _, rule := range output.Rules {
+			deleteInput := &waf.DeleteRuleInput{
+				RuleId: rule.RuleId,
+			}
+			id := aws.StringValue(rule.RuleId)
+			wr := newWafRegionalRetryer(conn, region)
+
+			_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+				deleteInput.ChangeToken = token
+				log.Printf("[INFO] Deleting WAF Regional Rule: %s", id)
+				return conn.DeleteRule(deleteInput)
+			})
+
+			if isAWSErr(err, wafregional.ErrCodeWAFNonEmptyEntityException, "") {
+				getRuleInput := &waf.GetRuleInput{
+					RuleId: rule.RuleId,
+				}
+
+				getRuleOutput, getRuleErr := conn.GetRule(getRuleInput)
+
+				if getRuleErr != nil {
+					return fmt.Errorf("error getting WAF Regional Rule (%s): %s", id, getRuleErr)
+				}
+
+				var updates []*waf.RuleUpdate
+				updateRuleInput := &waf.UpdateRuleInput{
+					RuleId:  rule.RuleId,
+					Updates: updates,
+				}
+
+				for _, predicate := range getRuleOutput.Rule.Predicates {
+					update := &waf.RuleUpdate{
+						Action:    aws.String(waf.ChangeActionDelete),
+						Predicate: predicate,
+					}
+
+					updateRuleInput.Updates = append(updateRuleInput.Updates, update)
+				}
+
+				_, updateWebACLErr := wr.RetryWithToken(func(token *string) (interface{}, error) {
+					updateRuleInput.ChangeToken = token
+					log.Printf("[INFO] Removing Predicates from WAF Regional Rule: %s", id)
+					return conn.UpdateRule(updateRuleInput)
+				})
+
+				if updateWebACLErr != nil {
+					return fmt.Errorf("error removing predicates from WAF Regional Rule (%s): %s", id, updateWebACLErr)
+				}
+
+				_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+					deleteInput.ChangeToken = token
+					log.Printf("[INFO] Deleting WAF Regional Rule: %s", id)
+					return conn.DeleteRule(deleteInput)
+				})
+			}
+
+			if err != nil {
+				return fmt.Errorf("error deleting WAF Regional Rule (%s): %s", id, err)
+			}
+		}
+
+		if aws.StringValue(output.NextMarker) == "" {
+			break
+		}
+
+		input.NextMarker = output.NextMarker
+	}
+
+	return nil
+}
 
 func TestAccAWSWafRegionalRule_basic(t *testing.T) {
 	var v waf.Rule


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSWafRegionalRateBasedRule_basic (94.97s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: WAFLimitsExceededException: Operation would result in exceeding resource limits.

--- FAIL: TestAccAWSWafRegionalRateBasedRule_changePredicates (206.52s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: WAFLimitsExceededException: Operation would result in exceeding resource limits.

--- FAIL: TestAccAWSWafRegionalRateBasedRule_changeNameForceNew (190.72s)
    testing.go:538: Step 1 error: Error applying: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: WAFLimitsExceededException: Operation would result in exceeding resource limits.

--- FAIL: TestAccAWSWafRegionalRateBasedRule_changeRateLimit (2.39s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: WAFLimitsExceededException: Operation would result in exceeding resource limits.

--- FAIL: TestAccAWSWafRegionalRateBasedRule_noPredicates (2.64s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: WAFLimitsExceededException: Operation would result in exceeding resource limits.

--- FAIL: TestAccAWSWafRegionalWebAcl_createRateBased (2.40s)
    testing.go:538: Step 0 error: Error applying: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: 1 error occurred:
          * aws_wafregional_rate_based_rule.wafrule: WAFLimitsExceededException: Operation would result in exceeding resource limits.
```

Previous output from AWS CLI:

```
$ aws waf-regional list-rules | jq '.Rules | length'
8

$ aws waf-regional list-rate-based-rules | jq '.Rules | length'
4

$ aws waf-regional list-web-acls | jq '.WebACLs | length'
7
```

Output from test sweepers:

```
$ go test ./aws -v -sweep=us-west-2 -sweep-run=aws_wafregional_rule,aws_wafregional_rate_based_rule -timeout 10h
2019/04/16 00:04:51 [DEBUG] Running Sweepers for region (us-west-2):
2019/04/16 00:04:53 [DEBUG] No AWS WAF Regional Rule Groups to sweep
2019/04/16 00:04:53 [DEBUG] Sweeper (aws_wafregional_rate_based_rule) has dependency (aws_wafregional_web_acl), running..
2019/04/16 00:04:55 [INFO] Deleting WAF Regional Web ACL: 0e945e41-a84c-4b90-91e9-2d77541264e7
2019/04/16 00:04:57 [INFO] Deleting WAF Regional Web ACL: 46895560-4aa2-49cb-899b-e8d6b85bb699
2019/04/16 00:04:58 [INFO] Removing Rules from WAF Regional Web ACL: 46895560-4aa2-49cb-899b-e8d6b85bb699
2019/04/16 00:04:59 [INFO] Deleting WAF Regional Web ACL: 46895560-4aa2-49cb-899b-e8d6b85bb699
2019/04/16 00:05:01 [INFO] Deleting WAF Regional Web ACL: 555119fd-9378-4754-9739-68d4912e5a7a
2019/04/16 00:05:03 [INFO] Removing Rules from WAF Regional Web ACL: 555119fd-9378-4754-9739-68d4912e5a7a
2019/04/16 00:05:04 [INFO] Deleting WAF Regional Web ACL: 555119fd-9378-4754-9739-68d4912e5a7a
2019/04/16 00:05:06 [INFO] Deleting WAF Regional Web ACL: 784b3a2a-3ecc-41ff-b6e6-faf88f0146fb
2019/04/16 00:05:07 [INFO] Removing Rules from WAF Regional Web ACL: 784b3a2a-3ecc-41ff-b6e6-faf88f0146fb
2019/04/16 00:05:09 [INFO] Deleting WAF Regional Web ACL: 784b3a2a-3ecc-41ff-b6e6-faf88f0146fb
2019/04/16 00:05:11 [INFO] Deleting WAF Regional Web ACL: 8d7809f7-8fd2-4370-a238-2d3328b99b16
2019/04/16 00:05:12 [INFO] Removing Rules from WAF Regional Web ACL: 8d7809f7-8fd2-4370-a238-2d3328b99b16
2019/04/16 00:05:14 [INFO] Deleting WAF Regional Web ACL: 8d7809f7-8fd2-4370-a238-2d3328b99b16
2019/04/16 00:05:16 [INFO] Deleting WAF Regional Web ACL: c901e2f1-3811-46f9-9ce1-c57f08ada0f4
2019/04/16 00:05:17 [INFO] Removing Rules from WAF Regional Web ACL: c901e2f1-3811-46f9-9ce1-c57f08ada0f4
2019/04/16 00:05:18 [INFO] Deleting WAF Regional Web ACL: c901e2f1-3811-46f9-9ce1-c57f08ada0f4
2019/04/16 00:05:20 [INFO] Deleting WAF Regional Web ACL: fdfb1214-bb95-479f-8bd2-f7417c1ed0e1
2019/04/16 00:05:21 [INFO] Removing Rules from WAF Regional Web ACL: fdfb1214-bb95-479f-8bd2-f7417c1ed0e1
2019/04/16 00:05:22 [INFO] Deleting WAF Regional Web ACL: fdfb1214-bb95-479f-8bd2-f7417c1ed0e1
2019/04/16 00:05:26 [INFO] Deleting WAF Regional Rate-Based Rule: 65626a7c-2837-455c-8331-bce59148ad91
2019/04/16 00:05:27 [INFO] Removing Predicates from WAF Regional Rate-Based Rule: 65626a7c-2837-455c-8331-bce59148ad91
2019/04/16 00:05:27 [ERR] error running (aws_wafregional_rate_based_rule): error removing predicates from WAF Regional Rate-Based Rule (65626a7c-2837-455c-8331-bce59148ad91): InvalidParameter: 1 validation error(s) found.
- missing required field, UpdateRateBasedRuleInput.RateLimit.

... after fixing error ...

2019/04/16 00:17:23 [INFO] Deleting WAF Regional Rate-Based Rule: 65626a7c-2837-455c-8331-bce59148ad91
2019/04/16 00:17:24 [INFO] Removing Predicates from WAF Regional Rate-Based Rule: 65626a7c-2837-455c-8331-bce59148ad91
2019/04/16 00:17:26 [INFO] Deleting WAF Regional Rate-Based Rule: 65626a7c-2837-455c-8331-bce59148ad91
2019/04/16 00:17:27 [INFO] Deleting WAF Regional Rate-Based Rule: 87d14e80-f44f-4b62-b2cc-c9de3584173d
2019/04/16 00:17:29 [INFO] Removing Predicates from WAF Regional Rate-Based Rule: 87d14e80-f44f-4b62-b2cc-c9de3584173d
2019/04/16 00:17:30 [INFO] Deleting WAF Regional Rate-Based Rule: 87d14e80-f44f-4b62-b2cc-c9de3584173d
2019/04/16 00:17:32 [INFO] Deleting WAF Regional Rate-Based Rule: bbcf3dc6-a5bb-40e9-aa15-7dc385feab98
2019/04/16 00:17:33 [INFO] Removing Predicates from WAF Regional Rate-Based Rule: bbcf3dc6-a5bb-40e9-aa15-7dc385feab98
2019/04/16 00:17:35 [INFO] Deleting WAF Regional Rate-Based Rule: bbcf3dc6-a5bb-40e9-aa15-7dc385feab98
2019/04/16 00:17:37 [INFO] Deleting WAF Regional Rate-Based Rule: ee08eeab-ad13-4b9e-aadc-6055298b2187
2019/04/16 00:17:38 [INFO] Removing Predicates from WAF Regional Rate-Based Rule: ee08eeab-ad13-4b9e-aadc-6055298b2187
2019/04/16 00:17:40 [INFO] Deleting WAF Regional Rate-Based Rule: ee08eeab-ad13-4b9e-aadc-6055298b2187
2019/04/16 00:17:42 [DEBUG] No AWS WAF Regional Rule Groups to sweep
2019/04/16 00:17:42 [DEBUG] Sweeper (aws_wafregional_rule) has dependency (aws_wafregional_web_acl), running..
2019/04/16 00:17:42 [DEBUG] Sweeper (aws_wafregional_web_acl) already ran in region (us-west-2)
2019/04/16 00:17:44 [INFO] Deleting WAF Regional Rule: 4eff1276-c239-42ac-b456-aac89858358b
2019/04/16 00:17:45 [INFO] Deleting WAF Regional Rule: 6c9a8818-8405-4659-9732-1dd76a0e798d
2019/04/16 00:17:47 [INFO] Deleting WAF Regional Rule: 925c6669-7ee0-41cc-aa7f-e3a444a3a05c
2019/04/16 00:17:48 [INFO] Deleting WAF Regional Rule: a07317d7-4bd2-4c2c-bbe5-0ece034e0e50
2019/04/16 00:17:49 [INFO] Deleting WAF Regional Rule: ac862a21-eb3d-4682-885e-78aa8605c54d
2019/04/16 00:17:50 [INFO] Deleting WAF Regional Rule: b2d75776-2933-4b49-8d32-b3d1cf07e7aa
2019/04/16 00:17:52 [INFO] Deleting WAF Regional Rule: d3263bd6-cc76-4af5-b6d9-4828e7697c5a
2019/04/16 00:17:53 [INFO] Deleting WAF Regional Rule: e210faaf-913e-42ff-98ec-08e76ee30e5d
2019/04/16 00:17:54 Sweeper Tests ran:
  - aws_wafregional_web_acl
  - aws_wafregional_rate_based_rule
  - aws_wafregional_rule_group
  - aws_wafregional_rule
```

Output from AWS CLI:

```
$ aws waf-regional list-rules | jq '.Rules | length'
0

$ aws waf-regional list-rate-based-rules | jq '.Rules | length'
0

$ aws waf-regional list-web-acls | jq '.WebACLs | length'
0
```
