### PR TITLE
tests/resource/aws_dynamodb_global_table: Add PreCheck for Global Table functionality

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -343,6 +343,9 @@ func testAccPreCheckSkipError(err error) bool {
 		return true
 	}
 	// Ignore unsupported API calls
+	if isAWSErr(err, "UnknownOperationException", "") {
+		return true
+	}
 	if isAWSErr(err, "UnsupportedOperation", "") {
 		return true
 	}

--- a/aws/resource_aws_dynamodb_global_table_test.go
+++ b/aws/resource_aws_dynamodb_global_table_test.go
@@ -17,7 +17,7 @@ func TestAccAWSDynamoDbGlobalTable_basic(t *testing.T) {
 	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDynamodbGlobalTable(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDynamoDbGlobalTableDestroy,
 		Steps: []resource.TestStep{
@@ -52,7 +52,7 @@ func TestAccAWSDynamoDbGlobalTable_multipleRegions(t *testing.T) {
 	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDynamodbGlobalTable(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsDynamoDbGlobalTableDestroy,
 		Steps: []resource.TestStep{
@@ -94,7 +94,7 @@ func TestAccAWSDynamoDbGlobalTable_import(t *testing.T) {
 	tableName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSDynamodbGlobalTable(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSesTemplateDestroy,
 		Steps: []resource.TestStep{
@@ -145,6 +145,22 @@ func testAccCheckAwsDynamoDbGlobalTableExists(name string) resource.TestCheckFun
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSDynamodbGlobalTable(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).dynamodbconn
+
+	input := &dynamodb.ListGlobalTablesInput{}
+
+	_, err := conn.ListGlobalTables(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSDynamoDbGlobalTable_import (2.01s)
    resource_aws_dynamodb_global_table_test.go:159: skipping acceptance testing: UnknownOperationException: Unknown operation exception
        	status code: 400, request id: MTC4HMIO1EEP4IV325E0DG9GAFVV4KQNSO5AEMVJF66Q9ASUAAJG
--- SKIP: TestAccAWSDynamoDbGlobalTable_basic (2.04s)
    resource_aws_dynamodb_global_table_test.go:159: skipping acceptance testing: UnknownOperationException: Unknown operation exception
        	status code: 400, request id: QQRG60MLBU42K7JMCD2QF7K82BVV4KQNSO5AEMVJF66Q9ASUAAJG
--- SKIP: TestAccAWSDynamoDbGlobalTable_multipleRegions (2.18s)
    resource_aws_dynamodb_global_table_test.go:159: skipping acceptance testing: UnknownOperationException: Unknown operation exception
        	status code: 400, request id: JSK4I2V93LQSFCV0OHGO8JMTORVV4KQNSO5AEMVJF66Q9ASUAAJG
```

