### PR TITLE
Add nil check for S3 bucket metric filter

### DIFF
--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -62,8 +62,9 @@ func resourceAwsS3BucketMetricPut(d *schema.ResourceData, meta interface{}) erro
 
 	if v, ok := d.GetOk("filter"); ok {
 		filterList := v.([]interface{})
-		filterMap := filterList[0].(map[string]interface{})
-		metricsConfiguration.Filter = expandS3MetricsFilter(filterMap)
+		if filterMap, ok := filterList[0].(map[string]interface{}); ok {
+			metricsConfiguration.Filter = expandS3MetricsFilter(filterMap)
+		}
 	}
 
 	input := &s3.PutBucketMetricsConfigurationInput{

--- a/aws/resource_aws_s3_bucket_metric_test.go
+++ b/aws/resource_aws_s3_bucket_metric_test.go
@@ -292,6 +292,29 @@ func TestAccAWSS3BucketMetric_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketMetric_WithEmptyFilter(t *testing.T) {
+	var conf s3.MetricsConfiguration
+	rInt := acctest.RandInt()
+	resourceName := "aws_s3_bucket_metric.test"
+
+	bucketName := fmt.Sprintf("tf-acc-%d", rInt)
+	metricName := t.Name()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketMetricDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSS3BucketMetricsConfigWithEmptyFilter(bucketName, metricName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketMetricsConfigExists(resourceName, &conf),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3BucketMetric_WithFilterPrefix(t *testing.T) {
 	var conf s3.MetricsConfiguration
 	rInt := acctest.RandInt()
@@ -602,6 +625,18 @@ resource "aws_s3_bucket" "bucket" {
   bucket = "%s"
 }
 `, name)
+}
+
+func testAccAWSS3BucketMetricsConfigWithEmptyFilter(bucketName, metricName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "aws_s3_bucket_metric" "test" {
+  bucket = "${aws_s3_bucket.bucket.id}"
+  name = "%s"
+  filter {}
+}
+`, testAccAWSS3BucketMetricsConfigBucket(bucketName), metricName)
 }
 
 func testAccAWSS3BucketMetricsConfigWithFilterPrefix(bucketName, metricName, prefix string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8344

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_s3_bucket_metric: Add a nil check for `filter` to avoid
panicking if empty
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSS3BucketMetric" 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSS3BucketMetric -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSS3BucketMetric_basic
=== PAUSE TestAccAWSS3BucketMetric_basic
=== RUN   TestAccAWSS3BucketMetric_WithEmptyFilter
=== PAUSE TestAccAWSS3BucketMetric_WithEmptyFilter
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefix
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefix
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
=== RUN   TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== PAUSE TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== RUN   TestAccAWSS3BucketMetric_WithFilterSingleTag
=== PAUSE TestAccAWSS3BucketMetric_WithFilterSingleTag
=== CONT  TestAccAWSS3BucketMetric_basic
=== CONT  TestAccAWSS3BucketMetric_WithFilterSingleTag
=== CONT  TestAccAWSS3BucketMetric_WithEmptyFilter
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefix
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags
=== CONT  TestAccAWSS3BucketMetric_WithFilterMultipleTags
=== CONT  TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag
--- PASS: TestAccAWSS3BucketMetric_basic (61.69s)
--- PASS: TestAccAWSS3BucketMetric_WithEmptyFilter (61.76s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndMultipleTags (105.55s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterSingleTag (106.06s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterMultipleTags (106.78s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefixAndSingleTag (106.96s)
--- PASS: TestAccAWSS3BucketMetric_WithFilterPrefix (108.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       108.891s
```