### PR TITLE
aws_acm_certificate resource domain_validation_options output not stable

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -312,6 +313,13 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 		}
 	}
 
+	// Sort these so we have a stable output
+	sort.SliceStable(domainValidationResult,
+		func(i, j int) bool {
+			return domainValidationResult[i]["domain_name"].(string) < domainValidationResult[j]["domain_name"].(string)
+		})
+
+	sort.Strings(emailValidationResult)
 	return domainValidationResult, emailValidationResult, nil
 }
 

--- a/aws/resource_aws_acm_certificate_test.go
+++ b/aws/resource_aws_acm_certificate_test.go
@@ -523,8 +523,8 @@ func TestConvertValidationOptionsStableOutput(t *testing.T) {
 	firstValidationOption := &acm.DomainValidation{
 		DomainName: aws.String("first"),
 		ResourceRecord: &acm.ResourceRecord{
-			Name: aws.String("first_name"),
-			Type: aws.String("first_type"),
+			Name:  aws.String("first_name"),
+			Type:  aws.String("first_type"),
 			Value: aws.String("first_value"),
 		},
 	}
@@ -532,23 +532,22 @@ func TestConvertValidationOptionsStableOutput(t *testing.T) {
 	secondValidationOption := &acm.DomainValidation{
 		DomainName: aws.String("second"),
 		ResourceRecord: &acm.ResourceRecord{
-			Name: aws.String("second_name"),
-			Type: aws.String("second_type"),
+			Name:  aws.String("second_name"),
+			Type:  aws.String("second_type"),
 			Value: aws.String("second_value"),
 		},
 	}
 
-
 	firstCert := &acm.CertificateDetail{
 		Type: aws.String(acm.CertificateTypeAmazonIssued),
-		DomainValidationOptions:[]*acm.DomainValidation{
+		DomainValidationOptions: []*acm.DomainValidation{
 			firstValidationOption,
 			secondValidationOption,
 		},
 	}
 	secondCert := &acm.CertificateDetail{
 		Type: aws.String(acm.CertificateTypeAmazonIssued),
-		DomainValidationOptions:[]*acm.DomainValidation{
+		DomainValidationOptions: []*acm.DomainValidation{
 			secondValidationOption,
 			firstValidationOption,
 		},
@@ -566,7 +565,7 @@ func TestConvertValidationOptionsStableOutput(t *testing.T) {
 	if len(firstDomainValidation) != len(secondDomainValidation) {
 		t.Fatalf("Cert domain validations expected to be of same length but aren't")
 	}
-	for idx := range firstDomainValidation{
+	for idx := range firstDomainValidation {
 		first := firstDomainValidation[idx]["domain_name"]
 		second := secondDomainValidation[idx]["domain_name"]
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8747

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
