### PR TITLE
resource/aws_iot_thing_type: Ensure properties configuration block is always present in state

### DIFF
--- a/aws/resource_aws_iot_thing_type.go
+++ b/aws/resource_aws_iot_thing_type.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -33,9 +34,10 @@ func resourceAwsIotThingType() *schema.Resource {
 				ValidateFunc: validateIotThingTypeName,
 			},
 			"properties": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"description": {
@@ -135,7 +137,10 @@ func resourceAwsIotThingTypeRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Set("arn", out.ThingTypeArn)
-	d.Set("properties", flattenIotThingTypeProperties(out.ThingTypeProperties))
+
+	if err := d.Set("properties", flattenIotThingTypeProperties(out.ThingTypeProperties)); err != nil {
+		return fmt.Errorf("error setting properties: %s", err)
+	}
 
 	return nil
 }

--- a/aws/resource_aws_iot_thing_type_test.go
+++ b/aws/resource_aws_iot_thing_type_test.go
@@ -11,27 +11,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSIotThingType_importBasic(t *testing.T) {
-	resourceName := "aws_iot_thing_type.foo"
-	rInt := acctest.RandInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSIotThingTypeDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSIotThingTypeConfig_basic(rInt),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAWSIotThingType_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -46,6 +25,11 @@ func TestAccAWSIotThingType_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_iot_thing_type.foo", "arn"),
 					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "name", fmt.Sprintf("tf_acc_iot_thing_type_%d", rInt)),
 				),
+			},
+			{
+				ResourceName:      "aws_iot_thing_type.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -67,6 +51,11 @@ func TestAccAWSIotThingType_full(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "properties.0.searchable_attributes.#", "3"),
 					resource.TestCheckResourceAttr("aws_iot_thing_type.foo", "deprecated", "true"),
 				),
+			},
+			{
+				ResourceName:      "aws_iot_thing_type.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccAWSIotThingTypeConfig_fullUpdated(rInt),

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4537,16 +4537,17 @@ func expandIotThingTypeProperties(config map[string]interface{}) *iot.ThingTypeP
 }
 
 func flattenIotThingTypeProperties(s *iot.ThingTypeProperties) []map[string]interface{} {
-	m := map[string]interface{}{}
+	m := map[string]interface{}{
+		"description":           "",
+		"searchable_attributes": flattenStringSet(nil),
+	}
 
 	if s == nil {
-		return nil
+		return []map[string]interface{}{m}
 	}
 
-	if s.ThingTypeDescription != nil {
-		m["description"] = *s.ThingTypeDescription
-	}
-	m["searchable_attributes"] = flattenStringList(s.SearchableAttributes)
+	m["description"] = aws.StringValue(s.ThingTypeDescription)
+	m["searchable_attributes"] = flattenStringSet(s.SearchableAttributes)
 
 	return []map[string]interface{}{m}
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This likely is a false positive from the acceptance testing shims in the Terraform 0.12 Provider SDK, however this updated logic will ensure the `properties` configuration block is always present in the Terraform state.

Previous output from Terraform 0.12 Provider SDK acceptance testing:

```
--- FAIL: TestAccAWSIotThingType_basic (311.64s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_iot_thing_type.foo
          arn:                                  "arn:aws:iot:us-west-2:*******:thingtype/tf_acc_iot_thing_type_1627460708221221238" => "arn:aws:iot:us-west-2:*******:thingtype/tf_acc_iot_thing_type_1627460708221221238"
          deprecated:                           "false" => "false"
          id:                                   "tf_acc_iot_thing_type_1627460708221221238" => "tf_acc_iot_thing_type_1627460708221221238"
          name:                                 "tf_acc_iot_thing_type_1627460708221221238" => "tf_acc_iot_thing_type_1627460708221221238"
          properties.#:                         "1" => "0"
          properties.0.description:             "" => ""
          properties.0.searchable_attributes.#: "0" => ""

--- FAIL: TestAccAWSIotThingType_importBasic (311.84s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_iot_thing_type.foo
          arn:                                  "arn:aws:iot:us-west-2:*******:thingtype/tf_acc_iot_thing_type_1246157822881638334" => "arn:aws:iot:us-west-2:*******:thingtype/tf_acc_iot_thing_type_1246157822881638334"
          deprecated:                           "false" => "false"
          id:                                   "tf_acc_iot_thing_type_1246157822881638334" => "tf_acc_iot_thing_type_1246157822881638334"
          name:                                 "tf_acc_iot_thing_type_1246157822881638334" => "tf_acc_iot_thing_type_1246157822881638334"
          properties.#:                         "1" => "0"
          properties.0.description:             "" => ""
          properties.0.searchable_attributes.#: "0" => ""

--- FAIL: TestAccAWSIotThing_full (311.95s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_iot_thing_type.test
          arn:                                  "arn:aws:iot:us-west-2:*******:thingtype/tf_acc_type_sfrzr0rx" => "arn:aws:iot:us-west-2:*******:thingtype/tf_acc_type_sfrzr0rx"
          deprecated:                           "false" => "false"
          id:                                   "tf_acc_type_sfrzr0rx" => "tf_acc_type_sfrzr0rx"
          name:                                 "tf_acc_type_sfrzr0rx" => "tf_acc_type_sfrzr0rx"
          properties.#:                         "1" => "0"
          properties.0.description:             "" => ""
          properties.0.searchable_attributes.#: "0" => ""
```

Output from Terraform 0.11 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSIotThingType_basic (320.99s)
--- PASS: TestAccAWSIotThingType_full (326.82s)
--- PASS: TestAccAWSIotThing_full (335.94s)
```

Output from Terraform 0.12 Provider SDK acceptance testing:

```
--- PASS: TestAccAWSIotThingType_basic (321.64s)
--- PASS: TestAccAWSIotThingType_full (327.74s)
--- PASS: TestAccAWSIotThing_full (336.31s)
```
