### PR TITLE
tests/resource/aws_docdb_cluster: Add apply_immediately virtual attribute to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_docdb_cluster_test.go
+++ b/aws/resource_aws_docdb_cluster_test.go
@@ -48,6 +48,7 @@ func TestAccAWSDocDBCluster_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -79,6 +80,7 @@ func TestAccAWSDocDBCluster_namePrefix(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -110,6 +112,7 @@ func TestAccAWSDocDBCluster_generatedName(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -140,6 +143,7 @@ func TestAccAWSDocDBCluster_takeFinalSnapshot(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -188,6 +192,7 @@ func TestAccAWSDocDBCluster_updateTags(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -226,6 +231,7 @@ func TestAccAWSDocDBCluster_updateCloudwatchLogsExports(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -264,6 +270,7 @@ func TestAccAWSDocDBCluster_kmsKey(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -297,6 +304,7 @@ func TestAccAWSDocDBCluster_encrypted(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -333,6 +341,7 @@ func TestAccAWSDocDBCluster_backupsUpdate(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",
@@ -377,6 +386,7 @@ func TestAccAWSDocDBCluster_Port(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"cluster_identifier_prefix",
 					"final_snapshot_identifier",
 					"master_password",


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, virtual attributes that do not call `ResourceData.Set()` are no longer automatically ignored during `ImportStateVerify` testing. Here we add the virtual attributes to the `ImportStateVerifyIgnore` list to match similar behavior of Terraform 0.11 acceptance testing. This change is backwards compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSDocDBCluster_basic (129.17s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_backupsUpdate (108.81s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_encrypted (119.32s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_generatedName (129.70s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_kmsKey (148.36s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_namePrefix (129.24s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_Port (110.44s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_takeFinalSnapshot (189.60s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (108.56s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBCluster_updateTags (118.80s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (7.35s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (122.05s)
--- PASS: TestAccAWSDocDBCluster_basic (122.08s)
--- PASS: TestAccAWSDocDBCluster_generatedName (140.48s)
--- PASS: TestAccAWSDocDBCluster_encrypted (140.73s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (160.10s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (160.11s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (162.46s)
--- PASS: TestAccAWSDocDBCluster_updateTags (181.33s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (185.19s)
--- PASS: TestAccAWSDocDBCluster_Port (248.26s)
```