### PR TITLE
aws_cloudwatch_log_group property

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -55,7 +55,7 @@ resource "aws_eks_cluster" "example" {
 
 resource "aws_cloudwatch_log_group" "example" {
   name             = "/aws/eks/${var.cluster_name}/cluster"
-  retention_period = 7
+  retention_in_days = 7
   # ... potentially other configuration ...
 }
 ```


### PR DESCRIPTION
aws_cloudwatch_log_group property "retention" within "Enabling Control Plan Logging" should be "retention_in_days"

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
