### PR TITLE
tests/resource/aws_cloudformation_stack_set: Allow both Terraform 0.11 and 0.12 error messages for ExpectError testing

### DIFF
--- a/aws/resource_aws_cloudformation_stack_set_test.go
+++ b/aws/resource_aws_cloudformation_stack_set_test.go
@@ -204,7 +204,7 @@ func TestAccAWSCloudFormationStackSet_Name(t *testing.T) {
 			},
 			{
 				Config:      testAccAWSCloudFormationStackSetConfigName(acctest.RandStringFromCharSet(129, acctest.CharSetAlpha)),
-				ExpectError: regexp.MustCompile(`expected length`),
+				ExpectError: regexp.MustCompile(`(cannot be longer|expected length)`),
 			},
 			{
 				Config:      testAccAWSCloudFormationStackSetConfigName("1"),


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSCloudFormationStackSet_Name (1.26s)
    testing.go:561: Step 1, expected error:

        config is invalid: "name" cannot be longer than 64 characters

        To match:

        expected length
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSCloudFormationStackSet_Name (38.02s)
```