### PR TITLE
Modify Aws Backup Selection Resource

### DIFF
--- a/aws/resource_aws_backup_selection.go
+++ b/aws/resource_aws_backup_selection.go
@@ -47,6 +47,7 @@ func resourceAwsBackupSelection() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								backup.ConditionTypeStringequals,
 							}, false),
@@ -54,10 +55,12 @@ func resourceAwsBackupSelection() *schema.Resource {
 						"key": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"value": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 					},
 				},

--- a/aws/resource_aws_backup_selection.go
+++ b/aws/resource_aws_backup_selection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/backup"
@@ -16,6 +17,9 @@ func resourceAwsBackupSelection() *schema.Resource {
 		Create: resourceAwsBackupSelectionCreate,
 		Read:   resourceAwsBackupSelectionRead,
 		Delete: resourceAwsBackupSelectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsBackupSelectionImportState,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -163,6 +167,21 @@ func resourceAwsBackupSelectionDelete(d *schema.ResourceData, meta interface{}) 
 	}
 
 	return nil
+}
+
+func resourceAwsBackupSelectionImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	idParts := strings.Split(d.Id(), "|")
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected <plan-id>:<selection-id>", d.Id())
+	}
+
+	planID := idParts[0]
+	selectionID := idParts[1]
+
+	d.Set("plan_id", planID)
+	d.SetId(selectionID)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func expandBackupConditionTags(tagList []interface{}) []*backup.Condition {

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -87,6 +87,32 @@ func TestAccAwsBackupSelection_withResources(t *testing.T) {
 	})
 }
 
+func TestAccAwsBackupSelection_updateTag(t *testing.T) {
+	var selection1, selection2 backup.GetBackupSelectionOutput
+	resourceName := "aws_backup_selection.test"
+	rInt := acctest.RandInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupSelectionConfigBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
+				),
+			},
+			{
+				Config: testAccBackupSelectionConfigUpdateTag(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsBackupSelectionExists(resourceName, &selection2),
+					testAccCheckAwsBackupSelectionRecreated(t, &selection1, &selection2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsBackupSelectionDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).backupconn
 	for _, rs := range s.RootModule().Resources {
@@ -149,6 +175,16 @@ func testAccCheckAwsBackupSelectionDisappears(selection *backup.GetBackupSelecti
 		_, err := conn.DeleteBackupSelection(input)
 
 		return err
+	}
+}
+
+func testAccCheckAwsBackupSelectionRecreated(t *testing.T,
+	before, after *backup.GetBackupSelectionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before.SelectionId == *after.SelectionId {
+			t.Fatalf("Expected change of Backup Selection IDs, but both were %s", *before.SelectionId)
+		}
+		return nil
 	}
 }
 
@@ -240,6 +276,27 @@ resource "aws_backup_selection" "test" {
 
   resources = [
     "arn:${data.aws_partition.current.partition}:elasticfilesystem:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:file-system/",
+    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/"
+  ]
+}
+`, rInt)
+}
+
+func testAccBackupSelectionConfigUpdateTag(rInt int) string {
+	return testAccBackupSelectionConfigBase(rInt) + fmt.Sprintf(`
+resource "aws_backup_selection" "test" {
+  plan_id      = "${aws_backup_plan.test.id}"
+
+  name         = "tf_acc_test_backup_selection_%d"
+  iam_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/service-role/AWSBackupDefaultServiceRole"
+
+  selection_tag {
+    type = "STRINGEQUALS"
+    key = "foo2"
+    value = "bar2"
+  }
+
+  resources = [
     "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/"
   ]
 }

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccAwsBackupSelection_basic(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
+	resourceName := "aws_backup_selection.test"
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,8 +23,14 @@ func TestAccAwsBackupSelection_basic(t *testing.T) {
 			{
 				Config: testAccBackupSelectionConfigBasic(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupSelectionExists("aws_backup_selection.test", &selection1),
+					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSBackupSelectionImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -51,6 +58,7 @@ func TestAccAwsBackupSelection_disappears(t *testing.T) {
 
 func TestAccAwsBackupSelection_withTags(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
+	resourceName := "aws_backup_selection.test"
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -60,9 +68,15 @@ func TestAccAwsBackupSelection_withTags(t *testing.T) {
 			{
 				Config: testAccBackupSelectionConfigWithTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupSelectionExists("aws_backup_selection.test", &selection1),
-					resource.TestCheckResourceAttr("aws_backup_selection.test", "selection_tag.#", "2"),
+					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
+					resource.TestCheckResourceAttr(resourceName, "selection_tag.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSBackupSelectionImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -70,6 +84,7 @@ func TestAccAwsBackupSelection_withTags(t *testing.T) {
 
 func TestAccAwsBackupSelection_withResources(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
+	resourceName := "aws_backup_selection.test"
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -79,9 +94,15 @@ func TestAccAwsBackupSelection_withResources(t *testing.T) {
 			{
 				Config: testAccBackupSelectionConfigWithResources(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupSelectionExists("aws_backup_selection.test", &selection1),
-					resource.TestCheckResourceAttr("aws_backup_selection.test", "resources.#", "2"),
+					testAccCheckAwsBackupSelectionExists(resourceName, &selection1),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSBackupSelectionImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -108,6 +129,12 @@ func TestAccAwsBackupSelection_updateTag(t *testing.T) {
 					testAccCheckAwsBackupSelectionExists(resourceName, &selection2),
 					testAccCheckAwsBackupSelectionRecreated(t, &selection1, &selection2),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSBackupSelectionImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -185,6 +212,21 @@ func testAccCheckAwsBackupSelectionRecreated(t *testing.T,
 			t.Fatalf("Expected change of Backup Selection IDs, but both were %s", *before.SelectionId)
 		}
 		return nil
+	}
+}
+
+func testAccAWSBackupSelectionImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := fmt.Sprintf("%s|%s",
+			rs.Primary.Attributes["plan_id"],
+			rs.Primary.ID)
+
+		return id, nil
 	}
 }
 

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -52,3 +52,11 @@ Tag conditions (`selection_tag`) support the following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Backup Selection identifier
+
+## Import
+
+Backup selection can be imported using the role plan_id and id separated by `|`.
+
+```
+$ terraform import aws_backup_selection.example plan-id/selection-id
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8443

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- resource/aws_backup_selection: Add `ForceNew` configuration for `selection_tag` attributes.
- resource/aws_backup_selection: Add resource import support.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsBackupSelection_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsBackupSelection_ -timeout 120m
=== RUN   TestAccAwsBackupSelection_basic
=== PAUSE TestAccAwsBackupSelection_basic
=== RUN   TestAccAwsBackupSelection_disappears
=== PAUSE TestAccAwsBackupSelection_disappears
=== RUN   TestAccAwsBackupSelection_withTags
=== PAUSE TestAccAwsBackupSelection_withTags
=== RUN   TestAccAwsBackupSelection_withResources
=== PAUSE TestAccAwsBackupSelection_withResources
=== RUN   TestAccAwsBackupSelection_updateTag
=== PAUSE TestAccAwsBackupSelection_updateTag
=== CONT  TestAccAwsBackupSelection_basic
=== CONT  TestAccAwsBackupSelection_withResources
=== CONT  TestAccAwsBackupSelection_updateTag
=== CONT  TestAccAwsBackupSelection_withTags
=== CONT  TestAccAwsBackupSelection_disappears
--- PASS: TestAccAwsBackupSelection_disappears (46.77s)
--- PASS: TestAccAwsBackupSelection_withResources (47.35s)
--- PASS: TestAccAwsBackupSelection_basic (47.77s)
--- PASS: TestAccAwsBackupSelection_withTags (47.89s)
--- PASS: TestAccAwsBackupSelection_updateTag (72.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	72.491s
```
