### PR TITLE
resource/aws_organizations_organization: Add accounts attribute

### DIFF
--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -2,12 +2,13 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
-	"testing"
 )
 
 func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
@@ -23,6 +24,10 @@ func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
 				Config: testAccAwsOrganizationsOrganizationConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationExists(resourceName, &organization),
+					resource.TestCheckResourceAttr(resourceName, "accounts.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "accounts.0.arn", resourceName, "master_account_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "accounts.0.email", resourceName, "master_account_email"),
+					resource.TestCheckResourceAttrPair(resourceName, "accounts.0.id", resourceName, "master_account_id"),
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "organizations", regexp.MustCompile(`organization/o-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "aws_service_access_principals.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "feature_set", organizations.OrganizationFeatureSetAll),

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -34,6 +34,11 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `accounts` - List of organization accounts (including the master account). All elements have these attributes:
+  * `arn` - ARN of the account
+  * `email` - Email of the account
+  * `id` - Identifier of the account
+  * `name` - Name of the account
 * `arn` - ARN of the organization
 * `id` - Identifier of the organization
 * `master_account_arn` - ARN of the master account


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8579

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_organizations_organization: Add accounts attribute
```

Output from acceptance testing:

```
    --- PASS: TestAccAWSOrganizations/Organization (49.62s)
        --- PASS: TestAccAWSOrganizations/Organization/basic (14.16s)
        --- PASS: TestAccAWSOrganizations/Organization/AwsServiceAccessPrincipals (25.03s)
        --- PASS: TestAccAWSOrganizations/Organization/FeatureSet (10.43s)
```
