### PR TITLE
resource/aws_cloudfront_distribution: Validate `*_cache_behavior` `forwarded_values` `cookies` configuration block `forward` argument

### DIFF
--- a/aws/cloudfront_distribution_configuration_structure.go
+++ b/aws/cloudfront_distribution_configuration_structure.go
@@ -414,7 +414,7 @@ func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues
 	fv := &cloudfront.ForwardedValues{
 		QueryString: aws.Bool(m["query_string"].(bool)),
 	}
-	if v, ok := m["cookies"]; ok && len(v.([]interface{})) > 0 {
+	if v, ok := m["cookies"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		fv.Cookies = expandCookiePreference(v.([]interface{})[0].(map[string]interface{}))
 	}
 	if v, ok := m["headers"]; ok {

--- a/aws/resource_aws_cloudfront_distribution.go
+++ b/aws/resource_aws_cloudfront_distribution.go
@@ -207,6 +207,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 												"forward": {
 													Type:     schema.TypeString,
 													Required: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														cloudfront.ItemSelectionAll,
+														cloudfront.ItemSelectionNone,
+														cloudfront.ItemSelectionWhitelist,
+													}, false),
 												},
 												"whitelisted_names": {
 													Type:     schema.TypeSet,
@@ -364,6 +369,11 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 												"forward": {
 													Type:     schema.TypeString,
 													Required: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														cloudfront.ItemSelectionAll,
+														cloudfront.ItemSelectionNone,
+														cloudfront.ItemSelectionWhitelist,
+													}, false),
 												},
 												"whitelisted_names": {
 													Type:     schema.TypeSet,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8493

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_cloudfront_distribution: Validate `*_cache_behavior` `forwarded_values` `cookies` configuration block `forward` argument
```

This also prevents panics with an additional `nil` check, which bubbles up the API error should the attribute validation be removed for some reason. Verified the panic by changing an existing test configuration to `forward = ""` without code updates:

```
=== CONT  TestAccAWSCloudFrontDistribution_S3Origin
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 668 [running]:
github.com/terraform-providers/terraform-provider-aws/aws.expandForwardedValues(0xc000cd72f0, 0xc000cd7170)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/cloudfront_distribution_configuration_structure.go:418 +0x515
github.com/terraform-providers/terraform-provider-aws/aws.expandCloudFrontDefaultCacheBehavior(0xc000cd7170, 0x5e9a943)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/cloudfront_distribution_configuration_structure.go:196 +0x21b
github.com/terraform-providers/terraform-provider-aws/aws.expandDistributionConfig(0xc00039fe30, 0xc000a89f20)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/cloudfront_distribution_configuration_structure.go:39 +0x23a
github.com/terraform-providers/terraform-provider-aws/aws.resourceAwsCloudFrontDistributionCreate(0xc00039fe30, 0x4fd92c0, 0xc0004b7000, 0x2, 0xa49a740)
  /Users/bflad/src/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_cloudfront_distribution.go:740 +0x6c
```

With the `nil` check in place, the API error is returned:

```
--- FAIL: TestAccAWSCloudFrontDistribution_S3Origin (18.14s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating CloudFront Distribution: InvalidParameter: 1 validation error(s) found.
        - missing required field, CreateDistributionWithTagsInput.DistributionConfigWithTags.DistributionConfig.DefaultCacheBehavior.ForwardedValues.Cookies.
```

By adding `ValidateFunc` we can prevent this issue during planning:

```
--- FAIL: TestAccAWSCloudFrontDistribution_S3Origin (1.73s)
    testing.go:568: Step 0 error: config is invalid: expected default_cache_behavior.0.forwarded_values.0.cookies.0.forward to be one of [all none whitelist], got
```

Output from acceptance testing:

```
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (1.90s)
--- PASS: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (2.03s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (604.75s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (605.93s)
--- PASS: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (604.23s)
--- PASS: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (606.72s)
--- PASS: TestAccAWSCloudFrontDistribution_disappears (697.81s)
--- PASS: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (2383.17s)
--- PASS: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (2384.35s)
--- PASS: TestAccAWSCloudFrontDistribution_RetainOnDelete (2384.95s)
--- PASS: TestAccAWSCloudFrontDistribution_OriginGroups (2385.23s)
--- PASS: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (2386.96s)
--- PASS: TestAccAWSCloudFrontDistribution_multiOrigin (2387.28s)
--- PASS: TestAccAWSCloudFrontDistribution_WaitForDeployment (2387.45s)
--- PASS: TestAccAWSCloudFrontDistribution_S3Origin (2387.61s)
--- PASS: TestAccAWSCloudFrontDistribution_HTTP11Config (2390.63s)
--- PASS: TestAccAWSCloudFrontDistribution_customOrigin (2392.71s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (2391.49s)
--- PASS: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (2393.55s)
--- PASS: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (2397.30s)
--- PASS: TestAccAWSCloudFrontDistribution_S3OriginWithTags (2956.22s)
--- PASS: TestAccAWSCloudFrontDistribution_Enabled (2959.58s)
```
