### PR TITLE
Adding retry to reading transit gateway route

### DIFF
--- a/aws/resource_aws_ec2_transit_gateway_route.go
+++ b/aws/resource_aws_ec2_transit_gateway_route.go
@@ -93,7 +93,7 @@ func resourceAwsEc2TransitGatewayRouteRead(d *schema.ResourceData, meta interfac
 	})
 
 	if isResourceTimeoutError(err) {
-		_, err = ec2DescribeTransitGatewayRoute(conn, transitGatewayRouteTableID, destination)
+		transitGatewayRoute, err = ec2DescribeTransitGatewayRoute(conn, transitGatewayRouteTableID, destination)
 	}
 
 	if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {

--- a/aws/resource_aws_ec2_transit_gateway_route.go
+++ b/aws/resource_aws_ec2_transit_gateway_route.go
@@ -92,6 +92,10 @@ func resourceAwsEc2TransitGatewayRouteRead(d *schema.ResourceData, meta interfac
 		return nil
 	})
 
+	if isResourceTimeoutError(err) {
+		_, err = ec2DescribeTransitGatewayRoute(conn, transitGatewayRouteTableID, destination)
+	}
+
 	if isAWSErr(err, "InvalidRouteTableID.NotFound", "") {
 		log.Printf("[WARN] EC2 Transit Gateway Route Table (%s) not found, removing from state", transitGatewayRouteTableID)
 		d.SetId("")


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000
Related to #8417

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ec2_transit_gateway_route - add retry to read method after
timeout
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEc2TransitGatewayRoute"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEc2TransitGatewayRoute -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter
=== PAUSE TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter
=== RUN   TestAccAWSEc2TransitGatewayRouteTableDataSource_ID
=== PAUSE TestAccAWSEc2TransitGatewayRouteTableDataSource_ID
=== RUN   TestAccAWSEc2TransitGatewayRouteTableAssociation_basic
=== PAUSE TestAccAWSEc2TransitGatewayRouteTableAssociation_basic
=== RUN   TestAccAWSEc2TransitGatewayRouteTablePropagation_basic
=== PAUSE TestAccAWSEc2TransitGatewayRouteTablePropagation_basic
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_basic
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_basic
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_disappears
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_disappears
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway
=== RUN   TestAccAWSEc2TransitGatewayRouteTable_Tags
=== PAUSE TestAccAWSEc2TransitGatewayRouteTable_Tags
=== RUN   TestAccAWSEc2TransitGatewayRoute_basic
=== PAUSE TestAccAWSEc2TransitGatewayRoute_basic
=== RUN   TestAccAWSEc2TransitGatewayRoute_disappears
=== PAUSE TestAccAWSEc2TransitGatewayRoute_disappears
=== RUN   TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment
=== PAUSE TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment
=== CONT  TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter
=== CONT  TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway
=== CONT  TestAccAWSEc2TransitGatewayRouteTableDataSource_ID
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_disappears
=== CONT  TestAccAWSEc2TransitGatewayRoute_disappears
=== CONT  TestAccAWSEc2TransitGatewayRoute_basic
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_Tags
=== CONT  TestAccAWSEc2TransitGatewayRouteTablePropagation_basic
=== CONT  TestAccAWSEc2TransitGatewayRouteTableAssociation_basic
=== CONT  TestAccAWSEc2TransitGatewayRouteTable_basic
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears_TransitGateway (264.17s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_disappears (317.62s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_basic (322.16s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTable_Tags (335.02s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_ID (380.46s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableDataSource_Filter (380.63s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_basic (432.81s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTableAssociation_basic (433.06s)
--- PASS: TestAccAWSEc2TransitGatewayRouteTablePropagation_basic (434.23s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears (436.79s)
--- PASS: TestAccAWSEc2TransitGatewayRoute_disappears_TransitGatewayAttachment (441.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       442.778s
```