### PR TITLE
docs/resource/aws_dynamodb_table: Remove unsupported Terraform 0.11 syntax workaround

### DIFF
--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -63,21 +63,6 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 }
 ```
 
-Notes: `attribute` can be lists
-
-```
-  attribute = [{
-    name = "UserId"
-    type = "S"
-  }, {
-    name = "GameTitle"
-    type = "S"
-  }, {
-    name = "TopScore"
-    type = "N"
-  }]
-```
-
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

While the Terraform 0.11 workaround of using a list of maps as an argument to a configuration block attribute did work in certain contexts, its support was unintentional from a configuration language perspective and the argument syntax is explicitly not allowed in Terraform 0.12.

The documentation above this removal shows the proper configuration block syntax for `attribute`.

Closes #8861

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A for this documentation removal
