### PR TITLE
tests/resource/aws_rds_cluster_instance: Add  virtual attributes to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_rds_cluster_instance_test.go
+++ b/aws/resource_aws_rds_cluster_instance_test.go
@@ -16,27 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
-func TestAccAWSRDSClusterInstance_importBasic(t *testing.T) {
-	resourceName := "aws_rds_cluster_instance.cluster_instances"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSClusterInstanceConfig(acctest.RandInt()),
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 	var v rds.DBInstance
 
@@ -60,6 +39,15 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_rds_cluster_instance.cluster_instances", "engine_version"),
 					resource.TestCheckResourceAttr("aws_rds_cluster_instance.cluster_instances", "engine", "aurora"),
 				),
+			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
 			},
 			{
 				Config: testAccAWSClusterInstanceConfigModified(acctest.RandInt()),
@@ -89,6 +77,15 @@ func TestAccAWSRDSClusterInstance_az(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_rds_cluster_instance.cluster_instances", "availability_zone", regexp.MustCompile("^us-west-2[a-z]{1}$")),
 				),
 			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
 		},
 	})
 }
@@ -113,6 +110,15 @@ func TestAccAWSRDSClusterInstance_namePrefix(t *testing.T) {
 						"aws_rds_cluster_instance.test", "identifier", regexp.MustCompile("^tf-cluster-instance-")),
 				),
 			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
 		},
 	})
 }
@@ -134,6 +140,15 @@ func TestAccAWSRDSClusterInstance_generatedName(t *testing.T) {
 						"aws_rds_cluster_instance.test", "identifier", regexp.MustCompile("^tf-")),
 				),
 			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
 		},
 	})
 }
@@ -154,6 +169,15 @@ func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_rds_cluster_instance.cluster_instances", "kms_key_id", keyRegex),
 				),
+			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
 			},
 		},
 	})
@@ -199,10 +223,13 @@ func TestAccAWSRDSClusterInstance_PubliclyAccessible(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
 			},
 			{
 				Config: testAccAWSRDSClusterInstanceConfig_PubliclyAccessible(rName, false),
@@ -231,6 +258,15 @@ func TestAccAWSRDSClusterInstance_CopyTagsToSnapshot(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster_instance.cluster_instances", "copy_tags_to_snapshot", "true"),
 				),
+			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
 			},
 			{
 				Config: testAccAWSClusterInstanceConfig_CopyTagsToSnapshot(rNameSuffix, false),
@@ -333,6 +369,15 @@ func TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor(t *testing.T) {
 					testAccCheckAWSDBClusterInstanceAttributes(&v),
 				),
 			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
+			},
 		},
 	})
 }
@@ -356,6 +401,15 @@ func TestAccAWSRDSClusterInstance_withInstancePerformanceInsights(t *testing.T) 
 					resource.TestMatchResourceAttr(
 						"aws_rds_cluster_instance.cluster_instances", "performance_insights_kms_key_id", keyRegex),
 				),
+			},
+			{
+				ResourceName:      "aws_rds_cluster_instance.cluster_instances",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"apply_immediately",
+					"identifier_prefix",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, virtual
attributes that do not call ResourceData.Set() are no longer
automatically ignored during ImportStateVerify testing. Here we add the
virtual attribute to the ImportStateVerifyIgnore list to match similar
behavior of Terraform 0.11 acceptance testing. This change is backwards
compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSRDSClusterInstance_importBasic (826.87s)
testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

    (map[string]string) {
    }

    (map[string]string) (len=1) {
     (string) (len=17) "apply_immediately": (string) (len=5) "false"
    }
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (506.89s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (587.64s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (705.85s)
--- PASS: TestAccAWSRDSClusterInstance_az (754.30s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (761.80s)
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (763.50s)
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (774.54s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (823.31s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (837.02s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1326.60s)
```