### PR TITLE
Use tag-on-create for sfn

### DIFF
--- a/aws/resource_aws_sfn_activity.go
+++ b/aws/resource_aws_sfn_activity.go
@@ -46,6 +46,7 @@ func resourceAwsSfnActivityCreate(d *schema.ResourceData, meta interface{}) erro
 
 	params := &sfn.CreateActivityInput{
 		Name: aws.String(d.Get("name").(string)),
+		Tags: tagsFromMapSfn(d.Get("tags").(map[string]interface{})),
 	}
 
 	activity, err := conn.CreateActivity(params)
@@ -55,17 +56,6 @@ func resourceAwsSfnActivityCreate(d *schema.ResourceData, meta interface{}) erro
 
 	d.SetId(*activity.ActivityArn)
 
-	if v, ok := d.GetOk("tags"); ok {
-		input := &sfn.TagResourceInput{
-			ResourceArn: aws.String(d.Id()),
-			Tags:        tagsFromMapSfn(v.(map[string]interface{})),
-		}
-		log.Printf("[DEBUG] Tagging SFN Activity: %s", input)
-		_, err := conn.TagResource(input)
-		if err != nil {
-			return fmt.Errorf("error tagging SFN Activity (%s): %s", d.Id(), input)
-		}
-	}
 	return resourceAwsSfnActivityRead(d, meta)
 }
 

--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -65,6 +65,7 @@ func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) 
 		Definition: aws.String(d.Get("definition").(string)),
 		Name:       aws.String(d.Get("name").(string)),
 		RoleArn:    aws.String(d.Get("role_arn").(string)),
+		Tags:       tagsFromMapSfn(d.Get("tags").(map[string]interface{})),
 	}
 
 	var activity *sfn.CreateStateMachineOutput
@@ -93,17 +94,6 @@ func resourceAwsSfnStateMachineCreate(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(*activity.StateMachineArn)
 
-	if v, ok := d.GetOk("tags"); ok {
-		input := &sfn.TagResourceInput{
-			ResourceArn: aws.String(d.Id()),
-			Tags:        tagsFromMapSfn(v.(map[string]interface{})),
-		}
-		log.Printf("[DEBUG] Tagging SFN State Machine: %s", input)
-		_, err := conn.TagResource(input)
-		if err != nil {
-			return fmt.Errorf("error tagging SFN State Machine (%s): %s", d.Id(), input)
-		}
-	}
 	return resourceAwsSfnStateMachineRead(d, meta)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7671

Changes proposed in this pull request:

* Set tags at creation time 

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSSfnActivity_Tags'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSSfnActivity_Tags -timeout 120m
=== RUN   TestAccAWSSfnActivity_Tags
=== PAUSE TestAccAWSSfnActivity_Tags
=== CONT  TestAccAWSSfnActivity_Tags
--- PASS: TestAccAWSSfnActivity_Tags (23.25s)
PASS
ok  	github.com/jukie/terraform-provider-aws/aws	23.303s

...
```
