### PR TITLE
github: Initial PR labeler action

### DIFF
--- a/.github/PULL_REQUEST_LABELS.yml
+++ b/.github/PULL_REQUEST_LABELS.yml
@@ -1,0 +1,51 @@
+# Experimental automatic PR label configuration
+# Documentation: https://github.com/actions/labeler
+#
+# The majority of PR labels are still handled by hashibot
+#
+# This file should be considered for automatic generation in the future
+
+service/appmesh:
+  - aws/{data_source,resource}_aws_appmesh_*
+  - website/docs/{d,r}/appmesh_*
+
+service/backup:
+  - aws/{data_source,resource}_aws_backup_*
+  - website/docs/{d,r}/backup_*
+
+service/comprehend:
+  - aws/{data_source,resource}_aws_comprehend_*
+  - website/docs/{d,r}/comprehend_*
+
+service/docdb:
+  - aws/{data_source,resource}_aws_docdb_*
+  - aws/tagsDocDB*
+  - website/docs/{d,r}/docdb_*
+
+service/licensemanager:
+  - aws/{data_source,resource}_aws_licensemanager_*
+  - aws/tagsLicenseManager*
+  - website/docs/{d,r}/licensemanager_*
+
+service/quicksight:
+  - aws/{data_source,resource}_aws_quicksight_*
+  - website/docs/{d,r}/quicksight_*
+
+service/ram:
+  - aws/{data_source,resource}_aws_ram_*
+  - aws/tagsRAM*
+  - website/docs/{d,r}/ram_*
+
+service/route53resolver:
+  - aws/{data_source,resource}_aws_route53resolver_*
+  - aws/tagsRoute53Resolver*
+  - website/docs/{d,r}/route53resolver_*
+
+service/transfer:
+  - aws/{data_source,resource}_aws_transfer_*
+  - aws/tagsTransfer*
+  - website/docs/{d,r}/transfer_*
+
+service/worklink:
+  - aws/{data_source,resource}_aws_worklink_*
+  - website/docs/{d,r}/worklink_*

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,7 +5,7 @@ workflow "Pull Request Updates" {
 
 action "pr-filter-sync" {
     uses = "actions/bin/filter@master"
-    args = "action synchronize"
+    args = "action 'opened|review_requested|synchronize'"
 }
 
 action "pr-label" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,22 @@
+workflow "Pull Request Updates" {
+    on       = "pull_request"
+    resolves = "pr-label"
+}
+
+action "pr-filter-sync" {
+    uses = "actions/bin/filter@master"
+    args = "action synchronize"
+}
+
+action "pr-label" {
+    uses    = "actions/labeler@v1.0.0"
+    needs   = "pr-filter-sync"
+
+    secrets = [
+        "GITHUB_TOKEN"
+    ]
+
+    env     = {
+        LABEL_SPEC_FILE = ".github/PULL_REQUEST_LABELS.yml"
+    }
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Experimental pull request labeling on updates. Similar to existing hashibot behavior, but configuration file can live in this repository.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A