### PR TITLE
service/dax: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_dax_cluster_test.go
+++ b/aws/resource_aws_dax_cluster_test.go
@@ -285,7 +285,7 @@ func testAccPreCheckAWSDax(t *testing.T) {
 	}
 }
 
-var baseConfig = `
+const baseConfig = `
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {

--- a/aws/resource_aws_dax_cluster_test.go
+++ b/aws/resource_aws_dax_cluster_test.go
@@ -63,7 +63,7 @@ func TestAccAWSDAXCluster_importBasic(t *testing.T) {
 	rString := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDAXClusterDestroy,
 		Steps: []resource.TestStep{
@@ -86,7 +86,7 @@ func TestAccAWSDAXCluster_basic(t *testing.T) {
 	iamRoleResourceName := "aws_iam_role.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDAXClusterDestroy,
 		Steps: []resource.TestStep{
@@ -132,7 +132,7 @@ func TestAccAWSDAXCluster_resize(t *testing.T) {
 	var dc dax.Cluster
 	rString := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDAXClusterDestroy,
 		Steps: []resource.TestStep{
@@ -168,7 +168,7 @@ func TestAccAWSDAXCluster_encryption_disabled(t *testing.T) {
 	var dc dax.Cluster
 	rString := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDAXClusterDestroy,
 		Steps: []resource.TestStep{
@@ -194,7 +194,7 @@ func TestAccAWSDAXCluster_encryption_enabled(t *testing.T) {
 	var dc dax.Cluster
 	rString := acctest.RandString(10)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDAXClusterDestroy,
 		Steps: []resource.TestStep{
@@ -269,11 +269,23 @@ func testAccCheckAWSDAXClusterExists(n string, v *dax.Cluster) resource.TestChec
 	}
 }
 
-var baseConfig = `
-provider "aws" {
-  region = "us-west-2"
+func testAccPreCheckAWSDax(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).daxconn
+
+	input := &dax.DescribeClustersInput{}
+
+	_, err := conn.DescribeClusters(input)
+
+	if testAccPreCheckSkipError(err) || isAWSErr(err, "InvalidParameterValueException", "Access Denied to API Version: DAX_V3") {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
+var baseConfig = `
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
 {

--- a/aws/resource_aws_dax_parameter_group_test.go
+++ b/aws/resource_aws_dax_parameter_group_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAwsDaxParameterGroup_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDaxParameterGroupDestroy,
 		Steps: []resource.TestStep{
@@ -41,7 +41,7 @@ func TestAccAwsDaxParameterGroup_import(t *testing.T) {
 	resourceName := "aws_dax_parameter_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDaxParameterGroupDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_dax_subnet_group_test.go
+++ b/aws/resource_aws_dax_subnet_group_test.go
@@ -16,7 +16,7 @@ func TestAccAwsDaxSubnetGroup_basic(t *testing.T) {
 	resourceName := "aws_dax_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDax(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDaxSubnetGroupDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This service is a little strange in that the endpoint exists in GovCloud but it always returns this special `Access Denied to API Version: DAX_V3` error.

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSDAXCluster_importBasic (2.57s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b37e8ce7-8796-11e9-af06-135ec879b3ef
--- SKIP: TestAccAWSDAXCluster_encryption_disabled (2.58s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b381246b-8796-11e9-a4f7-1fc3fef3041b
--- SKIP: TestAccAwsDaxParameterGroup_import (2.58s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b3817318-8796-11e9-af06-135ec879b3ef
--- SKIP: TestAccAWSDAXCluster_basic (2.61s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b384a6ba-8796-11e9-bce8-d97c7d99eb8f
--- SKIP: TestAccAwsDaxParameterGroup_basic (2.62s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b383e369-8796-11e9-bce8-d97c7d99eb8f
--- SKIP: TestAccAWSDAXCluster_resize (2.62s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b383bc58-8796-11e9-bce8-d97c7d99eb8f
--- SKIP: TestAccAwsDaxSubnetGroup_basic (3.08s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b3cad77b-8796-11e9-bce8-d97c7d99eb8f
--- SKIP: TestAccAWSDAXCluster_encryption_enabled (3.81s)
    resource_aws_dax_cluster_test.go:280: skipping acceptance testing: InvalidParameterValueException: Access Denied to API Version: DAX_V3
        	status code: 400, request id: b43d6f8c-8796-11e9-a4f7-1fc3fef3041b
```
