### PR TITLE
docs/resource/aws_elasticsearch_domain: Add missing equals sign for advanced_options in example

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -172,7 +172,7 @@ resource "aws_elasticsearch_domain" "es" {
     security_group_ids = ["${aws_security_group.elasticsearch.id}"]
   }
 
-  advanced_options {
+  advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References:

* https://github.com/terraform-providers/terraform-provider-aws/issues/8332
* https://github.com/terraform-providers/terraform-provider-aws/pull/7267

In Terraform 0.12, the equals sign is required as `advanced_options` is an argument. Without running `terraform 0.12upgrade` to upgrade configurations (or if the tool misses this particular configuration), operators will receive a potentially confusing error message on an element of the map, e.g.

```
Error: Invalid argument name

  on main.tf line 60, in resource "aws_elasticsearch_domain" "es":
  60:     "rest.action.multi.allow_explicit_index" = "true"

Argument names must not be quoted.
```

This change is backwards compatible with Terraform 0.11 and prior.