### PR TITLE
Not retrieve EMR AD Domain Join User from AWS API

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -1100,6 +1100,7 @@ func flattenEmrKerberosAttributes(d *schema.ResourceData, kerberosAttributes *em
 
 	// Do not set from API:
 	// * ad_domain_join_password
+	// * ad_domain_join_user
 	// * cross_realm_trust_principal_password
 	// * kdc_admin_password
 
@@ -1112,8 +1113,8 @@ func flattenEmrKerberosAttributes(d *schema.ResourceData, kerberosAttributes *em
 		m["ad_domain_join_password"] = v.(string)
 	}
 
-	if kerberosAttributes.ADDomainJoinUser != nil {
-		m["ad_domain_join_user"] = *kerberosAttributes.ADDomainJoinUser
+	if v, ok := d.GetOk("kerberos_attributes.0.ad_domain_join_user"); ok {
+		m["ad_domain_join_user"] = v.(string)
 	}
 
 	if v, ok := d.GetOk("kerberos_attributes.0.cross_realm_trust_principal_password"); ok {


### PR DESCRIPTION
The AWS API returns ******** for the ADDomainJoinUser attribute, the
same as for ADDomainJoinPassword, CrossRealmTrustPrincipalPassword, and
KdcAdminPassword. This causes a terraform plan to always attempt to
rebuild the cluster since the ad_domain_join_user attribute is seen as
changing from ******** to what is specified and desired in the plan.
This now configures EMR to not retrieve this attribute from the AWS APIs
so that it doesn't always attempt to rebuild the cluster.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Fix bug with AWS EMR clusters that have an `ad_domain_join_user` specified in the `kerberos_attributes` always attempting to recreate the cluster even when no changes are specified.
```

Output from acceptance testing:

N/A: I didn't run the acceptance tests as it looks like there is any test behavior for this aspect of EMR, and spinning up EMR clusters 