### PR TITLE
Mistake in the code example

### DIFF
--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -151,7 +151,7 @@ resource "aws_emr_cluster" "example" {
   # ... other configuration ...
 
   step {
-    action = "TERMINATE_CLUSTER"
+    action_on_failure  = "TERMINATE_CLUSTER"
     name   = "Setup Hadoop Debugging"
 
     hadoop_jar_step {


### PR DESCRIPTION
The parameter action set in the example doesn't exist. It should be action_on_failure

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
