### PR TITLE
tests/provider: Update testAccPreCheck to also note AWS_PROFILE environment variable usage

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -66,13 +66,12 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("AWS_PROFILE"); v == "" {
-		if v := os.Getenv("AWS_ACCESS_KEY_ID"); v == "" {
-			t.Fatal("AWS_ACCESS_KEY_ID must be set for acceptance tests")
-		}
-		if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v == "" {
-			t.Fatal("AWS_SECRET_ACCESS_KEY must be set for acceptance tests")
-		}
+	if os.Getenv("AWS_PROFILE") == "" && os.Getenv("AWS_ACCESS_KEY_ID") == "" {
+		t.Fatal("AWS_ACCESS_KEY_ID or AWS_PROFILE must be set for acceptance tests")
+	}
+
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+		t.Fatal("AWS_SECRET_ACCESS_KEY must be set for acceptance tests")
 	}
 
 	region := testAccGetRegion()


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Output from acceptance testing:

```console
$ env | grep AWS_
$ TF_ACC=1 go test ./aws -v -timeout 120m -parallel 20 -run='TestAccAWSAvailabilityZones_basic'
...
--- FAIL: TestAccAWSAvailabilityZones_basic (0.00s)
    provider_test.go:70: AWS_ACCESS_KEY_ID or AWS_PROFILE must be set for acceptance tests

$ export AWS_PROFILE=tf-acc
$ TF_ACC=1 go test ./aws -v -timeout 120m -parallel 20 -run='TestAccAWSAvailabilityZones_basic'
...
--- PASS: TestAccAWSAvailabilityZones_basic (9.53s)

$ export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id)
$ export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key)
$ unset AWS_PROFILE
$ TF_ACC=1 go test ./aws -v -timeout 120m -parallel 20 -run='TestAccAWSAvailabilityZones_basic'
...
--- PASS: TestAccAWSAvailabilityZones_basic (9.49s)
```