### PR TITLE
tests/service/xray: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_xray_sampling_rule_test.go
+++ b/aws/resource_aws_xray_sampling_rule_test.go
@@ -17,7 +17,7 @@ func TestAccAWSXraySamplingRule_basic(t *testing.T) {
 	ruleName := fmt.Sprintf("tf_acc_sampling_rule_%s", rString)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSXray(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSXraySamplingRuleDestroy,
 		Steps: []resource.TestStep{
@@ -57,7 +57,7 @@ func TestAccAWSXraySamplingRule_update(t *testing.T) {
 	updatedReservoirSize := acctest.RandIntRange(0, 2147483647)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSXray(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSXraySamplingRuleDestroy,
 		Steps: []resource.TestStep{
@@ -150,6 +150,22 @@ func testAccCheckAWSXraySamplingRuleDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccPreCheckAWSXray(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).xrayconn
+
+	input := &xray.GetSamplingRulesInput{}
+
+	_, err := conn.GetSamplingRules(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccAWSXraySamplingRuleConfig_basic(ruleName string) string {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Previously from AWS GovCloud (US) acceptance testing:

```
--- FAIL: TestAccAWSXraySamplingRule_basic (0.76s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating XRay Sampling Rule: RequestError: send request failed
        caused by: Post https://xray.us-gov-west-1.amazonaws.com/CreateSamplingRule: dial tcp: lookup xray.us-gov-west-1.amazonaws.com on 192.168.22.2:53: no such host
```

Output from AWS GovCloud (US) acceptance testing:

```
--- SKIP: TestAccAWSXraySamplingRule_update (7.17s)
    resource_aws_xray_sampling_rule_test.go:163: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://xray.us-gov-west-1.amazonaws.com/GetSamplingRules: dial tcp: lookup xray.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSXraySamplingRule_basic (7.17s)
    resource_aws_xray_sampling_rule_test.go:163: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://xray.us-gov-west-1.amazonaws.com/GetSamplingRules: dial tcp: lookup xray.us-gov-west-1.amazonaws.com: no such host
```
