### PR TITLE
tests/service/route53resolver: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_route53_resolver_endpoint_test.go
+++ b/aws/resource_aws_route53_resolver_endpoint_test.go
@@ -75,7 +75,7 @@ func TestAccAwsRoute53ResolverEndpoint_basicInbound(t *testing.T) {
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
 		Steps: []resource.TestStep{
@@ -107,7 +107,7 @@ func TestAccAwsRoute53ResolverEndpoint_updateOutbound(t *testing.T) {
 	updatedName := fmt.Sprintf("terraform-testacc-r53-rupdated-%d", rInt)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverEndpointDestroy,
 		Steps: []resource.TestStep{
@@ -184,6 +184,22 @@ func testAccCheckRoute53ResolverEndpointExists(n string, ep *route53resolver.Res
 		*ep = *resp.ResolverEndpoint
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSRoute53Resolver(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).route53resolverconn
+
+	input := &route53resolver.ListResolverEndpointsInput{}
+
+	_, err := conn.ListResolverEndpoints(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_route53_resolver_rule_association_test.go
+++ b/aws/resource_aws_route53_resolver_rule_association_test.go
@@ -20,7 +20,7 @@ func TestAccAwsRoute53ResolverRuleAssociation_basic(t *testing.T) {
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleAssociationDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_route53_resolver_rule_test.go
+++ b/aws/resource_aws_route53_resolver_rule_test.go
@@ -17,7 +17,7 @@ func TestAccAwsRoute53ResolverRule_basic(t *testing.T) {
 	resourceName := "aws_route53_resolver_rule.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -46,7 +46,7 @@ func TestAccAwsRoute53ResolverRule_tags(t *testing.T) {
 	resourceName := "aws_route53_resolver_rule.example"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -98,7 +98,7 @@ func TestAccAwsRoute53ResolverRule_updateName(t *testing.T) {
 	name2 := fmt.Sprintf("terraform-testacc-r53-resolver-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -138,7 +138,7 @@ func TestAccAwsRoute53ResolverRule_forward(t *testing.T) {
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{
@@ -203,7 +203,7 @@ func TestAccAwsRoute53ResolverRule_forwardEndpointRecreate(t *testing.T) {
 	name := fmt.Sprintf("terraform-testacc-r53-resolver-%d", acctest.RandInt())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRoute53ResolverRuleDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAwsRoute53ResolverEndpoint_basicInbound (5.14s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Route53 Resolver endpoint: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAwsRoute53ResolverRule_forwardEndpointRecreate (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsRoute53ResolverEndpoint_updateOutbound (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsRoute53ResolverEndpoint_basicInbound (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsRoute53ResolverRuleAssociation_basic (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsRoute53ResolverRule_forward (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsRoute53ResolverRule_basic (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsRoute53ResolverRule_tags (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAwsRoute53ResolverRule_updateName (2.60s)
    resource_aws_route53_resolver_endpoint_test.go:198: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://route53resolver.us-gov-west-1.amazonaws.com/: dial tcp: lookup route53resolver.us-gov-west-1.amazonaws.com: no such host
```