### PR TITLE
resource/aws_cloudwatch_event_rule: Ignore UnknownOperationException error on reading tags

### DIFF
--- a/aws/tagsCloudWatchEvent.go
+++ b/aws/tagsCloudWatchEvent.go
@@ -105,12 +105,12 @@ func saveTagsCloudWatchEvents(conn *events.CloudWatchEvents, d *schema.ResourceD
 		ResourceARN: aws.String(arn),
 	})
 
-	if err != nil {
+	if err != nil && !isAWSErr(err, "UnknownOperationException", "") {
 		return fmt.Errorf("Error retreiving tags for %s: %s", arn, err)
 	}
 
 	var tagList []*events.Tag
-	if len(resp.Tags) > 0 {
+	if resp != nil && len(resp.Tags) > 0 {
 		tagList = resp.Tags
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8654

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudwatch_event_rule: Ignore `UnknownOperationException` error on reading tags
```

The new `ap-east-1` region in AWS Commercial does not support the CloudWatch Event Rule tagging available in the rest of AWS Commercial.

Previous output from ap-east-1 region acceptance testing:

```
--- FAIL: TestAccAWSCloudWatchEventRule_full (17.82s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating tags for tf-acc-cw-event-rule-full: UnknownOperationException:
        	status code: 400, request id: ac4d6cdd-77fc-11e9-86ed-cdca472113e7

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test246660052/main.tf line 2:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule-full: UnknownOperationException:
        	status code: 400, request id: af588a11-77fc-11e9-8ad8-0792e26dbe7d

        State: <nil>
--- FAIL: TestAccAWSCloudWatchEventRule_tags (17.91s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating tags for tf-acc-cw-event-rule-tags: UnknownOperationException:
        	status code: 400, request id: ac4d1eb2-77fc-11e9-80a8-95f8eb560cb4

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test122506912/main.tf line 2:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule-tags: UnknownOperationException:
        	status code: 400, request id: af6841da-77fc-11e9-96c8-bb13b487ae4c

        State: <nil>
--- FAIL: TestAccAWSCloudWatchEventRule_prefix (19.74s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule-prefix-20190516170429862800000001: UnknownOperationException:
        	status code: 400, request id: ad6f7ed0-77fc-11e9-86ed-cdca472113e7

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test831543557/main.tf line 2:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule-prefix-20190516170429862800000001: UnknownOperationException:
        	status code: 400, request id: b07fcc05-77fc-11e9-80a8-95f8eb560cb4

        State: <nil>
--- FAIL: TestAccAWSCloudWatchEventRule_basic (20.54s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule: UnknownOperationException:
        	status code: 400, request id: ae0a86a1-77fc-11e9-97e4-539c846bebae

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test465041618/main.tf line 2:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule: UnknownOperationException:
        	status code: 400, request id: b0f91b41-77fc-11e9-a6ae-13317a02b493

        State: <nil>
--- FAIL: TestAccAWSCloudWatchEventRule_importBasic (20.56s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule: UnknownOperationException:
        	status code: 400, request id: ae009c0a-77fc-11e9-8ad8-0792e26dbe7d

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test417356671/main.tf line 2:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule: UnknownOperationException:
        	status code: 400, request id: b0fc4f36-77fc-11e9-89ba-8f98f3d46ebe

        State: <nil>
--- FAIL: TestAccAWSCloudWatchEventRule_enable (20.65s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule-state: UnknownOperationException:
        	status code: 400, request id: ae1f951c-77fc-11e9-a6ae-13317a02b493

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test047282185/main.tf line 2:
          (source code not available)

    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: error setting tags: Error retreiving tags for arn:aws:events:ap-east-1:--OMITTED--:rule/tf-acc-cw-event-rule-state: UnknownOperationException:
        	status code: 400, request id: b10aa776-77fc-11e9-97e4-539c846bebae

        State: <nil>
```

Output from ap-east-1 acceptance testing (failure creating tags expected as tags are not supported in this region):

```
--- PASS: TestAccAWSCloudWatchEventRule_importBasic (41.96s)
--- FAIL: TestAccAWSCloudWatchEventRule_full (21.75s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating tags for tf-acc-cw-event-rule-full: UnknownOperationException:
        	status code: 400, request id: 89571e62-77fd-11e9-acb1-9520865da030

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test386270447/main.tf line 2:
          (source code not available)

--- PASS: TestAccAWSCloudWatchEventRule_enable (96.28s)
--- PASS: TestAccAWSCloudWatchEventRule_prefix (36.77s)
--- FAIL: TestAccAWSCloudWatchEventRule_tags (20.89s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating tags for tf-acc-cw-event-rule-tags: UnknownOperationException:
        	status code: 400, request id: e5a41de0-77fd-11e9-8481-b3ad1760b794

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test274931831/main.tf line 2:
          (source code not available)

--- PASS: TestAccAWSCloudWatchEventRule_basic (67.65s)
```

Output from us-west-2 acceptance testing:

```
--- PASS: TestAccAWSCloudWatchEventRule_importBasic (14.84s)
--- PASS: TestAccAWSCloudWatchEventRule_full (15.14s)
--- PASS: TestAccAWSCloudWatchEventRule_enable (30.45s)
--- PASS: TestAccAWSCloudWatchEventRule_prefix (10.21s)
--- PASS: TestAccAWSCloudWatchEventRule_tags (32.39s)
--- PASS: TestAccAWSCloudWatchEventRule_basic (21.45s)
```
