### PR TITLE
resource/aws_organizations_account: Add parent_id argument (support moving accounts)

### DIFF
--- a/aws/resource_aws_organizations_account.go
+++ b/aws/resource_aws_organizations_account.go
@@ -35,6 +35,10 @@ func resourceAwsOrganizationsAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"parent_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -161,6 +165,13 @@ func resourceAwsOrganizationsAccountRead(d *schema.ResourceData, meta interface{
 	d.Set("joined_timestamp", account.JoinedTimestamp)
 	d.Set("name", account.Name)
 	d.Set("status", account.Status)
+
+	parentId, err := resourceAwsOrganizationsUnitGetParentId(conn, d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("parent_id", parentId)
+
 	return nil
 }
 

--- a/aws/resource_aws_organizations_account_test.go
+++ b/aws/resource_aws_organizations_account_test.go
@@ -36,6 +36,7 @@ func testAccAwsOrganizationsAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "arn"),
 					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "joined_method"),
 					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "joined_timestamp"),
+					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "parent_id"),
 					resource.TestCheckResourceAttr("aws_organizations_account.test", "name", name),
 					resource.TestCheckResourceAttr("aws_organizations_account.test", "email", email),
 					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "status"),

--- a/aws/resource_aws_organizations_account_test.go
+++ b/aws/resource_aws_organizations_account_test.go
@@ -51,6 +51,65 @@ func testAccAwsOrganizationsAccount_basic(t *testing.T) {
 	})
 }
 
+func testAccAwsOrganizationsAccount_parentRoot(t *testing.T) {
+	var account organizations.Account
+
+	orgsEmailDomain, ok := os.LookupEnv("TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN")
+
+	if !ok {
+		t.Skip("'TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN' not set, skipping test.")
+	}
+
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("tf_acctest_%d", rInt)
+	email := fmt.Sprintf("tf-acctest+%d@%s", rInt, orgsEmailDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsAccountConfigUnderRoot(name, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsAccountExists("aws_organizations_account.test", &account),
+					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "parent_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsOrganizationsAccount_parentOU(t *testing.T) {
+	var account organizations.Account
+
+	orgsEmailDomain, ok := os.LookupEnv("TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN")
+
+	if !ok {
+		t.Skip("'TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN' not set, skipping test.")
+	}
+
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("tf_acctest_%d", rInt)
+	email := fmt.Sprintf("tf-acctest+%d@%s", rInt, orgsEmailDomain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsAccountConfigUnderOU(name, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsAccountExists("aws_organizations_account.test", &account),
+					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "parent_id"),
+					// TODO actually check that it lives under the parent
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAwsOrganizationsAccountDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).organizationsconn
 
@@ -117,4 +176,37 @@ resource "aws_organizations_account" "test" {
   email = "%s"
 }
 `, name, email)
+}
+
+func testAccAwsOrganizationsAccountConfigUnderRoot(name, email string) string {
+	return fmt.Sprintf(`
+data "aws_organizations_unit" "root" {
+  root = true
+}
+
+resource "aws_organizations_account" "test" {
+  name = "%s"
+  email = "%s"
+  parent_id = "${data.aws_organizations_unit.root.id}"
+}
+`, name, email)
+}
+
+func testAccAwsOrganizationsAccountConfigUnderOU(name, email string) string {
+	return fmt.Sprintf(`
+data "aws_organizations_unit" "root" {
+  root = true
+}
+
+resource "aws_organizations_unit" "test" {
+  parent_id = "${data.aws_organizations_unit.root.id}"
+  name = "%s"
+}
+
+resource "aws_organizations_account" "test" {
+  name = "%s"
+  email = "%s"
+  parent_id = "${aws_organizations_unit.test.id}"
+}
+`, name, name, email)
 }

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -12,7 +12,9 @@ func TestAccAWSOrganizations(t *testing.T) {
 			"FeatureSet":                 testAccAwsOrganizationsOrganization_FeatureSet,
 		},
 		"Account": {
-			"basic": testAccAwsOrganizationsAccount_basic,
+			"basic":      testAccAwsOrganizationsAccount_basic,
+			"parentRoot": testAccAwsOrganizationsAccount_parentRoot,
+			"parentOU":   testAccAwsOrganizationsAccount_parentOU,
 		},
 		"OrganizationalUnit": {
 			"basic": testAccAwsOrganizationsOrganizationalUnit_basic,

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -12,9 +12,8 @@ func TestAccAWSOrganizations(t *testing.T) {
 			"FeatureSet":                 testAccAwsOrganizationsOrganization_FeatureSet,
 		},
 		"Account": {
-			"basic":      testAccAwsOrganizationsAccount_basic,
-			"parentRoot": testAccAwsOrganizationsAccount_parentRoot,
-			"parentOU":   testAccAwsOrganizationsAccount_parentOU,
+			"basic":    testAccAwsOrganizationsAccount_basic,
+			"ParentId": testAccAwsOrganizationsAccount_ParentId,
 		},
 		"OrganizationalUnit": {
 			"basic": testAccAwsOrganizationsOrganizationalUnit_basic,

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN for this account.
+* `parent_id` - The ID of the "root" the account is under.
 
 * `id` - The AWS account id
 

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 * `name` - (Required) A friendly name for the member account.
 * `email` - (Required) The email address of the owner to assign to the new member account. This email address must not already be associated with another AWS account.
 * `iam_user_access_to_billing` - (Optional) If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information.
-* `parent_id` - (Optional) The ID of the Organizational Unit or "root" the account should be under. Defaults to the root ID.
+* `parent_id` - (Optional) Parent Organizational Unit ID or Root ID for the account. Defaults to the Organization default Root ID. A configuration must be present for this argument to perform drift detection.
 * `role_name` - (Optional) The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the master account, allowing users in the master account to assume the role, as permitted by the master account administrator. The role has administrator permissions in the new member account.
 
 ## Attributes Reference
@@ -38,7 +38,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN for this account.
-
 * `id` - The AWS account id
 
 ## Import

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 * `name` - (Required) A friendly name for the member account.
 * `email` - (Required) The email address of the owner to assign to the new member account. This email address must not already be associated with another AWS account.
 * `iam_user_access_to_billing` - (Optional) If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information.
+* `parent_id` - (Optional) The ID of the Organizational Unit or "root" the account should be under. Defaults to the root ID.
 * `role_name` - (Optional) The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the master account, allowing users in the master account to assume the role, as permitted by the master account administrator. The role has administrator permissions in the new member account.
 
 ## Attributes Reference
@@ -37,7 +38,6 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - The ARN for this account.
-* `parent_id` - The ID of the "root" the account is under.
 
 * `id` - The AWS account id
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Includes 2 relevant commits from #4405
Closes #8281 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_organizations_account: Add parent_id argument (support moving accounts)
```

Please note that automated acceptance testing is not currently possible with this resource, due to manual steps required to remove an account from an organization: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html

These changes were manually verified via the following.

Given an existing configuration, previously applied with version 2.9.0 of the Terraform AWS Provider:

```hcl
resource "aws_organizations_organization" "organization" {
  feature_set = "ALL"
}

resource "aws_organizations_account" "bflad-dev1" {
  name  = "bflad-dev1"
  email = "--OMITTED--"
}

resource "aws_organizations_account" "bflad-dev2" {
  name  = "bflad-dev2"
  email = "--OMITTED--"
}
```

Overwrite Terraform AWS Provider binary including this changeset, ensure plan shows no changes, and ensure `parent_id` is properly written to Terraform state:

```console
$ cp ~/go/bin/terraform-provider-aws .terraform/plugins/darwin_amd64/terraform-provider-aws_v2.9.0_x4
$ terraform init
...
$ terraform plan
...
aws_organizations_organization.organization: Refreshing state... (ID: o-p687o6l073)
aws_organizations_account.bflad-dev2: Refreshing state... (ID: --OMITTED--)
aws_organizations_account.bflad-dev1: Refreshing state... (ID: --OMITTED--)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.
$ terraform refresh
...
$ terraform state show aws_organizations_account.bflad-dev1 | grep parent_id
parent_id     = r-cg2b
```

Add organizational unit to configuration and add `parent_id` to an existing account pointing to it:

```hcl
resource "aws_organizations_organization" "organization" {
  feature_set = "ALL"
}

resource "aws_organizations_organizational_unit" "test1" {
  name      = "test1"
  parent_id = "${aws_organizations_organization.organization.roots.0.id}"
}

resource "aws_organizations_account" "bflad-dev1" {
  name      = "bflad-dev1"
  email     = "--OMITTED--"
  parent_id = "${aws_organizations_organizational_unit.test1.id}"
}

resource "aws_organizations_account" "bflad-dev2" {
  name  = "bflad-dev2"
  email = "--OMITTED--"
}
```

Verifying `Update` functionality:

```
$ terraform apply
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_organizations_account.bflad-dev1
      parent_id: "r-cg2b" => "${aws_organizations_organizational_unit.test1.id}"

  + aws_organizations_organizational_unit.test1
      id:        <computed>
      arn:       <computed>
      name:      "test1"
      parent_id: "r-cg2b"


Plan: 1 to add, 1 to change, 0 to destroy.

...

aws_organizations_organizational_unit.test1: Creating...
  arn:       "" => "<computed>"
  name:      "" => "test1"
  parent_id: "" => "r-cg2b"
aws_organizations_organizational_unit.test1: Creation complete after 0s (ID: ou-cg2b-7aa8b56k)
aws_organizations_account.bflad-dev1: Modifying... (ID: --OMITTED--)
  parent_id: "r-cg2b" => "ou-cg2b-7aa8b56k"
aws_organizations_account.bflad-dev1: Modifications complete after 1s (ID: --OMITTED--)

$ terraform state show aws_organizations_account.bflad-dev1 | grep parent_id
parent_id     = ou-cg2b-7aa8b56k
```

Add account with `parent_id` to configuration:

```hcl
resource "aws_organizations_organization" "organization" {
  feature_set = "ALL"
}

resource "aws_organizations_organizational_unit" "test1" {
  name      = "test1"
  parent_id = "${aws_organizations_organization.organization.roots.0.id}"
}

resource "aws_organizations_account" "bflad-dev1" {
  name      = "bflad-dev1"
  email     = "--OMITTED--"
  parent_id = "${aws_organizations_organizational_unit.test1.id}"
}

resource "aws_organizations_account" "bflad-dev2" {
  name  = "bflad-dev2"
  email = "--OMITTED--"
}

resource "aws_organizations_account" "bflad-dev3" {
  name      = "bflad-dev3"
  email     = "--OMITTED--"
  parent_id = "${aws_organizations_organizational_unit.test1.id}"
}
```

Verifying `Create` functionality:

```
$ terraform apply
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + aws_organizations_account.bflad-dev3
      id:               <computed>
      arn:              <computed>
      email:            "--OMITTED--"
      joined_method:    <computed>
      joined_timestamp: <computed>
      name:             "bflad-dev3"
      parent_id:        "ou-cg2b-7aa8b56k"
      status:           <computed>


Plan: 1 to add, 0 to change, 0 to destroy.

...

aws_organizations_account.bflad-dev3: Creating...
  arn:              "" => "<computed>"
  email:            "" => "--OMITTED--"
  joined_method:    "" => "<computed>"
  joined_timestamp: "" => "<computed>"
  name:             "" => "bflad-dev3"
  parent_id:        "" => "ou-cg2b-7aa8b56k"
  status:           "" => "<computed>"
aws_organizations_account.bflad-dev3: Still creating... (10s elapsed)
aws_organizations_account.bflad-dev3: Creation complete after 12s (ID: --OMITTED--)
$ terraform state show aws_organizations_account.bflad-dev3 | grep parent_id
parent_id     = ou-cg2b-7aa8b56k
```
