### PR TITLE
resource/aws_instance: Always refresh associate_public_ip_address and  ipv6_address_count into Terraform state

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -770,9 +770,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		if primaryNetworkInterface.NetworkInterfaceId != nil {
 			d.Set("primary_network_interface_id", primaryNetworkInterface.NetworkInterfaceId)
 		}
-		if primaryNetworkInterface.Ipv6Addresses != nil {
-			d.Set("ipv6_address_count", len(primaryNetworkInterface.Ipv6Addresses))
-		}
+		d.Set("ipv6_address_count", len(primaryNetworkInterface.Ipv6Addresses))
 		if primaryNetworkInterface.SourceDestCheck != nil {
 			d.Set("source_dest_check", primaryNetworkInterface.SourceDestCheck)
 		}
@@ -784,8 +782,10 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 	} else {
-		d.Set("subnet_id", instance.SubnetId)
+		d.Set("associate_public_ip_address", instance.PublicIpAddress != nil)
+		d.Set("ipv6_address_count", 0)
 		d.Set("primary_network_interface_id", "")
+		d.Set("subnet_id", instance.SubnetId)
 	}
 
 	if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, attributes that do not call `ResourceData.Set()` are no longer automatically ignored during `ImportStateVerify` testing. Here we opt to always refresh the `associate_public_ip_address` and `ipv6_address_count` attributes into the Terraform state. This change is backwards compatible.

This changeset is the bare minimum to ensure the existing acceptance testing is in a better passing state with the Terraform 0.12 Provider SDK, however there are likely many more additional changes required once the `ImportStateVerify` test step is applied to all acceptance tests for the resource as part of some upcoming technical debt work (https://github.com/terraform-providers/terraform-provider-aws/issues/4987).

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSInstance_importBasic (93.87s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=18) "ipv6_address_count": (string) (len=1) "0"
        }

--- FAIL: TestAccAWSInstance_importInDefaultVpcBySgId (193.29s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=18) "ipv6_address_count": (string) (len=1) "0"
        }

--- FAIL: TestAccAWSInstance_importInDefaultVpcBySgName (183.91s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=18) "ipv6_address_count": (string) (len=1) "0"
        }

--- FAIL: TestAccAWSInstance_importInEc2Classic (108.87s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=2) {
         (string) (len=27) "associate_public_ip_address": (string) (len=5) "false",
         (string) (len=18) "ipv6_address_count": (string) (len=1) "0"
        }
```

Output from Terraform 0.11 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSInstance_addSecondaryInterface (85.27s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (227.80s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (183.36s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPublic (51.53s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (52.10s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (51.22s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (51.22s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (71.58s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (50.40s)
--- PASS: TestAccAWSInstance_basic (317.85s)
--- PASS: TestAccAWSInstance_blockDevices (101.23s)
--- PASS: TestAccAWSInstance_changeInstanceType (328.94s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (151.69s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (178.74s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (340.18s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (56.89s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (320.30s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (183.49s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (188.24s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (290.36s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (291.21s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (284.34s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (116.93s)
--- PASS: TestAccAWSInstance_disableApiTermination (257.56s)
--- PASS: TestAccAWSInstance_disappears (258.64s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (277.56s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (154.93s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (145.14s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (79.88s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (89.27s)
--- PASS: TestAccAWSInstance_importBasic (201.64s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgId (190.99s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgName (78.33s)
--- PASS: TestAccAWSInstance_importInEc2Classic (209.77s)
--- PASS: TestAccAWSInstance_instanceProfileChange (143.04s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (202.10s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (218.22s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (9.72s)
--- PASS: TestAccAWSInstance_keyPairCheck (78.74s)
--- PASS: TestAccAWSInstance_multipleRegions (280.08s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (73.45s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (96.32s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (68.35s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (53.25s)
--- PASS: TestAccAWSInstance_placementGroup (174.29s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (153.92s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (184.91s)
--- PASS: TestAccAWSInstance_privateIP (72.60s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (172.17s)
--- PASS: TestAccAWSInstance_rootInstanceStore (66.92s)
--- PASS: TestAccAWSInstance_sourceDestCheck (114.61s)
--- PASS: TestAccAWSInstance_tags (265.95s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (79.90s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (78.14s)
--- PASS: TestAccAWSInstance_userDataBase64 (276.05s)
--- PASS: TestAccAWSInstance_volumeTags (95.11s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (110.97s)
--- PASS: TestAccAWSInstance_vpc (109.50s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (128.98s)
```

Output from Terraform 0.12 Provider SDK acceptance testing (test failure related to EC2 eventual consistency):

```
--- FAIL: TestAccAWSInstance_associatePublic_defaultPublic (199.26s)
    testing.go:568: Step 0 error: Check failed: Check 2/3 error: aws_instance.foo: Attribute 'associate_public_ip_address' expected "true", got "false"

--- PASS: TestAccAWSInstance_addSecondaryInterface (87.28s)
--- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (228.83s)
--- PASS: TestAccAWSInstance_associatePublic_defaultPrivate (72.65s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPrivate (193.33s)
--- PASS: TestAccAWSInstance_associatePublic_explicitPublic (52.31s)
--- PASS: TestAccAWSInstance_associatePublic_overridePrivate (72.60s)
--- PASS: TestAccAWSInstance_associatePublic_overridePublic (71.89s)
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (218.20s)
--- PASS: TestAccAWSInstance_basic (333.50s)
--- PASS: TestAccAWSInstance_blockDevices (183.67s)
--- PASS: TestAccAWSInstance_changeInstanceType (328.80s)
--- PASS: TestAccAWSInstance_creditSpecification_isNotAppliedToNonBurstable (91.65s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits (80.29s)
--- PASS: TestAccAWSInstance_creditSpecification_standardCpuCredits_t2Tot3Taint (373.38s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits (89.86s)
--- PASS: TestAccAWSInstance_creditSpecification_unlimitedCpuCredits_t2Tot3Taint (352.61s)
--- PASS: TestAccAWSInstance_creditSpecification_unspecifiedDefaultsToStandard (71.34s)
--- PASS: TestAccAWSInstance_creditSpecification_updateCpuCredits (88.96s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_standardCpuCredits (294.12s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unlimitedCpuCredits (107.09s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_unspecifiedDefaultsToUnlimited (305.43s)
--- PASS: TestAccAWSInstance_creditSpecificationT3_updateCpuCredits (314.59s)
--- PASS: TestAccAWSInstance_disableApiTermination (186.23s)
--- PASS: TestAccAWSInstance_disappears (239.69s)
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (277.17s)
--- PASS: TestAccAWSInstance_getPasswordData_falseToTrue (136.94s)
--- PASS: TestAccAWSInstance_getPasswordData_trueToFalse (135.95s)
--- PASS: TestAccAWSInstance_GP2IopsDevice (84.83s)
--- PASS: TestAccAWSInstance_GP2WithIopsValue (77.64s)
--- PASS: TestAccAWSInstance_importBasic (114.84s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgId (88.80s)
--- PASS: TestAccAWSInstance_importInDefaultVpcBySgName (85.34s)
--- PASS: TestAccAWSInstance_importInEc2Classic (92.19s)
--- PASS: TestAccAWSInstance_instanceProfileChange (288.48s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (80.62s)
--- PASS: TestAccAWSInstance_ipv6_supportAddressCountWithIpv4 (84.83s)
--- PASS: TestAccAWSInstance_ipv6AddressCountAndSingleAddressCausesError (12.15s)
--- PASS: TestAccAWSInstance_keyPairCheck (185.46s)
--- PASS: TestAccAWSInstance_multipleRegions (253.31s)
--- PASS: TestAccAWSInstance_NetworkInstanceRemovingAllSecurityGroups (87.59s)
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (189.14s)
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (186.27s)
--- PASS: TestAccAWSInstance_noAMIEphemeralDevices (57.35s)
--- PASS: TestAccAWSInstance_placementGroup (92.35s)
--- PASS: TestAccAWSInstance_primaryNetworkInterface (54.41s)
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (186.46s)
--- PASS: TestAccAWSInstance_privateIP (71.72s)
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (174.52s)
--- PASS: TestAccAWSInstance_rootInstanceStore (71.25s)
--- PASS: TestAccAWSInstance_sourceDestCheck (118.67s)
--- PASS: TestAccAWSInstance_tags (245.43s)
--- PASS: TestAccAWSInstance_UserData_EmptyStringToUnspecified (127.46s)
--- PASS: TestAccAWSInstance_UserData_UnspecifiedToEmptyString (91.24s)
--- PASS: TestAccAWSInstance_userDataBase64 (229.08s)
--- PASS: TestAccAWSInstance_volumeTags (98.22s)
--- PASS: TestAccAWSInstance_volumeTagsComputed (102.21s)
--- PASS: TestAccAWSInstance_vpc (206.67s)
--- PASS: TestAccAWSInstance_withIamInstanceProfile (222.62s)
```
