### PR TITLE
Fix Shield Resources always being expanded in the sidebar

### DIFF
--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2421,7 +2421,7 @@
 
                 <li>
                     <a href="#">Shield Resources</a>
-                    <ul class="nav nav-visible">
+                    <ul class="nav">
 
                         <li>
                             <a href="/docs/providers/aws/r/shield_protection.html">aws_shield_protection</a>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixes the Shield Resources section of the sidebar from always being expanded.
```