### PR TITLE
Add aws_ecs_task_definition.proxy_configuration

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -455,6 +455,10 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	if err := d.Set("proxy_configuration", flattenProxyConfiguration(taskDefinition.ProxyConfiguration)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -470,6 +474,28 @@ func flattenPlacementConstraints(pcs []*ecs.TaskDefinitionPlacementConstraint) [
 		results = append(results, c)
 	}
 	return results
+}
+
+func flattenProxyConfiguration(pc *ecs.ProxyConfiguration) []map[string]interface{} {
+	if pc == nil {
+		return nil
+	}
+
+	meshProperties := make(map[string]string)
+	if pc.Properties != nil {
+		for _, prop := range pc.Properties {
+			meshProperties[*prop.Name] = *prop.Value
+		}
+	}
+
+	config := make(map[string]interface{})
+	config["container_name"] = *pc.ContainerName
+	config["type"] = *pc.Type
+	config["properties"] = meshProperties
+
+	return []map[string]interface{} {
+		config,
+	}
 }
 
 func resourceAwsEcsTaskDefinitionUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -493,7 +493,7 @@ func flattenProxyConfiguration(pc *ecs.ProxyConfiguration) []map[string]interfac
 	config["type"] = *pc.Type
 	config["properties"] = meshProperties
 
-	return []map[string]interface{} {
+	return []map[string]interface{}{
 		config,
 	}
 }

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -231,7 +231,8 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 			},
 
 			"proxy_configuration": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
+				MaxItems: 1,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
@@ -276,21 +277,6 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 							}, false),
 						},
 					},
-				},
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-					m := v.(map[string]interface{})
-					buf.WriteString(fmt.Sprintf("%s-", m["container_name"].(string)))
-					buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
-
-					rawProps := m["properties"].(*schema.Set).List()
-					for _, rawProp := range rawProps {
-						property := rawProp.(map[string]interface{})
-						buf.WriteString(fmt.Sprintf("%s-", property["name"].(string)))
-						buf.WriteString(fmt.Sprintf("%s-", property["value"].(string)))
-					}
-
-					return hashcode.String(buf.String())
 				},
 			},
 
@@ -385,7 +371,7 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 		input.RequiresCompatibilities = expandStringList(v.(*schema.Set).List())
 	}
 
-	proxyConfigs := d.Get("proxy_configuration").(*schema.Set).List()
+	proxyConfigs := d.Get("proxy_configuration").([]interface{})
 	if len(proxyConfigs) > 0 {
 		proxyConfig := proxyConfigs[0]
 		configMap := proxyConfig.(map[string]interface{})

--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -452,11 +452,11 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if err := d.Set("requires_compatibilities", flattenStringList(taskDefinition.RequiresCompatibilities)); err != nil {
-		return err
+		return fmt.Errorf("error setting requires_compatibilities: %s", err)
 	}
 
 	if err := d.Set("proxy_configuration", flattenProxyConfiguration(taskDefinition.ProxyConfiguration)); err != nil {
-		return err
+		return fmt.Errorf("error setting proxy_configuration: %s", err)
 	}
 
 	return nil
@@ -484,13 +484,13 @@ func flattenProxyConfiguration(pc *ecs.ProxyConfiguration) []map[string]interfac
 	meshProperties := make(map[string]string)
 	if pc.Properties != nil {
 		for _, prop := range pc.Properties {
-			meshProperties[*prop.Name] = *prop.Value
+			meshProperties[aws.StringValue(prop.Name)] = aws.StringValue(prop.Value)
 		}
 	}
 
 	config := make(map[string]interface{})
-	config["container_name"] = *pc.ContainerName
-	config["type"] = *pc.Type
+	config["container_name"] = aws.StringValue(pc.ContainerName)
+	config["type"] = aws.StringValue(pc.Type)
 	config["properties"] = meshProperties
 
 	return []map[string]interface{}{

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -504,7 +504,7 @@ func TestAccAWSEcsTaskDefinition_Tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSEcsTaskDefinition_ProxyConfiguration(t *testing.T){
+func TestAccAWSEcsTaskDefinition_ProxyConfiguration(t *testing.T) {
 	var taskDefinition ecs.TaskDefinition
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_ecs_task_definition.test"
@@ -537,7 +537,7 @@ func TestAccAWSEcsTaskDefinition_ProxyConfiguration(t *testing.T){
 
 func testAccAWSEcsTaskDefinitionConfigProxyConfiguration(rName string, containerName string, proxyType string,
 	ignoredUid string, ignoredGid string, appPorts string, proxyIngressPort string, proxyEgressPort string,
-	egressIgnoredPorts string, egressIgnoredIPs string)  string {
+	egressIgnoredPorts string, egressIgnoredIPs string) string {
 
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
@@ -618,7 +618,7 @@ func testAccCheckAWSEcsTaskDefinitionProxyConfiguration(after *ecs.TaskDefinitio
 		}
 
 		propertyLookups := make(map[string]string)
-		for _, property := range properties  {
+		for _, property := range properties {
 			propertyLookups[*property.Name] = *property.Value
 		}
 

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -531,6 +531,12 @@ func TestAccAWSEcsTaskDefinition_ProxyConfiguration(t *testing.T) {
 					testAccCheckAWSEcsTaskDefinitionProxyConfiguration(&taskDefinition, containerName, proxyType, ignoredUid, ignoredGid, appPorts, proxyIngressPort, proxyEgressPort, egressIgnoredPorts, egressIgnoredIPs),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccAWSEcsTaskDefinitionImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -548,39 +548,18 @@ resource "aws_ecs_task_definition" "test" {
   family = %q
   network_mode = "awsvpc"
 
-  proxy_configuration = {
+  proxy_configuration {
     type = %q
     container_name = %q
-    properties = [
-      {
-        name = "IgnoredUID"
-        value = %q
-      },
-      {
-        name = "IgnoredGID"
-        value = %q
-      },
-      {
-        name = "AppPorts"
-        value = %q
-      },
-      {
-        name = "ProxyIngressPort",
-        value = %q
-      },
-      {
-        name = "ProxyEgressPort",
-        value = %q
-      },
-      {
-        name = "EgressIgnoredPorts"
-        value = %q
-      },
-      {
-        name = "EgressIgnoredIPs",
-        value = %q
-      }
-    ]
+    properties = {
+      IgnoredUID = %q
+      IgnoredGID = %q
+      AppPorts = %q
+      ProxyIngressPort = %q
+      ProxyEgressPort = %q
+      EgressIgnoredPorts = %q
+      EgressIgnoredIPs = %q
+    }
   }
 
   container_definitions = <<DEFINITION
@@ -596,7 +575,7 @@ resource "aws_ecs_task_definition" "test" {
 DEFINITION
 
 }
-`, rName, rName, containerName, proxyType, containerName, ignoredUid, ignoredGid, appPorts, proxyIngressPort, proxyEgressPort, egressIgnoredPorts, egressIgnoredIPs)
+`, rName, rName, proxyType, containerName,  ignoredUid, ignoredGid, appPorts, proxyIngressPort, proxyEgressPort, egressIgnoredPorts, egressIgnoredIPs, containerName)
 }
 
 func testAccCheckAWSEcsTaskDefinitionProxyConfiguration(after *ecs.TaskDefinition, containerName string, proxyType string,

--- a/aws/resource_aws_ecs_task_definition_test.go
+++ b/aws/resource_aws_ecs_task_definition_test.go
@@ -575,7 +575,7 @@ resource "aws_ecs_task_definition" "test" {
 DEFINITION
 
 }
-`, rName, rName, proxyType, containerName,  ignoredUid, ignoredGid, appPorts, proxyIngressPort, proxyEgressPort, egressIgnoredPorts, egressIgnoredIPs, containerName)
+`, rName, rName, proxyType, containerName, ignoredUid, ignoredGid, appPorts, proxyIngressPort, proxyEgressPort, egressIgnoredPorts, egressIgnoredIPs, containerName)
 }
 
 func testAccCheckAWSEcsTaskDefinitionProxyConfiguration(after *ecs.TaskDefinition, containerName string, proxyType string,

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -65,6 +65,27 @@ contains only a small subset of the available parameters.
 ]
 ```
 
+### With AppMesh Proxy
+
+```hcl
+resource "aws_ecs_task_definition" "service" {
+  family                = "service"
+  container_definitions = "${file("task-definitions/service.json")}"
+
+  proxy_configuration {
+    type = "APPMESH"
+    container_name = "applicationContainerName"
+    properties = {
+      IgnoredUID = "1337"
+      AppPorts = "8080"
+      ProxyIngressPort = 15000
+      ProxyEgressPort = 15001
+      EgressIgnoredIPs = "169.254.170.2,169.254.169.254"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 ### Top-Level Arguments
@@ -139,48 +160,7 @@ Guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-
 
 * `type` - (Optional) The proxy type. The only supported value is `APPMESH`.
 * `container_name` - (Required) The name of the container that will serve as the App Mesh proxy.
-* `properties` - (Required) The set of network configuration parameters to provide the Container Network Interface (CNI) plugin, specified as a list of [Proxy Configuration Properties](#proxy-configuration-property-arguments).
-
-  
-##### Proxy Configuration Property Arguments
-* `name` - (Required) Variable name. The only supported names names are: `IgnoredUID`, `IgnoredGID`, `AppPorts`, `ProxyIngressPort`, `ProxyEgressPort`, `EgressIgnoredPorts`, `EgressIgnoredIPs` 
-* `value` - (Required) Variable value. Separate multiple values with a comma.
-
-
-##### Example Usage:
-```hcl
-resource "aws_ecs_task_definition" "service" {
-  family                = "service"
-  container_definitions = "${file("task-definitions/service.json")}"
-
-  proxy_configuration = {
-    type = "APPMESH"
-    container_name = "applicationContainerName"
-    properties = [
-      {
-        name = "IgnoredUID"
-        value = "1337"
-      },
-      {
-        name = "AppPorts"
-        value = "8080"
-      },
-      {
-        name = "ProxyIngressPort",
-        value = "15000"
-      },
-      {
-        name = "ProxyEgressPort",
-        value = "15001"
-      },
-      {
-        name = "EgressIgnoredIPs",
-        value = "169.254.170.2,169.254.169.254"
-      }
-    ]
-  }
-}
-```
+* `properties` - (Required) The set of network configuration parameters to provide the Container Network Interface (CNI) plugin, specified a key-value mapping.
 
 ## Attributes Reference
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -89,6 +89,7 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 * `cpu` - (Optional) The number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
 * `memory` - (Optional) The amount (in MiB) of memory used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
 * `requires_compatibilities` - (Optional) A set of launch types required by the task. The valid values are `EC2` and `FARGATE`.
+* `proxy_configuration` - (Optional) The [proxy configuration](#proxy-configuration-arguments) details for the App Mesh proxy.
 * `tags` - (Optional) Key-value mapping of resource tags
 
 #### Volume Block Arguments
@@ -134,6 +135,52 @@ For more information, see [Cluster Query Language in the Amazon EC2 Container
 Service Developer
 Guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html).
 
+#### Proxy Configuration Arguments
+
+* `type` - (Optional) The proxy type. The only supported value is `APPMESH`.
+* `container_name` - (Required) The name of the container that will serve as the App Mesh proxy.
+* `properties` - (Required) The set of network configuration parameters to provide the Container Network Interface (CNI) plugin, specified as a list of [Proxy Configuration Properties](#proxy-configuration-property-arguments).
+
+  
+##### Proxy Configuration Property Arguments
+* `name` - (Required) Variable name. The only supported names names are: `IgnoredUID`, `IgnoredGID`, `AppPorts`, `ProxyIngressPort`, `ProxyEgressPort`, `EgressIgnoredPorts`, `EgressIgnoredIPs` 
+* `value` - (Required) Variable value. Separate multiple values with a comma.
+
+
+##### Example Usage:
+```hcl
+resource "aws_ecs_task_definition" "service" {
+  family                = "service"
+  container_definitions = "${file("task-definitions/service.json")}"
+
+  proxy_configuration = {
+    type = "APPMESH"
+    container_name = "applicationContainerName"
+    properties = [
+      {
+        name = "IgnoredUID"
+        value = "1337"
+      },
+      {
+        name = "AppPorts"
+        value = "8080"
+      },
+      {
+        name = "ProxyIngressPort",
+        value = "15000"
+      },
+      {
+        name = "ProxyEgressPort",
+        value = "15001"
+      },
+      {
+        name = "EgressIgnoredIPs",
+        value = "169.254.170.2,169.254.169.254"
+      }
+    ]
+  }
+}
+```
 
 ## Attributes Reference
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -73,14 +73,14 @@ resource "aws_ecs_task_definition" "service" {
   container_definitions = "${file("task-definitions/service.json")}"
 
   proxy_configuration {
-    type = "APPMESH"
+    type           = "APPMESH"
     container_name = "applicationContainerName"
     properties = {
-      IgnoredUID = "1337"
-      AppPorts = "8080"
-      ProxyIngressPort = 15000
-      ProxyEgressPort = 15001
+      AppPorts         = "8080"
       EgressIgnoredIPs = "169.254.170.2,169.254.169.254"
+      IgnoredUID       = "1337"
+      ProxyEgressPort  = 15001
+      ProxyIngressPort = 15000
     }
   }
 }
@@ -158,9 +158,9 @@ Guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-
 
 #### Proxy Configuration Arguments
 
-* `type` - (Optional) The proxy type. The only supported value is `APPMESH`.
 * `container_name` - (Required) The name of the container that will serve as the App Mesh proxy.
 * `properties` - (Required) The set of network configuration parameters to provide the Container Network Interface (CNI) plugin, specified a key-value mapping.
+* `type` - (Optional) The proxy type. The default value is `APPMESH`. The only supported value is `APPMESH`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8253 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
adds proxy_configuration to aws_ecs_task_definition for AppMesh
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

Example usage:
```hcl
resource "aws_ecs_task_definition" "myTask" {
  container_definitions = "${file("./containerDefinitions.json")}"
  family = "nginx"
  requires_compatibilities = ["FARGATE"]
  execution_role_arn = "${aws_iam_role.ecs_task_role.arn}"
  task_role_arn = "${aws_iam_role.ecs_task_exec_role.arn}"
  network_mode = "awsvpc"
  cpu = "256"
  memory = "512"
  proxy_configuration = {
    type = "APPMESH"
    container_name = "nginx"
    properties = [
      {
        name = "IgnoredUID"
        value = "1337"
      },
      {
        name = "AppPorts"
        value = "8080"
      },
      {
        name = "ProxyIngressPort"
        value = "15000"
      },
      {
        name = "ProxyEgressPort"
        value = "15001"
      },
      {
        name = "EgressIgnoredIPs"
        value = "169.254.170.2,169.254.169.254"
      }
    ]
  }
}

```

I would like some guidance on passing the acceptance tests. when running the acceptance test I get the following error : `testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "proxy_configuration" is not expected here. Did you mean to define a block of type "proxy_configuration"?` and I am unable to see how to resolve this issue.

I have confirmed that the proxy configuration applies properly when using `terraform plan` followed by `terraform apply` if I build and then switch out aws providers.

Here is the full output of the acceptance test:
```
go test ./aws -v -parallel 1 -run=TestAccAWSEcsTaskDefinition_ProxyConfiguration -timeout 120m
=== RUN   TestAccAWSEcsTaskDefinition_ProxyConfiguration
=== PAUSE TestAccAWSEcsTaskDefinition_ProxyConfiguration
=== CONT  TestAccAWSEcsTaskDefinition_ProxyConfiguration
--- FAIL: TestAccAWSEcsTaskDefinition_ProxyConfiguration (1.16s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "proxy_configuration" is not expected here. Did you mean to define a block of type "proxy_configuration"?
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       5.338s
```
