### PR TITLE
aws_dms_endpoint: Add Kinesis as a target endpoint type

### DIFF
--- a/aws/resource_aws_dms_endpoint.go
+++ b/aws/resource_aws_dms_endpoint.go
@@ -141,10 +141,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 							Optional: true,
 							Default:  "PASSWORD",
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if strings.ToLower(old) == strings.ToLower(new) {
-									return true
-								}
-								return false
+								return strings.EqualFold(old, new)
 							},
 						},
 						"auth_mechanism": {
@@ -152,10 +149,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 							Optional: true,
 							Default:  "DEFAULT",
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if strings.ToLower(old) == strings.ToLower(new) {
-									return true
-								}
-								return false
+								return strings.EqualFold(old, new)
 							},
 						},
 						"nesting_level": {
@@ -163,10 +157,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 							Optional: true,
 							Default:  "NONE",
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if strings.ToLower(old) == strings.ToLower(new) {
-									return true
-								}
-								return false
+								return strings.EqualFold(old, new)
 							},
 						},
 						"extract_doc_id": {

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
     - Must not contain two consecutive hyphens
 
 * `endpoint_type` - (Required) The type of endpoint. Can be one of `source | target`.
-* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `aurora | azuredb | docdb | dynamodb | mariadb | mongodb | mysql | oracle | postgres | redshift | s3 | sqlserver | sybase`.
+* `engine_name` - (Required) The type of engine for the endpoint. Can be one of `aurora | azuredb | docdb | dynamodb | kinesis | mariadb | mongodb | mysql | oracle | postgres | redshift | s3 | sqlserver | sybase`.
 * `extra_connection_attributes` - (Optional) Additional attributes associated with the connection. For available attributes see [Using Extra Connection Attributes with AWS Database Migration Service](http://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.ConnectionAttributes.html).
 * `kms_key_arn` - (Required when `engine_name` is `mongodb`, optional otherwise) The Amazon Resource Name (ARN) for the KMS key that will be used to encrypt the connection parameters. If you do not specify a value for `kms_key_arn`, then AWS DMS will use your default encryption key. AWS KMS creates the default encryption key for your AWS account. Your AWS account has a different default encryption key for each AWS region.
 * `password` - (Optional) The password to be used to login to the endpoint database.
@@ -65,6 +65,7 @@ The following arguments are supported:
 * `service_access_role` - (Optional) The Amazon Resource Name (ARN) used by the service access IAM role for dynamodb endpoints.
 * `mongodb_settings` - (Optional) Settings for the source MongoDB endpoint. Available settings are `auth_type` (default: `PASSWORD`), `auth_mechanism` (default: `DEFAULT`), `nesting_level` (default: `NONE`), `extract_doc_id` (default: `false`), `docs_to_investigate` (default: `1000`) and `auth_source` (default: `admin`). For more details, see [Using MongoDB as a Source for AWS DMS](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html).
 * `s3_settings` - (Optional) Settings for the target S3 endpoint. Available settings are `service_access_role_arn`, `external_table_definition`, `csv_row_delimiter` (default: `\\n`), `csv_delimiter` (default: `,`), `bucket_folder`, `bucket_name` and `compression_type` (default: `NONE`). For more details, see [Using Amazon S3 as a Target for AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html).
+* `kinesis_settings` - (Optional) Settings for the target Kinesis endpoint. Available settings are `service_access_role_arn` and `stream_arn`. For more details, see [Using Amazon Kinesis Data Streams as a Target for AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Kinesis.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds Kinesis as a DMS target endpoint type. #6658 #8053

Also, the acceptance test for MongoDB DMS endpoints was broken, and I implemented a fix (or workaround?) here as well. #7492

Finally, I'd just like to request some input on @chrisjharding's #2305. Without that functionality, it's really not feasible to use DMS via Terraform (it's currently necessary to do work outside of Terraform to start a replication task, and it's not possible to modify an in-progress replication via Terraform). If the author of that PR is available to respond to review, great. If not, maybe I can implement whatever changes are needed to get it merged.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes:
* #7492 (aws_dms_endpoint TestAccAwsDmsEndpointMongoDb acceptance test is failing)
* #8053 (AWS DMS aws_dms_endpoint - Support 'kinesis data stream' target support)
* #6658 (Using kinesis firehose as a aws_dms_endpoint)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_dms_endpoint: Add Kinesis as a target
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAwsDmsEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsDmsEndpoint -timeout 120m
=== RUN   TestAccAwsDmsEndpointBasic
=== PAUSE TestAccAwsDmsEndpointBasic
=== RUN   TestAccAwsDmsEndpointS3
=== PAUSE TestAccAwsDmsEndpointS3
=== RUN   TestAccAwsDmsEndpointDynamoDb
=== PAUSE TestAccAwsDmsEndpointDynamoDb
=== RUN   TestAccAwsDmsEndpointKinesis
=== PAUSE TestAccAwsDmsEndpointKinesis
=== RUN   TestAccAwsDmsEndpointMongoDb
=== PAUSE TestAccAwsDmsEndpointMongoDb
=== RUN   TestAccAwsDmsEndpointDocDB
=== PAUSE TestAccAwsDmsEndpointDocDB
=== CONT  TestAccAwsDmsEndpointBasic
=== CONT  TestAccAwsDmsEndpointMongoDb
=== CONT  TestAccAwsDmsEndpointKinesis
=== CONT  TestAccAwsDmsEndpointDocDB
=== CONT  TestAccAwsDmsEndpointDynamoDb
=== CONT  TestAccAwsDmsEndpointS3
--- PASS: TestAccAwsDmsEndpointDocDB (26.69s)
--- PASS: TestAccAwsDmsEndpointBasic (26.73s)
--- PASS: TestAccAwsDmsEndpointMongoDb (32.25s)
--- PASS: TestAccAwsDmsEndpointDynamoDb (36.77s)
--- PASS: TestAccAwsDmsEndpointS3 (37.67s)
--- PASS: TestAccAwsDmsEndpointKinesis (114.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws   114.358s
```
