### PR TITLE
docs/provider: Specifically call out AWS_DEFAULT_REGION environment variable for AWS GovCloud (US) testing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -475,6 +475,14 @@ export AWS_SECRET_ACCESS_KEY=...
 export AWS_DEFAULT_REGION=...
 ```
 
+Please note that the default region for the testing is `us-west-2` and must be
+overriden via the `AWS_DEFAULT_REGION` environment variable, if necessary. This
+is especially important for testing AWS GovCloud (US), which requires:
+
+```sh
+export AWS_DEFAULT_REGION=us-gov-west-1
+```
+
 Tests can then be run by specifying the target provider and a regular
 expression defining the tests to run:
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A (just currently missing documentation)