### PR TITLE
tests/resource/aws_route53_resolver_rule_association: Ensure tags configurations use equals in testing

### DIFF
--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -96,21 +96,21 @@ resource "aws_vpc" "example" {
   cidr_block = "10.6.0.0/16"
   enable_dns_hostnames = true
   enable_dns_support = true
-  tags {
-    Name = %q
+  tags = {
+    Name = %[1]q
   }
 }
 
 resource "aws_route53_resolver_rule" "example" {
   domain_name = "example.com"
-  name        = %q
+  name        = %[1]q
   rule_type   = "SYSTEM"
 }
 
 resource "aws_route53_resolver_rule_association" "example" {
-  name             = %q
+  name             = %[1]q
   resolver_rule_id = "${aws_route53_resolver_rule.example.id}"
   vpc_id           = "${aws_vpc.example.id}"
 }
-`, name, name, name)
+`, name)
 }


### PR DESCRIPTION
This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 acceptance testing:

```
--- FAIL: TestAccAwsRoute53ResolverRuleAssociation_basic (0.85s)
  testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 acceptance testing:

```
--- PASS: TestAccAwsRoute53ResolverRuleAssociation_basic (165.11s)
```