### PR TITLE
tests/service/gamelift: Add PreCheck for service availability and skip undefined sample game regions

### DIFF
--- a/aws/resource_aws_gamelift_alias_test.go
+++ b/aws/resource_aws_gamelift_alias_test.go
@@ -90,7 +90,7 @@ func TestAccAWSGameliftAlias_basic(t *testing.T) {
 	uMessage := fmt.Sprintf("tf test updated message %s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
 		Steps: []resource.TestStep{
@@ -130,7 +130,7 @@ func TestAccAWSGameliftAlias_importBasic(t *testing.T) {
 	message := fmt.Sprintf("tf test message %s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
 		Steps: []resource.TestStep{
@@ -158,6 +158,11 @@ func TestAccAWSGameliftAlias_fleetRouting(t *testing.T) {
 
 	region := testAccGetRegion()
 	g, err := testAccAWSGameliftSampleGame(region)
+
+	if isResourceNotFoundError(err) {
+		t.Skip(err)
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +176,7 @@ func TestAccAWSGameliftAlias_fleetRouting(t *testing.T) {
 	params := g.Parameters(33435)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftAliasDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_gamelift_build_test.go
+++ b/aws/resource_aws_gamelift_build_test.go
@@ -68,6 +68,11 @@ func TestAccAWSGameliftBuild_basic(t *testing.T) {
 
 	region := testAccGetRegion()
 	g, err := testAccAWSGameliftSampleGame(region)
+
+	if isResourceNotFoundError(err) {
+		t.Skip(err)
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +83,7 @@ func TestAccAWSGameliftBuild_basic(t *testing.T) {
 	key := *loc.Key
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftBuildDestroy,
 		Steps: []resource.TestStep{
@@ -168,6 +173,22 @@ func testAccCheckAWSGameliftBuildDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccPreCheckAWSGamelift(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).gameliftconn
+
+	input := &gamelift.ListBuildsInput{}
+
+	_, err := conn.ListBuilds(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccAWSGameliftBuildBasicConfig(buildName, bucketName, key, roleArn string) string {

--- a/aws/resource_aws_gamelift_fleet_test.go
+++ b/aws/resource_aws_gamelift_fleet_test.go
@@ -246,6 +246,11 @@ func TestAccAWSGameliftFleet_basic(t *testing.T) {
 
 	region := testAccGetRegion()
 	g, err := testAccAWSGameliftSampleGame(region)
+
+	if isResourceNotFoundError(err) {
+		t.Skip(err)
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +264,7 @@ func TestAccAWSGameliftFleet_basic(t *testing.T) {
 	params := g.Parameters(33435)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftFleetDestroy,
 		Steps: []resource.TestStep{
@@ -320,6 +325,11 @@ func TestAccAWSGameliftFleet_allFields(t *testing.T) {
 
 	region := testAccGetRegion()
 	g, err := testAccAWSGameliftSampleGame(region)
+
+	if isResourceNotFoundError(err) {
+		t.Skip(err)
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +346,7 @@ func TestAccAWSGameliftFleet_allFields(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftFleetDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_gamelift_game_session_queue_test.go
+++ b/aws/resource_aws_gamelift_game_session_queue_test.go
@@ -91,7 +91,7 @@ func TestAccAWSGameliftGameSessionQueue_basic(t *testing.T) {
 	uTimeoutInSeconds := int64(600)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSGamelift(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGameliftGameSessionQueueDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_gamelift_test.go
+++ b/aws/resource_aws_gamelift_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/gamelift"
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 type testAccGameliftGame struct {
@@ -65,5 +66,5 @@ func testAccGameliftAccountIdByRegion(region string) (string, error) {
 		return accId, nil
 	}
 
-	return "", fmt.Errorf("Account ID not found for region %q", region)
+	return "", &resource.NotFoundError{Message: fmt.Sprintf("GameLift Account ID not found for region %q", region)}
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSGameliftAlias_basic (0.99s)
    testing.go:568: Step 0 error: errors during apply:

        Error: RequestError: send request failed
        caused by: Post https://gamelift.us-gov-west-1.amazonaws.com/: dial tcp: lookup gamelift.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host

--- FAIL: TestAccAWSGameliftBuild_basic (0.00s)
    resource_aws_gamelift_build_test.go:72: Account ID not found for region "us-gov-west-1"
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSGameliftAlias_fleetRouting (0.00s)
    resource_aws_gamelift_alias_test.go:163: GameLift Account ID not found for region "us-gov-west-1"
--- SKIP: TestAccAWSGameliftBuild_basic (0.00s)
    resource_aws_gamelift_build_test.go:73: GameLift Account ID not found for region "us-gov-west-1"
--- SKIP: TestAccAWSGameliftFleet_basic (0.00s)
    resource_aws_gamelift_fleet_test.go:251: GameLift Account ID not found for region "us-gov-west-1"
--- SKIP: TestAccAWSGameliftFleet_allFields (0.00s)
    resource_aws_gamelift_fleet_test.go:330: GameLift Account ID not found for region "us-gov-west-1"
--- SKIP: TestAccAWSGameliftGameSessionQueue_basic (1.95s)
    resource_aws_gamelift_build_test.go:186: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://gamelift.us-gov-west-1.amazonaws.com/: dial tcp: lookup gamelift.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSGameliftAlias_importBasic (1.23s)
    resource_aws_gamelift_build_test.go:186: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://gamelift.us-gov-west-1.amazonaws.com/: dial tcp: lookup gamelift.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSGameliftAlias_basic (1.23s)
    resource_aws_gamelift_build_test.go:186: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://gamelift.us-gov-west-1.amazonaws.com/: dial tcp: lookup gamelift.us-gov-west-1.amazonaws.com: no such host
```
