### PR TITLE
tests/resource/aws_budgets_budget: Add decimal to budget limit amount configuration

### DIFF
--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,8 +14,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"strconv"
-	"strings"
 )
 
 func TestAccAWSBudgetsBudget_basic(t *testing.T) {
@@ -344,7 +344,7 @@ func testAccAWSBudgetsBudgetConfigUpdate(name string) budgets.Budget {
 		BudgetName: aws.String(name),
 		BudgetType: aws.String("COST"),
 		BudgetLimit: &budgets.Spend{
-			Amount: aws.String("500"),
+			Amount: aws.String("500.0"),
 			Unit:   aws.String("USD"),
 		},
 		CostFilters: map[string][]*string{
@@ -379,7 +379,7 @@ func testAccAWSBudgetsBudgetConfigDefaults(name string) budgets.Budget {
 		BudgetName: aws.String(name),
 		BudgetType: aws.String("COST"),
 		BudgetLimit: &budgets.Spend{
-			Amount: aws.String("100"),
+			Amount: aws.String("100.0"),
 			Unit:   aws.String("USD"),
 		},
 		CostFilters: map[string][]*string{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Test failures for this began last week. For now we simply fix the test configuration so the testing passes, but this may be indicative of new API behavior that will require resource updates.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSBudgetsBudget_basic (8.61s)
    testing.go:568: Step 0 error: Check failed: Check 1/8 error: budget limit incorrectly set 100 != 100.0
--- FAIL: TestAccAWSBudgetsBudget_prefix (8.83s)
    testing.go:568: Step 0 error: Check failed: Check 1/8 error: budget limit incorrectly set 100 != 100.0
--- FAIL: TestAccAWSBudgetsBudget_notification (13.01s)
    testing.go:568: Step 1 error: Check failed: Check 1/1 error: budget limit incorrectly set 100 != 100.0
```

Output from acceptance testing:

```
--- PASS: TestAccAWSBudgetsBudget_prefix (17.80s)
--- PASS: TestAccAWSBudgetsBudget_basic (19.90s)
--- PASS: TestAccAWSBudgetsBudget_notification (59.14s)
```

