### PR TITLE
Add name, desc for SSM maintenance window targets

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
@@ -48,6 +49,20 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 				},
 			},
 
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsSSMMaintenanceWindowTargetName,
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(3, 128),
+			},
+
 			"owner_information": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -65,6 +80,8 @@ func resourceAwsSsmMaintenanceWindowTargetCreate(d *schema.ResourceData, meta in
 		WindowId:     aws.String(d.Get("window_id").(string)),
 		ResourceType: aws.String(d.Get("resource_type").(string)),
 		Targets:      expandAwsSsmTargets(d.Get("targets").([]interface{})),
+		Name:         aws.String(d.Get("name").(string)),
+		Description:  aws.String(d.Get("description").(string)),
 	}
 
 	if v, ok := d.GetOk("owner_information"); ok {
@@ -107,6 +124,8 @@ func resourceAwsSsmMaintenanceWindowTargetRead(d *schema.ResourceData, meta inte
 			d.Set("owner_information", t.OwnerInformation)
 			d.Set("window_id", t.WindowId)
 			d.Set("resource_type", t.ResourceType)
+			d.Set("name", t.Name)
+			d.Set("description", t.Description)
 
 			if err := d.Set("targets", flattenAwsSsmTargets(t.Targets)); err != nil {
 				return fmt.Errorf("Error setting targets error: %#v", err)

--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -53,7 +54,7 @@ func resourceAwsSsmMaintenanceWindowTarget() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAwsSSMMaintenanceWindowTargetName,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`), "Only alphanumeric characters, hyphens, dots & underscores allowed"),
 			},
 
 			"description": {

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -190,8 +190,8 @@ resource "aws_ssm_maintenance_window" "foo" {
 }
 
 resource "aws_ssm_maintenance_window_target" "target" {
-	name = "TestMaintenanceWindowTarget"
-	description = "This resource is for test purpose only"
+  name = "TestMaintenanceWindowTarget"
+  description = "This resource is for test purpose only"
   window_id = "${aws_ssm_maintenance_window.foo.id}"
   resource_type = "INSTANCE"
   targets {
@@ -216,8 +216,8 @@ resource "aws_ssm_maintenance_window" "foo" {
 }
 
 resource "aws_ssm_maintenance_window_target" "target" {
-	name = "TestMaintenanceWindowTarget"
-	description = "This resource is for test purpose only - updated"
+  name = "TestMaintenanceWindowTarget"
+  description = "This resource is for test purpose only - updated"
   window_id = "${aws_ssm_maintenance_window.foo.id}"
   resource_type = "INSTANCE"
   owner_information = "something"
@@ -243,8 +243,8 @@ resource "aws_ssm_maintenance_window" "foo" {
 }
 
 resource "aws_ssm_maintenance_window_target" "target" {
-	name = "%s"
-	description = "%s"
+  name = "%s"
+  description = "%s"
   window_id = "${aws_ssm_maintenance_window.foo.id}"
   resource_type = "INSTANCE"
   owner_information = "something"

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -57,11 +57,11 @@ func TestAccAWSSSMMaintenanceWindowTarget_validation(t *testing.T) {
 			},
 			{
 				Config:      testAccAWSSSMMaintenanceWindowTargetBasicConfigWithTarget(name, "goodname", "bd"),
-				ExpectError: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(3 - 128\\), got [\\w]+"),
+				ExpectError: regexp.MustCompile(`expected length of [\w]+ to be in the range \(3 - 128\), got [\w]+`),
 			},
 			{
 				Config:      testAccAWSSSMMaintenanceWindowTargetBasicConfigWithTarget(name, "goodname", "This description is tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long"),
-				ExpectError: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(3 - 128\\), got [\\w]+"),
+				ExpectError: regexp.MustCompile(`expected length of [\w]+ to be in the range \(3 - 128\), got [\w]+`),
 			},
 		},
 	})

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -30,6 +30,8 @@ func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.#", "2"),
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.0", "acceptance_test"),
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.1", "acceptance_test2"),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "name", "TestMaintenanceWindowTarget"),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "description", "This resource is for test purpose only"),
 				),
 			},
 			{
@@ -59,6 +61,8 @@ func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.#", "2"),
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.0", "acceptance_test"),
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.1", "acceptance_test2"),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "name", "TestMaintenanceWindowTarget"),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "description", "This resource is for test purpose only"),
 				),
 			},
 			{
@@ -72,6 +76,8 @@ func TestAccAWSSSMMaintenanceWindowTarget_update(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.key", "tag:Updated"),
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.#", "1"),
 					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "targets.1.values.0", "new-value"),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "name", "TestMaintenanceWindowTarget"),
+					resource.TestCheckResourceAttr("aws_ssm_maintenance_window_target.target", "description", "This resource is for test purpose only - updated"),
 				),
 			},
 		},
@@ -160,6 +166,8 @@ resource "aws_ssm_maintenance_window" "foo" {
 }
 
 resource "aws_ssm_maintenance_window_target" "target" {
+	name = "TestMaintenanceWindowTarget"
+	description = "This resource is for test purpose only"
   window_id = "${aws_ssm_maintenance_window.foo.id}"
   resource_type = "INSTANCE"
   targets {
@@ -184,6 +192,8 @@ resource "aws_ssm_maintenance_window" "foo" {
 }
 
 resource "aws_ssm_maintenance_window_target" "target" {
+	name = "TestMaintenanceWindowTarget"
+	description = "This resource is for test purpose only - updated"
   window_id = "${aws_ssm_maintenance_window.foo.id}"
   resource_type = "INSTANCE"
   owner_information = "something"

--- a/aws/resource_aws_ssm_maintenance_window_target_test.go
+++ b/aws/resource_aws_ssm_maintenance_window_target_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,6 +39,29 @@ func TestAccAWSSSMMaintenanceWindowTarget_basic(t *testing.T) {
 				ResourceName:      "aws_ssm_maintenance_window.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSSSMMaintenanceWindowTarget_validation(t *testing.T) {
+	name := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMMaintenanceWindowTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSSSMMaintenanceWindowTargetBasicConfigWithTarget(name, "Bäd Name!@#$%^", "good description"),
+				ExpectError: regexp.MustCompile(`Only alphanumeric characters, hyphens, dots & underscores allowed`),
+			},
+			{
+				Config:      testAccAWSSSMMaintenanceWindowTargetBasicConfigWithTarget(name, "goodname", "bd"),
+				ExpectError: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(3 - 128\\), got [\\w]+"),
+			},
+			{
+				Config:      testAccAWSSSMMaintenanceWindowTargetBasicConfigWithTarget(name, "goodname", "This description is tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long"),
+				ExpectError: regexp.MustCompile("expected length of [\\w]+ to be in the range \\(3 - 128\\), got [\\w]+"),
 			},
 		},
 	})
@@ -207,4 +231,31 @@ resource "aws_ssm_maintenance_window_target" "target" {
   }
 }
 `, rName)
+}
+
+func testAccAWSSSMMaintenanceWindowTargetBasicConfigWithTarget(rName, tName, tDesc string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_maintenance_window" "foo" {
+  name = "maintenance-window-%s"
+  schedule = "cron(0 16 ? * TUE *)"
+  duration = 3
+  cutoff = 1
+}
+
+resource "aws_ssm_maintenance_window_target" "target" {
+	name = "%s"
+	description = "%s"
+  window_id = "${aws_ssm_maintenance_window.foo.id}"
+  resource_type = "INSTANCE"
+  owner_information = "something"
+  targets {
+    key = "tag:Name"
+    values = ["acceptance_test"]
+  }
+  targets {
+    key = "tag:Updated"
+    values = ["new-value"]
+  }
+}
+`, rName, tName, tDesc)
 }

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1825,19 +1825,6 @@ func validateAwsSSMMaintenanceWindowTaskName(v interface{}, k string) (ws []stri
 	return
 }
 
-func validateAwsSSMMaintenanceWindowTargetName(v interface{}, k string) (ws []string, errors []error) {
-	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_RegisterTaskWithMaintenanceWindow.html#systemsmanager-RegisterTaskWithMaintenanceWindow-request-Name
-	value := v.(string)
-
-	if !regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"Only alphanumeric characters, hyphens, dots & underscores allowed in %q: %q (Must satisfy regular expression pattern: ^[a-zA-Z0-9_\\-.]{3,128}$)",
-			k, value))
-	}
-
-	return
-}
-
 func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-zA-Z]{1}[0-9a-zA-Z_\-]{0,127}$`).MatchString(value) {

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1825,6 +1825,19 @@ func validateAwsSSMMaintenanceWindowTaskName(v interface{}, k string) (ws []stri
 	return
 }
 
+func validateAwsSSMMaintenanceWindowTargetName(v interface{}, k string) (ws []string, errors []error) {
+	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_RegisterTaskWithMaintenanceWindow.html#systemsmanager-RegisterTaskWithMaintenanceWindow-request-Name
+	value := v.(string)
+
+	if !regexp.MustCompile(`^[a-zA-Z0-9_\-.]{3,128}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"Only alphanumeric characters, hyphens, dots & underscores allowed in %q: %q (Must satisfy regular expression pattern: ^[a-zA-Z0-9_\\-.]{3,128}$)",
+			k, value))
+	}
+
+	return
+}
+
 func validateBatchName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-zA-Z]{1}[0-9a-zA-Z_\-]{0,127}$`).MatchString(value) {

--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -22,6 +22,8 @@ resource "aws_ssm_maintenance_window" "window" {
 
 resource "aws_ssm_maintenance_window_target" "target1" {
   window_id     = "${aws_ssm_maintenance_window.window.id}"
+  name             = "maintenance-window-target"
+  description      = "This is a maintenance window target"
   resource_type = "INSTANCE"
 
   targets {
@@ -36,6 +38,8 @@ resource "aws_ssm_maintenance_window_target" "target1" {
 The following arguments are supported:
 
 * `window_id` - (Required) The Id of the maintenance window to register the target with.
+* `name` - (Optional) The name of the maintenance window target.
+* `description` - (Optional) The description of the maintenance window target.
 * `resource_type` - (Required) The type of target being registered with the Maintenance Window. Possible values `INSTANCE`.
 * `targets` - (Required) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value.
 * `owner_information` - (Optional) User-provided value that will be included in any CloudWatch events raised while running tasks for these targets in this Maintenance Window.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #6471

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ssm_maintenance_window_target: Add support for name and
description for maintenance window targets
```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSSSMMaintenanceWindowTarget"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSSMMaintenanceWindowTarget -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_validation
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_validation
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_update
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_update
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_update
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_validation
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_validation (3.10s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_basic (31.51s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_update (47.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       49.797s
...
```