### PR TITLE
Specifying default behavior network interface delete_on_termination for launch templates.

### DIFF
--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -252,7 +252,7 @@ Check limitations for autoscaling group in [Creating an Auto Scaling Group Using
 Each `network_interfaces` block supports the following:
 
 * `associate_public_ip_address` - Associate a public ip address with the network interface.  Boolean value.
-* `delete_on_termination` - Whether the network interface should be destroyed on instance termination.
+* `delete_on_termination` - Whether the network interface should be destroyed on instance termination.  Defaults to `False`.
 * `description` - Description of the network interface.
 * `device_index` - The integer index of the network interface attachment.
 * `ipv6_addresses` - One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet. Conflicts with `ipv6_address_count`


### PR DESCRIPTION
Improves the documentation for network interface `delete_on_termination` for launch templates by specifying the default behavior as `False`.  Current documentation can be found at: https://www.terraform.io/docs/providers/aws/r/launch_template.html#network-interfaces

Perhaps the default behavior should be `True` but I believe there is a separate issue opened for that proposal.

This is worth posting to the site immediately for the current version