### PR TITLE
tests/service/cloudfront: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_cloudfront_distribution_test.go
+++ b/aws/resource_aws_cloudfront_distribution_test.go
@@ -82,7 +82,7 @@ func TestAccAWSCloudFrontDistribution_disappears(t *testing.T) {
 	resourceName := "aws_cloudfront_distribution.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +108,7 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 	ri := acctest.RandInt()
 	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3Config, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -143,7 +143,7 @@ func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionS3ConfigWithTagsUpdated, ri, originBucket, logBucket, testAccAWSCloudFrontDistributionRetainConfig())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -190,7 +190,7 @@ func TestAccAWSCloudFrontDistribution_S3OriginWithTags(t *testing.T) {
 func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
 	var distribution cloudfront.Distribution
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -222,7 +222,7 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 	var distribution cloudfront.Distribution
 	resourceName := "aws_cloudfront_distribution.multi_origin_distribution"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -258,7 +258,7 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 	var distribution cloudfront.Distribution
 	resourceName := "aws_cloudfront_distribution.main"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -288,7 +288,7 @@ func TestAccAWSCloudFrontDistribution_orderedCacheBehavior(t *testing.T) {
 
 func TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -302,7 +302,7 @@ func TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName(t *testing.T) {
 
 func TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -323,7 +323,7 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 	var distribution cloudfront.Distribution
 	resourceName := "aws_cloudfront_distribution.no_optional_items"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -403,7 +403,7 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
 	var distribution cloudfront.Distribution
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -429,7 +429,7 @@ func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
 func TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig(t *testing.T) {
 	var distribution cloudfront.Distribution
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -457,7 +457,7 @@ func TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig(t *testing.T) {
 func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) {
 	var distribution cloudfront.Distribution
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -486,7 +486,7 @@ func TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cooki
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -529,7 +529,7 @@ func TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Heade
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -569,7 +569,7 @@ func TestAccAWSCloudFrontDistribution_Enabled(t *testing.T) {
 	resourceName := "aws_cloudfront_distribution.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -610,7 +610,7 @@ func TestAccAWSCloudFrontDistribution_RetainOnDelete(t *testing.T) {
 	resourceName := "aws_cloudfront_distribution.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -640,7 +640,7 @@ func TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cooki
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -683,7 +683,7 @@ func TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Heade
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -725,7 +725,7 @@ func TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn(t *tes
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -757,7 +757,7 @@ func TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_Confli
 	retainOnDelete := testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		ProviderFactories: testAccProviderFactories(&providers),
 		CheckDestroy:      testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -786,7 +786,7 @@ func TestAccAWSCloudFrontDistribution_WaitForDeployment(t *testing.T) {
 	resourceName := "aws_cloudfront_distribution.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
@@ -1011,6 +1011,22 @@ func testAccCheckCloudFrontDistributionWaitForDeployment(distribution *cloudfron
 	}
 }
 
+func testAccPreCheckAWSCloudFront(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).cloudfrontconn
+
+	input := &cloudfront.ListDistributionsInput{}
+
+	_, err := conn.ListDistributions(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
 func testAccAWSCloudFrontDistributionRetainOnDeleteFromEnv() bool {
 	_, ok := os.LookupEnv("TF_TEST_CLOUDFRONT_RETAIN")
 	return ok
@@ -1029,7 +1045,7 @@ func TestAccAWSCloudFrontDistribution_OriginGroups(t *testing.T) {
 	ri := acctest.RandInt()
 	testConfig := fmt.Sprintf(testAccAWSCloudFrontDistributionOriginGroupsConfig, ri, originBucket, backupBucket, testAccAWSCloudFrontDistributionRetainConfig())
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cloudfront_origin_access_identity_test.go
+++ b/aws/resource_aws_cloudfront_origin_access_identity_test.go
@@ -15,7 +15,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_importBasic(t *testing.T) {
 	resourceName := "aws_cloudfront_origin_access_identity.origin_access_identity"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -34,7 +34,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_importBasic(t *testing.T) {
 
 func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -63,7 +63,7 @@ func TestAccAWSCloudFrontOriginAccessIdentity_basic(t *testing.T) {
 
 func TestAccAWSCloudFrontOriginAccessIdentity_noComment(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontOriginAccessIdentityDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cloudfront_public_key_test.go
+++ b/aws/resource_aws_cloudfront_public_key_test.go
@@ -16,7 +16,7 @@ func TestAccAWSCloudFrontPublicKey_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
 		Steps: []resource.TestStep{
@@ -39,7 +39,7 @@ func TestAccAWSCloudFrontPublicKey_namePrefix(t *testing.T) {
 	startsWithPrefix := regexp.MustCompile("^tf-acc-test-")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
 		Steps: []resource.TestStep{
@@ -58,7 +58,7 @@ func TestAccAWSCloudFrontPublicKey_update(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCloudFront(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontPublicKeyDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSCloudFrontDistribution_S3Origin (2.34s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating CloudFront Distribution: RequestError: send request failed
        caused by: Post https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution?WithTags=: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn_ConflictsWithCloudFrontDefaultCertificate (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_WaitForDeployment (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Headers (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontPublicKey_basic (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Headers (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_RetainOnDelete (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontOriginAccessIdentity_basic (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_Enabled (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_ViewerCertificate_AcmCertificateArn (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontOriginAccessIdentity_importBasic (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontPublicKey_update (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_DefaultCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontOriginAccessIdentity_noComment (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_OriginGroups (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_Origin_EmptyOriginID (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_OrderedCacheBehavior_ForwardedValues_Cookies_WhitelistedNames (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_disappears (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontPublicKey_namePrefix (3.27s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_HTTP11Config (1.88s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_customOrigin (1.89s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_multiOrigin (1.91s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_S3OriginWithTags (1.93s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_S3Origin (1.98s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_orderedCacheBehavior (1.98s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_Origin_EmptyDomainName (1.99s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCloudFrontDistribution_noOptionalItemsConfig (2.03s)
    resource_aws_cloudfront_distribution_test.go:1022: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://cloudfront.us-gov-west-1.amazonaws.com/2018-11-05/distribution: dial tcp: lookup cloudfront.us-gov-west-1.amazonaws.com: no such host
```
