### PR TITLE
service/appsync: Various minor fixes

### DIFF
--- a/aws/resource_aws_appsync_api_key_test.go
+++ b/aws/resource_aws_appsync_api_key_test.go
@@ -20,7 +20,7 @@ func TestAccAWSAppsyncApiKey_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncApiKeyDestroy,
 		Steps: []resource.TestStep{
@@ -48,7 +48,7 @@ func TestAccAWSAppsyncApiKey_Description(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncApiKeyDestroy,
 		Steps: []resource.TestStep{
@@ -83,7 +83,7 @@ func TestAccAWSAppsyncApiKey_Expires(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncApiKeyDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -577,7 +577,7 @@ resource "aws_lambda_function" "test" {
   function_name = %q
   handler       = "exports.test"
   role          = "${aws_iam_role.lambda.arn}"
-  runtime       = "nodejs6.10"
+  runtime       = "nodejs8.10"
 }
 
 resource "aws_iam_role" "test" {

--- a/aws/resource_aws_appsync_datasource_test.go
+++ b/aws/resource_aws_appsync_datasource_test.go
@@ -17,7 +17,7 @@ func TestAccAwsAppsyncDatasource_basic(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccAwsAppsyncDatasource_Description(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -81,7 +81,7 @@ func TestAccAwsAppsyncDatasource_DynamoDBConfig_Region(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -115,7 +115,7 @@ func TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials(t *testing.
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -149,7 +149,7 @@ func TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -183,7 +183,7 @@ func TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -219,7 +219,7 @@ func TestAccAwsAppsyncDatasource_Type(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -248,7 +248,7 @@ func TestAccAwsAppsyncDatasource_Type_DynamoDB(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -278,7 +278,7 @@ func TestAccAwsAppsyncDatasource_Type_Elasticsearch(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -307,7 +307,7 @@ func TestAccAwsAppsyncDatasource_Type_HTTP(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -336,7 +336,7 @@ func TestAccAwsAppsyncDatasource_Type_Lambda(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{
@@ -364,7 +364,7 @@ func TestAccAwsAppsyncDatasource_Type_None(t *testing.T) {
 	resourceName := "aws_appsync_datasource.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncDatasourceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_appsync_graphql_api.go
+++ b/aws/resource_aws_appsync_graphql_api.go
@@ -166,7 +166,7 @@ func resourceAwsAppsyncGraphqlApiCreate(d *schema.ResourceData, meta interface{}
 
 	resp, err := conn.CreateGraphqlApi(input)
 	if err != nil {
-		return fmt.Errorf("error creating AppSync GraphQL API: %d", err)
+		return fmt.Errorf("error creating AppSync GraphQL API: %s", err)
 	}
 
 	d.SetId(*resp.GraphqlApi.ApiId)
@@ -186,13 +186,15 @@ func resourceAwsAppsyncGraphqlApiRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	resp, err := conn.GetGraphqlApi(input)
+
+	if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] No such entity found for Appsync Graphql API (%s)", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
-			log.Printf("[WARN] No such entity found for Appsync Graphql API (%s)", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error getting AppSync GraphQL API (%s): %s", d.Id(), err)
 	}
 
 	d.Set("arn", resp.GraphqlApi.Arn)
@@ -250,7 +252,7 @@ func resourceAwsAppsyncGraphqlApiUpdate(d *schema.ResourceData, meta interface{}
 
 	_, err := conn.UpdateGraphqlApi(input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating AppSync GraphQL API (%s): %s", d.Id(), err)
 	}
 
 	if d.HasChange("schema") {
@@ -269,11 +271,13 @@ func resourceAwsAppsyncGraphqlApiDelete(d *schema.ResourceData, meta interface{}
 		ApiId: aws.String(d.Id()),
 	}
 	_, err := conn.DeleteGraphqlApi(input)
+
+	if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
+		return nil
+	}
+
 	if err != nil {
-		if isAWSErr(err, appsync.ErrCodeNotFoundException, "") {
-			return nil
-		}
-		return err
+		return fmt.Errorf("error deleting AppSync GraphQL API (%s): %s", d.Id(), err)
 	}
 
 	return nil

--- a/aws/resource_aws_appsync_graphql_api_test.go
+++ b/aws/resource_aws_appsync_graphql_api_test.go
@@ -70,7 +70,7 @@ func TestAccAWSAppsyncGraphqlApi_basic(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -104,7 +104,7 @@ func TestAccAWSAppsyncGraphqlApi_disappears(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -126,7 +126,7 @@ func TestAccAWSAppsyncGraphqlApi_Schema(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -169,7 +169,7 @@ func TestAccAWSAppsyncGraphqlApi_AuthenticationType(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -202,7 +202,7 @@ func TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -230,7 +230,7 @@ func TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -259,7 +259,7 @@ func TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools(t *te
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -289,7 +289,7 @@ func TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect(t *testing.T) 
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -318,7 +318,7 @@ func TestAccAWSAppsyncGraphqlApi_LogConfig(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -347,7 +347,7 @@ func TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -393,7 +393,7 @@ func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -432,7 +432,7 @@ func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -471,7 +471,7 @@ func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -510,7 +510,7 @@ func TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -548,7 +548,7 @@ func TestAccAWSAppsyncGraphqlApi_Name(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -577,7 +577,7 @@ func TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -619,7 +619,7 @@ func TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -660,7 +660,7 @@ func TestAccAWSAppsyncGraphqlApi_Tags(t *testing.T) {
 	resourceName := "aws_appsync_graphql_api.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncGraphqlApiDestroy,
 		Steps: []resource.TestStep{
@@ -776,6 +776,22 @@ func testAccCheckAwsAppsyncTypeExists(name, typeName string) resource.TestCheckF
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSAppSync(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).appsyncconn
+
+	input := &appsync.ListGraphqlApisInput{}
+
+	_, err := conn.ListGraphqlApis(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_appsync_resolver_test.go
+++ b/aws/resource_aws_appsync_resolver_test.go
@@ -18,7 +18,7 @@ func TestAccAwsAppsyncResolver_basic(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{
@@ -48,7 +48,7 @@ func TestAccAwsAppsyncResolver_disappears(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{
@@ -71,7 +71,7 @@ func TestAccAwsAppsyncResolver_DataSource(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{
@@ -104,7 +104,7 @@ func TestAccAwsAppsyncResolver_RequestTemplate(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{
@@ -137,7 +137,7 @@ func TestAccAwsAppsyncResolver_ResponseTemplate(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{
@@ -170,7 +170,7 @@ func TestAccAwsAppsyncResolver_multipleResolvers(t *testing.T) {
 	resourceName := "aws_appsync_resolver.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSAppSync(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsAppsyncResolverDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Sorry for the "various" part here, but while adding the `PreCheck` function noticed these other minor items. There are three commits for easier review!

* resource/aws_appsync_graphql_api: Adjust error messaging for context and proper formatter typing (https://github.com/terraform-providers/terraform-provider-aws/commit/006cbfec76c30e0dfe3fc49dae75daf52112bf02)

Previously error messages during creation would use an incorrect format verb which was harder to read:

```
--- FAIL: TestAccAWSAppsyncGraphqlApi_basic (0.50s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating AppSync GraphQL API: &{%!d(string=RequestError) %!d(string=send request failed) [824649821952]}
```

Now error messages are properly formatted and consistently applied across Create/Read/Update/Delete functions.

```
--- FAIL: TestAccAWSAppsyncGraphqlApi_basic (6.36s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating AppSync GraphQL API: RequestError: send request failed
        caused by: Post https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
```

Output from acceptance testing:

```
--- PASS: TestAccAWSAppsyncGraphqlApi_disappears (12.98s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (13.22s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (13.49s)
--- PASS: TestAccAWSAppsyncGraphqlApi_basic (13.94s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig (15.25s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (15.56s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (15.93s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (19.66s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (19.78s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType (19.99s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (21.15s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (22.64s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (22.64s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (27.56s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (29.54s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Name (29.79s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Schema (29.99s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Tags (30.21s)
```

* tests/service/appsync: Add PreCheck for service availability (https://github.com/terraform-providers/terraform-provider-aws/commit/b9b193deac6120cd938d45321d2162c3dca6476c)

Previously in AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSAppsyncGraphqlApi_basic (6.36s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating AppSync GraphQL API: RequestError: send request failed
        caused by: Post https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
```

Output from AWS Standard acceptance testing:

```
--- PASS: TestAccAWSAppsyncGraphqlApi_disappears (11.00s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (12.86s)
--- PASS: TestAccAwsAppsyncDatasource_Type_HTTP (14.70s)
--- PASS: TestAccAWSAppsyncApiKey_basic (15.89s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (19.99s)
--- PASS: TestAccAwsAppsyncDatasource_Type (20.55s)
--- PASS: TestAccAWSAppsyncGraphqlApi_basic (23.15s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType (23.45s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (10.83s)
--- PASS: TestAccAwsAppsyncDatasource_Type_None (24.06s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig (13.60s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (24.69s)
--- FAIL: TestAccAwsAppsyncDatasource_Type_Lambda (25.53s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Lambda function: InvalidParameterValueException: The runtime parameter of nodejs6.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs8.10) while creating or updating functions.
        	status code: 400, request id: 2ad8fdcd-78dd-11e9-82e1-0b28c3b9519b

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test220210354/main.tf line 21:
          (source code not available)

--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (27.02s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (28.93s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (29.85s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Schema (30.41s)
--- PASS: TestAccAwsAppsyncDatasource_Type_DynamoDB (30.73s)
--- PASS: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (16.64s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Name (31.69s)
--- PASS: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (31.98s)
--- PASS: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (32.35s)
--- PASS: TestAccAwsAppsyncResolver_disappears (17.48s)
--- PASS: TestAccAwsAppsyncResolver_basic (18.71s)
--- PASS: TestAccAwsAppsyncDatasource_basic (14.51s)
--- PASS: TestAccAWSAppsyncGraphqlApi_Tags (19.65s)
--- PASS: TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint (20.76s)
--- PASS: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (21.72s)
--- PASS: TestAccAWSAppsyncApiKey_Expires (18.96s)
--- PASS: TestAccAwsAppsyncDatasource_Description (20.44s)
--- PASS: TestAccAWSAppsyncApiKey_Description (18.41s)
--- PASS: TestAccAwsAppsyncResolver_ResponseTemplate (23.14s)
--- PASS: TestAccAwsAppsyncResolver_DataSource (22.28s)
--- PASS: TestAccAwsAppsyncResolver_RequestTemplate (26.09s)
--- PASS: TestAccAwsAppsyncResolver_multipleResolvers (47.98s)
--- PASS: TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials (122.51s)
--- PASS: TestAccAwsAppsyncDatasource_DynamoDBConfig_Region (124.23s)
--- PASS: TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region (551.20s)
--- PASS: TestAccAwsAppsyncDatasource_Type_Elasticsearch (648.43s)
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAwsAppsyncDatasource_Type_Elasticsearch (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_Type_HTTP (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_Type_DynamoDB (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_Type_None (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_ElasticsearchConfig_Region (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_basic (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncApiKey_basic (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AWSIAM (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncApiKey_Expires (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_Type_Lambda (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_HTTPConfig_Endpoint (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_APIKey (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_Type (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_DynamoDBConfig_UseCallerCredentials (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_Schema (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_disappears (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_Description (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_basic (2.55s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncDatasource_DynamoDBConfig_Region (3.32s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_Tags (1.86s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncResolver_RequestTemplate (1.90s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_AuthTTL (1.90s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncResolver_disappears (1.91s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncResolver_DataSource (1.92s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_OpenIDConnect (1.92s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncResolver_basic (1.93s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncResolver_ResponseTemplate (1.93s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_AwsRegion (1.93s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_ClientID (1.93s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_LogConfig (1.93s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncApiKey_Description (1.95s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_LogConfig_FieldLogLevel (1.95s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsAppsyncResolver_multipleResolvers (1.96s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_Issuer (2.00s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_AuthenticationType_AmazonCognitoUserPools (2.00s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_UserPoolConfig_DefaultAction (2.01s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_Name (2.03s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSAppsyncGraphqlApi_OpenIDConnectConfig_IatTTL (2.04s)
    resource_aws_appsync_graphql_api_test.go:790: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://appsync.us-gov-west-1.amazonaws.com/v1/apis: dial tcp: lookup appsync.us-gov-west-1.amazonaws.com: no such host
```

* tests/resource/aws_appsync_datasource: Fix Lambda runtime (https://github.com/terraform-providers/terraform-provider-aws/commit/b01bfd63c1514863aaa692e7065dbcde720fc9f8)

Previous output from acceptance testing:

```
--- FAIL: TestAccAwsAppsyncDatasource_Type_Lambda (25.53s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Lambda function: InvalidParameterValueException: The runtime parameter of nodejs6.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs8.10) while creating or updating functions.
        	status code: 400, request id: 2ad8fdcd-78dd-11e9-82e1-0b28c3b9519b

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test220210354/main.tf line 21:
          (source code not available)
```

Output from acceptance testing:

```
--- PASS: TestAccAwsAppsyncDatasource_Type_Lambda (26.25s)
```
