### PR TITLE
tests/service/cognitoidentityprovider: Add PreCheck for service availability

### DIFF
--- a/aws/data_source_aws_cognito_user_pools_test.go
+++ b/aws/data_source_aws_cognito_user_pools_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceAwsCognitoUserPools_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf_acc_ds_cognito_user_pools_%s", acctest.RandString(7))
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_cognito_identity_provider_test.go
+++ b/aws/resource_aws_cognito_identity_provider_test.go
@@ -15,7 +15,7 @@ func TestAccAWSCognitoIdentityProvider_basic(t *testing.T) {
 	resourceName := "aws_cognito_identity_provider.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoIdentityProviderDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cognito_resource_server_test.go
+++ b/aws/resource_aws_cognito_resource_server_test.go
@@ -21,7 +21,7 @@ func TestAccAWSCognitoResourceServer_basic(t *testing.T) {
 	resourceName := "aws_cognito_resource_server.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoResourceServerDestroy,
 		Steps: []resource.TestStep{
@@ -62,7 +62,7 @@ func TestAccAWSCognitoResourceServer_scope(t *testing.T) {
 	resourceName := "aws_cognito_resource_server.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoResourceServerDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cognito_user_group_test.go
+++ b/aws/resource_aws_cognito_user_group_test.go
@@ -19,7 +19,7 @@ func TestAccAWSCognitoUserGroup_basic(t *testing.T) {
 	updatedGroupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserGroupDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccAWSCognitoUserGroup_complex(t *testing.T) {
 	updatedGroupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserGroupDestroy,
 		Steps: []resource.TestStep{
@@ -80,7 +80,7 @@ func TestAccAWSCognitoUserGroup_RoleArn(t *testing.T) {
 	resourceName := "aws_cognito_user_group.main"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserGroupDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +108,7 @@ func TestAccAWSCognitoUserGroup_importBasic(t *testing.T) {
 	groupName := fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserGroupDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cognito_user_pool_client_test.go
+++ b/aws/resource_aws_cognito_user_pool_client_test.go
@@ -18,7 +18,7 @@ func TestAccAWSCognitoUserPoolClient_basic(t *testing.T) {
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
@@ -71,7 +71,7 @@ func TestAccAWSCognitoUserPoolClient_importBasic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
 		Steps: []resource.TestStep{
@@ -92,7 +92,7 @@ func TestAccAWSCognitoUserPoolClient_RefreshTokenValidity(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
@@ -119,7 +119,7 @@ func TestAccAWSCognitoUserPoolClient_allFields(t *testing.T) {
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{
@@ -165,7 +165,7 @@ func TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField(t *testing.T) {
 	clientName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolClientDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cognito_user_pool_domain_test.go
+++ b/aws/resource_aws_cognito_user_pool_domain_test.go
@@ -18,7 +18,7 @@ func TestAccAWSCognitoUserPoolDomain_basic(t *testing.T) {
 	poolName := fmt.Sprintf("tf-acc-test-pool-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDomainDestroy,
 		Steps: []resource.TestStep{
@@ -70,7 +70,7 @@ func TestAccAWSCognitoUserPoolDomain_custom(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDomainDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_cognito_user_pool_test.go
+++ b/aws/resource_aws_cognito_user_pool_test.go
@@ -74,7 +74,7 @@ func TestAccAWSCognitoUserPool_importBasic(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudWatchDashboardDestroy,
 		Steps: []resource.TestStep{
@@ -94,7 +94,7 @@ func TestAccAWSCognitoUserPool_basic(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -119,7 +119,7 @@ func TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -152,7 +152,7 @@ func TestAccAWSCognitoUserPool_withAdvancedSecurityMode(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -183,7 +183,7 @@ func TestAccAWSCognitoUserPool_withDeviceConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -214,7 +214,7 @@ func TestAccAWSCognitoUserPool_withEmailVerificationMessage(t *testing.T) {
 	upatedMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -245,7 +245,7 @@ func TestAccAWSCognitoUserPool_withSmsVerificationMessage(t *testing.T) {
 	upatedVerificationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -272,7 +272,7 @@ func TestAccAWSCognitoUserPool_withEmailConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -299,7 +299,7 @@ func TestAccAWSCognitoUserPool_withSmsConfiguration(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -320,7 +320,7 @@ func TestAccAWSCognitoUserPool_withSmsConfigurationUpdated(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -347,7 +347,7 @@ func TestAccAWSCognitoUserPool_withTags(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -373,7 +373,7 @@ func TestAccAWSCognitoUserPool_withAliasAttributes(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -404,7 +404,7 @@ func TestAccAWSCognitoUserPool_withPasswordPolicy(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -439,7 +439,7 @@ func TestAccAWSCognitoUserPool_withLambdaConfig(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -484,7 +484,7 @@ func TestAccAWSCognitoUserPool_withSchemaAttributes(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -557,7 +557,7 @@ func TestAccAWSCognitoUserPool_withVerificationMessageTemplate(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -591,7 +591,7 @@ func TestAccAWSCognitoUserPool_update(t *testing.T) {
 	updatedAuthenticationMessage := fmt.Sprintf("%s {####}", acctest.RandString(10))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCognitoIdentityProvider(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCognitoUserPoolDestroy,
 		Steps: []resource.TestStep{
@@ -716,6 +716,24 @@ func testAccCheckAWSCognitoUserPoolExists(name string) resource.TestCheckFunc {
 		_, err := conn.DescribeUserPool(params)
 
 		return err
+	}
+}
+
+func testAccPreCheckAWSCognitoIdentityProvider(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).cognitoidpconn
+
+	input := &cognitoidentityprovider.ListUserPoolsInput{
+		MaxResults: aws.Int64(int64(1)),
+	}
+
+	_, err := conn.ListUserPools(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSCognitoUserPool_basic (1.98s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Cognito User Pool: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSCognitoUserPoolClient_basic (2.33s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withAdvancedSecurityMode (2.33s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withEmailVerificationMessage (2.33s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserGroup_importBasic (2.33s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoResourceServer_basic (2.33s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoResourceServer_scope (2.33s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserGroup_complex (2.33s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withSmsConfiguration (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoIdentityProvider_basic (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withSmsVerificationMessage (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withDeviceConfiguration (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_update (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withTags (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserGroup_RoleArn (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPoolClient_importBasic (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withAliasAttributes (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withEmailConfiguration (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserGroup_basic (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withSmsConfigurationUpdated (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withPasswordPolicy (2.34s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withVerificationMessageTemplate (1.87s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_basic (1.89s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withSchemaAttributes (1.92s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPoolClient_allFields (1.94s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPoolDomain_basic (1.94s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_importBasic (1.95s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPoolClient_RefreshTokenValidity (1.95s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withAdminCreateUserConfiguration (1.95s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPool_withLambdaConfig (1.98s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCognitoUserPoolClient_allFieldsUpdatingOneField (2.03s)
    resource_aws_cognito_user_pool_test.go:732: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://cognito-idp.us-gov-west-1.amazonaws.com/: dial tcp: lookup cognito-idp.us-gov-west-1.amazonaws.com: no such host
```