### PR TITLE
Update lambda_permission.html.markdown

### DIFF
--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -123,9 +123,9 @@ resource "aws_lambda_permission" "lambda_permission" {
   function_name = "MyDemoFunction"
   principal     = "apigateway.amazonaws.com"
 
-  # The /*/*/* part allows invocation from any stage, method and resource path
+  # The /*/* part allows invocation from any stage, method and resource path
   # within API Gateway REST API.
-  source_arn = "${aws_api_gateway_rest_api.MyDemoAPI.execution_arn}/*/*/*"
+  source_arn = "${aws_api_gateway_rest_api.MyDemoAPI.execution_arn}/*/*"
 }
 ```
 


### PR DESCRIPTION
ARN per API documentation
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html

is

```
arn:aws:execute-api:region:account-id:api-id/stage-name/HTTP-VERB/resource-path-specifier
```

i.e. 4 parameters at the end

Execution ARN in Terraform is

```
arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod
```

i.e. 2 parameters `api-id/stage-name` at the end, only 2 parameters left "HTTP-VERB/resource-path-specifier", not 3

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
