### PR TITLE
[docs] cloudwatch_metric_alarm

### DIFF
--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -57,11 +57,27 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
 }
 ```
 
+## Example for Alarms per Resource
+```
+resource "aws_cloudwatch_metric_alarm" "nat_gateway_egress" {
+  alarm_name          = "${format("terraform-test-nat-gateway-egress-%d", count.index)}"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "BytesOutToDestination"
+  namespace           = "AWS/NATGateway"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "0"
+  count               = "${length(aws_nat_gateway.gateways.*.id)}"
+}
+```
+
+
 ## Example with an Expression
 
 ```hcl
 resource "aws_cloudwatch_metric_alarm" "foobar" {
-  alarm_name                = "terraform-test-foobar%d"
+  alarm_name                = "terraform-test-foobar"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   threshold                 = "10"
@@ -148,8 +164,8 @@ The following values are supported: `ignore`, and `evaluate`.
 
 #### `metric_query`
 
-* `id` - (Required) A short name used to tie this object to the results in the response. If you are performing math expressions on this set of data, this name represents that data and can serve as a variable in the mathematical expression. The valid characters are letters, numbers, and underscore. The first character must be a lowercase letter. 
-* `expression` - (Optional) The math expression to be performed on the returned data, if this object is performing a math expression. This expression can use the id of the other metrics to refer to those metrics, and can also use the id of other expressions to use the result of those expressions. For more information about metric math expressions, see Metric Math Syntax and Functions in the [Amazon CloudWatch User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax). 
+* `id` - (Required) A short name used to tie this object to the results in the response. If you are performing math expressions on this set of data, this name represents that data and can serve as a variable in the mathematical expression. The valid characters are letters, numbers, and underscore. The first character must be a lowercase letter.
+* `expression` - (Optional) The math expression to be performed on the returned data, if this object is performing a math expression. This expression can use the id of the other metrics to refer to those metrics, and can also use the id of other expressions to use the result of those expressions. For more information about metric math expressions, see Metric Math Syntax and Functions in the [Amazon CloudWatch User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html#metric-math-syntax).
 * `label` - (Optional) A human-readable label for this metric or expression. This is especially useful if this is an expression, so that you know what the value represents.
 * `return_data` (Optional) Specify exactly one `metric_query` to be `true` to use that `metric_query` result as the alarm.
 * `metric` (Optional) The metric to be returned, along with statistics, period, and units. Use this parameter only if this object is retrieving a metric and not performing a math expression on returned data.

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
 ```
 
 ## Example for Alarms per Resource
-```
+```hcl
 resource "aws_cloudwatch_metric_alarm" "nat_gateway_egress" {
   alarm_name          = "${format("terraform-test-nat-gateway-egress-%d", count.index)}"
   comparison_operator = "LessThanOrEqualToThreshold"

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -57,22 +57,6 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
 }
 ```
 
-## Example for Alarms per Resource
-```hcl
-resource "aws_cloudwatch_metric_alarm" "nat_gateway_egress" {
-  alarm_name          = "${format("terraform-test-nat-gateway-egress-%d", count.index)}"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "BytesOutToDestination"
-  namespace           = "AWS/NATGateway"
-  period              = "120"
-  statistic           = "Average"
-  threshold           = "0"
-  count               = "${length(aws_nat_gateway.gateways.*.id)}"
-}
-```
-
-
 ## Example with an Expression
 
 ```hcl


### PR DESCRIPTION
There is a spurious %d in a resource name that makes it seem like it
will use format, and print a number when used with `count`.
This is not the case.

This removes the spurious %d, and adds an example using `format` with
`count`, as I *suspect* this could attribute to issues like:

- https://github.com/terraform-providers/terraform-provider-aws/issues/422

I along with at least one other user, noted that really they had mistakenly
duplicate alarm names. I suspect this could be the case for others as
well.

My hope is that by providing an example to do something like that above,
fewer issues will be opened.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
