### PR TITLE
tests/service/budgets: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_budgets_budget_test.go
+++ b/aws/resource_aws_budgets_budget_test.go
@@ -24,7 +24,7 @@ func TestAccAWSBudgetsBudget_basic(t *testing.T) {
 	configBasicUpdate := testAccAWSBudgetsBudgetConfigUpdate(name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBudgets(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
 		Steps: []resource.TestStep{
@@ -76,7 +76,7 @@ func TestAccAWSBudgetsBudget_prefix(t *testing.T) {
 	configBasicUpdate := testAccAWSBudgetsBudgetConfigUpdate(name)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBudgets(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
 		Steps: []resource.TestStep{
@@ -138,7 +138,7 @@ func TestAccAWSBudgetsBudget_notification(t *testing.T) {
 	oneTopic := []string{"${aws_sns_topic.budget_notifications.arn}"}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBudgets(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccAWSBudgetsBudgetDestroy,
 		Steps: []resource.TestStep{
@@ -334,6 +334,24 @@ func testAccAWSBudgetsBudgetDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccPreCheckAWSBudgets(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).budgetconn
+
+	input := &budgets.DescribeBudgetsInput{
+		AccountId: aws.String(testAccProvider.Meta().(*AWSClient).accountid),
+	}
+
+	_, err := conn.DescribeBudgets(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccAWSBudgetsBudgetConfigUpdate(name string) budgets.Budget {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSBudgetsBudget_basic (0.61s)
    testing.go:568: Step 0 error: errors during apply:

        Error: create budget failed: RequestError: send request failed
        caused by: Post https://budgets.us-gov-west-1.amazonaws.com/: dial tcp: lookup budgets.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSBudgetsBudget_prefix (2.40s)
    resource_aws_budgets_budget_test.go:349: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://budgets.us-gov-west-1.amazonaws.com/: dial tcp: lookup budgets.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBudgetsBudget_notification (2.40s)
    resource_aws_budgets_budget_test.go:349: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://budgets.us-gov-west-1.amazonaws.com/: dial tcp: lookup budgets.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSBudgetsBudget_basic (2.40s)
    resource_aws_budgets_budget_test.go:349: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://budgets.us-gov-west-1.amazonaws.com/: dial tcp: lookup budgets.us-gov-west-1.amazonaws.com: no such host
```
