### PR TITLE
Add support AppSync Function Resource and pipeline configuration for resolver

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -314,6 +314,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_appmesh_virtual_service":                             resourceAwsAppmeshVirtualService(),
 			"aws_appsync_api_key":                                     resourceAwsAppsyncApiKey(),
 			"aws_appsync_datasource":                                  resourceAwsAppsyncDatasource(),
+			"aws_appsync_function":                                    resourceAwsAppsyncFunction(),
 			"aws_appsync_graphql_api":                                 resourceAwsAppsyncGraphqlApi(),
 			"aws_appsync_resolver":                                    resourceAwsAppsyncResolver(),
 			"aws_athena_database":                                     resourceAwsAthenaDatabase(),

--- a/aws/resource_aws_appsync_function.go
+++ b/aws/resource_aws_appsync_function.go
@@ -1,0 +1,214 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appsync"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsAppsyncFunction() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsAppsyncFunctionCreate,
+		Read:   resourceAwsAppsyncFunctionRead,
+		Update: resourceAwsAppsyncFunctionUpdate,
+		Delete: resourceAwsAppsyncFunctionDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"api_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"data_source": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !regexp.MustCompile(`[_A-Za-z][_0-9A-Za-z]*`).MatchString(value) {
+						errors = append(errors, fmt.Errorf("%q must match [_A-Za-z][_0-9A-Za-z]*", k))
+					}
+					return
+				},
+			},
+			"request_mapping_template": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"response_mapping_template": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"function_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "2018-05-29",
+				ValidateFunc: validation.StringInSlice([]string{
+					"2018-05-29",
+				}, true),
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"function_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsAppsyncFunctionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+
+	apiID := d.Get("api_id").(string)
+
+	input := &appsync.CreateFunctionInput{
+		ApiId:                  aws.String(apiID),
+		DataSourceName:         aws.String(d.Get("data_source").(string)),
+		FunctionVersion:        aws.String(d.Get("function_version").(string)),
+		Name:                   aws.String(d.Get("name").(string)),
+		RequestMappingTemplate: aws.String(d.Get("request_mapping_template").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("response_mapping_template"); ok {
+		input.ResponseMappingTemplate = aws.String(v.(string))
+	}
+
+	resp, err := conn.CreateFunction(input)
+	if err != nil {
+		return fmt.Errorf("Error creating AppSync Function: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s-%s", apiID, aws.StringValue(resp.FunctionConfiguration.FunctionId)))
+
+	return resourceAwsAppsyncFunctionRead(d, meta)
+}
+
+func resourceAwsAppsyncFunctionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+
+	apiID, functionID, err := decodeAppsyncFunctionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &appsync.GetFunctionInput{
+		ApiId:      aws.String(apiID),
+		FunctionId: aws.String(functionID),
+	}
+
+	resp, err := conn.GetFunction(input)
+	if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] No such entity found for Appsync Function (%s)", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error getting AppSync Function %s: %s", d.Id(), err)
+	}
+
+	d.Set("api_id", apiID)
+	d.Set("function_id", functionID)
+	d.Set("data_source", aws.StringValue(resp.FunctionConfiguration.DataSourceName))
+	d.Set("description", aws.StringValue(resp.FunctionConfiguration.Description))
+	d.Set("arn", aws.StringValue(resp.FunctionConfiguration.FunctionArn))
+	d.Set("function_version", aws.StringValue(resp.FunctionConfiguration.FunctionVersion))
+	d.Set("name", aws.StringValue(resp.FunctionConfiguration.Name))
+	d.Set("request_mapping_template", aws.StringValue(resp.FunctionConfiguration.RequestMappingTemplate))
+	d.Set("response_mapping_template", aws.StringValue(resp.FunctionConfiguration.ResponseMappingTemplate))
+
+	return nil
+}
+
+func resourceAwsAppsyncFunctionUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+
+	apiID, functionID, err := decodeAppsyncFunctionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &appsync.UpdateFunctionInput{
+		ApiId:                  aws.String(apiID),
+		DataSourceName:         aws.String(d.Get("data_source").(string)),
+		FunctionId:             aws.String(functionID),
+		FunctionVersion:        aws.String(d.Get("function_version").(string)),
+		Name:                   aws.String(d.Get("name").(string)),
+		RequestMappingTemplate: aws.String(d.Get("request_mapping_template").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		input.Description = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("response_mapping_template"); ok {
+		input.ResponseMappingTemplate = aws.String(v.(string))
+	}
+
+	_, err = conn.UpdateFunction(input)
+	if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] No such entity found for Appsync Function (%s)", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error updating AppSync Function %s: %s", d.Id(), err)
+	}
+
+	return resourceAwsAppsyncFunctionRead(d, meta)
+}
+
+func resourceAwsAppsyncFunctionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).appsyncconn
+
+	apiID, functionID, err := decodeAppsyncFunctionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &appsync.DeleteFunctionInput{
+		ApiId:      aws.String(apiID),
+		FunctionId: aws.String(functionID),
+	}
+
+	_, err = conn.DeleteFunction(input)
+	if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting AppSync Function %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func decodeAppsyncFunctionID(id string) (string, string, error) {
+	idParts := strings.SplitN(id, "-", 2)
+	if len(idParts) != 2 {
+		return "", "", fmt.Errorf("expected ID in format ApiID-FunctionID, received: %s", id)
+	}
+	return idParts[0], idParts[1], nil
+}

--- a/aws/resource_aws_appsync_function_test.go
+++ b/aws/resource_aws_appsync_function_test.go
@@ -1,0 +1,314 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appsync"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsAppsyncFunction_basic(t *testing.T) {
+	rName1 := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	rName2 := fmt.Sprintf("tfexample%s", acctest.RandString(8))
+	rName3 := fmt.Sprintf("tfexample%s", acctest.RandString(8))
+	resourceName := "aws_appsync_function.test"
+	var config appsync.FunctionConfiguration
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAppsyncFunctionConfig(rName1, rName2, testAccGetRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncFunctionExists(resourceName, &config),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "appsync", regexp.MustCompile("apis/.+/functions/.+")),
+					resource.TestCheckResourceAttr(resourceName, "name", rName2),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "api_id", "aws_appsync_graphql_api.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "data_source", "aws_appsync_datasource.test", "name"),
+				),
+			},
+			{
+				Config: testAccAWSAppsyncFunctionConfig(rName1, rName3, testAccGetRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncFunctionExists(resourceName, &config),
+					resource.TestCheckResourceAttr(resourceName, "name", rName3),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncFunction_description(t *testing.T) {
+	rName1 := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	rName2 := fmt.Sprintf("tfexample%s", acctest.RandString(8))
+	resourceName := "aws_appsync_function.test"
+	var config appsync.FunctionConfiguration
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAppsyncFunctionConfigDescription(rName1, rName2, testAccGetRegion(), "test description 1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncFunctionExists(resourceName, &config),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description 1"),
+				),
+			},
+			{
+				Config: testAccAWSAppsyncFunctionConfigDescription(rName1, rName2, testAccGetRegion(), "test description 2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncFunctionExists(resourceName, &config),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description 2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncFunction_responseMappingTemplate(t *testing.T) {
+	rName1 := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	rName2 := fmt.Sprintf("tfexample%s", acctest.RandString(8))
+	resourceName := "aws_appsync_function.test"
+	var config appsync.FunctionConfiguration
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAppsyncFunctionConfigResponseMappingTemplate(rName1, rName2, testAccGetRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncFunctionExists(resourceName, &config),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAppsyncFunction_disappears(t *testing.T) {
+	rName1 := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	rName2 := fmt.Sprintf("tfexample%s", acctest.RandString(8))
+	resourceName := "aws_appsync_function.test"
+	var config appsync.FunctionConfiguration
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAppsyncFunctionConfig(rName1, rName2, testAccGetRegion()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncFunctionExists(resourceName, &config),
+					testAccCheckAwsAppsyncFunctionDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsAppsyncFunctionDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).appsyncconn
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_appsync_function" {
+			continue
+		}
+
+		apiID, functionID, err := decodeAppsyncFunctionID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &appsync.GetFunctionInput{
+			ApiId:      aws.String(apiID),
+			FunctionId: aws.String(functionID),
+		}
+
+		_, err = conn.GetFunction(input)
+		if err != nil {
+			if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsAppsyncFunctionExists(name string, config *appsync.FunctionConfiguration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).appsyncconn
+
+		apiID, functionID, err := decodeAppsyncFunctionID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &appsync.GetFunctionInput{
+			ApiId:      aws.String(apiID),
+			FunctionId: aws.String(functionID),
+		}
+
+		output, err := conn.GetFunction(input)
+
+		if err != nil {
+			return err
+		}
+
+		*config = *output.FunctionConfiguration
+
+		return nil
+	}
+}
+
+func testAccCheckAwsAppsyncFunctionDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No resource ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).appsyncconn
+		apiID, functionID, err := decodeAppsyncFunctionID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &appsync.DeleteFunctionInput{
+			ApiId:      aws.String(apiID),
+			FunctionId: aws.String(functionID),
+		}
+
+		_, err = conn.DeleteFunction(input)
+
+		return err
+	}
+}
+
+func testAccAWSAppsyncFunctionConfig(r1, r2, region string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "aws_appsync_function" "test" {
+	api_id      = "${aws_appsync_graphql_api.test.id}"
+	data_source = "${aws_appsync_datasource.test.name}"
+	name        = "%[2]s"
+	request_mapping_template = <<EOF
+{
+	"version": "2018-05-29",
+	"method": "GET",
+	"resourcePath": "/",
+	"params":{
+		"headers": $utils.http.copyheaders($ctx.request.headers)
+	}
+}
+EOF
+	response_mapping_template = <<EOF
+#if($ctx.result.statusCode == 200)
+	$ctx.result.body
+#else
+	$utils.appendError($ctx.result.body, $ctx.result.statusCode)
+#end
+EOF
+}
+
+`, testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(r1, region), r2)
+}
+
+func testAccAWSAppsyncFunctionConfigDescription(r1, r2, region, description string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "aws_appsync_function" "test" {
+	api_id      = "${aws_appsync_graphql_api.test.id}"
+	data_source = "${aws_appsync_datasource.test.name}"
+	name        = "%[2]s"
+	description = "%[3]s"
+	request_mapping_template = <<EOF
+{
+	"version": "2018-05-29",
+	"method": "GET",
+	"resourcePath": "/",
+	"params":{
+		"headers": $utils.http.copyheaders($ctx.request.headers)
+	}
+}
+EOF
+	response_mapping_template = <<EOF
+#if($ctx.result.statusCode == 200)
+	$ctx.result.body
+#else
+	$utils.appendError($ctx.result.body, $ctx.result.statusCode)
+#end
+EOF
+}
+
+`, testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(r1, region), r2, description)
+}
+
+func testAccAWSAppsyncFunctionConfigResponseMappingTemplate(r1, r2, region string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "aws_appsync_function" "test" {
+	api_id      = "${aws_appsync_graphql_api.test.id}"
+	data_source = "${aws_appsync_datasource.test.name}"
+	name        = "%[2]s"
+	request_mapping_template = <<EOF
+{
+	"version": "2018-05-29",
+	"method": "GET",
+	"resourcePath": "/",
+	"params":{
+		"headers": $utils.http.copyheaders($ctx.request.headers)
+	}
+}
+EOF
+	response_mapping_template = <<EOF
+#if($ctx.result.statusCode == 200)
+	$ctx.result.body
+#else
+	$utils.appendError($ctx.result.body, $ctx.result.statusCode)
+#end
+EOF
+}
+
+`, testAccAppsyncDatasourceConfig_DynamoDBConfig_Region(r1, region), r2)
+}

--- a/aws/resource_aws_appsync_resolver.go
+++ b/aws/resource_aws_appsync_resolver.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/appsync"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsAppsyncResolver() *schema.Resource {
@@ -38,8 +39,9 @@ func resourceAwsAppsyncResolver() *schema.Resource {
 				ForceNew: true,
 			},
 			"data_source": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"pipeline_config"},
 			},
 			"request_template": {
 				Type:     schema.TypeString,
@@ -48,6 +50,32 @@ func resourceAwsAppsyncResolver() *schema.Resource {
 			"response_template": {
 				Type:     schema.TypeString,
 				Required: true, // documentation bug, the api returns 400 if this is not specified.
+			},
+			"kind": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  appsync.ResolverKindUnit,
+				ValidateFunc: validation.StringInSlice([]string{
+					appsync.ResolverKindUnit,
+					appsync.ResolverKindPipeline,
+				}, true),
+			},
+			"pipeline_config": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"data_source"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"functions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
 			},
 			"arn": {
 				Type:     schema.TypeString,
@@ -62,11 +90,22 @@ func resourceAwsAppsyncResolverCreate(d *schema.ResourceData, meta interface{}) 
 
 	input := &appsync.CreateResolverInput{
 		ApiId:                   aws.String(d.Get("api_id").(string)),
-		DataSourceName:          aws.String(d.Get("data_source").(string)),
 		TypeName:                aws.String(d.Get("type").(string)),
 		FieldName:               aws.String(d.Get("field").(string)),
 		RequestMappingTemplate:  aws.String(d.Get("request_template").(string)),
 		ResponseMappingTemplate: aws.String(d.Get("response_template").(string)),
+		Kind:                    aws.String(d.Get("kind").(string)),
+	}
+
+	if v, ok := d.GetOk("data_source"); ok {
+		input.DataSourceName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("pipeline_config"); ok {
+		config := v.([]interface{})[0].(map[string]interface{})
+		input.PipelineConfig = &appsync.PipelineConfig{
+			Functions: expandStringList(config["functions"].([]interface{})),
+		}
 	}
 
 	mutexKey := fmt.Sprintf("appsync-schema-%s", d.Get("api_id").(string))
@@ -120,6 +159,11 @@ func resourceAwsAppsyncResolverRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("data_source", resp.Resolver.DataSourceName)
 	d.Set("request_template", resp.Resolver.RequestMappingTemplate)
 	d.Set("response_template", resp.Resolver.ResponseMappingTemplate)
+	d.Set("kind", resp.Resolver.Kind)
+
+	if err := d.Set("pipeline_config", flattenAppsyncPipelineConfig(resp.Resolver.PipelineConfig)); err != nil {
+		return fmt.Errorf("Error setting pipeline_config: %s", err)
+	}
 
 	return nil
 }
@@ -129,11 +173,22 @@ func resourceAwsAppsyncResolverUpdate(d *schema.ResourceData, meta interface{}) 
 
 	input := &appsync.UpdateResolverInput{
 		ApiId:                   aws.String(d.Get("api_id").(string)),
-		DataSourceName:          aws.String(d.Get("data_source").(string)),
 		FieldName:               aws.String(d.Get("field").(string)),
 		TypeName:                aws.String(d.Get("type").(string)),
 		RequestMappingTemplate:  aws.String(d.Get("request_template").(string)),
 		ResponseMappingTemplate: aws.String(d.Get("response_template").(string)),
+		Kind:                    aws.String(d.Get("kind").(string)),
+	}
+
+	if v, ok := d.GetOk("data_source"); ok {
+		input.DataSourceName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("pipeline_config"); ok {
+		config := v.([]interface{})[0].(map[string]interface{})
+		input.PipelineConfig = &appsync.PipelineConfig{
+			Functions: expandStringList(config["functions"].([]interface{})),
+		}
 	}
 
 	mutexKey := fmt.Sprintf("appsync-schema-%s", d.Get("api_id").(string))

--- a/aws/resource_aws_appsync_resolver_test.go
+++ b/aws/resource_aws_appsync_resolver_test.go
@@ -193,6 +193,33 @@ func TestAccAwsAppsyncResolver_multipleResolvers(t *testing.T) {
 	})
 }
 
+func TestAccAwsAppsyncResolver_PipelineConfig(t *testing.T) {
+	var resolver appsync.Resolver
+	rName := fmt.Sprintf("tfacctest%d", acctest.RandInt())
+	resourceName := "aws_appsync_resolver.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppsyncResolver_pipelineConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAppsyncResolverExists(resourceName, &resolver),
+					resource.TestCheckResourceAttr(resourceName, "pipeline_config.0.functions.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "pipeline_config.0.functions.0", "aws_appsync_function.test", "function_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAwsAppsyncResolverDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).appsyncconn
 	for _, rs := range s.RootModule().Resources {
@@ -610,4 +637,94 @@ resource "aws_appsync_datasource" "test" {
 %s
 
 `, rName, queryFields, rName, resolverResources)
+}
+
+func testAccAppsyncResolver_pipelineConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+	authentication_type = "API_KEY"
+	name                = "%[1]s"
+	schema              = <<EOF
+type Mutation {
+		putPost(id: ID!, title: String!): Post
+}
+
+type Post {
+		id: ID!
+		title: String!
+}
+
+type Query {
+		singlePost(id: ID!): Post
+}
+
+schema {
+		query: Query
+		mutation: Mutation
+}
+EOF
+}
+
+resource "aws_appsync_datasource" "test" {
+	api_id      = "${aws_appsync_graphql_api.test.id}"
+	name        = "%[1]s"
+	type        = "HTTP"
+
+	http_config {
+		endpoint = "http://example.com"
+	}
+}
+
+resource "aws_appsync_function" "test" {
+	api_id      = "${aws_appsync_graphql_api.test.id}"
+	data_source = "${aws_appsync_datasource.test.name}"
+	name        = "%[1]s"
+	request_mapping_template = <<EOF
+{
+		"version": "2018-05-29",
+		"method": "GET",
+		"resourcePath": "/",
+		"params":{
+				"headers": $utils.http.copyheaders($ctx.request.headers)
+		}
+}
+EOF
+	response_mapping_template = <<EOF
+#if($ctx.result.statusCode == 200)
+		$ctx.result.body
+#else
+		$utils.appendError($ctx.result.body, $ctx.result.statusCode)
+#end
+EOF
+}
+
+resource "aws_appsync_resolver" "test" {
+	api_id           = "${aws_appsync_graphql_api.test.id}"
+	field            = "singlePost"
+	type             = "Query"
+	kind					   = "PIPELINE"
+	request_template = <<EOF
+{
+		"version": "2018-05-29",
+		"method": "GET",
+		"resourcePath": "/",
+		"params":{
+				"headers": $utils.http.copyheaders($ctx.request.headers)
+		}
+}
+EOF
+	response_template = <<EOF
+#if($ctx.result.statusCode == 200)
+		$ctx.result.body
+#else
+		$utils.appendError($ctx.result.body, $ctx.result.statusCode)
+#end
+EOF
+
+	pipeline_config {
+		functions = ["${aws_appsync_function.test.function_id}"]
+	}
+}
+
+`, rName)
 }

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/service/apigateway"
 	"github.com/aws/aws-sdk-go/service/appmesh"
+	"github.com/aws/aws-sdk-go/service/appsync"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -5344,6 +5345,22 @@ func flattenAppmeshRouteSpec(spec *appmesh.RouteSpec) []interface{} {
 	}
 
 	return []interface{}{mSpec}
+}
+
+func flattenAppsyncPipelineConfig(c *appsync.PipelineConfig) []interface{} {
+	if c == nil {
+		return nil
+	}
+
+	if len(c.Functions) == 0 {
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"functions": flattenStringList(c.Functions),
+	}
+
+	return []interface{}{m}
 }
 
 func expandRoute53ResolverEndpointIpAddresses(vIpAddresses *schema.Set) []*route53resolver.IpAddressRequest {

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -559,6 +559,9 @@
                             <a href="/docs/providers/aws/r/appsync_datasource.html">aws_appsync_datasource</a>
                         </li>
                         <li>
+                            <a href="/docs/providers/aws/r/appsync_function.html">aws_appsync_function</a>
+                        </li>
+                        <li>
                             <a href="/docs/providers/aws/r/appsync_graphql_api.html">aws_appsync_graphql_api</a>
                         </li>
                         <li>

--- a/website/docs/r/appsync_function.html.markdown
+++ b/website/docs/r/appsync_function.html.markdown
@@ -1,0 +1,101 @@
+---
+layout: "aws"
+page_title: "AWS: aws_appsync_function"
+sidebar_current: "docs-aws-resource-appsync-function"
+description: |-
+  Provides an AppSync Function.
+---
+
+# Resource: aws_appsync_function
+
+Provides an AppSync Function.
+
+## Example Usage
+
+```hcl
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = "tf-example"
+  schema              = <<EOF
+type Mutation {
+    putPost(id: ID!, title: String!): Post
+}
+
+type Post {
+    id: ID!
+    title: String!
+}
+
+type Query {
+    singlePost(id: ID!): Post
+}
+
+schema {
+    query: Query
+    mutation: Mutation
+}
+EOF
+}
+
+resource "aws_appsync_datasource" "test" {
+  api_id      = "${aws_appsync_graphql_api.test.id}"
+  name        = "tf-example"
+  type        = "HTTP"
+
+  http_config {
+    endpoint = "http://example.com"
+  }
+}
+
+resource "aws_appsync_function" "test" {
+  api_id      = "${aws_appsync_graphql_api.test.id}"
+  data_source = "${aws_appsync_datasource.test.name}"
+  name        = "tf-example"
+  request_mapping_template = <<EOF
+{
+    "version": "2018-05-29",
+    "method": "GET",
+    "resourcePath": "/",
+    "params":{
+        "headers": $utils.http.copyheaders($ctx.request.headers)
+    }
+}
+EOF
+  response_mapping_template = <<EOF
+#if($ctx.result.statusCode == 200)
+    $ctx.result.body
+#else
+    $utils.appendError($ctx.result.body, $ctx.result.statusCode)
+#end
+EOF
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `api_id` - (Required) The ID of the associated AppSync API.
+* `data_source` - (Required) The Function DataSource name.
+* `name` - (Required) The Function name. The function name does not have to be unique.
+* `request_mapping_template` - (Required) The Function request mapping template. Functions support only the 2018-05-29 version of the request mapping template.
+* `response_mapping_template` - (Required) The Function response mapping template.
+* `description` - (Optional) The Function description.
+* `function_version` - (Optional) The version of the request mapping template. Currently the supported value is `2018-05-29`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - API Function ID (Formatted as ApiId-FunctionId)
+* `arn` - The ARN of the Function object.
+* `function_id` - A unique ID representing the Function object.
+
+## Import
+
+`aws_appsync_function` can be imported using the AppSync API ID and Function ID separated by `-`, e.g.
+
+```
+$ terraform import aws_appsync_function.example xxxxx-yyyyy
+```

--- a/website/docs/r/appsync_resolver.html.markdown
+++ b/website/docs/r/appsync_resolver.html.markdown
@@ -79,9 +79,15 @@ The following arguments are supported:
 * `api_id` - (Required) The API ID for the GraphQL API.
 * `type` - (Required) The type name from the schema defined in the GraphQL API.
 * `field` - (Required) The field name from the schema defined in the GraphQL API.
-* `data_source` - (Required) The DataSource name.
 * `request_template` - (Required) The request mapping template for this resolver.
 * `response_template` - (Required) The response mapping template for this resolver.
+* `data_source` - (Optional) The DataSource name.
+* `kind`  - (Optional) The resolver type. Valid values are `UNIT` and `PIPELINE`.
+* `pipeline_config` - (Optional) The PipelineConfig. A `pipeline_config` block is documented below.
+
+An `pipeline_config` block supports the following arguments:
+
+* `functions` - (Required) The list of Function ID.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8127

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- New Resource: aws_appsync_function (#8127)
- resource/aws_appsync_resolver: Add `pipeline_config` attribute (#8127)
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsAppsyncFunction_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsAppsyncFunction_ -timeout 120m
=== RUN   TestAccAwsAppsyncFunction_basic
=== PAUSE TestAccAwsAppsyncFunction_basic
=== RUN   TestAccAwsAppsyncFunction_description
=== PAUSE TestAccAwsAppsyncFunction_description
=== RUN   TestAccAwsAppsyncFunction_responseMappingTemplate
=== PAUSE TestAccAwsAppsyncFunction_responseMappingTemplate
=== RUN   TestAccAwsAppsyncFunction_disappears
=== PAUSE TestAccAwsAppsyncFunction_disappears
=== CONT  TestAccAwsAppsyncFunction_basic
=== CONT  TestAccAwsAppsyncFunction_disappears
=== CONT  TestAccAwsAppsyncFunction_responseMappingTemplate
=== CONT  TestAccAwsAppsyncFunction_description
--- PASS: TestAccAwsAppsyncFunction_disappears (73.59s)
--- PASS: TestAccAwsAppsyncFunction_description (95.39s)
--- PASS: TestAccAwsAppsyncFunction_basic (96.09s)
--- PASS: TestAccAwsAppsyncFunction_responseMappingTemplate (139.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	139.963s
```

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsAppsyncResolver_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsAppsyncResolver_ -timeout 120m
=== RUN   TestAccAwsAppsyncResolver_basic
=== PAUSE TestAccAwsAppsyncResolver_basic
=== RUN   TestAccAwsAppsyncResolver_disappears
=== PAUSE TestAccAwsAppsyncResolver_disappears
=== RUN   TestAccAwsAppsyncResolver_DataSource
=== PAUSE TestAccAwsAppsyncResolver_DataSource
=== RUN   TestAccAwsAppsyncResolver_RequestTemplate
=== PAUSE TestAccAwsAppsyncResolver_RequestTemplate
=== RUN   TestAccAwsAppsyncResolver_ResponseTemplate
=== PAUSE TestAccAwsAppsyncResolver_ResponseTemplate
=== RUN   TestAccAwsAppsyncResolver_multipleResolvers
=== PAUSE TestAccAwsAppsyncResolver_multipleResolvers
=== RUN   TestAccAwsAppsyncResolver_PipelineConfig
=== PAUSE TestAccAwsAppsyncResolver_PipelineConfig
=== CONT  TestAccAwsAppsyncResolver_basic
=== CONT  TestAccAwsAppsyncResolver_ResponseTemplate
=== CONT  TestAccAwsAppsyncResolver_PipelineConfig
=== CONT  TestAccAwsAppsyncResolver_multipleResolvers
=== CONT  TestAccAwsAppsyncResolver_RequestTemplate
=== CONT  TestAccAwsAppsyncResolver_disappears
=== CONT  TestAccAwsAppsyncResolver_DataSource
--- PASS: TestAccAwsAppsyncResolver_disappears (34.36s)
--- PASS: TestAccAwsAppsyncResolver_PipelineConfig (37.39s)
--- PASS: TestAccAwsAppsyncResolver_basic (40.98s)
--- PASS: TestAccAwsAppsyncResolver_RequestTemplate (52.62s)
--- PASS: TestAccAwsAppsyncResolver_ResponseTemplate (58.14s)
--- PASS: TestAccAwsAppsyncResolver_DataSource (59.19s)
--- PASS: TestAccAwsAppsyncResolver_multipleResolvers (62.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	62.168s
```