### PR TITLE
tests/service/worklink: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -18,7 +18,7 @@ func TestAccAWSWorkLinkFleet_Basic(t *testing.T) {
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -45,7 +45,7 @@ func TestAccAWSWorkLinkFleet_DisplayName(t *testing.T) {
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -77,7 +77,7 @@ func TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation(t *testing.T) {
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -109,7 +109,7 @@ func TestAccAWSWorkLinkFleet_AuditStreamArn(t *testing.T) {
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -134,7 +134,7 @@ func TestAccAWSWorkLinkFleet_Network(t *testing.T) {
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -177,7 +177,7 @@ func TestAccAWSWorkLinkFleet_DeviceCaCertificate(t *testing.T) {
 	fName := "test-fixtures/worklink-device-ca-certificate.pem"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -210,7 +210,7 @@ func TestAccAWSWorkLinkFleet_IdentityProvider(t *testing.T) {
 	fName := "test-fixtures/saml-metadata.xml"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -240,7 +240,7 @@ func TestAccAWSWorkLinkFleet_Disappears(t *testing.T) {
 	resourceName := "aws_worklink_fleet.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkFleetDestroy,
 		Steps: []resource.TestStep{
@@ -336,6 +336,22 @@ func testAccCheckAWSWorkLinkFleetExists(n string) resource.TestCheckFunc {
 		})
 
 		return err
+	}
+}
+
+func testAccPreCheckAWSWorkLink(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).worklinkconn
+
+	input := &worklink.ListFleetsInput{}
+
+	_, err := conn.ListFleets(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_worklink_website_certificate_authority_association_test.go
+++ b/aws/resource_aws_worklink_website_certificate_authority_association_test.go
@@ -18,7 +18,7 @@ func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic(t *t
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkWebsiteCertificateAuthorityAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -47,7 +47,7 @@ func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayNam
 	displayName1 := fmt.Sprintf("tf-website-certificate-%s", randomString(5))
 	displayName2 := fmt.Sprintf("tf-website-certificate-%s", randomString(5))
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkWebsiteCertificateAuthorityAssociationDestroy,
 		Steps: []resource.TestStep{
@@ -79,7 +79,7 @@ func TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWorkLink(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSWorkLinkWebsiteCertificateAuthorityAssociationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSWorkLinkFleet_Basic (0.52s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error creating Worklink Fleet: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/createFleet: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_DisplayName (2.40s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation (2.40s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_DisplayName (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_Disappears (2.40s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Disappears (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_Basic (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkWorkLinkWebsiteCertificateAuthorityAssociation_Basic (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_Network (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_DeviceCaCertificate (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_AuditStreamArn (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSWorkLinkFleet_IdentityProvider (2.41s)
    resource_aws_worklink_fleet_test.go:350: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://worklink.us-gov-west-1.amazonaws.com/listFleets: dial tcp: lookup worklink.us-gov-west-1.amazonaws.com: no such host
```
