### PR TITLE
Update aws_ssm_maintenance_window resource to support tags

### DIFF
--- a/aws/tagsSSM.go
+++ b/aws/tagsSSM.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"regexp"
 
@@ -100,6 +101,24 @@ func tagsToMapSSM(ts []*ssm.Tag) map[string]string {
 	}
 
 	return result
+}
+
+func saveTagsSSM(conn *ssm.SSM, d *schema.ResourceData, id string, resourceType string) error {
+	resp, err := conn.ListTagsForResource(&ssm.ListTagsForResourceInput{
+		ResourceId:   aws.String(id),
+		ResourceType: aws.String(resourceType),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retreiving tags for ResourceId(%s): %s", id, err)
+	}
+
+	var tagList []*ssm.Tag
+	if len(resp.TagList) > 0 {
+		tagList = resp.TagList
+	}
+
+	return d.Set("tags", tagsToMapSSM(tagList))
 }
 
 // compare a tag against a list of strings and checks if it should

--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `end_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to no longer run the maintenance window.
 * `schedule_timezone` - (Optional) Timezone for schedule in [Internet Assigned Numbers Authority (IANA) Time Zone Database format](https://www.iana.org/time-zones). For example: `America/Los_Angeles`, `etc/UTC`, or `Asia/Seoul`.
 * `start_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to begin the maintenance window.
+* `tags` - (Optional) A mapping of tags to assign to the object.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8006

Changes proposed in this pull request:

* Add tagging support for `aws_ssm_maintenance_window` resource.

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSSMMaintenanceWindow_Tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSSSMMaintenanceWindow_Tags -timeout 120m
=== RUN   TestAccAWSSSMMaintenanceWindow_Tags
=== PAUSE TestAccAWSSSMMaintenanceWindow_Tags
=== CONT  TestAccAWSSSMMaintenanceWindow_Tags
--- PASS: TestAccAWSSSMMaintenanceWindow_Tags (25.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.157s

...
```
