### PR TITLE
Fix reference to account-level ACL block

### DIFF
--- a/website/docs/r/s3_bucket_public_access_block.html.markdown
+++ b/website/docs/r/s3_bucket_public_access_block.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `block_public_policy` - (Optional) Whether Amazon S3 should block public bucket policies for this bucket. Defaults to `false`. Enabling this setting does not affect the existing bucket policy. When set to `true` causes Amazon S3 to:
   * Reject calls to PUT Bucket policy if the specified bucket policy allows public access.
 * `ignore_public_acls` - (Optional) Whether Amazon S3 should ignore public ACLs for this bucket. Defaults to `false`. Enabling this setting does not affect the persistence of any existing ACLs and doesn't prevent new public ACLs from being set. When set to `true` causes Amazon S3 to:
-  * Ignore all public ACLs on buckets in this account and any objects that they contain.
+  * Ignore public ACLs on this bucket and any objects that it contains.
 * `restrict_public_buckets` - (Optional) Whether Amazon S3 should restrict public bucket policies for this bucket. Defaults to `false`. Enabling this setting does not affect the previously stored bucket policy, except that public and cross-account access within the public bucket policy, including non-public delegation to specific accounts, is blocked. When set to `true`:
   * Only the bucket owner and AWS Services can access this buckets if it has a public policy.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes documentation on s3 **bucket** access block to remove a reference to it affecting all buckets in an AWS account.