### PR TITLE
tests/service/lightsail: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_lightsail_domain_test.go
+++ b/aws/resource_aws_lightsail_domain_test.go
@@ -18,7 +18,7 @@ func TestAccAWSLightsailDomain_basic(t *testing.T) {
 	lightsailDomainName := fmt.Sprintf("tf-test-lightsail-%s.com", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailDomainDestroy,
 		Steps: []resource.TestStep{
@@ -51,7 +51,7 @@ func TestAccAWSLightsailDomain_disappears(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailDomainDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -19,7 +19,7 @@ func TestAccAWSLightsailInstance_basic(t *testing.T) {
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
@@ -43,7 +43,7 @@ func TestAccAWSLightsailInstance_euRegion(t *testing.T) {
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
@@ -84,7 +84,7 @@ func TestAccAWSLightsailInstance_disapear(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailInstanceDestroy,
 		Steps: []resource.TestStep{
@@ -158,6 +158,22 @@ func testAccCheckAWSLightsailInstanceDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccPreCheckAWSLightsail(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+	input := &lightsail.GetInstancesInput{}
+
+	_, err := conn.GetInstances(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccAWSLightsailInstanceConfig_basic(lightsailName string) string {

--- a/aws/resource_aws_lightsail_key_pair_test.go
+++ b/aws/resource_aws_lightsail_key_pair_test.go
@@ -18,7 +18,7 @@ func TestAccAWSLightsailKeyPair_basic(t *testing.T) {
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailKeyPairDestroy,
 		Steps: []resource.TestStep{
@@ -41,7 +41,7 @@ func TestAccAWSLightsailKeyPair_imported(t *testing.T) {
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailKeyPairDestroy,
 		Steps: []resource.TestStep{
@@ -66,7 +66,7 @@ func TestAccAWSLightsailKeyPair_encrypted(t *testing.T) {
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailKeyPairDestroy,
 		Steps: []resource.TestStep{
@@ -90,7 +90,7 @@ func TestAccAWSLightsailKeyPair_nameprefix(t *testing.T) {
 	var conf1, conf2 lightsail.KeyPair
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailKeyPairDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_lightsail_static_ip_attachment_test.go
+++ b/aws/resource_aws_lightsail_static_ip_attachment_test.go
@@ -20,7 +20,7 @@ func TestAccAWSLightsailStaticIpAttachment_basic(t *testing.T) {
 	keypairName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailStaticIpAttachmentDestroy,
 		Steps: []resource.TestStep{
@@ -54,7 +54,7 @@ func TestAccAWSLightsailStaticIpAttachment_disappears(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailStaticIpAttachmentDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_lightsail_static_ip_test.go
+++ b/aws/resource_aws_lightsail_static_ip_test.go
@@ -71,7 +71,7 @@ func TestAccAWSLightsailStaticIp_basic(t *testing.T) {
 	staticIpName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailStaticIpDestroy,
 		Steps: []resource.TestStep{
@@ -103,7 +103,7 @@ func TestAccAWSLightsailStaticIp_disappears(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLightsailStaticIpDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSLightsailInstance_basic (1.16s)
    testing.go:568: Step 0 error: errors during plan:

        Error: error validating provider credentials: error calling sts:GetCallerIdentity: InvalidClientTokenId: The security token included in the request is invalid.
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSLightsailStaticIp_basic (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailStaticIpAttachment_disappears (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailKeyPair_encrypted (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailDomain_basic (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailKeyPair_imported (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailInstance_disapear (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailKeyPair_nameprefix (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailKeyPair_basic (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailInstance_euRegion (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailDomain_disappears (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailStaticIpAttachment_basic (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailStaticIp_disappears (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSLightsailInstance_basic (1.89s)
    resource_aws_lightsail_instance_test.go:171: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://lightsail.us-gov-west-1.amazonaws.com/: dial tcp: lookup lightsail.us-gov-west-1.amazonaws.com: no such host
```