### PR TITLE
💄 Added so aws_lb_listener_rule works with "" on priority

### DIFF
--- a/aws/resource_aws_lb_listener_rule.go
+++ b/aws/resource_aws_lb_listener_rule.go
@@ -467,7 +467,7 @@ func resourceAwsLbListenerRuleCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	var resp *elbv2.CreateRuleOutput
-	if v, ok := d.GetOk("priority"); ok {
+	if v, ok := d.GetOk("priority"); ok && v != "" {
 		var err error
 		params.Priority = aws.Int64(int64(v.(int)))
 		resp, err = elbconn.CreateRule(params)


### PR DESCRIPTION
Before when wanting "priority" to be auto-assigned, you would need to create a rule without "priority" not defined at all, this will add so it's the same behavior when having empty string, cause else you need 2 resources if you want to create a "module" that is the rule resource. Cause passing empty string right now breaks the code cause it tries to parse "" to int. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
