### PR TITLE
feature(sagemaker notebook): Add DirectInternetAccess support 

### DIFF
--- a/aws/resource_aws_sagemaker_notebook_instance_test.go
+++ b/aws/resource_aws_sagemaker_notebook_instance_test.go
@@ -324,6 +324,57 @@ func testAccCheckAWSSagemakerNotebookInstanceName(notebook *sagemaker.DescribeNo
 	}
 }
 
+func TestAccAWSSagemakerNotebookInstance_direct_internet_access(t *testing.T) {
+	var notebook sagemaker.DescribeNotebookInstanceOutput
+	notebookName := resource.PrefixedUniqueId(sagemakerTestAccSagemakerNotebookInstanceResourceNamePrefix)
+	var resourceName = "aws_sagemaker_notebook_instance.foo"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSagemakerNotebookInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(notebookName, "Disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerNotebookInstanceName(&notebook, notebookName),
+					testAccCheckAWSSagemakerNotebookDirectInternetAccess(&notebook, "Disabled"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_notebook_instance.foo", "name", notebookName),
+				),
+			},
+			{
+				Config: testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(notebookName, "Enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSagemakerNotebookInstanceExists(resourceName, &notebook),
+					testAccCheckAWSSagemakerNotebookInstanceName(&notebook, notebookName),
+					testAccCheckAWSSagemakerNotebookDirectInternetAccess(&notebook, "Enabled"),
+
+					resource.TestCheckResourceAttr(
+						"aws_sagemaker_notebook_instance.foo", "name", notebookName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSSagemakerNotebookDirectInternetAccess(notebook *sagemaker.DescribeNotebookInstanceOutput, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		directInternetAccess := notebook.DirectInternetAccess
+		if *directInternetAccess != expected {
+			return fmt.Errorf("direct_internet_access setting is incorrect: %s", *notebook.DirectInternetAccess)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckAWSSagemakerNotebookInstanceTags(notebook *sagemaker.DescribeNotebookInstanceOutput, key string, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).sagemakerconn
@@ -500,4 +551,49 @@ data "aws_iam_policy_document" "assume_role" {
   }
 }
 `, notebookName, notebookName)
+}
+
+func testAccAWSSagemakerNotebookInstanceConfigDirectInternetAccess(notebookName string, directInternetAccess string) string {
+	return fmt.Sprintf(`
+resource "aws_sagemaker_notebook_instance" "foo" {
+	name = %[1]q
+	role_arn = "${aws_iam_role.foo.arn}"
+	instance_type = "ml.t2.medium"
+	subnet_id = "${aws_subnet.sagemaker.id}"
+	direct_internet_access = %[2]q
+}
+
+resource "aws_iam_role" "foo" {
+	name = %[1]q
+	path = "/"
+	assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+	statement {
+		actions = [ "sts:AssumeRole" ]
+		principals {
+			type = "Service"
+			identifiers = [ "sagemaker.amazonaws.com" ]
+		}
+	}
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.10.0/24"
+
+  tags = {
+    Name = "tf-acc-test-sagemaker-notebook-instance-direct-internet-access"
+  }
+}
+
+resource "aws_subnet" "sagemaker" {
+  vpc_id     = "${aws_vpc.test.id}"
+  cidr_block = "10.0.0.0/27"
+
+  tags = {
+    Name = "tf-acc-test-sagemaker-notebook-instance-direct-internet-access"
+  }
+}
+`, notebookName, directInternetAccess)
 }

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -37,6 +37,7 @@ The following arguments are supported:
 * `security_groups` - (Optional) The associated security groups.
 * `kms_key_id` - (Optional) The AWS Key Management Service (AWS KMS) key that Amazon SageMaker uses to encrypt the model artifacts at rest using Amazon S3 server-side encryption.
 *  `lifecycle_config_name` - (Optional) The name of a lifecycle configuration to associate with the notebook instance.
+* `direct_internet_access` - (Optional) Set to `Disabled` to disable internet access to notebook. Requires `subnet_id` to be set. Supported values: `Enabled`(Default) or `Disabled`. If set to `Disabled`, the notebook instance will be able to access resources only in your VPC, and will not be able to connect to Amazon SageMaker training and endpoint services unless your configure a NAT Gateway in your VPC. 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Add direct_internet_access option to Sagemaker Notebook Resource
```

Output from acceptance testing:

~I'm not able to run tests locally, would need some help with my local go setup~

I'm not able to run tests. I will need these to be run by another maintainer.

```
⌂681% [brandon:~/go … terraform-provider-aws] feature/sagemaker-private-internet-access 1m7s ± make testacc TESTARGS='-run=TestAccAWSSagemakerNotebookInstance_directInternetAccess'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSagemakerNotebookInstance_directInternetAccess -timeout 120m
main.go:5:2: cannot find package "github.com/terraform-providers/terraform-provider-aws/aws" in any of:
	/Users/brandon/go/src/github.com/bcatubig/terraform-provider-aws/vendor/github.com/terraform-providers/terraform-provider-aws/aws (vendor tree)
	/usr/local/Cellar/go/1.12.1/libexec/src/github.com/terraform-providers/terraform-provider-aws/aws (from $GOROOT)
	/Users/brandon/go/src/github.com/terraform-providers/terraform-provider-aws/aws (from $GOPATH)
make: *** [testacc] Error 1
```
