### PR TITLE
tests/service/directoryservice: Support AWS GovCloud (US) testing

### DIFF
--- a/aws/resource_aws_directory_service_conditional_forwarder_test.go
+++ b/aws/resource_aws_directory_service_conditional_forwarder_test.go
@@ -17,7 +17,7 @@ func TestAccAWSDirectoryServiceConditionForwarder_basic(t *testing.T) {
 	ip1, ip2, ip3 := "8.8.8.8", "1.1.1.1", "8.8.4.4"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDirectoryService(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDirectoryServiceConditionalForwarderDestroy,
 		Steps: []resource.TestStep{
@@ -69,21 +69,20 @@ func testAccCheckAwsDirectoryServiceConditionalForwarderDestroy(s *terraform.Sta
 			RemoteDomainNames: []*string{aws.String(domainName)},
 		})
 
+		if isAWSErr(err, directoryservice.ErrCodeEntityDoesNotExistException, "") {
+			continue
+		}
+
 		if err != nil {
-			if isAWSErr(err, directoryservice.ErrCodeEntityDoesNotExistException, "") {
-				return nil
-			}
 			return err
 		}
 
 		if len(res.ConditionalForwarders) > 0 {
 			return fmt.Errorf("Expected AWS Directory Service Conditional Forwarder to be gone, but was still found")
 		}
-
-		return nil
 	}
 
-	return fmt.Errorf("Default error in Service Directory Test")
+	return nil
 }
 
 func testAccCheckAwsDirectoryServiceConditionalForwarderExists(name string, dnsIps []string) resource.TestCheckFunc {
@@ -137,6 +136,10 @@ func testAccCheckAwsDirectoryServiceConditionalForwarderExists(name string, dnsI
 
 func testAccDirectoryServiceConditionalForwarderConfig(ip1, ip2 string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_directory_service_directory" "bar" {
   name     = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
@@ -163,7 +166,7 @@ resource "aws_vpc" "main" {
 
 resource "aws_subnet" "foo" {
   vpc_id            = "${aws_vpc.main.id}"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   cidr_block        = "10.0.1.0/24"
 
   tags = {
@@ -173,7 +176,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   vpc_id            = "${aws_vpc.main.id}"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   cidr_block        = "10.0.2.0/24"
 
   tags = {

--- a/aws/resource_aws_directory_service_directory_test.go
+++ b/aws/resource_aws_directory_service_directory_test.go
@@ -247,7 +247,7 @@ func TestAccAWSDirectoryServiceDirectory_connector(t *testing.T) {
 }
 
 func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
-	randomInteger := acctest.RandInt()
+	alias := acctest.RandomWithPrefix("tf-acc-test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -259,29 +259,26 @@ func TestAccAWSDirectoryServiceDirectory_withAliasAndSso(t *testing.T) {
 		CheckDestroy: testAccCheckDirectoryServiceDirectoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDirectoryServiceDirectoryConfig_withAlias(randomInteger),
+				Config: testAccDirectoryServiceDirectoryConfig_withAlias(alias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar_a"),
-					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.bar_a",
-						fmt.Sprintf("tf-d-%d", randomInteger)),
+					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.bar_a", alias),
 					testAccCheckServiceDirectorySso("aws_directory_service_directory.bar_a", false),
 				),
 			},
 			{
-				Config: testAccDirectoryServiceDirectoryConfig_withSso(randomInteger),
+				Config: testAccDirectoryServiceDirectoryConfig_withSso(alias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar_a"),
-					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.bar_a",
-						fmt.Sprintf("tf-d-%d", randomInteger)),
+					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.bar_a", alias),
 					testAccCheckServiceDirectorySso("aws_directory_service_directory.bar_a", true),
 				),
 			},
 			{
-				Config: testAccDirectoryServiceDirectoryConfig_withSso_modified(randomInteger),
+				Config: testAccDirectoryServiceDirectoryConfig_withSso_modified(alias),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceDirectoryExists("aws_directory_service_directory.bar_a"),
-					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.bar_a",
-						fmt.Sprintf("tf-d-%d", randomInteger)),
+					testAccCheckServiceDirectoryAlias("aws_directory_service_directory.bar_a", alias),
 					testAccCheckServiceDirectorySso("aws_directory_service_directory.bar_a", false),
 				),
 			},
@@ -673,7 +670,7 @@ resource "aws_subnet" "bar" {
 }
 `
 
-func testAccDirectoryServiceDirectoryConfig_withAlias(randomInteger int) string {
+func testAccDirectoryServiceDirectoryConfig_withAlias(alias string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -683,7 +680,7 @@ resource "aws_directory_service_directory" "bar_a" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
-  alias = "tf-d-%d"
+  alias = %[1]q
 
   vpc_settings {
     vpc_id = "${aws_vpc.main.id}"
@@ -714,10 +711,10 @@ resource "aws_subnet" "bar" {
     Name = "tf-acc-directory-service-directory-with-alias-bar"
   }
 }
-`, randomInteger)
+`, alias)
 }
 
-func testAccDirectoryServiceDirectoryConfig_withSso(randomInteger int) string {
+func testAccDirectoryServiceDirectoryConfig_withSso(alias string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -727,7 +724,7 @@ resource "aws_directory_service_directory" "bar_a" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
-  alias = "tf-d-%d"
+  alias = %[1]q
   enable_sso = true
 
   vpc_settings {
@@ -759,10 +756,10 @@ resource "aws_subnet" "bar" {
     Name = "tf-acc-directory-service-directory-with-sso-bar"
   }
 }
-`, randomInteger)
+`, alias)
 }
 
-func testAccDirectoryServiceDirectoryConfig_withSso_modified(randomInteger int) string {
+func testAccDirectoryServiceDirectoryConfig_withSso_modified(alias string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {
   state = "available"
@@ -772,7 +769,7 @@ resource "aws_directory_service_directory" "bar_a" {
   name = "corp.notexample.com"
   password = "SuperSecretPassw0rd"
   size = "Small"
-  alias = "tf-d-%d"
+  alias = %[1]q
   enable_sso = false
 
   vpc_settings {
@@ -804,5 +801,5 @@ resource "aws_subnet" "bar" {
     Name = "tf-acc-directory-service-directory-with-sso-bar"
   }
 }
-`, randomInteger)
+`, alias)
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDirectoryServiceDirectory_importBasic (535.50s)
--- PASS: TestAccAWSDirectoryServiceDirectory_basic (567.07s)
--- PASS: TestAccAWSDirectoryServiceDirectory_tags (587.81s)
--- PASS: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (646.27s)
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (1095.91s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (1727.52s)
--- PASS: TestAccAWSDirectoryServiceConditionForwarder_basic (1795.06s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoftStandard (1996.54s)
PASS
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSDirectoryServiceDirectory_importBasic (2.29s)
    resource_aws_directory_service_directory_test.go:443: skipping acceptance testing: ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 9ab36a36-879f-11e9-a73e-3dac67640459 : RequestId: 9ab36a36-879f-11e9-a73e-3dac67640459
        	status code: 400, request id: 9ab36a36-879f-11e9-a73e-3dac67640459
--- SKIP: TestAccAWSDirectoryServiceDirectory_tags (2.30s)
    resource_aws_directory_service_directory_test.go:443: skipping acceptance testing: ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 9ab7b077-879f-11e9-abc7-73d88cf18f54 : RequestId: 9ab7b077-879f-11e9-abc7-73d88cf18f54
        	status code: 400, request id: 9ab7b077-879f-11e9-abc7-73d88cf18f54
--- SKIP: TestAccAWSDirectoryServiceDirectory_basic (2.31s)
    resource_aws_directory_service_directory_test.go:443: skipping acceptance testing: ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 9abb0b9b-879f-11e9-80a9-5ba7c103c75e : RequestId: 9abb0b9b-879f-11e9-80a9-5ba7c103c75e
        	status code: 400, request id: 9abb0b9b-879f-11e9-80a9-5ba7c103c75e
--- SKIP: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (2.32s)
    resource_aws_directory_service_directory_test.go:443: skipping acceptance testing: ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 9abc923c-879f-11e9-80a9-5ba7c103c75e : RequestId: 9abc923c-879f-11e9-80a9-5ba7c103c75e
        	status code: 400, request id: 9abc923c-879f-11e9-80a9-5ba7c103c75e
--- SKIP: TestAccAWSDirectoryServiceDirectory_connector (2.34s)
    resource_aws_directory_service_directory_test.go:443: skipping acceptance testing: ClientException: Simple AD directory creation is currently not supported in this region. : RequestId: 9abf78a8-879f-11e9-abc7-73d88cf18f54 : RequestId: 9abf78a8-879f-11e9-abc7-73d88cf18f54
        	status code: 400, request id: 9abf78a8-879f-11e9-abc7-73d88cf18f54
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (1645.07s)
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoftStandard (1682.17s)
--- PASS: TestAccAWSDirectoryServiceConditionForwarder_basic (1696.28s)
PASS
```