### PR TITLE
resource/aws_network_interface: Refresh private_ips_count into Terraform state and allow updates from 0 to greater than 0

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -165,25 +165,36 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	eni := describeResp.NetworkInterfaces[0]
-	d.Set("subnet_id", eni.SubnetId)
-	d.Set("private_ip", eni.PrivateIpAddress)
-	d.Set("private_dns_name", eni.PrivateDnsName)
-	d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses))
-	d.Set("security_groups", flattenGroupIdentifiers(eni.Groups))
-	d.Set("source_dest_check", eni.SourceDestCheck)
 
-	if eni.Description != nil {
-		d.Set("description", eni.Description)
-	}
-
-	// Tags
-	d.Set("tags", tagsToMap(eni.TagSet))
+	attachment := []map[string]interface{}{}
 
 	if eni.Attachment != nil {
-		attachment := []map[string]interface{}{flattenAttachment(eni.Attachment)}
-		d.Set("attachment", attachment)
-	} else {
-		d.Set("attachment", nil)
+		attachment = []map[string]interface{}{flattenAttachment(eni.Attachment)}
+	}
+
+	if err := d.Set("attachment", attachment); err != nil {
+		return fmt.Errorf("error setting attachment: %s", err)
+	}
+
+	d.Set("description", eni.Description)
+	d.Set("private_dns_name", eni.PrivateDnsName)
+	d.Set("private_ip", eni.PrivateIpAddress)
+
+	if err := d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses)); err != nil {
+		return fmt.Errorf("error setting private_ips: %s", err)
+	}
+
+	d.Set("private_ips_count", len(eni.PrivateIpAddresses)-1)
+
+	if err := d.Set("security_groups", flattenGroupIdentifiers(eni.Groups)); err != nil {
+		return fmt.Errorf("error setting security_groups: %s", err)
+	}
+
+	d.Set("source_dest_check", eni.SourceDestCheck)
+	d.Set("subnet_id", eni.SubnetId)
+
+	if err := d.Set("tags", tagsToMap(eni.TagSet)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil
@@ -324,7 +335,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 
 	d.SetPartial("source_dest_check")
 
-	if d.HasChange("private_ips_count") {
+	if d.HasChange("private_ips_count") && !d.IsNewResource() {
 		o, n := d.GetChange("private_ips_count")
 		private_ips := d.Get("private_ips").(*schema.Set).List()
 		private_ips_filtered := private_ips[:0]
@@ -336,7 +347,7 @@ func resourceAwsNetworkInterfaceUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
-		if o != nil && o != 0 && n != nil && n != len(private_ips_filtered) {
+		if o != nil && n != nil && n != len(private_ips_filtered) {
 
 			diff := n.(int) - o.(int)
 

--- a/aws/resource_aws_network_interface_test.go
+++ b/aws/resource_aws_network_interface_test.go
@@ -67,27 +67,6 @@ func testSweepEc2NetworkInterfaces(region string) error {
 	return nil
 }
 
-func TestAccAWSENI_importBasic(t *testing.T) {
-	resourceName := "aws_network_interface.bar"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSENIDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSENIConfig,
-			},
-
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSENI_basic(t *testing.T) {
 	var conf ec2.NetworkInterface
 
@@ -111,6 +90,11 @@ func TestAccAWSENI_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "description", "Managed by Terraform"),
 				),
+			},
+			{
+				ResourceName:      "aws_network_interface.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -154,7 +138,11 @@ func TestAccAWSENI_updatedDescription(t *testing.T) {
 						"aws_network_interface.bar", "description", "Managed by Terraform"),
 				),
 			},
-
+			{
+				ResourceName:      "aws_network_interface.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccAWSENIConfigUpdatedDescription,
 				Check: resource.ComposeTestCheckFunc(
@@ -187,6 +175,11 @@ func TestAccAWSENI_attached(t *testing.T) {
 						"aws_network_interface.bar", "tags.Name", "bar_interface"),
 				),
 			},
+			{
+				ResourceName:      "aws_network_interface.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -207,6 +200,11 @@ func TestAccAWSENI_ignoreExternalAttachment(t *testing.T) {
 					testAccCheckAWSENIAttributes(&conf),
 					testAccCheckAWSENIMakeExternalAttachment("aws_instance.foo", &conf),
 				),
+			},
+			{
+				ResourceName:      "aws_network_interface.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -229,6 +227,11 @@ func TestAccAWSENI_sourceDestCheck(t *testing.T) {
 						"aws_network_interface.bar", "source_dest_check", "false"),
 				),
 			},
+			{
+				ResourceName:      "aws_network_interface.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -249,6 +252,72 @@ func TestAccAWSENI_computedIPs(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_network_interface.bar", "private_ips.#", "1"),
 				),
+			},
+			{
+				ResourceName:      "aws_network_interface.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSENI_PrivateIpsCount(t *testing.T) {
+	var networkInterface1, networkInterface2, networkInterface3, networkInterface4 ec2.NetworkInterface
+	resourceName := "aws_network_interface.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSENIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSENIConfigPrivateIpsCount(1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists(resourceName, &networkInterface1),
+					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSENIConfigPrivateIpsCount(2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists(resourceName, &networkInterface2),
+					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSENIConfigPrivateIpsCount(0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists(resourceName, &networkInterface3),
+					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSENIConfigPrivateIpsCount(1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSENIExists(resourceName, &networkInterface4),
+					resource.TestCheckResourceAttr(resourceName, "private_ips_count", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -653,3 +722,29 @@ resource "aws_network_interface" "bar" {
     }
 }
 `
+
+func testAccAWSENIConfigPrivateIpsCount(privateIpsCount int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "tf-acc-test-network-interface-private-ips-count"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "10.0.0.0/24"
+  vpc_id = "${aws_vpc.test.id}"
+
+  tags = {
+    Name = "tf-acc-test-network-interface-private-ips-count"
+  }
+}
+
+resource "aws_network_interface" "test" {
+  private_ips_count = %[1]d
+  subnet_id         = "${aws_subnet.test.id}"
+}
+`, privateIpsCount)
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #3210

The Terraform 0.12 Provider SDK acceptance testing was catching that the `private_ips_count` attribute (used to signify _secondary_ private IPs) was not properly being read into the Terraform state during import.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSENI_importBasic (13.57s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=17) "private_ips_count": (string) (len=1) "0"
        }
```

To fix this particular issue, we prefer to always read this attribute into the Terraform state during `Read`. While looking through previous bug reports for this attribute, came across a report that the resource was not properly updating the count when going from 0 to greater than 0. Added a covering acceptance test and fixed the update logic.

Previous output from acceptance testing before `private_ips_count` update logic changes:

```
--- FAIL: TestAccAWSENI_PrivateIpsCount (82.51s)
    testing.go:568: Step 6 error: Check failed: Check 2/2 error: aws_network_interface.test: Attribute 'private_ips_count' expected "1", got "0"
```

Output from Terraform 0.11 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSENI_computedIPs (33.48s)
--- PASS: TestAccAWSENI_sourceDestCheck (35.03s)
--- PASS: TestAccAWSENI_disappears (36.04s)
--- PASS: TestAccAWSENI_basic (39.30s)
--- PASS: TestAccAWSENI_updatedDescription (64.26s)
--- PASS: TestAccAWSENI_PrivateIpsCount (90.29s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (119.86s)
--- PASS: TestAccAWSENI_attached (257.95s)
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSENI_computedIPs (35.09s)
--- PASS: TestAccAWSENI_sourceDestCheck (36.54s)
--- PASS: TestAccAWSENI_disappears (37.25s)
--- PASS: TestAccAWSENI_basic (39.92s)
--- PASS: TestAccAWSENI_updatedDescription (64.87s)
--- PASS: TestAccAWSENI_PrivateIpsCount (91.51s)
--- PASS: TestAccAWSENI_ignoreExternalAttachment (121.11s)
--- PASS: TestAccAWSENI_attached (261.48s)
```
