### PR TITLE
[WIP] adds roots attribute to the aws_organizations_organization resource

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -42,6 +42,42 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"roots": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"feature_set": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -106,7 +142,18 @@ func resourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("error describing Organization: %s", err)
 	}
 
+	log.Printf("[INFO] Listing Roots for Organization: %s", d.Id())
+	var roots []*organizations.Root
+	err = conn.ListRootsPages(&organizations.ListRootsInput{}, func(page *organizations.ListRootsOutput, lastPage bool) bool {
+		roots = append(roots, page.Roots...)
+		return !lastPage
+	})
+	if err != nil {
+		return err
+	}
+
 	d.Set("arn", org.Organization.Arn)
+	d.Set("roots", flattenOrgRoots(roots))
 	d.Set("feature_set", org.Organization.FeatureSet)
 	d.Set("master_account_arn", org.Organization.MasterAccountArn)
 	d.Set("master_account_email", org.Organization.MasterAccountEmail)

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -29,6 +29,11 @@ func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
 					testAccMatchResourceAttrGlobalARN(resourceName, "master_account_arn", "organizations", regexp.MustCompile(`account/o-.+/.+`)),
 					resource.TestMatchResourceAttr(resourceName, "master_account_email", regexp.MustCompile(`.+@.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "master_account_id"),
+					resource.TestCheckResourceAttr(resourceName, "roots.#", "1"),
+					resource.TestMatchResourceAttr(resourceName, "roots.0.id", regexp.MustCompile(`r-[a-z0-9]{4,32}`)),
+					resource.TestCheckResourceAttrSet(resourceName, "roots.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "roots.0.arn"),
+					resource.TestCheckResourceAttr(resourceName, "roots.0.policy_types.#", "0"),
 				),
 			},
 			{

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -37,6 +37,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/macie"
 	"github.com/aws/aws-sdk-go/service/mq"
 	"github.com/aws/aws-sdk-go/service/neptune"
+	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -5440,4 +5441,34 @@ func flattenRoute53ResolverRuleTargetIps(targetAddresses []*route53resolver.Targ
 	}
 
 	return vTargetIps
+}
+
+func flattenOrgRoots(roots []*organizations.Root) []map[string]interface{} {
+	if len(roots) == 0 {
+		return nil
+	}
+	var result []map[string]interface{}
+	for _, r := range roots {
+		result = append(result, map[string]interface{}{
+			"id":           aws.StringValue(r.Id),
+			"name":         aws.StringValue(r.Name),
+			"arn":          aws.StringValue(r.Arn),
+			"policy_types": flattenOrgRootPolicyTypeSummaries(r.PolicyTypes),
+		})
+	}
+	return result
+}
+
+func flattenOrgRootPolicyTypeSummaries(summaries []*organizations.PolicyTypeSummary) []map[string]interface{} {
+	if len(summaries) == 0 {
+		return nil
+	}
+	var result []map[string]interface{}
+	for _, s := range summaries {
+		result = append(result, map[string]interface{}{
+			"status": aws.StringValue(s.Status),
+			"type":   aws.StringValue(s.Type),
+		})
+	}
+	return result
 }

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -1226,6 +1227,65 @@ func TestNormalizeCloudFormationTemplate(t *testing.T) {
 	}
 	if actual != validNormalizedYaml {
 		t.Fatalf("Got:\n\n%s\n\nExpected:\n\n%s\n", actual, validNormalizedYaml)
+	}
+}
+
+func TestFlattenOrgRoots(t *testing.T) {
+	roots := []*organizations.Root{
+		&organizations.Root{
+			Name: aws.String("Root1"),
+			Arn:  aws.String("arn:1"),
+			Id:   aws.String("r-1"),
+			PolicyTypes: []*organizations.PolicyTypeSummary{
+				&organizations.PolicyTypeSummary{
+					Status: aws.String("ENABLED"),
+					Type:   aws.String("SERVICE_CONTROL_POLICY"),
+				},
+				&organizations.PolicyTypeSummary{
+					Status: aws.String("DISABLED"),
+					Type:   aws.String("SERVICE_CONTROL_POLICY"),
+				},
+			},
+		},
+	}
+	result := flattenOrgRoots(roots)
+
+	if len(result) != len(roots) {
+		t.Fatalf("expected result to have %d elements, got %d", len(roots), len(result))
+	}
+
+	for i, r := range roots {
+		if aws.StringValue(r.Name) != result[i]["name"] {
+			t.Fatalf(`expected result[%d]["name"] to equal %q, got %q`, i, aws.StringValue(r.Name), result[i]["name"])
+		}
+		if aws.StringValue(r.Arn) != result[i]["arn"] {
+			t.Fatalf(`expected result[%d]["arn"] to equal %q, got %q`, i, aws.StringValue(r.Arn), result[i]["arn"])
+		}
+		if aws.StringValue(r.Id) != result[i]["id"] {
+			t.Fatalf(`expected result[%d]["id"] to equal %q, got %q`, i, aws.StringValue(r.Id), result[i]["id"])
+		}
+		if result[i]["policy_types"] == nil {
+			continue
+		}
+		if types, ok := result[i]["policy_types"].([]map[string]interface{}); ok {
+			testFlattenOrgRootPolicyTypes(t, i, types, r.PolicyTypes)
+			continue
+		}
+		t.Fatalf(`result[%d]["policy_types"] could not be converted to []map[string]interface{}`, i)
+	}
+}
+
+func testFlattenOrgRootPolicyTypes(t *testing.T, index int, result []map[string]interface{}, types []*organizations.PolicyTypeSummary) {
+	if len(result) != len(types) {
+		t.Fatalf(`expected result[%d]["policy_types"] to have %d elements, got %d`, index, len(types), len(result))
+	}
+	for i, v := range types {
+		if aws.StringValue(v.Status) != result[i]["status"] {
+			t.Fatalf(`expected result[%d]["policy_types"][%d]["status"] to equal %q, got %q`, index, i, aws.StringValue(v.Status), result[i]["status"])
+		}
+		if aws.StringValue(v.Type) != result[i]["type"] {
+			t.Fatalf(`expected result[%d]["policy_types"][%d]["type"] to equal %q, got %q`, index, i, aws.StringValue(v.Type), result[i]["type"])
+		}
 	}
 }
 

--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -1232,16 +1232,16 @@ func TestNormalizeCloudFormationTemplate(t *testing.T) {
 
 func TestFlattenOrgRoots(t *testing.T) {
 	roots := []*organizations.Root{
-		&organizations.Root{
+		{
 			Name: aws.String("Root1"),
 			Arn:  aws.String("arn:1"),
 			Id:   aws.String("r-1"),
 			PolicyTypes: []*organizations.PolicyTypeSummary{
-				&organizations.PolicyTypeSummary{
+				{
 					Status: aws.String("ENABLED"),
 					Type:   aws.String("SERVICE_CONTROL_POLICY"),
 				},
-				&organizations.PolicyTypeSummary{
+				{
 					Status: aws.String("DISABLED"),
 					Type:   aws.String("SERVICE_CONTROL_POLICY"),
 				},

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -39,6 +39,13 @@ In addition to all arguments above, the following attributes are exported:
 * `master_account_arn` - ARN of the master account
 * `master_account_email` - Email address of the master account
 * `master_account_id` - Identifier of the master account
+* `roots` - List of organization roots. All elements have these attributes:
+  * `arn` - ARN of the root
+  * `id` - Identifier of the root
+  * `name` - Name of the root
+  * `policy_types` - List of policy types enabled for this root. All elements have these attributes:
+    * `name` - The name of the policy type
+    * `status` - The status of the policy type as it relates to the associated root
 
 ## Import
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

As mentioned in [#4207](https://github.com/terraform-providers/terraform-provider-aws/pull/4207#issuecomment-477838157) @bflad requested the modification of the `aws_organizations_organization` resource to contain the response from `organizations:ListRoots`. This will resolve the dependency on a data source when creating an `organizations_organizational_unit` mentioned in [#4207](https://github.com/terraform-providers/terraform-provider-aws/pull/4207).

Changes proposed in this pull request:

* adds the response from calling `organizations:ListRoots` to the `aws_organizations_organization` resource
* updates attribute documentation on website

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSOrganizations'

=== RUN   TestAccAWSOrganizations
=== RUN   TestAccAWSOrganizations/Organization
=== RUN   TestAccAWSOrganizations/Organization/basic
=== RUN   TestAccAWSOrganizations/Organization/importBasic
=== RUN   TestAccAWSOrganizations/Organization/consolidatedBilling
=== RUN   TestAccAWSOrganizations/Account
=== RUN   TestAccAWSOrganizations/Account/basic
--- PASS: TestAccAWSOrganizations (61.00s)
    --- PASS: TestAccAWSOrganizations/Organization (60.99s)
        --- PASS: TestAccAWSOrganizations/Organization/basic (19.64s)
        --- PASS: TestAccAWSOrganizations/Organization/importBasic (22.88s)
        --- PASS: TestAccAWSOrganizations/Organization/consolidatedBilling (18.46s)
    --- PASS: TestAccAWSOrganizations/Account (0.00s)
        --- SKIP: TestAccAWSOrganizations/Account/basic (0.00s)
            resource_aws_organizations_account_test.go:20: 'TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN' not set, skipping test.
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       61.288s
```
