### PR TITLE
tests/service/servicediscovery: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_service_discovery_http_namespace_test.go
+++ b/aws/resource_aws_service_discovery_http_namespace_test.go
@@ -16,7 +16,7 @@ func TestAccAWSServiceDiscoveryHttpNamespace_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryHttpNamespaceDestroy,
 		Steps: []resource.TestStep{
@@ -43,7 +43,7 @@ func TestAccAWSServiceDiscoveryHttpNamespace_Description(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryHttpNamespaceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_service_discovery_private_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_private_dns_namespace_test.go
@@ -16,7 +16,7 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic(t *testing.T) {
 	rName := acctest.RandString(5) + ".example.com"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
 		Steps: []resource.TestStep{
@@ -36,7 +36,7 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname(t *testing.T) {
 	rName := acctest.RandString(64-len("example.com")) + ".example.com"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
 		Steps: []resource.TestStep{
@@ -60,7 +60,7 @@ func TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap(t *testing.T) {
 	subDomain := acctest.RandString(5) + "." + rName
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceDestroy,
 		Steps: []resource.TestStep{
@@ -103,6 +103,22 @@ func testAccCheckAwsServiceDiscoveryPrivateDnsNamespaceExists(name string) resou
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSServiceDiscovery(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).sdconn
+
+	input := &servicediscovery.ListNamespacesInput{}
+
+	_, err := conn.ListNamespaces(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_service_discovery_public_dns_namespace_test.go
+++ b/aws/resource_aws_service_discovery_public_dns_namespace_test.go
@@ -16,7 +16,7 @@ func TestAccAWSServiceDiscoveryPublicDnsNamespace_basic(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha) + ".terraformtesting.com"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy,
 		Steps: []resource.TestStep{
@@ -42,7 +42,7 @@ func TestAccAWSServiceDiscoveryPublicDnsNamespace_longname(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(64-len("terraformtesting.com"), acctest.CharSetAlpha) + ".terraformtesting.com"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryPublicDnsNamespaceDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_service_discovery_service_test.go
+++ b/aws/resource_aws_service_discovery_service_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 	rName := acctest.RandString(5)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccAWSServiceDiscoveryService_private(t *testing.T) {
 func TestAccAWSServiceDiscoveryService_public(t *testing.T) {
 	rName := acctest.RandString(5)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
 		Steps: []resource.TestStep{
@@ -82,7 +82,7 @@ func TestAccAWSServiceDiscoveryService_import(t *testing.T) {
 	resourceName := "aws_service_discovery_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceDiscovery(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsServiceDiscoveryServiceDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (8.28s)
    testing.go:568: Step 0 error: errors during apply:

        Error: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSServiceDiscoveryPublicDnsNamespace_basic (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryHttpNamespace_basic (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryPrivateDnsNamespace_error_Overlap (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryHttpNamespace_Description (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryPublicDnsNamespace_longname (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryService_import (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryService_public (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryPrivateDnsNamespace_longname (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryService_private (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSServiceDiscoveryPrivateDnsNamespace_basic (2.41s)
    resource_aws_service_discovery_private_dns_namespace_test.go:117: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicediscovery.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicediscovery.us-gov-west-1.amazonaws.com: no such host
```
