### PR TITLE
#8506 ability to import an existing lambda alias to terraform state

### DIFF
--- a/aws/resource_aws_lambda_alias_test.go
+++ b/aws/resource_aws_lambda_alias_test.go
@@ -38,6 +38,12 @@ func TestAccAWSLambdaAlias_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "invoke_arn", regexp.MustCompile(fmt.Sprintf("^arn:[^:]+:apigateway:[^:]+:lambda:path/2015-03-31/functions/arn:[^:]+:lambda:[^:]+:[^:]+:function:%s:%s/invocations$", funcName, aliasName))),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s/%s", funcName, aliasName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/lambda_alias.html.markdown
+++ b/website/docs/r/lambda_alias.html.markdown
@@ -50,3 +50,11 @@ For **routing_config** the following attributes are supported:
 [1]: http://docs.aws.amazon.com/lambda/latest/dg/welcome.html
 [2]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/API_AliasRoutingConfiguration.html
+
+## Import
+
+Lambda Function Aliases can be imported using the `function_name/alias`, e.g.
+
+```
+$ terraform import aws_lambda_function_alias.test_lambda_alias my_test_lambda_function/my_alias
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8506

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Import of existing lambda aliases to terraform state
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaAlias_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLambdaAlias_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLambdaAlias_basic
=== PAUSE TestAccAWSLambdaAlias_basic
=== CONT  TestAccAWSLambdaAlias_basic
--- PASS: TestAccAWSLambdaAlias_basic (45.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       45.518s
```