### PR TITLE
tests/service/ses: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_ses_active_receipt_rule_set_test.go
+++ b/aws/resource_aws_ses_active_receipt_rule_set_test.go
@@ -13,6 +13,7 @@ func TestAccAWSSESActiveReceiptRuleSet_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESActiveReceiptRuleSetDestroy,

--- a/aws/resource_aws_ses_configuration_set_test.go
+++ b/aws/resource_aws_ses_configuration_set_test.go
@@ -14,6 +14,7 @@ func TestAccAWSSESConfigurationSet_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESConfigurationSetDestroy,

--- a/aws/resource_aws_ses_domain_dkim_test.go
+++ b/aws/resource_aws_ses_domain_dkim_test.go
@@ -21,6 +21,7 @@ func TestAccAWSSESDomainDkim_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_domain_identity_test.go
+++ b/aws/resource_aws_ses_domain_identity_test.go
@@ -19,7 +19,7 @@ func TestAccAWSSESDomainIdentity_basic(t *testing.T) {
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -40,7 +40,7 @@ func TestAccAWSSESDomainIdentity_disappears(t *testing.T) {
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -62,7 +62,7 @@ func TestAccAWSSESDomainIdentity_trailingPeriod(t *testing.T) {
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -170,6 +170,22 @@ func testAccCheckAwsSESDomainIdentityArn(n string, domain string) resource.TestC
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSSES(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).sesConn
+
+	input := &ses.ListIdentitiesInput{}
+
+	_, err := conn.ListIdentities(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_ses_domain_identity_verification_test.go
+++ b/aws/resource_aws_ses_domain_identity_verification_test.go
@@ -30,7 +30,7 @@ func TestAccAwsSesDomainIdentityVerification_basic(t *testing.T) {
 	domain := fmt.Sprintf("tf-acc-%d.%s", acctest.RandInt(), rootDomain)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -48,7 +48,7 @@ func TestAccAwsSesDomainIdentityVerification_timeout(t *testing.T) {
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -66,7 +66,7 @@ func TestAccAwsSesDomainIdentityVerification_nonexistent(t *testing.T) {
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_domain_mail_from_test.go
+++ b/aws/resource_aws_ses_domain_mail_from_test.go
@@ -20,7 +20,7 @@ func TestAccAWSSESDomainMailFrom_basic(t *testing.T) {
 	resourceName := "aws_ses_domain_mail_from.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESDomainMailFromDestroy,
 		Steps: []resource.TestStep{
@@ -59,7 +59,7 @@ func TestAccAWSSESDomainMailFrom_disappears(t *testing.T) {
 	resourceName := "aws_ses_domain_mail_from.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESDomainMailFromDestroy,
 		Steps: []resource.TestStep{
@@ -83,7 +83,7 @@ func TestAccAWSSESDomainMailFrom_disappears_Identity(t *testing.T) {
 	resourceName := "aws_ses_domain_mail_from.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESDomainMailFromDestroy,
 		Steps: []resource.TestStep{
@@ -106,7 +106,7 @@ func TestAccAWSSESDomainMailFrom_behaviorOnMxFailure(t *testing.T) {
 	resourceName := "aws_ses_domain_mail_from.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESDomainMailFromDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_email_identity_test.go
+++ b/aws/resource_aws_ses_email_identity_test.go
@@ -20,7 +20,7 @@ func TestAccAWSSESEmailIdentity_basic(t *testing.T) {
 	resourceName := "aws_ses_email_identity.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESEmailIdentityDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccAWSSESEmailIdentity_trailingPeriod(t *testing.T) {
 	resourceName := "aws_ses_email_identity.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESEmailIdentityDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_event_destination_test.go
+++ b/aws/resource_aws_ses_event_destination_test.go
@@ -26,6 +26,7 @@ func TestAccAWSSESEventDestination_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESEventDestinationDestroy,

--- a/aws/resource_aws_ses_identity_notification_topic_test.go
+++ b/aws/resource_aws_ses_identity_notification_topic_test.go
@@ -22,6 +22,7 @@ func TestAccAwsSESIdentityNotificationTopic_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSESIdentityNotificationTopicDestroy,

--- a/aws/resource_aws_ses_receipt_filter_test.go
+++ b/aws/resource_aws_ses_receipt_filter_test.go
@@ -16,7 +16,7 @@ func TestAccAWSSESReceiptFilter_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptFilterDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_receipt_rule_set_test.go
+++ b/aws/resource_aws_ses_receipt_rule_set_test.go
@@ -16,7 +16,7 @@ func TestAccAWSSESReceiptRuleSet_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleSetDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_ses_receipt_rule_test.go
+++ b/aws/resource_aws_ses_receipt_rule_test.go
@@ -18,6 +18,7 @@ func TestAccAWSSESReceiptRule_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -42,6 +43,7 @@ func TestAccAWSSESReceiptRule_s3Action(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -66,6 +68,7 @@ func TestAccAWSSESReceiptRule_order(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,
@@ -90,6 +93,7 @@ func TestAccAWSSESReceiptRule_actions(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAWSSES(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSESReceiptRuleDestroy,

--- a/aws/resource_aws_ses_template_test.go
+++ b/aws/resource_aws_ses_template_test.go
@@ -18,7 +18,7 @@ func TestAccAWSSesTemplate_Basic(t *testing.T) {
 	name := acctest.RandString(5)
 	var template ses.Template
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSesTemplateDestroy,
 		Steps: []resource.TestStep{
@@ -41,7 +41,7 @@ func TestAccAWSSesTemplate_Update(t *testing.T) {
 	name := acctest.RandString(5)
 	var template ses.Template
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSesTemplateDestroy,
 		Steps: []resource.TestStep{
@@ -85,7 +85,7 @@ func TestAccAWSSesTemplate_Import(t *testing.T) {
 	name := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSES(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSesTemplateDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSSESDomainIdentity_basic (2.91s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error requesting SES domain identity verification: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSSESEventDestination_basic (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESReceiptRule_order (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESActiveReceiptRuleSet_basic (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESReceiptRuleSet_basic (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSesTemplate_Import (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESReceiptRule_s3Action (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSesDomainIdentityVerification_timeout (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainMailFrom_disappears_Identity (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESReceiptFilter_basic (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainMailFrom_behaviorOnMxFailure (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESEmailIdentity_trailingPeriod (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESReceiptRule_basic (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESReceiptRule_actions (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSesDomainIdentityVerification_nonexistent (2.47s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainIdentity_trailingPeriod (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESEmailIdentity_basic (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSESIdentityNotificationTopic_basic (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainMailFrom_disappears (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSesTemplate_Basic (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainMailFrom_basic (2.48s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainDkim_basic (2.99s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainIdentity_basic (2.99s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESConfigurationSet_basic (2.99s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSSESDomainIdentity_disappears (3.17s)
    resource_aws_ses_domain_identity_test.go:184: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://email.us-gov-west-1.amazonaws.com/: dial tcp: lookup email.us-gov-west-1.amazonaws.com: no such host
```
