### PR TITLE
Added new filter to tag key kubernetes.io/cluster/

### DIFF
--- a/aws/tags.go
+++ b/aws/tags.go
@@ -335,7 +335,7 @@ func tagsFromMapELBv2(m map[string]interface{}) []*elbv2.Tag {
 // tagIgnored compares a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnored(t *ec2.Tag) bool {
-	filter := []string{"^aws:"}
+	filter := []string{"^aws:", "^kubernetes.io/cluster/"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		r, _ := regexp.MatchString(v, *t.Key)

--- a/aws/tags_test.go
+++ b/aws/tags_test.go
@@ -105,6 +105,14 @@ func TestIgnoringTags(t *testing.T) {
 		Key:   aws.String("aws:foo:bar"),
 		Value: aws.String("baz"),
 	})
+	ignoredTags = append(ignoredTags, &ec2.Tag{
+		Key:   aws.String("kubernetes.io/cluster/foo"),
+		Value: aws.String("owned"),
+	})
+	ignoredTags = append(ignoredTags, &ec2.Tag{
+		Key:   aws.String("kubernetes.io/cluster/bar"),
+		Value: aws.String("shared"),
+	})
 	for _, tag := range ignoredTags {
 		if !tagIgnored(tag) {
 			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8392 
Changes proposed in this pull request:

* Add tag prefix "kubernetes.io/cluster" in filter of tagIgnored
