### PR TITLE
r/appsync_graphql_api: add tags support

### DIFF
--- a/aws/tagsAppsync.go
+++ b/aws/tagsAppsync.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/appsync"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func setTagsAppsync(conn *appsync.AppSync, d *schema.ResourceData, arn string) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsGeneric(o, n)
+
+		// remove old tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			keys := make([]*string, 0, len(remove))
+			for k := range remove {
+				keys = append(keys, aws.String(k))
+			}
+
+			_, err := conn.UntagResource(&appsync.UntagResourceInput{
+				ResourceArn: aws.String(arn),
+				TagKeys:     keys,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		// create new tags
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+
+			_, err := conn.TagResource(&appsync.TagResourceInput{
+				ResourceArn: aws.String(arn),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -121,6 +121,7 @@ The following arguments are supported:
 * `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. Defined below.
 * `user_pool_config` - (Optional) The Amazon Cognito User Pool configuration. Defined below.
 * `schema` - (Optional) The schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ### log_config
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #8472 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
r/appsync_graphql_api: add `tags` support
```

Output from acceptance testing (note, seems some of these tests are dependent on us-west-2 as the region):

```
$ AWS_REGION=us-west-2 make testacc TESTARGS='-run=TestAccAWSAppsyncGraphqlApi'
--- PASS: TestAccAWSAppsyncGraphqlApi_disappears (12.48s)
--- PASS: TestAccAWSAppsyncGraphqlApi_basic (15.98s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (16.57s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig (18.23s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (19.62s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (24.53s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Name (24.83s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (25.98s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (27.21s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (28.95s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (30.05s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType (34.07s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Tags (35.48s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (35.77s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (35.88s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (37.19s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (37.99s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Schema (40.27s)
PASS
...
```