### PR TITLE
resource/aws_ssm_parameter: Remove Tier from PutParameter if unsupported, fix testing for GovCloud

### DIFF
--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,8 +48,7 @@ func TestAccAWSSSMParameter_basic(t *testing.T) {
 				Config: testAccAWSSSMParameterBasicConfig(name, "String", "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
-					resource.TestMatchResourceAttr("aws_ssm_parameter.foo", "arn",
-						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:parameter/%s$", name))),
+					testAccCheckResourceAttrRegionalARN("aws_ssm_parameter.foo", "arn", "ssm", fmt.Sprintf("parameter/%s", name)),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "value", "bar"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "type", "String"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "tier", "Standard"),
@@ -230,8 +228,7 @@ func TestAccAWSSSMParameter_fullPath(t *testing.T) {
 				Config: testAccAWSSSMParameterBasicConfig(name, "String", "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSSMParameterExists("aws_ssm_parameter.foo", &param),
-					resource.TestMatchResourceAttr("aws_ssm_parameter.foo", "arn",
-						regexp.MustCompile(fmt.Sprintf("^arn:aws:ssm:[a-z0-9-]+:[0-9]{12}:parameter%s$", name))),
+					testAccCheckResourceAttrRegionalARN("aws_ssm_parameter.foo", "arn", "ssm", fmt.Sprintf("parameter%s", name)),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "value", "bar"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "type", "String"),
 				),


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8662

AWS China does not yet support the API field. As noted in #8662 another option would instead be to switch to removing the attribute `Default`, using `d.GetOk()` with the `PutParameter` API call, and implementing `DiffSuppressFunc` on the attribute to prevent the difference of `"Standard"` to `""`.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ssm_parameter: Remove Tier from PutParameter if unsupported (fixes AWS China support)
```

Output from AWS Standard acceptance testing:

```
--- PASS: TestAccAWSSSMParameter_disappears (11.04s)
--- PASS: TestAccAWSSSMParameter_fullPath (15.19s)
--- PASS: TestAccAWSSSMParameter_secure (15.33s)
--- PASS: TestAccAWSSSMParameter_basic (15.34s)
--- PASS: TestAccAWSSSMParameter_importBasic (19.48s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (26.56s)
--- PASS: TestAccAWSSSMParameter_updateTags (29.97s)
--- PASS: TestAccAWSSSMParameter_updateDescription (31.60s)
--- PASS: TestAccAWSSSMParameter_overwrite (32.77s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (46.83s)
--- PASS: TestAccAWSSSMParameter_Tier (52.33s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (69.30s)
```

Output from AWS GovCloud (US) acceptance testing:

```
--- PASS: TestAccAWSSSMParameter_disappears (15.31s)
--- PASS: TestAccAWSSSMParameter_basic (21.15s)
--- PASS: TestAccAWSSSMParameter_secure (21.27s)
--- PASS: TestAccAWSSSMParameter_importBasic (22.57s)
--- PASS: TestAccAWSSSMParameter_fullPath (22.80s)
--- PASS: TestAccAWSSSMParameter_overwrite (35.12s)
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (38.59s)
--- PASS: TestAccAWSSSMParameter_updateDescription (39.42s)
--- PASS: TestAccAWSSSMParameter_updateTags (41.84s)
--- PASS: TestAccAWSSSMParameter_Tier (48.40s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (51.69s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (65.74s)
```
