### PR TITLE
tests/resource/aws_kinesis_firehose_delivery_stream: Ensure configuration is partition agnostic and fix ExpectError checks

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -188,7 +188,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource(t *testing.T)
 	var stream firehose.DeliveryStreamDescription
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccKinesisFirehoseDeliveryStreamConfig_s3KinesisStreamSource,
-		ri, ri, ri, ri, ri, ri, ri, ri)
+		ri, ri, ri, ri, ri, ri, ri)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -621,7 +621,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType(t *t
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile("must be 'Lambda'"),
+				ExpectError: regexp.MustCompile("(must be 'Lambda'|Member must satisfy enum value set)"),
 			},
 		},
 	})
@@ -645,7 +645,7 @@ func TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName(t *t
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile("must be one of 'LambdaArn', 'NumberOfRetries'"),
+				ExpectError: regexp.MustCompile("(must be one of 'LambdaArn', 'NumberOfRetries'|Member must satisfy enum value set)"),
 			},
 		},
 	})
@@ -1148,7 +1148,7 @@ resource "aws_iam_role_policy" "iam_policy_for_lambda" {
 			"logs:CreateLogStream",
 			"logs:PutLogEvents"
 		],
-		"Resource": "arn:aws:logs:*:*:*"
+		"Resource": "arn:${data.aws_partition.current.partition}:logs:*:*:*"
 	},
     {
       "Effect": "Allow",
@@ -1201,6 +1201,8 @@ resource "aws_lambda_function" "lambda_function_test" {
 const testAccKinesisFirehoseDeliveryStreamBaseConfig = `
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "firehose" {
   name = "tf_acctest_firehose_delivery_role_%d"
   assume_role_policy = <<EOF
@@ -1249,8 +1251,8 @@ resource "aws_iam_role_policy" "firehose" {
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*"
+        "${aws_s3_bucket.bucket.arn}",
+        "${aws_s3_bucket.bucket.arn}/*"
       ]
     },
     {
@@ -1316,7 +1318,7 @@ resource "aws_iam_role_policy" "kinesis_source" {
         "kinesis:GetRecords"
       ],
       "Resource": [
-        "arn:aws:kinesis:*:*:stream/terraform-kinesis-source-stream-basictest-%d"
+        "${aws_kinesis_stream.source.arn}"
       ]
     }
   ]
@@ -1329,6 +1331,8 @@ EOF
 func testAccKinesisFirehoseDeliveryStreamConfig_s3WithCloudwatchLogging(rInt int) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
 
 resource "aws_iam_role" "firehose" {
   name = "tf_acctest_firehose_delivery_role_%d"
@@ -1375,8 +1379,8 @@ resource "aws_iam_role_policy" "firehose" {
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*"
+        "${aws_s3_bucket.bucket.arn}",
+        "${aws_s3_bucket.bucket.arn}/*"
       ]
     },
     {
@@ -1385,7 +1389,7 @@ resource "aws_iam_role_policy" "firehose" {
         "logs:putLogEvents"
       ],
       "Resource": [
-        "arn:aws:logs::log-group:/aws/kinesisfirehose/*"
+        "arn:${data.aws_partition.current.partition}:logs::log-group:/aws/kinesisfirehose/*"
       ]
     }
   ]
@@ -2045,8 +2049,14 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 var testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
 resource "aws_elasticsearch_domain" "test_cluster" {
   domain_name = "es-test-%d"
+
   cluster_config {
-    instance_type = "m3.medium.elasticsearch"
+    instance_type = "m4.large.elasticsearch"
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
   }
 }
 
@@ -2122,6 +2132,8 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream_es" {
 
 func testAccKinesisFirehoseDeliveryStreamConfig_missingProcessingConfiguration(rInt int) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
 resource "aws_iam_role" "firehose" {
   name = "tf_acctest_firehose_delivery_role_%d"
 
@@ -2162,8 +2174,8 @@ resource "aws_iam_role_policy" "firehose" {
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
-        "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*"
+        "${aws_s3_bucket.bucket.arn}",
+        "${aws_s3_bucket.bucket.arn}/*"
       ]
     },
     {
@@ -2172,7 +2184,7 @@ resource "aws_iam_role_policy" "firehose" {
         "logs:putLogEvents"
       ],
       "Resource": [
-        "arn:aws:logs::log-group:/aws/kinesisfirehose/*"
+        "arn:${data.aws_partition.current.partition}:logs::log-group:/aws/kinesisfirehose/*"
       ]
     }
   ]


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (653.45s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (215.70s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (189.37s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (182.29s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (165.26s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (154.40s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (143.67s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (191.00s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (156.16s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (209.33s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (38.37s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (38.40s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (241.14s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (207.75s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (157.08s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (198.34s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (724.35s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (184.91s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (244.73s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (287.46s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (128.86s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (159.12s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (203.12s)
```

Output from acceptance testing in AWS GovCloud (US) (the failures will require a non-trivial `PreCheck` function):

```
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates (839.83s)
--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Deserializer_Update (25.71s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Firehose record format conversion is not available in the current region.

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Enabled (27.14s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Firehose record format conversion is not available in the current region.

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_HiveJsonSerDe_Empty (26.12s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Firehose record format conversion is not available in the current region.

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OpenXJsonSerDe_Empty (23.92s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Firehose record format conversion is not available in the current region.

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_OrcSerDe_Empty (23.87s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Firehose record format conversion is not available in the current region.

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_ParquetSerDe_Empty (23.21s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Firehose record format conversion is not available in the current region.

--- FAIL: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_DataFormatConversionConfiguration_Serializer_Update (25.91s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Kinesis Firehose Delivery Stream: InvalidArgumentException: Firehose record format conversion is not available in the current region.

--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3_ErrorOutputPrefix (121.55s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3basic (129.95s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidParameterName (36.08s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3InvalidProcessorType (34.17s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3KmsKeyArn (150.64s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_ExtendedS3Updates (144.37s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_importBasic (129.66s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_missingProcessingConfiguration (99.24s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates (565.82s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basic (115.40s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3basicWithTags (163.68s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3ConfigUpdates (203.74s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3KinesisStreamSource (130.98s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging (111.15s)
--- PASS: TestAccAWSKinesisFirehoseDeliveryStream_SplunkConfigUpdates (150.08s)
```
