### PR TITLE
tests/resource/aws_backup_plan: Add missing equals sign for tags configuration

### DIFF
--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -332,7 +332,7 @@ resource "aws_backup_plan" "test" {
     schedule           = "cron(0 12 * * ? *)"
   }
 
-  tags {
+  tags = {
 	  env = "test"
   }
 }
@@ -354,7 +354,7 @@ resource "aws_backup_plan" "test" {
     schedule           = "cron(0 12 * * ? *)"
   }
 
-  tags {
+  tags = {
 	  env = "test"
 	  app = "widget"
   }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This change is backwards compatible with Terraform 0.11.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAwsBackupPlan_withTags (1.08s)
    testing.go:568: Step 0 error: config is invalid: Unsupported block type: Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAwsBackupPlan_withTags (40.92s)
```
