### PR TITLE
tests/resource/aws_redshift_cluster: Add enable_logging removed attribute to ImportStateVerifyIgnore list

### DIFF
--- a/aws/resource_aws_redshift_cluster_test.go
+++ b/aws/resource_aws_redshift_cluster_test.go
@@ -95,29 +95,6 @@ func TestValidateRedshiftClusterDbName(t *testing.T) {
 	}
 }
 
-func TestAccAWSRedshiftCluster_importBasic(t *testing.T) {
-	resourceName := "aws_redshift_cluster.default"
-	config := testAccAWSRedshiftClusterConfig_basic(acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-			},
-
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"master_password", "skip_final_snapshot"},
-			},
-		},
-	})
-}
-
 func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 	var v redshift.Cluster
 
@@ -140,6 +117,16 @@ func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_redshift_cluster.default", "dns_name", regexp.MustCompile(fmt.Sprintf("^tf-redshift-cluster-%d.*\\.redshift\\..*", ri))),
 				),
 			},
+			{
+				ResourceName:      "aws_redshift_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"final_snapshot_identifier",
+					"master_password",
+					"skip_final_snapshot",
+				},
+			},
 		},
 	})
 }
@@ -159,6 +146,16 @@ func TestAccAWSRedshiftCluster_withFinalSnapshot(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
 				),
+			},
+			{
+				ResourceName:      "aws_redshift_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"final_snapshot_identifier",
+					"master_password",
+					"skip_final_snapshot",
+				},
 			},
 		},
 	})
@@ -187,6 +184,16 @@ func TestAccAWSRedshiftCluster_kmsKey(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_redshift_cluster.default", "kms_key_id", keyRegex),
 				),
 			},
+			{
+				ResourceName:      "aws_redshift_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"final_snapshot_identifier",
+					"master_password",
+					"skip_final_snapshot",
+				},
+			},
 		},
 	})
 }
@@ -210,6 +217,16 @@ func TestAccAWSRedshiftCluster_enhancedVpcRoutingEnabled(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "enhanced_vpc_routing", "true"),
 				),
+			},
+			{
+				ResourceName:      "aws_redshift_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"final_snapshot_identifier",
+					"master_password",
+					"skip_final_snapshot",
+				},
 			},
 			{
 				Config: postConfig,
@@ -242,7 +259,16 @@ func TestAccAWSRedshiftCluster_loggingEnabled(t *testing.T) {
 						"aws_redshift_cluster.default", "logging.0.bucket_name", fmt.Sprintf("tf-redshift-logging-%d", rInt)),
 				),
 			},
-
+			{
+				ResourceName:      "aws_redshift_cluster.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"final_snapshot_identifier",
+					"master_password",
+					"skip_final_snapshot",
+				},
+			},
 			{
 				Config: testAccAWSRedshiftClusterConfig_loggingDisabled(rInt),
 				Check: resource.ComposeTestCheckFunc(
@@ -951,7 +977,7 @@ resource "aws_kms_key" "foo" {
 	}
 	POLICY
 	}
-	  
+
 resource "aws_redshift_cluster" "default" {
   cluster_identifier = "tf-redshift-cluster-%d"
   availability_zone = "us-west-2a"
@@ -991,7 +1017,7 @@ resource "aws_kms_key" "foo" {
 	}
 	POLICY
 	}
-	  
+
 resource "aws_redshift_cluster" "default" {
   cluster_identifier = "tf-redshift-cluster-%d"
   availability_zone = "us-west-2a"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, removed
attributes that do not call ResourceData.Set() are no longer
automatically ignored during ImportStateVerify testing. Here we add the
removed attribute to the ImportStateVerifyIgnore list to match similar
behavior of Terraform 0.11 acceptance testing. This change is backwards
compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSRedshiftCluster_importBasic (577.26s)
testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

  (map[string]string) {
  }

  (map[string]string) (len=1) {
   (string) (len=14) "enable_logging": (string) (len=5) "false"
  }
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSRedshiftCluster_basic (476.37s)
```