### PR TITLE
values takes list

### DIFF
--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -79,7 +79,7 @@ which take the following arguments:
 data "aws_subnet" "selected" {
   filter {
     name   = "tag:Name"
-    values = "" # insert value here
+    values = [""] # insert value here
   }
 }
 ```


### PR DESCRIPTION
Without the braces, attempting to use the example code (w/ string value supplied) results in:
```
Error: data.aws_subnet.selected: filter.0.values: should be a list
```
