### PR TITLE
resource/aws_organizations_organization: Add enabled_policy_types argument

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -224,7 +224,7 @@ func resourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta inter
 	enabledPolicyTypes := make([]string, 0)
 
 	for _, policyType := range roots[0].PolicyTypes {
-		if aws.StringValue(policyType.Status) == organizations.PolicyTypeStatusEnabled || aws.StringValue(policyType.Status) == organizations.PolicyTypeStatusPendingEnable {
+		if aws.StringValue(policyType.Status) == organizations.PolicyTypeStatusEnabled {
 			enabledPolicyTypes = append(enabledPolicyTypes, aws.StringValue(policyType.Type))
 		}
 	}
@@ -300,7 +300,7 @@ func resourceAwsOrganizationsOrganizationUpdate(d *schema.ResourceData, meta int
 			policyType := v.(string)
 			input := &organizations.EnablePolicyTypeInput{
 				PolicyType: aws.String(policyType),
-				RootId:     aws.String(d.Get("roots.0.id").(string)),
+				RootId:     aws.String(defaultRootID),
 			}
 
 			log.Printf("[DEBUG] Enabling Policy Type in Organization: %s", input)

--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -3,12 +3,16 @@ package aws
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
+
+const organizationsPolicyTypeStatusDisabled = "DISABLED"
 
 func resourceAwsOrganizationsOrganization() *schema.Resource {
 	return &schema.Resource{
@@ -78,6 +82,16 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 					},
 				},
 			},
+			"enabled_policy_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						organizations.PolicyTypeServiceControlPolicy,
+					}, false),
+				},
+			},
 			"feature_set": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -120,6 +134,32 @@ func resourceAwsOrganizationsOrganizationCreate(d *schema.ResourceData, meta int
 
 		if err != nil {
 			return fmt.Errorf("error enabling AWS Service Access (%s) in Organization: %s", principal, err)
+		}
+	}
+
+	enabledPolicyTypes := d.Get("enabled_policy_types").(*schema.Set).List()
+
+	if len(enabledPolicyTypes) > 0 {
+		defaultRoot, err := getOrganizationDefaultRoot(conn)
+
+		if err != nil {
+			return fmt.Errorf("error getting AWS Organization (%s) default root: %s", d.Id(), err)
+		}
+
+		for _, v := range enabledPolicyTypes {
+			enabledPolicyType := v.(string)
+			input := &organizations.EnablePolicyTypeInput{
+				PolicyType: aws.String(enabledPolicyType),
+				RootId:     defaultRoot.Id,
+			}
+
+			if _, err := conn.EnablePolicyType(input); err != nil {
+				return fmt.Errorf("error enabling policy type (%s) in Organization (%s): %s", enabledPolicyType, d.Id(), err)
+			}
+
+			if err := waitForOrganizationDefaultRootPolicyTypeEnable(conn, enabledPolicyType); err != nil {
+				return fmt.Errorf("error waiting for policy type (%s) enabling in Organization (%s): %s", enabledPolicyType, d.Id(), err)
+			}
 		}
 	}
 
@@ -181,6 +221,18 @@ func resourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("error setting aws_service_access_principals: %s", err)
 	}
 
+	enabledPolicyTypes := make([]string, 0)
+
+	for _, policyType := range roots[0].PolicyTypes {
+		if aws.StringValue(policyType.Status) == organizations.PolicyTypeStatusEnabled || aws.StringValue(policyType.Status) == organizations.PolicyTypeStatusPendingEnable {
+			enabledPolicyTypes = append(enabledPolicyTypes, aws.StringValue(policyType.Type))
+		}
+	}
+
+	if err := d.Set("enabled_policy_types", enabledPolicyTypes); err != nil {
+		return fmt.Errorf("error setting enabled_policy_types: %s", err)
+	}
+
 	return nil
 }
 
@@ -217,6 +269,47 @@ func resourceAwsOrganizationsOrganizationUpdate(d *schema.ResourceData, meta int
 
 			if err != nil {
 				return fmt.Errorf("error enabling AWS Service Access (%s) in Organization: %s", principal, err)
+			}
+		}
+	}
+
+	if d.HasChange("enabled_policy_types") {
+		defaultRootID := d.Get("roots.0.id").(string)
+		o, n := d.GetChange("enabled_policy_types")
+		oldSet := o.(*schema.Set)
+		newSet := n.(*schema.Set)
+
+		for _, v := range oldSet.Difference(newSet).List() {
+			policyType := v.(string)
+			input := &organizations.DisablePolicyTypeInput{
+				PolicyType: aws.String(policyType),
+				RootId:     aws.String(defaultRootID),
+			}
+
+			log.Printf("[DEBUG] Disabling Policy Type in Organization: %s", input)
+			if _, err := conn.DisablePolicyType(input); err != nil {
+				return fmt.Errorf("error disabling policy type (%s) in Organization (%s) Root (%s): %s", policyType, d.Id(), defaultRootID, err)
+			}
+
+			if err := waitForOrganizationDefaultRootPolicyTypeDisable(conn, policyType); err != nil {
+				return fmt.Errorf("error waiting for policy type (%s) disabling in Organization (%s) Root (%s): %s", policyType, d.Id(), defaultRootID, err)
+			}
+		}
+
+		for _, v := range newSet.Difference(oldSet).List() {
+			policyType := v.(string)
+			input := &organizations.EnablePolicyTypeInput{
+				PolicyType: aws.String(policyType),
+				RootId:     aws.String(d.Get("roots.0.id").(string)),
+			}
+
+			log.Printf("[DEBUG] Enabling Policy Type in Organization: %s", input)
+			if _, err := conn.EnablePolicyType(input); err != nil {
+				return fmt.Errorf("error enabling policy type (%s) in Organization (%s) Root (%s): %s", policyType, d.Id(), defaultRootID, err)
+			}
+
+			if err := waitForOrganizationDefaultRootPolicyTypeEnable(conn, policyType); err != nil {
+				return fmt.Errorf("error waiting for policy type (%s) enabling in Organization (%s) Root (%s): %s", policyType, d.Id(), defaultRootID, err)
 			}
 		}
 	}
@@ -265,4 +358,74 @@ func flattenOrganizationsRootPolicyTypeSummaries(summaries []*organizations.Poli
 		})
 	}
 	return result
+}
+
+func getOrganizationDefaultRoot(conn *organizations.Organizations) (*organizations.Root, error) {
+	var roots []*organizations.Root
+
+	err := conn.ListRootsPages(&organizations.ListRootsInput{}, func(page *organizations.ListRootsOutput, lastPage bool) bool {
+		roots = append(roots, page.Roots...)
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("no roots found")
+	}
+
+	return roots[0], nil
+}
+
+func getOrganizationDefaultRootPolicyTypeRefreshFunc(conn *organizations.Organizations, policyType string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		defaultRoot, err := getOrganizationDefaultRoot(conn)
+
+		if err != nil {
+			return nil, "", fmt.Errorf("error getting default root: %s", err)
+		}
+
+		for _, pt := range defaultRoot.PolicyTypes {
+			if aws.StringValue(pt.Type) == policyType {
+				return pt, aws.StringValue(pt.Status), nil
+			}
+		}
+
+		return &organizations.PolicyTypeSummary{}, organizationsPolicyTypeStatusDisabled, nil
+	}
+}
+
+func waitForOrganizationDefaultRootPolicyTypeDisable(conn *organizations.Organizations, policyType string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			organizations.PolicyTypeStatusEnabled,
+			organizations.PolicyTypeStatusPendingDisable,
+		},
+		Target:  []string{organizationsPolicyTypeStatusDisabled},
+		Refresh: getOrganizationDefaultRootPolicyTypeRefreshFunc(conn, policyType),
+		Timeout: 5 * time.Minute,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func waitForOrganizationDefaultRootPolicyTypeEnable(conn *organizations.Organizations, policyType string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			organizationsPolicyTypeStatusDisabled,
+			organizations.PolicyTypeStatusPendingEnable,
+		},
+		Target:  []string{organizations.PolicyTypeStatusEnabled},
+		Refresh: getOrganizationDefaultRootPolicyTypeRefreshFunc(conn, policyType),
+		Timeout: 5 * time.Minute,
+	}
+
+	_, err := stateConf.WaitForState()
+
+	return err
 }

--- a/aws/resource_aws_organizations_policy_attachment_test.go
+++ b/aws/resource_aws_organizations_policy_attachment_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAwsOrganizationsPolicyAttachment_account(t *testing.T) {
+func testAccAwsOrganizationsPolicyAttachment_Account(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_organizations_policy_attachment.test"
+	policyIdResourceName := "aws_organizations_policy.test"
+	targetIdResourceName := "aws_organizations_organization.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
@@ -25,8 +27,64 @@ func TestAccAwsOrganizationsPolicyAttachment_account(t *testing.T) {
 				Config: testAccAwsOrganizationsPolicyAttachmentConfig_Account(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "target_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id", policyIdResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_id", targetIdResourceName, "master_account_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsOrganizationsPolicyAttachment_OrganizationalUnit(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_organizations_policy_attachment.test"
+	policyIdResourceName := "aws_organizations_policy.test"
+	targetIdResourceName := "aws_organizations_organizational_unit.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsPolicyAttachmentConfig_OrganizationalUnit(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id", policyIdResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_id", targetIdResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAwsOrganizationsPolicyAttachment_Root(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_organizations_policy_attachment.test"
+	policyIdResourceName := "aws_organizations_policy.test"
+	targetIdResourceName := "aws_organizations_organization.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccOrganizationsAccountPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsPolicyAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsPolicyAttachmentConfig_Root(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id", policyIdResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_id", targetIdResourceName, "roots.0.id"),
 				),
 			},
 			{
@@ -68,15 +126,20 @@ func testAccCheckAwsOrganizationsPolicyAttachmentDestroy(s *terraform.State) err
 			return !lastPage
 		})
 
+		if isAWSErr(err, organizations.ErrCodeAWSOrganizationsNotInUseException, "") {
+			continue
+		}
+
+		if isAWSErr(err, organizations.ErrCodeTargetNotFoundException, "") {
+			continue
+		}
+
 		if err != nil {
-			if isAWSErr(err, organizations.ErrCodeTargetNotFoundException, "") {
-				return nil
-			}
 			return err
 		}
 
 		if output == nil {
-			return nil
+			continue
 		}
 
 		return fmt.Errorf("Policy attachment %q still exists", rs.Primary.ID)
@@ -131,16 +194,65 @@ func testAccCheckAwsOrganizationsPolicyAttachmentExists(resourceName string) res
 
 func testAccAwsOrganizationsPolicyAttachmentConfig_Account(rName string) string {
 	return fmt.Sprintf(`
-data "aws_caller_identity" "current" {}
+resource "aws_organizations_organization" "test" {
+  enabled_policy_types = ["SERVICE_CONTROL_POLICY"]
+}
 
 resource "aws_organizations_policy" "test" {
+  depends_on = ["aws_organizations_organization.test"]
+
   content     = "{\"Version\": \"2012-10-17\", \"Statement\": { \"Effect\": \"Allow\", \"Action\": \"*\", \"Resource\": \"*\"}}"
   name        = "%s"
 }
 
 resource "aws_organizations_policy_attachment" "test" {
   policy_id = "${aws_organizations_policy.test.id}"
-  target_id = "${data.aws_caller_identity.current.account_id}"
+  target_id = "${aws_organizations_organization.test.master_account_id}"
+}
+`, rName)
+}
+
+func testAccAwsOrganizationsPolicyAttachmentConfig_OrganizationalUnit(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {
+  enabled_policy_types = ["SERVICE_CONTROL_POLICY"]
+}
+
+resource "aws_organizations_organizational_unit" "test" {
+  name      = %[1]q
+  parent_id = "${aws_organizations_organization.test.roots.0.id}"
+}
+
+resource "aws_organizations_policy" "test" {
+  depends_on = ["aws_organizations_organization.test"]
+
+  content     = "{\"Version\": \"2012-10-17\", \"Statement\": { \"Effect\": \"Allow\", \"Action\": \"*\", \"Resource\": \"*\"}}"
+  name        = %[1]q
+}
+
+resource "aws_organizations_policy_attachment" "test" {
+  policy_id = "${aws_organizations_policy.test.id}"
+  target_id = "${aws_organizations_organizational_unit.test.id}"
+}
+`, rName)
+}
+
+func testAccAwsOrganizationsPolicyAttachmentConfig_Root(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {
+  enabled_policy_types = ["SERVICE_CONTROL_POLICY"]
+}
+
+resource "aws_organizations_policy" "test" {
+  depends_on = ["aws_organizations_organization.test"]
+
+  content     = "{\"Version\": \"2012-10-17\", \"Statement\": { \"Effect\": \"Allow\", \"Action\": \"*\", \"Resource\": \"*\"}}"
+  name        = %[1]q
+}
+
+resource "aws_organizations_policy_attachment" "test" {
+  policy_id = "${aws_organizations_policy.test.id}"
+  target_id = "${aws_organizations_organization.test.roots.0.id}"
 }
 `, rName)
 }

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -9,6 +9,7 @@ func TestAccAWSOrganizations(t *testing.T) {
 		"Organization": {
 			"basic":                      testAccAwsOrganizationsOrganization_basic,
 			"AwsServiceAccessPrincipals": testAccAwsOrganizationsOrganization_AwsServiceAccessPrincipals,
+			"EnabledPolicyTypes":         testAccAwsOrganizationsOrganization_EnabledPolicyTypes,
 			"FeatureSet":                 testAccAwsOrganizationsOrganization_FeatureSet,
 		},
 		"Account": {
@@ -17,6 +18,11 @@ func TestAccAWSOrganizations(t *testing.T) {
 		"OrganizationalUnit": {
 			"basic": testAccAwsOrganizationsOrganizationalUnit_basic,
 			"Name":  testAccAwsOrganizationsOrganizationalUnit_Name,
+		},
+		"PolicyAttachment": {
+			"Account":            testAccAwsOrganizationsPolicyAttachment_Account,
+			"OrganizationalUnit": testAccAwsOrganizationsPolicyAttachment_OrganizationalUnit,
+			"Root":               testAccAwsOrganizationsPolicyAttachment_Root,
 		},
 	}
 

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -28,6 +28,7 @@ resource "aws_organizations_organization" "org" {
 The following arguments are supported:
 
 * `aws_service_access_principals` - (Optional) List of AWS service principal names for which you want to enable integration with your organization. This is typically in the form of a URL, such as service-abbreviation.amazonaws.com. Organization must have `feature_set` set to `ALL`. For additional information, see the [AWS Organizations User Guide](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html).
+* `enabled_policy_types` - (Optional) List of Organizations policy types to enable in the Organization Root. Organization must have `feature_set` set to `ALL`. For additional information about valid policy types (e.g. `SERVICE_CONTROL_POLICY`), see the [AWS Organizations API Reference](https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnablePolicyType.html).
 * `feature_set` - (Optional) Specify "ALL" (default) or "CONSOLIDATED_BILLING".
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #4545

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_organizations_organization: Add enabled_policy_types argument
```

The `aws_organizations_policy_attachment` acceptance testing was previously written to assume that the account running it was already in an Organization, manually had enabled Service Control Policies in the Root, and did not check Root or Organizational Unit policy attachments as the appropriate attributes/resources did not previously exist. The updates to those tests now verify the SCP attachment workflow end-to-end with creating a new Organization, enabling SCPs, and SCP attachments to an account, Root, and OU.

Previous output from acceptance testing (before `enabled_policy_types` implementation):

```
    --- FAIL: TestAccAWSOrganizations/PolicyAttachment (37.12s)
        --- FAIL: TestAccAWSOrganizations/PolicyAttachment/Account (14.00s)
            testing.go:568: Step 0 error: errors during apply:

                Error: error creating Organizations Policy Attachment: PolicyTypeNotEnabledException: This operation can be performed only for enabled policy types.
                  status code: 400, request id: 381509e0-7225-11e9-b974-09edfb312bea

                  on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test737240811/main.tf line 11:
                  (source code not available)

        --- FAIL: TestAccAWSOrganizations/PolicyAttachment/OrganizationalUnit (10.85s)
            testing.go:568: Step 0 error: errors during apply:

                Error: error creating Organizations Policy Attachment: PolicyTypeNotEnabledException: This operation can be performed only for enabled policy types.
                  status code: 400, request id: 3f587964-7225-11e9-96c5-1d623fb91cbf

                  on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test570985045/main.tf line 16:
                  (source code not available)

        --- FAIL: TestAccAWSOrganizations/PolicyAttachment/Root (12.27s)
            testing.go:568: Step 0 error: errors during apply:

                Error: error creating Organizations Policy Attachment: PolicyTypeNotEnabledException: This operation can be performed only for enabled policy types.
                  status code: 400, request id: 46589efd-7225-11e9-b974-09edfb312bea

                  on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test865604943/main.tf line 11:
                  (source code not available)
```

Output from acceptance testing:

```
    --- PASS: TestAccAWSOrganizations/Organization (79.29s)
        --- PASS: TestAccAWSOrganizations/Organization/basic (13.66s)
        --- PASS: TestAccAWSOrganizations/Organization/AwsServiceAccessPrincipals (24.59s)
        --- PASS: TestAccAWSOrganizations/Organization/EnabledPolicyTypes (30.29s)
        --- PASS: TestAccAWSOrganizations/Organization/FeatureSet (10.75s)
    --- PASS: TestAccAWSOrganizations/PolicyAttachment (58.58s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/Account (21.28s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/OrganizationalUnit (20.48s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/Root (16.82s)
```
