### PR TITLE
fix: Increases the timeout for TransitGateway routes

### DIFF
--- a/aws/resource_aws_ec2_transit_gateway_route.go
+++ b/aws/resource_aws_ec2_transit_gateway_route.go
@@ -77,7 +77,7 @@ func resourceAwsEc2TransitGatewayRouteRead(d *schema.ResourceData, meta interfac
 
 	// Handle EC2 eventual consistency
 	var transitGatewayRoute *ec2.TransitGatewayRoute
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
 		var err error
 		transitGatewayRoute, err = ec2DescribeTransitGatewayRoute(conn, transitGatewayRouteTableID, destination)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

When creating a lot of routes (+4), idempotency is broken. This is what happen:
- the routes creation stop exactly after 1m;
- the apply finishes without apparent issue;
- the routes are indeed created on AWS;
- the state file does not contain the routes (!);
- subsequent applies try to create the route again (because it’s not in the state file);
- subsequent applies fail.

There maybe a better solution to this problem, but this quick fix works.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
