### PR TITLE
tests/service/macie: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_macie_member_account_association_test.go
+++ b/aws/resource_aws_macie_member_account_association_test.go
@@ -19,7 +19,7 @@ func TestAccAWSMacieMemberAccountAssociation_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMacie(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSMacieMemberAccountAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -35,7 +35,7 @@ func TestAccAWSMacieMemberAccountAssociation_basic(t *testing.T) {
 
 func TestAccAWSMacieMemberAccountAssociation_self(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSMacie(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_macie_s3_bucket_association_test.go
+++ b/aws/resource_aws_macie_s3_bucket_association_test.go
@@ -15,7 +15,7 @@ func TestAccAWSMacieS3BucketAssociation_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMacie(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSMacieS3BucketAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -43,7 +43,7 @@ func TestAccAWSMacieS3BucketAssociation_accountIdAndPrefix(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMacie(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSMacieS3BucketAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -138,6 +138,22 @@ func testAccCheckAWSMacieS3BucketAssociationExists(name string) resource.TestChe
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSMacie(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).macieconn
+
+	input := &macie.ListS3ResourcesInput{}
+
+	_, err := conn.ListS3Resources(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSMacieS3BucketAssociation_basic (2.26s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Macie S3 bucket association: RequestError: send request failed
        caused by: Post https://macie.us-gov-west-1.amazonaws.com/: dial tcp: lookup macie.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSMacieMemberAccountAssociation_self (2.42s)
    resource_aws_macie_s3_bucket_association_test.go:152: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://macie.us-gov-west-1.amazonaws.com/: dial tcp: lookup macie.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMacieS3BucketAssociation_accountIdAndPrefix (2.42s)
    resource_aws_macie_s3_bucket_association_test.go:152: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://macie.us-gov-west-1.amazonaws.com/: dial tcp: lookup macie.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMacieS3BucketAssociation_basic (2.42s)
    resource_aws_macie_s3_bucket_association_test.go:152: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://macie.us-gov-west-1.amazonaws.com/: dial tcp: lookup macie.us-gov-west-1.amazonaws.com: no such host
```