### PR TITLE
tests/service/cloud9: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_cloud9_environment_ec2_test.go
+++ b/aws/resource_aws_cloud9_environment_ec2_test.go
@@ -22,7 +22,7 @@ func TestAccAWSCloud9EnvironmentEc2_basic(t *testing.T) {
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
@@ -63,7 +63,7 @@ func TestAccAWSCloud9EnvironmentEc2_allFields(t *testing.T) {
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
@@ -100,7 +100,7 @@ func TestAccAWSCloud9EnvironmentEc2_importBasic(t *testing.T) {
 	resourceName := "aws_cloud9_environment_ec2.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloud9(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloud9EnvironmentEc2Destroy,
 		Steps: []resource.TestStep{
@@ -178,6 +178,22 @@ func testAccCheckAWSCloud9EnvironmentEc2Destroy(s *terraform.State) error {
 		return fmt.Errorf("Cloud9 Environment EC2 %q still exists.", rs.Primary.ID)
 	}
 	return nil
+}
+
+func testAccPreCheckAWSCloud9(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).cloud9conn
+
+	input := &cloud9.ListEnvironmentsInput{}
+
+	_, err := conn.ListEnvironments(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccAWSCloud9EnvironmentEc2Config(name string) string {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSCloud9EnvironmentEc2_basic (0.80s)
    testing.go:568: Step 0 error: errors during apply:

        Error: RequestError: send request failed
        caused by: Post https://cloud9.us-gov-west-1.amazonaws.com/: dial tcp: lookup cloud9.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSCloud9EnvironmentEc2_allFields (2.35s)
    resource_aws_cloud9_environment_ec2_test.go:191: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cloud9.us-gov-west-1.amazonaws.com/: dial tcp: lookup cloud9.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloud9EnvironmentEc2_basic (2.35s)
    resource_aws_cloud9_environment_ec2_test.go:191: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cloud9.us-gov-west-1.amazonaws.com/: dial tcp: lookup cloud9.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloud9EnvironmentEc2_importBasic (2.35s)
    resource_aws_cloud9_environment_ec2_test.go:191: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cloud9.us-gov-west-1.amazonaws.com/: dial tcp: lookup cloud9.us-gov-west-1.amazonaws.com: no such host
```