### PR TITLE
tests/service/eks: Add PreCheck for service availability

### DIFF
--- a/aws/data_source_aws_eks_cluster_test.go
+++ b/aws/data_source_aws_eks_cluster_test.go
@@ -15,7 +15,7 @@ func TestAccAWSEksClusterDataSource_basic(t *testing.T) {
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_eks_cluster_test.go
+++ b/aws/resource_aws_eks_cluster_test.go
@@ -78,7 +78,7 @@ func TestAccAWSEksCluster_basic(t *testing.T) {
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{
@@ -118,7 +118,7 @@ func TestAccAWSEksCluster_Version(t *testing.T) {
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{
@@ -153,7 +153,7 @@ func TestAccAWSEksCluster_Logging(t *testing.T) {
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{
@@ -200,7 +200,7 @@ func TestAccAWSEksCluster_VpcConfig_SecurityGroupIds(t *testing.T) {
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{
@@ -228,7 +228,7 @@ func TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess(t *testing.T) {
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{
@@ -274,7 +274,7 @@ func TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess(t *testing.T) {
 	resourceName := "aws_eks_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEks(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEksClusterDestroy,
 		Steps: []resource.TestStep{
@@ -387,6 +387,22 @@ func testAccCheckAWSEksClusterNotRecreated(i, j *eks.Cluster) resource.TestCheck
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSEks(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).eksconn
+
+	input := &eks.ListClustersInput{}
+
+	_, err := conn.ListClusters(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSEksCluster_basic (32.31s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating IAM Role tf-acc-test-pgb4h: MalformedPolicyDocument: Invalid principal in policy: "SERVICE":"eks.amazonaws.com"
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSEksClusterDataSource_basic (2.28s)
    resource_aws_eks_cluster_test.go:401: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://eks.us-gov-west-1.amazonaws.com/clusters: dial tcp: lookup eks.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSEksCluster_VpcConfig_EndpointPublicAccess (2.28s)
    resource_aws_eks_cluster_test.go:401: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://eks.us-gov-west-1.amazonaws.com/clusters: dial tcp: lookup eks.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSEksCluster_VpcConfig_EndpointPrivateAccess (2.28s)
    resource_aws_eks_cluster_test.go:401: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://eks.us-gov-west-1.amazonaws.com/clusters: dial tcp: lookup eks.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSEksCluster_VpcConfig_SecurityGroupIds (2.28s)
    resource_aws_eks_cluster_test.go:401: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://eks.us-gov-west-1.amazonaws.com/clusters: dial tcp: lookup eks.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSEksCluster_Logging (2.28s)
    resource_aws_eks_cluster_test.go:401: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://eks.us-gov-west-1.amazonaws.com/clusters: dial tcp: lookup eks.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSEksCluster_Version (2.28s)
    resource_aws_eks_cluster_test.go:401: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://eks.us-gov-west-1.amazonaws.com/clusters: dial tcp: lookup eks.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSEksCluster_basic (2.28s)
    resource_aws_eks_cluster_test.go:401: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://eks.us-gov-west-1.amazonaws.com/clusters: dial tcp: lookup eks.us-gov-west-1.amazonaws.com: no such host
```