### PR TITLE
correct documentation to move tags to top-level resource rather than lifecycle settings

### DIFF
--- a/website/docs/r/elastic_beanstalk_application.html.markdown
+++ b/website/docs/r/elastic_beanstalk_application.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the application, must be unique within your account
 * `description` - (Optional) Short description of the application
+* `tags` - (Optional) Key-value mapping of tags for the Elastic Beanstalk Application.
 
 Application version lifecycle (`appversion_lifecycle`) supports the following settings.  Only one of either `max_count` or `max_age_in_days` can be provided:
 
@@ -43,7 +44,6 @@ Application version lifecycle (`appversion_lifecycle`) supports the following se
 * `max_count` - (Optional) The maximum number of application versions to retain.
 * `max_age_in_days` - (Optional) The number of days to retain an application version.
 * `delete_source_from_s3` - (Optional) Set to `true` to delete a version's source bundle from S3 when the application version is deleted.
-* `tags` - Key-value mapping of tags for the Elastic Beanstalk Application.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Tags cannot be applied to lifecycles, instead they are an optional top-level field of resource `aws_elastic_beanstalk_application`. 

Source code: https://github.com/terraform-providers/terraform-provider-aws/blob/6d337f5/aws/resource_aws_elastic_beanstalk_application.go#L25-L66

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fixed tags attribute documentation in resource aws_elastic_beanstalk_application
```

Output when using documentation as currently written prior to this PR:

```
$ terraform plan

Error: Unsupported argument

  on beanstalk.tf line 6, in resource "aws_elastic_beanstalk_application" "test":
   6:     tags = {

An argument named "tags" is not expected here.
```
