### PR TITLE
service/kafka: Enhancements for General Availability Release

### DIFF
--- a/aws/data_source_aws_msk_cluster.go
+++ b/aws/data_source_aws_msk_cluster.go
@@ -22,6 +22,10 @@ func dataSourceAwsMskCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"bootstrap_brokers_tls": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"cluster_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -92,23 +96,14 @@ func dataSourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error reading MSK Cluster (%s) bootstrap brokers: %s", aws.StringValue(cluster.ClusterArn), err)
 	}
 
-	listTagsInput := &kafka.ListTagsForResourceInput{
-		ResourceArn: cluster.ClusterArn,
-	}
-
-	listTagsOutput, err := conn.ListTagsForResource(listTagsInput)
-
-	if err != nil {
-		return fmt.Errorf("error reading MSK Cluster (%s) tags: %s", aws.StringValue(cluster.ClusterArn), err)
-	}
-
 	d.Set("arn", aws.StringValue(cluster.ClusterArn))
 	d.Set("bootstrap_brokers", aws.StringValue(bootstrapBrokersoOutput.BootstrapBrokerString))
+	d.Set("bootstrap_brokers_tls", aws.StringValue(bootstrapBrokersoOutput.BootstrapBrokerStringTls))
 	d.Set("cluster_name", aws.StringValue(cluster.ClusterName))
 	d.Set("kafka_version", aws.StringValue(cluster.CurrentBrokerSoftwareInfo.KafkaVersion))
 	d.Set("number_of_broker_nodes", aws.Int64Value(cluster.NumberOfBrokerNodes))
 
-	if err := d.Set("tags", tagsToMapMskCluster(listTagsOutput.Tags)); err != nil {
+	if err := d.Set("tags", tagsToMapMskCluster(cluster.Tags)); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
 

--- a/aws/data_source_aws_msk_cluster_test.go
+++ b/aws/data_source_aws_msk_cluster_test.go
@@ -23,6 +23,7 @@ func TestAccAWSMskClusterDataSource_Name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "bootstrap_brokers"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "bootstrap_brokers_tls"),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_name", dataSourceName, "cluster_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "kafka_version", dataSourceName, "kafka_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "number_of_broker_nodes", dataSourceName, "number_of_broker_nodes"),

--- a/aws/resource_aws_msk_cluster.go
+++ b/aws/resource_aws_msk_cluster.go
@@ -30,6 +30,10 @@ func resourceAwsMskCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"bootstrap_brokers_tls": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"broker_node_group_info": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -70,8 +74,36 @@ func resourceAwsMskCluster() *schema.Resource {
 						"ebs_volume_size": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(1, 16384),
+						},
+					},
+				},
+			},
+			"client_authentication": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tls": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"certificate_authority_arns": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										ForceNew: true,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validateArn,
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -82,12 +114,36 @@ func resourceAwsMskCluster() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(1, 64),
 			},
-			"encryption_info": {
-				Type:     schema.TypeList,
-				Optional: true,
+			"configuration_info": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+				MaxItems:         1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateArn,
+						},
+						"revision": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+					},
+				},
+			},
+			"current_version": {
+				Type:     schema.TypeString,
 				Computed: true,
-				ForceNew: true,
-				MaxItems: 1,
+			},
+			"encryption_info": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+				ForceNew:         true,
+				MaxItems:         1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"encryption_at_rest_kms_key_arn": {
@@ -96,6 +152,34 @@ func resourceAwsMskCluster() *schema.Resource {
 							Computed:     true,
 							ForceNew:     true,
 							ValidateFunc: validateArn,
+						},
+						"encryption_in_transit": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
+							ForceNew:         true,
+							MaxItems:         1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"client_broker": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										Default:  kafka.ClientBrokerTlsPlaintext,
+										ValidateFunc: validation.StringInSlice([]string{
+											kafka.ClientBrokerPlaintext,
+											kafka.ClientBrokerTlsPlaintext,
+											kafka.ClientBrokerTls,
+										}, false),
+									},
+									"in_cluster": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+										Default:  true,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -134,37 +218,16 @@ func resourceAwsMskCluster() *schema.Resource {
 func resourceAwsMskClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kafkaconn
 
-	nodeInfo := d.Get("broker_node_group_info").([]interface{})[0].(map[string]interface{})
-
 	input := &kafka.CreateClusterInput{
-		ClusterName:         aws.String(d.Get("cluster_name").(string)),
-		EnhancedMonitoring:  aws.String(d.Get("enhanced_monitoring").(string)),
-		NumberOfBrokerNodes: aws.Int64(int64(d.Get("number_of_broker_nodes").(int))),
-		BrokerNodeGroupInfo: &kafka.BrokerNodeGroupInfo{
-			BrokerAZDistribution: aws.String(nodeInfo["az_distribution"].(string)),
-			InstanceType:         aws.String(nodeInfo["instance_type"].(string)),
-			StorageInfo: &kafka.StorageInfo{
-				EbsStorageInfo: &kafka.EBSStorageInfo{
-					VolumeSize: aws.Int64(int64(nodeInfo["ebs_volume_size"].(int))),
-				},
-			},
-			ClientSubnets:  expandStringList(nodeInfo["client_subnets"].([]interface{})),
-			SecurityGroups: expandStringList(nodeInfo["security_groups"].([]interface{})),
-		},
-		KafkaVersion: aws.String(d.Get("kafka_version").(string)),
-	}
-
-	if v, ok := d.GetOk("encryption_info"); ok {
-		info := v.([]interface{})
-		if len(info) == 1 && info[0] != nil {
-			i := info[0].(map[string]interface{})
-
-			input.EncryptionInfo = &kafka.EncryptionInfo{
-				EncryptionAtRest: &kafka.EncryptionAtRest{
-					DataVolumeKMSKeyId: aws.String(i["encryption_at_rest_kms_key_arn"].(string)),
-				},
-			}
-		}
+		BrokerNodeGroupInfo:  expandMskClusterBrokerNodeGroupInfo(d.Get("broker_node_group_info").([]interface{})),
+		ClientAuthentication: expandMskClusterClientAuthentication(d.Get("client_authentication").([]interface{})),
+		ClusterName:          aws.String(d.Get("cluster_name").(string)),
+		ConfigurationInfo:    expandMskClusterConfigurationInfo(d.Get("configuration_info").([]interface{})),
+		EncryptionInfo:       expandMskClusterEncryptionInfo(d.Get("encryption_info").([]interface{})),
+		EnhancedMonitoring:   aws.String(d.Get("enhanced_monitoring").(string)),
+		KafkaVersion:         aws.String(d.Get("kafka_version").(string)),
+		NumberOfBrokerNodes:  aws.Int64(int64(d.Get("number_of_broker_nodes").(int))),
+		Tags:                 tagsFromMapMskCluster(d.Get("tags").(map[string]interface{})),
 	}
 
 	out, err := conn.CreateCluster(input)
@@ -174,10 +237,6 @@ func resourceAwsMskClusterCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(aws.StringValue(out.ClusterArn))
-
-	if err := setTagsMskCluster(conn, d, aws.StringValue(out.ClusterArn)); err != nil {
-		return err
-	}
 
 	log.Printf("[DEBUG] Waiting for MSK cluster %q to be created", d.Id())
 	err = waitForMskClusterCreation(conn, d.Id())
@@ -232,31 +291,39 @@ func resourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	cluster := out.ClusterInfo
 
-	d.SetId(aws.StringValue(cluster.ClusterArn))
 	d.Set("arn", aws.StringValue(cluster.ClusterArn))
 	d.Set("bootstrap_brokers", aws.StringValue(brokerOut.BootstrapBrokerString))
+	d.Set("bootstrap_brokers_tls", aws.StringValue(brokerOut.BootstrapBrokerStringTls))
 
 	if err := d.Set("broker_node_group_info", flattenMskBrokerNodeGroupInfo(cluster.BrokerNodeGroupInfo)); err != nil {
 		return fmt.Errorf("error setting broker_node_group_info: %s", err)
 	}
 
+	if err := d.Set("client_authentication", flattenMskClientAuthentication(cluster.ClientAuthentication)); err != nil {
+		return fmt.Errorf("error setting configuration_info: %s", err)
+	}
+
 	d.Set("cluster_name", aws.StringValue(cluster.ClusterName))
+
+	if err := d.Set("configuration_info", flattenMskConfigurationInfo(cluster.CurrentBrokerSoftwareInfo)); err != nil {
+		return fmt.Errorf("error setting configuration_info: %s", err)
+	}
+
+	d.Set("current_version", aws.StringValue(cluster.CurrentVersion))
 	d.Set("enhanced_monitoring", aws.StringValue(cluster.EnhancedMonitoring))
-	d.Set("encryption_info", flattenMskEncryptionInfo(cluster.EncryptionInfo))
+
+	if err := d.Set("encryption_info", flattenMskEncryptionInfo(cluster.EncryptionInfo)); err != nil {
+		return fmt.Errorf("error setting encryption_info: %s", err)
+	}
+
 	d.Set("kafka_version", aws.StringValue(cluster.CurrentBrokerSoftwareInfo.KafkaVersion))
 	d.Set("number_of_broker_nodes", aws.Int64Value(cluster.NumberOfBrokerNodes))
-	d.Set("zookeeper_connect_string", aws.StringValue(cluster.ZookeeperConnectString))
 
-	listTagsOut, err := conn.ListTagsForResource(&kafka.ListTagsForResourceInput{
-		ResourceArn: cluster.ClusterArn,
-	})
-	if err != nil {
-		return fmt.Errorf("failed listing tags for msk cluster %q: %s", d.Id(), err)
-	}
-
-	if err := d.Set("tags", tagsToMapMskCluster(listTagsOut.Tags)); err != nil {
+	if err := d.Set("tags", tagsToMapMskCluster(cluster.Tags)); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
 	}
+
+	d.Set("zookeeper_connect_string", aws.StringValue(cluster.ZookeeperConnectString))
 
 	return nil
 }
@@ -264,13 +331,167 @@ func resourceAwsMskClusterRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsMskClusterUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).kafkaconn
 
-	// currently tags are the only thing that are updatable..
-	if err := setTagsMskCluster(conn, d, d.Id()); err != nil {
-		return fmt.Errorf("failed updating tags for msk cluster %q: %s", d.Id(), err)
+	if d.HasChange("broker_node_group_info.0.ebs_volume_size") {
+		input := &kafka.UpdateBrokerStorageInput{
+			ClusterArn:     aws.String(d.Id()),
+			CurrentVersion: aws.String(d.Get("current_version").(string)),
+			TargetBrokerEBSVolumeInfo: []*kafka.BrokerEBSVolumeInfo{
+				{
+					KafkaBrokerNodeId: aws.String("All"),
+					VolumeSizeGB:      aws.Int64(int64(d.Get("broker_node_group_info.0.ebs_volume_size").(int))),
+				},
+			},
+		}
+
+		output, err := conn.UpdateBrokerStorage(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating MSK Cluster (%s) broker storage: %s", d.Id(), err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("error updating MSK Cluster (%s) broker storage: empty response", d.Id())
+		}
+
+		clusterOperationARN := aws.StringValue(output.ClusterOperationArn)
+
+		if err := waitForMskClusterOperation(conn, clusterOperationARN); err != nil {
+			return fmt.Errorf("error waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+		}
+	}
+
+	if d.HasChange("configuration_info") {
+		input := &kafka.UpdateClusterConfigurationInput{
+			ClusterArn:        aws.String(d.Id()),
+			ConfigurationInfo: expandMskClusterConfigurationInfo(d.Get("configuration_info").([]interface{})),
+			CurrentVersion:    aws.String(d.Get("current_version").(string)),
+		}
+
+		output, err := conn.UpdateClusterConfiguration(input)
+
+		if err != nil {
+			return fmt.Errorf("error updating MSK Cluster (%s) configuration: %s", d.Id(), err)
+		}
+
+		if output == nil {
+			return fmt.Errorf("error updating MSK Cluster (%s) configuration: empty response", d.Id())
+		}
+
+		clusterOperationARN := aws.StringValue(output.ClusterOperationArn)
+
+		if err := waitForMskClusterOperation(conn, clusterOperationARN); err != nil {
+			return fmt.Errorf("error waiting for MSK Cluster (%s) operation (%s): %s", d.Id(), clusterOperationARN, err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		if err := setTagsMskCluster(conn, d, d.Id()); err != nil {
+			return fmt.Errorf("failed updating tags for msk cluster %q: %s", d.Id(), err)
+		}
 	}
 
 	return resourceAwsMskClusterRead(d, meta)
 
+}
+
+func expandMskClusterBrokerNodeGroupInfo(l []interface{}) *kafka.BrokerNodeGroupInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	bngi := &kafka.BrokerNodeGroupInfo{
+		BrokerAZDistribution: aws.String(m["az_distribution"].(string)),
+		ClientSubnets:        expandStringList(m["client_subnets"].([]interface{})),
+		InstanceType:         aws.String(m["instance_type"].(string)),
+		SecurityGroups:       expandStringList(m["security_groups"].([]interface{})),
+		StorageInfo: &kafka.StorageInfo{
+			EbsStorageInfo: &kafka.EBSStorageInfo{
+				VolumeSize: aws.Int64(int64(m["ebs_volume_size"].(int))),
+			},
+		},
+	}
+
+	return bngi
+}
+
+func expandMskClusterClientAuthentication(l []interface{}) *kafka.ClientAuthentication {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	ca := &kafka.ClientAuthentication{
+		Tls: expandMskClusterTls(m["tls"].([]interface{})),
+	}
+
+	return ca
+}
+
+func expandMskClusterConfigurationInfo(l []interface{}) *kafka.ConfigurationInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	ci := &kafka.ConfigurationInfo{
+		Arn:      aws.String(m["arn"].(string)),
+		Revision: aws.Int64(int64(m["revision"].(int))),
+	}
+
+	return ci
+}
+
+func expandMskClusterEncryptionInfo(l []interface{}) *kafka.EncryptionInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	ei := &kafka.EncryptionInfo{
+		EncryptionInTransit: expandMskClusterEncryptionInTransit(m["encryption_in_transit"].([]interface{})),
+	}
+
+	if v, ok := m["encryption_at_rest_kms_key_arn"]; ok && v.(string) != "" {
+		ei.EncryptionAtRest = &kafka.EncryptionAtRest{
+			DataVolumeKMSKeyId: aws.String(v.(string)),
+		}
+	}
+
+	return ei
+}
+
+func expandMskClusterEncryptionInTransit(l []interface{}) *kafka.EncryptionInTransit {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	eit := &kafka.EncryptionInTransit{
+		ClientBroker: aws.String(m["client_broker"].(string)),
+		InCluster:    aws.Bool(m["in_cluster"].(bool)),
+	}
+
+	return eit
+}
+
+func expandMskClusterTls(l []interface{}) *kafka.Tls {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	tls := &kafka.Tls{
+		CertificateAuthorityArnList: expandStringSet(m["certificate_authority_arns"].(*schema.Set)),
+	}
+
+	return tls
 }
 
 func flattenMskBrokerNodeGroupInfo(b *kafka.BrokerNodeGroupInfo) []map[string]interface{} {
@@ -293,6 +514,31 @@ func flattenMskBrokerNodeGroupInfo(b *kafka.BrokerNodeGroupInfo) []map[string]in
 	return []map[string]interface{}{m}
 }
 
+func flattenMskClientAuthentication(ca *kafka.ClientAuthentication) []map[string]interface{} {
+	if ca == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"tls": flattenMskTls(ca.Tls),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenMskConfigurationInfo(bsi *kafka.BrokerSoftwareInfo) []map[string]interface{} {
+	if bsi == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"arn":      aws.StringValue(bsi.ConfigurationArn),
+		"revision": aws.Int64Value(bsi.ConfigurationRevision),
+	}
+
+	return []map[string]interface{}{m}
+}
+
 func flattenMskEncryptionInfo(e *kafka.EncryptionInfo) []map[string]interface{} {
 	if e == nil || e.EncryptionAtRest == nil {
 		return []map[string]interface{}{}
@@ -300,6 +546,32 @@ func flattenMskEncryptionInfo(e *kafka.EncryptionInfo) []map[string]interface{} 
 
 	m := map[string]interface{}{
 		"encryption_at_rest_kms_key_arn": aws.StringValue(e.EncryptionAtRest.DataVolumeKMSKeyId),
+		"encryption_in_transit":          flattenMskEncryptionInTransit(e.EncryptionInTransit),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenMskEncryptionInTransit(eit *kafka.EncryptionInTransit) []map[string]interface{} {
+	if eit == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"client_broker": aws.StringValue(eit.ClientBroker),
+		"in_cluster":    aws.BoolValue(eit.InCluster),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func flattenMskTls(tls *kafka.Tls) []map[string]interface{} {
+	if tls == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"certificate_authority_arns": aws.StringValueSlice(tls.CertificateAuthorityArnList),
 	}
 
 	return []map[string]interface{}{m}
@@ -339,4 +611,46 @@ func resourceAwsMskClusterDeleteWaiter(conn *kafka.Kafka, arn string) error {
 
 		return resource.RetryableError(fmt.Errorf("timeout while waiting for the cluster %q to be deleted", arn))
 	})
+}
+
+func mskClusterOperationRefreshFunc(conn *kafka.Kafka, clusterOperationARN string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		input := &kafka.DescribeClusterOperationInput{
+			ClusterOperationArn: aws.String(clusterOperationARN),
+		}
+
+		output, err := conn.DescribeClusterOperation(input)
+
+		if err != nil {
+			return nil, "UPDATE_FAILED", fmt.Errorf("error describing MSK Cluster Operation (%s): %s", clusterOperationARN, err)
+		}
+
+		if output == nil || output.ClusterOperationInfo == nil {
+			return nil, "UPDATE_FAILED", fmt.Errorf("error describing MSK Cluster Operation (%s): empty response", clusterOperationARN)
+		}
+
+		state := aws.StringValue(output.ClusterOperationInfo.OperationState)
+
+		if state == "UPDATE_FAILED" && output.ClusterOperationInfo.ErrorInfo != nil {
+			errorInfo := output.ClusterOperationInfo.ErrorInfo
+			err := fmt.Errorf("error code: %s, error string: %s", aws.StringValue(errorInfo.ErrorCode), aws.StringValue(errorInfo.ErrorString))
+			return output.ClusterOperationInfo, state, err
+		}
+
+		return output.ClusterOperationInfo, state, nil
+	}
+}
+
+func waitForMskClusterOperation(conn *kafka.Kafka, clusterOperationARN string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING", "UPDATE_IN_PROGRESS"},
+		Target:  []string{"UPDATE_COMPLETE"},
+		Refresh: mskClusterOperationRefreshFunc(conn, clusterOperationARN),
+		Timeout: 60 * time.Minute,
+	}
+
+	log.Printf("[DEBUG] Waiting for MSK Cluster Operation (%s) completion", clusterOperationARN)
+	_, err := stateConf.WaitForState()
+
+	return err
 }

--- a/aws/resource_aws_msk_cluster_test.go
+++ b/aws/resource_aws_msk_cluster_test.go
@@ -57,9 +57,8 @@ func testSweepMskClusters(region string) error {
 
 func TestAccAWSMskCluster_basic(t *testing.T) {
 	var cluster kafka.ClusterInfo
-	var td kafka.ListTagsForResourceOutput
-	ri := acctest.RandInt()
-	resourceName := "aws_msk_cluster.example"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,28 +66,35 @@ func TestAccAWSMskCluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfig_basic(ri),
+				Config: testAccMskClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMskClusterExists(resourceName, &cluster),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "kafka", regexp.MustCompile(`cluster/.+`)),
-					testAccMatchResourceAttrRegionalARN(resourceName, "encryption_info.0.encryption_at_rest_kms_key_arn", "kms", regexp.MustCompile(`key/.+`)),
-					resource.TestCheckResourceAttr(resourceName, "cluster_name", fmt.Sprintf("tf-test-%d", ri)),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.az_distribution", kafka.BrokerAZDistributionDefault),
-					resource.TestCheckResourceAttr(resourceName, "kafka_version", "1.1.1"),
-					resource.TestCheckResourceAttr(resourceName, "number_of_broker_nodes", "3"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.instance_type", "kafka.m5.large"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", "10"),
-					resource.TestMatchResourceAttr(resourceName, "zookeeper_connect_string", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)),
-					resource.TestCheckResourceAttr(resourceName, "enhanced_monitoring", kafka.EnhancedMonitoringDefault),
+					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers_tls", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.az_distribution", kafka.BrokerAZDistributionDefault),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", "10"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.client_subnets.#", "3"),
 					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.client_subnets.0", "aws_subnet.example_subnet_az1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.client_subnets.1", "aws_subnet.example_subnet_az2", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.client_subnets.2", "aws_subnet.example_subnet_az3", "id"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.instance_type", "kafka.m5.large"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.security_groups.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.security_groups.0", "aws_security_group.example_sg", "id"),
-					testAccLoadMskTags(&cluster, &td),
-					testAccCheckMskClusterTags(&td, "foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.#", "1"),
+					testAccMatchResourceAttrRegionalARN(resourceName, "encryption_info.0.encryption_at_rest_kms_key_arn", "kms", regexp.MustCompile(`key/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.client_broker", "TLS_PLAINTEXT"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.in_cluster", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enhanced_monitoring", kafka.EnhancedMonitoringDefault),
+					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.1.0"),
+					resource.TestCheckResourceAttr(resourceName, "number_of_broker_nodes", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestMatchResourceAttr(resourceName, "zookeeper_connect_string", regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+,\d+\.\d+\.\d+\.\d+:\d+$`)),
 				),
 			},
 			{
@@ -96,16 +102,18 @@ func TestAccAWSMskCluster_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"bootstrap_brokers", // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
 				},
 			},
 		},
 	})
 }
-func TestAccAWSMskCluster_kms(t *testing.T) {
-	var cluster kafka.ClusterInfo
-	ri := acctest.RandInt()
-	resourceName := "aws_msk_cluster.example"
+
+func TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize(t *testing.T) {
+	var cluster1, cluster2 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,7 +121,127 @@ func TestAccAWSMskCluster_kms(t *testing.T) {
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfig_kms(ri),
+				Config: testAccMskClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName, 11),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", "11"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+			{
+				// BadRequestException: The minimum increase in storage size of the cluster should be atleast 100GB
+				Config: testAccMskClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName, 112),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster2),
+					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", "112"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_ClientAuthentication_Tls_CertificateAuthorityArns(t *testing.T) {
+	t.Skip("Requires the aws_acmpca_certificate_authority resource to support importing the root CA certificate")
+
+	var cluster1 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "client_authentication.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_authentication.0.tls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration_info.0.tls.0.certificate_authority_arns.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_ConfigurationInfo_Revision(t *testing.T) {
+	t.Skip("aws_msk_cluster is correctly calling UpdateClusterConfiguration however API is always returning 429 and 500 errors")
+
+	var cluster1, cluster2 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	configurationResourceName := "aws_msk_configuration.test"
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigConfigurationInfoRevision1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.revision", configurationResourceName, "latest_revision"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+			{
+				Config: testAccMskClusterConfigConfigurationInfoRevision2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster2),
+					testAccCheckMskClusterNotRecreated(&cluster1, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, "configuration_info.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.arn", configurationResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "configuration_info.0.revision", configurationResourceName, "latest_revision"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn(t *testing.T) {
+	var cluster kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigEncryptionInfoEncryptionAtRestKmsKeyArn(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMskClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttrPair(resourceName, "encryption_info.0.encryption_at_rest_kms_key_arn", "aws_kms_key.example_key", "arn"),
@@ -124,17 +252,18 @@ func TestAccAWSMskCluster_kms(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"bootstrap_brokers", // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
 				},
 			},
 		},
 	})
 }
 
-func TestAccAWSMskCluster_enhancedMonitoring(t *testing.T) {
-	var cluster kafka.ClusterInfo
-	ri := acctest.RandInt()
-	resourceName := "aws_msk_cluster.example"
+func TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker(t *testing.T) {
+	var cluster1 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -142,7 +271,71 @@ func TestAccAWSMskCluster_enhancedMonitoring(t *testing.T) {
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfig_enhancedMonitoring(ri),
+				Config: testAccMskClusterConfigEncryptionInfoEncryptionInTransitClientBroker(rName, "PLAINTEXT"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.client_broker", "PLAINTEXT"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster(t *testing.T) {
+	var cluster1 kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigEncryptionInfoEncryptionInTransitInCluster(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_info.0.encryption_in_transit.0.in_cluster", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_EnhancedMonitoring(t *testing.T) {
+	var cluster kafka.ClusterInfo
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigEnhancedMonitoring(rName, "PER_BROKER"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMskClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "enhanced_monitoring", kafka.EnhancedMonitoringPerBroker),
@@ -153,17 +346,18 @@ func TestAccAWSMskCluster_enhancedMonitoring(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"bootstrap_brokers",
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
 				},
 			},
 		},
 	})
 }
-func TestAccAWSMskCluster_tagsUpdate(t *testing.T) {
+
+func TestAccAWSMskCluster_NumberOfBrokerNodes(t *testing.T) {
 	var cluster kafka.ClusterInfo
-	var td kafka.ListTagsForResourceOutput
-	ri := acctest.RandInt()
-	resourceName := "aws_msk_cluster.example"
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -171,50 +365,17 @@ func TestAccAWSMskCluster_tagsUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMskClusterConfig_basic(ri),
+				Config: testAccMskClusterConfigNumberOfBrokerNodes(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMskClusterExists(resourceName, &cluster),
-					testAccLoadMskTags(&cluster, &td),
-					testAccCheckMskClusterTags(&td, "foo", "bar"),
-				),
-			},
-			{
-				Config: testAccMskClusterConfig_tagsUpdate(ri),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster),
-					testAccLoadMskTags(&cluster, &td),
-					testAccCheckMskClusterTags(&td, "foo", "baz"),
-					testAccCheckMskClusterTags(&td, "new", "type"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAWSMskCluster_brokerNodes(t *testing.T) {
-	var cluster kafka.ClusterInfo
-	ri := acctest.RandInt()
-	resourceName := "aws_msk_cluster.example"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckMskClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMskClusterConfig_brokerNodes(ri),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMskClusterExists(resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "number_of_broker_nodes", "6"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.instance_type", "kafka.m5.large"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.ebs_volume_size", "1"),
+					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "bootstrap_brokers_tls", regexp.MustCompile(`^(([-\w]+\.){1,}[\w]+:\d+,){2,}([-\w]+\.){1,}[\w]+:\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.client_subnets.#", "3"),
 					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.client_subnets.0", "aws_subnet.example_subnet_az1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.client_subnets.1", "aws_subnet.example_subnet_az2", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.client_subnets.2", "aws_subnet.example_subnet_az3", "id"),
-					resource.TestCheckResourceAttr(resourceName, "broker_node_group_info.0.security_groups.#", "1"),
-					resource.TestCheckResourceAttrPair(resourceName, "broker_node_group_info.0.security_groups.0", "aws_security_group.example_sg", "id"),
-					resource.TestCheckResourceAttr(resourceName, "kafka_version", "2.1.0"),
+					resource.TestCheckResourceAttr(resourceName, "number_of_broker_nodes", "6"),
 				),
 			},
 			{
@@ -222,7 +383,49 @@ func TestAccAWSMskCluster_brokerNodes(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"bootstrap_brokers", // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
+				},
+			},
+		},
+	})
+}
+
+func TestAccAWSMskCluster_Tags(t *testing.T) {
+	var cluster kafka.ClusterInfo
+	var td kafka.ListTagsForResourceOutput
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_msk_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMskClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMskClusterConfigTags1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster),
+					testAccLoadMskTags(&cluster, &td),
+					testAccCheckMskClusterTags(&td, "foo", "bar"),
+				),
+			},
+			{
+				Config: testAccMskClusterConfigTags2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMskClusterExists(resourceName, &cluster),
+					testAccLoadMskTags(&cluster, &td),
+					testAccCheckMskClusterTags(&td, "foo", "baz"),
+					testAccCheckMskClusterTags(&td, "new", "type"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"bootstrap_brokers",     // API may mutate ordering and selection of brokers to return
+					"bootstrap_brokers_tls", // API may mutate ordering and selection of brokers to return
 				},
 			},
 		},
@@ -271,6 +474,16 @@ func testAccCheckMskClusterExists(n string, cluster *kafka.ClusterInfo) resource
 		}
 
 		*cluster = *resp.ClusterInfo
+		return nil
+	}
+}
+
+func testAccCheckMskClusterNotRecreated(i, j *kafka.ClusterInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.StringValue(i.ClusterArn) != aws.StringValue(j.ClusterArn) {
+			return fmt.Errorf("MSK Cluster (%s) recreated", aws.StringValue(i.ClusterArn))
+		}
+
 		return nil
 	}
 }
@@ -362,109 +575,295 @@ resource "aws_security_group" "example_sg" {
 `)
 
 }
-func testAccMskClusterConfig_basic(randInt int) string {
+func testAccMskClusterConfig_basic(rName string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
 
-resource "aws_msk_cluster" "example" {
-	cluster_name = "tf-test-%d"
-	kafka_version = "1.1.1"
-	number_of_broker_nodes = 3
-	broker_node_group_info {
-		instance_type = "kafka.m5.large"
-		ebs_volume_size = 10
-		client_subnets = [ "${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}" ] 
-		security_groups = [ "${aws_security_group.example_sg.id}" ]
-	}
-	tags = {
-		foo = "bar"
-	}
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
 }
-`, randInt)
+`, rName)
 }
 
-func testAccMskClusterConfig_kms(randInt int) string {
+func testAccMskClusterConfigBrokerNodeGroupInfoEbsVolumeSize(rName string, ebsVolumeSize int) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
 
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = %[2]d
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+}
+`, rName, ebsVolumeSize)
+}
+
+func testAccMskClusterConfigClientAuthenticationTlsCertificateAuthorityArns(rName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_acmpca_certificate_authority" "test" {
+  certificate_authority_configuration {
+    key_algorithm     = "RSA_4096"
+    signing_algorithm = "SHA512WITHRSA"
+
+    subject {
+      common_name = "terraformtesting.com"
+    }
+  }
+}
+
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  client_authentication {
+    tls {
+      certificate_authority_arns = ["${aws_acmpca_certificate_authority.test.arn}"]
+    }
+  }
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS"
+    }
+  }
+}
+`, rName)
+}
+
+func testAccMskClusterConfigConfigurationInfoRevision1(rName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_configuration" "test" {
+  kafka_versions = ["2.1.0"]
+  name           = "%[1]s-1"
+
+  server_properties = <<PROPERTIES
+log.cleaner.delete.retention.ms = 86400000
+PROPERTIES
+}
+
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  configuration_info {
+    arn      = "${aws_msk_configuration.test.arn}"
+    revision = "${aws_msk_configuration.test.latest_revision}"
+  }
+}
+`, rName)
+}
+
+func testAccMskClusterConfigConfigurationInfoRevision2(rName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_configuration" "test" {
+  kafka_versions = ["2.1.0"]
+  name           = "%[1]s-2"
+
+  server_properties = <<PROPERTIES
+log.cleaner.delete.retention.ms = 86400001
+PROPERTIES
+}
+
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  configuration_info {
+    arn      = "${aws_msk_configuration.test.arn}"
+    revision = "${aws_msk_configuration.test.latest_revision}"
+  }
+}
+`, rName)
+}
+
+func testAccMskClusterConfigEncryptionInfoEncryptionAtRestKmsKeyArn(rName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
 resource "aws_kms_key" "example_key" {
-	description = "tf-testacc-msk-cluster-kms"
-	tags = {
-		Name = "tf-testacc-msk-cluster-kms"
-	}
+  description = "tf-testacc-msk-cluster-kms"
+
+  tags = {
+    Name = "tf-testacc-msk-cluster-kms"
+  }
 }
 
-resource "aws_msk_cluster" "example" {
-	cluster_name = "tf-test-%d"
-	kafka_version = "1.1.1"
-	number_of_broker_nodes = 3
-	encryption_info {
-		encryption_at_rest_kms_key_arn = "${aws_kms_key.example_key.arn}"
-	}
-	broker_node_group_info {
-		instance_type = "kafka.m5.large"
-		ebs_volume_size = 10
-		client_subnets = [ "${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}" ] 
-		security_groups = [ "${aws_security_group.example_sg.id}" ]
-	}
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  encryption_info {
+    encryption_at_rest_kms_key_arn = "${aws_kms_key.example_key.arn}"
+  }
 }
-`, randInt)
+`, rName)
 
 }
 
-func testAccMskClusterConfig_enhancedMonitoring(randInt int) string {
+func testAccMskClusterConfigEncryptionInfoEncryptionInTransitClientBroker(rName, clientBroker string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
 
-resource "aws_msk_cluster" "example" {
-	cluster_name = "tf-test-%d"
-	kafka_version = "1.1.1"
-	number_of_broker_nodes = 3
-	broker_node_group_info {
-		instance_type = "kafka.m5.large"
-		ebs_volume_size = 10
-		client_subnets = [ "${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}" ] 
-		security_groups = [ "${aws_security_group.example_sg.id}" ]
-	}
-	enhanced_monitoring = "PER_BROKER"
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = %[2]q
+    }
+  }
 }
-`, randInt)
-
+`, rName, clientBroker)
 }
 
-func testAccMskClusterConfig_brokerNodes(randInt int) string {
+func testAccMskClusterConfigEncryptionInfoEncryptionInTransitInCluster(rName string, inCluster bool) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
 
-resource "aws_msk_cluster" "example" {
-	cluster_name = "tf-test-%d"
-	kafka_version = "2.1.0"
-	number_of_broker_nodes = 6
-	broker_node_group_info {
-		instance_type = "kafka.m5.large"
-		ebs_volume_size = 1
-		client_subnets = [ "${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}" ] 
-		security_groups = [ "${aws_security_group.example_sg.id}" ]
-	}
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  encryption_info {
+    encryption_in_transit {
+      in_cluster = %[2]t
+    }
+  }
 }
-`, randInt)
-
+`, rName, inCluster)
 }
 
-func testAccMskClusterConfig_tagsUpdate(randInt int) string {
+func testAccMskClusterConfigEnhancedMonitoring(rName, enhancedMonitoring string) string {
 	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  enhanced_monitoring    = %[2]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
 
-resource "aws_msk_cluster" "example" {
-	cluster_name = "tf-test-%d"
-	kafka_version = "1.1.1"
-	number_of_broker_nodes = 3
-	broker_node_group_info {
-		instance_type = "kafka.m5.large"
-		ebs_volume_size = 10
-		client_subnets = [ "${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}" ] 
-		security_groups = [ "${aws_security_group.example_sg.id}" ]
-	}
-	tags = {
-		foo = "baz"
-		new = "type"
-	}
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
 }
-`, randInt)
+`, rName, enhancedMonitoring)
+
+}
+
+func testAccMskClusterConfigNumberOfBrokerNodes(rName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 6
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+}
+`, rName)
+
+}
+
+func testAccMskClusterConfigTags1(rName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, rName)
+}
+
+func testAccMskClusterConfigTags2(rName string) string {
+	return testAccMskClusterBaseConfig() + fmt.Sprintf(`
+resource "aws_msk_cluster" "test" {
+  cluster_name           = %[1]q
+  kafka_version          = "2.1.0"
+  number_of_broker_nodes = 3
+
+  broker_node_group_info {
+    client_subnets  = ["${aws_subnet.example_subnet_az1.id}", "${aws_subnet.example_subnet_az2.id}", "${aws_subnet.example_subnet_az3.id}"]
+    ebs_volume_size = 10
+    instance_type   = "kafka.m5.large"
+    security_groups = ["${aws_security_group.example_sg.id}"]
+  }
+
+  tags = {
+    foo = "baz"
+    new = "type"
+  }
+}
+`, rName)
 
 }

--- a/website/docs/d/msk_cluster.html.markdown
+++ b/website/docs/d/msk_cluster.html.markdown
@@ -30,6 +30,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of the MSK cluster.
 * `bootstrap_brokers` - A comma separated list of one or more hostname:port pairs of Kafka brokers suitable to boostrap connectivity to the Kafka cluster.
+* `bootstrap_brokers_tls` - A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster.
 * `kafka_version` - Apache Kafka version.
 * `number_of_broker_nodes` - Number of broker nodes in the cluster.
 * `tags` - Map of key-value pairs assigned to the cluster.

--- a/website/docs/r/msk_cluster.html.markdown
+++ b/website/docs/r/msk_cluster.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages AWS Managed Streaming for Kafka cluster
 
-~> **NOTE:** This AWS service is in Preview and may change before General Availability release. Backwards compatibility is not guaranteed between Terraform AWS Provider releases.
-
 ## Example Usage
 
 ```hcl
@@ -88,19 +86,17 @@ output "bootstrap_brokers" {
 
 The following arguments are supported:
 
-* `broker_node_group_info` - (Required) Nested data for configuring the broker nodes of the Kafka cluster.
+* `broker_node_group_info` - (Required) Configuration block for the broker nodes of the Kafka cluster.
 * `cluster_name` - (Required) Name of the MSK cluster.
 * `kafka_version` - (Required) Specify the desired Kafka software version.
 * `number_of_broker_nodes` - (Required) The desired total number of broker nodes in the kafka cluster.  It must be a multiple of the number of specified client subnets.
-* `encryption_info` - (Optional) Nested data for specifying encryption at rest info.  See below.
+* `client_authentication` - (Optional) Configuration block for specifying a client authentication. See below.
+* `configuration_info` - (Optional) Configuration block for specifying a MSK Configuration to attach to Kafka brokers. See below.
+* `encryption_info` - (Optional) Configuration block for specifying encryption. See below.
 * `enhanced_monitoring` - (Optional) Specify the desired enhanced MSK CloudWatch monitoring level.  See [Monitoring Amazon MSK with Amazon CloudWatch](https://docs.aws.amazon.com/msk/latest/developerguide/monitoring.html)
 * `tags` - (Optional) A mapping of tags to assign to the resource
 
-**encryption_info** supports the following attributes:
-
-* `encryption_at_rest_kms_key_arn` - (Optional) You may specify a KMS key short ID or ARN (it will always output an ARN) to use for encrypting your data at rest.  If no key is specified, an AWS managed KMS ('aws/msk' managed service) key will be used for encrypting the data at rest.
-
-**broker_node_group_info** supports the following attributes:
+### broker_node_group_info Argument Reference
 
 * `client_subnets` - (Required) A list of subnets to connect to in client VPC ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-prop-brokernodegroupinfo-clientsubnets)).
 * `ebs_volume_size` - (Required) The size in GiB of the EBS volume for the data drive on each broker node.
@@ -108,12 +104,37 @@ The following arguments are supported:
 * `security_groups` - (Required) A list of the security groups to associate with the elastic network interfaces to control who can communicate with the cluster.
 * `az_distribution` - (Optional) The distribution of broker nodes across availability zones ([documentation](https://docs.aws.amazon.com/msk/1.0/apireference/clusters.html#clusters-model-brokerazdistribution)). Currently the only valid value is `DEFAULT`.
 
+### client_authentication Argument Reference
+
+* `tls` - (Optional) Configuration block for specifying TLS client authentication. See below.
+
+#### client_authenication tls Argument Reference
+
+* `certificate_authority_arns` - (Optional) List of ACM Certificate Authority Amazon Resource Names (ARNs).
+
+### configuration_info Argument Reference
+
+* `arn` - (Required) Amazon Resource Name (ARN) of the MSK Configuration to use in the cluster.
+* `revision` - (Required) Revision of the MSK Configuration to use in the cluster.
+
+### encryption_info Argument Reference
+
+* `encryption_in_transit` - (Optional) Configuration block to specify encryption in transit. See below.
+* `encryption_at_rest_kms_key_arn` - (Optional) You may specify a KMS key short ID or ARN (it will always output an ARN) to use for encrypting your data at rest.  If no key is specified, an AWS managed KMS ('aws/msk' managed service) key will be used for encrypting the data at rest.
+
+#### encryption_info encryption_in_transit Argument Reference
+
+* `client_broker` - (Optional) Encryption setting for data in transit between clients and brokers. Valid values: `TLS`, `TLS_PLAINTEXT`, and `PLAINTEXT`. Default value: `TLS_PLAINTEXT`.
+* `in_cluster` - (Optional) Whether data communication among broker nodes is encrypted. Default value: `true`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of the MSK cluster.
 * `bootstrap_brokers` - A comma separated list of one or more hostname:port pairs of kafka brokers suitable to boostrap connectivity to the kafka cluster.
+* `bootstrap_brokers_tls` - A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster.
+* `current_version` - Current version of the MSK Cluster used for updates, e.g. `K13V1IB3VIYZZH`
 * `encryption_info.0.encryption_at_rest_kms_key_arn` - The ARN of the KMS key used for encryption at rest of the broker data volumes.
 * `zookeeper_connect_string` - A comma separated list of one or more IP:port pairs to use to connect to the Apache Zookeeper cluster.
 

--- a/website/docs/r/msk_configuration.html.markdown
+++ b/website/docs/r/msk_configuration.html.markdown
@@ -12,8 +12,6 @@ Manages an Amazon Managed Streaming for Kafka configuration. More information ca
 
 ~> **NOTE:** The API does not support deleting MSK configurations. Removing this Terraform resource will only remove the Terraform state for it.
 
-~> **NOTE:** This AWS service is in Preview and may change before General Availability release. Backwards compatibility is not guaranteed between Terraform AWS Provider releases.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8823

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS

* data-source/aws_msk_cluster: Add `bootstrap_brokers_tls` attribute
* resource/aws_msk_cluster: Add `bootstrap_brokers_tls` attribute
* resource/aws_msk_cluster: Support `broker_node_group_into` configuration block `ebs_volume_size` argument updates
* resource/aws_msk_cluster: Add `client_authentication` configuration block
* resource/aws_msk_cluster: Add `configuration_info` configuration block
* resource/aws_msk_cluster: Add `current_version` attribute
* resource/aws_msk_cluster: Add `encryption_info` configuration block `encryption_in_transit` configuration block
* resource/aws_msk_cluster: Support tagging on creation
```

Output from acceptance testing:

```
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker (895.20s)
--- PASS: TestAccAWSMskCluster_basic (994.37s)
--- PASS: TestAccAWSMskCluster_NumberOfBrokerNodes (1005.95s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn (1058.52s)
--- PASS: TestAccAWSMskCluster_Tags (1088.06s)
--- PASS: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster (1089.38s)
--- PASS: TestAccAWSMskCluster_EnhancedMonitoring (1100.27s)
--- PASS: TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize (1383.23s)
```
