### PR TITLE
tests/resource/aws_spot_fleet_request: Add PreCheck for functionality

### DIFF
--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -62,7 +62,7 @@ func TestAccAWSSpotFleetRequest_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -84,7 +84,7 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -107,7 +107,7 @@ func TestAccAWSSpotFleetRequest_instanceInterruptionBehavior(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -129,7 +129,7 @@ func TestAccAWSSpotFleetRequest_fleetType(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -151,7 +151,7 @@ func TestAccAWSSpotFleetRequest_iamInstanceProfileArn(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -174,7 +174,7 @@ func TestAccAWSSpotFleetRequest_changePriceForcesNewRequest(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -209,7 +209,7 @@ func TestAccAWSSpotFleetRequest_updateTargetCapacity(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -246,7 +246,7 @@ func TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy(t *testing
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -275,7 +275,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -298,7 +298,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -323,7 +323,7 @@ func TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -346,7 +346,7 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -373,7 +373,7 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet(t *testing.T) 
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -396,7 +396,7 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -424,7 +424,7 @@ func TestAccAWSSpotFleetRequest_withoutSpotPrice(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -447,7 +447,7 @@ func TestAccAWSSpotFleetRequest_diversifiedAllocation(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -471,7 +471,7 @@ func TestAccAWSSpotFleetRequest_multipleInstancePools(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -510,7 +510,7 @@ func TestAccAWSSpotFleetRequest_withWeightedCapacity(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -538,7 +538,7 @@ func TestAccAWSSpotFleetRequest_withEBSDisk(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -561,7 +561,7 @@ func TestAccAWSSpotFleetRequest_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -584,7 +584,7 @@ func TestAccAWSSpotFleetRequest_placementTenancy(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -606,7 +606,7 @@ func TestAccAWSSpotFleetRequest_WithELBs(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -630,7 +630,7 @@ func TestAccAWSSpotFleetRequest_WithTargetGroups(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSEc2SpotFleetRequest(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSpotFleetRequestDestroy,
 		Steps: []resource.TestStep{
@@ -778,6 +778,22 @@ func testAccCheckAWSSpotFleetRequest_IamInstanceProfileArn(
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSEc2SpotFleetRequest(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	input := &ec2.DescribeSpotFleetRequestsInput{}
+
+	_, err := conn.DescribeSpotFleetRequests(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial (provided as a smoke test):

```
--- PASS: TestAccAWSSpotFleetRequest_basic (305.47s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (2.72s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 1cb13e57-543b-4712-b8a5-34dfa423e611
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
--- SKIP: TestAccAWSSpotFleetRequest_WithELBs (2.75s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: e07c2079-840a-4f7d-b0d7-844cfcd3cbc9
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
--- SKIP: TestAccAWSSpotFleetRequest_withTags (2.82s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: e3d2e557-6eb1-4017-ba89-e80c158e0d94
=== CONT  TestAccAWSSpotFleetRequest_withoutSpotPrice
--- SKIP: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (2.82s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 50cb320c-ce26-4063-9f00-8021635792e6
--- SKIP: TestAccAWSSpotFleetRequest_withEBSDisk (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 84f813a2-c8f8-4ace-a976-68335b3d94bf
--- SKIP: TestAccAWSSpotFleetRequest_fleetType (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 05dde2b6-5864-435e-8bcd-e95d84fa0ee1
--- SKIP: TestAccAWSSpotFleetRequest_overriddingSpotPrice (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 0bebba83-ff87-4f56-a47a-edb908702528
--- SKIP: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: b5d2e51e-d2c2-4a55-b6a8-8e067b2ea778
--- SKIP: TestAccAWSSpotFleetRequest_WithTargetGroups (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 92871a8c-206a-4bc3-b710-f1de01d6610c
--- SKIP: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: cab33c25-3385-4d9e-bafa-fc4825e3a75b
--- SKIP: TestAccAWSSpotFleetRequest_placementTenancy (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: dd4790fc-5ea0-493a-8364-6ed43b17fbd0
--- SKIP: TestAccAWSSpotFleetRequest_associatePublicIpAddress (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: ca75c03d-6895-44b6-8cd1-a4a043770dbd
--- SKIP: TestAccAWSSpotFleetRequest_diversifiedAllocation (2.84s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 1e81117e-4f49-43ec-83bb-f8abae2aa51e
--- SKIP: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 698a2092-686e-4197-a1b3-b7ce99525681
--- SKIP: TestAccAWSSpotFleetRequest_withWeightedCapacity (2.83s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 0d3747c5-223d-405e-ace8-e84ba96c70a9
--- SKIP: TestAccAWSSpotFleetRequest_multipleInstancePools (2.84s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 491260ff-ab70-4302-adb9-82bdd6a3f97e
--- SKIP: TestAccAWSSpotFleetRequest_basic (2.84s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 03a64cd1-d67d-4d49-ab59-2f7d8f83bec0
--- SKIP: TestAccAWSSpotFleetRequest_updateTargetCapacity (2.84s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 40a581a4-2743-4b54-9178-4e7084ec2ff9
--- SKIP: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (2.84s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: ea102526-d4df-4915-94a2-d73d8ce1c547
--- SKIP: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (2.85s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 360fa32d-5714-4514-8dc2-dcbf0f99fd9b
--- SKIP: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (2.09s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 335d9fa4-0885-4c3c-b7ca-3841ab3e263e
--- SKIP: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (2.33s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 167b47c0-1bfe-4de3-b48f-9dc2dfe0b25b
--- SKIP: TestAccAWSSpotFleetRequest_withoutSpotPrice (2.23s)
    resource_aws_spot_fleet_request_test.go:792: skipping acceptance testing: UnsupportedOperation: The functionality you requested is not available in this region.
        	status code: 400, request id: 32205828-3a92-4272-bc7c-1d28614eef0e
PASS
```
