### PR TITLE
r/aws_dx_gateway_association: Update for transit gateway support plus the second half (cross-account proposal acceptance) of support for Gateway Association Proposals

### DIFF
--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -117,7 +117,7 @@ func resourceAwsDxGatewayAssociationCreate(d *schema.ResourceData, meta interfac
 	if gwAcctIdOk || proposalIdOk {
 		// Cross-account association.
 		if !(gwAcctIdOk && proposalIdOk) {
-			return errors.New("associated_gateway_owner_account_id and proposal_id must be configured")
+			return fmt.Errorf("associated_gateway_owner_account_id and proposal_id must be configured")
 		}
 	} else if !(gwIdOk || vgwIdOk) {
 		return errors.New("either associated_gateway_owner_account_id and proposal_id or one of associated_gateway_id or vpn_gateway_id must be configured")

--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -120,7 +120,7 @@ func resourceAwsDxGatewayAssociationCreate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("associated_gateway_owner_account_id and proposal_id must be configured")
 		}
 	} else if !(gwIdOk || vgwIdOk) {
-		return errors.New("either associated_gateway_owner_account_id and proposal_id or one of associated_gateway_id or vpn_gateway_id must be configured")
+		return fmt.Errorf("either associated_gateway_owner_account_id and proposal_id or one of associated_gateway_id or vpn_gateway_id must be configured")
 	}
 
 	associationId := ""

--- a/aws/resource_aws_dx_gateway_association_proposal_test.go
+++ b/aws/resource_aws_dx_gateway_association_proposal_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsDxGatewayAssociationProposal_deprecated(t *testing.T) {
+func TestAccAwsDxGatewayAssociationProposal_VpnGatewayId(t *testing.T) {
 	var proposal1 directconnect.GatewayAssociationProposal
 	var providers []*schema.Provider
 	rBgpAsn := randIntRange(64512, 65534)
@@ -30,7 +30,7 @@ func TestAccAwsDxGatewayAssociationProposal_deprecated(t *testing.T) {
 		CheckDestroy:      testAccCheckAwsDxGatewayAssociationProposalDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationProposalConfig_deprecated(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationProposalConfig_vpnGatewayId(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationProposalExists(resourceName, &proposal1),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
@@ -152,7 +152,7 @@ func TestAccAwsDxGatewayAssociationProposal_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAwsDxGatewayAssociationProposal_allowedPrefixes(t *testing.T) {
+func TestAccAwsDxGatewayAssociationProposal_AllowedPrefixes(t *testing.T) {
 	var proposal1, proposal2 directconnect.GatewayAssociationProposal
 	var providers []*schema.Provider
 	rBgpAsn := randIntRange(64512, 65534)
@@ -292,7 +292,7 @@ resource "aws_vpn_gateway" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccDxGatewayAssociationProposalConfig_deprecated(rName string, rBgpAsn int) string {
+func testAccDxGatewayAssociationProposalConfig_vpnGatewayId(rName string, rBgpAsn int) string {
 	return testAccDxGatewayAssociationProposalConfigBase_vpnGateway(rName, rBgpAsn) + fmt.Sprintf(`
 resource "aws_dx_gateway_association_proposal" "test" {
   dx_gateway_id               = "${aws_dx_gateway.test.id}"

--- a/aws/resource_aws_dx_gateway_association_proposal_test.go
+++ b/aws/resource_aws_dx_gateway_association_proposal_test.go
@@ -236,7 +236,7 @@ resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "tf-acc-test-dx-gateway-association-proposal"
+    Name = %[1]q
   }
 }
 
@@ -244,7 +244,7 @@ resource "aws_vpn_gateway" "test" {
   vpc_id = "${aws_vpc.test.id}"
 
   tags = {
-    Name = "tf-acc-test-dx-gateway-association-proposal"
+    Name = %[1]q
   }
 }
 `, rName, rBgpAsn)

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -100,7 +102,7 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 	return nil
 }
 
-func TestAccAwsDxGatewayAssociation_deprecated(t *testing.T) {
+func TestAccAwsDxGatewayAssociation_deprecatedSingleAccount(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
@@ -113,15 +115,17 @@ func TestAccAwsDxGatewayAssociation_deprecated(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_deprecated(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_deprecatedSingleAccount(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "associated_gateway_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "transit_gateway_attachment_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
+					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1216997074", "10.255.255.0/28"),
 				),
@@ -130,7 +134,7 @@ func TestAccAwsDxGatewayAssociation_deprecated(t *testing.T) {
 	})
 }
 
-func TestAccAwsDxGatewayAssociation_basicVpnGateway(t *testing.T) {
+func TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
@@ -143,15 +147,17 @@ func TestAccAwsDxGatewayAssociation_basicVpnGateway(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_basicVpnGateway(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_basicVpnGatewaySingleAccount(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
-					resource.TestCheckNoResourceAttr(resourceName, "transit_gateway_attachment_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
+					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1216997074", "10.255.255.0/28"),
 				),
@@ -173,7 +179,44 @@ func TestAccAwsDxGatewayAssociation_basicVpnGateway(t *testing.T) {
 	})
 }
 
-func TestAccAwsDxGatewayAssociation_basicTransitGateway(t *testing.T) {
+func TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount(t *testing.T) {
+	var providers []*schema.Provider
+	resourceName := "aws_dx_gateway_association.test"
+	resourceNameDxGw := "aws_dx_gateway.test"
+	resourceNameVgw := "aws_vpn_gateway.test"
+	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
+	rBgpAsn := randIntRange(64512, 65534)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig_basicVpnGatewayCrossAccount(rName, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
+					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
+					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
+					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
+					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
+					// testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1216997074", "10.255.255.0/28"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameTgw := "aws_ec2_transit_gateway.test"
@@ -186,15 +229,17 @@ func TestAccAwsDxGatewayAssociation_basicTransitGateway(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_basicTransitGateway(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_basicTransitGatewaySingleAccount(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameTgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "transit_gateway_attachment_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
+					resource.TestMatchResourceAttr(resourceName, "transit_gateway_attachment_id", regexp.MustCompile(`^tgw-attach-.+`)),
+					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
+					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2173830893", "10.255.255.0/30"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2984398124", "10.255.255.8/30"),
@@ -217,7 +262,41 @@ func TestAccAwsDxGatewayAssociation_basicTransitGateway(t *testing.T) {
 	})
 }
 
-func TestAccAwsDxGatewayAssociation_multiVgws(t *testing.T) {
+func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T) {
+	resourceName := "aws_dx_gateway_association.test"
+	resourceNameDxGw := "aws_dx_gateway.test"
+	resourceNameTgw := "aws_ec2_transit_gateway.test"
+	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
+	rBgpAsn := randIntRange(64512, 65534)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig_basicTransitGatewayCrossAccount(rName, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameTgw, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
+					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
+					resource.TestMatchResourceAttr(resourceName, "transit_gateway_attachment_id", regexp.MustCompile(`^tgw-attach-.+`)),
+					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
+					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
+					// testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2173830893", "10.255.255.0/30"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2984398124", "10.255.255.8/30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGatewayAssociation_multiVpnGatewaysSingleAccount(t *testing.T) {
 	resourceName1 := "aws_dx_gateway_association.test1"
 	resourceName2 := "aws_dx_gateway_association.test2"
 	rName1 := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
@@ -230,7 +309,7 @@ func TestAccAwsDxGatewayAssociation_multiVgws(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_multiVgws(rName1, rName2, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_multiVpnGatewaysSingleAccount(rName1, rName2, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName1),
 					testAccCheckAwsDxGatewayAssociationExists(resourceName2),
@@ -246,7 +325,7 @@ func TestAccAwsDxGatewayAssociation_multiVgws(t *testing.T) {
 	})
 }
 
-func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGateway(t *testing.T) {
+func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewaySingleAccount(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
@@ -259,7 +338,7 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGateway(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGateway(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewaySingleAccount(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
@@ -271,11 +350,56 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGateway(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayUpdated(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewaySingleAccountUpdated(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1642241106", "10.255.255.8/29"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount(t *testing.T) {
+	var providers []*schema.Provider
+	resourceName := "aws_dx_gateway_association.test"
+	resourceNameDxGw := "aws_dx_gateway.test"
+	resourceNameVgw := "aws_vpn_gateway.test"
+	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
+	rBgpAsn := randIntRange(64512, 65534)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayCrossAccount(rName, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1642241106", "10.255.255.8/29"),
+				),
+				// Accepting the proposal with overridden prefixes changes the returned RequestedAllowedPrefixesToDirectConnectGateway value (allowed_prefixes attribute).
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayCrossAccountUpdated(rName, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2173830893", "10.255.255.0/30"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2984398124", "10.255.255.8/30"),
 				),
 			},
 		},
@@ -320,7 +444,7 @@ func testAccCheckAwsDxGatewayAssociationExists(name string) resource.TestCheckFu
 	}
 }
 
-func testAccDxGatewayAssociationConfig_deprecated(rName string, rBgpAsn int) string {
+func testAccDxGatewayAssociationConfigBase_vpnGatewaySingleAccount(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q
@@ -345,48 +469,82 @@ resource "aws_vpn_gateway_attachment" "test" {
   vpc_id         = "${aws_vpc.test.id}"
   vpn_gateway_id = "${aws_vpn_gateway.test.id}"
 }
+`, rName, rBgpAsn)
+}
 
+func testAccDxGatewayAssociationConfigBase_vpnGatewayCrossAccount(rName string, rBgpAsn int) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+# Creator
+data "aws_caller_identity" "creator" {}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.255.255.0/28"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway_attachment" "test" {
+  vpc_id         = "${aws_vpc.test.id}"
+  vpn_gateway_id = "${aws_vpn_gateway.test.id}"
+}
+
+# Accepter
+resource "aws_dx_gateway" "test" {
+  provider = "aws.alternate"
+
+  amazon_side_asn = %[2]d
+  name            = %[1]q
+}
+`, rName, rBgpAsn)
+}
+
+func testAccDxGatewayAssociationConfig_deprecatedSingleAccount(rName string, rBgpAsn int) string {
+	return testAccDxGatewayAssociationConfigBase_vpnGatewaySingleAccount(rName, rBgpAsn) + fmt.Sprintf(`
 resource "aws_dx_gateway_association" "test" {
   dx_gateway_id  = "${aws_dx_gateway.test.id}"
   vpn_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
 }
-`, rName, rBgpAsn)
+`)
 }
 
-func testAccDxGatewayAssociationConfig_basicVpnGateway(rName string, rBgpAsn int) string {
-	return fmt.Sprintf(`
-resource "aws_dx_gateway" "test" {
-  name            = %[1]q
-  amazon_side_asn = "%[2]d"
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.255.255.0/28"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpn_gateway" "test" {
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpn_gateway_attachment" "test" {
-  vpc_id         = "${aws_vpc.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway.test.id}"
-}
-
+func testAccDxGatewayAssociationConfig_basicVpnGatewaySingleAccount(rName string, rBgpAsn int) string {
+	return testAccDxGatewayAssociationConfigBase_vpnGatewaySingleAccount(rName, rBgpAsn) + fmt.Sprintf(`
 resource "aws_dx_gateway_association" "test" {
   dx_gateway_id         = "${aws_dx_gateway.test.id}"
   associated_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
 }
-`, rName, rBgpAsn)
+`)
 }
 
-func testAccDxGatewayAssociationConfig_basicTransitGateway(rName string, rBgpAsn int) string {
+func testAccDxGatewayAssociationConfig_basicVpnGatewayCrossAccount(rName string, rBgpAsn int) string {
+	return testAccDxGatewayAssociationConfigBase_vpnGatewayCrossAccount(rName, rBgpAsn) + fmt.Sprintf(`
+# Creator
+resource "aws_dx_gateway_association_proposal" "test" {
+  dx_gateway_id               = "${aws_dx_gateway.test.id}"
+  dx_gateway_owner_account_id = "${aws_dx_gateway.test.owner_account_id}"
+  associated_gateway_id       = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+}
+
+# Accepter
+resource "aws_dx_gateway_association" "test" {
+  provider = "aws.alternate"
+
+  proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
+  dx_gateway_id                       = "${aws_dx_gateway.test.id}"
+  associated_gateway_owner_account_id = "${data.aws_caller_identity.creator.account_id}"
+}
+`)
+}
+
+func testAccDxGatewayAssociationConfig_basicTransitGatewaySingleAccount(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q
@@ -411,7 +569,49 @@ resource "aws_dx_gateway_association" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccDxGatewayAssociationConfig_multiVgws(rName1, rName2 string, rBgpAsn int) string {
+func testAccDxGatewayAssociationConfig_basicTransitGatewayCrossAccount(rName string, rBgpAsn int) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+# Creator
+data "aws_caller_identity" "creator" {}
+
+# Accepter
+resource "aws_dx_gateway" "test" {
+  provider = "aws.alternate"
+
+  amazon_side_asn = %[2]d
+  name            = %[1]q
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+# Creator
+resource "aws_dx_gateway_association_proposal" "test" {
+  dx_gateway_id               = "${aws_dx_gateway.test.id}"
+  dx_gateway_owner_account_id = "${aws_dx_gateway.test.owner_account_id}"
+  associated_gateway_id       = "${aws_ec2_transit_gateway.test.id}"
+
+  allowed_prefixes = [
+    "10.255.255.0/30",
+    "10.255.255.8/30",
+  ]
+}
+
+# Accepter
+resource "aws_dx_gateway_association" "test" {
+  provider = "aws.alternate"
+
+  proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
+  dx_gateway_id                       = "${aws_dx_gateway.test.id}"
+  associated_gateway_owner_account_id = "${data.aws_caller_identity.creator.account_id}"
+}
+`, rName, rBgpAsn)
+}
+
+func testAccDxGatewayAssociationConfig_multiVpnGatewaysSingleAccount(rName1, rName2 string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
   name            = %[1]q
@@ -468,32 +668,8 @@ resource "aws_dx_gateway_association" "test2" {
 `, rName1, rName2, rBgpAsn)
 }
 
-func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGateway(rName string, rBgpAsn int) string {
-	return fmt.Sprintf(`
-resource "aws_dx_gateway" "test" {
-  name            = %[1]q
-  amazon_side_asn = "%[2]d"
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.255.255.0/28"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpn_gateway" "test" {
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpn_gateway_attachment" "test" {
-  vpc_id         = "${aws_vpc.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway.test.id}"
-}
-
+func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewaySingleAccount(rName string, rBgpAsn int) string {
+	return testAccDxGatewayAssociationConfigBase_vpnGatewaySingleAccount(rName, rBgpAsn) + fmt.Sprintf(`
 resource "aws_dx_gateway_association" "test" {
   dx_gateway_id         = "${aws_dx_gateway.test.id}"
   associated_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
@@ -503,35 +679,11 @@ resource "aws_dx_gateway_association" "test" {
     "10.255.255.8/30",
   ]
 }
-`, rName, rBgpAsn)
+`)
 }
 
-func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayUpdated(rName string, rBgpAsn int) string {
-	return fmt.Sprintf(`
-resource "aws_dx_gateway" "test" {
-  name            = %[1]q
-  amazon_side_asn = "%[2]d"
-}
-
-resource "aws_vpc" "test" {
-  cidr_block = "10.255.255.0/28"
-
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpn_gateway" "test" {
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_vpn_gateway_attachment" "test" {
-  vpc_id         = "${aws_vpc.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway.test.id}"
-}
-
+func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewaySingleAccountUpdated(rName string, rBgpAsn int) string {
+	return testAccDxGatewayAssociationConfigBase_vpnGatewaySingleAccount(rName, rBgpAsn) + fmt.Sprintf(`
 resource "aws_dx_gateway_association" "test" {
   dx_gateway_id         = "${aws_dx_gateway.test.id}"
   associated_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
@@ -540,5 +692,59 @@ resource "aws_dx_gateway_association" "test" {
     "10.255.255.8/29",
   ]
 }
-`, rName, rBgpAsn)
+`)
+}
+
+func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayCrossAccount(rName string, rBgpAsn int) string {
+	return testAccDxGatewayAssociationConfigBase_vpnGatewayCrossAccount(rName, rBgpAsn) + fmt.Sprintf(`
+# Creator
+resource "aws_dx_gateway_association_proposal" "test" {
+  dx_gateway_id               = "${aws_dx_gateway.test.id}"
+  dx_gateway_owner_account_id = "${aws_dx_gateway.test.owner_account_id}"
+  associated_gateway_id       = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+
+  allowed_prefixes = [
+    "10.255.255.0/30",
+    "10.255.255.8/30",
+  ]
+}
+
+# Accepter
+resource "aws_dx_gateway_association" "test" {
+  provider = "aws.alternate"
+
+  proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
+  dx_gateway_id                       = "${aws_dx_gateway.test.id}"
+  associated_gateway_owner_account_id = "${data.aws_caller_identity.creator.account_id}"
+
+  allowed_prefixes = [
+    "10.255.255.8/29",
+  ]
+}
+`)
+}
+
+func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayCrossAccountUpdated(rName string, rBgpAsn int) string {
+	return testAccDxGatewayAssociationConfigBase_vpnGatewayCrossAccount(rName, rBgpAsn) + fmt.Sprintf(`
+# Creator
+resource "aws_dx_gateway_association_proposal" "test" {
+  dx_gateway_id               = "${aws_dx_gateway.test.id}"
+  dx_gateway_owner_account_id = "${aws_dx_gateway.test.owner_account_id}"
+  associated_gateway_id       = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+}
+
+# Accepter
+resource "aws_dx_gateway_association" "test" {
+  provider = "aws.alternate"
+
+  proposal_id                         = "${aws_dx_gateway_association_proposal.test.id}"
+  dx_gateway_id                       = "${aws_dx_gateway.test.id}"
+  associated_gateway_owner_account_id = "${data.aws_caller_identity.creator.account_id}"
+
+  allowed_prefixes = [
+    "10.255.255.0/30",
+    "10.255.255.8/30",
+  ]
+}
+`)
 }

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -200,7 +200,7 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
@@ -263,6 +263,7 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount(t *testing.
 }
 
 func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T) {
+	var providers []*schema.Provider
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameTgw := "aws_ec2_transit_gateway.test"
@@ -270,9 +271,12 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T
 	rBgpAsn := randIntRange(64512, 65534)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDxGatewayAssociationConfig_basicTransitGatewayCrossAccount(rName, rBgpAsn),
@@ -382,7 +386,7 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount(t *tes
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1642241106", "10.255.255.8/29"),
@@ -395,7 +399,7 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGatewayCrossAccount(t *tes
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2173830893", "10.255.255.0/30"),

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"testing"
 	"time"
 
@@ -123,7 +122,6 @@ func TestAccAwsDxGatewayAssociation_deprecatedSingleAccount(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "associated_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
-					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
@@ -155,7 +153,6 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewaySingleAccount(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
-					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
@@ -204,7 +201,6 @@ func TestAccAwsDxGatewayAssociation_basicVpnGatewayCrossAccount(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
-					resource.TestCheckResourceAttr(resourceName, "transit_gateway_attachment_id", ""),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
 					// testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
@@ -237,7 +233,6 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewaySingleAccount(t *testing.
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
-					resource.TestMatchResourceAttr(resourceName, "transit_gateway_attachment_id", regexp.MustCompile(`^tgw-attach-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
@@ -287,7 +282,6 @@ func TestAccAwsDxGatewayAssociation_basicTransitGatewayCrossAccount(t *testing.T
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
 					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
-					resource.TestMatchResourceAttr(resourceName, "transit_gateway_attachment_id", regexp.MustCompile(`^tgw-attach-.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "associated_gateway_owner_account_id"),
 					// dx_gateway_owner_account_id is the "aws.alternate" provider's account ID.
 					// testAccCheckResourceAttrAccountID(resourceName, "dx_gateway_owner_account_id"),

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -55,19 +55,18 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 				}
 
 				for _, association := range associationOutput.DirectConnectGatewayAssociations {
-					virtualGatewayID := aws.StringValue(association.VirtualGatewayId)
+					gatewayID := aws.StringValue(association.AssociatedGateway.Id)
 
 					if aws.StringValue(association.AssociationState) != directconnect.GatewayAssociationStateAssociated {
-						log.Printf("[INFO] Skipping Direct Connect Gateway (%s) Association in non-available (%s) state: %s", directConnectGatewayID, aws.StringValue(association.AssociationState), virtualGatewayID)
+						log.Printf("[INFO] Skipping Direct Connect Gateway (%s) Association in non-available (%s) state: %s", directConnectGatewayID, aws.StringValue(association.AssociationState), gatewayID)
 						continue
 					}
 
 					input := &directconnect.DeleteDirectConnectGatewayAssociationInput{
-						DirectConnectGatewayId: gateway.DirectConnectGatewayId,
-						VirtualGatewayId:       association.VirtualGatewayId,
+						AssociationId: association.AssociationId,
 					}
 
-					log.Printf("[INFO] Deleting Direct Connect Gateway (%s) Association: %s", directConnectGatewayID, virtualGatewayID)
+					log.Printf("[INFO] Deleting Direct Connect Gateway (%s) Association: %s", directConnectGatewayID, gatewayID)
 					_, err := conn.DeleteDirectConnectGatewayAssociation(input)
 
 					if isAWSErr(err, directconnect.ErrCodeClientException, "No association exists") {
@@ -75,11 +74,11 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 					}
 
 					if err != nil {
-						return fmt.Errorf("error deleting Direct Connect Gateway (%s) Association (%s): %s", directConnectGatewayID, virtualGatewayID, err)
+						return fmt.Errorf("error deleting Direct Connect Gateway (%s) Association (%s): %s", directConnectGatewayID, gatewayID, err)
 					}
 
-					if err := waitForDirectConnectGatewayAssociationDeletion(conn, directConnectGatewayID, virtualGatewayID, 20*time.Minute); err != nil {
-						return fmt.Errorf("error waiting for Direct Connect Gateway (%s) Association (%s) to be deleted: %s", directConnectGatewayID, virtualGatewayID, err)
+					if err := waitForDirectConnectGatewayAssociationDeletion(conn, aws.StringValue(association.AssociationId), 20*time.Minute); err != nil {
+						return fmt.Errorf("error waiting for Direct Connect Gateway (%s) Association (%s) to be deleted: %s", directConnectGatewayID, gatewayID, err)
 					}
 				}
 
@@ -101,7 +100,7 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 	return nil
 }
 
-func TestAccAwsDxGatewayAssociation_basic(t *testing.T) {
+func TestAccAwsDxGatewayAssociation_deprecated(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
@@ -114,12 +113,45 @@ func TestAccAwsDxGatewayAssociation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_basic(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_deprecated(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "associated_gateway_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "transit_gateway_attachment_id"),
+					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1216997074", "10.255.255.0/28"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGatewayAssociation_basicVpnGateway(t *testing.T) {
+	resourceName := "aws_dx_gateway_association.test"
+	resourceNameDxGw := "aws_dx_gateway.test"
+	resourceNameVgw := "aws_vpn_gateway.test"
+	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
+	rBgpAsn := randIntRange(64512, 65534)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig_basicVpnGateway(rName, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "transit_gateway_attachment_id"),
+					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "virtualPrivateGateway"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.1216997074", "10.255.255.0/28"),
 				),
@@ -132,7 +164,51 @@ func TestAccAwsDxGatewayAssociation_basic(t *testing.T) {
 						return "", fmt.Errorf("Not Found: %s", resourceName)
 					}
 
-					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["dx_gateway_id"], rs.Primary.Attributes["vpn_gateway_id"]), nil
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["dx_gateway_id"], rs.Primary.Attributes["associated_gateway_id"]), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsDxGatewayAssociation_basicTransitGateway(t *testing.T) {
+	resourceName := "aws_dx_gateway_association.test"
+	resourceNameDxGw := "aws_dx_gateway.test"
+	resourceNameTgw := "aws_ec2_transit_gateway.test"
+	rName := fmt.Sprintf("terraform-testacc-dxgwassoc-%d", acctest.RandInt())
+	rBgpAsn := randIntRange(64512, 65534)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDxGatewayAssociationConfig_basicTransitGateway(rName, rBgpAsn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxGatewayAssociationExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameTgw, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
+					resource.TestCheckNoResourceAttr(resourceName, "vpn_gateway_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "transit_gateway_attachment_id"),
+					resource.TestCheckResourceAttr(resourceName, "associated_gateway_type", "transitGateway"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2173830893", "10.255.255.0/30"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2984398124", "10.255.255.8/30"),
+				),
+			},
+			{
+				ResourceName: resourceName,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return "", fmt.Errorf("Not Found: %s", resourceName)
+					}
+
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["dx_gateway_id"], rs.Primary.Attributes["associated_gateway_id"]), nil
 				},
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -170,7 +246,7 @@ func TestAccAwsDxGatewayAssociation_multiVgws(t *testing.T) {
 	})
 }
 
-func TestAccAwsDxGatewayAssociation_allowedPrefixes(t *testing.T) {
+func TestAccAwsDxGatewayAssociation_allowedPrefixesVpnGateway(t *testing.T) {
 	resourceName := "aws_dx_gateway_association.test"
 	resourceNameDxGw := "aws_dx_gateway.test"
 	resourceNameVgw := "aws_vpn_gateway.test"
@@ -183,11 +259,11 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixes(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_allowedPrefixes(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGateway(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "dx_gateway_id", resourceNameDxGw, "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "vpn_gateway_id", resourceNameVgw, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "associated_gateway_id", resourceNameVgw, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "dx_gateway_association_id"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.2173830893", "10.255.255.0/30"),
@@ -195,7 +271,7 @@ func TestAccAwsDxGatewayAssociation_allowedPrefixes(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDxGatewayAssociationConfig_allowedPrefixesUpdated(rName, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayUpdated(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsDxGatewayAssociationExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
@@ -214,13 +290,17 @@ func testAccCheckAwsDxGatewayAssociationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, _ := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
-			DirectConnectGatewayId: aws.String(rs.Primary.Attributes["dx_gateway_id"]),
-			VirtualGatewayId:       aws.String(rs.Primary.Attributes["vpn_gateway_id"]),
+		resp, err := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
+			AssociationId: aws.String(rs.Primary.Attributes["dx_gateway_association_id"]),
 		})
+		if err != nil {
+			return err
+		}
 
 		if len(resp.DirectConnectGatewayAssociations) > 0 {
-			return fmt.Errorf("Direct Connect Gateway (%s) is not dissociated from VGW %s", rs.Primary.Attributes["dx_gateway_id"], rs.Primary.Attributes["vpn_gateway_id"])
+			return fmt.Errorf("Direct Connect Gateway (%s) is not dissociated from GW %s",
+				aws.StringValue(resp.DirectConnectGatewayAssociations[0].DirectConnectGatewayId),
+				aws.StringValue(resp.DirectConnectGatewayAssociations[0].AssociatedGateway.Id))
 		}
 	}
 	return nil
@@ -240,15 +320,16 @@ func testAccCheckAwsDxGatewayAssociationExists(name string) resource.TestCheckFu
 	}
 }
 
-func testAccDxGatewayAssociationConfig_basic(rName string, rBgpAsn int) string {
+func testAccDxGatewayAssociationConfig_deprecated(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  name = %[1]q
+  name            = %[1]q
   amazon_side_asn = "%[2]d"
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.255.255.0/28"
+
   tags = {
     Name = %[1]q
   }
@@ -261,13 +342,71 @@ resource "aws_vpn_gateway" "test" {
 }
 
 resource "aws_vpn_gateway_attachment" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id         = "${aws_vpc.test.id}"
   vpn_gateway_id = "${aws_vpn_gateway.test.id}"
 }
 
 resource "aws_dx_gateway_association" "test" {
-  dx_gateway_id = "${aws_dx_gateway.test.id}"
+  dx_gateway_id  = "${aws_dx_gateway.test.id}"
   vpn_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+}
+`, rName, rBgpAsn)
+}
+
+func testAccDxGatewayAssociationConfig_basicVpnGateway(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name            = %[1]q
+  amazon_side_asn = "%[2]d"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.255.255.0/28"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_gateway_attachment" "test" {
+  vpc_id         = "${aws_vpc.test.id}"
+  vpn_gateway_id = "${aws_vpn_gateway.test.id}"
+}
+
+resource "aws_dx_gateway_association" "test" {
+  dx_gateway_id         = "${aws_dx_gateway.test.id}"
+  associated_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+}
+`, rName, rBgpAsn)
+}
+
+func testAccDxGatewayAssociationConfig_basicTransitGateway(rName string, rBgpAsn int) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  name            = %[1]q
+  amazon_side_asn = "%[2]d"
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_dx_gateway_association" "test" {
+  dx_gateway_id         = "${aws_dx_gateway.test.id}"
+  associated_gateway_id = "${aws_ec2_transit_gateway.test.id}"
+
+  allowed_prefixes = [
+    "10.255.255.0/30",
+    "10.255.255.8/30",
+  ]
 }
 `, rName, rBgpAsn)
 }
@@ -275,12 +414,13 @@ resource "aws_dx_gateway_association" "test" {
 func testAccDxGatewayAssociationConfig_multiVgws(rName1, rName2 string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  name = %[1]q
+  name            = %[1]q
   amazon_side_asn = "%[3]d"
 }
 
 resource "aws_vpc" "test1" {
   cidr_block = "10.255.255.16/28"
+
   tags = {
     Name = %[1]q
   }
@@ -293,17 +433,18 @@ resource "aws_vpn_gateway" "test1" {
 }
 
 resource "aws_vpn_gateway_attachment" "test1" {
-  vpc_id = "${aws_vpc.test1.id}"
+  vpc_id         = "${aws_vpc.test1.id}"
   vpn_gateway_id = "${aws_vpn_gateway.test1.id}"
 }
 
 resource "aws_dx_gateway_association" "test1" {
-  dx_gateway_id = "${aws_dx_gateway.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway_attachment.test1.vpn_gateway_id}"
+  dx_gateway_id         = "${aws_dx_gateway.test.id}"
+  associated_gateway_id = "${aws_vpn_gateway_attachment.test1.vpn_gateway_id}"
 }
 
 resource "aws_vpc" "test2" {
   cidr_block = "10.255.255.32/28"
+
   tags = {
     Name = %[2]q
   }
@@ -316,26 +457,27 @@ resource "aws_vpn_gateway" "test2" {
 }
 
 resource "aws_vpn_gateway_attachment" "test2" {
-  vpc_id = "${aws_vpc.test2.id}"
+  vpc_id         = "${aws_vpc.test2.id}"
   vpn_gateway_id = "${aws_vpn_gateway.test2.id}"
 }
 
 resource "aws_dx_gateway_association" "test2" {
-  dx_gateway_id = "${aws_dx_gateway.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway_attachment.test2.vpn_gateway_id}"
+  dx_gateway_id         = "${aws_dx_gateway.test.id}"
+  associated_gateway_id = "${aws_vpn_gateway_attachment.test2.vpn_gateway_id}"
 }
 `, rName1, rName2, rBgpAsn)
 }
 
-func testAccDxGatewayAssociationConfig_allowedPrefixes(rName string, rBgpAsn int) string {
+func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGateway(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  name = %[1]q
+  name            = %[1]q
   amazon_side_asn = "%[2]d"
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.255.255.0/28"
+
   tags = {
     Name = %[1]q
   }
@@ -348,13 +490,14 @@ resource "aws_vpn_gateway" "test" {
 }
 
 resource "aws_vpn_gateway_attachment" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id         = "${aws_vpc.test.id}"
   vpn_gateway_id = "${aws_vpn_gateway.test.id}"
 }
 
 resource "aws_dx_gateway_association" "test" {
-  dx_gateway_id = "${aws_dx_gateway.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+  dx_gateway_id         = "${aws_dx_gateway.test.id}"
+  associated_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+
   allowed_prefixes = [
     "10.255.255.0/30",
     "10.255.255.8/30",
@@ -363,15 +506,16 @@ resource "aws_dx_gateway_association" "test" {
 `, rName, rBgpAsn)
 }
 
-func testAccDxGatewayAssociationConfig_allowedPrefixesUpdated(rName string, rBgpAsn int) string {
+func testAccDxGatewayAssociationConfig_allowedPrefixesVpnGatewayUpdated(rName string, rBgpAsn int) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  name = %[1]q
+  name            = %[1]q
   amazon_side_asn = "%[2]d"
 }
 
 resource "aws_vpc" "test" {
   cidr_block = "10.255.255.0/28"
+
   tags = {
     Name = %[1]q
   }
@@ -384,13 +528,14 @@ resource "aws_vpn_gateway" "test" {
 }
 
 resource "aws_vpn_gateway_attachment" "test" {
-  vpc_id = "${aws_vpc.test.id}"
+  vpc_id         = "${aws_vpc.test.id}"
   vpn_gateway_id = "${aws_vpn_gateway.test.id}"
 }
 
 resource "aws_dx_gateway_association" "test" {
-  dx_gateway_id = "${aws_dx_gateway.test.id}"
-  vpn_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+  dx_gateway_id         = "${aws_dx_gateway.test.id}"
+  associated_gateway_id = "${aws_vpn_gateway_attachment.test.vpn_gateway_id}"
+
   allowed_prefixes = [
     "10.255.255.8/29",
   ]

--- a/aws/resource_aws_dx_gateway_test.go
+++ b/aws/resource_aws_dx_gateway_test.go
@@ -121,7 +121,7 @@ func TestAccAwsDxGateway_importComplex(t *testing.T) {
 		CheckDestroy: testAccCheckAwsDxGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxGatewayAssociationConfig_multiVgws(rName1, rName2, rBgpAsn),
+				Config: testAccDxGatewayAssociationConfig_multiVpnGatewaysSingleAccount(rName1, rName2, rBgpAsn),
 			},
 
 			{

--- a/examples/dx-gateway-cross-account-vgw-association/README.md
+++ b/examples/dx-gateway-cross-account-vgw-association/README.md
@@ -1,0 +1,18 @@
+# Direct Connect Gateway Cross-Account VGW Association
+
+This example demonstrates how to create a VPN Gateway in one AWS account, create a Direct Connect Gateway in a second AWS account, and associate the VPN Gateway with the Direct Connect Gateway via the `aws_dx_gateway_association_proposal` and `aws_dx_gateway_association` resources.
+
+See [more in the Direct Connect Gateway documentation](https://docs.aws.amazon.com/directconnect/latest/UserGuide/direct-connect-gateways.html).
+
+## Running this example
+
+Either `cp terraform.template.tfvars terraform.tfvars` and modify that new file accordingly or provide variables via CLI:
+
+```
+terraform apply \
+	-var="aws_first_access_key=AAAAAAAAAAAAAAAAAAA" \
+	-var="aws_first_secret_key=SuperSecretKeyForAccount1" \
+	-var="aws_second_access_key=BBBBBBBBBBBBBBBBBBB" \
+	-var="aws_second_secret_key=SuperSecretKeyForAccount2" \
+	-var="aws_region=us-east-1"
+```

--- a/examples/dx-gateway-cross-account-vgw-association/main.tf
+++ b/examples/dx-gateway-cross-account-vgw-association/main.tf
@@ -1,0 +1,64 @@
+// First account owns the VGW.
+provider "aws" {
+  alias = "first"
+
+  region     = "${var.aws_region}"
+  access_key = "${var.aws_first_access_key}"
+  secret_key = "${var.aws_first_secret_key}"
+}
+
+// Second account owns the DXGW.
+provider "aws" {
+  alias = "second"
+
+  region     = "${var.aws_region}"
+  access_key = "${var.aws_second_access_key}"
+  secret_key = "${var.aws_second_secret_key}"
+}
+
+data "aws_caller_identity" "first" {}
+
+resource "aws_vpc" "example" {
+  provider = "aws.first"
+
+  cidr_block = "10.255.255.0/28"
+
+  tags = {
+    Name = "terraform-example"
+  }
+}
+
+resource "aws_vpn_gateway" "example" {
+  provider = "aws.first"
+
+  vpc_id = "${aws_vpc.example.id}"
+
+  tags = {
+    Name = "terraform-example"
+  }
+}
+
+// Create the association proposal in the first account...
+resource "aws_dx_gateway_association_proposal" "example" {
+  provider = "aws.first"
+
+  dx_gateway_id               = "${aws_dx_gateway.example.id}"
+  dx_gateway_owner_account_id = "${aws_dx_gateway.example.owner_account_id}"
+  associated_gateway_id       = "${aws_vpn_gateway.example.id}"
+}
+
+// ...and accept it in the second account, creating the association.
+resource "aws_dx_gateway_association" "example" {
+  provider = "aws.second"
+
+  proposal_id                         = "${aws_dx_gateway_association_proposal.example.id}"
+  dx_gateway_id                       = "${aws_dx_gateway.example.id}"
+  associated_gateway_owner_account_id = "${data.aws_caller_identity.first.account_id}"
+}
+
+resource "aws_dx_gateway" "example" {
+  provider = "aws.second"
+
+  name            = "terraform-example"
+  amazon_side_asn = "64512"
+}

--- a/examples/dx-gateway-cross-account-vgw-association/terraform.template.tfvars
+++ b/examples/dx-gateway-cross-account-vgw-association/terraform.template.tfvars
@@ -1,0 +1,9 @@
+# First account
+aws_first_access_key = "AAAAAAAAAAAAAAAAAAA"
+aws_first_secret_key = "SuperSecretKeyForAccount1"
+
+# Second account
+aws_second_access_key = "BBBBBBBBBBBBBBBBBBB"
+aws_second_secret_key = "SuperSecretKeyForAccount2"
+
+aws_region = "us-east-1"

--- a/examples/dx-gateway-cross-account-vgw-association/variables.tf
+++ b/examples/dx-gateway-cross-account-vgw-association/variables.tf
@@ -1,0 +1,9 @@
+variable "aws_first_access_key" {}
+
+variable "aws_first_secret_key" {}
+
+variable "aws_second_access_key" {}
+
+variable "aws_second_secret_key" {}
+
+variable "aws_region" {}

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -38,7 +38,28 @@ resource "aws_dx_gateway_association" "example" {
 }
 ```
 
-### Single Account VGW With Allowed Prefixes
+### Transit Gateway Association
+
+```hcl
+resource "aws_dx_gateway" "example" {
+  name            = "example"
+  amazon_side_asn = "64512"
+}
+
+resource "aws_ec2_transit_gateway" "example" {}
+
+resource "aws_dx_gateway_association" "example" {
+  dx_gateway_id         = "${aws_dx_gateway.example.id}"
+  associated_gateway_id = "${aws_ec2_transit_gateway.example.id}"
+
+  allowed_prefixes = [
+    "10.255.255.0/30",
+    "10.255.255.8/30",
+  ]
+}
+```
+
+### Allowed Prefixes
 
 ```hcl
 resource "aws_dx_gateway" "example" {
@@ -61,27 +82,6 @@ resource "aws_dx_gateway_association" "example" {
   allowed_prefixes = [
     "210.52.109.0/24",
     "175.45.176.0/22",
-  ]
-}
-```
-
-### Transit Gateway Association
-
-```hcl
-resource "aws_dx_gateway" "example" {
-  name            = "example"
-  amazon_side_asn = "64512"
-}
-
-resource "aws_ec2_transit_gateway" "example" {}
-
-resource "aws_dx_gateway_association" "example" {
-  dx_gateway_id         = "${aws_dx_gateway.example.id}"
-  associated_gateway_id = "${aws_ec2_transit_gateway.example.id}"
-
-  allowed_prefixes = [
-    "10.255.255.0/30",
-    "10.255.255.8/30",
   ]
 }
 ```

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -16,7 +16,7 @@ by creating an `aws_dx_gateway_association` resource with the `proposal_id` and 
 
 ## Example Usage
 
-### VGW Single Account
+### VPN Gateway Association
 
 ```hcl
 resource "aws_dx_gateway" "example" {

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -3,16 +3,20 @@ layout: "aws"
 page_title: "AWS: aws_dx_gateway_association"
 sidebar_current: "docs-aws-resource-dx-gateway-association"
 description: |-
-  Associates a Direct Connect Gateway with a VGW.
+  Associates a Direct Connect Gateway with a VGW or transit gateway.
 ---
 
 # Resource: aws_dx_gateway_association
 
-Associates a Direct Connect Gateway with a VGW. For creating cross-account association proposals, see the [`aws_dx_gateway_association_proposal` resource](/docs/providers/aws/r/dx_gateway_association_proposal.html).
+Associates a Direct Connect Gateway with a VGW or transit gateway.
+
+To create a cross-account association, create an [`aws_dx_gateway_association_proposal` resource](/docs/providers/aws/r/dx_gateway_association_proposal.html)
+in the AWS account that owns the VGW or transit gateway and then accept the proposal in the AWS account that owns the Direct Connect Gateway
+by creating an `aws_dx_gateway_association` resource with the `proposal_id` and `associated_gateway_owner_account_id` attributes set.
 
 ## Example Usage
 
-### Basic
+### VGW Single Account
 
 ```hcl
 resource "aws_dx_gateway" "example" {
@@ -29,12 +33,12 @@ resource "aws_vpn_gateway" "example" {
 }
 
 resource "aws_dx_gateway_association" "example" {
-  dx_gateway_id  = "${aws_dx_gateway.example.id}"
-  vpn_gateway_id = "${aws_vpn_gateway.example.id}"
+  dx_gateway_id         = "${aws_dx_gateway.example.id}"
+  associated_gateway_id = "${aws_vpn_gateway.example.id}"
 }
 ```
 
-### Allowed Prefixes
+### Single Account VGW With Allowed Prefixes
 
 ```hcl
 resource "aws_dx_gateway" "example" {
@@ -51,8 +55,8 @@ resource "aws_vpn_gateway" "example" {
 }
 
 resource "aws_dx_gateway_association" "example" {
-  dx_gateway_id  = "${aws_dx_gateway.example.id}"
-  vpn_gateway_id = "${aws_vpn_gateway.example.id}"
+  dx_gateway_id         = "${aws_dx_gateway.example.id}"
+  associated_gateway_id = "${aws_vpn_gateway.example.id}"
 
   allowed_prefixes = [
     "210.52.109.0/24",
@@ -61,12 +65,36 @@ resource "aws_dx_gateway_association" "example" {
 }
 ```
 
+### Transit Gateway Single Account
+
+```hcl
+resource "aws_dx_gateway" "example" {
+  name            = "example"
+  amazon_side_asn = "64512"
+}
+
+resource "aws_ec2_transit_gateway" "example" {}
+
+resource "aws_dx_gateway_association" "example" {
+  dx_gateway_id         = "${aws_dx_gateway.example.id}"
+  associated_gateway_id = "${aws_ec2_transit_gateway.example.id}"
+
+  allowed_prefixes = [
+    "10.255.255.0/30",
+    "10.255.255.8/30",
+  ]
+}
+```
+
 ## Argument Reference
+
+~> **NOTE:** One of `associated_gateway_id`, or `vpn_gateway_id` must be specified.
 
 The following arguments are supported:
 
 * `dx_gateway_id` - (Required) The ID of the Direct Connect gateway.
-* `vpn_gateway_id` - (Required) The ID of the VGW with which to associate the gateway.
+* `associated_gateway_id` - (Optional) The ID of the VGW or transit gateway with which to associate the Direct Connect gateway.
+* `vpn_gateway_id` - (Optional) *Deprecated:* Use `associated_gateway_id` instead. The ID of the VGW with which to associate the gateway.
 * `allowed_prefixes` - (Optional) VPC prefixes (CIDRs) to advertise to the Direct Connect gateway. Defaults to the CIDR block of the VPC associated with the Virtual Gateway. To enable drift detection, must be configured.
 
 ## Attributes Reference
@@ -74,7 +102,9 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the Direct Connect gateway association resource.
+* `associated_gateway_type` - The type of the associated gateway, `transitGateway` or `virtualPrivateGateway`.
 * `dx_gateway_association_id` - The ID of the Direct Connect gateway association.
+* `transit_gateway_attachment_id` - The ID of the transit gateway attachment.
 
 ## Timeouts
 
@@ -87,7 +117,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Direct Connect gateway associations can be imported using `dx_gateway_id` together with `vpn_gateway_id`,
+Direct Connect gateway associations can be imported using `dx_gateway_id` together with `associated_gateway_id`,
 e.g.
 
 ```

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -86,52 +86,7 @@ resource "aws_dx_gateway_association" "example" {
 }
 ```
 
-### VGW Cross-Account
-
-```hcl
-provider "aws" {
-  # Creator's credentials.
-}
-
-provider "aws" {
-  alias = "accepter"
-
-  # Accepter's credentials.
-}
-
-# Creator's side of the proposal.
-data "aws_caller_identity" "creator" {}
-
-resource "aws_vpc" "example" {
-  cidr_block = "10.255.255.0/28"
-}
-
-resource "aws_vpn_gateway" "example" {
-  vpc_id = "${aws_vpc.example.id}"
-}
-
-resource "aws_dx_gateway_association_proposal" "example" {
-  dx_gateway_id               = "${aws_dx_gateway.example.id}"
-  dx_gateway_owner_account_id = "${aws_dx_gateway.example.owner_account_id}"
-  associated_gateway_id       = "${aws_vpn_gateway.example.id}"
-}
-
-# Accepter's side of the proposal.
-resource "aws_dx_gateway" "example" {
-  provider = "aws.accepter"
-
-  name            = "example"
-  amazon_side_asn = "64512"
-}
-
-resource "aws_dx_gateway_association" "example" {
-  provider = "aws.accepter"
-
-  proposal_id                         = "${aws_dx_gateway_association_proposal.example.id}"
-  dx_gateway_id                       = "${aws_dx_gateway.example.id}"
-  associated_gateway_owner_account_id = "${data.aws_caller_identity.creator.account_id}"
-}
-```
+A full example of how to to create a VPN Gateway in one AWS account, create a Direct Connect Gateway in a second AWS account, and associate the VPN Gateway with the Direct Connect Gateway via the `aws_dx_gateway_association_proposal` and `aws_dx_gateway_association` resources can be found in [the `./examples/dx-gateway-cross-account-vgw-association` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/dx-gateway-cross-account-vgw-association).
 
 ## Argument Reference
 

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -86,7 +86,7 @@ resource "aws_dx_gateway_association" "example" {
 }
 ```
 
-A full example of how to to create a VPN Gateway in one AWS account, create a Direct Connect Gateway in a second AWS account, and associate the VPN Gateway with the Direct Connect Gateway via the `aws_dx_gateway_association_proposal` and `aws_dx_gateway_association` resources can be found in [the `./examples/dx-gateway-cross-account-vgw-association` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/dx-gateway-cross-account-vgw-association).
+A full example of how to create a VPN Gateway in one AWS account, create a Direct Connect Gateway in a second AWS account, and associate the VPN Gateway with the Direct Connect Gateway via the `aws_dx_gateway_association_proposal` and `aws_dx_gateway_association` resources can be found in [the `./examples/dx-gateway-cross-account-vgw-association` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/dx-gateway-cross-account-vgw-association).
 
 ## Argument Reference
 

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -158,7 +158,6 @@ In addition to all arguments above, the following attributes are exported:
 * `associated_gateway_type` - The type of the associated gateway, `transitGateway` or `virtualPrivateGateway`.
 * `dx_gateway_association_id` - The ID of the Direct Connect gateway association.
 * `dx_gateway_owner_account_id` - The ID of the AWS account that owns the Direct Connect gateway.
-* `transit_gateway_attachment_id` - The ID of the transit gateway attachment.
 
 ## Timeouts
 

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -86,15 +86,68 @@ resource "aws_dx_gateway_association" "example" {
 }
 ```
 
+### VGW Cross-Account
+
+```hcl
+provider "aws" {
+  # Creator's credentials.
+}
+
+provider "aws" {
+  alias = "accepter"
+
+  # Accepter's credentials.
+}
+
+# Creator's side of the proposal.
+data "aws_caller_identity" "creator" {}
+
+resource "aws_vpc" "example" {
+  cidr_block = "10.255.255.0/28"
+}
+
+resource "aws_vpn_gateway" "example" {
+  vpc_id = "${aws_vpc.example.id}"
+}
+
+resource "aws_dx_gateway_association_proposal" "example" {
+  dx_gateway_id               = "${aws_dx_gateway.example.id}"
+  dx_gateway_owner_account_id = "${aws_dx_gateway.example.owner_account_id}"
+  associated_gateway_id       = "${aws_vpn_gateway.example.id}"
+}
+
+# Accepter's side of the proposal.
+resource "aws_dx_gateway" "example" {
+  provider = "aws.accepter"
+
+  name            = "example"
+  amazon_side_asn = "64512"
+}
+
+resource "aws_dx_gateway_association" "example" {
+  provider = "aws.accepter"
+
+  proposal_id                         = "${aws_dx_gateway_association_proposal.example.id}"
+  dx_gateway_id                       = "${aws_dx_gateway.example.id}"
+  associated_gateway_owner_account_id = "${data.aws_caller_identity.creator.account_id}"
+}
+```
+
 ## Argument Reference
 
-~> **NOTE:** One of `associated_gateway_id`, or `vpn_gateway_id` must be specified.
+~> **NOTE:** `dx_gateway_id` plus one of `associated_gateway_id`, or `vpn_gateway_id` must be specified for single account Direct Connect gateway associations.
 
 The following arguments are supported:
 
 * `dx_gateway_id` - (Required) The ID of the Direct Connect gateway.
 * `associated_gateway_id` - (Optional) The ID of the VGW or transit gateway with which to associate the Direct Connect gateway.
+Used for single account Direct Connect gateway associations.
 * `vpn_gateway_id` - (Optional) *Deprecated:* Use `associated_gateway_id` instead. The ID of the VGW with which to associate the gateway.
+Used for single account Direct Connect gateway associations.
+* `associated_gateway_owner_account_id` - (Optional) The ID of the AWS account that owns the VGW or transit gateway with which to associate the Direct Connect gateway.
+Used for cross-account Direct Connect gateway associations.
+* `proposal_id` - (Optional) The ID of the Direct Connect gateway association proposal.
+Used for cross-account Direct Connect gateway associations.
 * `allowed_prefixes` - (Optional) VPC prefixes (CIDRs) to advertise to the Direct Connect gateway. Defaults to the CIDR block of the VPC associated with the Virtual Gateway. To enable drift detection, must be configured.
 
 ## Attributes Reference
@@ -104,6 +157,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the Direct Connect gateway association resource.
 * `associated_gateway_type` - The type of the associated gateway, `transitGateway` or `virtualPrivateGateway`.
 * `dx_gateway_association_id` - The ID of the Direct Connect gateway association.
+* `dx_gateway_owner_account_id` - The ID of the AWS account that owns the Direct Connect gateway.
 * `transit_gateway_attachment_id` - The ID of the transit gateway attachment.
 
 ## Timeouts

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -65,7 +65,7 @@ resource "aws_dx_gateway_association" "example" {
 }
 ```
 
-### Transit Gateway Single Account
+### Transit Gateway Association
 
 ```hcl
 resource "aws_dx_gateway" "example" {

--- a/website/docs/r/dx_gateway_association_proposal.html.markdown
+++ b/website/docs/r/dx_gateway_association_proposal.html.markdown
@@ -13,11 +13,17 @@ Manages a Direct Connect Gateway Association Proposal, typically for enabling cr
 ## Example Usage
 
 ```hcl
-resource "aws_dx_gateway" "example" {
-  name            = "example"
-  amazon_side_asn = "64512"
+provider "aws" {
+  # Creator's credentials.
 }
 
+provider "aws" {
+  alias = "accepter"
+
+  # Accepter's credentials.
+}
+
+# Creator's side of the proposal.
 resource "aws_vpc" "example" {
   cidr_block = "10.255.255.0/28"
 }
@@ -29,24 +35,37 @@ resource "aws_vpn_gateway" "example" {
 resource "aws_dx_gateway_association_proposal" "example" {
   dx_gateway_id               = "${aws_dx_gateway.example.id}"
   dx_gateway_owner_account_id = "${aws_dx_gateway.example.owner_account_id}"
-  vpn_gateway_id              = "${aws_vpn_gateway.example.id}"
+  associated_gateway_id       = "${aws_vpn_gateway.example.id}"
+}
+
+# Accepter's side of the proposal.
+resource "aws_dx_gateway" "example" {
+  provider = "aws.accepter"
+
+  name            = "example"
+  amazon_side_asn = "64512"
 }
 ```
 
 ## Argument Reference
 
+~> **NOTE:** One of `associated_gateway_id`, or `vpn_gateway_id` must be specified.
+
 The following arguments are supported:
 
 * `dx_gateway_id` - (Required) Direct Connect Gateway identifier.
-* `dx_gateway_owner_account_id` - (Required) AWS Account identifier of the Direct Connect Gateway.
-* `vpn_gateway_id` - (Required) Virtual Gateway identifier to associate with the Direct Connect Gateway.
+* `dx_gateway_owner_account_id` - (Required) AWS Account identifier of the Direct Connect Gateway's owner.
+* `associated_gateway_id` - (Optional) The ID of the VGW or transit gateway with which to associate the Direct Connect gateway.
+* `vpn_gateway_id` - (Optional) *Deprecated:* Use `associated_gateway_id` instead. Virtual Gateway identifier to associate with the Direct Connect Gateway.
 * `allowed_prefixes` - (Optional) VPC prefixes (CIDRs) to advertise to the Direct Connect gateway. Defaults to the CIDR block of the VPC associated with the Virtual Gateway. To enable drift detection, must be configured.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Direct Connect Gateway Association Proposal identifier
+* `id` - Direct Connect Gateway Association Proposal identifier.
+* `associated_gateway_owner_account_id` - The ID of the AWS account that owns the VGW or transit gateway with which to associate the Direct Connect gateway.
+* `associated_gateway_type` - The type of the associated gateway, `transitGateway` or `virtualPrivateGateway`.
 
 ## Import
 

--- a/website/docs/r/dx_gateway_association_proposal.html.markdown
+++ b/website/docs/r/dx_gateway_association_proposal.html.markdown
@@ -13,39 +13,14 @@ Manages a Direct Connect Gateway Association Proposal, typically for enabling cr
 ## Example Usage
 
 ```hcl
-provider "aws" {
-  # Creator's credentials.
-}
-
-provider "aws" {
-  alias = "accepter"
-
-  # Accepter's credentials.
-}
-
-# Creator's side of the proposal.
-resource "aws_vpc" "example" {
-  cidr_block = "10.255.255.0/28"
-}
-
-resource "aws_vpn_gateway" "example" {
-  vpc_id = "${aws_vpc.example.id}"
-}
-
 resource "aws_dx_gateway_association_proposal" "example" {
   dx_gateway_id               = "${aws_dx_gateway.example.id}"
   dx_gateway_owner_account_id = "${aws_dx_gateway.example.owner_account_id}"
   associated_gateway_id       = "${aws_vpn_gateway.example.id}"
 }
-
-# Accepter's side of the proposal.
-resource "aws_dx_gateway" "example" {
-  provider = "aws.accepter"
-
-  name            = "example"
-  amazon_side_asn = "64512"
-}
 ```
+
+A full example of how to to create a VPN Gateway in one AWS account, create a Direct Connect Gateway in a second AWS account, and associate the VPN Gateway with the Direct Connect Gateway via the `aws_dx_gateway_association_proposal` and `aws_dx_gateway_association` resources can be found in [the `./examples/dx-gateway-cross-account-vgw-association` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/dx-gateway-cross-account-vgw-association).
 
 ## Argument Reference
 

--- a/website/docs/r/dx_gateway_association_proposal.html.markdown
+++ b/website/docs/r/dx_gateway_association_proposal.html.markdown
@@ -20,7 +20,7 @@ resource "aws_dx_gateway_association_proposal" "example" {
 }
 ```
 
-A full example of how to to create a VPN Gateway in one AWS account, create a Direct Connect Gateway in a second AWS account, and associate the VPN Gateway with the Direct Connect Gateway via the `aws_dx_gateway_association_proposal` and `aws_dx_gateway_association` resources can be found in [the `./examples/dx-gateway-cross-account-vgw-association` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/dx-gateway-cross-account-vgw-association).
+A full example of how to create a VPN Gateway in one AWS account, create a Direct Connect Gateway in a second AWS account, and associate the VPN Gateway with the Direct Connect Gateway via the `aws_dx_gateway_association_proposal` and `aws_dx_gateway_association` resources can be found in [the `./examples/dx-gateway-cross-account-vgw-association` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/dx-gateway-cross-account-vgw-association).
 
 ## Argument Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Transit gateway support

Part of the work for https://github.com/terraform-providers/terraform-provider-aws/issues/8490.

### Cross-account proposal acceptance

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8100.
Follows on from:
* https://github.com/terraform-providers/terraform-provider-aws/pull/8320
* https://github.com/terraform-providers/terraform-provider-aws/issues/8199

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* resource/aws_dx_gateway_association: The `vpn_gateway_id` attribute is being deprecated in favor of the new `associated_gateway_id` attribute to support transit gateway associations (https://github.com/terraform-providers/terraform-provider-aws/issues/8490)
* resource/aws_dx_gateway_association_proposal: The `vpn_gateway_id` attribute is being deprecated in favor of the new `associated_gateway_id` attribute to support transit gateway associations (https://github.com/terraform-providers/terraform-provider-aws/issues/8490)

ENHANCEMENTS:

* resource/aws_dx_gateway_association: New attributes `associated_gateway_owner_account_id` and `proposal_id` added to support the acceptance of a Direct Connect gateway association proposal and create a cross-account Direct Connect gateway association (https://github.com/terraform-providers/terraform-provider-aws/issues/8100).
New attribute `associated_gateway_id` replaces deprecated `vpn_gateway_id` attribute to support transit gateway associations (https://github.com/terraform-providers/terraform-provider-aws/issues/8490).
New exported attributes `associated_gateway_type` and `dx_gateway_owner_account_id`
* resource/aws_dx_gateway_association_proposal: New attribute `associated_gateway_id` replaces deprecated `vpn_gateway_id` attribute to support transit gateway associations (https://github.com/terraform-providers/terraform-provider-aws/issues/8490).
New exported attributes `associated_gateway_owner_account_id` and `associated_gateway_type`
```