### PR TITLE
Correctly refresh VGW attachment state

### DIFF
--- a/aws/resource_aws_vpn_gateway.go
+++ b/aws/resource_aws_vpn_gateway.go
@@ -104,7 +104,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	vpnAttachment := vpnGatewayGetAttachment(vpnGateway)
-	if len(vpnGateway.VpcAttachments) == 0 || *vpnAttachment.State == "detached" {
+	if vpnAttachment == nil {
 		// Gateway exists but not attached to the VPC
 		d.Set("vpc_id", "")
 	} else {
@@ -181,7 +181,9 @@ func resourceAwsVpnGatewayDelete(d *schema.ResourceData, meta interface{}) error
 func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	if d.Get("vpc_id").(string) == "" {
+	vpcId := d.Get("vpc_id").(string)
+
+	if vpcId == "" {
 		log.Printf(
 			"[DEBUG] Not attaching VPN Gateway '%s' as no VPC ID is set",
 			d.Id())
@@ -191,11 +193,11 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 	log.Printf(
 		"[INFO] Attaching VPN Gateway '%s' to VPC '%s'",
 		d.Id(),
-		d.Get("vpc_id").(string))
+		vpcId)
 
 	req := &ec2.AttachVpnGatewayInput{
 		VpnGatewayId: aws.String(d.Id()),
-		VpcId:        aws.String(d.Get("vpc_id").(string)),
+		VpcId:        aws.String(vpcId),
 	}
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
@@ -218,7 +220,7 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"detached", "attaching"},
 		Target:  []string{"attached"},
-		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id()),
+		Refresh: vpnGatewayAttachmentStateRefresh(conn, vpcId, d.Id()),
 		Timeout: 15 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -234,9 +236,10 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*AWSClient).ec2conn
 
 	// Get the old VPC ID to detach from
-	vpcID, _ := d.GetChange("vpc_id")
+	vpcIdRaw, _ := d.GetChange("vpc_id")
+	vpcId := vpcIdRaw.(string)
 
-	if vpcID.(string) == "" {
+	if vpcId == "" {
 		log.Printf(
 			"[DEBUG] Not detaching VPN Gateway '%s' as no VPC ID is set",
 			d.Id())
@@ -246,12 +249,12 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 	log.Printf(
 		"[INFO] Detaching VPN Gateway '%s' from VPC '%s'",
 		d.Id(),
-		vpcID.(string))
+		vpcId)
 
 	wait := true
 	_, err := conn.DetachVpnGateway(&ec2.DetachVpnGatewayInput{
 		VpnGatewayId: aws.String(d.Id()),
-		VpcId:        aws.String(vpcID.(string)),
+		VpcId:        aws.String(vpcId),
 	})
 	if err != nil {
 		ec2err, ok := err.(awserr.Error)
@@ -279,7 +282,7 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"attached", "detaching", "available"},
 		Target:  []string{"detached"},
-		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id()),
+		Refresh: vpnGatewayAttachmentStateRefresh(conn, vpcId, d.Id()),
 		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
@@ -291,50 +294,12 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-// vpnGatewayAttachStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
-// the state of a VPN gateway's attachment
-func vpnGatewayAttachStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
-	var start time.Time
-	return func() (interface{}, string, error) {
-		if start.IsZero() {
-			start = time.Now()
-		}
-
-		resp, err := conn.DescribeVpnGateways(&ec2.DescribeVpnGatewaysInput{
-			VpnGatewayIds: []*string{aws.String(id)},
-		})
-
-		if err != nil {
-			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnGatewayID.NotFound" {
-				resp = nil
-			} else {
-				log.Printf("[ERROR] Error on VpnGatewayStateRefresh: %s", err)
-				return nil, "", err
-			}
-		}
-
-		if resp == nil {
-			// Sometimes AWS just has consistency issues and doesn't see
-			// our instance yet. Return an empty state.
-			return nil, "", nil
-		}
-
-		vpnGateway := resp.VpnGateways[0]
-		if len(vpnGateway.VpcAttachments) == 0 {
-			// No attachments, we're detached
-			return vpnGateway, "detached", nil
-		}
-
-		vpnAttachment := vpnGatewayGetAttachment(vpnGateway)
-		return vpnGateway, *vpnAttachment.State, nil
-	}
-}
-
+// vpnGatewayGetAttachment returns any VGW attachment that's in "attached" state or nil.
 func vpnGatewayGetAttachment(vgw *ec2.VpnGateway) *ec2.VpcAttachment {
-	for _, v := range vgw.VpcAttachments {
-		if *v.State == "attached" {
-			return v
+	for _, vpcAttachment := range vgw.VpcAttachments {
+		if aws.StringValue(vpcAttachment.State) == ec2.AttachmentStatusAttached {
+			return vpcAttachment
 		}
 	}
-	return &ec2.VpcAttachment{State: aws.String("detached")}
+	return nil
 }

--- a/aws/resource_aws_vpn_gateway_attachment.go
+++ b/aws/resource_aws_vpn_gateway_attachment.go
@@ -101,7 +101,7 @@ func resourceAwsVpnGatewayAttachmentRead(d *schema.ResourceData, meta interface{
 	}
 
 	vga := vpnGatewayGetAttachment(vgw)
-	if len(vgw.VpcAttachments) == 0 || *vga.State == "detached" {
+	if vga == nil {
 		d.Set("vpc_id", "")
 		return nil
 	}
@@ -163,12 +163,9 @@ func resourceAwsVpnGatewayAttachmentDelete(d *schema.ResourceData, meta interfac
 func vpnGatewayAttachmentStateRefresh(conn *ec2.EC2, vpcId, vgwId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := conn.DescribeVpnGateways(&ec2.DescribeVpnGatewaysInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("attachment.vpc-id"),
-					Values: []*string{aws.String(vpcId)},
-				},
-			},
+			Filters: buildEC2AttributeFilterList(map[string]string{
+				"attachment.vpc-id": vpcId,
+			}),
 			VpnGatewayIds: []*string{aws.String(vgwId)},
 		})
 
@@ -187,15 +184,19 @@ func vpnGatewayAttachmentStateRefresh(conn *ec2.EC2, vpcId, vgwId string) resour
 		}
 
 		vgw := resp.VpnGateways[0]
-		if len(vgw.VpcAttachments) == 0 {
-			return vgw, "detached", nil
-		}
 
-		vga := vpnGatewayGetAttachment(vgw)
-
-		log.Printf("[DEBUG] VPN Gateway %q attachment status: %s", vgwId, *vga.State)
-		return vgw, *vga.State, nil
+		return vgw, vpnGatewayGetAttachmentState(vgw, vpcId), nil
 	}
+}
+
+// vpnGatewayGetAttachmentState returns the state of any VGW attachment to the specified VPC or "detached".
+func vpnGatewayGetAttachmentState(vgw *ec2.VpnGateway, vpcId string) string {
+	for _, vpcAttachment := range vgw.VpcAttachments {
+		if aws.StringValue(vpcAttachment.VpcId) == vpcId {
+			return aws.StringValue(vpcAttachment.State)
+		}
+	}
+	return ec2.AttachmentStatusDetached
 }
 
 func vpnGatewayAttachmentId(vpcId, vgwId string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8575.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpnGatewayAttachment_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSVpnGatewayAttachment_ -timeout 120m
=== RUN   TestAccAWSVpnGatewayAttachment_basic
=== PAUSE TestAccAWSVpnGatewayAttachment_basic
=== RUN   TestAccAWSVpnGatewayAttachment_deleted
=== PAUSE TestAccAWSVpnGatewayAttachment_deleted
=== CONT  TestAccAWSVpnGatewayAttachment_basic
=== CONT  TestAccAWSVpnGatewayAttachment_deleted
--- PASS: TestAccAWSVpnGatewayAttachment_basic (65.76s)
--- PASS: TestAccAWSVpnGatewayAttachment_deleted (85.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	85.673s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSVpnGateway_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 2 -run=TestAccAWSVpnGateway_ -timeout 120m
=== RUN   TestAccAWSVpnGateway_importBasic
=== PAUSE TestAccAWSVpnGateway_importBasic
=== RUN   TestAccAWSVpnGateway_basic
=== PAUSE TestAccAWSVpnGateway_basic
=== RUN   TestAccAWSVpnGateway_withAvailabilityZoneSetToState
=== PAUSE TestAccAWSVpnGateway_withAvailabilityZoneSetToState
=== RUN   TestAccAWSVpnGateway_withAmazonSideAsnSetToState
=== PAUSE TestAccAWSVpnGateway_withAmazonSideAsnSetToState
=== RUN   TestAccAWSVpnGateway_disappears
=== PAUSE TestAccAWSVpnGateway_disappears
=== RUN   TestAccAWSVpnGateway_reattach
=== PAUSE TestAccAWSVpnGateway_reattach
=== RUN   TestAccAWSVpnGateway_delete
=== PAUSE TestAccAWSVpnGateway_delete
=== RUN   TestAccAWSVpnGateway_tags
=== PAUSE TestAccAWSVpnGateway_tags
=== CONT  TestAccAWSVpnGateway_importBasic
=== CONT  TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGateway_importBasic (90.23s)
=== CONT  TestAccAWSVpnGateway_delete
--- PASS: TestAccAWSVpnGateway_delete (105.04s)
=== CONT  TestAccAWSVpnGateway_withAmazonSideAsnSetToState
--- PASS: TestAccAWSVpnGateway_reattach (212.81s)
=== CONT  TestAccAWSVpnGateway_disappears
--- PASS: TestAccAWSVpnGateway_withAmazonSideAsnSetToState (50.69s)
=== CONT  TestAccAWSVpnGateway_withAvailabilityZoneSetToState
--- PASS: TestAccAWSVpnGateway_disappears (50.12s)
=== CONT  TestAccAWSVpnGateway_basic
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (50.81s)
=== CONT  TestAccAWSVpnGateway_tags
--- PASS: TestAccAWSVpnGateway_basic (92.95s)
--- PASS: TestAccAWSVpnGateway_tags (76.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	373.757s
```
