### PR TITLE
Retry timeout error for acmpca cert authority

### DIFF
--- a/aws/resource_aws_acmpca_certificate_authority.go
+++ b/aws/resource_aws_acmpca_certificate_authority.go
@@ -288,6 +288,9 @@ func resourceAwsAcmpcaCertificateAuthorityCreate(d *schema.ResourceData, meta in
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		output, err = conn.CreateCertificateAuthority(input)
+	}
 	if err != nil {
 		return fmt.Errorf("error creating ACMPCA Certificate Authority: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Bug Fixes:
* resource/aws_acmpca_certificate_authority: Add retry after timeout
when creating CA

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAwsAcmpcaCertificateAuthority"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsAcmpcaCertificateAuthority -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsAcmpcaCertificateAuthority_Basic
=== PAUSE TestAccAwsAcmpcaCertificateAuthority_Basic
=== RUN   TestAccAwsAcmpcaCertificateAuthority_Enabled
--- SKIP: TestAccAwsAcmpcaCertificateAuthority_Enabled (0.00s)
    resource_aws_acmpca_certificate_authority_test.go:112: We need to fully sign the certificate authority CSR from another CA in order to test this functionality, which requires another resource
=== RUN   TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_CustomCname
=== PAUSE TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_CustomCname
=== RUN   TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_Enabled
=== PAUSE TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_Enabled
=== RUN   TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_ExpirationInDays
=== PAUSE TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_ExpirationInDays
=== RUN   TestAccAwsAcmpcaCertificateAuthority_Tags
=== PAUSE TestAccAwsAcmpcaCertificateAuthority_Tags
=== CONT  TestAccAwsAcmpcaCertificateAuthority_Basic
=== CONT  TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_ExpirationInDays
=== CONT  TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_CustomCname
=== CONT  TestAccAwsAcmpcaCertificateAuthority_Tags
=== CONT  TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_Enabled
--- PASS: TestAccAwsAcmpcaCertificateAuthority_Basic (20.09s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_Tags (50.81s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_ExpirationInDays (64.02s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_Enabled (81.72s)
--- PASS: TestAccAwsAcmpcaCertificateAuthority_RevocationConfiguration_CrlConfiguration_CustomCname (109.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       110.806s
```