### PR TITLE
Include access_key, secret_key, and session_token in aws_caller_identity

### DIFF
--- a/aws/data_source_aws_caller_identity.go
+++ b/aws/data_source_aws_caller_identity.go
@@ -28,6 +28,21 @@ func dataSourceAwsCallerIdentity() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"access_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"secret_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"session_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -44,10 +59,18 @@ func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Received Caller Identity: %s", res)
 
+	creds, err := client.Config.Credentials.Get()
+	if err != nil {
+		return fmt.Errorf("Error getting credentials: %v", err)
+	}
+
 	d.SetId(time.Now().UTC().String())
 	d.Set("account_id", res.Account)
 	d.Set("arn", res.Arn)
 	d.Set("user_id", res.UserId)
+	d.Set("access_key", creds.AccessKeyID)
+	d.Set("secret_key", creds.SecretAccessKey)
+	d.Set("session_token", creds.SessionToken)
 
 	return nil
 }

--- a/aws/data_source_aws_caller_identity_test.go
+++ b/aws/data_source_aws_caller_identity_test.go
@@ -64,6 +64,14 @@ func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 			return fmt.Errorf("ARN expected to not be nil")
 		}
 
+		if rs.Primary.Attributes["access_key"] == "" {
+			return fmt.Errorf("Access Key expected to not be nil")
+		}
+
+		if rs.Primary.Attributes["secret_key"] == "" {
+			return fmt.Errorf("Secret Key expected to not be nil")
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
This allows local-exec provisioners to be able to retrieve the
credentials that the aws provider is using.

Ex:
```
provider "aws" {}
data "aws_caller_identity" "current" {}

resource "null_resource" "my_resource" {
  provisioner "local-exec" {
    command = "some-command"
    environment {
      AWS_ACCESS_KEY_ID = "${data.aws_caller_identity.current.access_key}"
      AWS_SECRET_ACCESS_KEY = "${data.aws_caller_identity.current.secret_key}"
      AWS_SESSION_TOKEN = "${data.aws_caller_identity.current.session_token}"
    }
  }
}
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8242
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allows credentials (access_key, secret_key, and session_token) to be fetched from aws_caller_identity to be used within local-exec provisioners.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
