### PR TITLE
docs/provider/custom-service-endpoints: Reactively columnize Available Endpoint Customizations list

### DIFF
--- a/website/docs/guides/custom-service-endpoints.html.md
+++ b/website/docs/guides/custom-service-endpoints.html.md
@@ -45,6 +45,8 @@ If multiple, different Terraform AWS Provider configurations are required, see t
 
 The Terraform AWS Provider allows the following endpoints to be customized:
 
+<div style="column-width: 14em;">
+
 - `acm`
 - `acmpca`
 - `apigateway`
@@ -161,6 +163,8 @@ The Terraform AWS Provider allows the following endpoints to be customized:
 - `worklink`
 - `workspaces`
 - `xray`
+
+</div>
 
 ## Connecting to Local AWS Compatible Solutions
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Locally testable via `make website`. For a live example, see https://www.terraform.io/docs/glossary.html

Previously the list was a single, long column with lots of whitespace:

![Screen Shot 2019-05-22 at 5 08 57 AM](https://user-images.githubusercontent.com/189114/58162509-4fd38180-7c50-11e9-8e9f-60c5686f9360.png)

The `div` declaration here automatically scales the list into columns depending on the portal width. e.g.

![Screen Shot 2019-05-22 at 5 10 15 AM](https://user-images.githubusercontent.com/189114/58162590-74c7f480-7c50-11e9-8964-957d041cec2b.png)

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A
