### PR TITLE
r/aws_dx_gateway_association Handle missing dx_gateway_association_id attribute

### DIFF
--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -28,7 +28,13 @@ func resourceAwsDxGatewayAssociation() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		MigrateState:  resourceAwsDxGatewayAssociationMigrateState,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceAwsDxGatewayAssociationResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceAwsDxGatewayAssociationStateUpgradeV0,
+				Version: 0,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"allowed_prefixes": {

--- a/aws/resource_aws_dx_gateway_association.go
+++ b/aws/resource_aws_dx_gateway_association.go
@@ -27,6 +27,9 @@ func resourceAwsDxGatewayAssociation() *schema.Resource {
 			State: resourceAwsDxGatewayAssociationImport,
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsDxGatewayAssociationMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"allowed_prefixes": {
 				Type:     schema.TypeSet,

--- a/aws/resource_aws_dx_gateway_association_migrate.go
+++ b/aws/resource_aws_dx_gateway_association_migrate.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/directconnect"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsDxGatewayAssociationMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Direct Connect gateway association state v0; migrating to v1")
+		return migrateDxGatewayAssociationStateV0toV1(is, meta)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateDxGatewayAssociationStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	conn := meta.(*AWSClient).dxconn
+
+	// dx_gateway_association_id was introduced in v2.8.0. Handle the case where it's not yet present.
+	if _, ok := is.Attributes["dx_gateway_association_id"]; !ok {
+		resp, err := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
+			DirectConnectGatewayId: aws.String(is.Attributes["dx_gateway_id"]),
+			VirtualGatewayId:       aws.String(is.Attributes["vpn_gateway_id"]),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if len(resp.DirectConnectGatewayAssociations) == 0 {
+			return nil, fmt.Errorf("Direct Connect gateway association not found, remove from state using 'terraform state rm'")
+		}
+
+		is.Attributes["dx_gateway_association_id"] = aws.StringValue(resp.DirectConnectGatewayAssociations[0].AssociationId)
+	}
+
+	return is, nil
+}

--- a/aws/resource_aws_dx_gateway_association_migrate.go
+++ b/aws/resource_aws_dx_gateway_association_migrate.go
@@ -6,27 +6,85 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directconnect"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func resourceAwsDxGatewayAssociationMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
-	switch v {
-	case 0:
-		log.Println("[INFO] Found Direct Connect gateway association state v0; migrating to v1")
-		return migrateDxGatewayAssociationStateV0toV1(is, meta)
-	default:
-		return is, fmt.Errorf("Unexpected schema version: %d", v)
+func resourceAwsDxGatewayAssociationResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"allowed_prefixes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"associated_gateway_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"associated_gateway_owner_account_id", "proposal_id", "vpn_gateway_id"},
+			},
+
+			"associated_gateway_owner_account_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ValidateFunc:  validateAwsAccountId,
+				ConflictsWith: []string{"associated_gateway_id", "vpn_gateway_id"},
+			},
+
+			"associated_gateway_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"dx_gateway_association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"dx_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"dx_gateway_owner_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"proposal_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"associated_gateway_id", "vpn_gateway_id"},
+			},
+
+			"vpn_gateway_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
+				Deprecated:    "use 'associated_gateway_id' argument instead",
+			},
+		},
 	}
 }
 
-func migrateDxGatewayAssociationStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceAwsDxGatewayAssociationStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	conn := meta.(*AWSClient).dxconn
 
+	log.Println("[INFO] Found Direct Connect gateway association state v0; migrating to v1")
+
 	// dx_gateway_association_id was introduced in v2.8.0. Handle the case where it's not yet present.
-	if _, ok := is.Attributes["dx_gateway_association_id"]; !ok {
+	if _, ok := rawState["dx_gateway_association_id"]; !ok {
 		resp, err := conn.DescribeDirectConnectGatewayAssociations(&directconnect.DescribeDirectConnectGatewayAssociationsInput{
-			DirectConnectGatewayId: aws.String(is.Attributes["dx_gateway_id"]),
-			VirtualGatewayId:       aws.String(is.Attributes["vpn_gateway_id"]),
+			DirectConnectGatewayId: aws.String(rawState["dx_gateway_id"].(string)),
+			VirtualGatewayId:       aws.String(rawState["vpn_gateway_id"].(string)),
 		})
 		if err != nil {
 			return nil, err
@@ -36,8 +94,8 @@ func migrateDxGatewayAssociationStateV0toV1(is *terraform.InstanceState, meta in
 			return nil, fmt.Errorf("Direct Connect gateway association not found, remove from state using 'terraform state rm'")
 		}
 
-		is.Attributes["dx_gateway_association_id"] = aws.StringValue(resp.DirectConnectGatewayAssociations[0].AssociationId)
+		rawState["dx_gateway_association_id"] = aws.StringValue(resp.DirectConnectGatewayAssociations[0].AssociationId)
 	}
 
-	return is, nil
+	return rawState, nil
 }

--- a/aws/resource_aws_dx_gateway_association_migrate.go
+++ b/aws/resource_aws_dx_gateway_association_migrate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/directconnect"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func resourceAwsDxGatewayAssociationMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8773

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* resource/aws_dx_gateway_association Fix backwards compatibility issue with missing dx_gateway_association_id attribute
```

