### PR TITLE
r/lambda_function: support nodejs 10.x runtime

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -32,6 +32,7 @@ var validLambdaRuntimes = []string{
 	lambda.RuntimeNodejs43Edge,
 	lambda.RuntimeNodejs610,
 	lambda.RuntimeNodejs810,
+	lambda.RuntimeNodejs10X,
 	lambda.RuntimeProvided,
 	lambda.RuntimePython27,
 	lambda.RuntimePython36,

--- a/aws/resource_aws_lambda_function_test.go
+++ b/aws/resource_aws_lambda_function_test.go
@@ -1153,6 +1153,32 @@ func TestAccAWSLambdaFunction_runtimeValidation_NodeJs810(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x(t *testing.T) {
+	var conf lambda.GetFunctionOutput
+
+	rString := acctest.RandString(8)
+
+	funcName := fmt.Sprintf("tf_acc_lambda_func_runtime_valid_nodejs10x_%s", rString)
+	policyName := fmt.Sprintf("tf_acc_policy_lambda_func_runtime_valid_nodejs10x_%s", rString)
+	roleName := fmt.Sprintf("tf_acc_role_lambda_func_runtime_valid_nodejs10x_%s", rString)
+	sgName := fmt.Sprintf("tf_acc_sg_lambda_func_runtime_valid_nodejs10x_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaConfigNodeJs10xRuntime(funcName, policyName, roleName, sgName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", funcName, &conf),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", lambda.RuntimeNodejs10X),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLambdaFunction_runtimeValidation_python27(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
@@ -2156,6 +2182,18 @@ resource "aws_lambda_function" "lambda_function_test" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs8.10"
+}
+`, funcName)
+}
+
+func testAccAWSLambdaConfigNodeJs10xRuntime(funcName, policyName, roleName, sgName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(policyName, roleName, sgName)+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs10.x"
 }
 `, funcName)
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #8627 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
```release-note
resource/aws_lambda_function: support nodejs10.x runtime
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSLambdaFunction_runtimeValidation'
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (2.38s)
--- FAIL: TestAccAWSLambdaFunction_runtimeValidation_ruby25 (34.05s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.
                status code: 400, request id: c627d505-aca2-404b-9df4-19049657e699

          on /var/folders/5_/yp4n1h313nnck0dh22h7bzt4nbtrkm/T/tf-test266518313/main.tf line 73:
          (source code not available)


--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python37 (38.86s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs810 (38.90s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_provided (40.74s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_NodeJs10x (40.85s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python36 (43.05s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (45.29s)
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (47.04s)
```

Looks like it failed on trying to create another VPC.......must be an issue with the specific account I ran this in, everything else looked fine.