### PR TITLE
tests/service/secretsmanager: Add PreCheck for service availability

### DIFF
--- a/aws/data_source_aws_secretsmanager_secret_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccDataSourceAwsSecretsManagerSecret_Basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -37,7 +37,7 @@ func TestAccDataSourceAwsSecretsManagerSecret_ARN(t *testing.T) {
 	datasourceName := "data.aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccDataSourceAwsSecretsManagerSecret_Name(t *testing.T) {
 	datasourceName := "data.aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -75,7 +75,7 @@ func TestAccDataSourceAwsSecretsManagerSecret_Policy(t *testing.T) {
 	datasourceName := "data.aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/data_source_aws_secretsmanager_secret_version_test.go
+++ b/aws/data_source_aws_secretsmanager_secret_version_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceAwsSecretsManagerSecretVersion_Basic(t *testing.T) {
 	datasourceName := "data.aws_secretsmanager_secret_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -39,7 +39,7 @@ func TestAccDataSourceAwsSecretsManagerSecretVersion_VersionID(t *testing.T) {
 	datasourceName := "data.aws_secretsmanager_secret_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -58,7 +58,7 @@ func TestAccDataSourceAwsSecretsManagerSecretVersion_VersionStage(t *testing.T) 
 	datasourceName := "data.aws_secretsmanager_secret_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_secretsmanager_secret_test.go
+++ b/aws/resource_aws_secretsmanager_secret_test.go
@@ -70,7 +70,7 @@ func TestAccAwsSecretsManagerSecret_Basic(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -105,7 +105,7 @@ func TestAccAwsSecretsManagerSecret_withNamePrefix(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -133,7 +133,7 @@ func TestAccAwsSecretsManagerSecret_Description(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -167,7 +167,7 @@ func TestAccAwsSecretsManagerSecret_KmsKeyID(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -201,7 +201,7 @@ func TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate(t *testing.T) 
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -236,7 +236,7 @@ func TestAccAwsSecretsManagerSecret_RotationLambdaARN(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -288,7 +288,7 @@ func TestAccAwsSecretsManagerSecret_RotationRules(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -342,7 +342,7 @@ func TestAccAwsSecretsManagerSecret_Tags(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -396,7 +396,7 @@ func TestAccAwsSecretsManagerSecret_policy(t *testing.T) {
 	expectedPolicyText := `{"Version":"2012-10-17","Statement":[{"Sid":"EnableAllPermissions","Effect":"Allow","Principal":{"AWS":"*"},"Action":"secretsmanager:GetSecretValue","Resource":"*"}]}`
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretDestroy,
 		Steps: []resource.TestStep{
@@ -499,6 +499,22 @@ func testAccCheckAwsSecretsManagerSecretHasPolicy(name string, expectedPolicyTex
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSSecretsManager(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).secretsmanagerconn
+
+	input := &secretsmanager.ListSecretsInput{}
+
+	_, err := conn.ListSecrets(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_secretsmanager_secret_version_test.go
+++ b/aws/resource_aws_secretsmanager_secret_version_test.go
@@ -18,7 +18,7 @@ func TestAccAwsSecretsManagerSecretVersion_BasicString(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretVersionDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccAwsSecretsManagerSecretVersion_Base64Binary(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretVersionDestroy,
 		Steps: []resource.TestStep{
@@ -80,7 +80,7 @@ func TestAccAwsSecretsManagerSecretVersion_VersionStages(t *testing.T) {
 	resourceName := "aws_secretsmanager_secret_version.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSSecretsManager(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsSecretsManagerSecretVersionDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAwsSecretsManagerSecret_Basic (0.57s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Secrets Manager Secret: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAwsSecretsManagerSecret_Basic (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecretVersion_VersionStages (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecretVersion_Base64Binary (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsSecretsManagerSecret_Name (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_withNamePrefix (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsSecretsManagerSecretVersion_Basic (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_RotationRules (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_KmsKeyID (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_Tags (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsSecretsManagerSecretVersion_VersionStage (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_policy (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsSecretsManagerSecretVersion_VersionID (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsSecretsManagerSecret_Policy (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsSecretsManagerSecret_ARN (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecretVersion_BasicString (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_Description (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsSecretsManagerSecret_Basic (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsSecretsManagerSecret_RotationLambdaARN (2.56s)
    resource_aws_secretsmanager_secret_test.go:513: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://secretsmanager.us-gov-west-1.amazonaws.com/: dial tcp: lookup secretsmanager.us-gov-west-1.amazonaws.com: no such host
```