### PR TITLE
tests/service/backup: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_backup_plan_test.go
+++ b/aws/resource_aws_backup_plan_test.go
@@ -17,7 +17,7 @@ func TestAccAwsBackupPlan_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -40,7 +40,7 @@ func TestAccAwsBackupPlan_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -78,7 +78,7 @@ func TestAccAwsBackupPlan_withRules(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -98,7 +98,7 @@ func TestAccAwsBackupPlan_withRuleRemove(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -125,7 +125,7 @@ func TestAccAwsBackupPlan_withRuleAdd(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -152,7 +152,7 @@ func TestAccAwsBackupPlan_withLifecycle(t *testing.T) {
 	rStr := "lifecycle_policy"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -172,7 +172,7 @@ func TestAccAwsBackupPlan_withLifecycleDeleteAfterOnly(t *testing.T) {
 	rStr := "lifecycle_policy_two"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -194,7 +194,7 @@ func TestAccAwsBackupPlan_withLifecycleColdStorageAfterOnly(t *testing.T) {
 	rStr := "lifecycle_policy_three"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{
@@ -216,7 +216,7 @@ func TestAccAwsBackupPlan_disappears(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupPlanDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_backup_selection_test.go
+++ b/aws/resource_aws_backup_selection_test.go
@@ -16,7 +16,7 @@ func TestAccAwsBackupSelection_basic(t *testing.T) {
 	resourceName := "aws_backup_selection.test"
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
@@ -40,7 +40,7 @@ func TestAccAwsBackupSelection_disappears(t *testing.T) {
 	var selection1 backup.GetBackupSelectionOutput
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
@@ -61,7 +61,7 @@ func TestAccAwsBackupSelection_withTags(t *testing.T) {
 	resourceName := "aws_backup_selection.test"
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
@@ -87,7 +87,7 @@ func TestAccAwsBackupSelection_withResources(t *testing.T) {
 	resourceName := "aws_backup_selection.test"
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{
@@ -113,7 +113,7 @@ func TestAccAwsBackupSelection_updateTag(t *testing.T) {
 	resourceName := "aws_backup_selection.test"
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupSelectionDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_backup_vault_test.go
+++ b/aws/resource_aws_backup_vault_test.go
@@ -16,7 +16,7 @@ func TestAccAwsBackupVault_basic(t *testing.T) {
 
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupVaultDestroy,
 		Steps: []resource.TestStep{
@@ -35,7 +35,7 @@ func TestAccAwsBackupVault_withKmsKey(t *testing.T) {
 
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupVaultDestroy,
 		Steps: []resource.TestStep{
@@ -55,7 +55,7 @@ func TestAccAwsBackupVault_withTags(t *testing.T) {
 
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsBackupVaultDestroy,
 		Steps: []resource.TestStep{
@@ -134,6 +134,22 @@ func testAccCheckAwsBackupVaultExists(name string, vault *backup.DescribeBackupV
 		*vault = *resp
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSBackup(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).backupconn
+
+	input := &backup.ListBackupVaultsInput{}
+
+	_, err := conn.ListBackupVaults(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously in AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAwsBackupVault_basic (6.91s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Backup Vault (): RequestError: send request failed
        caused by: Put https://backup.us-gov-west-1.amazonaws.com/backup-vaults/tf_acc_test_backup_vault_5570772252950055746: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
```

Output from AWS Standard acceptance testing:

```
--- PASS: TestAccAwsBackupVault_basic (13.66s)
--- PASS: TestAccAwsBackupPlan_disappears (15.83s)
--- PASS: TestAccAwsBackupPlan_withRules (17.25s)
--- PASS: TestAccAwsBackupPlan_basic (17.54s)
--- PASS: TestAccAwsBackupPlan_withLifecycleColdStorageAfterOnly (17.64s)
--- PASS: TestAccAwsBackupPlan_withLifecycle (17.76s)
--- PASS: TestAccAwsBackupPlan_withLifecycleDeleteAfterOnly (17.76s)
--- PASS: TestAccAwsBackupSelection_disappears (19.88s)
--- PASS: TestAccAwsBackupSelection_withTags (21.30s)
--- PASS: TestAccAwsBackupSelection_basic (21.36s)
--- PASS: TestAccAwsBackupSelection_withResources (21.46s)
--- PASS: TestAccAwsBackupPlan_withRuleAdd (28.56s)
--- PASS: TestAccAwsBackupPlan_withRuleRemove (29.33s)
--- PASS: TestAccAwsBackupVault_withTags (31.91s)
--- PASS: TestAccAwsBackupSelection_updateTag (33.08s)
--- PASS: TestAccAwsBackupPlan_withTags (40.05s)
--- PASS: TestAccAwsBackupVault_withKmsKey (44.04s)
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAwsBackupSelection_disappears (2.20s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_withLifecycleDeleteAfterOnly (2.20s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_withRuleRemove (2.20s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupSelection_updateTag (2.20s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupVault_withTags (2.20s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_withTags (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_basic (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupSelection_basic (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_withRules (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_withRuleAdd (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_withLifecycleColdStorageAfterOnly (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_disappears (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupVault_basic (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupSelection_withTags (2.21s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupSelection_withResources (2.22s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupPlan_withLifecycle (2.23s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsBackupVault_withKmsKey (2.23s)
    resource_aws_backup_vault_test.go:148: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://backup.us-gov-west-1.amazonaws.com/backup-vaults/: dial tcp: lookup backup.us-gov-west-1.amazonaws.com: no such host
```