### PR TITLE
tests/service/codebuild: Add AccessDeniedException to testAccPreCheckSkipError

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -332,6 +332,12 @@ func testAccCheckWithProviders(f func(*terraform.State, *schema.Provider) error,
 // Check service API call error for reasons to skip acceptance testing
 // These include missing API endpoints and unsupported API calls
 func testAccPreCheckSkipError(err error) bool {
+	// GovCloud has endpoints that respond with (no message provided after the error code):
+	// AccessDeniedException:
+	// Ignore these API endpoints that exist but are not officially enabled
+	if isAWSErr(err, "AccessDeniedException", "") {
+		return true
+	}
 	// Ignore missing API endpoints
 	if isAWSErr(err, "RequestError", "send request failed") {
 		return true


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

To match the equivalent check in `testSweepSkipSweepError`

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSCodeBuildProject_basic (3.15s)
    resource_aws_codebuild_project_test.go:974: unexpected PreCheck error: AccessDeniedException:
```

Output from AWS Standard acceptance testing (test failures unrelated):

```
--- PASS: TestAccAWSCodeBuildProject_BadgeEnabled (25.33s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (25.77s)
--- PASS: TestAccAWSCodeBuildWebhook_GitHub (32.58s)
--- PASS: TestAccAWSCodeBuildProject_BuildTimeout (34.56s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (34.56s)
--- PASS: TestAccAWSCodeBuildProject_Description (34.67s)
--- PASS: TestAccAWSCodeBuildProject_Source_Auth (35.19s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (35.22s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (35.30s)
--- PASS: TestAccAWSCodeBuildProject_Source_GitCloneDepth (35.47s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (35.53s)
--- PASS: TestAccAWSCodeBuildProject_importBasic (35.62s)
--- PASS: TestAccAWSCodeBuildProject_Environment_Certificate (40.46s)
--- PASS: TestAccAWSCodeBuildWebhook_GitHubEnterprise (41.29s)
--- PASS: TestAccAWSCodeBuildWebhook_BranchFilter (41.85s)
--- PASS: TestAccAWSCodeBuildProject_Source_InsecureSSL (42.39s)
--- PASS: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (42.87s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (8.11s)
--- FAIL: TestAccAWSCodeBuildWebhook_Bitbucket (21.36s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating CodeBuild Webhook: OAuthProviderException: Unable to create webhook at this time. Please try again later.
            status code: 400, request id: 89da26f9-78e5-11e9-b7af-99e5e79d7396

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test599672425/main.tf line 81:
          (source code not available)

--- PASS: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (23.16s)
--- PASS: TestAccAWSCodeBuildProject_EncryptionKey (57.51s)
--- PASS: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (57.67s)
--- PASS: TestAccAWSCodeBuildProject_WindowsContainer (25.45s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_NoSource (25.60s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (25.42s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (25.37s)
--- PASS: TestAccAWSCodeBuildProject_Cache (61.01s)
--- PASS: TestAccAWSCodeBuildProject_basic (22.53s)
--- PASS: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (35.18s)
--- PASS: TestAccAWSCodeBuildProject_SecondaryArtifacts (38.80s)
--- PASS: TestAccAWSCodeBuildProject_Tags (37.26s)
--- PASS: TestAccAWSCodeBuildProject_Source_Type_S3 (37.45s)
--- FAIL: TestAccAWSCodeBuildProject_VpcConfig (49.48s)
    testing.go:568: Step 1 error: errors during apply:

        Error: Unsupported attribute

          on /var/folders/v0/_d108fkx1pbbg4_sh864_7740000gn/T/tf-test775403233/main.tf line 99:
          (source code not available)
            |----------------
            | aws_subnet.test is empty tuple

        This value does not have any attributes.
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSCodeBuildProject_Source_Type_CodePipeline (2.32s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cb59f2-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Source_Type_S3 (2.33s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cce0cf-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildProject_VpcConfig (2.33s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cce054-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildWebhook_GitHub (2.33s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cce0ce-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildProject_SecondaryArtifacts (2.33s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cce053-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_Source_Type_NoSource (2.33s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cdcab5-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_Source_Type_NoSourceInvalid (2.33s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cc4412-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_Source_Type_GitHubEnterprise (2.34s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28ce66f6-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_Tags (2.34s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28ce6733-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable (2.34s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf2a85-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Artifacts_EncryptionDisabled (2.34s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf5158-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_Source_Type_Bitbucket (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf51d2-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHubEnterprise (2.34s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf2a86-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Source_Type_CodeCommit (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf2a47-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_importBasic (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf2ac1-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildWebhook_Bitbucket (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf5159-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildWebhook_GitHubEnterprise (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf2ac0-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildWebhook_BranchFilter (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cf0374-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_WindowsContainer (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cfc68a-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_SecondarySources_CodeCommit (2.35s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 28cfc6c7-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_EncryptionKey (1.64s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c5230c-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_Environment_Certificate (1.62s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c6a9ad-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_BadgeEnabled (1.64s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c68315-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildProject_Cache (1.65s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c79449-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Source_InsecureSSL (1.64s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c8f417-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildProject_Environment_EnvironmentVariable_Type (1.65s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c8ccca-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_GitHub (1.64s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c8f416-78e5-11e9-b46e-03a0009be95b
--- SKIP: TestAccAWSCodeBuildProject_Source_GitCloneDepth (1.64s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c91aeb-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Source_Auth (1.64s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c91aec-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Description (1.66s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c9ddff-78e5-11e9-95d2-bbe6bbb67894
--- SKIP: TestAccAWSCodeBuildProject_basic (1.65s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29ca054e-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_Source_ReportBuildStatus_Bitbucket (1.64s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c9de3d-78e5-11e9-b0e1-a76e3313d23b
--- SKIP: TestAccAWSCodeBuildProject_BuildTimeout (1.66s)
    resource_aws_codebuild_project_test.go:970: skipping acceptance testing: AccessDeniedException:
        	status code: 400, request id: 29c9b6ee-78e5-11e9-95d2-bbe6bbb67894
```
