### PR TITLE
d/lambda_layer_version: Add Lambda Layer Version datasource

### DIFF
--- a/aws/data_source_aws_lambda_layer_version.go
+++ b/aws/data_source_aws_lambda_layer_version.go
@@ -1,0 +1,150 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func dataSourceAwsLambdaLayerVersion() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsLambdaLayerVersionRead,
+
+		Schema: map[string]*schema.Schema{
+			"layer_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"compatible_runtimes"},
+			},
+			"compatible_runtime": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  validation.StringInSlice(validLambdaRuntimes, false),
+				ConflictsWith: []string{"version"},
+			},
+			"compatible_runtimes": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"license_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"layer_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_code_hash": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_code_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsLambdaLayerVersionRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lambdaconn
+	layerName := d.Get("layer_name").(string)
+
+	var version int64
+
+	if v, ok := d.GetOk("version"); ok {
+		version = int64(v.(int))
+	} else {
+		listInput := &lambda.ListLayerVersionsInput{
+			LayerName: aws.String(layerName),
+		}
+		if v, ok := d.GetOk("compatible_runtime"); ok {
+			listInput.CompatibleRuntime = aws.String(v.(string))
+		}
+
+		log.Printf("[DEBUG] Looking up latest version for lambda layer %s", layerName)
+		listOutput, err := conn.ListLayerVersions(listInput)
+		if err != nil {
+			return fmt.Errorf("error listing Lambda Layer Versions (%s): %s", layerName, err)
+		}
+
+		if len(listOutput.LayerVersions) == 0 {
+			return fmt.Errorf("error listing Lambda Layer Versions (%s): empty response", layerName)
+		}
+
+		version = aws.Int64Value(listOutput.LayerVersions[0].Version)
+	}
+
+	input := &lambda.GetLayerVersionInput{
+		LayerName:     aws.String(layerName),
+		VersionNumber: aws.Int64(version),
+	}
+
+	log.Printf("[DEBUG] Getting Lambda Layer Version: %s, version %d", layerName, version)
+	output, err := conn.GetLayerVersion(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Lambda Layer Version (%s, version %d): %s", layerName, version, err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Lambda Layer Version (%s, version %d): empty response", layerName, version)
+	}
+
+	if err := d.Set("version", int(aws.Int64Value(output.Version))); err != nil {
+		return fmt.Errorf("error setting lambda layer version: %s", err)
+	}
+	if err := d.Set("compatible_runtimes", flattenStringList(output.CompatibleRuntimes)); err != nil {
+		return fmt.Errorf("error setting lambda layer compatible runtimes: %s", err)
+	}
+	if err := d.Set("description", output.Description); err != nil {
+		return fmt.Errorf("error setting lambda layer description: %s", err)
+	}
+	if err := d.Set("license_info", output.LicenseInfo); err != nil {
+		return fmt.Errorf("error setting lambda layer license info: %s", err)
+	}
+	if err := d.Set("arn", output.LayerVersionArn); err != nil {
+		return fmt.Errorf("error setting lambda layer version arn: %s", err)
+	}
+	if err := d.Set("layer_arn", output.LayerArn); err != nil {
+		return fmt.Errorf("error setting lambda layer arn: %s", err)
+	}
+	if err := d.Set("created_date", output.CreatedDate); err != nil {
+		return fmt.Errorf("error setting lambda layer created date: %s", err)
+	}
+	if err := d.Set("source_code_hash", output.Content.CodeSha256); err != nil {
+		return fmt.Errorf("error setting lambda layer source code hash: %s", err)
+	}
+	if err := d.Set("source_code_size", output.Content.CodeSize); err != nil {
+		return fmt.Errorf("error setting lambda layer source code size: %s", err)
+	}
+
+	d.SetId(aws.StringValue(output.LayerVersionArn))
+
+	return nil
+}

--- a/aws/data_source_aws_lambda_layer_version_test.go
+++ b/aws/data_source_aws_lambda_layer_version_test.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAWSLambdaLayerVersion_basic(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_lambda_layer_version.test"
+	resourceName := "aws_lambda_layer_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaLayerVersionConfigBasic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "layer_name", resourceName, "layer_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "compatible_runtimes.%", resourceName, "compatible_runtimes.%s"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "license_info", resourceName, "license_info"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "layer_arn", resourceName, "layer_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "created_date", resourceName, "created_date"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "source_code_hash", resourceName, "source_code_hash"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "source_code_size", resourceName, "source_code_size"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSLambdaLayerVersion_version(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_lambda_layer_version.test"
+	resourceName := "aws_lambda_layer_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaLayerVersionConfigVersion(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "layer_name", resourceName, "layer_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSLambdaLayerVersion_runtime(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	dataSourceName := "data.aws_lambda_layer_version.test"
+	resourceName := "aws_lambda_layer_version.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSLambdaLayerVersionConfigRuntimes(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "layer_name", resourceName, "layer_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSLambdaLayerVersionConfigBasic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "test" {
+  filename = "test-fixtures/lambdatest.zip"
+  layer_name = %[1]q
+  compatible_runtimes = ["nodejs8.10"]
+}
+
+data "aws_lambda_layer_version" "test" {
+  layer_name = "${aws_lambda_layer_version.test.layer_name}"
+}
+`, rName)
+}
+
+func testAccDataSourceAWSLambdaLayerVersionConfigVersion(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "test" {
+  filename = "test-fixtures/lambdatest.zip"
+  layer_name = %[1]q
+  compatible_runtimes = ["nodejs8.10"]
+}
+
+resource "aws_lambda_layer_version" "test_two" {
+  filename = "test-fixtures/lambdatest_modified.zip"
+  layer_name = %[1]q
+  compatible_runtimes = ["nodejs8.10"]
+}
+
+data "aws_lambda_layer_version" "test" {
+  layer_name = "${aws_lambda_layer_version.test_two.layer_name}"
+  version = "${aws_lambda_layer_version.test.version}"
+}
+`, rName)
+}
+
+func testAccDataSourceAWSLambdaLayerVersionConfigRuntimes(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_lambda_layer_version" "test" {
+  filename = "test-fixtures/lambdatest.zip"
+  layer_name = %[1]q
+  compatible_runtimes = ["go1.x"]
+}
+
+resource "aws_lambda_layer_version" "test_two" {
+  filename = "test-fixtures/lambdatest_modified.zip"
+  layer_name = "${aws_lambda_layer_version.test.layer_name}"
+  compatible_runtimes = ["nodejs8.10"]
+}
+
+data "aws_lambda_layer_version" "test" {
+  layer_name = "${aws_lambda_layer_version.test_two.layer_name}"
+  compatible_runtime = "go1.x"
+}
+`, rName)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -221,6 +221,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_kms_secrets":                        dataSourceAwsKmsSecrets(),
 			"aws_lambda_function":                    dataSourceAwsLambdaFunction(),
 			"aws_lambda_invocation":                  dataSourceAwsLambdaInvocation(),
+			"aws_lambda_layer_version":               dataSourceAwsLambdaLayerVersion(),
 			"aws_launch_configuration":               dataSourceAwsLaunchConfiguration(),
 			"aws_launch_template":                    dataSourceAwsLaunchTemplate(),
 			"aws_mq_broker":                          dataSourceAwsMqBroker(),

--- a/website/docs/d/lambda_layer_version.html.markdown
+++ b/website/docs/d/lambda_layer_version.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lambda_layer_version"
+sidebar_current: "docs-aws-datasource-lambda-layer-version"
+description: |-
+  Provides a Lambda Layer Version data source.
+---
+
+# aws_lambda_layer_version
+
+Provides information about a Lambda Layer Version.
+
+## Example Usage
+
+```hcl
+variable "layer_name" {
+  type = "string"
+}
+
+data "aws_lambda_layer_version" "existing" {
+  layer_name = "${var.layer_name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `layer_name` - (Required) Name of the lambda layer.
+* `version` - (Optional) Specific layer version. Conflicts with `compatible_runtime`. If omitted, the latest available layer version will be used.
+* `compatible_runtime` (Optional) Specific runtime the layer version must support. Conflicts with `version`. If specified, the latest available layer version supporting the provided runtime will be used.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - Description of the specific Lambda Layer version.
+* `license_info` - License info associated with the specific Lambda Layer version.
+* `compatible_runtimes` - A list of [Runtimes][1] the specific Lambda Layer version is compatible with.
+* `arn` - The Amazon Resource Name (ARN) of the Lambda Layer with version.
+* `layer_arn` - The Amazon Resource Name (ARN) of the Lambda Layer without version.
+* `created_date` - The date this resource was created.
+* `source_code_hash` - Base64-encoded representation of raw SHA-256 sum of the zip file.
+* `source_code_size` - The size in bytes of the function .zip file.
+* `version` - This Lamba Layer version.
+
+[1]: https://docs.aws.amazon.com/lambda/latest/dg/API_GetLayerVersion.html#SSS-GetLayerVersion-response-CompatibleRuntimes
+


### PR DESCRIPTION
refs #6651
- add lambda_layer_version datasource & related documentation

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
**New Data Source:** `aws_lambda_layer_version`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAWSLambdaLayerVersion'
--- PASS: TestAccDataSourceAWSLambdaLayerVersion_basic (22.10s)
--- PASS: TestAccDataSourceAWSLambdaLayerVersion_version (30.01s)
--- PASS: TestAccDataSourceAWSLambdaLayerVersion_runtime (35.94s)
PASS
```
