### PR TITLE
[WIP] ACM Certificate: sort domain validation options by domain name

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -322,17 +322,17 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 // the remaining options are sorted alphabetically by their domain name.
 // Sorting is necessary because the API endpoint returns the validation options in random
 // order different each time.
-func sortDomainValidationOptions(domainName *string, domainValiationOptions []map[string]interface{}) {
-	sort.Slice(domainValiationOptions, func(i, j int) bool {
-		if domainValiationOptions[i]["domain_name"].(string) == *domainName {
+func sortDomainValidationOptions(domainName *string, domainValidationOptions []map[string]interface{}) {
+	sort.Slice(domainValidationOptions, func(i, j int) bool {
+		if domainValidationOptions[i]["domain_name"].(string) == *domainName {
 			return true
 		}
-		if domainValiationOptions[j]["domain_name"].(string) == *domainName {
+		if domainValidationOptions[j]["domain_name"].(string) == *domainName {
 			return false
 		}
 
-		return domainValiationOptions[i]["domain_name"].(string) <
-			domainValiationOptions[j]["domain_name"].(string)
+		return domainValidationOptions[i]["domain_name"].(string) <
+			domainValidationOptions[j]["domain_name"].(string)
 	})
 }
 

--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -215,6 +216,7 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		}
 
 		domainValidationOptions, emailValidationOptions, err := convertValidationOptions(resp.Certificate)
+		sortDomainValidationOptions(resp.Certificate.DomainName, domainValidationOptions)
 
 		if err != nil {
 			return resource.RetryableError(err)
@@ -313,6 +315,25 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 	}
 
 	return domainValidationResult, emailValidationResult, nil
+}
+
+// sortDomainValidationOptions sorts a slice of domain validation options as follows:
+// the option corresponding to the certficate's domain name is first;
+// the remaining options are sorted alphabetically by their domain name.
+// Sorting is necessary because the API endpoint returns the validation options in random
+// order different each time.
+func sortDomainValidationOptions(domainName *string, domainValiationOptions []map[string]interface{}) {
+	sort.Slice(domainValiationOptions, func(i, j int) bool {
+		if domainValiationOptions[i]["domain_name"].(string) == *domainName {
+			return true
+		}
+		if domainValiationOptions[j]["domain_name"].(string) == *domainName {
+			return false
+		}
+
+		return domainValiationOptions[i]["domain_name"].(string) <
+			domainValiationOptions[j]["domain_name"].(string)
+	})
 }
 
 func resourceAwsAcmCertificateDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -650,3 +650,70 @@ func testAccCheckAcmCertificateDestroy(s *terraform.State) error {
 
 	return nil
 }
+
+func TestSortDomainValidationOptions(t *testing.T) {
+	domainName := "www.example.com"
+
+	data := []map[string][]string{
+		{
+			"input":  {},
+			"sorted": {},
+		},
+		{
+			"input":  {"www.example.com"},
+			"sorted": {"www.example.com"},
+		},
+		{
+			"input":  {"www.example.com", "a.example.com", "b.example.com"},
+			"sorted": {"www.example.com", "a.example.com", "b.example.com"},
+		},
+		{
+			"input":  {"a.example.com", "b.example.com", "www.example.com", "c.example.com"},
+			"sorted": {"www.example.com", "a.example.com", "b.example.com", "c.example.com"},
+		},
+		{
+			"input":  {"a.example.com", "b.example.com", "c.example.com", "www.example.com"},
+			"sorted": {"www.example.com", "a.example.com", "b.example.com", "c.example.com"},
+		},
+		{
+			"input":  {"a.example.com", "z.example.com", "b.example.com", "www.example.com"},
+			"sorted": {"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
+		},
+		{
+			"input":  {"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
+			"sorted": {"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
+		},
+		{
+			"input":  {"www.example.com", "z.example.com", "b.example.com", "a.example.com"},
+			"sorted": {"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
+		},
+		{
+			"input":  {"www.example.com", "z.example.com", "b.example.com", "a.example.com"},
+			"sorted": {"www.example.com", "a.example.com", "b.example.com", "z.example.com"},
+		},
+	}
+
+	for _, testCase := range data {
+		var options []map[string]interface{}
+
+		for _, domainName := range testCase["input"] {
+			options = append(options,
+				map[string]interface{}{
+					"domain_name": domainName,
+				},
+			)
+		}
+
+		sortDomainValidationOptions(&domainName, options)
+
+		for i := range options {
+			actual := options[i]["domain_name"].(string)
+			expected := testCase["sorted"][i]
+
+			if actual != expected {
+				t.Errorf("\ninput was: %v\ngot: %v\nwant: %v\n", testCase["input"], options, testCase["sorted"])
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR ads a fix for https://github.com/terraform-providers/terraform-provider-aws/issues/8531.

Domain validation options (DVOs) are sorted to guarantee the same order even when the AWS API returns them jumbled up. To order imposed is as follows: (1) the certificate's domain name comes first, (2) the remaining options are sorted by their respective `domain_name` attribute alphabetically.

This PR does not address the issue of unsorted `subject alternative names`. However, these may be ignored by lifecycle `ignore_changes`.

I have included unit tests but I'm not sure if they belong here at all.

I would be grateful if someone could run the acceptance tests.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes: https://github.com/terraform-providers/terraform-provider-aws/issues/8531

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
For several regions [it has been reported](https://github.com/terraform-providers/terraform-provider-aws/issues/8531) that the ACM API returns randomly sorted *subject alternative names* (SANs) and *domain validation options* (DVOs) elements. This resulted in non-empty plans after apply, indefinitely.

The release imposes an ordering on only the DVOs attribute lists. As a consequence, there will be a one-time re-ordering of the elements.

If you apply this change in a region not affected before, this is the first and only time you will notice the change. Dependent resources maybe require re-creating. In regions affected by the API change already, the problem should go away after applying one more time.

You may chose to ignore the changing ordering on the SANs.
```

Output from acceptance testing:

I did not run the acc tests on this because I did not want to run the email validation. However, I tested the implementation by compiling and using it.