### PR TITLE
resource/aws_sqs_queue: Always refresh all attributes into Terraform state, add import testing to all tests

### DIFF
--- a/aws/resource_aws_sqs_queue.go
+++ b/aws/resource_aws_sqs_queue.go
@@ -280,42 +280,121 @@ func resourceAwsSqsQueueRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("name", name)
 
-	if attributeOutput.Attributes != nil && len(attributeOutput.Attributes) > 0 {
-		attrmap := attributeOutput.Attributes
-		resource := *resourceAwsSqsQueue()
-		// iKey = internal struct key, oKey = AWS Attribute Map key
-		for iKey, oKey := range sqsQueueAttributeMap {
-			if attrmap[oKey] != nil {
-				switch resource.Schema[iKey].Type {
-				case schema.TypeInt:
-					value, err := strconv.Atoi(*attrmap[oKey])
-					if err != nil {
-						return err
-					}
-					d.Set(iKey, value)
-					log.Printf("[DEBUG] Reading %s => %s -> %d", iKey, oKey, value)
-				case schema.TypeBool:
-					value, err := strconv.ParseBool(*attrmap[oKey])
-					if err != nil {
-						return err
-					}
-					d.Set(iKey, value)
-					log.Printf("[DEBUG] Reading %s => %s -> %t", iKey, oKey, value)
-				default:
-					log.Printf("[DEBUG] Reading %s => %s -> %s", iKey, oKey, *attrmap[oKey])
-					d.Set(iKey, *attrmap[oKey])
-				}
+	// Always set attribute defaults
+	d.Set("arn", "")
+	d.Set("content_based_deduplication", false)
+	d.Set("delay_seconds", 0)
+	d.Set("fifo_queue", false)
+	d.Set("kms_data_key_reuse_period_seconds", 300)
+	d.Set("kms_master_key_id", "")
+	d.Set("max_message_size", 262144)
+	d.Set("message_retention_seconds", 345600)
+	d.Set("name", name)
+	d.Set("policy", "")
+	d.Set("receive_wait_time_seconds", 0)
+	d.Set("redrive_policy", "")
+	d.Set("visibility_timeout_seconds", 30)
+
+	if attributeOutput != nil {
+		queueAttributes := aws.StringValueMap(attributeOutput.Attributes)
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameQueueArn]; ok {
+			d.Set("arn", v)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameContentBasedDeduplication]; ok && v != "" {
+			vBool, err := strconv.ParseBool(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing content_based_deduplication value (%s) into boolean: %s", v, err)
 			}
+
+			d.Set("content_based_deduplication", vBool)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameDelaySeconds]; ok && v != "" {
+			vInt, err := strconv.Atoi(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing delay_seconds value (%s) into integer: %s", v, err)
+			}
+
+			d.Set("delay_seconds", vInt)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameFifoQueue]; ok && v != "" {
+			vBool, err := strconv.ParseBool(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing fifo_queue value (%s) into boolean: %s", v, err)
+			}
+
+			d.Set("fifo_queue", vBool)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameKmsDataKeyReusePeriodSeconds]; ok && v != "" {
+			vInt, err := strconv.Atoi(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing kms_data_key_reuse_period_seconds value (%s) into integer: %s", v, err)
+			}
+
+			d.Set("kms_data_key_reuse_period_seconds", vInt)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameKmsMasterKeyId]; ok {
+			d.Set("kms_master_key_id", v)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameMaximumMessageSize]; ok && v != "" {
+			vInt, err := strconv.Atoi(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing max_message_size value (%s) into integer: %s", v, err)
+			}
+
+			d.Set("max_message_size", vInt)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameMessageRetentionPeriod]; ok && v != "" {
+			vInt, err := strconv.Atoi(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing message_retention_seconds value (%s) into integer: %s", v, err)
+			}
+
+			d.Set("message_retention_seconds", vInt)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNamePolicy]; ok {
+			d.Set("policy", v)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameReceiveMessageWaitTimeSeconds]; ok && v != "" {
+			vInt, err := strconv.Atoi(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing receive_wait_time_seconds value (%s) into integer: %s", v, err)
+			}
+
+			d.Set("receive_wait_time_seconds", vInt)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameRedrivePolicy]; ok {
+			d.Set("redrive_policy", v)
+		}
+
+		if v, ok := queueAttributes[sqs.QueueAttributeNameVisibilityTimeout]; ok && v != "" {
+			vInt, err := strconv.Atoi(v)
+
+			if err != nil {
+				return fmt.Errorf("error parsing visibility_timeout_seconds value (%s) into integer: %s", v, err)
+			}
+
+			d.Set("visibility_timeout_seconds", vInt)
 		}
 	}
-
-	// Since AWS does not send the FifoQueue attribute back when the queue
-	// is a standard one (even to false), this enforces the queue to be set
-	// to the correct value.
-	d.Set("fifo_queue", d.Get("fifo_queue").(bool))
-	d.Set("content_based_deduplication", d.Get("content_based_deduplication").(bool))
 
 	tags := make(map[string]string)
 	listTagsOutput, err := sqsconn.ListQueueTags(&sqs.ListQueueTagsInput{

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -11,80 +11,8 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/jen20/awspolicyequivalence"
+	awspolicy "github.com/jen20/awspolicyequivalence"
 )
-
-func TestAccAWSSQSQueue_importBasic(t *testing.T) {
-	resourceName := "aws_sqs_queue.queue"
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfigWithDefaults(queueName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "fifo_queue", "false"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueue_importFifo(t *testing.T) {
-	resourceName := "aws_sqs_queue.queue"
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSFifoConfigWithDefaults(queueName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "fifo_queue", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSSQSQueue_importEncryption(t *testing.T) {
-	resourceName := "aws_sqs_queue.queue"
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSSQSConfigWithEncryption(queueName),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "kms_master_key_id", "alias/aws/sqs"),
-				),
-			},
-		},
-	})
-}
 
 func TestAccAWSSQSQueue_basic(t *testing.T) {
 	var queueAttributes map[string]*string
@@ -101,6 +29,14 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 					testAccCheckAWSSQSQueueExists("aws_sqs_queue.queue", &queueAttributes),
 					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
 				),
+			},
+			{
+				ResourceName:      "aws_sqs_queue.queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
 			},
 			{
 				Config: testAccAWSSQSConfigWithOverrides(queueName),
@@ -137,6 +73,14 @@ func TestAccAWSSQSQueue_tags(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "tags.%", "2"),
 					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "tags.Usage", "original"),
 				),
+			},
+			{
+				ResourceName:      "aws_sqs_queue.queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
 			},
 			{
 				Config: testAccAWSSQSConfigWithTagsChanged(queueName),
@@ -176,6 +120,14 @@ func TestAccAWSSQSQueue_namePrefix(t *testing.T) {
 					resource.TestMatchResourceAttr("aws_sqs_queue.queue", "name", regexp.MustCompile(`^acctest-sqs-queue`)),
 				),
 			},
+			{
+				ResourceName:      "aws_sqs_queue.queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
+			},
 		},
 	})
 }
@@ -196,6 +148,14 @@ func TestAccAWSSQSQueue_namePrefix_fifo(t *testing.T) {
 					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
 					resource.TestMatchResourceAttr("aws_sqs_queue.queue", "name", regexp.MustCompile(`^acctest-sqs-queue.*\.fifo$`)),
 				),
+			},
+			{
+				ResourceName:      "aws_sqs_queue.queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
 			},
 		},
 	})
@@ -222,6 +182,14 @@ func TestAccAWSSQSQueue_policy(t *testing.T) {
 					testAccCheckAWSSQSQueueExists("aws_sqs_queue.test-email-events", &queueAttributes),
 					testAccCheckAWSSQSQueuePolicyAttribute(&queueAttributes, expectedPolicyText),
 				),
+			},
+			{
+				ResourceName:      "aws_sqs_queue.test-email-events",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
 			},
 		},
 	})
@@ -270,6 +238,14 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 					testAccCheckAWSSQSQueueDefaultAttributes(&queueAttributes),
 				),
 			},
+			{
+				ResourceName:      "aws_sqs_queue.my_dead_letter_queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
+			},
 		},
 	})
 }
@@ -292,6 +268,14 @@ func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
 					testAccCheckAWSSQSQueueOverrideAttributes(&queueAttributes),
 				),
 			},
+			{
+				ResourceName:      "aws_sqs_queue.test-email-events",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
+			},
 		},
 	})
 }
@@ -310,6 +294,14 @@ func TestAccAWSSQSQueue_FIFO(t *testing.T) {
 					testAccCheckAWSSQSQueueExists("aws_sqs_queue.queue", &queueAttributes),
 					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "fifo_queue", "true"),
 				),
+			},
+			{
+				ResourceName:      "aws_sqs_queue.queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
 			},
 		},
 	})
@@ -345,6 +337,14 @@ func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "content_based_deduplication", "true"),
 				),
 			},
+			{
+				ResourceName:      "aws_sqs_queue.queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
+			},
 		},
 	})
 }
@@ -377,6 +377,14 @@ func TestAccAWSSQSQueue_Encryption(t *testing.T) {
 					testAccCheckAWSSQSQueueExists("aws_sqs_queue.queue", &queueAttributes),
 					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "kms_master_key_id", "alias/aws/sqs"),
 				),
+			},
+			{
+				ResourceName:      "aws_sqs_queue.queue",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"name_prefix",
+				},
 			},
 		},
 	})

--- a/aws/resource_aws_sqs_queue_test.go
+++ b/aws/resource_aws_sqs_queue_test.go
@@ -556,15 +556,6 @@ resource "aws_sqs_queue" "queue" {
 `, r)
 }
 
-func testAccAWSSQSFifoConfigWithDefaults(r string) string {
-	return fmt.Sprintf(`
-resource "aws_sqs_queue" "queue" {
-  name = "%s.fifo"
-  fifo_queue = true
-}
-`, r)
-}
-
 func testAccAWSSQSConfigWithOverrides(r string) string {
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "queue" {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

In the Terraform 0.12 Provider SDK acceptance testing framework, attributes that do not call `ResourceData.Set()` are no longer automatically ignored during `ImportStateVerify` testing. Here we explicitly refresh all attributes into the Terraform state and remove the schema parsing logic during `Read`, which is an anti-pattern for resources due to its complexity. We also add import testing to all acceptance tests to ensure we have covered all attributes properly. This change is backwards compatible.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSSQSQueue_importBasic (7.48s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=33) "kms_data_key_reuse_period_seconds": (string) (len=1) "0"
        }

--- FAIL: TestAccAWSSQSQueue_importFifo (7.63s)
    testing.go:568: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }

        (map[string]string) (len=1) {
         (string) (len=33) "kms_data_key_reuse_period_seconds": (string) (len=1) "0"
        }
```

Output from Terraform 0.11 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (4.71s)
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (4.78s)
--- PASS: TestAccAWSSQSQueue_Encryption (14.17s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (14.19s)
--- PASS: TestAccAWSSQSQueue_FIFO (14.27s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (14.29s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (18.54s)
--- PASS: TestAccAWSSQSQueue_policy (18.60s)
--- PASS: TestAccAWSSQSQueue_Policybasic (18.82s)
--- PASS: TestAccAWSSQSQueue_namePrefix (24.31s)
--- PASS: TestAccAWSSQSQueue_basic (30.62s)
--- PASS: TestAccAWSSQSQueue_tags (30.73s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (93.16s)
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (6.95s)
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (7.24s)
--- PASS: TestAccAWSSQSQueue_Encryption (15.35s)
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (15.41s)
--- PASS: TestAccAWSSQSQueue_namePrefix (15.41s)
--- PASS: TestAccAWSSQSQueue_FIFO (15.46s)
--- PASS: TestAccAWSSQSQueue_namePrefix_fifo (15.50s)
--- PASS: TestAccAWSSQSQueue_policy (19.05s)
--- PASS: TestAccAWSSQSQueue_redrivePolicy (19.14s)
--- PASS: TestAccAWSSQSQueue_Policybasic (19.68s)
--- PASS: TestAccAWSSQSQueue_basic (30.59s)
--- PASS: TestAccAWSSQSQueue_tags (31.16s)
--- PASS: TestAccAWSSQSQueue_queueDeletedRecently (94.39s)
```
