### PR TITLE
aws/resource_aws_iot_role_alias: Add arn to the IoT role alias resource

### DIFF
--- a/aws/resource_aws_iot_role_alias.go
+++ b/aws/resource_aws_iot_role_alias.go
@@ -20,6 +20,10 @@ func resourceAwsIotRoleAlias() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"alias": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -94,6 +98,7 @@ func resourceAwsIotRoleAliasRead(d *schema.ResourceData, meta interface{}) error
 		return nil
 	}
 
+	d.Set("arn", roleAliasDescription.RoleAliasArn)
 	d.Set("alias", roleAliasDescription.RoleAlias)
 	d.Set("role_arn", roleAliasDescription.RoleArn)
 	d.Set("credential_duration", roleAliasDescription.CredentialDurationSeconds)

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -24,6 +24,9 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 				Config: testAccAWSIotRoleAliasConfig(alias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
+					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "arn"),
+					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "role_arn"),
+					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "alias"),
 					resource.TestCheckResourceAttr(
 						"aws_iot_role_alias.ra", "credential_duration", "3600"),
 				),
@@ -33,6 +36,9 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
 					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
+					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "arn"),
+					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "role_arn"),
+					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "alias"),
 					resource.TestCheckResourceAttr(
 						"aws_iot_role_alias.ra", "credential_duration", "1800"),
 				),

--- a/aws/resource_aws_iot_role_alias_test.go
+++ b/aws/resource_aws_iot_role_alias_test.go
@@ -24,9 +24,7 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 				Config: testAccAWSIotRoleAliasConfig(alias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
-					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "role_arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "alias"),
+					testAccCheckResourceAttrRegionalARN("aws_iot_role_alias.ra", "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
 					resource.TestCheckResourceAttr(
 						"aws_iot_role_alias.ra", "credential_duration", "3600"),
 				),
@@ -36,9 +34,7 @@ func TestAccAWSIotRoleAlias_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra"),
 					testAccCheckAWSIotRoleAliasExists("aws_iot_role_alias.ra2"),
-					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "role_arn"),
-					resource.TestCheckResourceAttrSet("aws_iot_role_alias.ra", "alias"),
+					testAccCheckResourceAttrRegionalARN("aws_iot_role_alias.ra", "arn", "iot", fmt.Sprintf("rolealias/%s", alias)),
 					resource.TestCheckResourceAttr(
 						"aws_iot_role_alias.ra", "credential_duration", "1800"),
 				),

--- a/website/docs/r/iot_role_alias.html.markdown
+++ b/website/docs/r/iot_role_alias.html.markdown
@@ -44,6 +44,12 @@ The following arguments are supported:
 * `role_arn` - (Required) The identity of the role to which the alias refers.
 * `credential_duration` - (Optional) The duration of the credential, in seconds. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 900 seconds (15 minutes) to 3600 seconds (60 minutes).
 
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `arn` - The ARN assigned by AWS to this role alias.
+
 ## Import
 
 IOT Role Alias can be imported via the alias, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8811

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_iot_role_alias: Add `arn` attribute (#8811)
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIotRoleAlias_basic'
make testacc TESTARGS='-run=TestAccAWSIotRoleAlias_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIotRoleAlias_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIotRoleAlias_basic
=== PAUSE TestAccAWSIotRoleAlias_basic
=== CONT  TestAccAWSIotRoleAlias_basic
--- PASS: TestAccAWSIotRoleAlias_basic (89.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	89.370s
```
