### PR TITLE
tests/service/kinesisanalytics: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_kinesis_analytics_application_test.go
+++ b/aws/resource_aws_kinesis_analytics_application_test.go
@@ -17,7 +17,7 @@ func TestAccAWSKinesisAnalyticsApplication_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -44,7 +44,7 @@ func TestAccAWSKinesisAnalyticsApplication_update(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -78,7 +78,7 @@ func TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions(t *testin
 	thirdStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_cloudwatchLoggingOptions(rInt, "testStream")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -115,7 +115,7 @@ func TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions(t *tes
 	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_cloudwatchLoggingOptions(rInt, "testStream2")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -152,7 +152,7 @@ func TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -179,7 +179,7 @@ func TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -215,7 +215,7 @@ func TestAccAWSKinesisAnalyticsApplication_inputsAdd(t *testing.T) {
 	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsKinesisStream(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -259,7 +259,7 @@ func TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream(t *testing.
 	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_inputsUpdateKinesisStream(rInt, "testStream")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -303,7 +303,7 @@ func TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream(t *testing.T) {
 	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_outputsKinesisStream(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -336,7 +336,7 @@ func TestAccAWSKinesisAnalyticsApplication_outputsMultiple(t *testing.T) {
 	step := testAccKinesisAnalyticsApplication_prereq(rInt1) + testAccKinesisAnalyticsApplication_outputsMultiple(rInt1, rInt2)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -364,7 +364,7 @@ func TestAccAWSKinesisAnalyticsApplication_outputsAdd(t *testing.T) {
 	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_outputsKinesisStream(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -404,7 +404,7 @@ func TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream(t *testing
 	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_outputsUpdateKinesisStream(rInt, "testStream")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -450,7 +450,7 @@ func TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -490,7 +490,7 @@ func TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -521,7 +521,7 @@ func TestAccAWSKinesisAnalyticsApplication_referenceDataSource(t *testing.T) {
 	firstStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_referenceDataSource(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -554,7 +554,7 @@ func TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate(t *testing.
 	secondStep := testAccKinesisAnalyticsApplication_prereq(rInt) + testAccKinesisAnalyticsApplication_referenceDataSourceUpdate(rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -589,7 +589,7 @@ func TestAccAWSKinesisAnalyticsApplication_tags(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSKinesisAnalytics(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKinesisAnalyticsApplicationDestroy,
 		Steps: []resource.TestStep{
@@ -681,6 +681,22 @@ func testAccCheckKinesisAnalyticsApplicationExists(n string, application *kinesi
 		*application = *resp.ApplicationDetail
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSKinesisAnalytics(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).kinesisanalyticsconn
+
+	input := &kinesisanalytics.ListApplicationsInput{}
+
+	_, err := conn.ListApplications(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSKinesisAnalyticsApplication_basic (1.04s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Unable to create Kinesis Analytics application: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_outputsAdd (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_tags (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_inputsAdd (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_update (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSKinesisAnalyticsApplication_basic (2.45s)
    resource_aws_kinesis_analytics_application_test.go:695: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://kinesisanalytics.us-gov-west-1.amazonaws.com/: dial tcp: lookup kinesisanalytics.us-gov-west-1.amazonaws.com: no such host
```