### PR TITLE
Fix aws_autoscaling_group default_cooldown in case explicitly set to 0

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -538,7 +538,7 @@ func resourceAwsAutoscalingGroupCreate(d *schema.ResourceData, meta interface{})
 		createOpts.Tags = append(createOpts.Tags, tags...)
 	}
 
-	if v, ok := d.GetOk("default_cooldown"); ok {
+	if v, ok := d.GetOkExists("default_cooldown"); ok {
 		createOpts.DefaultCooldown = aws.Int64(int64(v.(int)))
 	}
 


### PR DESCRIPTION
The GetOk will compare the value to the default zero value of a
type. When the default_cooldown is set to 0, the value matches the default zero
value of the type Integer and will be ignored for the api request.
Normally not a problem, but in this case, this results in an default_cooldown
of 300s on AWS side.
This change will use getOkExists, which doesn't compare to the default zero value.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8412
