### PR TITLE
tests/service/mediapackage: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_media_package_channel_test.go
+++ b/aws/resource_aws_media_package_channel_test.go
@@ -16,7 +16,7 @@ func TestAccAWSMediaPackageChannel_basic(t *testing.T) {
 	resourceName := "aws_media_package_channel.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaPackage(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMediaPackageChannelDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccAWSMediaPackageChannel_description(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaPackage(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMediaPackageChannelDestroy,
 		Steps: []resource.TestStep{
@@ -79,7 +79,7 @@ func TestAccAWSMediaPackageChannel_tags(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaPackage(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMediaPackageChannelDestroy,
 		Steps: []resource.TestStep{
@@ -158,6 +158,22 @@ func testAccCheckAwsMediaPackageChannelExists(name string) resource.TestCheckFun
 		_, err := conn.DescribeChannel(input)
 
 		return err
+	}
+}
+
+func testAccPreCheckAWSMediaPackage(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).mediapackageconn
+
+	input := &mediapackage.ListChannelsInput{}
+
+	_, err := conn.ListChannels(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSMediaPackageChannel_basic (0.79s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating MediaPackage Channel: RequestError: send request failed
        caused by: Post https://mediapackage.us-gov-west-1.amazonaws.com/channels: dial tcp: lookup mediapackage.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSMediaPackageChannel_tags (2.37s)
    resource_aws_media_package_channel_test.go:172: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mediapackage.us-gov-west-1.amazonaws.com/channels: dial tcp: lookup mediapackage.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMediaPackageChannel_description (2.37s)
    resource_aws_media_package_channel_test.go:172: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mediapackage.us-gov-west-1.amazonaws.com/channels: dial tcp: lookup mediapackage.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMediaPackageChannel_basic (2.37s)
    resource_aws_media_package_channel_test.go:172: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mediapackage.us-gov-west-1.amazonaws.com/channels: dial tcp: lookup mediapackage.us-gov-west-1.amazonaws.com: no such host
```
