### PR TITLE
tests/service/dlm: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_dlm_lifecycle_policy_test.go
+++ b/aws/resource_aws_dlm_lifecycle_policy_test.go
@@ -16,7 +16,7 @@ func TestAccAWSDlmLifecyclePolicy_Basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDlm(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: dlmLifecyclePolicyDestroy,
 		Steps: []resource.TestStep{
@@ -50,7 +50,7 @@ func TestAccAWSDlmLifecyclePolicy_Full(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDlm(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: dlmLifecyclePolicyDestroy,
 		Steps: []resource.TestStep{
@@ -144,6 +144,22 @@ func checkDlmLifecyclePolicyExists(name string) resource.TestCheckFunc {
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSDlm(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).dlmconn
+
+	input := &dlm.GetLifecyclePoliciesInput{}
+
+	_, err := conn.GetLifecyclePolicies(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSDlmLifecyclePolicy_Basic (1.40s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating DLM Lifecycle Policy: RequestError: send request failed
        caused by: Post https://dlm.us-gov-west-1.amazonaws.com/policies: dial tcp: lookup dlm.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSDlmLifecyclePolicy_Basic (1.97s)
    resource_aws_dlm_lifecycle_policy_test.go:158: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://dlm.us-gov-west-1.amazonaws.com/policies: dial tcp: lookup dlm.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSDlmLifecyclePolicy_Full (1.97s)
    resource_aws_dlm_lifecycle_policy_test.go:158: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://dlm.us-gov-west-1.amazonaws.com/policies: dial tcp: lookup dlm.us-gov-west-1.amazonaws.com: no such host
```
