### PR TITLE
Updates on ebs_volume documentation

### DIFF
--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ebs_volume" "example" {
 }
 ```
 
-~> **NOTE**: One of `size` or `snapshot_id` is required when specifying an EBS volume 
+~> **NOTE**: One of `size` or `snapshot_id` is required when specifying an EBS volume
 
 ## Argument Reference
 
@@ -50,8 +50,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-EBS Volumes can be imported using the `id`, e.g. 
+EBS Volumes can be imported using the `id`, e.g.
 
 ```
-$ terraform import aws_ebs_volume.data vol-049df61146c4d7901
+$ terraform import aws_ebs_volume.id vol-049df61146c4d7901
 ```


### PR DESCRIPTION
**Reasoning for Change:** I found the reference to the importing ebs into terraform state is incorrect. 
The correct format is `terraform import aws_ebs_volume.smp_endgame_volume.id vol-0916459ccfa79313d`

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
