### PR TITLE
Data sources for EBS default encryption

### DIFF
--- a/aws/data_source_aws_ebs_default_kms_key.go
+++ b/aws/data_source_aws_ebs_default_kms_key.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEbsDefaultKmsKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEbsDefaultKmsKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+func dataSourceAwsEbsDefaultKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	res, err := conn.GetEbsDefaultKmsKeyId(&ec2.GetEbsDefaultKmsKeyIdInput{})
+	if err != nil {
+		return fmt.Errorf("Error reading EBS default KMS key: %q", err)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("key_id", *res.KmsKeyId)
+
+	return nil
+}

--- a/aws/data_source_aws_ebs_default_kms_key.go
+++ b/aws/data_source_aws_ebs_default_kms_key.go
@@ -13,7 +13,7 @@ func dataSourceAwsEbsDefaultKmsKey() *schema.Resource {
 		Read: dataSourceAwsEbsDefaultKmsKeyRead,
 
 		Schema: map[string]*schema.Schema{
-			"key_id": {
+			"key_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -29,7 +29,7 @@ func dataSourceAwsEbsDefaultKmsKeyRead(d *schema.ResourceData, meta interface{})
 	}
 
 	d.SetId(time.Now().UTC().String())
-	d.Set("key_id", *res.KmsKeyId)
+	d.Set("key_arn", res.KmsKeyId)
 
 	return nil
 }

--- a/aws/data_source_aws_ebs_default_kms_key_test.go
+++ b/aws/data_source_aws_ebs_default_kms_key_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsEBSDefaultKmsKey_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsEBSDefaultKmsKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceAwsEBSDefaultKmsKey("data.aws_ebs_default_kms_key.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDataSourceAwsEBSDefaultKmsKey(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		actual, err := conn.GetEbsDefaultKmsKeyId(&ec2.GetEbsDefaultKmsKeyIdInput{})
+		if err != nil {
+			return fmt.Errorf("Error reading EBS default KMS key: %q", err)
+		}
+
+		attr := rs.Primary.Attributes["key_id"]
+
+		if attr != *actual.KmsKeyId {
+			return fmt.Errorf("EBS default KMS key is not the expected value (%v)", actual.KmsKeyId)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsEBSDefaultKmsKeyConfig = `
+data "aws_ebs_default_kms_key" "current" { }
+`

--- a/aws/data_source_aws_ebs_default_kms_key_test.go
+++ b/aws/data_source_aws_ebs_default_kms_key_test.go
@@ -42,7 +42,7 @@ func testAccCheckDataSourceAwsEBSDefaultKmsKey(n string) resource.TestCheckFunc 
 			return fmt.Errorf("Error reading EBS default KMS key: %q", err)
 		}
 
-		attr := rs.Primary.Attributes["key_id"]
+		attr := rs.Primary.Attributes["key_arn"]
 
 		if attr != *actual.KmsKeyId {
 			return fmt.Errorf("EBS default KMS key is not the expected value (%v)", actual.KmsKeyId)

--- a/aws/data_source_aws_ebs_encryption_by_default.go
+++ b/aws/data_source_aws_ebs_encryption_by_default.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEbsEncryptionByDefault() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEbsEncryptionByDefaultRead,
+
+		Schema: map[string]*schema.Schema{
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+func dataSourceAwsEbsEncryptionByDefaultRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	res, err := conn.GetEbsEncryptionByDefault(&ec2.GetEbsEncryptionByDefaultInput{})
+	if err != nil {
+		return fmt.Errorf("Error reading default EBS encryption toggle: %q", err)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("enabled", res.EbsEncryptionByDefault)
+
+	return nil
+}

--- a/aws/data_source_aws_ebs_encryption_by_default_test.go
+++ b/aws/data_source_aws_ebs_encryption_by_default_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"strconv"
+	"testing"
+)
+
+func TestAccDataSourceAwsEBSEncryptionByDefault_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsEBSEncryptionByDefaultConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceAwsEBSEncryptionByDefault("data.aws_ebs_encryption_by_default.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDataSourceAwsEBSEncryptionByDefault(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		actual, err := conn.GetEbsEncryptionByDefault(&ec2.GetEbsEncryptionByDefaultInput{})
+		if err != nil {
+			return fmt.Errorf("Error reading default EBS encryption toggle: %q", err)
+		}
+
+		attr, _ := strconv.ParseBool(rs.Primary.Attributes["enabled"])
+
+		if attr != *actual.EbsEncryptionByDefault {
+			return fmt.Errorf("EBS encryption by default is not in expected state (%t)", *actual.EbsEncryptionByDefault)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsEBSEncryptionByDefaultConfig = `
+data "aws_ebs_encryption_by_default" "current" { }
+`

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -173,6 +173,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_db_snapshot":                               dataSourceAwsDbSnapshot(),
 			"aws_dx_gateway":                                dataSourceAwsDxGateway(),
 			"aws_dynamodb_table":                            dataSourceAwsDynamoDbTable(),
+			"aws_ebs_encryption_by_default":                 dataSourceAwsEbsEncryptionByDefault(),
 			"aws_ebs_snapshot":                              dataSourceAwsEbsSnapshot(),
 			"aws_ebs_snapshot_ids":                          dataSourceAwsEbsSnapshotIds(),
 			"aws_ebs_volume":                                dataSourceAwsEbsVolume(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -173,6 +173,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_db_snapshot":                               dataSourceAwsDbSnapshot(),
 			"aws_dx_gateway":                                dataSourceAwsDxGateway(),
 			"aws_dynamodb_table":                            dataSourceAwsDynamoDbTable(),
+			"aws_ebs_default_kms_key":                       dataSourceAwsEbsDefaultKmsKey(),
 			"aws_ebs_encryption_by_default":                 dataSourceAwsEbsEncryptionByDefault(),
 			"aws_ebs_snapshot":                              dataSourceAwsEbsSnapshot(),
 			"aws_ebs_snapshot_ids":                          dataSourceAwsEbsSnapshotIds(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -145,6 +145,12 @@
                           <a href="/docs/providers/aws/d/dynamodb_table.html">aws_dynamodb_table</a>
                         </li>
                         <li>
+                          <a href="/docs/providers/aws/d/ebs_default_kms_key.html">aws_ebs_default_kms_key</a>
+                        </li>
+                        <li>
+                          <a href="/docs/providers/aws/d/ebs_encryption_by_default.html">aws_ebs_encryption_by_default</a>
+                        </li>
+                        <li>
                           <a href="/docs/providers/aws/d/ebs_snapshot.html">aws_ebs_snapshot</a>
                         </li>
                         <li>

--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ebs_default_kms_key"
+sidebar_current: "docs-aws-ebs-default-kms-key"
+description: |-
+  Provides metadata about the KMS key set for EBS default encryption
+---
+
+# Data Source: aws_ebs_default_kms_key
+Use this data source to get the default EBS encryption KMS key in the current region.
+
+## Example Usage
+```hcl
+data "aws_ebs_default_kms_key" "current" { }
+
+resource "aws_ebs_volume" "example" {
+  availability_zone = "us-west-2a"
+  
+  encrypted         = true
+  kms_key_id        = "${data.aws_ebs_default_kms_key.current.key_id}"
+
+}
+```
+
+## Attributes Reference
+The following attributes are exported:
+* `key_id` - The full ARN of the default KMS key that your account uses to encrypt an EBS volume when no key is specified in an API call that creates the volume.

--- a/website/docs/d/ebs_default_kms_key.html.markdown
+++ b/website/docs/d/ebs_default_kms_key.html.markdown
@@ -24,4 +24,4 @@ resource "aws_ebs_volume" "example" {
 
 ## Attributes Reference
 The following attributes are exported:
-* `key_id` - The full ARN of the default KMS key that your account uses to encrypt an EBS volume when no key is specified in an API call that creates the volume.
+* `key_arn` - Amazon Resource Name (ARN) of the default KMS key uses to encrypt an EBS volume in this region when no key is specified in an API call that creates the volume and encryption by default is enabled.

--- a/website/docs/d/ebs_encryption_by_default.html.markdown
+++ b/website/docs/d/ebs_encryption_by_default.html.markdown
@@ -1,0 +1,23 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ebs_encryption_by_default"
+sidebar_current: "docs-aws-ebs-encryption-by-default"
+description: |-
+  Checks whether default EBS encryption is enabled for your AWS account in the current AWS region.
+---
+
+# Data Source: aws_ebs_encryption_by_default
+
+Provides a way to check whether default EBS encryption is enabled for your AWS account in the current AWS region.
+
+## Example Usage
+
+```hcl
+data "aws_ebs_encryption_by_default" "current" { }
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `enabled` - Whether or not default EBS encryption is enabled. Returns as `true` or `false`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8772

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:

* New Data Source: `aws_ebs_encryption_by_default`
* New Data Source: `aws_ebs_default_kms_key`
```

Output from acceptance testing:

```
$  make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsEBSEncryptionByDefault_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsEBSEncryptionByDefault_ -timeout 120m
=== RUN   TestAccDataSourceAwsEBSEncryptionByDefault_basic
=== PAUSE TestAccDataSourceAwsEBSEncryptionByDefault_basic
=== CONT  TestAccDataSourceAwsEBSEncryptionByDefault_basic
--- PASS: TestAccDataSourceAwsEBSEncryptionByDefault_basic (10.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.084s

$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsEBSDefaultKmsKey_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsEBSDefaultKmsKey_ -timeout 120m
=== RUN   TestAccDataSourceAwsEBSDefaultKmsKey_basic
=== PAUSE TestAccDataSourceAwsEBSDefaultKmsKey_basic
=== CONT  TestAccDataSourceAwsEBSDefaultKmsKey_basic
--- PASS: TestAccDataSourceAwsEBSDefaultKmsKey_basic (10.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	10.655s
...
```


Also related to #8760