### PR TITLE
Direct Connect hosted virtual interface cross-account tests

### DIFF
--- a/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_private_virtual_interface_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -18,81 +19,49 @@ func TestAccAwsDxHostedPrivateVirtualInterface_basic(t *testing.T) {
 	if connectionId == "" {
 		t.Skipf("Environment variable %s is not set", key)
 	}
-	key = "DX_HOSTED_VIF_OWNER_ACCOUNT"
-	ownerAccountId := os.Getenv(key)
-	if ownerAccountId == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-	vifName := fmt.Sprintf("terraform-testacc-dxvif-%s", acctest.RandString(5))
+
+	var providers []*schema.Provider
+	resourceNameHostedVif := "aws_dx_hosted_private_virtual_interface.test"
+	resourceNameHostedVifAccepter := "aws_dx_hosted_private_virtual_interface_accepter.test"
+	rName := fmt.Sprintf("tf-testacc-private-vif-%s", acctest.RandString(9))
 	bgpAsn := randIntRange(64512, 65534)
 	vlan := randIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxHostedPrivateVirtualInterfaceDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsDxHostedPrivateVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
+				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, rName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
+					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists(resourceNameHostedVif),
+					testAccCheckAwsDxHostedPrivateVirtualInterfaceAccepterExists(resourceNameHostedVifAccepter),
+					resource.TestCheckResourceAttr(resourceNameHostedVif, "name", rName),
+					resource.TestCheckResourceAttr(resourceNameHostedVif, "mtu", "1500"),
+					resource.TestCheckResourceAttr(resourceNameHostedVif, "jumbo_frame_capable", "true"),
+					resource.TestCheckResourceAttr(resourceNameHostedVifAccepter, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccDxHostedPrivateVirtualInterfaceConfig_updated(connectionId, rName, bgpAsn, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists(resourceNameHostedVif),
+					testAccCheckAwsDxHostedPrivateVirtualInterfaceAccepterExists(resourceNameHostedVifAccepter),
+					resource.TestCheckResourceAttr(resourceNameHostedVif, "name", rName),
+					resource.TestCheckResourceAttr(resourceNameHostedVifAccepter, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceNameHostedVifAccepter, "tags.Environment", "test"),
 				),
 			},
 			// Test import.
 			{
-				ResourceName:      "aws_dx_hosted_private_virtual_interface.foo",
+				Config:            testAccDxHostedPrivateVirtualInterfaceConfig_updated(connectionId, rName, bgpAsn, vlan),
+				ResourceName:      resourceNameHostedVif,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAwsDxHostedPrivateVirtualInterface_mtuUpdate(t *testing.T) {
-	key := "DX_CONNECTION_ID"
-	connectionId := os.Getenv(key)
-	if connectionId == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-	key = "DX_HOSTED_VIF_OWNER_ACCOUNT"
-	ownerAccountId := os.Getenv(key)
-	if ownerAccountId == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-	vifName := fmt.Sprintf("terraform-testacc-dxvif-%s", acctest.RandString(5))
-	bgpAsn := randIntRange(64512, 65534)
-	vlan := randIntRange(2049, 4094)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxHostedPrivateVirtualInterfaceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "mtu", "1500"),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "jumbo_frame_capable", "true"),
-				),
-			},
-			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_JumboFrames(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "mtu", "9001"),
-				),
-			},
-			{
-				Config: testAccDxHostedPrivateVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxHostedPrivateVirtualInterfaceExists("aws_dx_hosted_private_virtual_interface.foo"),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "name", vifName),
-					resource.TestCheckResourceAttr("aws_dx_hosted_private_virtual_interface.foo", "mtu", "1500"),
-				),
 			},
 		},
 	})
@@ -134,31 +103,71 @@ func testAccCheckAwsDxHostedPrivateVirtualInterfaceExists(name string) resource.
 	}
 }
 
-func testAccDxHostedPrivateVirtualInterfaceConfig_basic(cid, ownerAcctId, n string, bgpAsn, vlan int) string {
-	return fmt.Sprintf(`
-resource "aws_dx_hosted_private_virtual_interface" "foo" {
-  connection_id    = "%s"
-  owner_account_id = "%s"
+func testAccCheckAwsDxHostedPrivateVirtualInterfaceAccepterExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
 
-  name           = "%s"
-  vlan           = %d
+		return nil
+	}
+}
+
+func testAccDxHostedPrivateVirtualInterfaceConfig_base(cid, rName string, bgpAsn, vlan int) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+# Creator
+resource "aws_dx_hosted_private_virtual_interface" "test" {
+  connection_id    = %[1]q
+  owner_account_id = "${data.aws_caller_identity.accepter.account_id}"
+
+  name           = %[2]q
+  vlan           = %[4]d
   address_family = "ipv4"
-  bgp_asn        = %d
-}
-`, cid, ownerAcctId, n, vlan, bgpAsn)
+  bgp_asn        = %[3]d
+
+  # The aws_dx_hosted_private_virtual_interface
+  # must be destroyed before the aws_vpn_gateway.
+  depends_on = ["aws_vpn_gateway.test"]
 }
 
-func testAccDxHostedPrivateVirtualInterfaceConfig_JumboFrames(cid, ownerAcctId, n string, bgpAsn, vlan int) string {
-	return fmt.Sprintf(`
-resource "aws_dx_hosted_private_virtual_interface" "foo" {
-  connection_id    = "%s"
-  owner_account_id = "%s"
-
-  name           = "%s"
-  vlan           = %d
-  address_family = "ipv4"
-  bgp_asn        = %d
-  mtu			 = 9001
+# Accepter
+data "aws_caller_identity" "accepter" {
+  provider = "aws.alternate"
 }
-`, cid, ownerAcctId, n, vlan, bgpAsn)
+
+resource "aws_vpn_gateway" "test" {
+  provider = "aws.alternate"
+
+  tags = {
+    Name = %[2]q
+  }
+}
+`, cid, rName, bgpAsn, vlan)
+}
+
+func testAccDxHostedPrivateVirtualInterfaceConfig_basic(cid, rName string, bgpAsn, vlan int) string {
+	return testAccDxHostedPrivateVirtualInterfaceConfig_base(cid, rName, bgpAsn, vlan) + fmt.Sprintf(`
+resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
+  provider             = "aws.alternate"
+
+  virtual_interface_id = "${aws_dx_hosted_private_virtual_interface.test.id}"
+  vpn_gateway_id       = "${aws_vpn_gateway.test.id}"
+}
+`)
+}
+
+func testAccDxHostedPrivateVirtualInterfaceConfig_updated(cid, rName string, bgpAsn, vlan int) string {
+	return testAccDxHostedPrivateVirtualInterfaceConfig_base(cid, rName, bgpAsn, vlan) + fmt.Sprintf(`
+resource "aws_dx_hosted_private_virtual_interface_accepter" "test" {
+  provider             = "aws.alternate"
+
+  virtual_interface_id = "${aws_dx_hosted_private_virtual_interface.test.id}"
+  vpn_gateway_id       = "${aws_vpn_gateway.test.id}"
+
+  tags = {
+    Environment = "test"
+  }
+}
+`)
 }

--- a/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
+++ b/aws/resource_aws_dx_hosted_public_virtual_interface_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/directconnect"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -18,30 +19,45 @@ func TestAccAwsDxHostedPublicVirtualInterface_basic(t *testing.T) {
 	if connectionId == "" {
 		t.Skipf("Environment variable %s is not set", key)
 	}
-	key = "DX_HOSTED_VIF_OWNER_ACCOUNT"
-	ownerAccountId := os.Getenv(key)
-	if ownerAccountId == "" {
-		t.Skipf("Environment variable %s is not set", key)
-	}
-	vifName := fmt.Sprintf("terraform-testacc-dxvif-%s", acctest.RandString(5))
+
+	var providers []*schema.Provider
+	resourceNameHostedVif := "aws_dx_hosted_public_virtual_interface.test"
+	resourceNameHostedVifAccepter := "aws_dx_hosted_public_virtual_interface_accepter.test"
+	rName := fmt.Sprintf("tf-testacc-public-vif-%s", acctest.RandString(10))
 	bgpAsn := randIntRange(64512, 65534)
 	vlan := randIntRange(2049, 4094)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAwsDxHostedPublicVirtualInterfaceDestroy,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccAlternateAccountPreCheck(t)
+		},
+		ProviderFactories: testAccProviderFactories(&providers),
+		CheckDestroy:      testAccCheckAwsDxHostedPublicVirtualInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDxHostedPublicVirtualInterfaceConfig_basic(connectionId, ownerAccountId, vifName, bgpAsn, vlan),
+				Config: testAccDxHostedPublicVirtualInterfaceConfig_basic(connectionId, rName, bgpAsn, vlan),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsDxHostedPublicVirtualInterfaceExists("aws_dx_hosted_public_virtual_interface.foo"),
-					resource.TestCheckResourceAttr("aws_dx_hosted_public_virtual_interface.foo", "name", vifName),
+					testAccCheckAwsDxHostedPublicVirtualInterfaceExists(resourceNameHostedVif),
+					testAccCheckAwsDxHostedPublicVirtualInterfaceAccepterExists(resourceNameHostedVifAccepter),
+					resource.TestCheckResourceAttr(resourceNameHostedVif, "name", rName),
+					resource.TestCheckResourceAttr(resourceNameHostedVifAccepter, "tags.%", "0"),
+				),
+			},
+			{
+				Config: testAccDxHostedPublicVirtualInterfaceConfig_updated(connectionId, rName, bgpAsn, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDxHostedPublicVirtualInterfaceExists(resourceNameHostedVif),
+					testAccCheckAwsDxHostedPublicVirtualInterfaceAccepterExists(resourceNameHostedVifAccepter),
+					resource.TestCheckResourceAttr(resourceNameHostedVif, "name", rName),
+					resource.TestCheckResourceAttr(resourceNameHostedVifAccepter, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceNameHostedVifAccepter, "tags.Environment", "test"),
 				),
 			},
 			// Test import.
 			{
-				ResourceName:      "aws_dx_hosted_public_virtual_interface.foo",
+				Config:            testAccDxHostedPublicVirtualInterfaceConfig_updated(connectionId, rName, bgpAsn, vlan),
+				ResourceName:      resourceNameHostedVif,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -85,23 +101,65 @@ func testAccCheckAwsDxHostedPublicVirtualInterfaceExists(name string) resource.T
 	}
 }
 
-func testAccDxHostedPublicVirtualInterfaceConfig_basic(cid, ownerAcctId, n string, bgpAsn, vlan int) string {
-	return fmt.Sprintf(`
-resource "aws_dx_hosted_public_virtual_interface" "foo" {
-  connection_id    = "%s"
-  owner_account_id = "%s"
+func testAccCheckAwsDxHostedPublicVirtualInterfaceAccepterExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
 
-  name           = "%s"
-  vlan           = %d
+		return nil
+	}
+}
+
+func testAccDxHostedPublicVirtualInterfaceConfig_base(cid, rName string, bgpAsn, vlan int) string {
+	return testAccAlternateAccountProviderConfig() + fmt.Sprintf(`
+# Creator
+resource "aws_dx_hosted_public_virtual_interface" "test" {
+  connection_id    = %[1]q
+  owner_account_id = "${data.aws_caller_identity.accepter.account_id}"
+
+  name           = %[2]q
+  vlan           = %[4]d
   address_family = "ipv4"
-  bgp_asn        = %d
+  bgp_asn        = %[3]d
 
   customer_address = "175.45.176.1/30"
   amazon_address   = "175.45.176.2/30"
+
   route_filter_prefixes = [
     "210.52.109.0/24",
-	"175.45.176.0/22"
+    "175.45.176.0/22",
   ]
 }
-`, cid, ownerAcctId, n, vlan, bgpAsn)
+
+# Accepter
+data "aws_caller_identity" "accepter" {
+  provider = "aws.alternate"
+}
+`, cid, rName, bgpAsn, vlan)
+}
+
+func testAccDxHostedPublicVirtualInterfaceConfig_basic(cid, rName string, bgpAsn, vlan int) string {
+	return testAccDxHostedPublicVirtualInterfaceConfig_base(cid, rName, bgpAsn, vlan) + fmt.Sprintf(`
+resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
+  provider             = "aws.alternate"
+
+  virtual_interface_id = "${aws_dx_hosted_public_virtual_interface.test.id}"
+}
+`)
+}
+
+func testAccDxHostedPublicVirtualInterfaceConfig_updated(cid, rName string, bgpAsn, vlan int) string {
+	return testAccDxHostedPublicVirtualInterfaceConfig_base(cid, rName, bgpAsn, vlan) + fmt.Sprintf(`
+resource "aws_dx_hosted_public_virtual_interface_accepter" "test" {
+  provider             = "aws.alternate"
+
+  virtual_interface_id = "${aws_dx_hosted_public_virtual_interface.test.id}"
+
+  tags = {
+    Environment = "test"
+  }
+}
+`)
 }

--- a/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
+++ b/website/docs/r/dx_hosted_private_virtual_interface_accepter.html.markdown
@@ -37,6 +37,10 @@ resource "aws_dx_hosted_private_virtual_interface" "creator" {
   vlan           = 4094
   address_family = "ipv4"
   bgp_asn        = 65352
+
+  # The aws_dx_hosted_private_virtual_interface
+  # must be destroyed before the aws_vpn_gateway.
+  depends_on = ["aws_vpn_gateway.vpn_gw"]
 }
 
 # Accepter's side of the VIF.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

For https://github.com/terraform-providers/terraform-provider-aws/pull/8523 cross-account acceptance tests were added. Do the same for the:
* `aws_dx_hosted_public_virtual_interface`, `aws_dx_hosted_public_virtual_interface_accepter`
* `aws_dx_hosted_private_virtual_interface`, `aws_dx_hosted_private_virtual_interface_accepter`

resources.

Acceptance tests:

```console
$ AWS_ALTERNATE_PROFILE=pppppppp DX_CONNECTION_ID=dxcon-aaaaaaaa make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsDxHostedPublicVirtualInterface_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsDxHostedPublicVirtualInterface_basic -timeout 120m
=== RUN   TestAccAwsDxHostedPublicVirtualInterface_basic
=== PAUSE TestAccAwsDxHostedPublicVirtualInterface_basic
=== CONT  TestAccAwsDxHostedPublicVirtualInterface_basic
--- PASS: TestAccAwsDxHostedPublicVirtualInterface_basic (71.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.836s
$ AWS_ALTERNATE_PROFILE=pppppppp DX_CONNECTION_ID=dxcon-aaaaaaaa make testacc TEST=./aws/ TESTARGS='-run=TestAccAwsDxHostedPrivateVirtualInterface_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAwsDxHostedPrivateVirtualInterface_basic -timeout 120m
=== RUN   TestAccAwsDxHostedPrivateVirtualInterface_basic
=== PAUSE TestAccAwsDxHostedPrivateVirtualInterface_basic
=== CONT  TestAccAwsDxHostedPrivateVirtualInterface_basic
--- PASS: TestAccAwsDxHostedPrivateVirtualInterface_basic (430.10s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	430.187s
```