### PR TITLE
tests/resource/aws_rds_global_cluster: Bypass sweeper error in AWS GovCloud (US)

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -359,6 +359,10 @@ func testSweepSkipSweepError(err error) bool {
 	if isAWSErr(err, "InvalidParameterValue", "not permitted in this API version for your account") {
 		return true
 	}
+	// InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
+	if isAWSErr(err, "InvalidParameterValue", "Access Denied to API Version") {
+		return true
+	}
 	// GovCloud has endpoints that respond with (no message provided):
 	// AccessDeniedException:
 	// Since acceptance test sweepers are best effort and this response is very common,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This partition does not currently support the RDS Global Cluster APIs.

Previous output from test sweeper in AWS GovCloud (US):

```console
$  go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_rds_global_cluster -timeout 10h
...
2019/05/17 09:04:41 [ERR] error running (aws_rds_global_cluster): error retrieving RDS Global Clusters: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
```

Output from test sweeper in AWS GovCloud (US):

```console
$  go test ./aws -v -sweep=us-gov-west-1 -sweep-run=aws_rds_global_cluster -timeout 10h
...
2019/05/17 09:08:01 Sweeper Tests ran:
  - aws_db_instance
  - aws_rds_cluster
  - aws_rds_global_cluster
```