### PR TITLE
docs/resource/lambda_event_source_mapping: Update import docs to clarify missing data

### DIFF
--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -75,9 +75,6 @@ Lambda event source mappings can be imported using the `UUID` (event source mapp
 $ terraform import aws_lambda_event_source_mapping.event_source_mapping 12345kxodurf3443
 ```
 
-~> **Note:** Terraform will recreate the imported resource as AWS does not expose `startingPosition` information for existing Lambda event source mappings.
-
-For information about retrieving event source mappings, see [GetEventSourceMapping][3] in the API docs.
+~> **Note:** Terraform will recreate the imported resource as AWS does not expose `startingPosition` information for existing Lambda event source mappings. For information about retrieving event source mappings, see [GetEventSourceMapping][3] in the API docs.
 
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html
-you import a mapping Terraform will want to create the mapping on the next apply.

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -75,7 +75,11 @@ Lambda event source mappings can be imported using the `UUID` (event source mapp
 $ terraform import aws_lambda_event_source_mapping.event_source_mapping 12345kxodurf3443
 ```
 
-Note: AWS does not expose `startingPosition` when getting Lambda event source mappings, as such, if
+~> **Note:** Terraform will recreate the imported resource as AWS does not expose `startingPosition` information for existing Lambda event source mappings.
+
+For information about retrieving event source mappings, see [GetEventSourceMapping][3] in the API docs.
+
+[3]: https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html
 you import a mapping Terraform will want to create the mapping on the next apply.
 
 For information about retrieving event source mappings, see [GetEventSourceMapping][3] in the API docs.

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -76,8 +76,7 @@ $ terraform import aws_lambda_event_source_mapping.event_source_mapping 12345kxo
 ```
 
 Note: AWS does not expose `startingPosition` when getting Lambda event source mappings, as such, if
-you import a mapping Terraform will want to create the mapping on the next apply,
-unless you update the value to your known setting in the `tfstate` file. 
+you import a mapping Terraform will want to create the mapping on the next apply.
 
 For information about retrieving event source mappings, see [GetEventSourceMapping][3] in the API docs.
 

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -81,7 +81,3 @@ For information about retrieving event source mappings, see [GetEventSourceMappi
 
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html
 you import a mapping Terraform will want to create the mapping on the next apply.
-
-For information about retrieving event source mappings, see [GetEventSourceMapping][3] in the API docs.
-
-[3]: https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # Resource: aws_lambda_event_source_mapping
 
-Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB and SQS
+Provides a Lambda event source mapping. This allows Lambda functions to get events from Kinesis, DynamoDB and SQS.
 
-For information about Lambda and how to use it, see [What is AWS Lambda?][1]
+For information about Lambda and how to use it, see [What is AWS Lambda?][1].
 For information about event source mappings, see [CreateEventSourceMapping][2] in the API docs.
 
 ## Example Usage
@@ -69,8 +69,16 @@ resource "aws_lambda_event_source_mapping" "example" {
 
 ## Import
 
-Lambda Event Source Mappings can be imported using the `UUID` (event source mapping identifier), e.g.
+Lambda event source mappings can be imported using the `UUID` (event source mapping identifier), e.g.
 
 ```
 $ terraform import aws_lambda_event_source_mapping.event_source_mapping 12345kxodurf3443
 ```
+
+Note: AWS does not expose `startingPosition` when getting Lambda event source mappings, as such, if
+you import a mapping Terraform will want to create the mapping on the next apply,
+unless you update the value to your known setting in the `tfstate` file. 
+
+For information about retrieving event source mappings, see [GetEventSourceMapping][3] in the API docs.
+
+[3]: https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html


### PR DESCRIPTION
Update event source mapping page to note limitation of AWS API
when reading in current state. This addresses issue #1133.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #1133
