### PR TITLE
resource/aws_lightsail_instance: Add validation for instance name

### DIFF
--- a/aws/resource_aws_lightsail_instance.go
+++ b/aws/resource_aws_lightsail_instance.go
@@ -31,8 +31,8 @@ func resourceAwsLightsailInstance() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(3, 255),
-					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character, and contain only alphanumeric characters, underscores, hyphens, and dots"),
-					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must begin with an alphabetic character, and contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must contain only alphanumeric characters, underscores, hyphens, and dots"),
 				),
 			},
 			"availability_zone": {

--- a/aws/resource_aws_lightsail_instance.go
+++ b/aws/resource_aws_lightsail_instance.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsLightsailInstance() *schema.Resource {
@@ -27,6 +29,11 @@ func resourceAwsLightsailInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(3, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]`), "must begin with an alphabetic character, and contain only alphanumeric characters, underscores, hyphens, and dots"),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]+[^._\-]$`), "must begin with an alphabetic character, and contain only alphanumeric characters, underscores, hyphens, and dots"),
+				),
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -62,6 +63,51 @@ func TestAccAWSLightsailInstance_euRegion(t *testing.T) {
 	})
 }
 
+func TestAccAWSLightsailInstance_Name(t *testing.T) {
+	var conf lightsail.Instance
+	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
+	lightsailNameWithSpace := fmt.Sprint(lightsailName, "string with more spaces")
+	lightsailNameWithTrailingDot := fmt.Sprintf("%s.", lightsailName)
+	lightsailNameWithUnderscore := fmt.Sprintf("%s_123456", lightsailName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSLightsailInstanceConfig_basic(lightsailNameWithSpace),
+				ExpectError: regexp.MustCompile(`must begin with an alphabetic character.*`),
+			},
+			{
+				Config:      testAccAWSLightsailInstanceConfig_basic(lightsailNameWithTrailingDot),
+				ExpectError: regexp.MustCompile(`must begin with an alphabetic character.*`),
+			},
+			{
+				Config: testAccAWSLightsailInstanceConfig_basic(lightsailName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailInstanceExists("aws_lightsail_instance.lightsail_instance_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "availability_zone"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
+				),
+			},
+			{
+				Config: testAccAWSLightsailInstanceConfig_basic(lightsailNameWithUnderscore),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailInstanceExists("aws_lightsail_instance.lightsail_instance_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "availability_zone"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLightsailInstance_disapear(t *testing.T) {
 	var conf lightsail.Instance
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
@@ -74,7 +120,7 @@ func TestAccAWSLightsailInstance_disapear(t *testing.T) {
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error deleting Lightsail Instance in disapear test")
+			return fmt.Errorf("error deleting Lightsail Instance in disappear test")
 		}
 
 		// sleep 7 seconds to give it time, so we don't have to poll

--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -66,8 +66,8 @@ func TestAccAWSLightsailInstance_euRegion(t *testing.T) {
 func TestAccAWSLightsailInstance_Name(t *testing.T) {
 	var conf lightsail.Instance
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
-	lightsailNameWithSpace := fmt.Sprint(lightsailName, "string with more spaces")
-	lightsailNameWithTrailingDot := fmt.Sprintf("%s.", lightsailName)
+	lightsailNameWithSpaces := fmt.Sprint(lightsailName, "string with spaces")
+	lightsailNameWithStartingDigit := fmt.Sprintf("01-%s", lightsailName)
 	lightsailNameWithUnderscore := fmt.Sprintf("%s_123456", lightsailName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -77,12 +77,12 @@ func TestAccAWSLightsailInstance_Name(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSLightsailInstanceConfig_basic(lightsailNameWithSpace),
-				ExpectError: regexp.MustCompile(`must begin with an alphabetic character.*`),
+				Config:      testAccAWSLightsailInstanceConfig_basic(lightsailNameWithSpaces),
+				ExpectError: regexp.MustCompile(`must contain only alphanumeric characters, underscores, hyphens, and dots`),
 			},
 			{
-				Config:      testAccAWSLightsailInstanceConfig_basic(lightsailNameWithTrailingDot),
-				ExpectError: regexp.MustCompile(`must begin with an alphabetic character.*`),
+				Config:      testAccAWSLightsailInstanceConfig_basic(lightsailNameWithStartingDigit),
+				ExpectError: regexp.MustCompile(`must begin with an alphabetic character`),
 			},
 			{
 				Config: testAccAWSLightsailInstanceConfig_basic(lightsailName),


### PR DESCRIPTION
related to #8647

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

Output from acceptance testing:

```
--- PASS: TestAccAWSLightsailInstance_Name (99.68s)
```