### PR TITLE
tests/resource/aws_rds_global_cluster: Add PreCheck for functionality

### DIFF
--- a/aws/resource_aws_rds_global_cluster_test.go
+++ b/aws/resource_aws_rds_global_cluster_test.go
@@ -75,7 +75,7 @@ func TestAccAWSRdsGlobalCluster_basic(t *testing.T) {
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +108,7 @@ func TestAccAWSRdsGlobalCluster_disappears(t *testing.T) {
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
@@ -130,7 +130,7 @@ func TestAccAWSRdsGlobalCluster_DatabaseName(t *testing.T) {
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
@@ -164,7 +164,7 @@ func TestAccAWSRdsGlobalCluster_DeletionProtection(t *testing.T) {
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
@@ -198,7 +198,7 @@ func TestAccAWSRdsGlobalCluster_Engine_Aurora(t *testing.T) {
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
@@ -224,7 +224,7 @@ func TestAccAWSRdsGlobalCluster_EngineVersion_Aurora(t *testing.T) {
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
@@ -250,7 +250,7 @@ func TestAccAWSRdsGlobalCluster_StorageEncrypted(t *testing.T) {
 	resourceName := "aws_rds_global_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRdsGlobalClusterDestroy,
 		Steps: []resource.TestStep{
@@ -374,6 +374,22 @@ func testAccCheckAWSRdsGlobalClusterRecreated(i, j *rds.GlobalCluster) resource.
 		}
 
 		return nil
+	}
+}
+
+func testAccPreCheckAWSRdsGlobalCluster(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+	input := &rds.DescribeGlobalClustersInput{}
+
+	_, err := conn.DescribeGlobalClusters(input)
+
+	if testAccPreCheckSkipError(err) || isAWSErr(err, "InvalidParameterValue", "Access Denied to API Version: APIGlobalDatabases") {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial (provided as a smoke test):

```
--- PASS: TestAccAWSRdsGlobalCluster_basic (11.83s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSRdsGlobalCluster_DeletionProtection (2.32s)
    resource_aws_rds_global_cluster_test.go:388: skipping acceptance testing: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
        	status code: 400, request id: e747fab8-2fb4-4c3a-8560-c819150280ef
--- SKIP: TestAccAWSRdsGlobalCluster_StorageEncrypted (2.32s)
    resource_aws_rds_global_cluster_test.go:388: skipping acceptance testing: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
        	status code: 400, request id: e412003b-11a0-4ac1-aa0e-c4da089d1fa8
--- SKIP: TestAccAWSRdsGlobalCluster_EngineVersion_Aurora (2.33s)
    resource_aws_rds_global_cluster_test.go:388: skipping acceptance testing: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
        	status code: 400, request id: 717e34c4-8eb7-4357-97ab-885c21bde784
--- SKIP: TestAccAWSRdsGlobalCluster_Engine_Aurora (2.33s)
    resource_aws_rds_global_cluster_test.go:388: skipping acceptance testing: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
        	status code: 400, request id: 4eee110b-f578-4bf6-954f-912c9c64081e
--- SKIP: TestAccAWSRdsGlobalCluster_DatabaseName (2.74s)
    resource_aws_rds_global_cluster_test.go:388: skipping acceptance testing: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
        	status code: 400, request id: 758b8f57-ca90-45a0-b375-28c14a2d5014
--- SKIP: TestAccAWSRdsGlobalCluster_disappears (2.85s)
    resource_aws_rds_global_cluster_test.go:388: skipping acceptance testing: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
        	status code: 400, request id: dfb2f8d2-3c48-4605-bbe7-a09847af46a8
--- SKIP: TestAccAWSRdsGlobalCluster_basic (3.35s)
    resource_aws_rds_global_cluster_test.go:388: skipping acceptance testing: InvalidParameterValue: Access Denied to API Version: APIGlobalDatabases
        	status code: 400, request id: 6c64db9f-fbec-4520-ae06-eb224fb27a71
PASS
```
