### PR TITLE
aws_eks_cluster: Increase create timeout to 30 mins

### DIFF
--- a/aws/resource_aws_eks_cluster.go
+++ b/aws/resource_aws_eks_cluster.go
@@ -33,7 +33,7 @@ func resourceAwsEksCluster() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -98,7 +98,7 @@ In addition to all arguments above, the following attributes are exported:
 `aws_eks_cluster` provides the following
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
-* `create` - (Default `15 minutes`) How long to wait for the EKS Cluster to be created.
+* `create` - (Default `30 minutes`) How long to wait for the EKS Cluster to be created.
 * `update` - (Default `60 minutes`) How long to wait for the EKS Cluster to be updated.
 Note that the `update` timeout is used separately for both `version` and `vpc_config` update timeouts.
 * `delete` - (Default `15 minutes`) How long to wait for the EKS Cluster to be deleted.


### PR DESCRIPTION
It seems that as reported in #5165, an EKS cluster frequently takes more to actually bring up than the default create timeout allows for. While the timeout is configurable, the default should be sufficient to actually provision a cluster in most cases.

This commit increases the default timeout to 30 minutes.

Fixes #5165.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Increase default create timeout for `aws_eks_cluster` to 30 minutes.
```