### PR TITLE
provider: Include error messages when failing to retrieve tags

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1285,7 +1285,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving tags for ARN: %s", arn)
+		return fmt.Errorf("Error retrieving tags for ARN (%s): %s", arn, err)
 	}
 
 	var dt []*rds.Tag

--- a/aws/resource_aws_docdb_subnet_group.go
+++ b/aws/resource_aws_docdb_subnet_group.go
@@ -140,7 +140,7 @@ func resourceAwsDocDBSubnetGroupRead(d *schema.ResourceData, meta interface{}) e
 	})
 
 	if err != nil {
-		return fmt.Errorf("error retrieving tags for ARN: %s", aws.StringValue(subnetGroup.DBSubnetGroupArn))
+		return fmt.Errorf("error retrieving tags for ARN (%s): %s", aws.StringValue(subnetGroup.DBSubnetGroupArn), err)
 	}
 
 	if err := d.Set("tags", tagsToMapDocDB(resp.TagList)); err != nil {

--- a/aws/tagsSSM.go
+++ b/aws/tagsSSM.go
@@ -125,7 +125,7 @@ func saveTagsSSM(conn *ssm.SSM, d *schema.ResourceData, id, resourceType string)
 	})
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving tags for SSM resource: %s", id)
+		return fmt.Errorf("Error retrieving tags for SSM resource (%s): %s", id, err)
 	}
 
 	var dt []*ssm.Tag


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8762

NOTE: This only updates code where we are already returning an error message and not converting any where we are currently just logging the error.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
--- PASS: TestAccAWSSSMMaintenanceWindow_tags (51.12s)
```
