### PR TITLE
resource/aws_sfn_state_machine: Bypass UnknownOperationException error for ListTagsForResource

### DIFF
--- a/aws/resource_aws_sfn_state_machine.go
+++ b/aws/resource_aws_sfn_state_machine.go
@@ -133,15 +133,24 @@ func resourceAwsSfnStateMachineRead(d *schema.ResourceData, meta interface{}) er
 	if err := d.Set("creation_date", sm.CreationDate.Format(time.RFC3339)); err != nil {
 		log.Printf("[DEBUG] Error setting creation_date: %s", err)
 	}
+
+	tags := map[string]string{}
+
 	tagsResp, err := conn.ListTagsForResource(
 		&sfn.ListTagsForResourceInput{
 			ResourceArn: aws.String(d.Id()),
 		},
 	)
-	if err != nil {
+
+	if err != nil && !isAWSErr(err, "UnknownOperationException", "") {
 		return fmt.Errorf("error listing SFN Activity (%s) tags: %s", d.Id(), err)
 	}
-	if err := d.Set("tags", tagsToMapSfn(tagsResp.Tags)); err != nil {
+
+	if tagsResp != nil {
+		tags = tagsToMapSfn(tagsResp.Tags)
+	}
+
+	if err := d.Set("tags", tags); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8450

Verified against LocalStack:

```
aws_sfn_state_machine.state_machine: Creating...
  creation_date: "" => "<computed>"
  definition:    "" => "{\n  \"StartAt\": \"finish\",\n  \"States\": {\n    \"finish\": {\n      \"Type\": \"Succeed\"\n    }\n  }\n}\n"
  name:          "" => "machine"
  role_arn:      "" => "arn:aws:iam::123123123123:role/some_role"
  status:        "" => "<computed>"
aws_sfn_state_machine.state_machine: Creation complete after 0s (ID: arn:aws:states:us-east-1:000000000000:stateMachine:machine)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Output from acceptance testing (update eventual consistency test error is also present on master):

```
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (38.23s)
    testing.go:568: Step 1 error: Check failed: Check 5/6 error: aws_sfn_state_machine.foo: Attribute 'definition' didn't match ".*\\\"MaxAttempts\\\": 10.*", got "{\n  \"Comment\": \"A Hello World example of the Amazon States Language using an AWS Lambda Function\",\n  \"StartAt\": \"HelloWorld\",\n  \"States\": {\n    \"HelloWorld\": {\n      \"Type\": \"Task\",\n      \"Resource\": \"arn:aws:lambda:us-west-2:187416307283:function:sfn-weedqxml47\",\n      \"Retry\": [\n        {\n          \"ErrorEquals\": [\"States.ALL\"],\n          \"IntervalSeconds\": 5,\n          \"MaxAttempts\": 5,\n          \"BackoffRate\": 8.0\n        }\n      ],\n      \"End\": true\n    }\n  }\n}\n"
--- PASS: TestAccAWSSfnStateMachine_Tags (53.08s)
```
