### PR TITLE
Update ram_resource_share.html.markdown

### DIFF
--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -13,6 +13,7 @@ description: |-
 ## Example Usage
 ```hcl
 data "aws_ram_resource_share" "example" {
+  resource_owner = "SELF"
   name = "example"
 }
 ```

--- a/website/docs/d/ram_resource_share.html.markdown
+++ b/website/docs/d/ram_resource_share.html.markdown
@@ -13,8 +13,8 @@ description: |-
 ## Example Usage
 ```hcl
 data "aws_ram_resource_share" "example" {
-  resource_owner = "SELF"
   name = "example"
+  resource_owner = "SELF"
 }
 ```
 


### PR DESCRIPTION
resource_owner is a required field, but it is not included in the example.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
