### PR TITLE
docfix: add the CAPABILITY_AUTO_EXPAND option to docs

### DIFF
--- a/website/docs/r/cloudformation_stack.html.markdown
+++ b/website/docs/r/cloudformation_stack.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `template_body` - (Optional) Structure containing the template body (max size: 51,200 bytes).
 * `template_url` - (Optional) Location of a file containing the template body (max size: 460,800 bytes).
 * `capabilities` - (Optional) A list of capabilities.
-  Valid values: `CAPABILITY_IAM` or `CAPABILITY_NAMED_IAM`
+  Valid values: `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`, or `CAPABILITY_AUTO_EXPAND`
 * `disable_rollback` - (Optional) Set to true to disable rollback of the stack if stack creation failed.
   Conflicts with `on_failure`.
 * `notification_arns` - (Optional) A list of SNS topic ARNs to publish stack related events.


### PR DESCRIPTION
No code change needed, just adding it to reduce confusion.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

N/A on testing.