### PR TITLE
tests/resource/aws_glue_crawler: Ensure IAM configuration is partition agnostic

### DIFF
--- a/aws/resource_aws_glue_crawler_test.go
+++ b/aws/resource_aws_glue_crawler_test.go
@@ -889,6 +889,8 @@ func testAccCheckAWSGlueCrawlerConfiguration(crawler *glue.Crawler, acctestJSON 
 
 func testAccGlueCrawlerConfig_Base(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %q
 
@@ -910,7 +912,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test-AWSGlueServiceRole" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
   role       = "${aws_iam_role.test.name}"
 }
 `, rName)
@@ -1209,6 +1211,8 @@ resource "aws_glue_crawler" "test" {
 
 func testAccGlueCrawlerConfig_Role_ARN_Path(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %q
   path = "/path/"
@@ -1231,7 +1235,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test-AWSGlueServiceRole" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
   role       = "${aws_iam_role.test.name}"
 }
 
@@ -1255,6 +1259,8 @@ resource "aws_glue_crawler" "test" {
 
 func testAccGlueCrawlerConfig_Role_Name_Path(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "test" {
   name = %q
   path = "/path/"
@@ -1277,7 +1283,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test-AWSGlueServiceRole" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
   role       = "${aws_iam_role.test.name}"
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSGlueCrawler_Role_ARN_Path (33.67s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_NoPath (45.34s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (56.58s)
--- PASS: TestAccAWSGlueCrawler_Configuration (56.62s)
--- PASS: TestAccAWSGlueCrawler_Description (60.46s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (66.51s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (69.65s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (73.64s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (74.62s)
--- PASS: TestAccAWSGlueCrawler_Classifiers (75.33s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (77.27s)
--- PASS: TestAccAWSGlueCrawler_Role_Name_Path (77.71s)
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (78.79s)
--- PASS: TestAccAWSGlueCrawler_Schedule (80.12s)
--- PASS: TestAccAWSGlueCrawler_recreates (87.15s)
--- PASS: TestAccAWSGlueCrawler_S3Target (91.97s)
--- PASS: TestAccAWSGlueCrawler_SecurityConfiguration (99.70s)
--- PASS: TestAccAWSGlueCrawler_TablePrefix (132.27s)
PASS
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSGlueCrawler_Role_ARN_NoPath (35.68s)
--- PASS: TestAccAWSGlueCrawler_SecurityConfiguration (47.19s)
--- PASS: TestAccAWSGlueCrawler_Role_Name_Path (47.19s)
--- PASS: TestAccAWSGlueCrawler_Role_ARN_Path (55.03s)
--- PASS: TestAccAWSGlueCrawler_recreates (60.21s)
--- PASS: TestAccAWSGlueCrawler_Description (61.34s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Exclusions (64.85s)
--- PASS: TestAccAWSGlueCrawler_DynamodbTarget (67.98s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Exclusions (72.84s)
--- PASS: TestAccAWSGlueCrawler_Configuration (74.95s)
--- PASS: TestAccAWSGlueCrawler_TablePrefix (77.30s)
--- PASS: TestAccAWSGlueCrawler_Schedule (79.70s)
--- PASS: TestAccAWSGlueCrawler_SchemaChangePolicy (83.72s)
--- PASS: TestAccAWSGlueCrawler_S3Target (88.27s)
--- PASS: TestAccAWSGlueCrawler_Classifiers (90.87s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget (98.84s)
--- PASS: TestAccAWSGlueCrawler_S3Target_Multiple (107.84s)
--- PASS: TestAccAWSGlueCrawler_JdbcTarget_Multiple (116.48s)
PASS
```
