### PR TITLE
Fixes for more resource.Retry calls

### DIFF
--- a/aws/resource_aws_appautoscaling_target.go
+++ b/aws/resource_aws_appautoscaling_target.go
@@ -87,6 +87,10 @@ func resourceAwsAppautoscalingTargetPut(d *schema.ResourceData, meta interface{}
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.RegisterScalableTarget(&targetOpts)
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error creating application autoscaling target: %s", err)
 	}

--- a/aws/resource_aws_dx_connection_association.go
+++ b/aws/resource_aws_dx_connection_association.go
@@ -81,7 +81,7 @@ func resourceAwsDxConnectionAssociationDelete(d *schema.ResourceData, meta inter
 		LagId:        aws.String(d.Get("lag_id").(string)),
 	}
 
-	return resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		_, err := conn.DisassociateConnectionFromLag(input)
 		if err != nil {
 			if isAWSErr(err, directconnect.ErrCodeClientException, "is in a transitioning state.") {
@@ -91,4 +91,10 @@ func resourceAwsDxConnectionAssociationDelete(d *schema.ResourceData, meta inter
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DisassociateConnectionFromLag(input)
+	}
+
+	return err
 }

--- a/aws/resource_aws_elasticache_cluster.go
+++ b/aws/resource_aws_elasticache_cluster.go
@@ -801,6 +801,10 @@ func deleteElasticacheCacheCluster(conn *elasticache.ElastiCache, cacheClusterID
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteCacheCluster(input)
+	}
+
 	return err
 }
 

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -370,7 +370,7 @@ func TestAccAWSElasticacheCluster_vpc(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
 					testAccCheckAWSElasticacheClusterAttributes(&ec),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_cluster.bar", "availability_zone", "us-east-1a"),
+						"aws_elasticache_cluster.bar", "availability_zone", "us-west-2a"),
 				),
 			},
 		},
@@ -1105,7 +1105,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
-    availability_zone = "us-east-1a"
+    availability_zone = "us-west-2a"
   tags = {
         Name = "tf-acc-elasticache-cluster-in-vpc"
     }
@@ -1143,7 +1143,7 @@ resource "aws_elasticache_cluster" "bar" {
     security_group_ids = ["${aws_security_group.bar.id}"]
     parameter_group_name = "default.redis2.8"
     notification_topic_arn      = "${aws_sns_topic.topic_example.arn}"
-    availability_zone = "us-east-1a"
+    availability_zone = "us-west-2a"
 }
 
 resource "aws_sns_topic" "topic_example" {
@@ -1162,7 +1162,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
-    availability_zone = "us-east-1a"
+    availability_zone = "us-west-2a"
   tags = {
         Name = "tf-acc-elasticache-cluster-multi-az-in-vpc-foo"
     }
@@ -1208,8 +1208,8 @@ resource "aws_elasticache_cluster" "bar" {
     security_group_ids = ["${aws_security_group.bar.id}"]
     az_mode = "cross-az"
     preferred_availability_zones = [
-        "us-east-1a",
-        "us-east-1c"
+        "us-west-2a",
+        "us-west-2b"
     ]
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))

--- a/aws/resource_aws_elasticache_cluster_test.go
+++ b/aws/resource_aws_elasticache_cluster_test.go
@@ -370,7 +370,7 @@ func TestAccAWSElasticacheCluster_vpc(t *testing.T) {
 					testAccCheckAWSElasticacheClusterExists("aws_elasticache_cluster.bar", &ec),
 					testAccCheckAWSElasticacheClusterAttributes(&ec),
 					resource.TestCheckResourceAttr(
-						"aws_elasticache_cluster.bar", "availability_zone", "us-west-2a"),
+						"aws_elasticache_cluster.bar", "availability_zone", "us-east-1a"),
 				),
 			},
 		},
@@ -1105,7 +1105,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
-    availability_zone = "us-west-2a"
+    availability_zone = "us-east-1a"
   tags = {
         Name = "tf-acc-elasticache-cluster-in-vpc"
     }
@@ -1143,7 +1143,7 @@ resource "aws_elasticache_cluster" "bar" {
     security_group_ids = ["${aws_security_group.bar.id}"]
     parameter_group_name = "default.redis2.8"
     notification_topic_arn      = "${aws_sns_topic.topic_example.arn}"
-    availability_zone = "us-west-2a"
+    availability_zone = "us-east-1a"
 }
 
 resource "aws_sns_topic" "topic_example" {
@@ -1162,7 +1162,7 @@ resource "aws_vpc" "foo" {
 resource "aws_subnet" "foo" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.0.0/20"
-    availability_zone = "us-west-2a"
+    availability_zone = "us-east-1a"
   tags = {
         Name = "tf-acc-elasticache-cluster-multi-az-in-vpc-foo"
     }
@@ -1171,7 +1171,7 @@ resource "aws_subnet" "foo" {
 resource "aws_subnet" "bar" {
     vpc_id = "${aws_vpc.foo.id}"
     cidr_block = "192.168.16.0/20"
-    availability_zone = "us-west-2b"
+    availability_zone = "us-east-1c"
   tags = {
         Name = "tf-acc-elasticache-cluster-multi-az-in-vpc-bar"
     }
@@ -1208,8 +1208,8 @@ resource "aws_elasticache_cluster" "bar" {
     security_group_ids = ["${aws_security_group.bar.id}"]
     az_mode = "cross-az"
     preferred_availability_zones = [
-        "us-west-2a",
-        "us-west-2b"
+        "us-east-1a",
+        "us-east-1c"
     ]
 }
 `, acctest.RandInt(), acctest.RandInt(), acctest.RandString(10))

--- a/aws/resource_aws_iam_server_certificate.go
+++ b/aws/resource_aws_iam_server_certificate.go
@@ -183,6 +183,12 @@ func resourceAwsIAMServerCertificateDelete(d *schema.ResourceData, meta interfac
 		return nil
 	})
 
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteServerCertificate(&iam.DeleteServerCertificateInput{
+			ServerCertificateName: aws.String(d.Get("name").(string)),
+		})
+	}
+
 	return err
 }
 

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -250,7 +250,12 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 		})
 
 		if isResourceTimeoutError(err) {
-			_, err = findSubscriptionByNonID(d, snsconn)
+			var subscription *sns.Subscription
+			subscription, err = findSubscriptionByNonID(d, snsconn)
+			
+			if subscription != nil {
+				output.SubscriptionArn = subscription.SubscriptionArn
+			}
 		}
 
 		if err != nil {

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -252,7 +252,7 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 		if isResourceTimeoutError(err) {
 			var subscription *sns.Subscription
 			subscription, err = findSubscriptionByNonID(d, snsconn)
-			
+
 			if subscription != nil {
 				output.SubscriptionArn = subscription.SubscriptionArn
 			}

--- a/aws/resource_aws_sns_topic_subscription.go
+++ b/aws/resource_aws_sns_topic_subscription.go
@@ -249,6 +249,10 @@ func subscribeToSNSTopic(d *schema.ResourceData, snsconn *sns.SNS) (output *sns.
 				fmt.Errorf("Endpoint (%s) did not autoconfirm the subscription for topic %s", endpoint, topic_arn))
 		})
 
+		if isResourceTimeoutError(err) {
+			_, err = findSubscriptionByNonID(d, snsconn)
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/aws/resource_aws_sns_topic_subscription_test.go
+++ b/aws/resource_aws_sns_topic_subscription_test.go
@@ -759,7 +759,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = "tf-acc-test-authorizer-%d"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
   handler          = "main.authenticate"
-  runtime          = "nodejs6.10"
+  runtime          = "nodejs8.10"
 
   environment {
     variables = {

--- a/aws/resource_aws_ssm_activation.go
+++ b/aws/resource_aws_ssm_activation.go
@@ -109,6 +109,10 @@ func resourceAwsSsmActivationCreate(d *schema.ResourceData, meta interface{}) er
 		return resource.NonRetryableError(err)
 	})
 
+	if isResourceTimeoutError(err) {
+		resp, err = ssmconn.CreateActivation(activationInput)
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error creating SSM activation: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

BUG FIXES:
* resource/aws_api_gateway_resource - Final retry for deleting api gateway resource 
* resource/aws_appautoscaling_target - Final retry for registering autoscaling target 
* resource/aws_dx_connection_association - Final retry for deleting dx connection association 
* resource/aws_elasticache_cluster - Final retry when deleting elasticache cluster
* resource/aws_iam_server_certificate - Final retry for deleting IAM server cert 
* resource/aws_sns_topic_subscription - Final retry for SNS topic subscription
* resource/aws_ssm_activation - Final retry for creating SSM activation 
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSAPIGatewayResource"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayResource -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayResource_basic
=== PAUSE TestAccAWSAPIGatewayResource_basic
=== RUN   TestAccAWSAPIGatewayResource_update
=== PAUSE TestAccAWSAPIGatewayResource_update
=== CONT  TestAccAWSAPIGatewayResource_basic
=== CONT  TestAccAWSAPIGatewayResource_update
--- PASS: TestAccAWSAPIGatewayResource_basic (23.81s)
--- PASS: TestAccAWSAPIGatewayResource_update (67.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws


make testacc TESTARGS="-run=TestAccAWSAppautoScalingTarget"   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAppautoScalingTarget -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAppautoScalingTarget_basic
=== PAUSE TestAccAWSAppautoScalingTarget_basic
=== RUN   TestAccAWSAppautoScalingTarget_spotFleetRequest
=== PAUSE TestAccAWSAppautoScalingTarget_spotFleetRequest
=== RUN   TestAccAWSAppautoScalingTarget_emrCluster
=== PAUSE TestAccAWSAppautoScalingTarget_emrCluster
=== RUN   TestAccAWSAppautoScalingTarget_multipleTargets
=== PAUSE TestAccAWSAppautoScalingTarget_multipleTargets
=== RUN   TestAccAWSAppautoScalingTarget_optionalRoleArn
=== PAUSE TestAccAWSAppautoScalingTarget_optionalRoleArn
=== CONT  TestAccAWSAppautoScalingTarget_basic
=== CONT  TestAccAWSAppautoScalingTarget_emrCluster
=== CONT  TestAccAWSAppautoScalingTarget_optionalRoleArn
=== CONT  TestAccAWSAppautoScalingTarget_spotFleetRequest
=== CONT  TestAccAWSAppautoScalingTarget_multipleTargets
--- PASS: TestAccAWSAppautoScalingTarget_spotFleetRequest (78.49s)
--- PASS: TestAccAWSAppautoScalingTarget_basic (109.21s)
--- PASS: TestAccAWSAppautoScalingTarget_optionalRoleArn (138.87s)
--- PASS: TestAccAWSAppautoScalingTarget_multipleTargets (139.85s)
--- PASS: TestAccAWSAppautoScalingTarget_emrCluster (540.66s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       541.458s


make testacc TESTARGS="-run=TestAccAWSDxConnectionAssociation"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDxConnectionAssociation -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDxConnectionAssociation_basic
=== PAUSE TestAccAWSDxConnectionAssociation_basic
=== RUN   TestAccAWSDxConnectionAssociation_multiConns
=== PAUSE TestAccAWSDxConnectionAssociation_multiConns
=== CONT  TestAccAWSDxConnectionAssociation_basic
=== CONT  TestAccAWSDxConnectionAssociation_multiConns
--- PASS: TestAccAWSDxConnectionAssociation_basic (43.96s)
--- PASS: TestAccAWSDxConnectionAssociation_multiConns (44.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       44.893s


make testacc TESTARGS="-run=TestAccAWSElasticacheCluster"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSElasticacheCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_ParameterGroupName_Default
=== PAUSE TestAccAWSElasticacheCluster_ParameterGroupName_Default
=== RUN   TestAccAWSElasticacheCluster_Port_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_Port_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_SecurityGroup
=== PAUSE TestAccAWSElasticacheCluster_SecurityGroup
=== RUN   TestAccAWSElasticacheCluster_snapshotsWithUpdates
=== PAUSE TestAccAWSElasticacheCluster_snapshotsWithUpdates
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Decrease
=== PAUSE TestAccAWSElasticacheCluster_NumCacheNodes_Decrease
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Increase
=== PAUSE TestAccAWSElasticacheCluster_NumCacheNodes_Increase
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones
=== PAUSE TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones
=== RUN   TestAccAWSElasticacheCluster_vpc
=== PAUSE TestAccAWSElasticacheCluster_vpc
=== RUN   TestAccAWSElasticacheCluster_multiAZInVpc
=== PAUSE TestAccAWSElasticacheCluster_multiAZInVpc
=== RUN   TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes
=== PAUSE TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic
=== RUN   TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic
=== PAUSE TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_multiAZInVpc
=== CONT  TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes
=== CONT  TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_NumCacheNodes_Decrease
=== CONT  TestAccAWSElasticacheCluster_snapshotsWithUpdates
=== CONT  TestAccAWSElasticacheCluster_SecurityGroup
=== CONT  TestAccAWSElasticacheCluster_Port_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_ParameterGroupName_Default
=== CONT  TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic
=== CONT  TestAccAWSElasticacheCluster_vpc
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_InvalidAttributes (4.80s)
=== CONT  TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Redis_Ec2Classic (7.15s)
=== CONT  TestAccAWSElasticacheCluster_NumCacheNodes_Increase
--- PASS: TestAccAWSElasticacheCluster_AZMode_Redis_Ec2Classic (474.21s)
--- PASS: TestAccAWSElasticacheCluster_AZMode_Memcached_Ec2Classic (478.54s)
--- PASS: TestAccAWSElasticacheCluster_Port_Ec2Classic (566.39s)
--- PASS: TestAccAWSElasticacheCluster_ParameterGroupName_Default (580.98s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Memcached_Ec2Classic (604.96s)
--- PASS: TestAccAWSElasticacheCluster_Engine_Redis_Ec2Classic (629.11s)
--- PASS: TestAccAWSElasticacheCluster_SecurityGroup (632.38s)
--- PASS: TestAccAWSElasticacheCluster_multiAZInVpc (732.85s)
--- PASS: TestAccAWSElasticacheCluster_vpc (874.50s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Decrease (942.26s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Redis_Ec2Classic (959.13s)
--- PASS: TestAccAWSElasticacheCluster_NodeTypeResize_Memcached_Ec2Classic (965.91s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_Increase (1010.64s)
--- PASS: TestAccAWSElasticacheCluster_NumCacheNodes_IncreaseWithPreferredAvailabilityZones (1022.75s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_SingleReplica_Ec2Classic (1152.18s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_MultipleReplica_Ec2Classic (1162.97s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Memcached_Ec2Classic (1186.01s)
--- PASS: TestAccAWSElasticacheCluster_snapshotsWithUpdates (1216.86s)
--- PASS: TestAccAWSElasticacheCluster_ReplicationGroupID_AvailabilityZone_Ec2Classic (1239.93s)
--- PASS: TestAccAWSElasticacheCluster_EngineVersion_Redis_Ec2Classic (1382.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1383.145s


make testacc TESTARGS="-run=TestAccAWSIAMServerCertificate"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMServerCertificate -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMServerCertificate_importBasic
=== PAUSE TestAccAWSIAMServerCertificate_importBasic
=== RUN   TestAccAWSIAMServerCertificate_basic
=== PAUSE TestAccAWSIAMServerCertificate_basic
=== RUN   TestAccAWSIAMServerCertificate_name_prefix
=== PAUSE TestAccAWSIAMServerCertificate_name_prefix
=== RUN   TestAccAWSIAMServerCertificate_disappears
=== PAUSE TestAccAWSIAMServerCertificate_disappears
=== RUN   TestAccAWSIAMServerCertificate_file
=== PAUSE TestAccAWSIAMServerCertificate_file
=== CONT  TestAccAWSIAMServerCertificate_importBasic
=== CONT  TestAccAWSIAMServerCertificate_name_prefix
=== CONT  TestAccAWSIAMServerCertificate_file
=== CONT  TestAccAWSIAMServerCertificate_basic
=== CONT  TestAccAWSIAMServerCertificate_disappears
--- PASS: TestAccAWSIAMServerCertificate_disappears (18.69s)
--- PASS: TestAccAWSIAMServerCertificate_name_prefix (20.62s)
--- PASS: TestAccAWSIAMServerCertificate_basic (21.35s)
--- PASS: TestAccAWSIAMServerCertificate_importBasic (22.55s)
--- PASS: TestAccAWSIAMServerCertificate_file (34.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       35.578s


make testacc TESTARGS="-run=TestAccAWSSNSTopicSubscription"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSNSTopicSubscription -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSNSTopicSubscription_basic
=== PAUSE TestAccAWSSNSTopicSubscription_basic
=== RUN   TestAccAWSSNSTopicSubscription_filterPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_filterPolicy
=== RUN   TestAccAWSSNSTopicSubscription_deliveryPolicy
=== PAUSE TestAccAWSSNSTopicSubscription_deliveryPolicy
=== RUN   TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== PAUSE TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_basic
=== CONT  TestAccAWSSNSTopicSubscription_rawMessageDelivery
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
=== CONT  TestAccAWSSNSTopicSubscription_filterPolicy
=== CONT  TestAccAWSSNSTopicSubscription_deliveryPolicy
--- PASS: TestAccAWSSNSTopicSubscription_basic (24.91s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (52.21s)
--- PASS: TestAccAWSSNSTopicSubscription_rawMessageDelivery (54.41s)
--- PASS: TestAccAWSSNSTopicSubscription_deliveryPolicy (54.87s)
--- PASS: TestAccAWSSNSTopicSubscription_filterPolicy (56.28s)
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingSecuredEndpoint (109.11s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       109.957s


make testacc TESTARGS="-run=TestAccAWSSSMActivation"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSSMActivation -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMActivation_basic
=== PAUSE TestAccAWSSSMActivation_basic
=== RUN   TestAccAWSSSMActivation_update
=== PAUSE TestAccAWSSSMActivation_update
=== RUN   TestAccAWSSSMActivation_expirationDate
=== PAUSE TestAccAWSSSMActivation_expirationDate
=== CONT  TestAccAWSSSMActivation_basic
=== CONT  TestAccAWSSSMActivation_expirationDate
=== CONT  TestAccAWSSSMActivation_update
--- PASS: TestAccAWSSSMActivation_expirationDate (33.91s)
--- PASS: TestAccAWSSSMActivation_basic (34.07s)
--- PASS: TestAccAWSSSMActivation_update (48.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       49.694s


```