### PR TITLE
Add tags attribute support for redshift parameter group

### DIFF
--- a/aws/resource_aws_redshift_cluster.go
+++ b/aws/resource_aws_redshift_cluster.go
@@ -610,7 +610,9 @@ func resourceAwsRedshiftClusterRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("cluster_public_key", rsc.ClusterPublicKey)
 	d.Set("cluster_revision_number", rsc.ClusterRevisionNumber)
-	d.Set("tags", tagsToMapRedshift(rsc.Tags))
+	if err := d.Set("tags", tagsToMapRedshift(rsc.Tags)); err != nil {
+		return fmt.Errorf("Error setting Redshift Cluster Tags: %#v", err)
+	}
 
 	d.Set("snapshot_copy", flattenRedshiftSnapshotCopy(rsc.ClusterSnapshotCopyStatus))
 

--- a/aws/resource_aws_redshift_parameter_group.go
+++ b/aws/resource_aws_redshift_parameter_group.go
@@ -112,7 +112,9 @@ func resourceAwsRedshiftParameterGroupRead(d *schema.ResourceData, meta interfac
 	d.Set("name", describeResp.ParameterGroups[0].ParameterGroupName)
 	d.Set("family", describeResp.ParameterGroups[0].ParameterGroupFamily)
 	d.Set("description", describeResp.ParameterGroups[0].Description)
-	d.Set("tags", tagsToMapRedshift(describeResp.ParameterGroups[0].Tags))
+	if err := d.Set("tags", tagsToMapRedshift(describeResp.ParameterGroups[0].Tags)); err != nil {
+		return fmt.Errorf("Error setting Redshift Parameter Group Tags: %#v", err)
+	}
 
 	describeParametersOpts := redshift.DescribeClusterParametersInput{
 		ParameterGroupName: aws.String(d.Id()),

--- a/aws/resource_aws_redshift_parameter_group_test.go
+++ b/aws/resource_aws_redshift_parameter_group_test.go
@@ -96,6 +96,50 @@ func TestAccAWSRedshiftParameterGroup_withoutParameters(t *testing.T) {
 	})
 }
 
+func TestAccAWSRedshiftParameterGroup_withTags(t *testing.T) {
+	var v redshift.ClusterParameterGroup
+
+	rInt := acctest.RandInt()
+	resourceName := "aws_redshift_parameter_group.default"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRedshiftParameterGroupConfigWithTags(rInt, "aaa"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.name", fmt.Sprintf("test-terraform-%d", rInt)),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.description", fmt.Sprintf("Test parameter group for terraform %s", "aaa")),
+				),
+			},
+			{
+				Config: testAccAWSRedshiftParameterGroupConfigWithTags(rInt, "bbb"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.description", fmt.Sprintf("Test parameter group for terraform %s", "bbb")),
+				),
+			},
+			{
+				Config: testAccAWSRedshiftParameterGroupConfigWithTagsUpdate(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftParameterGroupExists(resourceName, &v),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.name", fmt.Sprintf("test-terraform-%d", rInt)),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceAWSRedshiftParameterGroupNameValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -233,6 +277,36 @@ resource "aws_redshift_parameter_group" "bar" {
   parameter {
     name  = "enable_user_activity_logging"
     value = "true"
+  }
+}
+`, rInt)
+}
+
+func testAccAWSRedshiftParameterGroupConfigWithTags(rInt int, rString string) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_parameter_group" "default" {
+  name        = "test-terraform-%[1]d"
+  family      = "redshift-1.0"
+  description = "Test parameter group for terraform"
+
+  tags = {
+    environment = "Production"
+	name     	= "test-terraform-%[1]d"
+	description = "Test parameter group for terraform %[2]s"
+  }
+}
+`, rInt, rString)
+}
+
+func testAccAWSRedshiftParameterGroupConfigWithTagsUpdate(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_parameter_group" "default" {
+  name        = "test-terraform-%[1]d"
+  family      = "redshift-1.0"
+  description = "Test parameter group for terraform"
+
+  tags = {
+	name     	= "test-terraform-%[1]d"
   }
 }
 `, rInt)

--- a/aws/resource_aws_redshift_parameter_group_test.go
+++ b/aws/resource_aws_redshift_parameter_group_test.go
@@ -290,9 +290,9 @@ resource "aws_redshift_parameter_group" "default" {
   description = "Test parameter group for terraform"
 
   tags = {
-    environment = "Production"
-	name     	= "test-terraform-%[1]d"
-	description = "Test parameter group for terraform %[2]s"
+		environment = "Production"
+		name     		= "test-terraform-%[1]d"
+		description = "Test parameter group for terraform %[2]s"
   }
 }
 `, rInt, rString)
@@ -306,7 +306,7 @@ resource "aws_redshift_parameter_group" "default" {
   description = "Test parameter group for terraform"
 
   tags = {
-	name     	= "test-terraform-%[1]d"
+		name     	= "test-terraform-%[1]d"
   }
 }
 `, rInt)

--- a/aws/resource_aws_redshift_snapshot_copy_grant.go
+++ b/aws/resource_aws_redshift_snapshot_copy_grant.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -17,10 +18,15 @@ func resourceAwsRedshiftSnapshotCopyGrant() *schema.Resource {
 		// Instead changes to most fields will force a new resource
 		Create: resourceAwsRedshiftSnapshotCopyGrantCreate,
 		Read:   resourceAwsRedshiftSnapshotCopyGrantRead,
+		Update: resourceAwsRedshiftSnapshotCopyGrantUpdate,
 		Delete: resourceAwsRedshiftSnapshotCopyGrantDelete,
 		Exists: resourceAwsRedshiftSnapshotCopyGrantExists,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"snapshot_copy_grant_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -32,11 +38,7 @@ func resourceAwsRedshiftSnapshotCopyGrant() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -90,6 +92,16 @@ func resourceAwsRedshiftSnapshotCopyGrantRead(d *schema.ResourceData, meta inter
 		return nil
 	}
 
+	arn := arn.ARN{
+		Partition: meta.(*AWSClient).partition,
+		Service:   "redshift",
+		Region:    meta.(*AWSClient).region,
+		AccountID: meta.(*AWSClient).accountid,
+		Resource:  fmt.Sprintf("snapshotcopygrant:%s", grantName),
+	}.String()
+
+	d.Set("arn", arn)
+
 	d.Set("kms_key_id", grant.KmsKeyId)
 	d.Set("snapshot_copy_grant_name", grant.SnapshotCopyGrantName)
 	if err := d.Set("tags", tagsToMapRedshift(grant.Tags)); err != nil {
@@ -97,6 +109,22 @@ func resourceAwsRedshiftSnapshotCopyGrantRead(d *schema.ResourceData, meta inter
 	}
 
 	return nil
+}
+
+func resourceAwsRedshiftSnapshotCopyGrantUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).redshiftconn
+
+	d.Partial(true)
+
+	if tagErr := setTagsRedshift(conn, d); tagErr != nil {
+		return tagErr
+	} else {
+		d.SetPartial("tags")
+	}
+
+	d.Partial(false)
+
+	return resourceAwsRedshiftSnapshotCopyGrantRead(d, meta)
 }
 
 func resourceAwsRedshiftSnapshotCopyGrantDelete(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_redshift_snapshot_copy_grant_test.go
+++ b/aws/resource_aws_redshift_snapshot_copy_grant_test.go
@@ -33,6 +33,48 @@ func TestAccAWSRedshiftSnapshotCopyGrant_Basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRedshiftSnapshotCopyGrant_Update(t *testing.T) {
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_redshift_snapshot_copy_grant.basic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftSnapshotCopyGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRedshiftSnapshotCopyGrant_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSnapshotCopyGrantExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-redshift-snapshot-copy-grant-basic"),
+				),
+			},
+			{
+				Config: testAccAWSRedshiftSnapshotCopyGrantWithTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSnapshotCopyGrantExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-redshift-snapshot-copy-grant-basic"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Env", "Production"),
+				),
+			},
+			{
+				Config: testAccAWSRedshiftSnapshotCopyGrant_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftSnapshotCopyGrantExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", "tf-redshift-snapshot-copy-grant-basic"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSRedshiftSnapshotCopyGrantDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).redshiftconn
 
@@ -91,6 +133,19 @@ resource "aws_redshift_snapshot_copy_grant" "basic" {
 
   tags = {
     Name = "tf-redshift-snapshot-copy-grant-basic"
+  }
+}
+`, rName)
+}
+
+func testAccAWSRedshiftSnapshotCopyGrantWithTags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_snapshot_copy_grant" "basic" {
+  snapshot_copy_grant_name = "%s"
+
+  tags = {
+	Name = "tf-redshift-snapshot-copy-grant-basic"
+	Env	 = "Production"
   }
 }
 `, rName)

--- a/aws/tagsRedshift.go
+++ b/aws/tagsRedshift.go
@@ -9,8 +9,9 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func setTagsRedshift(conn *redshift.Redshift, d *schema.ResourceData, arn string) error {
+func setTagsRedshift(conn *redshift.Redshift, d *schema.ResourceData) error {
 	if d.HasChange("tags") {
+		arn := d.Get("arn").(string)
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})
 		n := nraw.(map[string]interface{})

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -101,6 +101,7 @@ For more information on the permissions required for the bucket, please read the
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - Amazon Resource Name (ARN) of cluster
 * `id` - The Redshift Cluster ID.
 * `cluster_identifier` - The Cluster Identifier
 * `cluster_type` - The cluster type

--- a/website/docs/r/redshift_event_subscription.html.markdown
+++ b/website/docs/r/redshift_event_subscription.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 
 The following additional atttributes are provided:
 
+* `arn` - Amazon Resource Name (ARN) of the Redshift event notification subscription
 * `id` - The name of the Redshift event notification subscription
 * `customer_aws_id` - The AWS customer account associated with the Redshift event notification subscription
 

--- a/website/docs/r/redshift_parameter_group.html.markdown
+++ b/website/docs/r/redshift_parameter_group.html.markdown
@@ -55,6 +55,7 @@ You can read more about the parameters that Redshift supports in the [documentat
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - Amazon Resource Name (ARN) of parameter group
 * `id` - The Redshift parameter group name.
 
 ## Import

--- a/website/docs/r/redshift_parameter_group.html.markdown
+++ b/website/docs/r/redshift_parameter_group.html.markdown
@@ -47,6 +47,7 @@ Parameter blocks support the following:
 
 * `name` - (Required) The name of the Redshift parameter.
 * `value` - (Required) The value of the Redshift parameter.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 You can read more about the parameters that Redshift supports in the [documentation](http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html)
 

--- a/website/docs/r/redshift_snapshot_copy_grant.html.markdown
+++ b/website/docs/r/redshift_snapshot_copy_grant.html.markdown
@@ -38,4 +38,4 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-No additional attributes beyond the arguments above are exported.
+* `arn` - Amazon Resource Name (ARN) of snapshot copy grant

--- a/website/docs/r/redshift_subnet_group.html.markdown
+++ b/website/docs/r/redshift_subnet_group.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `arn` - Amazon Resource Name (ARN) of the Redshift Subnet group name
 * `id` - The Redshift Subnet group ID.
 
 ## Import


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8882 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
adds tags attribute for "aws_redshift_parameter_group"
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSRedshiftParameterGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSRedshiftParameterGroup_ -timeout 120m
=== RUN   TestAccAWSRedshiftParameterGroup_importBasic
=== PAUSE TestAccAWSRedshiftParameterGroup_importBasic
=== RUN   TestAccAWSRedshiftParameterGroup_withParameters
=== PAUSE TestAccAWSRedshiftParameterGroup_withParameters
=== RUN   TestAccAWSRedshiftParameterGroup_withoutParameters
=== PAUSE TestAccAWSRedshiftParameterGroup_withoutParameters
=== RUN   TestAccAWSRedshiftParameterGroup_withTags
=== PAUSE TestAccAWSRedshiftParameterGroup_withTags
=== CONT  TestAccAWSRedshiftParameterGroup_importBasic
=== CONT  TestAccAWSRedshiftParameterGroup_withTags
=== CONT  TestAccAWSRedshiftParameterGroup_withoutParameters
=== CONT  TestAccAWSRedshiftParameterGroup_withParameters
--- PASS: TestAccAWSRedshiftParameterGroup_withoutParameters (24.66s)
--- PASS: TestAccAWSRedshiftParameterGroup_withParameters (25.35s)
--- PASS: TestAccAWSRedshiftParameterGroup_importBasic (28.48s)
--- PASS: TestAccAWSRedshiftParameterGroup_withTags (61.68s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	61.767s
```
