### PR TITLE
Requester-managed Interface VPC Endpoints

### DIFF
--- a/aws/data_source_aws_vpc_endpoint.go
+++ b/aws/data_source_aws_vpc_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
 )
 
 func dataSourceAwsVpcEndpoint() *schema.Resource {
@@ -15,11 +16,6 @@ func dataSourceAwsVpcEndpoint() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -34,50 +30,15 @@ func dataSourceAwsVpcEndpoint() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"vpc_endpoint_type": {
+			"vpc_id": {
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"policy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"route_table_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"prefix_list_id": {
-				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"cidr_blocks": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"subnet_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"network_interface_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"security_group_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
-			"private_dns_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
 			},
 			"dns_entry": {
 				Type:     schema.TypeList,
@@ -94,6 +55,50 @@ func dataSourceAwsVpcEndpoint() *schema.Resource {
 						},
 					},
 				},
+			},
+			"network_interface_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"prefix_list_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_dns_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"requester_managed": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"route_table_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"vpc_endpoint_type": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -121,19 +126,80 @@ func dataSourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Reading VPC Endpoint: %s", req)
-	resp, err := conn.DescribeVpcEndpoints(req)
+	respVpce, err := conn.DescribeVpcEndpoints(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading VPC Endpoint: %s", err)
 	}
-	if resp == nil || len(resp.VpcEndpoints) == 0 {
-		return fmt.Errorf("no matching VPC endpoint found")
+	if respVpce == nil || len(respVpce.VpcEndpoints) == 0 {
+		return fmt.Errorf("no matching VPC Endpoint found")
 	}
-	if len(resp.VpcEndpoints) > 1 {
-		return fmt.Errorf("multiple VPC endpoints matched; use additional constraints to reduce matches to a single VPC endpoint")
+	if len(respVpce.VpcEndpoints) > 1 {
+		return fmt.Errorf("multiple VPC Endpoints matched; use additional constraints to reduce matches to a single VPC Endpoint")
 	}
 
-	vpce := resp.VpcEndpoints[0]
+	vpce := respVpce.VpcEndpoints[0]
 	d.SetId(aws.StringValue(vpce.VpcEndpointId))
 
-	return vpcEndpointAttributes(d, vpce, conn)
+	serviceName := aws.StringValue(vpce.ServiceName)
+	d.Set("service_name", serviceName)
+	d.Set("state", vpce.State)
+	d.Set("vpc_id", vpce.VpcId)
+
+	respPl, err := conn.DescribePrefixLists(&ec2.DescribePrefixListsInput{
+		Filters: buildEC2AttributeFilterList(map[string]string{
+			"prefix-list-name": serviceName,
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("error reading Prefix List (%s): %s", serviceName, err)
+	}
+	if respPl == nil || len(respPl.PrefixLists) == 0 {
+		d.Set("cidr_blocks", []interface{}{})
+	} else if len(respPl.PrefixLists) > 1 {
+		return fmt.Errorf("multiple prefix lists associated with the service name '%s'. Unexpected", serviceName)
+	} else {
+		pl := respPl.PrefixLists[0]
+
+		d.Set("prefix_list_id", pl.PrefixListId)
+		err = d.Set("cidr_blocks", flattenStringList(pl.Cidrs))
+		if err != nil {
+			return fmt.Errorf("error setting cidr_blocks: %s", err)
+		}
+	}
+
+	err = d.Set("dns_entry", flattenVpcEndpointDnsEntries(vpce.DnsEntries))
+	if err != nil {
+		return fmt.Errorf("error setting dns_entry: %s", err)
+	}
+	err = d.Set("network_interface_ids", flattenStringSet(vpce.NetworkInterfaceIds))
+	if err != nil {
+		return fmt.Errorf("error setting network_interface_ids: %s", err)
+	}
+	policy, err := structure.NormalizeJsonString(aws.StringValue(vpce.PolicyDocument))
+	if err != nil {
+		return fmt.Errorf("policy contains an invalid JSON: %s", err)
+	}
+	d.Set("policy", policy)
+	d.Set("private_dns_enabled", vpce.PrivateDnsEnabled)
+	err = d.Set("route_table_ids", flattenStringSet(vpce.RouteTableIds))
+	if err != nil {
+		return fmt.Errorf("error setting route_table_ids: %s", err)
+	}
+	d.Set("requester_managed", vpce.RequesterManaged)
+	err = d.Set("security_group_ids", flattenVpcEndpointSecurityGroupIds(vpce.Groups))
+	if err != nil {
+		return fmt.Errorf("error setting security_group_ids: %s", err)
+	}
+	err = d.Set("subnet_ids", flattenStringSet(vpce.SubnetIds))
+	if err != nil {
+		return fmt.Errorf("error setting subnet_ids: %s", err)
+	}
+	// VPC endpoints don't have types in GovCloud, so set type to default if empty
+	if vpceType := aws.StringValue(vpce.VpcEndpointType); vpceType == "" {
+		d.Set("vpc_endpoint_type", ec2.VpcEndpointTypeGateway)
+	} else {
+		d.Set("vpc_endpoint_type", vpceType)
+	}
+
+	return nil
 }

--- a/aws/data_source_aws_vpc_endpoint_service.go
+++ b/aws/data_source_aws_vpc_endpoint_service.go
@@ -27,18 +27,6 @@ func dataSourceAwsVpcEndpointService() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"service"},
 			},
-			"service_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"owner": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"vpc_endpoint_policy_supported": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
 			"acceptance_required": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -49,15 +37,31 @@ func dataSourceAwsVpcEndpointService() *schema.Resource {
 				Computed: true,
 				Set:      schema.HashString,
 			},
-			"private_dns_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"base_endpoint_dns_names": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 				Set:      schema.HashString,
+			},
+			"manages_vpc_endpoints": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_endpoint_policy_supported": {
+				Type:     schema.TypeBool,
+				Computed: true,
 			},
 		},
 	}
@@ -80,10 +84,10 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 		ServiceNames: aws.StringSlice([]string{serviceName}),
 	}
 
-	log.Printf("[DEBUG] Reading VPC Endpoint Services: %s", req)
+	log.Printf("[DEBUG] Reading VPC Endpoint Service: %s", req)
 	resp, err := conn.DescribeVpcEndpointServices(req)
 	if err != nil {
-		return fmt.Errorf("Error fetching VPC Endpoint Services: %s", err)
+		return fmt.Errorf("error reading VPC Endpoint Service (%s): %s", serviceName, err)
 	}
 
 	if resp == nil || (len(resp.ServiceNames) == 0 && len(resp.ServiceDetails) == 0) {
@@ -114,13 +118,20 @@ func dataSourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{
 	serviceName = aws.StringValue(sd.ServiceName)
 	d.SetId(strconv.Itoa(hashcode.String(serviceName)))
 	d.Set("service_name", serviceName)
-	d.Set("service_type", sd.ServiceType[0].ServiceType)
-	d.Set("owner", sd.Owner)
-	d.Set("vpc_endpoint_policy_supported", sd.VpcEndpointPolicySupported)
 	d.Set("acceptance_required", sd.AcceptanceRequired)
-	d.Set("availability_zones", flattenStringList(sd.AvailabilityZones))
+	err = d.Set("availability_zones", flattenStringSet(sd.AvailabilityZones))
+	if err != nil {
+		return fmt.Errorf("error setting availability_zones: %s", err)
+	}
+	err = d.Set("base_endpoint_dns_names", flattenStringSet(sd.BaseEndpointDnsNames))
+	if err != nil {
+		return fmt.Errorf("error setting base_endpoint_dns_names: %s", err)
+	}
+	d.Set("manages_vpc_endpoints", sd.ManagesVpcEndpoints)
+	d.Set("owner", sd.Owner)
 	d.Set("private_dns_name", sd.PrivateDnsName)
-	d.Set("base_endpoint_dns_names", flattenStringList(sd.BaseEndpointDnsNames))
+	d.Set("service_type", sd.ServiceType[0].ServiceType)
+	d.Set("vpc_endpoint_policy_supported", sd.VpcEndpointPolicySupported)
 
 	return nil
 }

--- a/aws/data_source_aws_vpc_endpoint_service_test.go
+++ b/aws/data_source_aws_vpc_endpoint_service_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -10,6 +9,8 @@ import (
 )
 
 func TestAccDataSourceAwsVpcEndpointService_gateway(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint_service.s3"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -17,32 +18,20 @@ func TestAccDataSourceAwsVpcEndpointService_gateway(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsVpcEndpointServiceGatewayConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "service_name", "com.amazonaws.us-west-2.s3"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "service_type", "Gateway"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "owner", "amazon"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "vpc_endpoint_policy_supported", "true"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "acceptance_required", "false"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "availability_zones.#", "4"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "availability_zones.2487133097", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "availability_zones.221770259", "us-west-2b"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "availability_zones.2050015877", "us-west-2c"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "availability_zones.3830732582", "us-west-2d"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "private_dns_name", ""),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "base_endpoint_dns_names.#", "1"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.s3", "base_endpoint_dns_names.3003388505", "s3.us-west-2.amazonaws.com"),
+					resource.TestCheckResourceAttr(datasourceName, "service_name", "com.amazonaws.us-west-2.s3"),
+					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.#", "4"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.2487133097", "us-west-2a"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.221770259", "us-west-2b"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.2050015877", "us-west-2c"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.3830732582", "us-west-2d"),
+					resource.TestCheckResourceAttr(datasourceName, "base_endpoint_dns_names.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "base_endpoint_dns_names.3003388505", "s3.us-west-2.amazonaws.com"),
+					resource.TestCheckResourceAttr(datasourceName, "manages_vpc_endpoints", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "owner", "amazon"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_name", ""),
+					resource.TestCheckResourceAttr(datasourceName, "service_type", "Gateway"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_policy_supported", "true"),
 				),
 			},
 		},
@@ -50,6 +39,8 @@ func TestAccDataSourceAwsVpcEndpointService_gateway(t *testing.T) {
 }
 
 func TestAccDataSourceAwsVpcEndpointService_interface(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint_service.ec2"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -57,30 +48,19 @@ func TestAccDataSourceAwsVpcEndpointService_interface(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsVpcEndpointServiceInterfaceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "service_name", "com.amazonaws.us-west-2.ec2"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "service_type", "Interface"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "owner", "amazon"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "vpc_endpoint_policy_supported", "false"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "acceptance_required", "false"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "availability_zones.#", "3"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "availability_zones.2487133097", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "availability_zones.221770259", "us-west-2b"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "availability_zones.2050015877", "us-west-2c"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "private_dns_name", "ec2.us-west-2.amazonaws.com"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "base_endpoint_dns_names.#", "1"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.ec2", "base_endpoint_dns_names.1880016359", "ec2.us-west-2.vpce.amazonaws.com"),
+					resource.TestCheckResourceAttr(datasourceName, "service_name", "com.amazonaws.us-west-2.ec2"),
+					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.#", "3"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.2487133097", "us-west-2a"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.221770259", "us-west-2b"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.2050015877", "us-west-2c"),
+					resource.TestCheckResourceAttr(datasourceName, "base_endpoint_dns_names.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "base_endpoint_dns_names.1880016359", "ec2.us-west-2.vpce.amazonaws.com"),
+					resource.TestCheckResourceAttr(datasourceName, "manages_vpc_endpoints", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "owner", "amazon"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_name", "ec2.us-west-2.amazonaws.com"),
+					resource.TestCheckResourceAttr(datasourceName, "service_type", "Interface"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_policy_supported", "false"),
 				),
 			},
 		},
@@ -88,29 +68,24 @@ func TestAccDataSourceAwsVpcEndpointService_interface(t *testing.T) {
 }
 
 func TestAccDataSourceAwsVpcEndpointService_custom(t *testing.T) {
-	lbName := fmt.Sprintf("testaccawsnlb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	datasourceName := "data.aws_vpc_endpoint_service.foo"
+	rName := fmt.Sprintf("tf-testacc-vpcesvc-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsVpcEndpointServiceCustomConfig(lbName),
+				Config: testAccDataSourceAwsVpcEndpointServiceCustomConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.foo", "service_type", "Interface"),
-					resource.TestMatchResourceAttr( // AWS account ID
-						"data.aws_vpc_endpoint_service.foo", "owner", regexp.MustCompile("^[0-9]{12}$")),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.foo", "vpc_endpoint_policy_supported", "false"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.foo", "acceptance_required", "true"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.foo", "availability_zones.#", "2"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.foo", "availability_zones.2487133097", "us-west-2a"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint_service.foo", "availability_zones.221770259", "us-west-2b"),
+					resource.TestCheckResourceAttr(datasourceName, "acceptance_required", "true"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.#", "2"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.2487133097", "us-west-2a"),
+					resource.TestCheckResourceAttr(datasourceName, "availability_zones.221770259", "us-west-2b"),
+					resource.TestCheckResourceAttr(datasourceName, "manages_vpc_endpoints", "false"),
+					testAccCheckResourceAttrAccountID(datasourceName, "owner"),
+					resource.TestCheckResourceAttr(datasourceName, "service_type", "Interface"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_policy_supported", "false"),
 				),
 			},
 		},
@@ -137,19 +112,19 @@ data "aws_vpc_endpoint_service" "ec2" {
 }
 `
 
-func testAccDataSourceAwsVpcEndpointServiceCustomConfig(lbName string) string {
+func testAccDataSourceAwsVpcEndpointServiceCustomConfig(rName string) string {
 	return fmt.Sprintf(
 		`
 resource "aws_vpc" "nlb_test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "terraform-testacc-vpc-endpoint-service-custom"
+    Name = %[1]q
   }
 }
 
 resource "aws_lb" "nlb_test_1" {
-  name = "%s"
+  name = %[1]q
 
   subnets = [
     "${aws_subnet.nlb_test_1.id}",
@@ -162,7 +137,7 @@ resource "aws_lb" "nlb_test_1" {
   enable_deletion_protection = false
 
   tags = {
-    Name = "testAccVpcEndpointServiceBasicConfig_nlb1"
+    Name = %[1]q
   }
 }
 
@@ -172,7 +147,7 @@ resource "aws_subnet" "nlb_test_1" {
   availability_zone = "us-west-2a"
 
   tags = {
-    Name = "tf-acc-vpc-endpoint-service-custom"
+    Name = %[1]q
   }
 }
 
@@ -182,7 +157,7 @@ resource "aws_subnet" "nlb_test_2" {
   availability_zone = "us-west-2b"
 
   tags = {
-    Name = "tf-acc-vpc-endpoint-service-custom"
+    Name = %[1]q
   }
 }
 
@@ -197,5 +172,5 @@ resource "aws_vpc_endpoint_service" "foo" {
 data "aws_vpc_endpoint_service" "foo" {
   service_name = "${aws_vpc_endpoint_service.foo.service_name}"
 }
-`, lbName)
+`, rName)
 }

--- a/aws/data_source_aws_vpc_endpoint_test.go
+++ b/aws/data_source_aws_vpc_endpoint_test.go
@@ -1,14 +1,14 @@
 package aws
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceAwsVpcEndpoint_gatewayBasic(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint.s3"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -16,15 +16,15 @@ func TestAccDataSourceAwsVpcEndpoint_gatewayBasic(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsVpcEndpointConfig_gatewayBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsVpcEndpointCheckExists("data.aws_vpc_endpoint.s3", "aws_vpc_endpoint.s3"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint.s3", "vpc_endpoint_type", "Gateway"),
-					resource.TestCheckResourceAttrSet("data.aws_vpc_endpoint.s3", "prefix_list_id"),
-					resource.TestCheckResourceAttrSet("data.aws_vpc_endpoint.s3", "cidr_blocks.#"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.s3", "route_table_ids.#", "0"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.s3", "subnet_ids.#", "0"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.s3", "network_interface_ids.#", "0"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.s3", "security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_type", "Gateway"),
+					resource.TestCheckResourceAttrSet(datasourceName, "prefix_list_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "cidr_blocks.#"),
+					resource.TestCheckResourceAttr(datasourceName, "route_table_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "subnet_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "network_interface_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "requester_managed", "false"),
 				),
 			},
 		},
@@ -32,6 +32,8 @@ func TestAccDataSourceAwsVpcEndpoint_gatewayBasic(t *testing.T) {
 }
 
 func TestAccDataSourceAwsVpcEndpoint_byId(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint.s3"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -39,7 +41,15 @@ func TestAccDataSourceAwsVpcEndpoint_byId(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsVpcEndpointConfig_byId,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsVpcEndpointCheckExists("data.aws_vpc_endpoint.by_id", "aws_vpc_endpoint.s3"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_type", "Gateway"),
+					resource.TestCheckResourceAttrSet(datasourceName, "prefix_list_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "cidr_blocks.#"),
+					resource.TestCheckResourceAttr(datasourceName, "route_table_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "subnet_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "network_interface_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "requester_managed", "false"),
 				),
 			},
 		},
@@ -47,6 +57,8 @@ func TestAccDataSourceAwsVpcEndpoint_byId(t *testing.T) {
 }
 
 func TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint.s3"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -54,11 +66,15 @@ func TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsVpcEndpointConfig_gatewayWithRouteTable,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsVpcEndpointCheckExists("data.aws_vpc_endpoint.s3", "aws_vpc_endpoint.s3"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint.s3", "vpc_endpoint_type", "Gateway"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint.s3", "route_table_ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_type", "Gateway"),
+					resource.TestCheckResourceAttrSet(datasourceName, "prefix_list_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "cidr_blocks.#"),
+					resource.TestCheckResourceAttr(datasourceName, "route_table_ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "subnet_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "network_interface_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "security_group_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "requester_managed", "false"),
 				),
 			},
 		},
@@ -66,6 +82,8 @@ func TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable(t *testing.T) {
 }
 
 func TestAccDataSourceAwsVpcEndpoint_interface(t *testing.T) {
+	datasourceName := "data.aws_vpc_endpoint.ec2"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -73,45 +91,19 @@ func TestAccDataSourceAwsVpcEndpoint_interface(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsVpcEndpointConfig_interface,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsVpcEndpointCheckExists("data.aws_vpc_endpoint.ec2", "aws_vpc_endpoint.ec2"),
-					resource.TestCheckResourceAttr(
-						"data.aws_vpc_endpoint.ec2", "vpc_endpoint_type", "Interface"),
-					resource.TestCheckNoResourceAttr("data.aws_vpc_endpoint.ec2", "prefix_list_id"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.ec2", "cidr_blocks.#", "0"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.ec2", "route_table_ids.#", "0"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.ec2", "subnet_ids.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.ec2", "security_group_ids.#", "1"),
-					resource.TestCheckResourceAttr("data.aws_vpc_endpoint.ec2", "private_dns_enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "vpc_endpoint_type", "Interface"),
+					resource.TestCheckNoResourceAttr(datasourceName, "prefix_list_id"),
+					resource.TestCheckResourceAttr(datasourceName, "cidr_blocks.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "route_table_ids.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "network_interface_ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "private_dns_enabled", "false"),
+					resource.TestCheckResourceAttr(datasourceName, "requester_managed", "false"),
 				),
 			},
 		},
 	})
-}
-
-func testAccDataSourceAwsVpcEndpointCheckExists(dsName, rsName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[dsName]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", dsName)
-		}
-
-		vpceRs, ok := s.RootModule().Resources[rsName]
-		if !ok {
-			return fmt.Errorf("can't find %s in state", rsName)
-		}
-
-		attr := rs.Primary.Attributes
-
-		if attr["id"] != vpceRs.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"id is %s; want %s",
-				attr["id"],
-				vpceRs.Primary.Attributes["id"],
-			)
-		}
-
-		return nil
-	}
 }
 
 const testAccDataSourceAwsVpcEndpointConfig_gatewayBasic = `
@@ -157,7 +149,7 @@ resource "aws_vpc_endpoint" "s3" {
   service_name = "com.amazonaws.us-west-2.s3"
 }
 
-data "aws_vpc_endpoint" "by_id" {
+data "aws_vpc_endpoint" "s3" {
   id = "${aws_vpc_endpoint.s3.id}"
 }
 `

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -460,3 +460,26 @@ func setVpcEndpointUpdateLists(d *schema.ResourceData, key string, a, r *[]*stri
 		}
 	}
 }
+
+func flattenVpcEndpointDnsEntries(dnsEntries []*ec2.DnsEntry) []interface{} {
+	vDnsEntries := []interface{}{}
+
+	for _, dnsEntry := range dnsEntries {
+		vDnsEntries = append(vDnsEntries, map[string]interface{}{
+			"dns_name":       aws.StringValue(dnsEntry.DnsName),
+			"hosted_zone_id": aws.StringValue(dnsEntry.HostedZoneId),
+		})
+	}
+
+	return vDnsEntries
+}
+
+func flattenVpcEndpointSecurityGroupIds(groups []*ec2.SecurityGroupIdentifier) *schema.Set {
+	vSecurityGroupIds := []interface{}{}
+
+	for _, group := range groups {
+		vSecurityGroupIds = append(vSecurityGroupIds, aws.StringValue(group.GroupId))
+	}
+
+	return schema.NewSet(schema.HashString, vSecurityGroupIds)
+}

--- a/aws/resource_aws_vpc_endpoint.go
+++ b/aws/resource_aws_vpc_endpoint.go
@@ -25,25 +25,19 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"vpc_endpoint_type": {
-				Type:     schema.TypeString,
+			"auto_accept": {
+				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
-				Default:  ec2.VpcEndpointTypeGateway,
-				ValidateFunc: validation.StringInSlice([]string{
-					ec2.VpcEndpointTypeGateway,
-					ec2.VpcEndpointTypeInterface,
-				}, false),
-			},
-			"service_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
 			},
 			"policy": {
 				Type:             schema.TypeString,
@@ -56,14 +50,12 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 					return json
 				},
 			},
-			"route_table_ids": {
-				Type:     schema.TypeSet,
+			"private_dns_enabled": {
+				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Default:  false,
 			},
-			"subnet_ids": {
+			"route_table_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
@@ -77,29 +69,27 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"private_dns_enabled": {
-				Type:     schema.TypeBool,
+			"subnet_ids": {
+				Type:     schema.TypeSet,
 				Optional: true,
-				Default:  false,
-			},
-			"state": {
-				Type:     schema.TypeString,
 				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
-			"prefix_list_id": {
+			"vpc_endpoint_type": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
+				Default:  ec2.VpcEndpointTypeGateway,
+				ValidateFunc: validation.StringInSlice([]string{
+					ec2.VpcEndpointTypeGateway,
+					ec2.VpcEndpointTypeInterface,
+				}, false),
 			},
 			"cidr_blocks": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"network_interface_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
 			},
 			"dns_entry": {
 				Type:     schema.TypeList,
@@ -117,9 +107,23 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 					},
 				},
 			},
-			"auto_accept": {
+			"network_interface_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"prefix_list_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"requester_managed": {
 				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 
@@ -183,9 +187,9 @@ func resourceAwsVpcEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 func resourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	vpce, state, err := vpcEndpointStateRefresh(conn, d.Id())()
+	vpceRaw, state, err := vpcEndpointStateRefresh(conn, d.Id())()
 	if err != nil && state != "failed" {
-		return fmt.Errorf("Error reading VPC Endpoint: %s", err)
+		return fmt.Errorf("error reading VPC Endpoint (%s): %s", d.Id(), err)
 	}
 
 	terminalStates := map[string]bool{
@@ -201,7 +205,70 @@ func resourceAwsVpcEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	return vpcEndpointAttributes(d, vpce.(*ec2.VpcEndpoint), conn)
+	vpce := vpceRaw.(*ec2.VpcEndpoint)
+
+	serviceName := aws.StringValue(vpce.ServiceName)
+	d.Set("service_name", serviceName)
+	d.Set("state", vpce.State)
+	d.Set("vpc_id", vpce.VpcId)
+
+	respPl, err := conn.DescribePrefixLists(&ec2.DescribePrefixListsInput{
+		Filters: buildEC2AttributeFilterList(map[string]string{
+			"prefix-list-name": serviceName,
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("error reading Prefix List (%s): %s", serviceName, err)
+	}
+	if respPl == nil || len(respPl.PrefixLists) == 0 {
+		d.Set("cidr_blocks", []interface{}{})
+	} else if len(respPl.PrefixLists) > 1 {
+		return fmt.Errorf("multiple prefix lists associated with the service name '%s'. Unexpected", serviceName)
+	} else {
+		pl := respPl.PrefixLists[0]
+
+		d.Set("prefix_list_id", pl.PrefixListId)
+		err = d.Set("cidr_blocks", flattenStringList(pl.Cidrs))
+		if err != nil {
+			return fmt.Errorf("error setting cidr_blocks: %s", err)
+		}
+	}
+
+	err = d.Set("dns_entry", flattenVpcEndpointDnsEntries(vpce.DnsEntries))
+	if err != nil {
+		return fmt.Errorf("error setting dns_entry: %s", err)
+	}
+	err = d.Set("network_interface_ids", flattenStringSet(vpce.NetworkInterfaceIds))
+	if err != nil {
+		return fmt.Errorf("error setting network_interface_ids: %s", err)
+	}
+	policy, err := structure.NormalizeJsonString(aws.StringValue(vpce.PolicyDocument))
+	if err != nil {
+		return fmt.Errorf("policy contains an invalid JSON: %s", err)
+	}
+	d.Set("policy", policy)
+	d.Set("private_dns_enabled", vpce.PrivateDnsEnabled)
+	err = d.Set("route_table_ids", flattenStringSet(vpce.RouteTableIds))
+	if err != nil {
+		return fmt.Errorf("error setting route_table_ids: %s", err)
+	}
+	d.Set("requester_managed", vpce.RequesterManaged)
+	err = d.Set("security_group_ids", flattenVpcEndpointSecurityGroupIds(vpce.Groups))
+	if err != nil {
+		return fmt.Errorf("error setting security_group_ids: %s", err)
+	}
+	err = d.Set("subnet_ids", flattenStringSet(vpce.SubnetIds))
+	if err != nil {
+		return fmt.Errorf("error setting subnet_ids: %s", err)
+	}
+	// VPC endpoints don't have types in GovCloud, so set type to default if empty
+	if vpceType := aws.StringValue(vpce.VpcEndpointType); vpceType == "" {
+		d.Set("vpc_endpoint_type", ec2.VpcEndpointTypeGateway)
+	} else {
+		d.Set("vpc_endpoint_type", vpceType)
+	}
+
+	return nil
 }
 
 func resourceAwsVpcEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -365,72 +432,6 @@ func vpcEndpointWaitUntilDeleted(conn *ec2.EC2, vpceId string, timeout time.Dura
 	_, err := stateConf.WaitForState()
 
 	return err
-}
-
-func vpcEndpointAttributes(d *schema.ResourceData, vpce *ec2.VpcEndpoint, conn *ec2.EC2) error {
-	d.Set("state", vpce.State)
-	d.Set("vpc_id", vpce.VpcId)
-
-	serviceName := aws.StringValue(vpce.ServiceName)
-	d.Set("service_name", serviceName)
-	// VPC endpoints don't have types in GovCloud, so set type to default if empty
-	if aws.StringValue(vpce.VpcEndpointType) == "" {
-		d.Set("vpc_endpoint_type", ec2.VpcEndpointTypeGateway)
-	} else {
-		d.Set("vpc_endpoint_type", vpce.VpcEndpointType)
-	}
-
-	policy, err := structure.NormalizeJsonString(aws.StringValue(vpce.PolicyDocument))
-	if err != nil {
-		return fmt.Errorf("policy contains an invalid JSON: %s", err)
-	}
-	d.Set("policy", policy)
-
-	d.Set("route_table_ids", flattenStringList(vpce.RouteTableIds))
-
-	req := &ec2.DescribePrefixListsInput{}
-	req.Filters = buildEC2AttributeFilterList(
-		map[string]string{
-			"prefix-list-name": serviceName,
-		},
-	)
-	resp, err := conn.DescribePrefixLists(req)
-	if err != nil {
-		return err
-	}
-	if resp != nil && len(resp.PrefixLists) > 0 {
-		if len(resp.PrefixLists) > 1 {
-			return fmt.Errorf("multiple prefix lists associated with the service name '%s'. Unexpected", serviceName)
-		}
-
-		pl := resp.PrefixLists[0]
-		d.Set("prefix_list_id", pl.PrefixListId)
-		d.Set("cidr_blocks", flattenStringList(pl.Cidrs))
-	} else {
-		d.Set("cidr_blocks", make([]string, 0))
-	}
-
-	d.Set("subnet_ids", flattenStringList(vpce.SubnetIds))
-	d.Set("network_interface_ids", flattenStringList(vpce.NetworkInterfaceIds))
-
-	sgIds := make([]interface{}, 0, len(vpce.Groups))
-	for _, group := range vpce.Groups {
-		sgIds = append(sgIds, aws.StringValue(group.GroupId))
-	}
-	d.Set("security_group_ids", sgIds)
-
-	d.Set("private_dns_enabled", vpce.PrivateDnsEnabled)
-
-	dnsEntries := make([]interface{}, len(vpce.DnsEntries))
-	for i, entry := range vpce.DnsEntries {
-		m := make(map[string]interface{})
-		m["dns_name"] = aws.StringValue(entry.DnsName)
-		m["hosted_zone_id"] = aws.StringValue(entry.HostedZoneId)
-		dnsEntries[i] = m
-	}
-	d.Set("dns_entry", dnsEntries)
-
-	return nil
 }
 
 func setVpcEndpointCreateList(d *schema.ResourceData, key string, c *[]*string) {

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -41,7 +41,23 @@ func resourceAwsVpcEndpointService() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"state": {
+			"availability_zones": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+			"base_endpoint_dns_names": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+			"manages_vpc_endpoints": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"private_dns_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -53,21 +69,9 @@ func resourceAwsVpcEndpointService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"availability_zones": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-				Set:      schema.HashString,
-			},
-			"private_dns_name": {
+			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-			"base_endpoint_dns_names": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-				Set:      schema.HashString,
 			},
 		},
 	}
@@ -99,9 +103,9 @@ func resourceAwsVpcEndpointServiceCreate(d *schema.ResourceData, meta interface{
 func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	svcCfg, state, err := vpcEndpointServiceStateRefresh(conn, d.Id())()
+	svcCfgRaw, state, err := vpcEndpointServiceStateRefresh(conn, d.Id())()
 	if err != nil && state != ec2.ServiceStateFailed {
-		return fmt.Errorf("Error reading VPC Endpoint Service: %s", err.Error())
+		return fmt.Errorf("error reading VPC Endpoint Service (%s): %s", d.Id(), err.Error())
 	}
 
 	terminalStates := map[string]bool{
@@ -115,7 +119,39 @@ func resourceAwsVpcEndpointServiceRead(d *schema.ResourceData, meta interface{})
 		return nil
 	}
 
-	return vpcEndpointServiceAttributes(d, svcCfg.(*ec2.ServiceConfiguration), conn)
+	svcCfg := svcCfgRaw.(*ec2.ServiceConfiguration)
+	d.Set("acceptance_required", svcCfg.AcceptanceRequired)
+	err = d.Set("network_load_balancer_arns", flattenStringSet(svcCfg.NetworkLoadBalancerArns))
+	if err != nil {
+		return fmt.Errorf("error setting network_load_balancer_arns: %s", err)
+	}
+	err = d.Set("availability_zones", flattenStringSet(svcCfg.AvailabilityZones))
+	if err != nil {
+		return fmt.Errorf("error setting availability_zones: %s", err)
+	}
+	err = d.Set("base_endpoint_dns_names", flattenStringSet(svcCfg.BaseEndpointDnsNames))
+	if err != nil {
+		return fmt.Errorf("error setting base_endpoint_dns_names: %s", err)
+	}
+	d.Set("manages_vpc_endpoints", svcCfg.ManagesVpcEndpoints)
+	d.Set("private_dns_name", svcCfg.PrivateDnsName)
+	d.Set("service_name", svcCfg.ServiceName)
+	d.Set("service_type", svcCfg.ServiceType[0].ServiceType)
+	d.Set("state", svcCfg.ServiceState)
+
+	resp, err := conn.DescribeVpcEndpointServicePermissions(&ec2.DescribeVpcEndpointServicePermissionsInput{
+		ServiceId: aws.String(d.Id()),
+	})
+	if err != nil {
+		return fmt.Errorf("error reading VPC Endpoint Service permissions (%s): %s", d.Id(), err.Error())
+	}
+
+	err = d.Set("allowed_principals", flattenVpcEndpointServiceAllowedPrincipals(resp.AllowedPrincipals))
+	if err != nil {
+		return fmt.Errorf("error setting allowed_principals: %s", err)
+	}
+
+	return nil
 }
 
 func resourceAwsVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -240,27 +276,6 @@ func waitForVpcEndpointServiceDeletion(conn *ec2.EC2, serviceID string) error {
 	_, err := stateConf.WaitForState()
 
 	return err
-}
-
-func vpcEndpointServiceAttributes(d *schema.ResourceData, svcCfg *ec2.ServiceConfiguration, conn *ec2.EC2) error {
-	d.Set("acceptance_required", svcCfg.AcceptanceRequired)
-	d.Set("network_load_balancer_arns", flattenStringList(svcCfg.NetworkLoadBalancerArns))
-	d.Set("state", svcCfg.ServiceState)
-	d.Set("service_name", svcCfg.ServiceName)
-	d.Set("service_type", svcCfg.ServiceType[0].ServiceType)
-	d.Set("availability_zones", flattenStringList(svcCfg.AvailabilityZones))
-	d.Set("private_dns_name", svcCfg.PrivateDnsName)
-	d.Set("base_endpoint_dns_names", flattenStringList(svcCfg.BaseEndpointDnsNames))
-
-	resp, err := conn.DescribeVpcEndpointServicePermissions(&ec2.DescribeVpcEndpointServicePermissionsInput{
-		ServiceId: aws.String(d.Id()),
-	})
-	if err != nil {
-		return err
-	}
-	d.Set("allowed_principals", flattenVpcEndpointServiceAllowedPrincipals(resp.AllowedPrincipals))
-
-	return nil
 }
 
 func setVpcEndpointServiceUpdateLists(d *schema.ResourceData, key string, a, r *[]*string) bool {

--- a/aws/resource_aws_vpc_endpoint_service.go
+++ b/aws/resource_aws_vpc_endpoint_service.go
@@ -299,3 +299,15 @@ func setVpcEndpointServiceUpdateLists(d *schema.ResourceData, key string, a, r *
 
 	return true
 }
+
+func flattenVpcEndpointServiceAllowedPrincipals(allowedPrincipals []*ec2.AllowedPrincipal) *schema.Set {
+	vPrincipals := []interface{}{}
+
+	for _, allowedPrincipal := range allowedPrincipals {
+		if allowedPrincipal.Principal != nil {
+			vPrincipals = append(vPrincipals, aws.StringValue(allowedPrincipal.Principal))
+		}
+	}
+
+	return schema.NewSet(schema.HashString, vPrincipals)
+}

--- a/aws/resource_aws_vpc_endpoint_test.go
+++ b/aws/resource_aws_vpc_endpoint_test.go
@@ -495,8 +495,9 @@ resource "aws_subnet" "foo" {
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id          = "${aws_vpc.foo.id}"
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_id       = "${aws_vpc.foo.id}"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+
   route_table_ids = [
     "${aws_route_table.default.id}",
   ]
@@ -605,9 +606,10 @@ data "aws_security_group" "default" {
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "ec2" {
-  vpc_id             = "${aws_vpc.foo.id}"
-  service_name       = "com.amazonaws.${data.aws_region.current.name}.ec2"
-  vpc_endpoint_type  = "Interface"
+  vpc_id            = "${aws_vpc.foo.id}"
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  vpc_endpoint_type = "Interface"
+
   security_group_ids = [
     "${data.aws_security_group.default.id}",
   ]
@@ -700,16 +702,19 @@ resource "aws_security_group" "sg2" {
 }
 
 resource "aws_vpc_endpoint" "ec2" {
-  vpc_id              = "${aws_vpc.foo.id}"
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [
+  vpc_id            = "${aws_vpc.foo.id}"
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
     "${aws_subnet.sn1.id}",
   ]
-  security_group_ids  = [
+
+  security_group_ids = [
     "${aws_security_group.sg1.id}",
     "${aws_security_group.sg2.id}",
   ]
+
   private_dns_enabled = false
 }
 `, rName)
@@ -778,17 +783,20 @@ resource "aws_security_group" "sg2" {
 }
 
 resource "aws_vpc_endpoint" "ec2" {
-  vpc_id              = "${aws_vpc.foo.id}"
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [
+  vpc_id            = "${aws_vpc.foo.id}"
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  vpc_endpoint_type = "Interface"
+
+  subnet_ids = [
     "${aws_subnet.sn1.id}",
     "${aws_subnet.sn2.id}",
     "${aws_subnet.sn3.id}",
   ]
-  security_group_ids  = [
+
+  security_group_ids = [
     "${aws_security_group.sg1.id}",
   ]
+
   private_dns_enabled = true
 }
 `, rName)
@@ -863,12 +871,14 @@ resource "aws_security_group" "sg1" {
 }
 
 resource "aws_vpc_endpoint" "foo" {
-  vpc_id              = "${aws_vpc.foo.id}"
-  service_name        = "${aws_vpc_endpoint_service.foo.service_name}"
-  vpc_endpoint_type   = "Interface"
-  security_group_ids  = [
+  vpc_id            = "${aws_vpc.foo.id}"
+  service_name      = "${aws_vpc_endpoint_service.foo.service_name}"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
     "${aws_security_group.sg1.id}",
   ]
+
   private_dns_enabled = false
   auto_accept         = true
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4467,39 +4467,6 @@ func expandDynamoDbEncryptAtRestOptions(m map[string]interface{}) *dynamodb.SSES
 	return &options
 }
 
-func flattenVpcEndpointServiceAllowedPrincipals(allowedPrincipals []*ec2.AllowedPrincipal) []string {
-	result := make([]string, 0, len(allowedPrincipals))
-	for _, allowedPrincipal := range allowedPrincipals {
-		if allowedPrincipal.Principal != nil {
-			result = append(result, *allowedPrincipal.Principal)
-		}
-	}
-	return result
-}
-
-func flattenVpcEndpointSecurityGroupIds(groups []*ec2.SecurityGroupIdentifier) *schema.Set {
-	vSecurityGroupIds := []interface{}{}
-
-	for _, group := range groups {
-		vSecurityGroupIds = append(vSecurityGroupIds, aws.StringValue(group.GroupId))
-	}
-
-	return schema.NewSet(schema.HashString, vSecurityGroupIds)
-}
-
-func flattenVpcEndpointDnsEntries(dnsEntries []*ec2.DnsEntry) []interface{} {
-	vDnsEntries := []interface{}{}
-
-	for _, dnsEntry := range dnsEntries {
-		vDnsEntries = append(vDnsEntries, map[string]interface{}{
-			"dns_name":       aws.StringValue(dnsEntry.DnsName),
-			"hosted_zone_id": aws.StringValue(dnsEntry.HostedZoneId),
-		})
-	}
-
-	return vDnsEntries
-}
-
 func expandDynamoDbTableItemAttributes(input string) (map[string]*dynamodb.AttributeValue, error) {
 	var attributes map[string]*dynamodb.AttributeValue
 

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -4477,6 +4477,29 @@ func flattenVpcEndpointServiceAllowedPrincipals(allowedPrincipals []*ec2.Allowed
 	return result
 }
 
+func flattenVpcEndpointSecurityGroupIds(groups []*ec2.SecurityGroupIdentifier) *schema.Set {
+	vSecurityGroupIds := []interface{}{}
+
+	for _, group := range groups {
+		vSecurityGroupIds = append(vSecurityGroupIds, aws.StringValue(group.GroupId))
+	}
+
+	return schema.NewSet(schema.HashString, vSecurityGroupIds)
+}
+
+func flattenVpcEndpointDnsEntries(dnsEntries []*ec2.DnsEntry) []interface{} {
+	vDnsEntries := []interface{}{}
+
+	for _, dnsEntry := range dnsEntries {
+		vDnsEntries = append(vDnsEntries, map[string]interface{}{
+			"dns_name":       aws.StringValue(dnsEntry.DnsName),
+			"hosted_zone_id": aws.StringValue(dnsEntry.HostedZoneId),
+		})
+	}
+
+	return vDnsEntries
+}
+
 func expandDynamoDbTableItemAttributes(input string) (map[string]*dynamodb.AttributeValue, error) {
 	var attributes map[string]*dynamodb.AttributeValue
 

--- a/website/docs/d/vpc_endpoint.html.markdown
+++ b/website/docs/d/vpc_endpoint.html.markdown
@@ -32,27 +32,25 @@ The arguments of this data source act as filters for querying the available VPC 
 The given filters must match exactly one VPC endpoint whose data will be exported as attributes.
 
 * `id` - (Optional) The ID of the specific VPC Endpoint to retrieve.
-
-* `state` - (Optional) The state of the specific VPC Endpoint to retrieve.
-
-* `vpc_id` - (Optional) The ID of the VPC in which the specific VPC Endpoint is used.
-
 * `service_name` - (Optional) The AWS service name of the specific VPC Endpoint to retrieve.
+* `state` - (Optional) The state of the specific VPC Endpoint to retrieve.
+* `vpc_id` - (Optional) The ID of the VPC in which the specific VPC Endpoint is used.
 
 ## Attributes Reference
 
-All of the argument attributes are also exported as result attributes.
+In addition to all arguments above, the following attributes are exported:
 
-* `vpc_endpoint_type` - The VPC Endpoint type, `Gateway` or `Interface`.
-* `policy` - The policy document associated with the VPC Endpoint. Applicable for endpoints of type `Gateway`.
-* `route_table_ids` - One or more route tables associated with the VPC Endpoint. Applicable for endpoints of type `Gateway`.
-* `prefix_list_id` - The prefix list ID of the exposed AWS service. Applicable for endpoints of type `Gateway`.
 * `cidr_blocks` - The list of CIDR blocks for the exposed AWS service. Applicable for endpoints of type `Gateway`.
-* `subnet_ids` - One or more subnets in which the VPC Endpoint is located. Applicable for endpoints of type `Interface`.
-* `network_interface_ids` - One or more network interfaces for the VPC Endpoint. Applicable for endpoints of type `Interface`.
-* `security_group_ids` - One or more security groups associated with the network interfaces. Applicable for endpoints of type `Interface`.
-* `private_dns_enabled` - Whether or not the VPC is associated with a private hosted zone - `true` or `false`. Applicable for endpoints of type `Interface`.
 * `dns_entry` - The DNS entries for the VPC Endpoint. Applicable for endpoints of type `Interface`. DNS blocks are documented below.
+* `network_interface_ids` - One or more network interfaces for the VPC Endpoint. Applicable for endpoints of type `Interface`.
+* `policy` - The policy document associated with the VPC Endpoint. Applicable for endpoints of type `Gateway`.
+* `prefix_list_id` - The prefix list ID of the exposed AWS service. Applicable for endpoints of type `Gateway`.
+* `private_dns_enabled` - Whether or not the VPC is associated with a private hosted zone - `true` or `false`. Applicable for endpoints of type `Interface`.
+* `requester_managed` -  Whether or not the VPC Endpoint is being managed by its service - `true` or `false`.
+* `route_table_ids` - One or more route tables associated with the VPC Endpoint. Applicable for endpoints of type `Gateway`.
+* `security_group_ids` - One or more security groups associated with the network interfaces. Applicable for endpoints of type `Interface`.
+* `subnet_ids` - One or more subnets in which the VPC Endpoint is located. Applicable for endpoints of type `Interface`.
+* `vpc_endpoint_type` - The VPC Endpoint type, `Gateway` or `Interface`.
 
 DNS blocks (for `dns_entry`) support the following attributes:
 

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -55,10 +55,11 @@ The given filters must match exactly one VPC endpoint service whose data will be
 
 In addition to all arguments above, the following attributes are exported:
 
-* `service_type` - The service type, `Gateway` or `Interface`.
-* `owner` - The AWS account ID of the service owner or `amazon`.
-* `vpc_endpoint_policy_supported` - Whether or not the service supports endpoint policies - `true` or `false`.
 * `acceptance_required` - Whether or not VPC endpoint connection requests to the service must be accepted by the service owner - `true` or `false`.
 * `availability_zones` - The Availability Zones in which the service is available.
-* `private_dns_name` - The private DNS name for the service.
 * `base_endpoint_dns_names` - The DNS names for the service.
+* `manages_vpc_endpoints` - Whether or not the service manages its VPC endpoints - `true` or `false`.
+* `owner` - The AWS account ID of the service owner or `amazon`.
+* `private_dns_name` - The private DNS name for the service.
+* `service_type` - The service type, `Gateway` or `Interface`.
+* `vpc_endpoint_policy_supported` - Whether or not the service supports endpoint policies - `true` or `false`.

--- a/website/docs/r/vpc_endpoint.html.markdown
+++ b/website/docs/r/vpc_endpoint.html.markdown
@@ -81,16 +81,16 @@ resource "aws_route53_record" "ptfe_service" {
 
 The following arguments are supported:
 
-* `vpc_id` - (Required) The ID of the VPC in which the endpoint will be used.
-* `vpc_endpoint_type` - (Optional) The VPC endpoint type, `Gateway` or `Interface`. Defaults to `Gateway`.
 * `service_name` - (Required) The service name, in the form `com.amazonaws.region.service` for AWS services.
+* `vpc_id` - (Required) The ID of the VPC in which the endpoint will be used.
 * `auto_accept` - (Optional) Accept the VPC endpoint (the VPC endpoint and service need to be in the same AWS account).
 * `policy` - (Optional) A policy to attach to the endpoint that controls access to the service. Defaults to full access. All `Gateway` and some `Interface` endpoints support policies - see the [relevant AWS documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-access.html) for more details. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](/docs/providers/aws/guides/iam-policy-documents.html).
+* `private_dns_enabled` - (Optional; AWS services and AWS Marketplace partner services only) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.
+Defaults to `false`.
 * `route_table_ids` - (Optional) One or more route table IDs. Applicable for endpoints of type `Gateway`.
 * `subnet_ids` - (Optional) The ID of one or more subnets in which to create a network interface for the endpoint. Applicable for endpoints of type `Interface`.
 * `security_group_ids` - (Optional) The ID of one or more security groups to associate with the network interface. Required for endpoints of type `Interface`.
-* `private_dns_enabled` - (Optional; AWS services and AWS Marketplace partner services only) Whether or not to associate a private hosted zone with the specified VPC. Applicable for endpoints of type `Interface`.
-Defaults to `false`.
+* `vpc_endpoint_type` - (Optional) The VPC endpoint type, `Gateway` or `Interface`. Defaults to `Gateway`.
 
 ### Timeouts
 
@@ -106,11 +106,12 @@ Defaults to `false`.
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the VPC endpoint.
-* `state` - The state of the VPC endpoint.
-* `prefix_list_id` - The prefix list ID of the exposed AWS service. Applicable for endpoints of type `Gateway`.
 * `cidr_blocks` - The list of CIDR blocks for the exposed AWS service. Applicable for endpoints of type `Gateway`.
-* `network_interface_ids` - One or more network interfaces for the VPC Endpoint. Applicable for endpoints of type `Interface`.
 * `dns_entry` - The DNS entries for the VPC Endpoint. Applicable for endpoints of type `Interface`. DNS blocks are documented below.
+* `network_interface_ids` - One or more network interfaces for the VPC Endpoint. Applicable for endpoints of type `Interface`.
+* `prefix_list_id` - The prefix list ID of the exposed AWS service. Applicable for endpoints of type `Gateway`.
+* `requester_managed` -  Whether or not the VPC Endpoint is being managed by its service - `true` or `false`.
+* `state` - The state of the VPC endpoint.
 
 DNS blocks (for `dns_entry`) support the following attributes:
 

--- a/website/docs/r/vpc_endpoint_service.html.markdown
+++ b/website/docs/r/vpc_endpoint_service.html.markdown
@@ -41,12 +41,13 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the VPC endpoint service.
-* `state` - The state of the VPC endpoint service.
+* `availability_zones` - The Availability Zones in which the service is available.
+* `base_endpoint_dns_names` - The DNS names for the service.
+* `manages_vpc_endpoints` - Whether or not the service manages its VPC endpoints - `true` or `false`.
+* `private_dns_name` - The private DNS name for the service.
 * `service_name` - The service name.
 * `service_type` - The service type, `Gateway` or `Interface`.
-* `availability_zones` - The Availability Zones in which the service is available.
-* `private_dns_name` - The private DNS name for the service.
-* `base_endpoint_dns_names` - The DNS names for the service.
+* `state` - The state of the VPC endpoint service.
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8386.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* data-source/aws_vpc_endpoint: New exported attribute `requester_managed` (https://github.com/terraform-providers/terraform-provider-aws/issues/8386).
* data-source/aws_vpc_endpoint_service: New exported attribute `manages_vpc_endpoints` (https://github.com/terraform-providers/terraform-provider-aws/issues/8386).
* resource/aws_vpc_endpoint: New exported attribute `requester_managed` (https://github.com/terraform-providers/terraform-provider-aws/issues/8386).
* resource/aws_vpc_endpoint_service: New exported attribute `manages_vpc_endpoints` (https://github.com/terraform-providers/terraform-provider-aws/issues/8386).
```

Acceptance tests:

### d/aws_vpc_endpoint_service

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsVpcEndpointService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsVpcEndpointService_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpcEndpointService_gateway
=== PAUSE TestAccDataSourceAwsVpcEndpointService_gateway
=== RUN   TestAccDataSourceAwsVpcEndpointService_interface
=== PAUSE TestAccDataSourceAwsVpcEndpointService_interface
=== RUN   TestAccDataSourceAwsVpcEndpointService_custom
=== PAUSE TestAccDataSourceAwsVpcEndpointService_custom
=== CONT  TestAccDataSourceAwsVpcEndpointService_gateway
=== CONT  TestAccDataSourceAwsVpcEndpointService_custom
=== CONT  TestAccDataSourceAwsVpcEndpointService_interface
--- PASS: TestAccDataSourceAwsVpcEndpointService_interface (17.36s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_gateway (17.41s)
--- PASS: TestAccDataSourceAwsVpcEndpointService_custom (263.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	263.804s
```

### r/aws_vpc_endpoint_service

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpcEndpointService_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSVpcEndpointService_ -timeout 120m
=== RUN   TestAccAWSVpcEndpointService_basic
=== PAUSE TestAccAWSVpcEndpointService_basic
=== RUN   TestAccAWSVpcEndpointService_removed
=== PAUSE TestAccAWSVpcEndpointService_removed
=== CONT  TestAccAWSVpcEndpointService_basic
=== CONT  TestAccAWSVpcEndpointService_removed
--- PASS: TestAccAWSVpcEndpointService_removed (244.82s)
--- PASS: TestAccAWSVpcEndpointService_basic (491.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	491.320s
```

### d/aws_vpc_endpoint

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsVpcEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsVpcEndpoint_ -timeout 120m
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== PAUSE TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== RUN   TestAccDataSourceAwsVpcEndpoint_byId
=== PAUSE TestAccDataSourceAwsVpcEndpoint_byId
=== RUN   TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable
=== PAUSE TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable
=== RUN   TestAccDataSourceAwsVpcEndpoint_interface
=== PAUSE TestAccDataSourceAwsVpcEndpoint_interface
=== CONT  TestAccDataSourceAwsVpcEndpoint_gatewayBasic
=== CONT  TestAccDataSourceAwsVpcEndpoint_interface
=== CONT  TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable
=== CONT  TestAccDataSourceAwsVpcEndpoint_byId
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayBasic (44.76s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_byId (44.80s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_gatewayWithRouteTable (48.22s)
--- PASS: TestAccDataSourceAwsVpcEndpoint_interface (184.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	184.690s
```

### r/aws_vpc_endpoint

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpcEndpoint_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSVpcEndpoint_ -timeout 120m
=== RUN   TestAccAWSVpcEndpoint_gatewayBasic
=== PAUSE TestAccAWSVpcEndpoint_gatewayBasic
=== RUN   TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy
=== PAUSE TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy
=== RUN   TestAccAWSVpcEndpoint_gatewayPolicy
=== PAUSE TestAccAWSVpcEndpoint_gatewayPolicy
=== RUN   TestAccAWSVpcEndpoint_interfaceBasic
=== PAUSE TestAccAWSVpcEndpoint_interfaceBasic
=== RUN   TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== PAUSE TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== RUN   TestAccAWSVpcEndpoint_interfaceNonAWSService
=== PAUSE TestAccAWSVpcEndpoint_interfaceNonAWSService
=== RUN   TestAccAWSVpcEndpoint_removed
=== PAUSE TestAccAWSVpcEndpoint_removed
=== CONT  TestAccAWSVpcEndpoint_gatewayBasic
=== CONT  TestAccAWSVpcEndpoint_removed
=== CONT  TestAccAWSVpcEndpoint_interfaceNonAWSService
=== CONT  TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup
=== CONT  TestAccAWSVpcEndpoint_interfaceBasic
=== CONT  TestAccAWSVpcEndpoint_gatewayPolicy
=== CONT  TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy
--- PASS: TestAccAWSVpcEndpoint_removed (37.15s)
--- PASS: TestAccAWSVpcEndpoint_gatewayBasic (44.24s)
--- PASS: TestAccAWSVpcEndpoint_interfaceBasic (60.38s)
--- PASS: TestAccAWSVpcEndpoint_gatewayPolicy (71.08s)
--- PASS: TestAccAWSVpcEndpoint_gatewayWithRouteTableAndPolicy (86.65s)
--- PASS: TestAccAWSVpcEndpoint_interfaceNonAWSService (320.69s)
--- PASS: TestAccAWSVpcEndpoint_interfaceWithSubnetAndSecurityGroup (374.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	374.092s
```