### PR TITLE
r/aws_kinesis_analytics_application: Add support for resource tags

### DIFF
--- a/aws/tagsKinesisAnalytics.go
+++ b/aws/tagsKinesisAnalytics.go
@@ -1,0 +1,135 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// getTags is a helper to get the tags for a resource. It expects the
+// tags field to be named "tags" and the ARN field to be named "arn".
+func getTagsKinesisAnalytics(conn *kinesisanalytics.KinesisAnalytics, d *schema.ResourceData) error {
+	resp, err := conn.ListTagsForResource(&kinesisanalytics.ListTagsForResourceInput{
+		ResourceARN: aws.String(d.Get("arn").(string)),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("tags", tagsToMapKinesisAnalytics(resp.Tags)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags" and the ARN field to be named "arn".
+func setTagsKinesisAnalytics(conn *kinesisanalytics.KinesisAnalytics, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsKinesisAnalytics(tagsFromMapKinesisAnalytics(o), tagsFromMapKinesisAnalytics(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&kinesisanalytics.UntagResourceInput{
+				ResourceARN: aws.String(d.Get("arn").(string)),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&kinesisanalytics.TagResourceInput{
+				ResourceARN: aws.String(d.Get("arn").(string)),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsKinesisAnalytics(oldTags, newTags []*kinesisanalytics.Tag) ([]*kinesisanalytics.Tag, []*kinesisanalytics.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*kinesisanalytics.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapKinesisAnalytics(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapKinesisAnalytics(m map[string]interface{}) []*kinesisanalytics.Tag {
+	result := make([]*kinesisanalytics.Tag, 0, len(m))
+	for k, v := range m {
+		t := &kinesisanalytics.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredKinesisAnalytics(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapKinesisAnalytics(ts []*kinesisanalytics.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredKinesisAnalytics(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredKinesisAnalytics(t *kinesisanalytics.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
+		r, _ := regexp.MatchString(v, *t.Key)
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", *t.Key, *t.Value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsKinesisAnalytics_test.go
+++ b/aws/tagsKinesisAnalytics_test.go
@@ -1,0 +1,109 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesisanalytics"
+)
+
+func TestDiffKinesisAnalyticsTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Add
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsKinesisAnalytics(tagsFromMapKinesisAnalytics(tc.Old), tagsFromMapKinesisAnalytics(tc.New))
+		cm := tagsToMapKinesisAnalytics(c)
+		rm := tagsToMapKinesisAnalytics(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+func TestIgnoringTagsKinesisAnalytics(t *testing.T) {
+	var ignoredTags []*kinesisanalytics.Tag
+	ignoredTags = append(ignoredTags, &kinesisanalytics.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &kinesisanalytics.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredKinesisAnalytics(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/kinesis_analytics_application.html.markdown
+++ b/website/docs/r/kinesis_analytics_application.html.markdown
@@ -65,6 +65,7 @@ See [CloudWatch Logging Options](#cloudwatch-logging-options) below for more det
 * `outputs` - (Optional) Output destination configuration of the application. See [Outputs](#outputs) below for more details.
 * `reference_data_sources` - (Optional) An S3 Reference Data Source for the application.
 See [Reference Data Sources](#reference-data-sources) below for more details.
+* `tags` - Key-value mapping of tags for the Kinesis Analytics Application.
 
 ### CloudWatch Logging Options
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8609 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_kinesis_analytics_application: Add support for resource tags
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisAnalyticsApplication_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSKinesisAnalyticsApplication_ -timeout 120m
=== RUN   TestAccAWSKinesisAnalyticsApplication_basic
=== PAUSE TestAccAWSKinesisAnalyticsApplication_basic
=== RUN   TestAccAWSKinesisAnalyticsApplication_update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_update
=== RUN   TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== RUN   TestAccAWSKinesisAnalyticsApplication_tags
=== PAUSE TestAccAWSKinesisAnalyticsApplication_tags
=== CONT  TestAccAWSKinesisAnalyticsApplication_basic
=== CONT  TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_update
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== CONT  TestAccAWSKinesisAnalyticsApplication_tags
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (42.06s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (63.75s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (65.60s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (70.75s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (78.22s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (90.22s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (91.11s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_tags (111.11s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (118.12s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (123.64s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (123.97s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (124.08s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (149.84s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (151.57s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (151.77s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (225.97s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (240.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	240.976s
```
