### PR TITLE
tests/resource/aws_db_instance: Add all virtual attributes to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -113,9 +113,10 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"final_snapshot_identifier",
 					"password",
 					"skip_final_snapshot",
-					"final_snapshot_identifier",
 				},
 			},
 		},
@@ -1609,10 +1610,15 @@ func TestAccAWSDBInstance_cloudwatchLogsExportConfiguration(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "aws_db_instance.bar",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ResourceName:      "aws_db_instance.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"final_snapshot_identifier",
+					"password",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -1693,10 +1699,15 @@ func TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"final_snapshot_identifier",
+					"password",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -1721,10 +1732,15 @@ func TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql(t *testing.T) 
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"password"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"final_snapshot_identifier",
+					"password",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, virtual attributes that do not call `ResourceData.Set()` are no longer automatically ignored during `ImportStateVerify` testing. Here we add the virtual attributes to the `ImportStateVerifyIgnore` list to match similar behavior of Terraform 0.11 acceptance testing. This change is backwards compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (745.69s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (495.15s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDBInstance_basic (372.34s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (512.23s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (426.36s)
--- PASS: TestAccAWSDBInstance_basic (521.73s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (555.42s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (859.04s)
```
