### PR TITLE
Add support for tags for sns topic

### DIFF
--- a/aws/resource_aws_sns_topic.go
+++ b/aws/resource_aws_sns_topic.go
@@ -144,13 +144,14 @@ func resourceAwsSnsTopic() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
 
 func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	snsconn := meta.(*AWSClient).snsconn
-
+	tags := tagsFromMapSNS(d.Get("tags").(map[string]interface{}))
 	var name string
 	if v, ok := d.GetOk("name"); ok {
 		name = v.(string)
@@ -164,6 +165,7 @@ func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 
 	req := &sns.CreateTopicInput{
 		Name: aws.String(name),
+		Tags: tags,
 	}
 
 	output, err := snsconn.CreateTopic(req)
@@ -172,7 +174,6 @@ func resourceAwsSnsTopicCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(*output.TopicArn)
-
 	return resourceAwsSnsTopicUpdate(d, meta)
 }
 
@@ -186,6 +187,11 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 			if err != nil {
 				return err
 			}
+		}
+	}
+	if !d.IsNewResource() {
+		if err := setTagsSNS(conn, d); err != nil {
+			return fmt.Errorf("error updating SNS Topic tags for %s: %s", d.Id(), err)
 		}
 	}
 
@@ -229,6 +235,18 @@ func resourceAwsSnsTopicRead(d *schema.ResourceData, meta interface{}) error {
 		if idx > -1 {
 			d.Set("name", arn[idx+1:])
 		}
+	}
+
+	// List tags
+
+	tagList, err := snsconn.ListTagsForResource(&sns.ListTagsForResourceInput{
+		ResourceArn: aws.String(d.Id()),
+	})
+	if err != nil {
+		return fmt.Errorf("error listing SNS Topic tags for %s: %s", d.Id(), err)
+	}
+	if err := d.Set("tags", tagsToMapSNS(tagList.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil

--- a/aws/tagsSNS.go
+++ b/aws/tagsSNS.go
@@ -9,23 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-// getTags is a helper to get the tags for a resource. It expects the
-// tags field to be named "tags" and the ARN field to be named "arn".
-func getTagsSNS(conn *sns.SNS, d *schema.ResourceData) error {
-	resp, err := conn.ListTagsForResource(&sns.ListTagsForResourceInput{
-		ResourceArn: aws.String(d.Get("arn").(string)),
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := d.Set("tags", tagsToMapSNS(resp.Tags)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tags" and the ARN field to be named "arn".
 func setTagsSNS(conn *sns.SNS, d *schema.ResourceData) error {

--- a/aws/tagsSNS.go
+++ b/aws/tagsSNS.go
@@ -1,0 +1,135 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// getTags is a helper to get the tags for a resource. It expects the
+// tags field to be named "tags" and the ARN field to be named "arn".
+func getTagsSNS(conn *sns.SNS, d *schema.ResourceData) error {
+	resp, err := conn.ListTagsForResource(&sns.ListTagsForResourceInput{
+		ResourceArn: aws.String(d.Get("arn").(string)),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("tags", tagsToMapSNS(resp.Tags)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags" and the ARN field to be named "arn".
+func setTagsSNS(conn *sns.SNS, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsSNS(tagsFromMapSNS(o), tagsFromMapSNS(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&sns.UntagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&sns.TagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsSNS(oldTags, newTags []*sns.Tag) ([]*sns.Tag, []*sns.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*sns.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapSNS(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapSNS(m map[string]interface{}) []*sns.Tag {
+	result := make([]*sns.Tag, 0, len(m))
+	for k, v := range m {
+		t := &sns.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredSNS(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapSNS(ts []*sns.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredSNS(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredSNS(t *sns.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		r, _ := regexp.MatchString(v, *t.Key)
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsSNS_test.go
+++ b/aws/tagsSNS_test.go
@@ -1,0 +1,110 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
+)
+
+func TestDiffSNSTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Add
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsSNS(tagsFromMapSNS(tc.Old), tagsFromMapSNS(tc.New))
+		cm := tagsToMapSNS(c)
+		rm := tagsToMapSNS(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+func TestIgnoringTagsSNS(t *testing.T) {
+	ignoredTags := []*sns.Tag{
+		{
+			Key:   aws.String("aws:cloudformation:logical-id"),
+			Value: aws.String("foo"),
+		},
+		{
+			Key:   aws.String("aws:foo:bar"),
+			Value: aws.String("baz"),
+		},
+	}
+	for _, tag := range ignoredTags {
+		if !tagIgnoredSNS(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/sns_topic.html.markdown
+++ b/website/docs/r/sns_topic.html.markdown
@@ -80,6 +80,7 @@ The following arguments are supported:
 * `sqs_success_feedback_role_arn` - (Optional) The IAM role permitted to receive success feedback for this topic
 * `sqs_success_feedback_sample_rate` - (Optional) Percentage of success to sample
 * `sqs_failure_feedback_role_arn` - (Optional) IAM role for failure feedback
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #8460

Changes proposed in this pull request:

* Support for tags added for sns topic

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSSNSTopic_tags'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSSNSTopic_tags -timeout 120m
=== RUN   TestAccAWSSNSTopic_tags
=== PAUSE TestAccAWSSNSTopic_tags
=== CONT  TestAccAWSSNSTopic_tags
--- PASS: TestAccAWSSNSTopic_tags (69.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       69.110s
```