### PR TITLE
Increase EMR Cluster deletion timeout to 20 minutes

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -990,7 +990,7 @@ func resourceAwsEMRClusterDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
 		resp, err := conn.ListInstances(&emr.ListInstancesInput{
 			ClusterId: aws.String(d.Id()),
 		})


### PR DESCRIPTION
Per AWS Docs, it may take up to 20 minutes for the cluster to terminate completely:
https://docs.aws.amazon.com/cli/latest/reference/emr/terminate-clusters.html

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Fixes #7957

Changes proposed in this pull request:

* Increase timeout to terminate EMR clusters to 20 minutes

Output from acceptance testing:
Sorry, I had trouble running TestAccAWSEMRCluster 
