### PR TITLE
New Data Source: aws_db_engine_version

### DIFF
--- a/aws/data_source_aws_db_engine_version.go
+++ b/aws/data_source_aws_db_engine_version.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	gversion "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsDbEngineVersion() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsDbEngineVersionRead,
+
+		Schema: map[string]*schema.Schema{
+			//selection criteria
+			"engine": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			//Computed values returned
+			"db_engine_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_engine_version_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_parameter_group_family": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"exportable_log_types": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"supported_engine_modes": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"supported_feature_names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"supports_log_exports_to_cloudwatch_logs": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"supports_read_replica": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsDbEngineVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	req := &rds.DescribeDBEngineVersionsInput{
+		Engine: aws.String(d.Get("engine").(string)),
+	}
+	if v, ok := d.GetOk("engine_version"); ok {
+		req.EngineVersion = aws.String(v.(string))
+	}
+
+	resp, err := conn.DescribeDBEngineVersions(req)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.DBEngineVersions) < 1 {
+		return errors.New("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	var version *rds.DBEngineVersion
+	if len(resp.DBEngineVersions) > 1 {
+		recent := d.Get("most_recent").(bool)
+		log.Printf("[DEBUG] aws_db_engine_version - multiple results found and `most_recent` is set to: %t", recent)
+		if recent {
+			version = mostRecentDbEngineVersion(resp.DBEngineVersions)
+		} else {
+			return errors.New("Your query returned more than one result. Please try a more specific search criteria.")
+		}
+	} else {
+		version = resp.DBEngineVersions[0]
+	}
+
+	d.SetId(aws.StringValue(version.EngineVersion))
+	d.Set("db_engine_description", version.DBEngineDescription)
+	d.Set("db_engine_version_description", version.DBEngineVersionDescription)
+	d.Set("db_parameter_group_family", version.DBParameterGroupFamily)
+	d.Set("engine_version", version.EngineVersion)
+	d.Set("exportable_log_types", version.ExportableLogTypes)
+	d.Set("supported_engine_modes", version.SupportedEngineModes)
+	d.Set("supported_feature_names", version.SupportedFeatureNames)
+	d.Set("supports_log_exports_to_cloudwatch_logs", version.SupportsLogExportsToCloudwatchLogs)
+	d.Set("supports_read_replica", version.SupportsReadReplica)
+
+	return nil
+}
+
+func mostRecentDbEngineVersion(versions []*rds.DBEngineVersion) *rds.DBEngineVersion {
+	sortedVersions := versions
+	sort.Slice(sortedVersions, func(i, j int) bool {
+		iEngineVersion, err := gversion.NewVersion(aws.StringValue(sortedVersions[i].EngineVersion))
+		if err != nil {
+			panic(fmt.Sprintf("error converting (%s) to go-version: %s", aws.StringValue(sortedVersions[i].EngineVersion), err))
+		}
+
+		jEngineVersion, err := gversion.NewVersion(aws.StringValue(sortedVersions[j].EngineVersion))
+		if err != nil {
+			panic(fmt.Sprintf("error converting (%s) to go-version: %s", aws.StringValue(sortedVersions[j].EngineVersion), err))
+		}
+
+		return iEngineVersion.GreaterThan(jEngineVersion)
+	})
+	return sortedVersions[0]
+}

--- a/aws/data_source_aws_db_engine_version_test.go
+++ b/aws/data_source_aws_db_engine_version_test.go
@@ -1,0 +1,66 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDBEngineVersionDataSource_mariadb(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsDBEngineVersionDataSourceConfig("mariadb"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "db_engine_description", "MariaDB Community Edition"),
+					resource.TestMatchResourceAttr("data.aws_db_engine_version.test", "db_engine_version_description", regexp.MustCompile("^MariaDB ")),
+					resource.TestMatchResourceAttr("data.aws_db_engine_version.test", "db_parameter_group_family", regexp.MustCompile("^mariadb")),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "engine", "mariadb"),
+					resource.TestMatchResourceAttr("data.aws_db_engine_version.test", "engine_version", regexp.MustCompile(`^\d+\.\d+\.\d+$`)),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "exportable_log_types.#", "4"),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "supported_engine_modes.#", "0"),
+					resource.TestCheckResourceAttrSet("data.aws_db_engine_version.test", "supported_feature_names.#"),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "supports_log_exports_to_cloudwatch_logs", "true"),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "supports_read_replica", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBEngineVersionDataSource_postgres(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsDBEngineVersionDataSourceConfig("postgres"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "db_engine_description", "PostgreSQL"),
+					resource.TestMatchResourceAttr("data.aws_db_engine_version.test", "db_engine_version_description", regexp.MustCompile("^PostgreSQL ")),
+					resource.TestMatchResourceAttr("data.aws_db_engine_version.test", "db_parameter_group_family", regexp.MustCompile("^postgres")),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "engine", "postgres"),
+					resource.TestMatchResourceAttr("data.aws_db_engine_version.test", "engine_version", regexp.MustCompile(`^\d+\.\d+$`)),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "exportable_log_types.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "supported_engine_modes.#", "0"),
+					resource.TestCheckResourceAttrSet("data.aws_db_engine_version.test", "supported_feature_names.#"),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "supports_log_exports_to_cloudwatch_logs", "true"),
+					resource.TestCheckResourceAttr("data.aws_db_engine_version.test", "supports_read_replica", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDBEngineVersionDataSourceConfig(engine string) string {
+	return fmt.Sprintf(`
+data "aws_db_engine_version" "test" {
+  engine      = "%s"
+  most_recent = true
+}
+`, engine)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -168,6 +168,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_codecommit_repository":              dataSourceAwsCodeCommitRepository(),
 			"aws_cur_report_definition":              dataSourceAwsCurReportDefinition(),
 			"aws_db_cluster_snapshot":                dataSourceAwsDbClusterSnapshot(),
+			"aws_db_engine_version":                  dataSourceAwsDbEngineVersion(),
 			"aws_db_event_categories":                dataSourceAwsDbEventCategories(),
 			"aws_db_instance":                        dataSourceAwsDbInstance(),
 			"aws_db_snapshot":                        dataSourceAwsDbSnapshot(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -126,6 +126,9 @@
                           <a href="/docs/providers/aws/d/db_cluster_snapshot.html">aws_db_cluster_snapshot</a>
                         </li>
                         <li>
+                          <a href="/docs/providers/aws/d/db_engine_version.html">aws_db_engine_version</a>
+                        </li>
+                        <li>
                           <a href="/docs/providers/aws/d/db_event_categories.html">aws_db_event_categories</a>
                         </li>
                         <li>

--- a/website/docs/d/db_engine_version.html.markdown
+++ b/website/docs/d/db_engine_version.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_db_engine_version"
+sidebar_current: "docs-aws-datasource-db-engine-version"
+description: |-
+  Get information on a DB Engine Version.
+---
+
+# Data Source: aws_db_engine_version
+
+Use this data source to get information about a DB Engine Version.
+
+## Example Usage
+
+```hcl
+data "aws_db_engine_version" "example" {
+  engine      = "postgres"
+  most_recent = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `engine` - (Required) The database engine to return.
+* `engine_version` - (Optional) The database engine version to return.
+* `most_recent` - (Optional) If more than one result is returned, use the most recent Snapshot.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `db_engine_description` - The description of the database engine.
+* `db_engine_version_description` - The description of the database engine version.
+* `db_parameter_group_family` - The name of the DB parameter group family for the database engine.
+* `exportable_log_types` - The types of logs that the database engine has available for export to CloudWatch Logs.
+* `supported_engine_modes` - A list of the supported DB engine modes.
+* `supported_feature_names` - A list of features supported by the DB engine. Supported feature names include the following.
+* `supports_log_exports_to_cloudwatch_logs` - A value that indicates whether the engine version supports exporting the log types specified by ExportableLogTypes to CloudWatch Logs.
+* `supports_read_replica` - Indicates whether the database engine version supports Read Replicas.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Data Source:** `aws_db_engine_version`
```

Output from acceptance testing:

```
% make testacc TESTARGS='-run=TestAccAWSDBEngineVersionDataSource_mariadb'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDBEngineVersionDataSource_mariadb -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBEngineVersionDataSource_mariadb
=== PAUSE TestAccAWSDBEngineVersionDataSource_mariadb
=== CONT  TestAccAWSDBEngineVersionDataSource_mariadb
--- PASS: TestAccAWSDBEngineVersionDataSource_mariadb (11.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.935s
% make testacc TESTARGS='-run=TestAccAWSDBEngineVersionDataSource_postgres'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDBEngineVersionDataSource_postgres -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBEngineVersionDataSource_postgres
=== PAUSE TestAccAWSDBEngineVersionDataSource_postgres
=== CONT  TestAccAWSDBEngineVersionDataSource_postgres
--- PASS: TestAccAWSDBEngineVersionDataSource_postgres (11.95s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	11.996s
```
