### PR TITLE
tests/resource/aws_docdb_cluster_instance: Add apply_immediately virtual attribute to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_docdb_cluster_instance_test.go
+++ b/aws/resource_aws_docdb_cluster_instance_test.go
@@ -54,6 +54,7 @@ func TestAccAWSDocDBClusterInstance_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"identifier_prefix",
 				},
 			},
@@ -84,6 +85,7 @@ func TestAccAWSDocDBClusterInstance_az(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"identifier_prefix",
 				},
 			},
@@ -116,6 +118,7 @@ func TestAccAWSDocDBClusterInstance_namePrefix(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"identifier_prefix",
 				},
 			},
@@ -146,6 +149,7 @@ func TestAccAWSDocDBClusterInstance_generatedName(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"identifier_prefix",
 				},
 			},
@@ -175,6 +179,7 @@ func TestAccAWSDocDBClusterInstance_kmsKey(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
 					"identifier_prefix",
 				},
 			},


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, virtual attributes that do not call `ResourceData.Set()` are no longer automatically ignored during `ImportStateVerify` testing. Here we add the virtual attributes to the `ImportStateVerifyIgnore` list to match similar behavior of Terraform 0.11 acceptance testing. This change is backwards compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSDocDBClusterInstance_basic (1319.19s)
    testing.go:568: Step 2 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBClusterInstance_az (636.71s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBClusterInstance_generatedName (650.41s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBClusterInstance_kmsKey (675.53s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }

--- FAIL: TestAccAWSDocDBClusterInstance_namePrefix (710.27s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSDocDBClusterInstance_disappears (655.59s)
--- PASS: TestAccAWSDocDBClusterInstance_namePrefix (677.65s)
--- PASS: TestAccAWSDocDBClusterInstance_az (692.68s)
--- PASS: TestAccAWSDocDBClusterInstance_kmsKey (724.25s)
--- PASS: TestAccAWSDocDBClusterInstance_generatedName (748.10s)
--- PASS: TestAccAWSDocDBClusterInstance_basic (1348.56s)
```
