### PR TITLE
Remove flatmap dependency

### DIFF
--- a/aws/structure_test.go
+++ b/aws/structure_test.go
@@ -16,32 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/hashicorp/terraform/flatmap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
-
-// Returns test configuration
-func testConf() map[string]string {
-	return map[string]string{
-		"listener.#":                   "1",
-		"listener.0.lb_port":           "80",
-		"listener.0.lb_protocol":       "http",
-		"listener.0.instance_port":     "8000",
-		"listener.0.instance_protocol": "http",
-		"availability_zones.#":         "2",
-		"availability_zones.0":         "us-east-1a",
-		"availability_zones.1":         "us-east-1b",
-		"ingress.#":                    "1",
-		"ingress.0.protocol":           "icmp",
-		"ingress.0.from_port":          "1",
-		"ingress.0.to_port":            "-1",
-		"ingress.0.cidr_blocks.#":      "1",
-		"ingress.0.cidr_blocks.0":      "0.0.0.0/0",
-		"ingress.0.security_groups.#":  "2",
-		"ingress.0.security_groups.0":  "sg-11111",
-		"ingress.0.security_groups.1":  "foo/sg-22222",
-	}
-}
 
 func TestExpandIPPerms(t *testing.T) {
 	hash := schema.HashString
@@ -443,7 +419,7 @@ func TestFlattenHealthCheck(t *testing.T) {
 }
 
 func TestExpandStringList(t *testing.T) {
-	expanded := flatmap.Expand(testConf(), "availability_zones").([]interface{})
+	expanded := []interface{}{"us-east-1a", "us-east-1b"}
 	stringList := expandStringList(expanded)
 	expected := []*string{
 		aws.String("us-east-1a"),
@@ -459,12 +435,8 @@ func TestExpandStringList(t *testing.T) {
 }
 
 func TestExpandStringListEmptyItems(t *testing.T) {
-	initialList := []string{"foo", "bar", "", "baz"}
-	l := make([]interface{}, len(initialList))
-	for i, v := range initialList {
-		l[i] = v
-	}
-	stringList := expandStringList(l)
+	expanded := []interface{}{"foo", "bar", "", "baz"}
+	stringList := expandStringList(expanded)
 	expected := []*string{
 		aws.String("foo"),
 		aws.String("bar"),


### PR DESCRIPTION
As part of some prep work for SDK decoupling I found this provider imports a legacy `flatmap` package - this isn't the way we plan to represent data in the SDK in the future anymore and regardless of that it seems unnecessary to import the whole package for what can practically be done in 1 line of code.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ go test ./aws -run=TestExpandStringList -v
=== RUN   TestExpandStringList
--- PASS: TestExpandStringList (0.00s)
=== RUN   TestExpandStringListEmptyItems
--- PASS: TestExpandStringListEmptyItems (0.00s)
```

There's one more place where this provider imports this package, but changing that may require a bit more effort, so I filed a separate issue for that: https://github.com/terraform-providers/terraform-provider-aws/issues/8902