### PR TITLE
r/aws_kinesis_stream: Add Support enforce_consumer_deletion attribute

### DIFF
--- a/aws/resource_aws_kinesis_stream.go
+++ b/aws/resource_aws_kinesis_stream.go
@@ -57,6 +57,12 @@ func resourceAwsKinesisStream() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"enforce_consumer_deletion": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"encryption_type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -204,7 +210,8 @@ func resourceAwsKinesisStreamDelete(d *schema.ResourceData, meta interface{}) er
 	sn := d.Get("name").(string)
 
 	_, err := conn.DeleteStream(&kinesis.DeleteStreamInput{
-		StreamName: aws.String(sn),
+		StreamName:              aws.String(sn),
+		EnforceConsumerDeletion: aws.Bool(d.Get("enforce_consumer_deletion").(bool)),
 	})
 	if err != nil {
 		return err

--- a/aws/resource_aws_kinesis_stream_test.go
+++ b/aws/resource_aws_kinesis_stream_test.go
@@ -143,10 +143,11 @@ func TestAccAWSKinesisStream_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateId:     streamName,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateId:           streamName,
+				ImportStateVerifyIgnore: []string{"enforce_consumer_deletion"},
 			},
 		},
 	})
@@ -282,6 +283,28 @@ func TestAccAWSKinesisStream_shardLevelMetrics(t *testing.T) {
 	})
 }
 
+func TestAccAWSKinesisStream_enforceConsumerDeletion(t *testing.T) {
+	var stream kinesis.StreamDescription
+
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisStreamDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKinesisStreamConfigWithEnforceConsumerDeletion(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisStreamExists("aws_kinesis_stream.test_stream", &stream),
+					testAccCheckAWSKinesisStreamAttributes(&stream),
+					testAccAWSKinesisStreamRegisterStreamConsumer(&stream, fmt.Sprintf("tf-test-%d", rInt)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSKinesisStream_Tags(t *testing.T) {
 	var stream kinesis.StreamDescription
 	resourceName := "aws_kinesis_stream.test"
@@ -379,6 +402,21 @@ func testAccCheckKinesisStreamDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSKinesisStreamRegisterStreamConsumer(stream *kinesis.StreamDescription, rStr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).kinesisconn
+
+		if _, err := conn.RegisterStreamConsumer(&kinesis.RegisterStreamConsumerInput{
+			ConsumerName: aws.String(rStr),
+			StreamARN:    stream.StreamARN,
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	}
 }
 
 func testAccKinesisStreamConfig(rInt int) string {
@@ -536,4 +574,17 @@ resource "aws_kinesis_stream" "test" {
 %s
 	}
 }`, rInt, tagPairs)
+}
+
+func testAccKinesisStreamConfigWithEnforceConsumerDeletion(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_kinesis_stream" "test_stream" {
+	name 											= "terraform-kinesis-test-%d"
+	shard_count 							= 2
+	enforce_consumer_deletion	= true
+
+	tags = {
+		Name = "tf-test"
+	}
+}`, rInt)
 }

--- a/website/docs/r/kinesis_stream.html.markdown
+++ b/website/docs/r/kinesis_stream.html.markdown
@@ -43,6 +43,7 @@ Amazon has guidlines for specifying the Stream size that should be referenced
 when creating a Kinesis stream. See [Amazon Kinesis Streams][2] for more.
 * `retention_period` - (Optional) Length of time data records are accessible after they are added to the stream. The maximum value of a stream's retention period is 168 hours. Minimum value is 24. Default is 24.
 * `shard_level_metrics` - (Optional) A list of shard-level CloudWatch metrics which can be enabled for the stream. See [Monitoring with CloudWatch][3] for more. Note that the value ALL should not be used; instead you should provide an explicit list of metrics you wish to enable.
+* `enforce_consumer_deletion` - (Optional) A boolean that indicates all registered consumers should be deregistered from the stream so that the stream can be destroyed without error. The default value is `false`.
 * `encryption_type` - (Optional) The encryption type to use. The only acceptable values are `NONE` or `KMS`. The default value is `NONE`.
 * `kms_key_id` - (Optional) The GUID for the customer-managed KMS key to use for encryption. You can also use a Kinesis-owned master key by specifying the alias `alias/aws/kinesis`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8420

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/aws_kinesis_stream: Add Support enforce_consumer_deletion attribute
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSKinesisStream_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSKinesisStream_ -timeout 120m
=== RUN   TestAccAWSKinesisStream_basic
=== PAUSE TestAccAWSKinesisStream_basic
=== RUN   TestAccAWSKinesisStream_createMultipleConcurrentStreams
=== PAUSE TestAccAWSKinesisStream_createMultipleConcurrentStreams
=== RUN   TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError
=== PAUSE TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError
=== RUN   TestAccAWSKinesisStream_encryption
=== PAUSE TestAccAWSKinesisStream_encryption
=== RUN   TestAccAWSKinesisStream_importBasic
=== PAUSE TestAccAWSKinesisStream_importBasic
=== RUN   TestAccAWSKinesisStream_shardCount
=== PAUSE TestAccAWSKinesisStream_shardCount
=== RUN   TestAccAWSKinesisStream_retentionPeriod
=== PAUSE TestAccAWSKinesisStream_retentionPeriod
=== RUN   TestAccAWSKinesisStream_shardLevelMetrics
=== PAUSE TestAccAWSKinesisStream_shardLevelMetrics
=== RUN   TestAccAWSKinesisStream_enforceConsumerDeletion
=== PAUSE TestAccAWSKinesisStream_enforceConsumerDeletion
=== RUN   TestAccAWSKinesisStream_Tags
=== PAUSE TestAccAWSKinesisStream_Tags
=== CONT  TestAccAWSKinesisStream_basic
=== CONT  TestAccAWSKinesisStream_retentionPeriod
=== CONT  TestAccAWSKinesisStream_shardCount
=== CONT  TestAccAWSKinesisStream_encryption
=== CONT  TestAccAWSKinesisStream_importBasic
=== CONT  TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError
=== CONT  TestAccAWSKinesisStream_createMultipleConcurrentStreams
=== CONT  TestAccAWSKinesisStream_enforceConsumerDeletion
=== CONT  TestAccAWSKinesisStream_shardLevelMetrics
=== CONT  TestAccAWSKinesisStream_Tags
--- PASS: TestAccAWSKinesisStream_encryptionWithoutKmsKeyThrowsError (86.01s)
--- PASS: TestAccAWSKinesisStream_basic (103.23s)
--- PASS: TestAccAWSKinesisStream_enforceConsumerDeletion (103.77s)
--- PASS: TestAccAWSKinesisStream_Tags (134.00s)
--- PASS: TestAccAWSKinesisStream_importBasic (157.76s)
--- PASS: TestAccAWSKinesisStream_retentionPeriod (177.53s)
--- PASS: TestAccAWSKinesisStream_shardCount (216.48s)
--- PASS: TestAccAWSKinesisStream_createMultipleConcurrentStreams (266.76s)
--- PASS: TestAccAWSKinesisStream_encryption (279.71s)
--- PASS: TestAccAWSKinesisStream_shardLevelMetrics (311.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	311.714s
```
