### PR TITLE
resource/aws_organizations_organizational_unit: Add accounts attribute

### DIFF
--- a/aws/resource_aws_organizations_organizational_unit_test.go
+++ b/aws/resource_aws_organizations_organizational_unit_test.go
@@ -27,6 +27,7 @@ func testAccAwsOrganizationsOrganizationalUnit_basic(t *testing.T) {
 				Config: testAccAwsOrganizationsOrganizationalUnitConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsOrganizationalUnitExists(resourceName, &unit),
+					resource.TestCheckResourceAttr(resourceName, "accounts.#", "0"),
 					testAccMatchResourceAttrGlobalARN(resourceName, "arn", "organizations", regexp.MustCompile(`ou/o-.+/ou-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 				),

--- a/website/docs/r/organizations_organizational_unit.html.markdown
+++ b/website/docs/r/organizations_organizational_unit.html.markdown
@@ -30,6 +30,11 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `accounts` - List of child accounts for this Organizational Unit. Does not return account information for child Organizational Units. All elements have these attributes:
+  * `arn` - ARN of the account
+  * `email` - Email of the account
+  * `id` - Identifier of the account
+  * `name` - Name of the account
 * `arn` - ARN of the organizational unit
 * `id` - Identifier of the organization unit
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8580

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_organizations_organizational_unit: Add accounts attribute
```

Output from acceptance testing:

```
    --- PASS: TestAccAWSOrganizations/OrganizationalUnit (41.04s)
        --- PASS: TestAccAWSOrganizations/OrganizationalUnit/basic (18.46s)
        --- PASS: TestAccAWSOrganizations/OrganizationalUnit/Name (22.58s)
```
