### PR TITLE
tests/service/cognitoidentity: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
+++ b/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
@@ -19,7 +19,7 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
 	updatedName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
 		Steps: []resource.TestStep{
@@ -95,7 +95,7 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleR
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
 		Steps: []resource.TestStep{
@@ -111,7 +111,7 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
 		Steps: []resource.TestStep{
@@ -127,7 +127,7 @@ func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cognito_identity_pool_test.go
+++ b/aws/resource_aws_cognito_identity_pool_test.go
@@ -19,7 +19,7 @@ func TestAccAWSCognitoIdentityPool_importBasic(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayAccountDestroy,
 		Steps: []resource.TestStep{
@@ -41,7 +41,7 @@ func TestAccAWSCognitoIdentityPool_basic(t *testing.T) {
 	updatedName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolDestroy,
 		Steps: []resource.TestStep{
@@ -70,7 +70,7 @@ func TestAccAWSCognitoIdentityPool_supportedLoginProviders(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolDestroy,
 		Steps: []resource.TestStep{
@@ -106,7 +106,7 @@ func TestAccAWSCognitoIdentityPool_openidConnectProviderArns(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolDestroy,
 		Steps: []resource.TestStep{
@@ -141,7 +141,7 @@ func TestAccAWSCognitoIdentityPool_samlProviderArns(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolDestroy,
 		Steps: []resource.TestStep{
@@ -177,7 +177,7 @@ func TestAccAWSCognitoIdentityPool_cognitoIdentityProviders(t *testing.T) {
 	name := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentity(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityPoolDestroy,
 		Steps: []resource.TestStep{
@@ -257,6 +257,24 @@ func testAccCheckAWSCognitoIdentityPoolDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccPreCheckAWSCognitoIdentity(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).cognitoconn
+
+	input := &cognitoidentity.ListIdentityPoolsInput{
+		MaxResults: aws.Int64(int64(1)),
+	}
+
+	_, err := conn.ListIdentityPools(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccAWSCognitoIdentityPoolConfig_basic(name string) string {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSCognitoIdentityPool_basic (1.11s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Cognito Identity Pool: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPool_supportedLoginProviders (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPool_samlProviderArns (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPool_openidConnectProviderArns (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPool_basic (2.25s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPool_importBasic (2.25s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPool_cognitoIdentityProviders (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError (2.24s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (2.25s)
    resource_aws_cognito_identity_pool_test.go:272: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-identity.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-identity.us-gov-west-1.amazonaws.com: no such host
```
