### PR TITLE
Documentation: added autoscaling:EC2_INSTANCE_TERMINATE_ERROR

### DIFF
--- a/website/docs/r/autoscaling_notification.html.markdown
+++ b/website/docs/r/autoscaling_notification.html.markdown
@@ -27,6 +27,7 @@ resource "aws_autoscaling_notification" "example_notifications" {
     "autoscaling:EC2_INSTANCE_LAUNCH",
     "autoscaling:EC2_INSTANCE_TERMINATE",
     "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+    "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
   ]
 
   topic_arn = "${aws_sns_topic.example.arn}"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Documentation update.

Adds `autoscaling:EC2_INSTANCE_TERMINATE_ERROR` to the example. Only 4 values are allowed and the example contains 3. Adding the 4th one will make the example complete.

This is the page we are talking about: https://www.terraform.io/docs/providers/aws/r/autoscaling_notification.html

