### PR TITLE
update the waf_web_acl documentation with rules Optional

### DIFF
--- a/website/docs/r/waf_web_acl.html.markdown
+++ b/website/docs/r/waf_web_acl.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `default_action` - (Required) Configuration block with action that you want AWS WAF to take when a request doesn't match the criteria in any of the rules that are associated with the web ACL. Detailed below.
 * `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this web ACL.
 * `name` - (Required) The name or description of the web ACL.
-* `rules` - (Required) Configuration blocks containing rules to associate with the web ACL and the settings for each rule. Detailed below.
+* `rules` - (Optional) Configuration blocks containing rules to associate with the web ACL and the settings for each rule. Detailed below.
 * `logging_configuration` - (Optional) Configuration block to enable WAF logging. Detailed below.
 
 ### `default_action` Configuration Block


### PR DESCRIPTION
updating the documentation for the `waf_web_acl` resource to reflect that the `rules` argument is `Optional` to match what's in that resource's code.
