### PR TITLE
tests/resource/aws_sfn_state_machine: Allow test configurations to be partition agnostic in IAM ARNs

### DIFF
--- a/aws/resource_aws_sfn_state_machine_test.go
+++ b/aws/resource_aws_sfn_state_machine_test.go
@@ -137,6 +137,8 @@ func testAccCheckAWSSfnStateMachineDestroy(s *terraform.State) error {
 
 func testAccAWSSfnStateMachineConfig(rName string, rMaxAttempts int) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
@@ -152,7 +154,7 @@ resource "aws_iam_role_policy" "iam_policy_for_lambda" {
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ],
-    "Resource": "arn:aws:logs:*:*:*"
+    "Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
   }]
 }
 EOF
@@ -254,6 +256,8 @@ EOF
 
 func testAccAWSSfnStateMachineConfigTags1(rName string, tag1Key, tag1Value string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
@@ -269,7 +273,7 @@ resource "aws_iam_role_policy" "iam_policy_for_lambda" {
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ],
-    "Resource": "arn:aws:logs:*:*:*"
+    "Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
   }]
 }
 EOF
@@ -373,6 +377,8 @@ tags = {
 
 func testAccAWSSfnStateMachineConfigTags2(rName string, tag1Key, tag1Value, tag2Key, tag2Value string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 data "aws_region" "current" {}
 
 resource "aws_iam_role_policy" "iam_policy_for_lambda" {
@@ -388,7 +394,7 @@ resource "aws_iam_role_policy" "iam_policy_for_lambda" {
       "logs:CreateLogStream",
       "logs:PutLogEvents"
     ],
-    "Resource": "arn:aws:logs:*:*:*"
+    "Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
   }]
 }
 EOF


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US):

```
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (29.54s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error putting IAM role policy iam_policy_for_lambda_34t3c04qud: MalformedPolicyDocument: Partition "aws" is not valid for resource "arn:aws:logs:*:*:*".

--- FAIL: TestAccAWSSfnStateMachine_Tags (30.83s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error putting IAM role policy iam_policy_for_lambda_wbvfeozq3v: MalformedPolicyDocument: Partition "aws" is not valid for resource "arn:aws:logs:*:*:*".
```

Output from AWS Standard acceptance testing (test failure unrelated):

```
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (36.66s)
    testing.go:568: Step 1 error: Check failed: Check 5/6 error: aws_sfn_state_machine.foo: Attribute 'definition' didn't match ".*\\\"MaxAttempts\\\": 10.*", got "{\n  \"Comment\": \"A Hello World example of the Amazon States Language using an AWS Lambda Function\",\n  \"StartAt\": \"HelloWorld\",\n  \"States\": {\n    \"HelloWorld\": {\n      \"Type\": \"Task\",\n      \"Resource\": \"arn:aws:lambda:us-west-2:187416307283:function:sfn-qqccgc0m48\",\n      \"Retry\": [\n        {\n          \"ErrorEquals\": [\"States.ALL\"],\n          \"IntervalSeconds\": 5,\n          \"MaxAttempts\": 5,\n          \"BackoffRate\": 8.0\n        }\n      ],\n      \"End\": true\n    }\n  }\n}\n"
--- PASS: TestAccAWSSfnStateMachine_Tags (50.20s)
```

Output from AWS GovCloud (US) acceptance testing (test failure unrelated):

```
--- FAIL: TestAccAWSSfnStateMachine_createUpdate (41.69s)
    testing.go:568: Step 1 error: Check failed: Check 5/6 error: aws_sfn_state_machine.foo: Attribute 'definition' didn't match ".*\\\"MaxAttempts\\\": 10.*", got "{\n  \"Comment\": \"A Hello World example of the Amazon States Language using an AWS Lambda Function\",\n  \"StartAt\": \"HelloWorld\",\n  \"States\": {\n    \"HelloWorld\": {\n      \"Type\": \"Task\",\n      \"Resource\": \"arn:aws-us-gov:lambda:us-gov-west-1:357342307427:function:sfn-18y92jitjb\",\n      \"Retry\": [\n        {\n          \"ErrorEquals\": [\"States.ALL\"],\n          \"IntervalSeconds\": 5,\n          \"MaxAttempts\": 5,\n          \"BackoffRate\": 8.0\n        }\n      ],\n      \"End\": true\n    }\n  }\n}\n"
--- PASS: TestAccAWSSfnStateMachine_Tags (62.98s)
```