### PR TITLE
Fix page titles to include full resource/data source name

### DIFF
--- a/website/docs/d/cloudhsm_v2_cluster.html.markdown
+++ b/website/docs/d/cloudhsm_v2_cluster.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudhsm_v2_cluster"
+page_title: "AWS: aws_cloudhsm_v2_cluster"
 sidebar_current: "docs-aws-datasource-cloudhsm-v2-cluster"
 description: |-
   Get information on a CloudHSM v2 cluster.

--- a/website/docs/d/efs_file_system.html.markdown
+++ b/website/docs/d/efs_file_system.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: efs_file_system"
+page_title: "AWS: aws_efs_file_system"
 sidebar_current: "docs-aws-datasource-efs-file-system"
 description: |-
   Provides an Elastic File System (EFS) data source.

--- a/website/docs/d/efs_mount_target.html.markdown
+++ b/website/docs/d/efs_mount_target.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: efs_mount_target"
+page_title: "AWS: aws_efs_mount_target"
 sidebar_current: "docs-aws-datasource-efs-mount-target"
 description: |-
   Provides an Elastic File System Mount Target (EFS) data source.

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: batch"
+page_title: "AWS: aws_batch_job_definition"
 sidebar_current: "docs-aws-resource-batch-job-definition"
 description: |-
   Provides a Batch Job Definition resource.

--- a/website/docs/r/batch_job_queue.html.markdown
+++ b/website/docs/r/batch_job_queue.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: batch"
+page_title: "AWS: aws_batch_job_queue"
 sidebar_current: "docs-aws-resource-batch-job-queue"
 description: |-
   Provides a Batch Job Queue resource.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudfront_distribution"
+page_title: "AWS: aws_cloudfront_distribution"
 sidebar_current: "docs-aws-resource-cloudfront-distribution"
 description: |-
   Provides a CloudFront web distribution resource.

--- a/website/docs/r/cloudfront_origin_access_identity.html.markdown
+++ b/website/docs/r/cloudfront_origin_access_identity.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudfront_origin_access_identity"
+page_title: "AWS: aws_cloudfront_origin_access_identity"
 sidebar_current: "docs-aws-resource-cloudfront-origin-access-identity"
 description: |-
   Provides a CloudFront origin access identity.

--- a/website/docs/r/cloudfront_public_key.html.markdown
+++ b/website/docs/r/cloudfront_public_key.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudfront_public_key"
+page_title: "AWS: aws_cloudfront_public_key"
 sidebar_current: "docs-aws-resource-cloudfront-public-key"
 description: |-
   Provides a CloudFront Public Key which you add to CloudFront to use with features like field-level encryption.

--- a/website/docs/r/cloudhsm_v2_cluster.html.markdown
+++ b/website/docs/r/cloudhsm_v2_cluster.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudhsm_v2_cluster"
+page_title: "AWS: aws_cloudhsm_v2_cluster"
 sidebar_current: "docs-aws-resource-cloudhsm-v2-cluster"
 description: |-
   Provides a CloudHSM v2 resource.

--- a/website/docs/r/cloudhsm_v2_hsm.html.markdown
+++ b/website/docs/r/cloudhsm_v2_hsm.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudhsm_v2_hsm"
+page_title: "AWS: aws_cloudhsm_v2_hsm"
 sidebar_current: "docs-aws-resource-cloudhsm-v2-hsm"
 description: |-
   Provides a CloudHSM v2 HSM module resource.

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudtrail"
+page_title: "AWS: aws_cloudtrail"
 sidebar_current: "docs-aws-resource-cloudtrail"
 description: |-
   Provides a CloudTrail resource.

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: cloudwatch_metric_alarm"
+page_title: "AWS: aws_cloudwatch_metric_alarm"
 sidebar_current: "docs-aws-resource-cloudwatch-metric-alarm"
 description: |-
   Provides a CloudWatch Metric Alarm resource.

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: dynamodb_table"
+page_title: "AWS: aws_dynamodb_table"
 sidebar_current: "docs-aws-resource-dynamodb-table"
 description: |-
   Provides a DynamoDB table resource

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: dynamodb_table_item"
+page_title: "AWS: aws_dynamodb_table_item"
 sidebar_current: "docs-aws-resource-dynamodb-table-item"
 description: |-
   Provides a DynamoDB table item resource

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: sagemaker_notebook_instance"
+page_title: "AWS: aws_sagemaker_notebook_instance"
 sidebar_current: "docs-aws-resource-sagemaker-notebook-instance"
 description: |-
   Provides a Sagemaker Notebook Instance resource.

--- a/website/docs/r/ses_active_receipt_rule_set.html.markdown
+++ b/website/docs/r/ses_active_receipt_rule_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_active_receipt_rule_set"
+page_title: "AWS: aws_ses_active_receipt_rule_set"
 sidebar_current: "docs-aws-resource-ses-active-receipt-rule-set"
 description: |-
   Provides a resource to designate the active SES receipt rule set

--- a/website/docs/r/ses_configuration_set.markdown
+++ b/website/docs/r/ses_configuration_set.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_configuration_set"
+page_title: "AWS: aws_ses_configuration_set"
 sidebar_current: "docs-aws-resource-ses-configuration-set"
 description: |-
   Provides an SES configuration set

--- a/website/docs/r/ses_domain_dkim.html.markdown
+++ b/website/docs/r/ses_domain_dkim.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_domain_dkim"
+page_title: "AWS: aws_ses_domain_dkim"
 sidebar_current: "docs-aws-resource-ses-domain-dkim"
 description: |-
   Provides an SES domain DKIM generation resource

--- a/website/docs/r/ses_domain_identity.html.markdown
+++ b/website/docs/r/ses_domain_identity.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_domain_identity"
+page_title: "AWS: aws_ses_domain_identity"
 sidebar_current: "docs-aws-resource-ses-domain-identity"
 description: |-
   Provides an SES domain identity resource

--- a/website/docs/r/ses_domain_identity_verification.html.markdown
+++ b/website/docs/r/ses_domain_identity_verification.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_domain_identity_verification"
+page_title: "AWS: aws_ses_domain_identity_verification"
 sidebar_current: "docs-aws-resource-ses-domain-identity-verification"
 description: |-
   Waits for and checks successful verification of an SES domain identity.

--- a/website/docs/r/ses_domain_mail_from.html.markdown
+++ b/website/docs/r/ses_domain_mail_from.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_domain_mail_from"
+page_title: "AWS: aws_ses_domain_mail_from"
 sidebar_current: "docs-aws-resource-ses-domain-mail-from"
 description: |-
   Provides an SES domain MAIL FROM resource

--- a/website/docs/r/ses_email_identity.html.markdown
+++ b/website/docs/r/ses_email_identity.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_email_identity"
+page_title: "AWS: aws_ses_email_identity"
 sidebar_current: "docs-aws-resource-ses-email-identity"
 description: |-
   Provides an SES email identity resource
 ---
 
-# aws_ses_email_identity
+# Resource: aws_ses_email_identity
 
 Provides an SES email identity resource
 

--- a/website/docs/r/ses_event_destination.markdown
+++ b/website/docs/r/ses_event_destination.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_event_destination"
+page_title: "AWS: aws_ses_event_destination"
 sidebar_current: "docs-aws-resource-ses-event-destination"
 description: |-
   Provides an SES event destination

--- a/website/docs/r/ses_receipt_filter.html.markdown
+++ b/website/docs/r/ses_receipt_filter.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_receipt_filter"
+page_title: "AWS: aws_ses_receipt_filter"
 sidebar_current: "docs-aws-resource-ses-receipt-filter"
 description: |-
   Provides an SES receipt filter

--- a/website/docs/r/ses_receipt_rule.html.markdown
+++ b/website/docs/r/ses_receipt_rule.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_receipt_rule"
+page_title: "AWS: aws_ses_receipt_rule"
 sidebar_current: "docs-aws-resource-ses-receipt-rule"
 description: |-
   Provides an SES receipt rule resource

--- a/website/docs/r/ses_receipt_rule_set.html.markdown
+++ b/website/docs/r/ses_receipt_rule_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: ses_receipt_rule_set"
+page_title: "AWS: aws_ses_receipt_rule_set"
 sidebar_current: "docs-aws-resource-ses-receipt-rule-set"
 description: |-
   Provides an SES receipt rule set resource

--- a/website/docs/r/sfn_activity.html.markdown
+++ b/website/docs/r/sfn_activity.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "aws"
-page_title: "AWS: sfn_activity"
+page_title: "AWS: aws_sfn_activity"
 sidebar_current: "docs-aws-resource-sfn-activity"
 description: |-
   Provides a Step Function Activity resource.
 ---
 
-# Resource: sfn_activity
+# Resource: aws_sfn_activity
 
 Provides a Step Function Activity resource
 

--- a/website/docs/r/sfn_state_machine.html.markdown
+++ b/website/docs/r/sfn_state_machine.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "aws"
-page_title: "AWS: sfn_state_machine"
+page_title: "AWS: aws_sfn_state_machine"
 sidebar_current: "docs-aws-resource-sfn-state-machine"
 description: |-
   Provides a Step Function State Machine resource.
 ---
 
-# Resource: sfn_state_machine
+# Resource: aws_sfn_state_machine
 
 Provides a Step Function State Machine resource
 

--- a/website/docs/r/simpledb_domain.html.markdown
+++ b/website/docs/r/simpledb_domain.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: simpledb_domain"
+page_title: "AWS: aws_simpledb_domain"
 sidebar_current: "docs-aws-resource-simpledb-domain"
 description: |-
   Provides a SimpleDB domain resource.

--- a/website/docs/r/sns_platform_application.html.markdown
+++ b/website/docs/r/sns_platform_application.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: sns_platform_application"
+page_title: "AWS: aws_sns_platform_application"
 sidebar_current: "docs-aws-resource-sns-platform-application"
 description: |-
   Provides an SNS platform application resource.

--- a/website/docs/r/sns_sms_preferences.html.markdown
+++ b/website/docs/r/sns_sms_preferences.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: sns_sms_preferences"
+page_title: "AWS: aws_sns_sms_preferences"
 sidebar_current: "docs-aws-resource-sns-sms-preferences"
 description: |-
   Provides a way to set SNS SMS preferences.

--- a/website/docs/r/sns_topic.html.markdown
+++ b/website/docs/r/sns_topic.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: sns_topic"
+page_title: "AWS: aws_sns_topic"
 sidebar_current: "docs-aws-resource-sns-topic"
 description: |-
   Provides an SNS topic resource.

--- a/website/docs/r/sns_topic_policy.html.markdown
+++ b/website/docs/r/sns_topic_policy.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: sns_topic_policy"
+page_title: "AWS: aws_sns_topic_policy"
 sidebar_current: "docs-aws-resource-sns-topic-policy"
 description: |-
   Provides an SNS topic policy resource.

--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: sns_topic_subscription"
+page_title: "AWS: aws_sns_topic_subscription"
 sidebar_current: "docs-aws-resource-sns-topic-subscription"
 description: |-
   Provides a resource for subscribing to SNS topics.

--- a/website/docs/r/waf_byte_match_set.html.markdown
+++ b/website/docs/r/waf_byte_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_byte_match_set"
+page_title: "AWS: aws_waf_byte_match_set"
 sidebar_current: "docs-aws-resource-waf-bytematchset"
 description: |-
   Provides a AWS WAF Byte Match Set resource.

--- a/website/docs/r/waf_geo_match_set.html.markdown
+++ b/website/docs/r/waf_geo_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_geo_match_set"
+page_title: "AWS: aws_waf_geo_match_set"
 sidebar_current: "docs-aws-resource-waf-geo-match-set"
 description: |-
   Provides a AWS WAF GeoMatchSet resource.

--- a/website/docs/r/waf_ipset.html.markdown
+++ b/website/docs/r/waf_ipset.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_ipset"
+page_title: "AWS: aws_waf_ipset"
 sidebar_current: "docs-aws-resource-waf-ipset"
 description: |-
   Provides a AWS WAF IPSet resource.

--- a/website/docs/r/waf_rate_based_rule.html.markdown
+++ b/website/docs/r/waf_rate_based_rule.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_rate_based_rule"
+page_title: "AWS: aws_waf_rate_based_rule"
 sidebar_current: "docs-aws-resource-waf-rate-based-rule"
 description: |-
   Provides a AWS WAF rule resource.

--- a/website/docs/r/waf_regex_match_set.html.markdown
+++ b/website/docs/r/waf_regex_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_regex_match_set"
+page_title: "AWS: aws_waf_regex_match_set"
 sidebar_current: "docs-aws-resource-waf-regex-match-set"
 description: |-
   Provides a AWS WAF Regex Match Set resource.

--- a/website/docs/r/waf_regex_pattern_set.html.markdown
+++ b/website/docs/r/waf_regex_pattern_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_regex_pattern_set"
+page_title: "AWS: aws_waf_regex_pattern_set"
 sidebar_current: "docs-aws-resource-waf-regex-pattern-set"
 description: |-
   Provides a AWS WAF Regex Pattern Set resource.

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_rule"
+page_title: "AWS: aws_waf_rule"
 sidebar_current: "docs-aws-resource-waf-rule"
 description: |-
   Provides a AWS WAF rule resource.

--- a/website/docs/r/waf_rule_group.html.markdown
+++ b/website/docs/r/waf_rule_group.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_rule_group"
+page_title: "AWS: aws_waf_rule_group"
 sidebar_current: "docs-aws-resource-waf-rule-group"
 description: |-
   Provides a AWS WAF rule group resource.

--- a/website/docs/r/waf_size_constraint_set.html.markdown
+++ b/website/docs/r/waf_size_constraint_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_size_constraint_set"
+page_title: "AWS: aws_waf_size_constraint_set"
 sidebar_current: "docs-aws-resource-waf-size-constraint-set"
 description: |-
   Provides a AWS WAF Size Constraint Set resource.

--- a/website/docs/r/waf_sql_injection_match_set.html.markdown
+++ b/website/docs/r/waf_sql_injection_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_sql_injection_match_set"
+page_title: "AWS: aws_waf_sql_injection_match_set"
 sidebar_current: "docs-aws-resource-waf-sql-injection-match-set"
 description: |-
   Provides a AWS WAF SQL Injection Match Set resource.

--- a/website/docs/r/waf_xss_match_set.html.markdown
+++ b/website/docs/r/waf_xss_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: waf_xss_match_set"
+page_title: "AWS: aws_waf_xss_match_set"
 sidebar_current: "docs-aws-resource-waf-xss-match-set"
 description: |-
   Provides a AWS WAF XssMatchSet resource.

--- a/website/docs/r/wafregional_byte_match_set.html.markdown
+++ b/website/docs/r/wafregional_byte_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_byte_match_set"
+page_title: "AWS: aws_wafregional_byte_match_set"
 sidebar_current: "docs-aws-resource-wafregional-bytematchset"
 description: |-
   Provides a AWS WAF Regional ByteMatchSet resource for use with ALB.

--- a/website/docs/r/wafregional_geo_match_set.html.markdown
+++ b/website/docs/r/wafregional_geo_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_geo_match_set"
+page_title: "AWS: aws_wafregional_geo_match_set"
 sidebar_current: "docs-aws-resource-wafregional-geo-match-set"
 description: |-
   Provides a AWS WAF Regional Geo Match Set resource.

--- a/website/docs/r/wafregional_ipset.html.markdown
+++ b/website/docs/r/wafregional_ipset.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_ipset"
+page_title: "AWS: aws_wafregional_ipset"
 sidebar_current: "docs-aws-resource-wafregional-ipset"
 description: |-
   Provides a AWS WAF Regional IPSet resource for use with ALB.

--- a/website/docs/r/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/r/wafregional_rate_based_rule.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_rate_based_rule"
+page_title: "AWS: aws_wafregional_rate_based_rule"
 sidebar_current: "docs-aws-resource-wafregional-rate-based-rule"
 description: |-
   Provides a AWS WAF Regional rate based rule resource.

--- a/website/docs/r/wafregional_regex_match_set.html.markdown
+++ b/website/docs/r/wafregional_regex_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_regex_match_set"
+page_title: "AWS: aws_wafregional_regex_match_set"
 sidebar_current: "docs-aws-resource-wafregional-regex-match-set"
 description: |-
   Provides a AWS WAF Regional Regex Match Set resource.

--- a/website/docs/r/wafregional_regex_pattern_set.html.markdown
+++ b/website/docs/r/wafregional_regex_pattern_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_regex_pattern_set"
+page_title: "AWS: aws_wafregional_regex_pattern_set"
 sidebar_current: "docs-aws-resource-wafregional-regex-pattern-set"
 description: |-
   Provides a AWS WAF Regional Regex Pattern Set resource.

--- a/website/docs/r/wafregional_rule.html.markdown
+++ b/website/docs/r/wafregional_rule.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_rule"
+page_title: "AWS: aws_wafregional_rule"
 sidebar_current: "docs-aws-resource-wafregional-rule"
 description: |-
   Provides an AWS WAF Regional rule resource for use with ALB.

--- a/website/docs/r/wafregional_rule_group.html.markdown
+++ b/website/docs/r/wafregional_rule_group.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_rule_group"
+page_title: "AWS: aws_wafregional_rule_group"
 sidebar_current: "docs-aws-resource-wafregional-rule-group"
 description: |-
   Provides a AWS WAF Regional Rule Group resource.

--- a/website/docs/r/wafregional_size_constraint_set.html.markdown
+++ b/website/docs/r/wafregional_size_constraint_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_size_constraint_set"
+page_title: "AWS: aws_wafregional_size_constraint_set"
 sidebar_current: "docs-aws-resource-wafregional-size-constraint-set"
 description: |-
   Provides an AWS WAF Regional Size Constraint Set resource for use with ALB.

--- a/website/docs/r/wafregional_sql_injection_match_set.html.markdown
+++ b/website/docs/r/wafregional_sql_injection_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_sql_injection_match_set"
+page_title: "AWS: aws_wafregional_sql_injection_match_set"
 sidebar_current: "docs-aws-resource-wafregional-sql-injection-match-set"
 description: |-
   Provides a AWS WAF Regional SqlInjectionMatchSet resource for use with ALB.

--- a/website/docs/r/wafregional_xss_match_set.html.markdown
+++ b/website/docs/r/wafregional_xss_match_set.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: wafregional_xss_match_set"
+page_title: "AWS: aws_wafregional_xss_match_set"
 sidebar_current: "docs-aws-resource-wafregional-xss-match-set"
 description: |-
   Provides an AWS WAF Regional XSS Match Set resource for use with ALB.


### PR DESCRIPTION
This changes many documentation files that previously included only part
of the resource name in the page title. For example, the page title for
`aws_cloudwatch_metric_alarm` was `AWS: cloudwatch_metric_alarm` instead
of `AWS: aws_cloudwatch_metric_alarm`.

This was changed to make it easier to search pages from the browser,
searching the history for `aws_cloudwatch_metric` wouldn't show
`cloudwatch_metric_alarm`. Most of the other resources already use the
full name, so it makes sense to standardize on a single form.

Some pages, like the page for `aws_batch_job_queue`, had even less of the
resource name in the title (`AWS: batch`) and were changed as well.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related to #8225

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
adds the 'aws_' prefix to resources/data sources documentation page titles
```
