### PR TITLE
Format AWS client VPN example with terraform fmt

### DIFF
--- a/website/docs/r/ec2_client_vpn_endpoint.html.markdown
+++ b/website/docs/r/ec2_client_vpn_endpoint.html.markdown
@@ -15,18 +15,18 @@ Provides an AWS Client VPN endpoint for OpenVPN clients. For more information on
 
 ```hcl
 resource "aws_ec2_client_vpn_endpoint" "example" {
-  description = "terraform-clientvpn-example"
+  description            = "terraform-clientvpn-example"
   server_certificate_arn = "${aws_acm_certificate.cert.arn}"
-  client_cidr_block = "10.0.0.0/16"
+  client_cidr_block      = "10.0.0.0/16"
 
   authentication_options {
-    type = "certificate-authentication"
+    type                       = "certificate-authentication"
     root_certificate_chain_arn = "${aws_acm_certificate.root_cert.arn}"
   }
 
   connection_log_options {
-    enabled = true
-    cloudwatch_log_group = "${aws_cloudwatch_log_group.lg.name}"
+    enabled               = true
+    cloudwatch_log_group  = "${aws_cloudwatch_log_group.lg.name}"
     cloudwatch_log_stream = "${aws_cloudwatch_log_stream.ls.name}"
   }
 }


### PR DESCRIPTION
Code examples should adhere to Terraform standard formatting. This change therefore updates the VPN client example to be correctly formatted.