### PR TITLE
Updates for go1.12 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 Developing the Provider
 ---------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is *required*). 
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (please check the [requirements](https://github.com/terraform-providers/terraform-provider-aws#requirements) before proceeding).
 
 *Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your home directory outside of the standard GOPATH (i.e `$HOME/development/terraform-providers/`). If you are using go1.11 please make sure that `GO111MODULE=on` is set.
 
@@ -69,7 +69,7 @@ ok   github.com/terraform-providers/terraform-provider-aws/aws  2.625s
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+*Note:* Acceptance tests create real resources, and often cost money to run. Please read [Running an Acceptance Test](https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#running-an-acceptance-test) in the contribution guidelines for more information on usage.
 
 ```sh
 $ make testacc

--- a/README.md
+++ b/README.md
@@ -13,40 +13,43 @@ Requirements
 - [Terraform](https://www.terraform.io/downloads.html) 0.10+
 - [Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
 
-Building the Provider
+Developing the Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-aws`
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is *required*). 
+
+*Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your home directory outside of the standard GOPATH (i.e `$HOME/development/terraform-providers/`). If you are using go1.11 please make sure that `GO111MODULE=on` is set.
+
+Clone repository to: `$HOME/development/terraform-providers/`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
+$ mkdir -p $HOME/development/terraform-providers/; cd $HOME/development/terraform-providers/
 $ git clone git@github.com:terraform-providers/terraform-provider-aws
+...
+Cloning into 'terraform-provider-aws'...
 ```
 
-Enter the provider directory and build the provider
+Enter the provider directory and run `make tools`. This will install the needed tools for the provider.
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-aws
-$ make build
+$ make tools
+...
 ```
-
-Using the Provider
-----------------------
-If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it. Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/aws/index.html).
-
-Developing the Provider
----------------------------
-
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
 $ make build
+==> Checking that code complies with gofmt requirements...
 ...
 $ $GOPATH/bin/terraform-provider-aws
 ...
 ```
+
+Using the Provider
+----------------------
+
+If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it. Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/aws/index.html).
 
 Testing the Provider
 ---------------------------
@@ -57,6 +60,11 @@ In order to test the provider, you can simply run `make test`.
 
 ```sh
 $ make test
+==> Checking that code complies with gofmt requirements...
+go test ./... -timeout=30s -parallel=4
+...
+ok   github.com/terraform-providers/terraform-provider-aws/aws  2.625s
+...
 ```
 
 In order to run the full suite of Acceptance tests, run `make testacc`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (please check the [requirements](https://github.com/terraform-providers/terraform-provider-aws#requirements) before proceeding).
 
-*Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your home directory outside of the standard GOPATH (i.e `$HOME/development/terraform-providers/`). If you are using Go 1.11, please make sure that `GO111MODULE=on` is set.
+*Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your home directory outside of the standard GOPATH (i.e `$HOME/development/terraform-providers/`).
 
 Clone repository to: `$HOME/development/terraform-providers/`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (please check the [requirements](https://github.com/terraform-providers/terraform-provider-aws#requirements) before proceeding).
 
-*Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your home directory outside of the standard GOPATH (i.e `$HOME/development/terraform-providers/`). If you are using go1.11 please make sure that `GO111MODULE=on` is set.
+*Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your home directory outside of the standard GOPATH (i.e `$HOME/development/terraform-providers/`). If you are using Go 1.11, please make sure that `GO111MODULE=on` is set.
 
 Clone repository to: `$HOME/development/terraform-providers/`
 
@@ -26,21 +26,18 @@ Clone repository to: `$HOME/development/terraform-providers/`
 $ mkdir -p $HOME/development/terraform-providers/; cd $HOME/development/terraform-providers/
 $ git clone git@github.com:terraform-providers/terraform-provider-aws
 ...
-Cloning into 'terraform-provider-aws'...
 ```
 
 Enter the provider directory and run `make tools`. This will install the needed tools for the provider.
 
 ```sh
 $ make tools
-...
 ```
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
 $ make build
-==> Checking that code complies with gofmt requirements...
 ...
 $ $GOPATH/bin/terraform-provider-aws
 ...
@@ -54,17 +51,12 @@ If you're building the provider, follow the instructions to [install it as a plu
 Testing the Provider
 ---------------------------
 
-In order to test the provider, you can simply run `make test`.
+In order to test the provider, you can run `make test`.
 
 *Note:* Make sure no `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` variables are set, and there's no `[default]` section in the AWS credentials file `~/.aws/credentials`.
 
 ```sh
 $ make test
-==> Checking that code complies with gofmt requirements...
-go test ./... -timeout=30s -parallel=4
-...
-ok   github.com/terraform-providers/terraform-provider-aws/aws  2.625s
-...
 ```
 
 In order to run the full suite of Acceptance tests, run `make testacc`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ $ $GOPATH/bin/terraform-provider-aws
 Using the Provider
 ----------------------
 
-If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it. Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/aws/index.html).
+To use a released provider in your Terraform environment, run [`terraform init`](https://www.terraform.io/docs/commands/init.html) and Terraform will automatically install the provider. To specify a particular provider version when installing released providers, see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#version-provider-versions).
+
+To instead use a custom-built provider in your Terraform environment (e.g. the provider binary from the build instructions above), follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it.
+
+For either installation method, documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/aws/index.html).
 
 Testing the Provider
 ---------------------------


### PR DESCRIPTION
This PR 
* gets rid of the redundancy present in the setup/install instructions
* updates the instructions for 1.12/modules