### PR TITLE
tests/service/batch: Add PreCheck for service availability

### DIFF
--- a/aws/data_source_aws_batch_compute_environment_test.go
+++ b/aws/data_source_aws_batch_compute_environment_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceAwsBatchComputeEnvironment(t *testing.T) {
 	datasourceName := "data.aws_batch_compute_environment.by_name"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_batch_job_queue_test.go
+++ b/aws/data_source_aws_batch_job_queue_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceAwsBatchJobQueue(t *testing.T) {
 	datasourceName := "data.aws_batch_job_queue.by_name"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_batch_compute_environment_test.go
+++ b/aws/resource_aws_batch_compute_environment_test.go
@@ -67,7 +67,7 @@ func TestAccAWSBatchComputeEnvironment_createEc2(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -85,7 +85,7 @@ func TestAccAWSBatchComputeEnvironment_createEc2WithTags(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -105,7 +105,7 @@ func TestAccAWSBatchComputeEnvironment_createSpot(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -123,7 +123,7 @@ func TestAccAWSBatchComputeEnvironment_createUnmanaged(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -141,7 +141,7 @@ func TestAccAWSBatchComputeEnvironment_updateMaxvCpus(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -167,7 +167,7 @@ func TestAccAWSBatchComputeEnvironment_updateInstanceType(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -195,7 +195,7 @@ func TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName(t *testing.T
 	expectedUpdatedName := fmt.Sprintf("tf_acc_test_updated_%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -221,7 +221,7 @@ func TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources(t *testi
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -237,7 +237,7 @@ func TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources(t *te
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -256,7 +256,7 @@ func TestAccAWSBatchComputeEnvironment_launchTemplate(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -280,7 +280,7 @@ func TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage(t *testing
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -296,7 +296,7 @@ func TestAccAWSBatchComputeEnvironment_updateState(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchComputeEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -370,6 +370,22 @@ func testAccCheckAwsBatchComputeEnvironmentExists() resource.TestCheckFunc {
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSBatch(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).batchconn
+
+	input := &batch.DescribeComputeEnvironmentsInput{}
+
+	_, err := conn.DescribeComputeEnvironments(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_batch_job_definition_test.go
+++ b/aws/resource_aws_batch_job_definition_test.go
@@ -52,7 +52,7 @@ func TestAccAWSBatchJobDefinition_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccBatchJobDefinitionBaseConfig, ri)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
 		Steps: []resource.TestStep{
@@ -74,7 +74,7 @@ func TestAccAWSBatchJobDefinition_updateForcesNewResource(t *testing.T) {
 	config := fmt.Sprintf(testAccBatchJobDefinitionBaseConfig, ri)
 	updateConfig := fmt.Sprintf(testAccBatchJobDefinitionUpdateConfig, ri)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobDefinitionDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_batch_job_queue_test.go
+++ b/aws/resource_aws_batch_job_queue_test.go
@@ -76,7 +76,7 @@ func TestAccAWSBatchJobQueue_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobQueueDestroy,
 		Steps: []resource.TestStep{
@@ -97,7 +97,7 @@ func TestAccAWSBatchJobQueue_disappears(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLaunchTemplateDestroy,
 		Steps: []resource.TestStep{
@@ -119,7 +119,7 @@ func TestAccAWSBatchJobQueue_update(t *testing.T) {
 	config := fmt.Sprintf(testAccBatchJobQueueBasic, ri)
 	updateConfig := fmt.Sprintf(testAccBatchJobQueueUpdate, ri)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBatch(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBatchJobQueueDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSBatchJobDefinition_basic (0.90s)
    testing.go:568: Step 0 error: errors during apply:

        Error: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/registerjobdefinition: dial tcp: lookup batch.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host "tf_acctest_batch_job_definition_4884891207041435957"
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSBatchComputeEnvironment_createEc2WithoutComputeResources (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_createUnmanagedWithComputeResources (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchJobQueue_basic (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_createUnmanaged (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_createEc2 (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_updateComputeEnvironmentName (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_updateState (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_launchTemplate (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_createSpotWithoutBidPercentage (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchJobDefinition_updateForcesNewResource (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_updateMaxvCpus (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_createEc2WithTags (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_updateInstanceType (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchJobQueue_update (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchJobDefinition_basic (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchComputeEnvironment_createSpot (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBatchJobQueue_disappears (2.43s)
    resource_aws_batch_compute_environment_test.go:384: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://batch.us-gov-west-1.amazonaws.com/v1/describecomputeenvironments: dial tcp: lookup batch.us-gov-west-1.amazonaws.com: no such host
```