### PR TITLE
Update default example to use json instead of form

### DIFF
--- a/website/docs/r/codepipeline_webhook.markdown
+++ b/website/docs/r/codepipeline_webhook.markdown
@@ -96,7 +96,7 @@ resource "github_repository_webhook" "bar" {
 
   configuration {
     url          = "${aws_codepipeline_webhook.bar.url}"
-    content_type = "form"
+    content_type = "json"
     insecure_ssl = true
     secret       = "${local.webhook_secret}"
   }


### PR DESCRIPTION
Using json successfully triggers the pipeline, when using form it is now failing with AWS code pipeline

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update documentation for GitHub -> Codepipeline web hook
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
