### PR TITLE
docs/resource/aws_glue_catalog_table: Use Terraform 0.11 and 0.12 compatible syntax

### DIFF
--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -31,8 +31,8 @@ resource "aws_glue_catalog_table" "aws_glue_catalog_table" {
   table_type = "EXTERNAL_TABLE"
 
   parameters = {
-    EXTERNAL            = "TRUE"
-    parquet.compression = "SNAPPY"
+    EXTERNAL              = "TRUE"
+    "parquet.compression" = "SNAPPY"
   }
 
   storage_descriptor {
@@ -45,7 +45,7 @@ resource "aws_glue_catalog_table" "aws_glue_catalog_table" {
       serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
 
       parameters = {
-        serialization.format = 1
+        "serialization.format" = 1
       }
     }
 

--- a/website/docs/r/glue_catalog_table.html.markdown
+++ b/website/docs/r/glue_catalog_table.html.markdown
@@ -44,36 +44,38 @@ resource "aws_glue_catalog_table" "aws_glue_catalog_table" {
       name                  = "my-stream"
       serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
 
-      parameters {
+      parameters = {
         serialization.format = 1
       }
     }
 
-    columns = [
-      {
-        name = "my_string"
-        type = "string"
-      },
-      {
-        name = "my_double"
-        type = "double"
-      },
-      {
-        name    = "my_date"
-        type    = "date"
-        comment = ""
-      },
-      {
-        name    = "my_bigint"
-        type    = "bigint"
-        comment = ""
-      },
-      {
-        name    = "my_struct"
-        type    = "struct<my_nested_string:string>"
-        comment = ""
-      },
-    ]
+    columns {
+      name = "my_string"
+      type = "string"
+    }
+
+    columns {
+      name = "my_double"
+      type = "double"
+    }
+
+    columns {
+      name    = "my_date"
+      type    = "date"
+      comment = ""
+    }
+
+    columns {
+      name    = "my_bigint"
+      type    = "bigint"
+      comment = ""
+    }
+
+    columns {
+      name    = "my_struct"
+      type    = "struct<my_nested_string:string>"
+      comment = ""
+    }
   }
 }
 ```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8877

While the Terraform 0.11 workaround of using a list of maps as an argument to a configuration block attribute did work in certain contexts, its support was unintentional from a configuration language perspective and the argument syntax is explicitly not allowed in Terraform 0.12. This example configuration update is compatible with both Terraform 0.11 and 0.12.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A documentation update
