### PR TITLE
docs/resource/aws_guardduty_member: Cross-link aws_guardduty_invite_accepter resource

### DIFF
--- a/website/docs/r/guardduty_member.html.markdown
+++ b/website/docs/r/guardduty_member.html.markdown
@@ -8,9 +8,7 @@ description: |-
 
 # Resource: aws_guardduty_member
 
-Provides a resource to manage a GuardDuty member.
-
-~> **NOTE:** Currently after using this resource, you must manually accept member account invitations before GuardDuty will begin sending cross-account events. More information for how to accomplish this via the AWS Console or API can be found in the [GuardDuty User Guide](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_accounts.html). Terraform implementation of the member acceptance resource can be tracked in [Github](https://github.com/terraform-providers/terraform-provider-aws/issues/2489).
+Provides a resource to manage a GuardDuty member. To accept invitations in member accounts, see the [`aws_guardduty_invite_accepter` resource](/docs/providers/aws/r/guardduty_invite_accepter.html).
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The `aws_guardduty_invite_accepter` resource for accepting GuardDuty member invites was released in [version 2.2.0 of the Terraform AWS Provider](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#220-march-15-2019). Remove the note about manually accepting invites and cross-link the Terraform resource.
