### PR TITLE
tests/resource/aws_dms_replication_instance: Support AWS GovCloud (US) testing

### DIFF
--- a/aws/resource_aws_dms_replication_instance_test.go
+++ b/aws/resource_aws_dms_replication_instance_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAccAWSDmsReplicationInstance_Basic(t *testing.T) {
+	// NOTE: Using larger dms.c4.large here for AWS GovCloud (US) support
+	replicationInstanceClass := "dms.c4.large"
 	resourceName := "aws_dms_replication_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -23,10 +25,10 @@ func TestAccAWSDmsReplicationInstance_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, "dms.t2.micro"),
+				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, replicationInstanceClass),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "50"),
+					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "100"),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "kms_key_arn"),
@@ -36,7 +38,7 @@ func TestAccAWSDmsReplicationInstance_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replication_instance_private_ips.#", "1"),
 					// ARN resource is its own unique identifier
 					resource.TestCheckResourceAttrSet(resourceName, "replication_instance_arn"),
-					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", "dms.t2.micro"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", replicationInstanceClass),
 					resource.TestCheckResourceAttr(resourceName, "replication_instance_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
@@ -329,6 +331,9 @@ func TestAccAWSDmsReplicationInstance_PubliclyAccessible(t *testing.T) {
 }
 
 func TestAccAWSDmsReplicationInstance_ReplicationInstanceClass(t *testing.T) {
+	// NOTE: Using larger dms.c4.(x)?large here for AWS GovCloud (US) support
+	replicationInstanceClass1 := "dms.c4.large"
+	replicationInstanceClass2 := "dms.c4.xlarge"
 	resourceName := "aws_dms_replication_instance.test"
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 
@@ -338,10 +343,10 @@ func TestAccAWSDmsReplicationInstance_ReplicationInstanceClass(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDmsReplicationInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, "dms.t2.micro"),
+				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, replicationInstanceClass1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", "dms.t2.micro"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", replicationInstanceClass1),
 				),
 			},
 			{
@@ -351,10 +356,10 @@ func TestAccAWSDmsReplicationInstance_ReplicationInstanceClass(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"apply_immediately"},
 			},
 			{
-				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, "dms.t2.small"),
+				Config: testAccAWSDmsReplicationInstanceConfig_ReplicationInstanceClass(rName, replicationInstanceClass2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDmsReplicationInstanceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", "dms.t2.small"),
+					resource.TestCheckResourceAttr(resourceName, "replication_instance_class", replicationInstanceClass2),
 				),
 			},
 		},
@@ -535,7 +540,8 @@ func testAccAWSDmsReplicationInstanceEngineVersionsPreCheck(t *testing.T) []stri
 	// parameter to the describe API call.
 	var orderableReplicationInstances []*dms.OrderableReplicationInstance
 	input := &dms.DescribeOrderableReplicationInstancesInput{}
-	replicationInstanceClass := "dms.t2.micro"
+	// NOTE: Using larger dms.c4.large here for AWS GovCloud (US) support
+	replicationInstanceClass := "dms.c4.large"
 
 	err := conn.DescribeOrderableReplicationInstancesPages(input, func(output *dms.DescribeOrderableReplicationInstancesOutput, lastPage bool) bool {
 		for _, orderableReplicationInstance := range output.OrderableReplicationInstances {
@@ -588,10 +594,12 @@ func testAccAWSDmsReplicationInstanceEngineVersionsPreCheck(t *testing.T) []stri
 
 func testAccAWSDmsReplicationInstanceConfig_AllocatedStorage(rName string, allocatedStorage int) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
   allocated_storage          = %d
   apply_immediately          = true
-  replication_instance_class = "dms.t2.micro"
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id    = %q
 }
 `, allocatedStorage, rName)
@@ -599,10 +607,12 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_AutoMinorVersionUpgrade(rName string, autoMinorVersionUpgrade bool) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
   apply_immediately          = true
   auto_minor_version_upgrade = %t
-  replication_instance_class = "dms.t2.micro"
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id    = %q
 }
 `, autoMinorVersionUpgrade, rName)
@@ -612,10 +622,12 @@ func testAccAWSDmsReplicationInstanceConfig_AvailabilityZone(rName string) strin
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
   apply_immediately          = true
   availability_zone          = "${data.aws_availability_zones.available.names[0]}"
-  replication_instance_class = "dms.t2.micro"
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id    = %q
 }
 `, rName)
@@ -623,10 +635,12 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_EngineVersion(rName, engineVersion string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
   apply_immediately          = true
   engine_version             = %q
-  replication_instance_class = "dms.t2.micro"
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id    = %q
 }
 `, engineVersion, rName)
@@ -634,6 +648,8 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_KmsKeyArn(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
 }
@@ -641,7 +657,7 @@ resource "aws_kms_key" "test" {
 resource "aws_dms_replication_instance" "test" {
   apply_immediately          = true
   kms_key_arn                = "${aws_kms_key.test.arn}"
-  replication_instance_class = "dms.t2.micro"
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id    = %q
 }
 `, rName)
@@ -649,10 +665,12 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_MultiAz(rName string, multiAz bool) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
   apply_immediately          = true
   multi_az                   = %t
-  replication_instance_class = "dms.t2.micro"
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id    = %q
 }
 `, multiAz, rName)
@@ -660,10 +678,12 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_PreferredMaintenanceWindow(rName, preferredMaintenanceWindow string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
   apply_immediately            = true
   preferred_maintenance_window = %q
-  replication_instance_class   = "dms.t2.micro"
+  replication_instance_class   = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id      = %q
 }
 `, preferredMaintenanceWindow, rName)
@@ -671,10 +691,12 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_PubliclyAccessible(rName string, publiclyAccessible bool) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
   apply_immediately          = true
   publicly_accessible        = %t
-  replication_instance_class = "dms.t2.micro"
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id    = %q
 }
 `, publiclyAccessible, rName)
@@ -693,6 +715,8 @@ resource "aws_dms_replication_instance" "test" {
 func testAccAWSDmsReplicationInstanceConfig_ReplicationSubnetGroupId(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
+
+data "aws_partition" "current" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -722,7 +746,7 @@ resource "aws_dms_replication_subnet_group" "test" {
 
 resource "aws_dms_replication_instance" "test" {
   apply_immediately           = true
-  replication_instance_class  = "dms.t2.micro"
+  replication_instance_class  = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id     = %q
   replication_subnet_group_id = "${aws_dms_replication_subnet_group.test.replication_subnet_group_id}"
 }
@@ -731,10 +755,12 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_Tags_One(rName, key1, value1 string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
-  apply_immediately            = true
-  replication_instance_class   = "dms.t2.micro"
-  replication_instance_id      = %q
+  apply_immediately          = true
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
+  replication_instance_id    = %q
 
   tags = {
     %q = %q
@@ -745,10 +771,12 @@ resource "aws_dms_replication_instance" "test" {
 
 func testAccAWSDmsReplicationInstanceConfig_Tags_Two(rName, key1, value1, key2, value2 string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_dms_replication_instance" "test" {
-  apply_immediately            = true
-  replication_instance_class   = "dms.t2.micro"
-  replication_instance_id      = %q
+  apply_immediately          = true
+  replication_instance_class = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
+  replication_instance_id    = %q
 
   tags = {
     %q = %q
@@ -761,6 +789,8 @@ resource "aws_dms_replication_instance" "test" {
 func testAccAWSDmsReplicationInstanceConfig_VpcSecurityGroupIds(rName string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
+
+data "aws_partition" "current" {}
 
 resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
@@ -795,7 +825,7 @@ resource "aws_dms_replication_subnet_group" "test" {
 
 resource "aws_dms_replication_instance" "test" {
   apply_immediately           = true
-  replication_instance_class  = "dms.t2.micro"
+  replication_instance_class  = "${data.aws_partition.current.partition == "aws" ? "dms.t2.micro" : "dms.c4.large"}"
   replication_instance_id     = %q
   replication_subnet_group_id = "${aws_dms_replication_subnet_group.test.replication_subnet_group_id}"
   vpc_security_group_ids      = ["${aws_security_group.test.id}"]


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

The DMS service in AWS GovCloud (US) does not currently support T2 instance class. We will still try to save money where possible though.

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDmsReplicationInstance_AllocatedStorage (1034.86s)
--- PASS: TestAccAWSDmsReplicationInstance_AutoMinorVersionUpgrade (507.90s)
--- PASS: TestAccAWSDmsReplicationInstance_AvailabilityZone (473.39s)
--- PASS: TestAccAWSDmsReplicationInstance_Basic (366.60s)
--- PASS: TestAccAWSDmsReplicationInstance_EngineVersion (970.96s)
--- PASS: TestAccAWSDmsReplicationInstance_KmsKeyArn (489.68s)
--- PASS: TestAccAWSDmsReplicationInstance_MultiAz (1940.95s)
--- PASS: TestAccAWSDmsReplicationInstance_PreferredMaintenanceWindow (535.95s)
--- PASS: TestAccAWSDmsReplicationInstance_PubliclyAccessible (472.09s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationInstanceClass (556.70s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId (440.81s)
--- PASS: TestAccAWSDmsReplicationInstance_Tags (479.24s)
--- PASS: TestAccAWSDmsReplicationInstance_VpcSecurityGroupIds (467.40s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSDmsReplicationInstance_AllocatedStorage (926.88s)
--- PASS: TestAccAWSDmsReplicationInstance_AutoMinorVersionUpgrade (403.52s)
--- PASS: TestAccAWSDmsReplicationInstance_AvailabilityZone (331.15s)
--- PASS: TestAccAWSDmsReplicationInstance_Basic (265.48s)
--- PASS: TestAccAWSDmsReplicationInstance_EngineVersion (753.28s)
--- PASS: TestAccAWSDmsReplicationInstance_KmsKeyArn (357.70s)
--- PASS: TestAccAWSDmsReplicationInstance_MultiAz (1718.37s)
--- PASS: TestAccAWSDmsReplicationInstance_PreferredMaintenanceWindow (313.07s)
--- PASS: TestAccAWSDmsReplicationInstance_PubliclyAccessible (256.04s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationInstanceClass (537.72s)
--- PASS: TestAccAWSDmsReplicationInstance_ReplicationSubnetGroupId (278.96s)
--- PASS: TestAccAWSDmsReplicationInstance_Tags (321.97s)
--- PASS: TestAccAWSDmsReplicationInstance_VpcSecurityGroupIds (280.15s)
```
