### PR TITLE
fix: doc api_gateway_integration example wrong function name

### DIFF
--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -94,7 +94,7 @@ resource "aws_api_gateway_integration" "integration" {
 resource "aws_lambda_permission" "apigw_lambda" {
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda.arn}"
+  function_name = "${aws_lambda_function.lambda.function_name}"
   principal     = "apigateway.amazonaws.com"
 
   # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html


### PR DESCRIPTION
Fix wrong example in aws_api_gateway_integration example usage (lambda integration)
function name must not be lambda arn.
