### PR TITLE
tests/service/mediastore: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_media_store_container_policy_test.go
+++ b/aws/resource_aws_media_store_container_policy_test.go
@@ -15,7 +15,7 @@ func TestAccAWSMediaStoreContainerPolicy_basic(t *testing.T) {
 	rname := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaStore(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMediaStoreContainerPolicyDestroy,
 		Steps: []resource.TestStep{
@@ -43,7 +43,7 @@ func TestAccAWSMediaStoreContainerPolicy_import(t *testing.T) {
 	resourceName := "aws_media_store_container_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaStore(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMediaStoreContainerPolicyDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_media_store_container_test.go
+++ b/aws/resource_aws_media_store_container_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccAWSMediaStoreContainer_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaStore(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMediaStoreContainerDestroy,
 		Steps: []resource.TestStep{
@@ -31,7 +31,7 @@ func TestAccAWSMediaStoreContainer_import(t *testing.T) {
 	resourceName := "aws_media_store_container.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMediaStore(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMediaStoreContainerDestroy,
 		Steps: []resource.TestStep{
@@ -90,6 +90,22 @@ func testAccCheckAwsMediaStoreContainerExists(name string) resource.TestCheckFun
 		_, err := conn.DescribeContainer(input)
 
 		return err
+	}
+}
+
+func testAccPreCheckAWSMediaStore(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).mediastoreconn
+
+	input := &mediastore.ListContainersInput{}
+
+	_, err := conn.ListContainers(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSMediaStoreContainer_basic (1.48s)
    testing.go:568: Step 0 error: errors during apply:

        Error: RequestError: send request failed
        caused by: Post https://mediastore.us-gov-west-1.amazonaws.com/: dial tcp: lookup mediastore.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSMediaStoreContainerPolicy_import (2.40s)
    resource_aws_media_store_container_test.go:104: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://mediastore.us-gov-west-1.amazonaws.com/: dial tcp: lookup mediastore.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMediaStoreContainer_import (2.40s)
    resource_aws_media_store_container_test.go:104: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://mediastore.us-gov-west-1.amazonaws.com/: dial tcp: lookup mediastore.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMediaStoreContainer_basic (2.40s)
    resource_aws_media_store_container_test.go:104: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://mediastore.us-gov-west-1.amazonaws.com/: dial tcp: lookup mediastore.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMediaStoreContainerPolicy_basic (2.40s)
    resource_aws_media_store_container_test.go:104: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://mediastore.us-gov-west-1.amazonaws.com/: dial tcp: lookup mediastore.us-gov-west-1.amazonaws.com: no such host
```
