### PR TITLE
Retry for deleting default DHCP options, plus pagination plus a test sweeper

### DIFF
--- a/aws/resource_aws_default_vpc_dhcp_options.go
+++ b/aws/resource_aws_default_vpc_dhcp_options.go
@@ -65,16 +65,28 @@ func resourceAwsDefaultVpcDhcpOptionsCreate(d *schema.ResourceData, meta interfa
 		},
 	}
 
-	resp, err := conn.DescribeDhcpOptions(req)
+	var dhcpOptions []*ec2.DhcpOptions
+	err := conn.DescribeDhcpOptionsPages(req, func(page *ec2.DescribeDhcpOptionsOutput, lastPage bool) bool {
+		dhcpOptions = append(dhcpOptions, page.DhcpOptions...)
+		return !lastPage
+	})
+
 	if err != nil {
-		return err
+		return fmt.Errorf("Error describing DHCP options: %s", err)
 	}
 
-	if len(resp.DhcpOptions) != 1 || resp.DhcpOptions[0] == nil {
+	if len(dhcpOptions) == 0 {
 		return fmt.Errorf("Default DHCP Options Set not found")
 	}
 
-	d.SetId(aws.StringValue(resp.DhcpOptions[0].DhcpOptionsId))
+	if len(dhcpOptions) > 1 {
+		return fmt.Errorf("Multiple default DHCP Options Sets found")
+	}
+
+	if dhcpOptions[0] == nil {
+		return fmt.Errorf("Default DHCP Options Set is empty")
+	}
+	d.SetId(aws.StringValue(dhcpOptions[0].DhcpOptionsId))
 
 	return resourceAwsVpcDhcpOptionsUpdate(d, meta)
 }

--- a/aws/resource_aws_default_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_default_vpc_dhcp_options_test.go
@@ -41,10 +41,6 @@ func testAccCheckAWSDefaultVpcDhcpOptionsDestroy(s *terraform.State) error {
 }
 
 const testAccAWSDefaultVpcDhcpOptionsConfigBasic = `
-provider "aws" {
-    region = "us-west-2"
-}
-
 resource "aws_default_vpc_dhcp_options" "foo" {
 	tags = {
 		Name = "Default DHCP Option Set"

--- a/aws/resource_aws_vpc_dhcp_options.go
+++ b/aws/resource_aws_vpc_dhcp_options.go
@@ -196,7 +196,7 @@ func resourceAwsVpcDhcpOptionsUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceAwsVpcDhcpOptionsDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	return resource.Retry(3*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 		log.Printf("[INFO] Deleting DHCP Options ID %s...", d.Id())
 		_, err := conn.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{
 			DhcpOptionsId: aws.String(d.Id()),
@@ -239,6 +239,13 @@ func resourceAwsVpcDhcpOptionsDelete(d *schema.ResourceData, meta interface{}) e
 			return resource.NonRetryableError(err)
 		}
 	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{
+			DhcpOptionsId: aws.String(d.Id()),
+		})
+	}
+	return err
 }
 
 func findVPCsByDHCPOptionsID(conn *ec2.EC2, id string) ([]*ec2.Vpc, error) {

--- a/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +11,82 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_vpc_dhcp_options", &resource.Sweeper{
+		Name: "aws_vpc_dhcp_options",
+		F:    testSweepVpcDhcpOptions,
+	})
+}
+
+func testSweepVpcDhcpOptions(region string) error {
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.(*AWSClient).ec2conn
+
+	input := &ec2.DescribeDhcpOptionsInput{}
+
+	err = conn.DescribeDhcpOptionsPages(input, func(page *ec2.DescribeDhcpOptionsOutput, lastPage bool) bool {
+		for _, dhcpOption := range page.DhcpOptions {
+			var domainName string
+			var defaultDomainNameFound, defaultDomainNameServersFound bool
+
+			if region == "us-east-1" {
+				domainName = "ec2.internal"
+			} else {
+				domainName = region + ".compute.internal"
+			}
+
+			for _, dhcpConfiguration := range dhcpOption.DhcpConfigurations {
+				if aws.StringValue(dhcpConfiguration.Key) == "domain-name" {
+					if len(dhcpConfiguration.Values) == 0 || len(dhcpConfiguration.Values) > 1 {
+						continue
+					}
+
+					if dhcpConfiguration.Values[0] != nil && aws.StringValue(dhcpConfiguration.Values[0].Value) == domainName {
+						defaultDomainNameFound = true
+					}
+				} else if aws.StringValue(dhcpConfiguration.Key) == "domain-name-servers" {
+					if len(dhcpConfiguration.Values) == 0 || len(dhcpConfiguration.Values) > 1 {
+						continue
+					}
+
+					if dhcpConfiguration.Values[0] != nil && aws.StringValue(dhcpConfiguration.Values[0].Value) == "AmazonProvidedDNS" {
+						defaultDomainNameServersFound = true
+					}
+				}
+			}
+
+			if defaultDomainNameFound && defaultDomainNameServersFound {
+				continue
+			}
+
+			input := &ec2.DeleteDhcpOptionsInput{
+				DhcpOptionsId: dhcpOption.DhcpOptionsId,
+			}
+
+			_, err := conn.DeleteDhcpOptions(input)
+
+			if err != nil {
+				log.Printf("[ERROR] Error deleting EC2 DHCP Option (%s): %s", aws.StringValue(dhcpOption.DhcpOptionsId), err)
+			}
+		}
+		return !lastPage
+	})
+
+	if testSweepSkipSweepError(err) {
+		log.Printf("[WARN] Skipping EC2 DHCP Option sweep for %s: %s", region, err)
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error describing DHCP Options: %s", err)
+	}
+
+	return nil
+}
 
 func TestAccAWSDHCPOptions_importBasic(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options.foo"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/default_vpc_dhcp_options: Add pagination to get the default DHCP options correctly
* resource/vpc_dhcp_options: Add final retry to deleting DHCP options
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDefaultVpcDhcpOptions"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDefaultVpcDhcpOptions -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDefaultVpcDhcpOptions_basic
=== PAUSE TestAccAWSDefaultVpcDhcpOptions_basic
=== CONT  TestAccAWSDefaultVpcDhcpOptions_basic
--- PASS: TestAccAWSDefaultVpcDhcpOptions_basic (20.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       22.668s


$ make testacc TESTARGS="-run=TestAccAWSDHCPOptions" ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDHCPOptions -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDHCPOptionsAssociation_basic
=== PAUSE TestAccAWSDHCPOptionsAssociation_basic
=== RUN   TestAccAWSDHCPOptions_importBasic
=== PAUSE TestAccAWSDHCPOptions_importBasic
=== RUN   TestAccAWSDHCPOptions_basic
=== PAUSE TestAccAWSDHCPOptions_basic
=== RUN   TestAccAWSDHCPOptions_deleteOptions
=== PAUSE TestAccAWSDHCPOptions_deleteOptions
=== CONT  TestAccAWSDHCPOptionsAssociation_basic
=== CONT  TestAccAWSDHCPOptions_deleteOptions
=== CONT  TestAccAWSDHCPOptions_importBasic
=== CONT  TestAccAWSDHCPOptions_basic
--- PASS: TestAccAWSDHCPOptions_deleteOptions (19.86s)
--- PASS: TestAccAWSDHCPOptions_basic (23.54s)
--- PASS: TestAccAWSDHCPOptions_importBasic (25.10s)
--- PASS: TestAccAWSDHCPOptionsAssociation_basic (49.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       49.880s

```