### PR TITLE
tests/resource/aws_ami: Add manage_ebs_snapshots virtual attribute to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_ami_test.go
+++ b/aws/resource_aws_ami_test.go
@@ -38,6 +38,9 @@ func TestAccAWSAMI_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manage_ebs_snapshots",
+				},
 			},
 		},
 	})
@@ -76,6 +79,9 @@ func TestAccAWSAMI_snapshotSize(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manage_ebs_snapshots",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, virtual attributes that do not call `ResourceData.Set()` are no longer automatically ignored during `ImportStateVerify` testing. Here we add the virtual attribute to the `ImportStateVerifyIgnore` list to match similar behavior of Terraform 0.11 acceptance testing. This change is backwards compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSAMI_snapshotSize (59.00s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=20) "manage_ebs_snapshots": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSAMI_basic (59.04s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=20) "manage_ebs_snapshots": (string) (len=5) "false"
        }
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSAMI_basic (43.17s)
--- PASS: TestAccAWSAMI_snapshotSize (43.35s)
```