### PR TITLE
Secure basic CloudTrail example

### DIFF
--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -22,6 +22,8 @@ Enable CloudTrail to capture all compatible management events in region.
 For capturing events from services like IAM, `include_global_service_events` must be enabled.
 
 ```hcl
+data "aws_caller_identity" "current" {}
+
 resource "aws_cloudtrail" "foobar" {
   name                          = "tf-trail-foobar"
   s3_bucket_name                = "${aws_s3_bucket.foo.id}"
@@ -53,7 +55,7 @@ resource "aws_s3_bucket" "foo" {
               "Service": "cloudtrail.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::tf-test-trail/*",
+            "Resource": "arn:aws:s3:::tf-test-trail/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
             "Condition": {
                 "StringEquals": {
                     "s3:x-amz-acl": "bucket-owner-full-control"


### PR DESCRIPTION
The problem with the original example is that it sets up a bucket
policy allowing any AWS account to send their CloudTrail logs to the
bucket in question. Perhaps not the most dangerous of attacks, but not
very hygienic either.

The CloudTrail service principal writes to a known bucket path which
includes the origin account id. That is the recommended method to
restrict access.

See also https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->