### PR TITLE
tests/service/ec2: Blacklist usw2-az4 zone ID for EC2 Transit Gateway acceptance testing

### DIFF
--- a/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/data_source_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -59,6 +59,12 @@ func TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID(t *testing.T) {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigFilter() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -68,8 +74,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -95,6 +102,12 @@ data "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentDataSourceConfigID() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -104,8 +117,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"

--- a/aws/resource_aws_ec2_transit_gateway_route_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_route_test.go
@@ -175,6 +175,12 @@ func testAccCheckAWSEc2TransitGatewayRouteDisappears(transitGateway *ec2.Transit
 
 func testAccAWSEc2TransitGatewayRouteConfigDestinationCidrBlock() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -184,8 +190,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-route"

--- a/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
+++ b/aws/resource_aws_ec2_transit_gateway_vpc_attachment_test.go
@@ -545,6 +545,12 @@ func testAccCheckAWSEc2TransitGatewayVpcAttachmentNotRecreated(i, j *ec2.Transit
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfig() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -554,8 +560,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -574,6 +581,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigDnsSupport(dnsSupport string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -583,8 +596,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -604,6 +618,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigIpv6Support(ipv6Support string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
   cidr_block                       = "10.0.0.0/16"
@@ -614,9 +634,10 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block      = "10.0.0.0/24"
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
-  vpc_id          = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  ipv6_cidr_block   = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -636,6 +657,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigSharedTransitGateway(rName string) string {
 	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 data "aws_organizations_organization" "test" {}
 
 resource "aws_ec2_transit_gateway" "test" {
@@ -671,8 +698,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -691,7 +719,11 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigSubnetIds1() string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -725,7 +757,11 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigSubnetIds2() string {
 	return fmt.Sprintf(`
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -759,6 +795,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTags1(tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -768,8 +810,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -792,6 +835,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTags2(tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -801,8 +850,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -826,6 +876,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTableAssociationAndPropagationDisabled() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -835,8 +891,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -860,6 +917,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTableAssociation(transitGatewayDefaultRouteTableAssociation bool) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -869,8 +932,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"
@@ -890,6 +954,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "test" {
 
 func testAccAWSEc2TransitGatewayVpcAttachmentConfigTransitGatewayDefaultRouteTablePropagation(transitGatewayDefaultRouteTablePropagation bool) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -899,8 +969,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-transit-gateway-vpc-attachment"

--- a/aws/resource_aws_route_test.go
+++ b/aws/resource_aws_route_test.go
@@ -955,6 +955,12 @@ resource "aws_route" "bar" {
 
 func testAccAWSRouteConfigTransitGatewayIDDestinatationCidrBlock() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -964,8 +970,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-route-transit-gateway-id"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

AWS recently added a fourth Availability Zone to the US West (Oregon) Region, which does not yet support EC2 Transit Gateway. This new AZ has the zone ID of `usw2-az4` and here we blacklist it to prevent random acceptance testing failures due to random AZ selection for VPC subnets.

Previous output from acceptance testing (due to randomized AZ selection potentially including usw2-az4):

```
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
=== CONT  TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
--- PASS: TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock (335.39s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport (338.24s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Tags
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (343.74s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support (373.39s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation (138.80s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating EC2 Transit Gateway VPC Attachment: IncorrectState: Transit Gateway is not available in availability zone us-west-2d (subnet subnet-02fadf209fbcea990).
          status code: 400, request id: d3dab975-9fd1-498f-96b5-4a25c35e766e

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test833613409/main.tf line 21:
          (source code not available)

=== CONT  TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Tags (354.65s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_disappears
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation (361.32s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment (300.08s)
=== CONT  TestAccAWSEc2TransitGatewayRoute_basic
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds (472.20s)
=== CONT  TestAccAWSEc2TransitGatewayRoute_disappears
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachment_disappears (159.14s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating EC2 Transit Gateway VPC Attachment: IncorrectState: Transit Gateway is not available in availability zone us-west-2d (subnet subnet-0e42651c64da6948d).
          status code: 400, request id: 01a3bd02-49a9-4e51-9209-29c4ea3bda57

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test261015898/main.tf line 21:
          (source code not available)

=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_basic
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (244.74s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
--- FAIL: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (162.97s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating EC2 Transit Gateway VPC Attachment: IncorrectState: Transit Gateway is not available in availability zone us-west-2d (subnet subnet-0696ec949e8fc2f35).
          status code: 400, request id: 6ebf453e-341d-4305-b6ed-fb9a6e9df73e

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test789981369/main.tf line 21:
          (source code not available)

--- PASS: TestAccAWSEc2TransitGatewayRoute_basic (305.49s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_basic (321.71s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears (360.25s)
```

Output from acceptance testing:

```
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_disappears
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_disappears (339.47s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_basic
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_DnsSupport (358.09s)
=== CONT  TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Ipv6Support (365.36s)
=== CONT  TestAccAWSEc2TransitGatewayRoute_disappears
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_Filter (366.51s)
=== CONT  TestAccAWSEc2TransitGatewayRoute_basic
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_basic (315.36s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears (293.49s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment (341.21s)
=== CONT  TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock
--- PASS: TestAccAWSEc2TransitGatewayRoute_basic (354.87s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachmentDataSource_ID (303.98s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_Tags
--- PASS: TestAccAWSRoute_TransitGatewayID_DestinationCidrBlock (324.51s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociation (417.19s)
=== CONT  TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTablePropagation (354.84s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled (271.61s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_Tags (360.89s)
--- PASS: TestAccAWSEc2TransitGatewayVpcAttachment_SubnetIds (488.30s)
```
