### PR TITLE
tests/service/ec2: Additional EC2 Transit Gateway test configuration blacklisting for usw2-az4

### DIFF
--- a/aws/data_source_aws_route_test.go
+++ b/aws/data_source_aws_route_test.go
@@ -195,6 +195,12 @@ data "aws_route" "by_instance_id"{
 
 func testAccAWSRouteDataSourceConfigTransitGatewayID() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -204,8 +210,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-route-datasource-transit-gateway-id"

--- a/aws/resource_aws_route_table_test.go
+++ b/aws/resource_aws_route_table_test.go
@@ -828,6 +828,12 @@ resource "aws_route_table" "test" {
 
 func testAccAWSRouteTableConfigRouteTransitGatewayID() string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  # IncorrectState: Transit Gateway is not available in availability zone us-west-2d
+  blacklisted_zone_ids = ["usw2-az4"]
+  state                = "available"
+}
+
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -837,8 +843,9 @@ resource "aws_vpc" "test" {
 }
 
 resource "aws_subnet" "test" {
-  cidr_block = "10.0.0.0/24"
-  vpc_id     = "${aws_vpc.test.id}"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block        = "10.0.0.0/24"
+  vpc_id            = "${aws_vpc.test.id}"
 
   tags = {
     Name = "tf-acc-test-ec2-route-table-transit-gateway-id"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Followup to 9babb9ca88a6d0a5324911d41b0530fb76a15c37

AWS recently added a fourth Availability Zone to the US West (Oregon) Region, which does not yet support EC2 Transit Gateway. This new AZ has the zone ID of `usw2-az4` and here we blacklist it to prevent random acceptance testing failures due to random AZ selection for VPC subnets.

Previous output from acceptance testing:

```
--- FAIL: TestAccAWSRouteDataSource_TransitGatewayID (70.80s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating EC2 Transit Gateway VPC Attachment: IncorrectState: Transit Gateway is not available in availability zone us-west-2d (subnet subnet-022d8187b0a3f3bd7).

--- FAIL: TestAccAWSRouteTable_Route_TransitGatewayID (154.66s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating EC2 Transit Gateway VPC Attachment: IncorrectState: Transit Gateway is not available in availability zone us-west-2d (subnet subnet-0081b6f66536f80b4).
```

Output from acceptance testing:

```
--- PASS: TestAccAWSRouteTable_Route_TransitGatewayID (310.00s)
--- PASS: TestAccAWSRouteDataSource_TransitGatewayID (312.35s)
```