### PR TITLE
Update cloudwatch_event_target.html.markdown

### DIFF
--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -217,7 +217,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
   rule      = "${aws_cloudwatch_event_rule.every_hour.name}"
   role_arn  = "${aws_iam_role.ecs_events.arn}"
 
-  ecs_target = {
+  ecs_target {
     task_count          = 1
     task_definition_arn = "${aws_ecs_task_definition.task_name.arn}"
   }


### PR DESCRIPTION
Terraform Version
-----
Terraform v0.12.0
+ provider.aws v2.13.0

Description
-----
A similar error to the following will be thrown:

```
Error: Unsupported argument

  on .terraform/modules/myCompany-ecs-service/cron.tf line 6, in resource "aws_cloudwatch_event_target" "ecs_microservice":
   6:     ecs_target  = {

An argument named "ecs_target" is not expected here. Did you mean to define a
block of type "ecs_target"?

```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
