### PR TITLE
Retry LB listener methods after timeout

### DIFF
--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -493,6 +493,14 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 		return nil
 	})
 
+	if isResourceTimeoutError(err) {
+		_, err := elbconn.CreateListener(params)
+
+		if err != nil {
+			return fmt.Errorf("Error creating LB Listener: %s", err)
+		}
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error creating LB Listener: %s", err)
 	}
@@ -525,6 +533,14 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		_, err := elbconn.DescribeListeners(request)
+
+		if err != nil {
+			return fmt.Errorf("Error retrieving Listener: %s", err)
+		}
+	}
 
 	if isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
 		log.Printf("[WARN] ELBv2 Listener (%s) not found - removing from state", d.Id())

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -494,11 +494,7 @@ func resourceAwsLbListenerCreate(d *schema.ResourceData, meta interface{}) error
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err := elbconn.CreateListener(params)
-
-		if err != nil {
-			return fmt.Errorf("Error creating LB Listener: %s", err)
-		}
+		_, err = elbconn.CreateListener(params)
 	}
 
 	if err != nil {
@@ -535,11 +531,7 @@ func resourceAwsLbListenerRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err := elbconn.DescribeListeners(request)
-
-		if err != nil {
-			return fmt.Errorf("Error retrieving Listener: %s", err)
-		}
+		_, err = elbconn.DescribeListeners(request)
 	}
 
 	if isAWSErr(err, elbv2.ErrCodeListenerNotFoundException, "") {
@@ -817,11 +809,7 @@ func resourceAwsLbListenerUpdate(d *schema.ResourceData, meta interface{}) error
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err := elbconn.ModifyListener(params)
-
-		if err != nil {
-			return fmt.Errorf("Error modifying LB Listener: %s", err)
-		}
+		_, err = elbconn.ModifyListener(params)
 	}
 
 	if err != nil {

--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -799,6 +799,15 @@ func resourceAwsLbListenerUpdate(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		_, err := elbconn.ModifyListener(params)
+
+		if err != nil {
+			return fmt.Errorf("Error modifying LB Listener: %s", err)
+		}
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error modifying LB Listener: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8025

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds a final retry to LB Listener requests if the requests originally timed out
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSLBListener"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLBListener -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLBListenerRule_basic
=== PAUSE TestAccAWSLBListenerRule_basic
=== RUN   TestAccAWSLBListenerRuleBackwardsCompatibility
=== PAUSE TestAccAWSLBListenerRuleBackwardsCompatibility
=== RUN   TestAccAWSLBListenerRule_redirect
=== PAUSE TestAccAWSLBListenerRule_redirect
=== RUN   TestAccAWSLBListenerRule_fixedResponse
=== PAUSE TestAccAWSLBListenerRule_fixedResponse
=== RUN   TestAccAWSLBListenerRule_updateRulePriority
=== PAUSE TestAccAWSLBListenerRule_updateRulePriority
=== RUN   TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
=== PAUSE TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
=== RUN   TestAccAWSLBListenerRule_multipleConditionThrowsError
=== PAUSE TestAccAWSLBListenerRule_multipleConditionThrowsError
=== RUN   TestAccAWSLBListenerRule_priority
=== PAUSE TestAccAWSLBListenerRule_priority
=== RUN   TestAccAWSLBListenerRule_cognito
=== PAUSE TestAccAWSLBListenerRule_cognito
=== RUN   TestAccAWSLBListenerRule_oidc
=== PAUSE TestAccAWSLBListenerRule_oidc
=== RUN   TestAccAWSLBListenerRule_Action_Order
=== PAUSE TestAccAWSLBListenerRule_Action_Order
=== RUN   TestAccAWSLBListenerRule_Action_Order_Recreates
=== PAUSE TestAccAWSLBListenerRule_Action_Order_Recreates
=== RUN   TestAccAWSLBListener_basic
=== PAUSE TestAccAWSLBListener_basic
=== RUN   TestAccAWSLBListener_BackwardsCompatibility
=== PAUSE TestAccAWSLBListener_BackwardsCompatibility
=== RUN   TestAccAWSLBListener_https
=== PAUSE TestAccAWSLBListener_https
=== RUN   TestAccAWSLBListener_Protocol_Tls
=== PAUSE TestAccAWSLBListener_Protocol_Tls
=== RUN   TestAccAWSLBListener_redirect
=== PAUSE TestAccAWSLBListener_redirect
=== RUN   TestAccAWSLBListener_fixedResponse
=== PAUSE TestAccAWSLBListener_fixedResponse
=== RUN   TestAccAWSLBListener_cognito
=== PAUSE TestAccAWSLBListener_cognito
=== RUN   TestAccAWSLBListener_oidc
=== PAUSE TestAccAWSLBListener_oidc
=== RUN   TestAccAWSLBListener_DefaultAction_Order
=== PAUSE TestAccAWSLBListener_DefaultAction_Order
=== RUN   TestAccAWSLBListener_DefaultAction_Order_Recreates
=== PAUSE TestAccAWSLBListener_DefaultAction_Order_Recreates
=== CONT  TestAccAWSLBListenerRule_basic
=== CONT  TestAccAWSLBListener_DefaultAction_Order_Recreates
=== CONT  TestAccAWSLBListener_basic
=== CONT  TestAccAWSLBListener_redirect
=== CONT  TestAccAWSLBListenerRule_Action_Order_Recreates
=== CONT  TestAccAWSLBListener_DefaultAction_Order
=== CONT  TestAccAWSLBListener_Protocol_Tls
=== CONT  TestAccAWSLBListener_https
=== CONT  TestAccAWSLBListener_BackwardsCompatibility
=== CONT  TestAccAWSLBListenerRule_Action_Order
=== CONT  TestAccAWSLBListenerRule_oidc
=== CONT  TestAccAWSLBListenerRule_cognito
=== CONT  TestAccAWSLBListenerRule_priority
=== CONT  TestAccAWSLBListenerRule_multipleConditionThrowsError
=== CONT  TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew
=== CONT  TestAccAWSLBListenerRule_updateRulePriority
=== CONT  TestAccAWSLBListenerRule_fixedResponse
=== CONT  TestAccAWSLBListenerRule_redirect
=== CONT  TestAccAWSLBListenerRuleBackwardsCompatibility
=== CONT  TestAccAWSLBListener_cognito
--- PASS: TestAccAWSLBListenerRule_multipleConditionThrowsError (3.36s)
=== CONT  TestAccAWSLBListener_oidc
--- PASS: TestAccAWSLBListenerRuleBackwardsCompatibility (226.95s)
=== CONT  TestAccAWSLBListener_fixedResponse
--- PASS: TestAccAWSLBListenerRule_Action_Order_Recreates (228.69s)
--- PASS: TestAccAWSLBListener_cognito (232.67s)
--- PASS: TestAccAWSLBListener_BackwardsCompatibility (233.78s)
--- PASS: TestAccAWSLBListener_redirect (233.94s)
--- PASS: TestAccAWSLBListener_https (234.14s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order (234.72s)
--- PASS: TestAccAWSLBListenerRule_oidc (235.91s)
--- PASS: TestAccAWSLBListenerRule_cognito (241.32s)
--- PASS: TestAccAWSLBListener_basic (243.72s)
--- PASS: TestAccAWSLBListener_DefaultAction_Order_Recreates (245.55s)
--- PASS: TestAccAWSLBListenerRule_Action_Order (249.00s)
--- PASS: TestAccAWSLBListener_oidc (249.84s)
--- PASS: TestAccAWSLBListenerRule_fixedResponse (257.92s)
--- PASS: TestAccAWSLBListenerRule_changeListenerRuleArnForcesNew (295.45s)
--- PASS: TestAccAWSLBListenerRule_updateRulePriority (306.47s)
--- PASS: TestAccAWSLBListenerRule_redirect (313.82s)
--- PASS: TestAccAWSLBListenerRule_basic (325.63s)
--- PASS: TestAccAWSLBListener_Protocol_Tls (353.97s)
--- PASS: TestAccAWSLBListener_fixedResponse (250.96s)
--- PASS: TestAccAWSLBListenerRule_priority (557.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       558.022s
```
