### PR TITLE
[WIP] Adds tags to aws_acm_certificate data source

### DIFF
--- a/website/docs/d/acm_certificate.html.markdown
+++ b/website/docs/d/acm_certificate.html.markdown
@@ -8,9 +8,11 @@ description: |-
 
 # Data Source: aws_acm_certificate
 
+~> **Note:** When not specifying `domain` terraform needs to iterate over all certificates in the region. 
+
 Use this data source to get the ARN of a certificate in AWS Certificate
-Manager (ACM), you can reference
-it by domain without having to hard code the ARNs as input.
+Manager (ACM), you can reference certificates by domain, type, status or 
+tags without having to hard code the ARNs as input.
 
 ## Example Usage
 
@@ -25,16 +27,33 @@ data "aws_acm_certificate" "example" {
   types       = ["AMAZON_ISSUED"]
   most_recent = true
 }
+
+data "aws_acm_certificate_arns" "example" {
+  domain   = "tf.example.com"
+  statuses = ["ISSUED"]
+  tags {
+    Foo = "BAR"
+  }
+}
+
+data "aws_acm_certificate_arns" "example" {
+  tags {
+    Name = "dev-cert"
+    TerraformWorkspace = "${terraform.workspace}"
+  }
+}
 ```
 
 ## Argument Reference
 
- * `domain` - (Required) The domain of the certificate to look up. If no certificate is found with this name, an error will be returned.
+ * `domain` - (Optional) The domain of the certificate to look up. If set and no certificate is found with this name, an error will be returned.
  * `statuses` - (Optional) A list of statuses on which to filter the returned list. Valid values are `PENDING_VALIDATION`, `ISSUED`,
    `INACTIVE`, `EXPIRED`, `VALIDATION_TIMED_OUT`, `REVOKED` and `FAILED`. If no value is specified, only certificates in the `ISSUED` state
    are returned.
  * `types` - (Optional) A list of types on which to filter the returned list. Valid values are `AMAZON_ISSUED` and `IMPORTED`.
  * `most_recent` - (Optional) If set to true, it sorts the certificates matched by previous criteria by the NotBefore field, returning only the most recent one. If set to false, it returns an error if more than one certificate is found. Defaults to false.
+ * `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+    a pair on the desired certificates.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #1918

Changes proposed in this pull request:

* Implements a new option for the ACM data source allowing you to select ACM certificates based on tags

TODO: Implement acceptance test

It's not completely clear to me how the acceptance test for this data source work. It seems to rely on some certificates created somewhere else (I don't know where). And to test these changes I need those certificates to have certain specific tags. If I could get some assistance/hints here, that would be appreciated.

<!---
Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
-->