### PR TITLE
Documentation: Add note for aws_route53_zone_association indicating that out of band work is required for cross account vpc-zone associations.

### DIFF
--- a/website/docs/r/route53_zone_association.html.markdown
+++ b/website/docs/r/route53_zone_association.html.markdown
@@ -14,7 +14,7 @@ Manages a Route53 Hosted Zone VPC association. VPC associations can only be made
 
 ~> **NOTE:** Terraform provides both this standalone Zone VPC Association resource and exclusive VPC associations defined in-line in the [`aws_route53_zone` resource](/docs/providers/aws/r/route53_zone.html) via `vpc` configuration blocks. At this time, you cannot use those in-line VPC associations in conjunction with this resource and the same zone ID otherwise it will cause a perpetual difference in plan output. You can optionally use the generic Terraform resource [lifecycle configuration block](/docs/configuration/resources.html#lifecycle) with `ignore_changes` in the `aws_route53_zone` resource to manage additional associations via this resource.
 
-~> **NOTE:** This resource does not perform the `CreateVPCAssociationAuthorization` operation, which is necessary to perform a route53 zone association between vpcs in different AWS accounts. At the present time this operation must be done out of band of terraform or by using a provisioner. For more details on how to do this consult the [AWS Documentation on the matter](https://aws.amazon.com/premiumsupport/knowledge-center/private-hosted-zone-different-account/)
+~> **NOTE:** This resource does not perform the `CreateVPCAssociationAuthorization` operation, which is necessary to perform a route53 zone association between vpcs in different AWS accounts. At the present time there is not a terrform resource to perorm this operation. For information on how to do perform this operation out of band of terraform consult the [AWS Documentation on the matter](https://aws.amazon.com/premiumsupport/knowledge-center/private-hosted-zone-different-account/)
 
 ## Example Usage
 

--- a/website/docs/r/route53_zone_association.html.markdown
+++ b/website/docs/r/route53_zone_association.html.markdown
@@ -14,7 +14,7 @@ Manages a Route53 Hosted Zone VPC association. VPC associations can only be made
 
 ~> **NOTE:** Terraform provides both this standalone Zone VPC Association resource and exclusive VPC associations defined in-line in the [`aws_route53_zone` resource](/docs/providers/aws/r/route53_zone.html) via `vpc` configuration blocks. At this time, you cannot use those in-line VPC associations in conjunction with this resource and the same zone ID otherwise it will cause a perpetual difference in plan output. You can optionally use the generic Terraform resource [lifecycle configuration block](/docs/configuration/resources.html#lifecycle) with `ignore_changes` in the `aws_route53_zone` resource to manage additional associations via this resource.
 
-~> **NOTE:** This resource does not perform the `CreateVPCAssociationAuthorization` operation, which is necessary to perform a route53 zone association between vpcs in different AWS accounts. At the present time there is not a terrform resource to perorm this operation. For information on how to do perform this operation out of band of terraform consult the [AWS Documentation on the matter](https://aws.amazon.com/premiumsupport/knowledge-center/private-hosted-zone-different-account/)
+~> **NOTE:** This resource does not perform the `CreateVPCAssociationAuthorization` operation, which is necessary to perform a route53 zone association between vpcs in different AWS accounts. At the present time there is not a Terraform resource to perform this operation. For information on how to do perform this operation out of band of the terraform cli consult the [AWS Documentation on the matter](https://aws.amazon.com/premiumsupport/knowledge-center/private-hosted-zone-different-account/)
 
 ## Example Usage
 

--- a/website/docs/r/route53_zone_association.html.markdown
+++ b/website/docs/r/route53_zone_association.html.markdown
@@ -14,6 +14,8 @@ Manages a Route53 Hosted Zone VPC association. VPC associations can only be made
 
 ~> **NOTE:** Terraform provides both this standalone Zone VPC Association resource and exclusive VPC associations defined in-line in the [`aws_route53_zone` resource](/docs/providers/aws/r/route53_zone.html) via `vpc` configuration blocks. At this time, you cannot use those in-line VPC associations in conjunction with this resource and the same zone ID otherwise it will cause a perpetual difference in plan output. You can optionally use the generic Terraform resource [lifecycle configuration block](/docs/configuration/resources.html#lifecycle) with `ignore_changes` in the `aws_route53_zone` resource to manage additional associations via this resource.
 
+~> **NOTE:** This resource does not perform the `CreateVPCAssociationAuthorization` operation, which is necessary to perform a route53 zone association between vpcs in different AWS accounts. At the present time this operation must be done out of band of terraform or by using a provisioner. For more details on how to do this consult the [AWS Documentation on the matter](https://aws.amazon.com/premiumsupport/knowledge-center/private-hosted-zone-different-account/)
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes ##8593

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):


```release-note
* Adds note indicating that out of band creation of VPC Zone Association authorization is required for for cross account Zone association when using the aws_route53_zone_association resource
```

