### PR TITLE
Add a nil check for reading instance market options

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -1421,7 +1421,10 @@ func readInstanceMarketOptionsFromConfig(imo map[string]interface{}) (*ec2.Launc
 	if v, ok := imo["spot_options"]; ok {
 		vL := v.([]interface{})
 		for _, v := range vL {
-			so := v.(map[string]interface{})
+			so, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
 
 			if v, ok := so["block_duration_minutes"].(int); ok && v != 0 {
 				spotOptions.BlockDurationMinutes = aws.Int64(int64(v))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #7885

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_launch_template: Add a nil check for `spot_options` to
avoiding panicking if options are empty

```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSLaunchTemplate"  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSLaunchTemplate -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSLaunchTemplateDataSource_basic
=== PAUSE TestAccAWSLaunchTemplateDataSource_basic
=== RUN   TestAccAWSLaunchTemplate_importBasic
=== PAUSE TestAccAWSLaunchTemplate_importBasic
=== RUN   TestAccAWSLaunchTemplate_importData
=== PAUSE TestAccAWSLaunchTemplate_importData
=== RUN   TestAccAWSLaunchTemplate_basic
=== PAUSE TestAccAWSLaunchTemplate_basic
=== RUN   TestAccAWSLaunchTemplate_disappears
=== PAUSE TestAccAWSLaunchTemplate_disappears
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== RUN   TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== PAUSE TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== RUN   TestAccAWSLaunchTemplate_EbsOptimized
=== PAUSE TestAccAWSLaunchTemplate_EbsOptimized
=== RUN   TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== PAUSE TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== RUN   TestAccAWSLaunchTemplate_data
=== PAUSE TestAccAWSLaunchTemplate_data
=== RUN   TestAccAWSLaunchTemplate_description
=== PAUSE TestAccAWSLaunchTemplate_description
=== RUN   TestAccAWSLaunchTemplate_update
=== PAUSE TestAccAWSLaunchTemplate_update
=== RUN   TestAccAWSLaunchTemplate_tags
=== PAUSE TestAccAWSLaunchTemplate_tags
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_preference
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_preference
=== RUN   TestAccAWSLaunchTemplate_capacityReservation_target
=== PAUSE TestAccAWSLaunchTemplate_capacityReservation_target
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t2
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t2
=== RUN   TestAccAWSLaunchTemplate_creditSpecification_t3
=== PAUSE TestAccAWSLaunchTemplate_creditSpecification_t3
=== RUN   TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== PAUSE TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
=== RUN   TestAccAWSLaunchTemplate_networkInterface
=== PAUSE TestAccAWSLaunchTemplate_networkInterface
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
=== RUN   TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== PAUSE TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== RUN   TestAccAWSLaunchTemplate_instanceMarketOptions
=== PAUSE TestAccAWSLaunchTemplate_instanceMarketOptions
=== RUN   TestAccAWSLaunchTemplate_licenseSpecification
=== PAUSE TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplateDataSource_basic
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount
=== CONT  TestAccAWSLaunchTemplate_EbsOptimized
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS
=== CONT  TestAccAWSLaunchTemplate_licenseSpecification
=== CONT  TestAccAWSLaunchTemplate_instanceMarketOptions
=== CONT  TestAccAWSLaunchTemplate_disappears
=== CONT  TestAccAWSLaunchTemplate_basic
=== CONT  TestAccAWSLaunchTemplate_importData
=== CONT  TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination
=== CONT  TestAccAWSLaunchTemplate_update
=== CONT  TestAccAWSLaunchTemplate_description
=== CONT  TestAccAWSLaunchTemplate_data
=== CONT  TestAccAWSLaunchTemplate_ElasticInferenceAccelerator
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t2
=== CONT  TestAccAWSLaunchTemplate_importBasic
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_nonBurstable
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_target
=== CONT  TestAccAWSLaunchTemplate_capacityReservation_preference
=== CONT  TestAccAWSLaunchTemplate_tags
--- PASS: TestAccAWSLaunchTemplate_disappears (20.54s)
=== CONT  TestAccAWSLaunchTemplate_creditSpecification_t3
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6AddressCount (24.22s)
=== CONT  TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_preference (24.30s)
=== CONT  TestAccAWSLaunchTemplate_networkInterface
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_nonBurstable (24.34s)
=== CONT  TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t2 (24.63s)
--- PASS: TestAccAWSLaunchTemplate_data (24.67s)
--- PASS: TestAccAWSLaunchTemplate_basic (25.29s)
--- PASS: TestAccAWSLaunchTemplate_importData (27.14s)
--- PASS: TestAccAWSLaunchTemplate_licenseSpecification (28.44s)
--- PASS: TestAccAWSLaunchTemplate_importBasic (29.65s)
--- PASS: TestAccAWSLaunchTemplateDataSource_basic (33.42s)
--- PASS: TestAccAWSLaunchTemplate_capacityReservation_target (36.05s)
--- PASS: TestAccAWSLaunchTemplate_description (42.21s)
--- PASS: TestAccAWSLaunchTemplate_creditSpecification_t3 (23.51s)
--- PASS: TestAccAWSLaunchTemplate_tags (44.05s)
--- PASS: TestAccAWSLaunchTemplate_ElasticInferenceAccelerator (45.57s)
--- PASS: TestAccAWSLaunchTemplate_IamInstanceProfile_EmptyConfigurationBlock (23.51s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface_ipv6Addresses (24.83s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS (51.34s)
--- PASS: TestAccAWSLaunchTemplate_instanceMarketOptions (80.88s)
--- PASS: TestAccAWSLaunchTemplate_update (86.36s)
--- PASS: TestAccAWSLaunchTemplate_networkInterface (62.83s)
--- PASS: TestAccAWSLaunchTemplate_BlockDeviceMappings_EBS_DeleteOnTermination (91.77s)
--- PASS: TestAccAWSLaunchTemplate_EbsOptimized (104.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       105.039s
```