### PR TITLE
tests/service/elastictranscoder: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_elastic_transcoder_pipeline_test.go
+++ b/aws/resource_aws_elastic_transcoder_pipeline_test.go
@@ -22,7 +22,7 @@ func TestAccAWSElasticTranscoderPipeline_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
 		IDRefreshName: "aws_elastictranscoder_pipeline.bar",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckElasticTranscoderPipelineDestroy,
@@ -49,7 +49,7 @@ func TestAccAWSElasticTranscoderPipeline_kmsKey(t *testing.T) {
 	keyRegex := regexp.MustCompile(`^arn:aws:([a-zA-Z0-9\-])+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:(.*)$`)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
 		IDRefreshName: "aws_elastictranscoder_pipeline.bar",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckElasticTranscoderPipelineDestroy,
@@ -71,7 +71,7 @@ func TestAccAWSElasticTranscoderPipeline_notifications(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
 		IDRefreshName: "aws_elastictranscoder_pipeline.bar",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckElasticTranscoderPipelineDestroy,
@@ -136,7 +136,7 @@ func TestAccAWSElasticTranscoderPipeline_withContentConfig(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
 		IDRefreshName: "aws_elastictranscoder_pipeline.bar",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckElasticTranscoderPipelineDestroy,
@@ -163,7 +163,7 @@ func TestAccAWSElasticTranscoderPipeline_withPermissions(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
 		IDRefreshName: "aws_elastictranscoder_pipeline.baz",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckElasticTranscoderPipelineDestroy,
@@ -234,6 +234,22 @@ func testAccCheckElasticTranscoderPipelineDestroy(s *terraform.State) error {
 
 	}
 	return nil
+}
+
+func testAccPreCheckAWSElasticTranscoder(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).elastictranscoderconn
+
+	input := &elastictranscoder.ListPipelinesInput{}
+
+	_, err := conn.ListPipelines(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func awsElasticTranscoderPipelineConfigBasic(rName string) string {

--- a/aws/resource_aws_elastic_transcoder_preset_test.go
+++ b/aws/resource_aws_elastic_transcoder_preset_test.go
@@ -15,7 +15,7 @@ func TestAccAWSElasticTranscoderPreset_import(t *testing.T) {
 	resourceName := "aws_elastictranscoder_preset.bar"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckElasticTranscoderPresetDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +75,7 @@ func TestAccAWSElasticTranscoderPreset_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSElasticTranscoder(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckElasticTranscoderPresetDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSElasticTranscoderPreset_basic (0.66s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Elastic Transcoder Preset: RequestError: send request failed
        caused by: Post https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/presets: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSElasticTranscoderPreset_basic (2.40s)
    resource_aws_elastic_transcoder_pipeline_test.go:247: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/pipelines: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSElasticTranscoderPipeline_withContentConfig (2.40s)
    resource_aws_elastic_transcoder_pipeline_test.go:247: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/pipelines: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSElasticTranscoderPipeline_notifications (2.40s)
    resource_aws_elastic_transcoder_pipeline_test.go:247: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/pipelines: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSElasticTranscoderPipeline_kmsKey (2.40s)
    resource_aws_elastic_transcoder_pipeline_test.go:247: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/pipelines: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSElasticTranscoderPreset_import (2.40s)
    resource_aws_elastic_transcoder_pipeline_test.go:247: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/pipelines: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSElasticTranscoderPipeline_basic (2.40s)
    resource_aws_elastic_transcoder_pipeline_test.go:247: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/pipelines: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSElasticTranscoderPipeline_withPermissions (2.40s)
    resource_aws_elastic_transcoder_pipeline_test.go:247: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://elastictranscoder.us-gov-west-1.amazonaws.com/2012-09-25/pipelines: dial tcp: lookup elastictranscoder.us-gov-west-1.amazonaws.com: no such host
```

