### PR TITLE
New resource: aws_dx_transit_virtual_interface

### DIFF
--- a/aws/dx_vif.go
+++ b/aws/dx_vif.go
@@ -32,7 +32,7 @@ func dxVirtualInterfaceUpdate(d *schema.ResourceData, meta interface{}) error {
 			VirtualInterfaceId: aws.String(d.Id()),
 		}
 
-		log.Printf("[DEBUG] Modifying Direct Connect virtual interface attributes: %#v", req)
+		log.Printf("[DEBUG] Modifying Direct Connect virtual interface attributes: %s", req)
 		_, err := conn.UpdateVirtualInterfaceAttributes(req)
 		if err != nil {
 			return fmt.Errorf("error modifying Direct Connect virtual interface (%s) attributes, error: %s", d.Id(), err)

--- a/aws/dx_vif.go
+++ b/aws/dx_vif.go
@@ -14,7 +14,7 @@ import (
 func dxVirtualInterfaceRead(id string, conn *directconnect.DirectConnect) (*directconnect.VirtualInterface, error) {
 	resp, state, err := dxVirtualInterfaceStateRefresh(conn, id)()
 	if err != nil {
-		return nil, fmt.Errorf("Error reading Direct Connect virtual interface: %s", err)
+		return nil, fmt.Errorf("error reading Direct Connect virtual interface (%s): %s", id, err)
 	}
 	if state == directconnect.VirtualInterfaceStateDeleted {
 		return nil, nil
@@ -26,26 +26,21 @@ func dxVirtualInterfaceRead(id string, conn *directconnect.DirectConnect) (*dire
 func dxVirtualInterfaceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).dxconn
 
-	req := &directconnect.UpdateVirtualInterfaceAttributesInput{
-		VirtualInterfaceId: aws.String(d.Id()),
-	}
-
-	requestUpdate := false
 	if d.HasChange("mtu") {
-		req.Mtu = aws.Int64(int64(d.Get("mtu").(int)))
-		requestUpdate = true
-	}
+		req := &directconnect.UpdateVirtualInterfaceAttributesInput{
+			Mtu:                aws.Int64(int64(d.Get("mtu").(int))),
+			VirtualInterfaceId: aws.String(d.Id()),
+		}
 
-	if requestUpdate {
 		log.Printf("[DEBUG] Modifying Direct Connect virtual interface attributes: %#v", req)
 		_, err := conn.UpdateVirtualInterfaceAttributes(req)
 		if err != nil {
-			return fmt.Errorf("Error modifying Direct Connect virtual interface (%s) attributes, error: %s", d.Id(), err)
+			return fmt.Errorf("error modifying Direct Connect virtual interface (%s) attributes, error: %s", d.Id(), err)
 		}
 	}
 
 	if err := setTagsDX(conn, d, d.Get("arn").(string)); err != nil {
-		return err
+		return fmt.Errorf("error setting Direct Connect virtual interface (%s) tags: %s", d.Id(), err)
 	}
 
 	return nil
@@ -62,7 +57,7 @@ func dxVirtualInterfaceDelete(d *schema.ResourceData, meta interface{}) error {
 		if isAWSErr(err, directconnect.ErrCodeClientException, "does not exist") {
 			return nil
 		}
-		return fmt.Errorf("Error deleting Direct Connect virtual interface: %s", err)
+		return fmt.Errorf("error deleting Direct Connect virtual interface (%s): %s", d.Id(), err)
 	}
 
 	deleteStateConf := &resource.StateChangeConf{
@@ -85,7 +80,7 @@ func dxVirtualInterfaceDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	_, err = deleteStateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for Direct Connect virtual interface (%s) to be deleted: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for Direct Connect virtual interface (%s) to be deleted: %s", d.Id(), err)
 	}
 
 	return nil
@@ -125,7 +120,7 @@ func dxVirtualInterfaceWaitUntilAvailable(conn *directconnect.DirectConnect, vif
 		MinTimeout: 5 * time.Second,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Direct Connect virtual interface (%s) to become available: %s", vifId, err)
+		return fmt.Errorf("error waiting for Direct Connect virtual interface (%s) to become available: %s", vifId, err)
 	}
 
 	return nil

--- a/aws/dx_vif_test.go
+++ b/aws/dx_vif_test.go
@@ -1,0 +1,72 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testAccCheckDxVirtualInterfaceExists(name string, vif *directconnect.VirtualInterface) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		resp, err := conn.DescribeVirtualInterfaces(&directconnect.DescribeVirtualInterfacesInput{
+			VirtualInterfaceId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, v := range resp.VirtualInterfaces {
+			if aws.StringValue(v.VirtualInterfaceId) == rs.Primary.ID {
+				*vif = *v
+
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Direct Connect virtual interface (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckDxVirtualInterfaceDestroy(s *terraform.State, t string) error {
+	conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != t {
+			continue
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		resp, err := conn.DescribeVirtualInterfaces(&directconnect.DescribeVirtualInterfacesInput{
+			VirtualInterfaceId: aws.String(rs.Primary.ID),
+		})
+		if isAWSErr(err, directconnect.ErrCodeClientException, "does not exist") {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		for _, v := range resp.VirtualInterfaces {
+			if aws.StringValue(v.VirtualInterfaceId) == rs.Primary.ID && aws.StringValue(v.VirtualInterfaceState) != directconnect.VirtualInterfaceStateDeleted {
+				return fmt.Errorf("[DESTROY ERROR] Direct Connect virtual interface (%s) not deleted", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -441,6 +441,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_dx_lag":                                              resourceAwsDxLag(),
 			"aws_dx_private_virtual_interface":                        resourceAwsDxPrivateVirtualInterface(),
 			"aws_dx_public_virtual_interface":                         resourceAwsDxPublicVirtualInterface(),
+			"aws_dx_transit_virtual_interface":                        resourceAwsDxTransitVirtualInterface(),
 			"aws_dynamodb_table":                                      resourceAwsDynamoDbTable(),
 			"aws_dynamodb_table_item":                                 resourceAwsDynamoDbTableItem(),
 			"aws_dynamodb_global_table":                               resourceAwsDynamoDbGlobalTable(),

--- a/aws/resource_aws_dx_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_transit_virtual_interface.go
@@ -1,0 +1,228 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceAwsDxTransitVirtualInterface() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDxTransitVirtualInterfaceCreate,
+		Read:   resourceAwsDxTransitVirtualInterfaceRead,
+		Update: resourceAwsDxTransitVirtualInterfaceUpdate,
+		Delete: resourceAwsDxTransitVirtualInterfaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsDxTransitVirtualInterfaceImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"address_family": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					directconnect.AddressFamilyIpv4,
+					directconnect.AddressFamilyIpv6,
+				}, false),
+			},
+			"amazon_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"aws_device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bgp_asn": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"bgp_auth_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"connection_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"customer_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"dx_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"jumbo_frame_capable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"mtu": {
+				Type:         schema.TypeInt,
+				Default:      1500,
+				Optional:     true,
+				ValidateFunc: validation.IntInSlice([]int{1500, 8500}),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
+			"vlan": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 4094),
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	req := &directconnect.CreateTransitVirtualInterfaceInput{
+		ConnectionId: aws.String(d.Get("connection_id").(string)),
+		NewTransitVirtualInterface: &directconnect.NewTransitVirtualInterface{
+			AddressFamily:          aws.String(d.Get("address_family").(string)),
+			Asn:                    aws.Int64(int64(d.Get("bgp_asn").(int))),
+			DirectConnectGatewayId: aws.String(d.Get("dx_gateway_id").(string)),
+			Mtu:                    aws.Int64(int64(d.Get("mtu").(int))),
+			VirtualInterfaceName:   aws.String(d.Get("name").(string)),
+			Vlan:                   aws.Int64(int64(d.Get("vlan").(int))),
+		},
+	}
+	if v, ok := d.GetOk("amazon_address"); ok && v.(string) != "" {
+		req.NewTransitVirtualInterface.AmazonAddress = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("bgp_auth_key"); ok {
+		req.NewTransitVirtualInterface.AuthKey = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
+		req.NewTransitVirtualInterface.CustomerAddress = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] Creating Direct Connect transit virtual interface: %#v", req)
+	resp, err := conn.CreateTransitVirtualInterface(req)
+	if err != nil {
+		return fmt.Errorf("error creating Direct Connect transit virtual interface: %s", err)
+	}
+
+	d.SetId(aws.StringValue(resp.VirtualInterface.VirtualInterfaceId))
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "directconnect",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("dxvif/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+
+	if err := dxTransitVirtualInterfaceWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return err
+	}
+
+	return resourceAwsDxTransitVirtualInterfaceUpdate(d, meta)
+}
+
+func resourceAwsDxTransitVirtualInterfaceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).dxconn
+
+	vif, err := dxVirtualInterfaceRead(d.Id(), conn)
+	if err != nil {
+		return err
+	}
+	if vif == nil {
+		log.Printf("[WARN] Direct Connect transit virtual interface (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("address_family", vif.AddressFamily)
+	d.Set("amazon_address", vif.AmazonAddress)
+	d.Set("aws_device", vif.AwsDeviceV2)
+	d.Set("bgp_asn", vif.Asn)
+	d.Set("bgp_auth_key", vif.AuthKey)
+	d.Set("connection_id", vif.ConnectionId)
+	d.Set("customer_address", vif.CustomerAddress)
+	d.Set("dx_gateway_id", vif.DirectConnectGatewayId)
+	d.Set("jumbo_frame_capable", vif.JumboFrameCapable)
+	d.Set("mtu", vif.Mtu)
+	d.Set("name", vif.VirtualInterfaceName)
+	d.Set("vlan", vif.Vlan)
+	if err := getTagsDX(conn, d, d.Get("arn").(string)); err != nil {
+		return fmt.Errorf("error getting Direct Connect transit virtual interface (%s) tags: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceAwsDxTransitVirtualInterfaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	if err := dxVirtualInterfaceUpdate(d, meta); err != nil {
+		return err
+	}
+
+	if err := dxTransitVirtualInterfaceWaitUntilAvailable(meta.(*AWSClient).dxconn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return err
+	}
+
+	return resourceAwsDxTransitVirtualInterfaceRead(d, meta)
+}
+
+func resourceAwsDxTransitVirtualInterfaceDelete(d *schema.ResourceData, meta interface{}) error {
+	return dxVirtualInterfaceDelete(d, meta)
+}
+
+func resourceAwsDxTransitVirtualInterfaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "directconnect",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("dxvif/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func dxTransitVirtualInterfaceWaitUntilAvailable(conn *directconnect.DirectConnect, vifId string, timeout time.Duration) error {
+	return dxVirtualInterfaceWaitUntilAvailable(
+		conn,
+		vifId,
+		timeout,
+		[]string{
+			directconnect.VirtualInterfaceStatePending,
+		},
+		[]string{
+			directconnect.VirtualInterfaceStateAvailable,
+			directconnect.VirtualInterfaceStateDown,
+		})
+}

--- a/aws/resource_aws_dx_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_transit_virtual_interface.go
@@ -115,6 +115,7 @@ func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta int
 			Asn:                    aws.Int64(int64(d.Get("bgp_asn").(int))),
 			DirectConnectGatewayId: aws.String(d.Get("dx_gateway_id").(string)),
 			Mtu:                    aws.Int64(int64(d.Get("mtu").(int))),
+			Tags:                   tagsFromMapDX(d.Get("tags").(map[string]interface{})),
 			VirtualInterfaceName:   aws.String(d.Get("name").(string)),
 			Vlan:                   aws.Int64(int64(d.Get("vlan").(int))),
 		},
@@ -149,7 +150,7 @@ func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta int
 		return err
 	}
 
-	return resourceAwsDxTransitVirtualInterfaceUpdate(d, meta)
+	return resourceAwsDxTransitVirtualInterfaceRead(d, meta)
 }
 
 func resourceAwsDxTransitVirtualInterfaceRead(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_dx_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_transit_virtual_interface.go
@@ -132,7 +132,7 @@ func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta int
 		req.NewTransitVirtualInterface.Tags = tagsFromMapDX(v.(map[string]interface{}))
 	}
 
-	log.Printf("[DEBUG] Creating Direct Connect transit virtual interface: %#v", req)
+	log.Printf("[DEBUG] Creating Direct Connect transit virtual interface: %s", req)
 	resp, err := conn.CreateTransitVirtualInterface(req)
 	if err != nil {
 		return fmt.Errorf("error creating Direct Connect transit virtual interface: %s", err)

--- a/aws/resource_aws_dx_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_transit_virtual_interface.go
@@ -115,7 +115,6 @@ func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta int
 			Asn:                    aws.Int64(int64(d.Get("bgp_asn").(int))),
 			DirectConnectGatewayId: aws.String(d.Get("dx_gateway_id").(string)),
 			Mtu:                    aws.Int64(int64(d.Get("mtu").(int))),
-			Tags:                   tagsFromMapDX(d.Get("tags").(map[string]interface{})),
 			VirtualInterfaceName:   aws.String(d.Get("name").(string)),
 			Vlan:                   aws.Int64(int64(d.Get("vlan").(int))),
 		},
@@ -128,6 +127,9 @@ func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta int
 	}
 	if v, ok := d.GetOk("customer_address"); ok && v.(string) != "" {
 		req.NewTransitVirtualInterface.CustomerAddress = aws.String(v.(string))
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		req.NewTransitVirtualInterface.Tags = tagsFromMapDX(v.(map[string]interface{}))
 	}
 
 	log.Printf("[DEBUG] Creating Direct Connect transit virtual interface: %#v", req)

--- a/aws/resource_aws_dx_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_transit_virtual_interface.go
@@ -202,6 +202,20 @@ func resourceAwsDxTransitVirtualInterfaceDelete(d *schema.ResourceData, meta int
 }
 
 func resourceAwsDxTransitVirtualInterfaceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conn := meta.(*AWSClient).dxconn
+
+	vif, err := dxVirtualInterfaceRead(d.Id(), conn)
+	if err != nil {
+		return nil, err
+	}
+	if vif == nil {
+		return nil, fmt.Errorf("virtual interface (%s) not found", d.Id())
+	}
+
+	if vifType := aws.StringValue(vif.VirtualInterfaceType); vifType != "transit" {
+		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
+	}
+
 	arn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Region:    meta.(*AWSClient).region,

--- a/aws/resource_aws_dx_transit_virtual_interface.go
+++ b/aws/resource_aws_dx_transit_virtual_interface.go
@@ -139,14 +139,6 @@ func resourceAwsDxTransitVirtualInterfaceCreate(d *schema.ResourceData, meta int
 	}
 
 	d.SetId(aws.StringValue(resp.VirtualInterface.VirtualInterfaceId))
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Region:    meta.(*AWSClient).region,
-		Service:   "directconnect",
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("dxvif/%s", d.Id()),
-	}.String()
-	d.Set("arn", arn)
 
 	if err := dxTransitVirtualInterfaceWaitUntilAvailable(conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return err
@@ -170,6 +162,14 @@ func resourceAwsDxTransitVirtualInterfaceRead(d *schema.ResourceData, meta inter
 
 	d.Set("address_family", vif.AddressFamily)
 	d.Set("amazon_address", vif.AmazonAddress)
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Region:    meta.(*AWSClient).region,
+		Service:   "directconnect",
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("dxvif/%s", d.Id()),
+	}.String()
+	d.Set("arn", arn)
 	d.Set("aws_device", vif.AwsDeviceV2)
 	d.Set("bgp_asn", vif.Asn)
 	d.Set("bgp_auth_key", vif.AuthKey)
@@ -217,15 +217,6 @@ func resourceAwsDxTransitVirtualInterfaceImport(d *schema.ResourceData, meta int
 	if vifType := aws.StringValue(vif.VirtualInterfaceType); vifType != "transit" {
 		return nil, fmt.Errorf("virtual interface (%s) has incorrect type: %s", d.Id(), vifType)
 	}
-
-	arn := arn.ARN{
-		Partition: meta.(*AWSClient).partition,
-		Region:    meta.(*AWSClient).region,
-		Service:   "directconnect",
-		AccountID: meta.(*AWSClient).accountid,
-		Resource:  fmt.Sprintf("dxvif/%s", d.Id()),
-	}.String()
-	d.Set("arn", arn)
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/aws/resource_aws_dx_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_transit_virtual_interface_test.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,20 +14,36 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsDxTransitVirtualInterface_basic(t *testing.T) {
+func TestAccAwsDxTransitVirtualInterface(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		"basic": testAccAwsDxTransitVirtualInterface_basic,
+		"tags":  testAccAwsDxTransitVirtualInterface_Tags,
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccAwsDxTransitVirtualInterface_basic(t *testing.T) {
 	key := "DX_CONNECTION_ID"
 	connectionId := os.Getenv(key)
 	if connectionId == "" {
 		t.Skipf("Environment variable %s is not set", key)
 	}
 
+	var vif directconnect.VirtualInterface
 	resourceName := "aws_dx_transit_virtual_interface.test"
+	dxGatewayResourceName := "aws_dx_gateway.test"
 	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(9))
 	amzAsn := randIntRange(64512, 65534)
 	bgpAsn := randIntRange(64512, 65534)
 	vlan := randIntRange(2049, 4094)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDxTransitVirtualInterfaceDestroy,
@@ -33,21 +51,117 @@ func TestAccAwsDxTransitVirtualInterface_basic(t *testing.T) {
 			{
 				Config: testAccDxTransitVirtualInterfaceConfig_basic(connectionId, rName, amzAsn, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName),
+					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "address_family", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "amazon_address"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "directconnect", regexp.MustCompile(fmt.Sprintf("dxvif/%s", aws.StringValue(vif.VirtualInterfaceId)))),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_device"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn", strconv.Itoa(bgpAsn)),
+					resource.TestCheckResourceAttrSet(resourceName, "bgp_auth_key"),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", connectionId),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", dxGatewayResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "jumbo_frame_capable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "1500"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mtu", "1500"),
-					resource.TestCheckResourceAttr(resourceName, "jumbo_frame_capable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
 				),
 			},
 			{
 				Config: testAccDxTransitVirtualInterfaceConfig_updated(connectionId, rName, amzAsn, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "test"),
+					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "address_family", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "amazon_address"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "directconnect", regexp.MustCompile(fmt.Sprintf("dxvif/%s", aws.StringValue(vif.VirtualInterfaceId)))),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_device"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn", strconv.Itoa(bgpAsn)),
+					resource.TestCheckResourceAttrSet(resourceName, "bgp_auth_key"),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", connectionId),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", dxGatewayResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "jumbo_frame_capable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "mtu", "8500"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
+				),
+			},
+			// Test import.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsDxTransitVirtualInterface_Tags(t *testing.T) {
+	key := "DX_CONNECTION_ID"
+	connectionId := os.Getenv(key)
+	if connectionId == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
+	var vif directconnect.VirtualInterface
+	resourceName := "aws_dx_transit_virtual_interface.test"
+	dxGatewayResourceName := "aws_dx_gateway.test"
+	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(9))
+	amzAsn := randIntRange(64512, 65534)
+	bgpAsn := randIntRange(64512, 65534)
+	vlan := randIntRange(2049, 4094)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxTransitVirtualInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxTransitVirtualInterfaceConfig_tags(connectionId, rName, amzAsn, bgpAsn, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "address_family", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "amazon_address"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "directconnect", regexp.MustCompile(fmt.Sprintf("dxvif/%s", aws.StringValue(vif.VirtualInterfaceId)))),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_device"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn", strconv.Itoa(bgpAsn)),
+					resource.TestCheckResourceAttrSet(resourceName, "bgp_auth_key"),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", connectionId),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", dxGatewayResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "jumbo_frame_capable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key1", "Value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2a"),
+					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
+				),
+			},
+			{
+				Config: testAccDxTransitVirtualInterfaceConfig_tagsUpdated(connectionId, rName, amzAsn, bgpAsn, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName, &vif),
+					resource.TestCheckResourceAttr(resourceName, "address_family", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "amazon_address"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "directconnect", regexp.MustCompile(fmt.Sprintf("dxvif/%s", aws.StringValue(vif.VirtualInterfaceId)))),
+					resource.TestCheckResourceAttrSet(resourceName, "aws_device"),
+					resource.TestCheckResourceAttr(resourceName, "bgp_asn", strconv.Itoa(bgpAsn)),
+					resource.TestCheckResourceAttrSet(resourceName, "bgp_auth_key"),
+					resource.TestCheckResourceAttr(resourceName, "connection_id", connectionId),
+					resource.TestCheckResourceAttrSet(resourceName, "customer_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", dxGatewayResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "jumbo_frame_capable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2b"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value3"),
+					resource.TestCheckResourceAttr(resourceName, "vlan", strconv.Itoa(vlan)),
 				),
 			},
 			// Test import.
@@ -98,7 +212,7 @@ func testAccCheckAwsDxTransitVirtualInterfaceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAwsDxTransitVirtualInterfaceExists(name string) resource.TestCheckFunc {
+func testAccCheckAwsDxTransitVirtualInterfaceExists(name string, vif *directconnect.VirtualInterface) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).dxconn
 
@@ -110,56 +224,93 @@ func testAccCheckAwsDxTransitVirtualInterfaceExists(name string) resource.TestCh
 			return fmt.Errorf("No ID is set")
 		}
 
-		_, err := conn.DescribeVirtualInterfaces(&directconnect.DescribeVirtualInterfacesInput{
+		resp, err := conn.DescribeVirtualInterfaces(&directconnect.DescribeVirtualInterfacesInput{
 			VirtualInterfaceId: aws.String(rs.Primary.ID),
 		})
 		if err != nil {
 			return err
 		}
 
+		if n := len(resp.VirtualInterfaces); n != 1 {
+			return fmt.Errorf("Found %d Direct Connect virtual interfaces for %s, expected 1", n, rs.Primary.ID)
+		}
+
+		*vif = *resp.VirtualInterfaces[0]
+
 		return nil
 	}
 }
 
-func testAccDxTransitVirtualInterfaceConfig_basic(cid, rName string, amzAsn, bgpAsn, vlan int) string {
+func testAccDxTransitVirtualInterfaceConfig_base(rName string, amzAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  name            = %[2]q
-  amazon_side_asn = %[3]d
+  name            = %[1]q
+  amazon_side_asn = %[2]d
+}
+`, rName, amzAsn)
 }
 
+func testAccDxTransitVirtualInterfaceConfig_basic(cid, rName string, amzAsn, bgpAsn, vlan int) string {
+	return testAccDxTransitVirtualInterfaceConfig_base(rName, amzAsn) + fmt.Sprintf(`
 resource "aws_dx_transit_virtual_interface" "test" {
-  connection_id    = %[1]q
-
-  dx_gateway_id  = "${aws_dx_gateway.test.id}"
-  name           = %[2]q
-  vlan           = %[5]d
   address_family = "ipv4"
-  bgp_asn        = %[4]d
+  bgp_asn        = %[3]d
+  dx_gateway_id  = "${aws_dx_gateway.test.id}"
+  connection_id  = %[1]q
+  name           = %[2]q
+  vlan           = %[4]d
 }
-`, cid, rName, amzAsn, bgpAsn, vlan)
+`, cid, rName, bgpAsn, vlan)
 }
 
 func testAccDxTransitVirtualInterfaceConfig_updated(cid, rName string, amzAsn, bgpAsn, vlan int) string {
-	return fmt.Sprintf(`
-resource "aws_dx_gateway" "test" {
-  name            = %[2]q
-  amazon_side_asn = %[3]d
+	return testAccDxTransitVirtualInterfaceConfig_base(rName, amzAsn) + fmt.Sprintf(`
+resource "aws_dx_transit_virtual_interface" "test" {
+  address_family = "ipv4"
+  bgp_asn        = %[3]d
+  dx_gateway_id  = "${aws_dx_gateway.test.id}"
+  connection_id  = %[1]q
+  mtu            = 8500
+  name           = %[2]q
+  vlan           = %[4]d
+}
+`, cid, rName, bgpAsn, vlan)
 }
 
+func testAccDxTransitVirtualInterfaceConfig_tags(cid, rName string, amzAsn, bgpAsn, vlan int) string {
+	return testAccDxTransitVirtualInterfaceConfig_base(rName, amzAsn) + fmt.Sprintf(`
 resource "aws_dx_transit_virtual_interface" "test" {
-  connection_id    = %[1]q
-
-  dx_gateway_id  = "${aws_dx_gateway.test.id}"
-  name           = %[2]q
-  vlan           = %[5]d
   address_family = "ipv4"
-  bgp_asn        = %[4]d
-  mtu            = 8500
+  bgp_asn        = %[3]d
+  dx_gateway_id  = "${aws_dx_gateway.test.id}"
+  connection_id  = %[1]q
+  name           = %[2]q
+  vlan           = %[4]d
 
   tags = {
-    Environment = "test"
+    Name = %[2]q
+    Key1 = "Value1"
+    Key2 = "Value2a"
   }
 }
-`, cid, rName, amzAsn, bgpAsn, vlan)
+`, cid, rName, bgpAsn, vlan)
+}
+
+func testAccDxTransitVirtualInterfaceConfig_tagsUpdated(cid, rName string, amzAsn, bgpAsn, vlan int) string {
+	return testAccDxTransitVirtualInterfaceConfig_base(rName, amzAsn) + fmt.Sprintf(`
+resource "aws_dx_transit_virtual_interface" "test" {
+  address_family = "ipv4"
+  bgp_asn        = %[3]d
+  dx_gateway_id  = "${aws_dx_gateway.test.id}"
+  connection_id  = %[1]q
+  name           = %[2]q
+  vlan           = %[4]d
+
+  tags = {
+    Name = %[2]q
+    Key2 = "Value2b"
+    Key3 = "Value3"
+  }
+}
+`, cid, rName, bgpAsn, vlan)
 }

--- a/aws/resource_aws_dx_transit_virtual_interface_test.go
+++ b/aws/resource_aws_dx_transit_virtual_interface_test.go
@@ -1,0 +1,140 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsDxTransitVirtualInterface_basic(t *testing.T) {
+	key := "DX_CONNECTION_ID"
+	connectionId := os.Getenv(key)
+	if connectionId == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
+	resourceName := "aws_dx_transit_virtual_interface.test"
+	rName := fmt.Sprintf("tf-testacc-transit-vif-%s", acctest.RandString(9))
+	amzAsn := randIntRange(64512, 65534)
+	bgpAsn := randIntRange(64512, 65534)
+	vlan := randIntRange(2049, 4094)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxTransitVirtualInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxTransitVirtualInterfaceConfig_basic(connectionId, rName, amzAsn, bgpAsn, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "1500"),
+					resource.TestCheckResourceAttr(resourceName, "jumbo_frame_capable", "true"),
+				),
+			},
+			{
+				Config: testAccDxTransitVirtualInterfaceConfig_updated(connectionId, rName, amzAsn, bgpAsn, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxTransitVirtualInterfaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "test"),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "8500"),
+				),
+			},
+			// Test import.
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDxTransitVirtualInterfaceDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).dxconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_dx_transit_virtual_interface" {
+			continue
+		}
+
+		input := &directconnect.DescribeVirtualInterfacesInput{
+			VirtualInterfaceId: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeVirtualInterfaces(input)
+		if err != nil {
+			return err
+		}
+		for _, v := range resp.VirtualInterfaces {
+			if *v.VirtualInterfaceId == rs.Primary.ID && !(*v.VirtualInterfaceState == directconnect.VirtualInterfaceStateDeleted) {
+				return fmt.Errorf("[DESTROY ERROR] Dx Transit VIF (%s) not deleted", rs.Primary.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccCheckAwsDxTransitVirtualInterfaceExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccDxTransitVirtualInterfaceConfig_basic(cid, rName string, amzAsn, bgpAsn, vlan int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name            = %[2]q
+  amazon_side_asn = %[3]d
+}
+
+resource "aws_dx_transit_virtual_interface" "test" {
+  connection_id    = %[1]q
+
+  dx_gateway_id  = "${aws_dx_gateway.test.id}"
+  name           = %[2]q
+  vlan           = %[5]d
+  address_family = "ipv4"
+  bgp_asn        = %[4]d
+}
+`, cid, rName, amzAsn, bgpAsn, vlan)
+}
+
+func testAccDxTransitVirtualInterfaceConfig_updated(cid, rName string, amzAsn, bgpAsn, vlan int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name            = %[2]q
+  amazon_side_asn = %[3]d
+}
+
+resource "aws_dx_transit_virtual_interface" "test" {
+  connection_id    = %[1]q
+
+  dx_gateway_id  = "${aws_dx_gateway.test.id}"
+  name           = %[2]q
+  vlan           = %[5]d
+  address_family = "ipv4"
+  bgp_asn        = %[4]d
+  mtu            = 8500
+
+  tags = {
+    Environment = "test"
+  }
+}
+`, cid, rName, amzAsn, bgpAsn, vlan)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -876,6 +876,9 @@
                                 <li>
                                     <a href="/docs/providers/aws/r/dx_public_virtual_interface.html">aws_dx_public_virtual_interface</a>
                                 </li>
+                                <li>
+                                    <a href="/docs/providers/aws/r/dx_transit_virtual_interface.html">aws_dx_transit_virtual_interface</a>
+                                </li>
                             </ul>
                         </li>
                     </ul>

--- a/website/docs/r/dx_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_transit_virtual_interface.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "aws"
+page_title: "AWS: aws_dx_transit_virtual_interface"
+sidebar_current: "docs-aws-resource-dx-transit-virtual-interface"
+description: |-
+  Provides a Direct Connect transit virtual interface resource.
+---
+
+# Resource: aws_dx_transit_virtual_interface
+
+Provides a Direct Connect transit virtual interface resource.
+A transit virtual interface is a VLAN that transports traffic from a [Direct Connect gateway](dx_gateway.html) to one or more [transit gateways](ec2_transit_gateway.html).
+
+## Example Usage
+
+```hcl
+resource "aws_dx_gateway" "example" {
+  name            = "tf-dxg-example"
+  amazon_side_asn = 64512
+}
+
+resource "aws_dx_transit_virtual_interface" "example" {
+  connection_id = "dxcon-zzzzzzzz"
+
+  dx_gateway_id  = "${aws_dx_gateway.example.id}"
+  name           = "tf-transit-vif-example"
+  vlan           = 4094
+  address_family = "ipv4"
+  bgp_asn        = 65352
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `address_family` - (Required) The address family for the BGP peer. `ipv4 ` or `ipv6`.
+* `bgp_asn` - (Required) The autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.
+* `connection_id` - (Required) The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
+* `dx_gateway_id` - (Required) The ID of the Direct Connect gateway to which to connect the virtual interface.
+* `name` - (Required) The name for the virtual interface.
+* `vlan` - (Required) The VLAN ID.
+* `amazon_address` - (Optional) The IPv4 CIDR address to use to send traffic to Amazon. Required for IPv4 BGP peers.
+* `bgp_auth_key` - (Optional) The authentication key for BGP configuration.
+* `customer_address` - (Optional) The IPv4 CIDR destination address to which Amazon should send traffic. Required for IPv4 BGP peers.
+* `mtu` - (Optional) The maximum transmission unit (MTU) is the size, in bytes, of the largest permissible packet that can be passed over the connection.
+The MTU of a virtual transit interface can be either `1500` or `8500` (jumbo frames). Default is `1500`.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the virtual interface.
+* `arn` - The ARN of the virtual interface.
+* `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
+* `jumbo_frame_capable` - Indicates whether jumbo frames (9001 MTU) are supported.
+
+## Timeouts
+
+`aws_dx_transit_virtual_interface` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating virtual interface
+- `update` - (Default `10 minutes`) Used for virtual interface modifications
+- `delete` - (Default `10 minutes`) Used for destroying virtual interface
+
+## Import
+
+Direct Connect transit virtual interfaces can be imported using the `vif id`, e.g.
+
+```
+$ terraform import aws_dx_transit_virtual_interface.test dxvif-33cc44dd
+```

--- a/website/docs/r/dx_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_transit_virtual_interface.html.markdown
@@ -20,7 +20,7 @@ resource "aws_dx_gateway" "example" {
 }
 
 resource "aws_dx_transit_virtual_interface" "example" {
-  connection_id = "dxcon-zzzzzzzz"
+  connection_id = "${aws_dx_connection.example.id}"
 
   dx_gateway_id  = "${aws_dx_gateway.example.id}"
   name           = "tf-transit-vif-example"

--- a/website/docs/r/dx_transit_virtual_interface.html.markdown
+++ b/website/docs/r/dx_transit_virtual_interface.html.markdown
@@ -54,7 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the virtual interface.
 * `arn` - The ARN of the virtual interface.
 * `aws_device` - The Direct Connect endpoint on which the virtual interface terminates.
-* `jumbo_frame_capable` - Indicates whether jumbo frames (9001 MTU) are supported.
+* `jumbo_frame_capable` - Indicates whether jumbo frames (8500 MTU) are supported.
 
 ## Timeouts
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Part of the work for https://github.com/terraform-providers/terraform-provider-aws/issues/8490.
Replaces https://github.com/terraform-providers/terraform-provider-aws/pull/8514.

Acceptance tests (requires an existing Direct Connect connection in _available_ state):

```console
$ DX_CONNECTION_ID=dxcon-aaaaaaaa make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsDxTransitVirtualInterface_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsDxTransitVirtualInterface_ -timeout 120m
=== RUN   TestAccAwsDxTransitVirtualInterface_basic
=== PAUSE TestAccAwsDxTransitVirtualInterface_basic
=== CONT  TestAccAwsDxTransitVirtualInterface_basic
--- PASS: TestAccAwsDxTransitVirtualInterface_basic (1074.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	1074.672s
```