### PR TITLE
tests/service/transfer: Add PreCheck for service availability

### DIFF
--- a/aws/data_source_aws_transfer_server_test.go
+++ b/aws/data_source_aws_transfer_server_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceAwsTransferServer_basic(t *testing.T) {
 	datasourceName := "data.aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -35,7 +35,7 @@ func TestAccDataSourceAwsTransferServer_service_managed(t *testing.T) {
 	datasourceName := "data.aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -57,7 +57,7 @@ func TestAccDataSourceAwsTransferServer_apigateway(t *testing.T) {
 	datasourceName := "data.aws_transfer_server.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aws/resource_aws_transfer_server_test.go
+++ b/aws/resource_aws_transfer_server_test.go
@@ -19,7 +19,7 @@ func TestAccAWSTransferServer_basic(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		IDRefreshName: "aws_transfer_server.foo",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
@@ -65,7 +65,7 @@ func TestAccAWSTransferServer_apigateway(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		IDRefreshName: "aws_transfer_server.foo",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
@@ -94,7 +94,7 @@ func TestAccAWSTransferServer_disappears(t *testing.T) {
 	var conf transfer.DescribedServer
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTransferServerDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +116,7 @@ func TestAccAWSTransferServer_forcedestroy(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		IDRefreshName: "aws_transfer_server.foo",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
@@ -149,7 +149,7 @@ func TestAccAWSTransferServer_vpcEndpointId(t *testing.T) {
 	resourceName := "aws_transfer_server.default"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferServerDestroy,
@@ -274,6 +274,22 @@ func testAccCheckAWSTransferCreateSshKey(describedServer *transfer.DescribedServ
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSTransfer(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).transferconn
+
+	input := &transfer.ListServersInput{}
+
+	_, err := conn.ListServers(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_transfer_ssh_key_test.go
+++ b/aws/resource_aws_transfer_ssh_key_test.go
@@ -17,7 +17,7 @@ func TestAccAWSTransferSshKey_basic(t *testing.T) {
 	rName := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTransferSshKeyDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_transfer_user_test.go
+++ b/aws/resource_aws_transfer_user_test.go
@@ -18,7 +18,7 @@ func TestAccAWSTransferUser_basic(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		IDRefreshName: "aws_transfer_user.foo",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
@@ -49,7 +49,7 @@ func TestAccAWSTransferUser_modifyWithOptions(t *testing.T) {
 	rName2 := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
+		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		IDRefreshName: "aws_transfer_user.foo",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSTransferUserDestroy,
@@ -108,7 +108,7 @@ func TestAccAWSTransferUser_disappears(t *testing.T) {
 	rName := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{
@@ -127,7 +127,7 @@ func TestAccAWSTransferUser_disappears(t *testing.T) {
 
 func TestAccAWSTransferUser_UserName_Validation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSTransfer(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTransferUserDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSTransferServer_basic (1.07s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Transfer Server: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccDataSourceAwsTransferServer_apigateway (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferServer_forcedestroy (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferServer_vpcEndpointId (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsTransferServer_service_managed (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferSshKey_basic (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccDataSourceAwsTransferServer_basic (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferServer_apigateway (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferUser_basic (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferUser_disappears (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferServer_disappears (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferUser_modifyWithOptions (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferUser_UserName_Validation (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSTransferServer_basic (2.58s)
    resource_aws_transfer_server_test.go:288: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://transfer.us-gov-west-1.amazonaws.com/: dial tcp: lookup transfer.us-gov-west-1.amazonaws.com: no such host
```