### PR TITLE
tests/resource/aws_emr_cluster: Use configuration block syntax for instance_group name argument test configuration

### DIFF
--- a/aws/resource_aws_emr_cluster_test.go
+++ b/aws/resource_aws_emr_cluster_test.go
@@ -3031,46 +3031,6 @@ resource "aws_iam_role_policy_attachment" "emr-autoscaling-role" {
 
 func testAccAWSEmrClusterConfigInstanceGroupsName(r int) string {
 	return fmt.Sprintf(`
-variable "instance_groups" {
-  type = "list"
-  default = [
-      {
-          name = "MasterInstanceGroup"
-          instance_role = "MASTER"
-          instance_type = "m3.xlarge"
-          instance_count = 1
-      },
-      {
-          name = "CoreInstanceGroup"
-          instance_role = "CORE"
-          instance_type = "r4.xlarge"
-          instance_count = 2
-          ebs_config = [
-              {
-                  iops = 0
-                  size = 100
-                  type = "gp2"
-                  volumes_per_instance = 1
-              }
-          ]
-      },
-      {
-          name = "TaskInstanceGroup"
-          instance_role = "TASK"
-          instance_type = "r4.xlarge"
-          instance_count = 3
-          ebs_config = [
-              {
-                  iops = 0
-                  size = 100
-                  type = "gp2"
-                  volumes_per_instance = 1
-              }
-          ]
-      },
-  ]
-}
-
 resource "aws_emr_cluster" "tf-test-cluster" {
   name          = "emr-test-%[1]d"
   release_label = "emr-4.6.0"
@@ -3083,7 +3043,40 @@ resource "aws_emr_cluster" "tf-test-cluster" {
     instance_profile                  = "${aws_iam_instance_profile.emr_profile.arn}"
   }
 
-  instance_group = "${var.instance_groups}"
+  instance_group {
+    instance_count = 1
+    instance_role  = "MASTER"
+    instance_type  = "m3.xlarge"
+    name           = "MasterInstanceGroup"
+  }
+
+  instance_group {
+    instance_count = 2
+    instance_role  = "CORE"
+    instance_type  = "r4.xlarge"
+    name           = "CoreInstanceGroup"
+
+    ebs_config {
+      iops                 = 0
+      size                 = 100
+      type                 = "gp2"
+      volumes_per_instance = 1
+    }
+  }
+
+  instance_group {
+    instance_count = 3
+    instance_role  = "TASK"
+    instance_type  = "r4.xlarge"
+    name           = "TaskInstanceGroup"
+
+    ebs_config {
+      iops                 = 0
+      size                 = 100
+      type                 = "gp2"
+      volumes_per_instance = 1
+    }
+  }
 
   tags = {
     role     = "rolename"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Previously, the test configuration was relying on undocumented behavior with using a list variable to assign the instance_group configuration blocks. The acceptance testing framework in the Terraform 0.12 Provider SDK rightfully notes the unexpected handling of the variable:

```
--- FAIL: TestAccAWSEMRCluster_instance_group_names (0.84s)
    testing.go:568: Step 0 error: /opt/teamcity-agent/temp/buildTmp/tf-test731826738/main.tf:4,13-39,4: Invalid default value for variable; This default value is not compatible with the variable's type constraint: all list elements must have the same type.
```

Since this test is valuable (no others are testing the `name` argument within `instance_group` configuration blocks), we update the test configuration syntax to use configuration blocks in a backwards and forwards compatible manner.

Output from Terraform 0.11 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSEMRCluster_instance_group_names (580.28s)
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSEMRCluster_instance_group_names (420.79s)
```