### PR TITLE
AWS Systems Manager resources: Add support for resource tags

### DIFF
--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -57,6 +57,7 @@ func resourceAwsSsmActivation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchemaForceNew(),
 		},
 	}
 }
@@ -89,6 +90,9 @@ func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) er
 
 	if _, ok := d.GetOk("registration_limit"); ok {
 		activationInput.RegistrationLimit = aws.Int64(int64(d.Get("registration_limit").(int)))
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		activationInput.Tags = tagsFromMapSSM(v.(map[string]interface{}))
 	}
 
 	// Retry to allow iam_role to be created and policy attachment to take place

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -25,7 +25,8 @@ func TestAccAWSSSMActivation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo"),
 					resource.TestCheckResourceAttrSet("aws_ssm_activation.foo", "activation_code"),
-				),
+					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.Name", "My Activation")),
 			},
 		},
 	})
@@ -155,6 +156,9 @@ resource "aws_ssm_activation" "foo" {
   iam_role           = "${aws_iam_role.test_role.name}"
   registration_limit = "5"
   depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
+  tags               = {
+    Name = "My Activation"
+  }
 }
 `, rName, rName)
 }

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -65,15 +65,6 @@ func TestAccAWSSSMActivation_update(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSSSMActivationRecreated(t *testing.T, before, after *ssm.Activation) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *before.ActivationId == *after.ActivationId {
-			t.Fatalf("expected SSM activation Ids to be different but got %v == %v", before.ActivationId, after.ActivationId)
-		}
-		return nil
-	}
-}
-
 func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 	var ssmActivation ssm.Activation
 	rName := acctest.RandString(10)
@@ -99,6 +90,15 @@ func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSSSMActivationRecreated(t *testing.T, before, after *ssm.Activation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before.ActivationId == *after.ActivationId {
+			t.Fatalf("expected SSM activation Ids to be different but got %v == %v", before.ActivationId, after.ActivationId)
+		}
+		return nil
+	}
 }
 
 func testAccCheckAWSSSMActivationExists(n string, ssmActivation *ssm.Activation) resource.TestCheckFunc {

--- a/aws/resource_aws_ssm_activation_test.go
+++ b/aws/resource_aws_ssm_activation_test.go
@@ -14,6 +14,28 @@ import (
 )
 
 func TestAccAWSSSMActivation_basic(t *testing.T) {
+	var ssmActivation ssm.Activation
+	name := acctest.RandString(10)
+	tag := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMActivationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMActivationBasicConfig(name, tag),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo", &ssmActivation),
+					resource.TestCheckResourceAttrSet("aws_ssm_activation.foo", "activation_code"),
+					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.Name", tag)),
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMActivation_update(t *testing.T) {
+	var ssmActivation1, ssmActivation2 ssm.Activation
 	name := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,18 +43,39 @@ func TestAccAWSSSMActivation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSSMActivationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSSMActivationBasicConfig(name),
+				Config: testAccAWSSSMActivationBasicConfig(name, "My Activation"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo"),
+					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo", &ssmActivation1),
 					resource.TestCheckResourceAttrSet("aws_ssm_activation.foo", "activation_code"),
 					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.%", "1"),
-					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.Name", "My Activation")),
+					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.Name", "My Activation"),
+				),
+			},
+			{
+				Config: testAccAWSSSMActivationBasicConfig(name, "Foo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMActivationExists("aws_ssm_activation.foo", &ssmActivation2),
+					resource.TestCheckResourceAttrSet("aws_ssm_activation.foo", "activation_code"),
+					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_ssm_activation.foo", "tags.Name", "Foo"),
+					testAccCheckAWSSSMActivationRecreated(t, &ssmActivation1, &ssmActivation2),
+				),
 			},
 		},
 	})
 }
 
+func testAccCheckAWSSSMActivationRecreated(t *testing.T, before, after *ssm.Activation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before.ActivationId == *after.ActivationId {
+			t.Fatalf("expected SSM activation Ids to be different but got %v == %v", before.ActivationId, after.ActivationId)
+		}
+		return nil
+	}
+}
+
 func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
+	var ssmActivation ssm.Activation
 	rName := acctest.RandString(10)
 	expirationTime := time.Now().Add(48 * time.Hour)
 	expirationDateS := expirationTime.Format(time.RFC3339)
@@ -50,7 +93,7 @@ func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 			{
 				Config: testAccAWSSSMActivationConfig_expirationDate(rName, expirationDateS),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSSSMActivationExists(resourceName),
+					testAccCheckAWSSSMActivationExists(resourceName, &ssmActivation),
 					resource.TestCheckResourceAttr(resourceName, "expiration_date", expirationDateS),
 				),
 			},
@@ -58,7 +101,7 @@ func TestAccAWSSSMActivation_expirationDate(t *testing.T) {
 	})
 }
 
-func testAccCheckAWSSSMActivationExists(n string) resource.TestCheckFunc {
+func testAccCheckAWSSSMActivationExists(n string, ssmActivation *ssm.Activation) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -71,7 +114,7 @@ func testAccCheckAWSSSMActivationExists(n string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*AWSClient).ssmconn
 
-		_, err := conn.DescribeActivations(&ssm.DescribeActivationsInput{
+		resp, err := conn.DescribeActivations(&ssm.DescribeActivationsInput{
 			Filters: []*ssm.DescribeActivationsFilter{
 				{
 					FilterKey: aws.String("ActivationIds"),
@@ -84,8 +127,10 @@ func testAccCheckAWSSSMActivationExists(n string) resource.TestCheckFunc {
 		})
 
 		if err != nil {
-			return fmt.Errorf("Could not descripbe the activation - %s", err)
+			return fmt.Errorf("Could not describe the activation - %s", err)
 		}
+
+		*ssmActivation = *resp.ActivationList[0]
 
 		return nil
 	}
@@ -125,7 +170,7 @@ func testAccCheckAWSSSMActivationDestroy(s *terraform.State) error {
 	return fmt.Errorf("Default error in SSM Activation Test")
 }
 
-func testAccAWSSSMActivationBasicConfig(rName string) string {
+func testAccAWSSSMActivationBasicConfig(rName string, rTag string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test_role" {
   name = "test_role-%s"
@@ -157,10 +202,10 @@ resource "aws_ssm_activation" "foo" {
   registration_limit = "5"
   depends_on         = ["aws_iam_role_policy_attachment.test_attach"]
   tags               = {
-    Name = "My Activation"
+    Name = "%s"
   }
 }
-`, rName, rName)
+`, rName, rName, rTag)
 }
 
 func testAccAWSSSMActivationConfig_expirationDate(rName, expirationDate string) string {

--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -159,6 +159,10 @@ func resourceAwsSsmDocumentCreate(d *schema.ResourceData, meta interface{}) erro
 		DocumentType:   aws.String(d.Get("document_type").(string)),
 	}
 
+	if v, ok := d.GetOk("tags"); ok {
+		docInput.Tags = tagsFromMapSSM(v.(map[string]interface{}))
+	}
+
 	log.Printf("[DEBUG] Waiting for SSM Document %q to be created", d.Get("name").(string))
 	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		resp, err := ssmconn.CreateDocument(docInput)

--- a/aws/resource_aws_ssm_document_test.go
+++ b/aws/resource_aws_ssm_document_test.go
@@ -27,7 +27,9 @@ func TestAccAWSSSMDocument_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ssm_document.foo", "document_format", "JSON"),
 					resource.TestMatchResourceAttr("aws_ssm_document.foo", "arn",
 						regexp.MustCompile(`^arn:aws:ssm:[a-z]{2}-[a-z]+-\d{1}:\d{12}:document/.*$`)),
-					resource.TestCheckResourceAttr("aws_ssm_document.foo", "tags.%", "0"),
+					resource.TestCheckResourceAttr("aws_ssm_document.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "tags.Name", "My Document"),
 				),
 			},
 		},
@@ -382,14 +384,16 @@ func testAccAWSSSMDocumentBasicConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_document" "foo" {
   name = "test_document-%s"
-	document_type = "Command"
+  document_type = "Command"
+  tags = {
+    Name = "My Document"
+  }
 
   content = <<DOC
     {
       "schemaVersion": "1.2",
       "description": "Check ip configuration of a Linux instance.",
       "parameters": {
-
       },
       "runtimeConfig": {
         "aws:runShellScript": {

--- a/aws/resource_aws_ssm_maintenance_window_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_test.go
@@ -34,12 +34,47 @@ func TestAccAWSSSMMaintenanceWindow_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "schedule_timezone", ""),
 					resource.TestCheckResourceAttr(resourceName, "schedule", "cron(0 16 ? * TUE *)"),
 					resource.TestCheckResourceAttr(resourceName, "start_date", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindow_tags(t *testing.T) {
+	var winId ssm.MaintenanceWindowIdentity
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ssm_maintenance_window.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfigTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &winId),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "My Maintenance Window"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSSSMMaintenanceWindowConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMMaintenanceWindowExists(resourceName, &winId),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
 			},
 		},
 	})
@@ -449,6 +484,20 @@ resource "aws_ssm_maintenance_window" "test" {
   duration = 3
   name     = %q
   schedule = "cron(0 16 ? * TUE *)"
+}
+`, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowConfigTags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "test" {
+  cutoff   = 1
+  duration = 3
+  name     = %q
+  schedule = "cron(0 16 ? * TUE *)"
+  tags = {
+    Name = "My Maintenance Window"
+  }
 }
 `, rName)
 }

--- a/aws/resource_aws_ssm_patch_baseline_test.go
+++ b/aws/resource_aws_ssm_patch_baseline_test.go
@@ -33,6 +33,8 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 						"aws_ssm_patch_baseline.foo", "approved_patches_compliance_level", ssm.PatchComplianceLevelCritical),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "description", "Baseline containing all updates approved for production systems"),
+					resource.TestCheckResourceAttr("aws_ssm_patch_baseline.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_ssm_patch_baseline.foo", "tags.Name", "My Patch Baseline"),
 				),
 			},
 			{
@@ -56,6 +58,9 @@ func TestAccAWSSSMPatchBaseline_basic(t *testing.T) {
 						"aws_ssm_patch_baseline.foo", "approved_patches_compliance_level", ssm.PatchComplianceLevelHigh),
 					resource.TestCheckResourceAttr(
 						"aws_ssm_patch_baseline.foo", "description", "Baseline containing all updates approved for production systems - August 2017"),
+					resource.TestCheckResourceAttr("aws_ssm_patch_baseline.foo", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_ssm_patch_baseline.foo", "tags.Name", "My Patch Baseline Aug 17"),
+					resource.TestCheckResourceAttr("aws_ssm_patch_baseline.foo", "tags.Environment", "production"),
 					func(*terraform.State) error {
 						if *before.BaselineId != *after.BaselineId {
 							t.Fatal("Baseline IDs changed unexpectedly")
@@ -245,6 +250,9 @@ resource "aws_ssm_patch_baseline" "foo" {
   description = "Baseline containing all updates approved for production systems"
   approved_patches = ["KB123456"]
   approved_patches_compliance_level = "CRITICAL"
+  tags = {
+    Name = "My Patch Baseline"
+  }
 }
 
 `, rName)
@@ -258,6 +266,10 @@ resource "aws_ssm_patch_baseline" "foo" {
   description = "Baseline containing all updates approved for production systems - August 2017"
   approved_patches = ["KB123456","KB456789"]
   approved_patches_compliance_level = "HIGH"
+  tags = {
+    Name = "My Patch Baseline Aug 17"
+    Environment = "production"
+  }
 }
 
 `, rName)
@@ -270,6 +282,9 @@ resource "aws_ssm_patch_baseline" "foo" {
   name  = "patch-baseline-%s"
   operating_system = "AMAZON_LINUX"
   description = "Baseline containing all updates approved for production systems"
+  tags = {
+    Name = "My Patch Baseline"
+  }
   approval_rule {
   	approve_after_days = 7
 	enable_non_security = true
@@ -297,6 +312,9 @@ resource "aws_ssm_patch_baseline" "foo" {
   name  = "patch-baseline-%s"
   operating_system = "WINDOWS"
   description = "Baseline containing all updates approved for production systems"
+  tags = {
+    Name = "My Patch Baseline"
+  }
   approval_rule {
   	approve_after_days = 7
   	compliance_level = "INFORMATIONAL"

--- a/aws/tags.go
+++ b/aws/tags.go
@@ -34,6 +34,14 @@ func tagsSchemaComputed() *schema.Schema {
 	}
 }
 
+func tagsSchemaForceNew() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		ForceNew: true,
+	}
+}
+
 func setElbV2Tags(conn *elbv2.ELBV2, d *schema.ResourceData) error {
 	if d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")

--- a/aws/tagsSSM.go
+++ b/aws/tagsSSM.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"regexp"
 
@@ -115,4 +116,22 @@ func tagIgnoredSSM(t *ssm.Tag) bool {
 		}
 	}
 	return false
+}
+
+func saveTagsSSM(conn *ssm.SSM, d *schema.ResourceData, id, resourceType string) error {
+	resp, err := conn.ListTagsForResource(&ssm.ListTagsForResourceInput{
+		ResourceId:   aws.String(id),
+		ResourceType: aws.String(resourceType),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving tags for SSM resource: %s", id)
+	}
+
+	var dt []*ssm.Tag
+	if len(resp.TagList) > 0 {
+		dt = resp.TagList
+	}
+
+	return d.Set("tags", tagsToMapSSM(dt))
 }

--- a/website/docs/r/ssm_activation.html.markdown
+++ b/website/docs/r/ssm_activation.html.markdown
@@ -51,6 +51,7 @@ The following arguments are supported:
 * `expiration_date` - (Optional) A timestamp in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) by which this activation request should expire. The default value is 24 hours from resource creation time.
 * `iam_role` - (Required) The IAM Role to attach to the managed instance.
 * `registration_limit` - (Optional) The maximum number of managed instances you want to register. The default value is 1 instance.
+* `tags` - (Optional) A mapping of tags to assign to the object.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -34,6 +34,7 @@ The following arguments are supported:
 * `end_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to no longer run the maintenance window.
 * `schedule_timezone` - (Optional) Timezone for schedule in [Internet Assigned Numbers Authority (IANA) Time Zone Database format](https://www.iana.org/time-zones). For example: `America/Los_Angeles`, `etc/UTC`, or `Asia/Seoul`.
 * `start_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to begin the maintenance window.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -100,6 +100,7 @@ The `approval_rule` block supports:
 * `patch_filter` - (Required) The patch filter group that defines the criteria for the rule. Up to 4 patch filters can be specified per approval rule using Key/Value pairs. Valid Keys are `PRODUCT | CLASSIFICATION | MSRC_SEVERITY | PATCH_ID`.
 * `compliance_level` - (Optional) Defines the compliance level for patches approved by this rule. Valid compliance levels include the following: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFORMATIONAL`, `UNSPECIFIED`. The default value is `UNSPECIFIED`.
 * `enable_non_security` - (Optional) Boolean enabling the application of non-security updates. The default value is 'false'. Valid for Linux instances only.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7673 

Changes proposed in this pull request:

* Support adding and updating tags wherever possible for SSM Activations, Parameters, Maintenance Windows, Patch Baselines, and Documents

Output from acceptance testing:

```
$  make testacc TEST=./aws TESTARGS='"-run=TestAccAWSSSM(Parameter|Document|MaintenanceWindow|Activation|PatchBaseline)"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 "-run=TestAccAWSSSM(Parameter|Document|MaintenanceWindow|Activation|PatchBaseline)" -timeout 120m
=== RUN   TestAccAWSSSMActivation_basic
=== PAUSE TestAccAWSSSMActivation_basic
=== RUN   TestAccAWSSSMActivation_expirationDate
=== PAUSE TestAccAWSSSMActivation_expirationDate
=== RUN   TestAccAWSSSMDocument_basic
=== PAUSE TestAccAWSSSMDocument_basic
=== RUN   TestAccAWSSSMDocument_update
=== PAUSE TestAccAWSSSMDocument_update
=== RUN   TestAccAWSSSMDocument_permission_public
=== PAUSE TestAccAWSSSMDocument_permission_public
=== RUN   TestAccAWSSSMDocument_permission_private
=== PAUSE TestAccAWSSSMDocument_permission_private
=== RUN   TestAccAWSSSMDocument_permission_batching
=== PAUSE TestAccAWSSSMDocument_permission_batching
=== RUN   TestAccAWSSSMDocument_permission_change
=== PAUSE TestAccAWSSSMDocument_permission_change
=== RUN   TestAccAWSSSMDocument_params
=== PAUSE TestAccAWSSSMDocument_params
=== RUN   TestAccAWSSSMDocument_automation
=== PAUSE TestAccAWSSSMDocument_automation
=== RUN   TestAccAWSSSMDocument_session
=== PAUSE TestAccAWSSSMDocument_session
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
=== PAUSE TestAccAWSSSMDocument_DocumentFormat_YAML
=== RUN   TestAccAWSSSMDocument_Tags
=== PAUSE TestAccAWSSSMDocument_Tags
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_update
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_update
=== RUN   TestAccAWSSSMMaintenanceWindowTask_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== PAUSE TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== RUN   TestAccAWSSSMMaintenanceWindow_basic
=== PAUSE TestAccAWSSSMMaintenanceWindow_basic
=== RUN   TestAccAWSSSMMaintenanceWindow_tags
=== PAUSE TestAccAWSSSMMaintenanceWindow_tags
=== RUN   TestAccAWSSSMMaintenanceWindow_disappears
=== PAUSE TestAccAWSSSMMaintenanceWindow_disappears
=== RUN   TestAccAWSSSMMaintenanceWindow_multipleUpdates
=== PAUSE TestAccAWSSSMMaintenanceWindow_multipleUpdates
=== RUN   TestAccAWSSSMMaintenanceWindow_Cutoff
=== PAUSE TestAccAWSSSMMaintenanceWindow_Cutoff
=== RUN   TestAccAWSSSMMaintenanceWindow_Duration
=== PAUSE TestAccAWSSSMMaintenanceWindow_Duration
=== RUN   TestAccAWSSSMMaintenanceWindow_Enabled
=== PAUSE TestAccAWSSSMMaintenanceWindow_Enabled
=== RUN   TestAccAWSSSMMaintenanceWindow_EndDate
=== PAUSE TestAccAWSSSMMaintenanceWindow_EndDate
=== RUN   TestAccAWSSSMMaintenanceWindow_Schedule
=== PAUSE TestAccAWSSSMMaintenanceWindow_Schedule
=== RUN   TestAccAWSSSMMaintenanceWindow_ScheduleTimezone
=== PAUSE TestAccAWSSSMMaintenanceWindow_ScheduleTimezone
=== RUN   TestAccAWSSSMMaintenanceWindow_StartDate
=== PAUSE TestAccAWSSSMMaintenanceWindow_StartDate
=== RUN   TestAccAWSSSMParameter_importBasic
=== PAUSE TestAccAWSSSMParameter_importBasic
=== RUN   TestAccAWSSSMParameter_basic
=== PAUSE TestAccAWSSSMParameter_basic
=== RUN   TestAccAWSSSMParameter_disappears
=== PAUSE TestAccAWSSSMParameter_disappears
=== RUN   TestAccAWSSSMParameter_overwrite
=== PAUSE TestAccAWSSSMParameter_overwrite
=== RUN   TestAccAWSSSMParameter_updateTags
=== PAUSE TestAccAWSSSMParameter_updateTags
=== RUN   TestAccAWSSSMParameter_updateDescription
=== PAUSE TestAccAWSSSMParameter_updateDescription
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
=== PAUSE TestAccAWSSSMParameter_changeNameForcesNew
=== RUN   TestAccAWSSSMParameter_fullPath
=== PAUSE TestAccAWSSSMParameter_fullPath
=== RUN   TestAccAWSSSMParameter_secure
=== PAUSE TestAccAWSSSMParameter_secure
=== RUN   TestAccAWSSSMParameter_secure_with_key
=== PAUSE TestAccAWSSSMParameter_secure_with_key
=== RUN   TestAccAWSSSMParameter_secure_keyUpdate
=== PAUSE TestAccAWSSSMParameter_secure_keyUpdate
=== RUN   TestAccAWSSSMPatchBaseline_basic
=== PAUSE TestAccAWSSSMPatchBaseline_basic
=== RUN   TestAccAWSSSMPatchBaseline_disappears
=== PAUSE TestAccAWSSSMPatchBaseline_disappears
=== RUN   TestAccAWSSSMPatchBaseline_OperatingSystem
=== PAUSE TestAccAWSSSMPatchBaseline_OperatingSystem
=== CONT  TestAccAWSSSMActivation_basic
=== CONT  TestAccAWSSSMMaintenanceWindow_Duration
=== CONT  TestAccAWSSSMParameter_updateDescription
=== CONT  TestAccAWSSSMParameter_secure_keyUpdate
=== CONT  TestAccAWSSSMPatchBaseline_OperatingSystem
=== CONT  TestAccAWSSSMPatchBaseline_disappears
=== CONT  TestAccAWSSSMPatchBaseline_basic
=== CONT  TestAccAWSSSMDocument_DocumentFormat_YAML
=== CONT  TestAccAWSSSMMaintenanceWindow_Cutoff
=== CONT  TestAccAWSSSMMaintenanceWindow_multipleUpdates
=== CONT  TestAccAWSSSMMaintenanceWindow_disappears
=== CONT  TestAccAWSSSMMaintenanceWindow_tags
=== CONT  TestAccAWSSSMMaintenanceWindow_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource
=== CONT  TestAccAWSSSMParameter_secure
=== CONT  TestAccAWSSSMParameter_secure_with_key
=== CONT  TestAccAWSSSMDocument_permission_batching
=== CONT  TestAccAWSSSMDocument_session
=== CONT  TestAccAWSSSMDocument_automation
=== CONT  TestAccAWSSSMDocument_params
--- FAIL: TestAccAWSSSMDocument_automation (3.01s)
    testing.go:568: Step 0 error: config is invalid: 2 problems:
        
        - "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
        - Missing required argument: The argument "owners" is required, but no definition was found.
=== CONT  TestAccAWSSSMDocument_permission_change
--- PASS: TestAccAWSSSMPatchBaseline_disappears (18.86s)
=== CONT  TestAccAWSSSMParameter_changeNameForcesNew
--- PASS: TestAccAWSSSMMaintenanceWindow_disappears (19.04s)
=== CONT  TestAccAWSSSMDocument_update
--- PASS: TestAccAWSSSMMaintenanceWindow_basic (31.23s)
=== CONT  TestAccAWSSSMDocument_permission_private
--- PASS: TestAccAWSSSMDocument_permission_batching (31.35s)
=== CONT  TestAccAWSSSMDocument_permission_public
--- PASS: TestAccAWSSSMActivation_basic (35.06s)
=== CONT  TestAccAWSSSMDocument_basic
--- PASS: TestAccAWSSSMDocument_session (36.16s)
=== CONT  TestAccAWSSSMParameter_fullPath
--- PASS: TestAccAWSSSMMaintenanceWindow_tags (46.18s)
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_basic
--- PASS: TestAccAWSSSMMaintenanceWindow_Cutoff (46.60s)
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_update
--- PASS: TestAccAWSSSMMaintenanceWindow_Duration (47.44s)
=== CONT  TestAccAWSSSMDocument_Tags
--- PASS: TestAccAWSSSMParameter_secure (47.98s)
=== CONT  TestAccAWSSSMParameter_importBasic
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (56.83s)
=== CONT  TestAccAWSSSMParameter_updateTags
--- PASS: TestAccAWSSSMDocument_permission_public (25.92s)
=== CONT  TestAccAWSSSMActivation_expirationDate
--- PASS: TestAccAWSSSMDocument_permission_private (26.08s)
=== CONT  TestAccAWSSSMParameter_overwrite
--- PASS: TestAccAWSSSMPatchBaseline_OperatingSystem (57.85s)
=== CONT  TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMMaintenanceWindow_multipleUpdates (57.87s)
=== CONT  TestAccAWSSSMParameter_disappears
--- PASS: TestAccAWSSSMPatchBaseline_basic (59.56s)
=== CONT  TestAccAWSSSMMaintenanceWindow_StartDate
--- PASS: TestAccAWSSSMDocument_basic (24.96s)
=== CONT  TestAccAWSSSMMaintenanceWindow_ScheduleTimezone
--- PASS: TestAccAWSSSMParameter_updateDescription (64.34s)
=== CONT  TestAccAWSSSMMaintenanceWindow_EndDate
--- PASS: TestAccAWSSSMParameter_secure_with_key (64.44s)
=== CONT  TestAccAWSSSMMaintenanceWindow_Enabled
--- PASS: TestAccAWSSSMDocument_update (47.28s)
=== CONT  TestAccAWSSSMMaintenanceWindowTask_basic
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (49.99s)
=== CONT  TestAccAWSSSMMaintenanceWindow_Schedule
--- PASS: TestAccAWSSSMDocument_permission_change (69.52s)
--- PASS: TestAccAWSSSMDocument_params (75.32s)
--- PASS: TestAccAWSSSMParameter_disappears (18.93s)
--- PASS: TestAccAWSSSMParameter_importBasic (32.66s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_basic (35.66s)
--- PASS: TestAccAWSSSMParameter_basic (26.37s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (87.25s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_update (41.25s)
--- PASS: TestAccAWSSSMActivation_expirationDate (33.59s)
--- PASS: TestAccAWSSSMParameter_updateTags (45.37s)
--- PASS: TestAccAWSSSMParameter_overwrite (44.99s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Enabled (42.50s)
--- PASS: TestAccAWSSSMDocument_Tags (60.80s)
--- PASS: TestAccAWSSSMParameter_fullPath (73.48s)
--- PASS: TestAccAWSSSMMaintenanceWindow_Schedule (43.07s)
--- PASS: TestAccAWSSSMMaintenanceWindow_ScheduleTimezone (58.01s)
--- PASS: TestAccAWSSSMMaintenanceWindow_StartDate (60.76s)
--- PASS: TestAccAWSSSMMaintenanceWindow_EndDate (58.20s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_updateForcesNewResource (130.77s)
--- PASS: TestAccAWSSSMMaintenanceWindowTask_basic (117.63s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	184.000s
make: *** [GNUmakefile:20: testacc] Error 1
```
Note the one existing test fail, which will be fixed by https://github.com/terraform-providers/terraform-provider-aws/pull/8324. 