### PR TITLE
d/aws_ram_resource_share: Adding new data source for RAM resource share

### DIFF
--- a/aws/data_source_aws_ram_resource_share.go
+++ b/aws/data_source_aws_ram_resource_share.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ram"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsRamResourceShare() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRamResourceShareRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+
+			"resource_owner": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsRamResourceShareRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ramconn
+
+	name := d.Get("name").(string)
+	owner := d.Get("resource_owner").(string)
+
+	filters, filtersOk := d.GetOk("filter")
+
+	params := &ram.GetResourceSharesInput{
+		Name:          aws.String(name),
+		ResourceOwner: aws.String(owner),
+	}
+
+	if filtersOk {
+		params.TagFilters = buildRAMTagFilters(filters.(*schema.Set))
+	}
+
+	for {
+		resp, err := conn.GetResourceShares(params)
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving resource share: empty response for: %s", params)
+		}
+
+		if len(resp.ResourceShares) > 1 {
+			return fmt.Errorf("Multiple resource shares found for: %s", name)
+		}
+
+		if resp == nil || len(resp.ResourceShares) == 0 {
+			return fmt.Errorf("No matching resource found: %s", err)
+		}
+
+		for _, r := range resp.ResourceShares {
+			if aws.StringValue(r.Name) == name {
+				d.SetId(aws.StringValue(r.ResourceShareArn))
+				d.Set("arn", aws.StringValue(r.ResourceShareArn))
+				d.Set("owning_account_id", aws.StringValue(r.OwningAccountId))
+				d.Set("status", aws.StringValue(r.Status))
+				d.Set("tags", r.Tags)
+				break
+			}
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return nil
+}
+
+func buildRAMTagFilters(set *schema.Set) []*ram.TagFilter {
+	var filters []*ram.TagFilter
+
+	for _, v := range set.List() {
+		m := v.(map[string]interface{})
+		var filterValues []*string
+		for _, e := range m["values"].([]interface{}) {
+			filterValues = append(filterValues, aws.String(e.(string)))
+		}
+		filters = append(filters, &ram.TagFilter{
+			TagKey:    aws.String(m["name"].(string)),
+			TagValues: filterValues,
+		})
+	}
+
+	return filters
+}

--- a/aws/data_source_aws_ram_resource_share_test.go
+++ b/aws/data_source_aws_ram_resource_share_test.go
@@ -47,6 +47,7 @@ func TestAccDataSourceAwsRamResourceShare_Tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.%", resourceName, "tags.%"),
 				),
 			},
 		},
@@ -81,12 +82,12 @@ resource "aws_ram_resource_share" "test" {
 
 data "aws_ram_resource_share" "test" {
   name = "${aws_ram_resource_share.test.name}"
-	resource_owner = "SELF"
+  resource_owner = "SELF"
 	
-	filter = {
-		name = "Name"
-		values = ["%s-Tags"]
-	}
+  filter {
+	name = "Name"
+	values = ["%s-Tags"]
+  }
 }
 `, rName, rName, rName)
 }

--- a/aws/data_source_aws_ram_resource_share_test.go
+++ b/aws/data_source_aws_ram_resource_share_test.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsRamResourceShare_Basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ram_resource_share.test"
+	datasourceName := "data.aws_ram_resource_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceAwsRamResourceShareConfig_NonExistent,
+				ExpectError: regexp.MustCompile(`No matching resource found`),
+			},
+			{
+				Config: testAccDataSourceAwsRamResourceShareConfig_Name(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRamResourceShare_Tags(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_ram_resource_share.test"
+	datasourceName := "data.aws_ram_resource_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRamResourceShareConfig_Tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRamResourceShareConfig_Name(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ram_resource_share" "wrong" {
+  name            = "%s-wrong"
+}
+resource "aws_ram_resource_share" "test" {
+	name            = "%s"
+}
+
+data "aws_ram_resource_share" "test" {
+  name = "${aws_ram_resource_share.test.name}"
+  resource_owner = "SELF"
+}
+`, rName, rName)
+}
+
+func testAccDataSourceAwsRamResourceShareConfig_Tags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ram_resource_share" "test" {
+	name            = "%s"
+
+	tags = {
+		Name = "%s-Tags"
+	}
+}
+
+data "aws_ram_resource_share" "test" {
+  name = "${aws_ram_resource_share.test.name}"
+	resource_owner = "SELF"
+	
+	filter = {
+		name = "Name"
+		values = ["%s-Tags"]
+	}
+}
+`, rName, rName, rName)
+}
+
+const testAccDataSourceAwsRamResourceShareConfig_NonExistent = `
+data "aws_ram_resource_share" "test" {
+	name = "tf-acc-test-does-not-exist"
+	resource_owner = "SELF"
+}
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -231,6 +231,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_partition":                          dataSourceAwsPartition(),
 			"aws_prefix_list":                        dataSourceAwsPrefixList(),
 			"aws_pricing_product":                    dataSourceAwsPricingProduct(),
+			"aws_ram_resource_share":                 dataSourceAwsRamResourceShare(),
 			"aws_rds_cluster":                        dataSourceAwsRdsCluster(),
 			"aws_redshift_cluster":                   dataSourceAwsRedshiftCluster(),
 			"aws_redshift_service_account":           dataSourceAwsRedshiftServiceAccount(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -327,6 +327,9 @@
                             <a href="/docs/providers/aws/d/rds_cluster.html">aws_rds_cluster</a>
                         </li>
                         <li>
+                        <a href="/docs/providers/aws/d/ram_resource_share.html">aws_ram_resource_share</a>
+                        </li>
+                        <li>
                             <a href="/docs/providers/aws/d/redshift_cluster.html">aws_redshift_cluster</a>
                         </li>
                         <li>

--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -39,7 +39,7 @@ The following Arguments are supported
 
 * `filter` - (Optional) A filter used to scope the list e.g. by tags. See [related docs] (https://docs.aws.amazon.com/ram/latest/APIReference/API_TagFilter.html).
   * `name` - (Required) The name of the tag key to filter on.
-  * `values` - (Required) The value of the tag ke.
+  * `values` - (Required) The value of the tag key.
 
 ## Attributes Reference
 

--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ram_resource_share"
+sidebar_current: "docs-aws-datasource-ram-resource-share"
+description: |-
+  Retrieve information about a RAM Resource Share
+---
+
+# Data Source: aws_ram_resource_share
+
+`aws_ram_resource_share` Retrieve information about a RAM Resource Share.
+
+## Example Usage
+```hcl
+data "aws_ram_resource_share" "example" {
+  name = "example"
+}
+```
+
+## Search by filters
+```hcl
+data "aws_ram_resource_share" "tag_filter" {
+  name = "MyResourceName"
+  resource_owner = "SELF"
+
+  filter {
+    name = "NameOfTag"
+    values = ["exampleNameTagValue"]
+  }
+}
+```
+
+## Argument Reference
+
+The following Arguments are supported
+
+* `name` - (Required) The name of the resource share to retrieve.
+* `resource_owner` (Required) The owner of the resource share. Valid values are SELF or OTHER-ACCOUNTS
+
+* `filter` - (Optional) A filter used to scope the list e.g. by tags. See [related docs] (https://docs.aws.amazon.com/ram/latest/APIReference/API_TagFilter.html).
+  * `name` - (Required) The name of the tag key to filter on.
+  * `values` - (Required) The value of the tag ke.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The Amazon Resource Name (ARN) of the resource share.
+* `id` - The Amazon Resource Name (ARN) of the resource share.
+* `status` - The Status of the RAM share.
+* `tags` - The Tags attached to the RAM share


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8280 

Changes proposed in this pull request:

* Adds a new data resource `aws_ram_resource_share`

Lookup RAM resource shares.

example
```hcl
data "aws_ram_resource_share" "example" {
  name = "example-name"
  resource_owner = "SELF"
}
```
Output from acceptance testing:
make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsRamResourceShare_Basic'                                                                                           [9:44:23]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsRamResourceShare_Basic -timeout 120m
=== RUN   TestAccDataSourceAwsRamResourceShare_Basic
=== PAUSE TestAccDataSourceAwsRamResourceShare_Basic
=== CONT  TestAccDataSourceAwsRamResourceShare_Basic
--- PASS: TestAccDataSourceAwsRamResourceShare_Basic (33.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.540s

make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsRamResourceShare_Tags'                                                                                            [9:45:51]
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsRamResourceShare_Tags -timeout 120m
=== RUN   TestAccDataSourceAwsRamResourceShare_Tags
=== PAUSE TestAccDataSourceAwsRamResourceShare_Tags
=== CONT  TestAccDataSourceAwsRamResourceShare_Tags
--- PASS: TestAccDataSourceAwsRamResourceShare_Tags (30.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	30.526s
```
$ make testacc TESTARGS='-run=TestAccDataSourceAwsRamResourceShare_Basic'
$ make testacc TESTARGS='-run=TestAccDataSourceAwsRamResourceShare_Tags'
...
```
