### PR TITLE
Add email sending account

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -131,6 +131,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"reply_to_email_address": {
@@ -142,6 +143,15 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validateArn,
+						},
+						"email_sending_account": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								cognitoidentityprovider.EmailSendingAccountTypeCognitoDefault,
+								cognitoidentityprovider.EmailSendingAccountTypeDeveloper,
+							}, false),
 						},
 					},
 				},
@@ -529,6 +539,10 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 				emailConfigurationType.SourceArn = aws.String(v.(string))
 			}
 
+			if v, ok := config["email_sending_account"]; ok && v.(string) != "" {
+				emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
+			}
+
 			params.EmailConfiguration = emailConfigurationType
 		}
 	}
@@ -723,8 +737,10 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Failed setting device_configuration: %s", err)
 	}
 
-	if err := d.Set("email_configuration", flattenCognitoUserPoolEmailConfiguration(resp.UserPool.EmailConfiguration)); err != nil {
-		return fmt.Errorf("Failed setting email_configuration: %s", err)
+	if resp.UserPool.EmailConfiguration != nil {
+		if err := d.Set("email_configuration", flattenCognitoUserPoolEmailConfiguration(resp.UserPool.EmailConfiguration)); err != nil {
+			return fmt.Errorf("Failed setting email_configuration: %s", err)
+		}
 	}
 
 	if resp.UserPool.Policies != nil && resp.UserPool.Policies.PasswordPolicy != nil {
@@ -795,10 +811,13 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if v, ok := d.GetOk("email_configuration"); ok {
+
 		configs := v.([]interface{})
 		config, ok := configs[0].(map[string]interface{})
 
+
 		if ok && config != nil {
+			log.Printf("[DEBUG] Set Values to update from configs")
 			emailConfigurationType := &cognitoidentityprovider.EmailConfigurationType{}
 
 			if v, ok := config["reply_to_email_address"]; ok && v.(string) != "" {
@@ -807,6 +826,10 @@ func resourceAwsCognitoUserPoolUpdate(d *schema.ResourceData, meta interface{}) 
 
 			if v, ok := config["source_arn"]; ok && v.(string) != "" {
 				emailConfigurationType.SourceArn = aws.String(v.(string))
+			}
+
+			if v, ok := config["email_sending_account"]; ok && v.(string) != "" {
+				emailConfigurationType.EmailSendingAccount = aws.String(v.(string))
 			}
 
 			params.EmailConfiguration = emailConfigurationType

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -284,9 +284,11 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCognitoUserPoolConfig_basic(name),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, "", "", "COGNITO_DEFAULT"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSCognitoUserPoolExists("aws_cognito_user_pool.pool"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.#", "1"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.reply_to_email_address", ""),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.email_sending_account", "COGNITO_DEFAULT"),
 				),
 			},
 			{
@@ -868,15 +870,15 @@ resource "aws_cognito_user_pool" "pool" {
 
 func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, account string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {                                                                                                                                                                                                                                                                                
-    name = "terraform-test-pool-%[1]s"                                                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                                                                                      
-                                                                                                                                                                                                                                                                                                      
-    email_configuration {                                                                                                                                                                                                                                                                             
-      reply_to_email_address = %[2]q                                                                                                                                                                                                                                                                  
-      source_arn = %[3]q                                                                                                                                                                                                                                                                              
-      email_sending_account = %[4]q                                                                                                                                                                                                                                                                   
-    }                                                                                                                                                                                                                                                                                                 
+resource "aws_cognito_user_pool" "pool" {
+    name = "terraform-test-pool-%[1]s"
+
+
+    email_configuration {
+      reply_to_email_address = %[2]q
+      source_arn = %[3]q
+      email_sending_account = %[4]q
+    }
   }`, name, email, arn, account)
 }
 

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"testing"
 
@@ -270,6 +271,12 @@ func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
 
 func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
+	replyTo := fmt.Sprintf("tf-acc-reply-%s@terraformtesting.com", name)
+
+	sourceARN, ok := os.LookupEnv("TEST_AWS_SES_VERIFIED_EMAIL_ARN")
+	if !ok {
+		t.Skip("'TEST_AWS_SES_VERIFIED_EMAIL_ARN' not set, skipping test.")
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
@@ -283,10 +290,12 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name),
+				Config: testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, replyTo, sourceARN, "DEVELOPER"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.#", "1"),
-					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.reply_to_email_address", "foo.bar@baz"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.reply_to_email_address", replyTo),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.email_sending_account", "DEVELOPER"),
+					resource.TestCheckResourceAttr("aws_cognito_user_pool.pool", "email_configuration.0.source_arn", sourceARN),
 				),
 			},
 		},
@@ -857,16 +866,18 @@ resource "aws_cognito_user_pool" "pool" {
 `, name)
 }
 
-func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name string) string {
+func testAccAWSCognitoUserPoolConfig_withEmailConfiguration(name, email, arn, account string) string {
 	return fmt.Sprintf(`
-resource "aws_cognito_user_pool" "pool" {
-  name = "terraform-test-pool-%s"
-
-  email_configuration {
-    reply_to_email_address = "foo.bar@baz"
-  }
-}
-`, name)
+resource "aws_cognito_user_pool" "pool" {                                                                                                                                                                                                                                                                                
+    name = "terraform-test-pool-%[1]s"                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                      
+                                                                                                                                                                                                                                                                                                      
+    email_configuration {                                                                                                                                                                                                                                                                             
+      reply_to_email_address = %[2]q                                                                                                                                                                                                                                                                  
+      source_arn = %[3]q                                                                                                                                                                                                                                                                              
+      email_sending_account = %[4]q                                                                                                                                                                                                                                                                   
+    }                                                                                                                                                                                                                                                                                                 
+  }`, name, email, arn, account)
 }
 
 func testAccAWSCognitoUserPoolConfig_withSmsConfiguration(name string) string {

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2464,6 +2464,10 @@ func flattenCognitoUserPoolEmailConfiguration(s *cognitoidentityprovider.EmailCo
 		m["source_arn"] = *s.SourceArn
 	}
 
+	if s.EmailSendingAccount != nil {
+		m["email_sending_account"] = *s.EmailSendingAccount
+	}
+
 	if len(m) > 0 {
 		return []map[string]interface{}{m}
 	}

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1705,16 +1705,6 @@ func validateCognitoUserPoolInviteTemplateSmsMessage(v interface{}, k string) (w
 	return
 }
 
-func validateCognitoUserPoolReplyEmailAddress(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	if !regexp.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+@[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}]+@[\p{L}\p{M}\p{S}\p{N}\p{P}]+`, k))
-	}
-	return
-}
-
 func validateCognitoUserPoolSchemaName(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 	if len(value) < 1 {

--- a/aws/validators_test.go
+++ b/aws/validators_test.go
@@ -2465,32 +2465,6 @@ func TestValidateKmsKey(t *testing.T) {
 	}
 }
 
-func TestValidateCognitoUserPoolReplyEmailAddress(t *testing.T) {
-	validTypes := []string{
-		"foo@gmail.com",
-		"foo@bar",
-		"foo bar@gmail.com",
-		"foo+bar.baz@gmail.com",
-	}
-	for _, v := range validTypes {
-		_, errors := validateCognitoUserPoolReplyEmailAddress(v, "name")
-		if len(errors) != 0 {
-			t.Fatalf("%q should be a valid Cognito User Pool Reply Email Address: %q", v, errors)
-		}
-	}
-
-	invalidTypes := []string{
-		"foo",
-		"@bar.baz",
-	}
-	for _, v := range invalidTypes {
-		_, errors := validateCognitoUserPoolReplyEmailAddress(v, "name")
-		if len(errors) == 0 {
-			t.Fatalf("%q should be an invalid Cognito User Pool Reply Email Address", v)
-		}
-	}
-}
-
 func TestResourceAWSElastiCacheReplicationGroupAuthTokenValidation(t *testing.T) {
 	cases := []struct {
 		Value    string

--- a/website/docs/r/cognito_user_pool.markdown
+++ b/website/docs/r/cognito_user_pool.markdown
@@ -65,6 +65,7 @@ The following arguments are supported:
 
   * `reply_to_email_address` (Optional) - The REPLY-TO email address.
   * `source_arn` (Optional) - The ARN of the email source.
+  * `email_sending_account` (Optional) - Instruct Cognito to either use its built-in functional or Amazon SES to send out emails.
 
 #### Lambda Configuration
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8434

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```
Adds an option to set the email_sending_account for the cognito email configuration
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCognitoUserPool_withEmailConfiguration'
=> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCognitoUserPool_withEmailConfiguration -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCognitoUserPool_withEmailConfiguration
=== PAUSE TestAccAWSCognitoUserPool_withEmailConfiguration
=== CONT  TestAccAWSCognitoUserPool_withEmailConfiguration
--- FAIL: TestAccAWSCognitoUserPool_withEmailConfiguration (14.04s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_cognito_user_pool.pool
          admin_create_user_config.#:                              "1" => "1"
          admin_create_user_config.0.allow_admin_create_user_only: "false" => "false"
          admin_create_user_config.0.invite_message_template.#:    "0" => "0"
          admin_create_user_config.0.unused_account_validity_days: "7" => "7"
          arn:                                                     "arn:aws:cognito-idp:us-west-2:304080159981:userpool/us-west-2_BVFzGb9lf" => "arn:aws:cognito-idp:us-west-2:304080159981:userpool/us-west-2_BVFzGb9lf"
          creation_date:                                           "2019-05-14T09:47:38Z" => "2019-05-14T09:47:38Z"
          device_configuration.#:                                  "0" => "0"
          email_configuration.#:                                   "1" => "0"
          email_configuration.0.email_sending_account:             "COGNITO_DEFAULT" => ""
          email_configuration.0.reply_to_email_address:            "" => ""
          email_configuration.0.source_arn:                        "" => ""
          endpoint:                                                "cognito-idp.us-west-2.amazonaws.com/us-west-2_BVFzGb9lf" => "cognito-idp.us-west-2.amazonaws.com/us-west-2_BVFzGb9lf"
          id:                                                      "us-west-2_BVFzGb9lf" => "us-west-2_BVFzGb9lf"
          lambda_config.#:                                         "0" => "0"
          last_modified_date:                                      "2019-05-14T09:47:38Z" => "2019-05-14T09:47:38Z"
          mfa_configuration:                                       "OFF" => "OFF"
          name:                                                    "terraform-test-pool-4jh1e" => "terraform-test-pool-4jh1e"
          password_policy.#:                                       "1" => "1"
          password_policy.0.minimum_length:                        "8" => "8"
          password_policy.0.require_lowercase:                     "true" => "true"
          password_policy.0.require_numbers:                       "true" => "true"
          password_policy.0.require_symbols:                       "true" => "true"
          password_policy.0.require_uppercase:                     "true" => "true"
          schema.#:                                                "0" => "0"
          sms_configuration.#:                                     "0" => "0"
          user_pool_add_ons.#:                                     "0" => "0"
          verification_message_template.#:                         "1" => "1"
          verification_message_template.0.default_email_option:    "CONFIRM_WITH_CODE" => "CONFIRM_WITH_CODE"
          verification_message_template.0.email_message:           "" => ""
          verification_message_template.0.email_message_by_link:   "" => ""
          verification_message_template.0.email_subject:           "" => ""
          verification_message_template.0.email_subject_by_link:   "" => ""
          verification_message_template.0.sms_message:             "" => ""



        STATE:

        aws_cognito_user_pool.pool:
          ID = us-west-2_BVFzGb9lf
          provider = provider.aws
          admin_create_user_config.# = 1
          admin_create_user_config.0.allow_admin_create_user_only = false
          admin_create_user_config.0.unused_account_validity_days = 7
          arn = arn:aws:cognito-idp:us-west-2:304080159981:userpool/us-west-2_BVFzGb9lf
          creation_date = 2019-05-14T09:47:38Z
          email_configuration.# = 1
          email_configuration.0.email_sending_account = COGNITO_DEFAULT
          email_configuration.0.reply_to_email_address =
          email_configuration.0.source_arn =
          endpoint = cognito-idp.us-west-2.amazonaws.com/us-west-2_BVFzGb9lf
          last_modified_date = 2019-05-14T09:47:38Z
          mfa_configuration = OFF
          name = terraform-test-pool-4jh1e
          password_policy.# = 1
          password_policy.0.minimum_length = 8
          password_policy.0.require_lowercase = true
          password_policy.0.require_numbers = true
          password_policy.0.require_symbols = true
          password_policy.0.require_uppercase = true
          verification_message_template.# = 1
          verification_message_template.0.default_email_option = CONFIRM_WITH_CODE
          verification_message_template.0.email_message =
          verification_message_template.0.email_message_by_link =
          verification_message_template.0.email_subject =
          verification_message_template.0.email_subject_by_link =
          verification_message_template.0.sms_message =
    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: Argument or block definition required: On /var/folders/q3/x4rq343n57x5v8pccndssw3r0000gn/T/tf-test921011959/main.tf line 6: An argument or block definition is required here. To set an argument, use the equals sign "=" to introduce the argument value.

        State: aws_cognito_user_pool.pool:
          ID = us-west-2_BVFzGb9lf
          provider = provider.aws
          admin_create_user_config.# = 1
          admin_create_user_config.0.allow_admin_create_user_only = false
          admin_create_user_config.0.invite_message_template.# = 0
          admin_create_user_config.0.unused_account_validity_days = 7
          arn = arn:aws:cognito-idp:us-west-2:304080159981:userpool/us-west-2_BVFzGb9lf
          creation_date = 2019-05-14T09:47:38Z
          device_configuration.# = 0
          email_configuration.# = 1
          email_configuration.0.email_sending_account = COGNITO_DEFAULT
          email_configuration.0.reply_to_email_address =
          email_configuration.0.source_arn =
          endpoint = cognito-idp.us-west-2.amazonaws.com/us-west-2_BVFzGb9lf
          lambda_config.# = 0
          last_modified_date = 2019-05-14T09:47:38Z
          mfa_configuration = OFF
          name = terraform-test-pool-4jh1e
          password_policy.# = 1
          password_policy.0.minimum_length = 8
          password_policy.0.require_lowercase = true
          password_policy.0.require_numbers = true
          password_policy.0.require_symbols = true
          password_policy.0.require_uppercase = true
          schema.# = 0
          sms_configuration.# = 0
          user_pool_add_ons.# = 0
          verification_message_template.# = 1
          verification_message_template.0.default_email_option = CONFIRM_WITH_CODE
          verification_message_template.0.email_message =
          verification_message_template.0.email_message_by_link =
          verification_message_template.0.email_subject =
          verification_message_template.0.email_subject_by_link =
          verification_message_template.0.sms_message =
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	14.088s
```

Looks like the tests can not clean up. Probably an issue with my account? I also  don't know how to add that case to the AcceptanceTests (as sourceArn is also not included yet), but I did a manual test. See screenshot attached.

![image](https://user-images.githubusercontent.com/1031255/57688193-26f23180-763d-11e9-85d2-60ba52dc2eec.png)

If someone has a guiding to get that into the Acceptance Tests, I'm happy to help :)

