### PR TITLE
tests/resource/aws_rds_cluster: Add apply_immediately virtual attribute to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -118,7 +118,12 @@ func TestAccAWSRDSCluster_importBasic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"master_password", "skip_final_snapshot"},
+					"apply_immediately",
+					"cluster_identifier_prefix",
+					"master_password",
+					"skip_final_snapshot",
+					"snapshot_identifier",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, virtual
attributes that do not call ResourceData.Set() are no longer
automatically ignored during ImportStateVerify testing. Here we add the
virtual attribute to the ImportStateVerifyIgnore list to match similar
behavior of Terraform 0.11 acceptance testing. This change is backwards
compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSRDSCluster_importBasic (133.37s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "apply_immediately": (string) (len=5) "false"
        }
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSRDSCluster_importBasic (133.12s)
```