### PR TITLE
tests/resource/aws_neptune_cluster: Add apply_immediately virtual attribute to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_neptune_cluster_test.go
+++ b/aws/resource_aws_neptune_cluster_test.go
@@ -40,10 +40,15 @@ func TestAccAWSNeptuneCluster_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -66,10 +71,15 @@ func TestAccAWSNeptuneCluster_namePrefix(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"cluster_identifier_prefix", "skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -91,10 +101,15 @@ func TestAccAWSNeptuneCluster_takeFinalSnapshot(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"final_snapshot_identifier", "skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -126,10 +141,15 @@ func TestAccAWSNeptuneCluster_updateTags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -167,10 +187,15 @@ func TestAccAWSNeptuneCluster_updateIamRoles(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -194,10 +219,15 @@ func TestAccAWSNeptuneCluster_kmsKey(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -220,10 +250,15 @@ func TestAccAWSNeptuneCluster_encrypted(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -263,10 +298,15 @@ func TestAccAWSNeptuneCluster_backupsUpdate(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -289,10 +329,15 @@ func TestAccAWSNeptuneCluster_iamAuth(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_neptune_cluster.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_final_snapshot"},
+				ResourceName:      "aws_neptune_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"final_snapshot_identifier",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
In the Terraform 0.12 Provider SDK acceptance testing framework, virtual
attributes that do not call ResourceData.Set() are no longer
automatically ignored during ImportStateVerify testing. Here we add the
virtual attribute to the ImportStateVerifyIgnore list to match similar
behavior of Terraform 0.11 acceptance testing. This change is backwards
compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSNeptuneCluster_iamAuth (113.49s)                                                                                                                                                                                                                                                                  [61/437]
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSNeptuneCluster_updateTags (135.95s)
    testing.go:568: Step 2 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSNeptuneCluster_updateIamRoles (138.68s)
    testing.go:568: Step 3 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSNeptuneCluster_kmsKey (153.26s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSNeptuneCluster_namePrefix (154.10s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSNeptuneCluster_encrypted (154.13s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSNeptuneCluster_basic (154.75s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSNeptuneCluster_takeFinalSnapshot (179.76s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSNeptuneCluster_iamAuth (122.22s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (122.26s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (122.72s)
--- PASS: TestAccAWSNeptuneCluster_basic (122.94s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (142.70s)
--- PASS: TestAccAWSNeptuneCluster_updateTags (145.47s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (148.15s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (186.39s)

```


<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```