### PR TITLE
tests/service/mq: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_mq_broker_test.go
+++ b/aws/resource_aws_mq_broker_test.go
@@ -238,7 +238,7 @@ func TestAccAWSMqBroker_basic(t *testing.T) {
 	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -308,7 +308,7 @@ func TestAccAWSMqBroker_allFieldsDefaultVpc(t *testing.T) {
 </broker>`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -417,7 +417,7 @@ func TestAccAWSMqBroker_allFieldsCustomVpc(t *testing.T) {
 </broker>`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -512,7 +512,7 @@ func TestAccAWSMqBroker_updateUsers(t *testing.T) {
 	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -565,7 +565,7 @@ func TestAccAWSMqBroker_updateTags(t *testing.T) {
 	brokerName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqBrokerDestroy,
 		Steps: []resource.TestStep{
@@ -634,6 +634,22 @@ func testAccCheckAwsMqBrokerExists(name string) resource.TestCheckFunc {
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSMq(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).mqconn
+
+	input := &mq.ListBrokersInput{}
+
+	_, err := conn.ListBrokers(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_mq_configuration_test.go
+++ b/aws/resource_aws_mq_configuration_test.go
@@ -15,7 +15,7 @@ func TestAccAWSMqConfiguration_basic(t *testing.T) {
 	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -51,7 +51,7 @@ func TestAccAWSMqConfiguration_withData(t *testing.T) {
 	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +75,7 @@ func TestAccAWSMqConfiguration_updateTags(t *testing.T) {
 	configurationName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMq(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsMqConfigurationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSMqBroker_basic (2.63s)
    testing.go:568: Step 0 error: errors during apply:

        Error: RequestError: send request failed
        caused by: Post https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSMqBroker_basic (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMqBroker_allFieldsCustomVpc (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMqConfiguration_updateTags (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMqBroker_updateUsers (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMqConfiguration_withData (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMqBroker_allFieldsDefaultVpc (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMqConfiguration_basic (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMqBroker_updateTags (2.41s)
    resource_aws_mq_broker_test.go:648: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://mq.us-gov-west-1.amazonaws.com/v1/brokers: dial tcp: lookup mq.us-gov-west-1.amazonaws.com: no such host
```
