### PR TITLE
resource/aws_organizations_organization: Add non_master_accounts attribute

### DIFF
--- a/aws/resource_aws_organizations_organization.go
+++ b/aws/resource_aws_organizations_organization.go
@@ -70,6 +70,30 @@ func resourceAwsOrganizationsOrganization() *schema.Resource {
 					},
 				},
 			},
+			"non_master_accounts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"roots": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -208,8 +232,16 @@ func resourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta inter
 
 	log.Printf("[INFO] Listing Accounts for Organization: %s", d.Id())
 	var accounts []*organizations.Account
+	var nonMasterAccounts []*organizations.Account
 	err = conn.ListAccountsPages(&organizations.ListAccountsInput{}, func(page *organizations.ListAccountsOutput, lastPage bool) bool {
-		accounts = append(accounts, page.Accounts...)
+		for _, account := range page.Accounts {
+			if aws.StringValue(account.Id) != aws.StringValue(org.Organization.MasterAccountId) {
+				nonMasterAccounts = append(nonMasterAccounts, account)
+			}
+
+			accounts = append(accounts, account)
+		}
+
 		return !lastPage
 	})
 	if err != nil {
@@ -235,6 +267,10 @@ func resourceAwsOrganizationsOrganizationRead(d *schema.ResourceData, meta inter
 	d.Set("master_account_arn", org.Organization.MasterAccountArn)
 	d.Set("master_account_email", org.Organization.MasterAccountEmail)
 	d.Set("master_account_id", org.Organization.MasterAccountId)
+
+	if err := d.Set("non_master_accounts", flattenOrganizationsAccounts(nonMasterAccounts)); err != nil {
+		return fmt.Errorf("error setting non_master_accounts: %s", err)
+	}
 
 	if err := d.Set("roots", flattenOrganizationsRoots(roots)); err != nil {
 		return fmt.Errorf("error setting roots: %s", err)

--- a/aws/resource_aws_organizations_organization_test.go
+++ b/aws/resource_aws_organizations_organization_test.go
@@ -34,6 +34,7 @@ func testAccAwsOrganizationsOrganization_basic(t *testing.T) {
 					testAccMatchResourceAttrGlobalARN(resourceName, "master_account_arn", "organizations", regexp.MustCompile(`account/o-.+/.+`)),
 					resource.TestMatchResourceAttr(resourceName, "master_account_email", regexp.MustCompile(`.+@.+`)),
 					testAccCheckResourceAttrAccountID(resourceName, "master_account_id"),
+					resource.TestCheckResourceAttr(resourceName, "non_master_accounts.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "roots.#", "1"),
 					resource.TestMatchResourceAttr(resourceName, "roots.0.id", regexp.MustCompile(`r-[a-z0-9]{4,32}`)),
 					resource.TestCheckResourceAttrSet(resourceName, "roots.0.name"),

--- a/website/docs/r/organizations_organization.html.markdown
+++ b/website/docs/r/organizations_organization.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `accounts` - List of organization accounts (including the master account). All elements have these attributes:
+* `accounts` - List of organization accounts including the master account. For a list excluding the master account, see the `non_master_accounts` attribute. All elements have these attributes:
   * `arn` - ARN of the account
   * `email` - Email of the account
   * `id` - Identifier of the account
@@ -45,6 +45,11 @@ In addition to all arguments above, the following attributes are exported:
 * `master_account_arn` - ARN of the master account
 * `master_account_email` - Email address of the master account
 * `master_account_id` - Identifier of the master account
+* `non_master_accounts` - List of organization accounts excluding the master account. For a list including the master account, see the `accounts` attribute. All elements have these attributes:
+  * `arn` - ARN of the account
+  * `email` - Email of the account
+  * `id` - Identifier of the account
+  * `name` - Name of the account
 * `roots` - List of organization roots. All elements have these attributes:
   * `arn` - ARN of the root
   * `id` - Identifier of the root


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8903

This seems like it might be a common use case, so we provide a native attribute rather than requiring all implementations to filter the existing `accounts` attribute.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_organizations_organization: Add `non_master_accounts` attribute
```

Output from acceptance testing:

```
        --- PASS: TestAccAWSOrganizations/Organization/basic (14.39s)
```
