### PR TITLE
[WIP] #8722 Add support for RDS cluster snapshot tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.formatTool": "goimports"
+}

--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -40,7 +40,6 @@ func TestAccAWSDBClusterSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
 					resource.TestMatchResourceAttr(resourceName, "vpc_id", regexp.MustCompile(`^vpc-.+`)),
-					testAccCheckDbClusterSnapshotExists("aws_db_cluster_snapshot.test", &v),
 					resource.TestCheckResourceAttr("aws_db_cluster_snapshot.test", "tags.Name", "value1"),
 				),
 			},

--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -16,6 +16,7 @@ func TestAccAWSDBClusterSnapshot_basic(t *testing.T) {
 	var dbClusterSnapshot rds.DBClusterSnapshot
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_db_cluster_snapshot.test"
+	var v rds.DBClusterSnapshot
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,7 +24,7 @@ func TestAccAWSDBClusterSnapshot_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDbClusterSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsDbClusterSnapshotConfig(rName),
+				Config: testAccAwsDbClusterSnapshotConfig(rName, "value1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDbClusterSnapshotExists(resourceName, &dbClusterSnapshot),
 					resource.TestCheckResourceAttrSet(resourceName, "allocated_storage"),
@@ -39,6 +40,8 @@ func TestAccAWSDBClusterSnapshot_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "false"),
 					resource.TestMatchResourceAttr(resourceName, "vpc_id", regexp.MustCompile(`^vpc-.+`)),
+					testAccCheckDbClusterSnapshotExists("aws_db_cluster_snapshot.test", &v),
+					resource.TestCheckResourceAttr("aws_db_cluster_snapshot.test", "tags.Name", "value1"),
 				),
 			},
 			{
@@ -110,7 +113,7 @@ func testAccCheckDbClusterSnapshotExists(resourceName string, dbClusterSnapshot 
 	}
 }
 
-func testAccAwsDbClusterSnapshotConfig(rName string) string {
+func testAccAwsDbClusterSnapshotConfig(rName string, tag1Value string) string {
 	return fmt.Sprintf(`
 data "aws_availability_zones" "available" {}
 
@@ -150,6 +153,9 @@ resource "aws_rds_cluster" "test" {
 resource "aws_db_cluster_snapshot" "test" {
   db_cluster_identifier          = "${aws_rds_cluster.test.id}"
   db_cluster_snapshot_identifier = %q
+  tags = {
+	Name = %q
+  }
 }
-`, rName, rName, rName, rName, rName)
+`, rName, rName, rName, rName, rName, tag1Value)
 }

--- a/aws/resource_aws_db_cluster_snapshot_test.go
+++ b/aws/resource_aws_db_cluster_snapshot_test.go
@@ -16,7 +16,6 @@ func TestAccAWSDBClusterSnapshot_basic(t *testing.T) {
 	var dbClusterSnapshot rds.DBClusterSnapshot
 	rName := acctest.RandomWithPrefix("tf-acc-test")
 	resourceName := "aws_db_cluster_snapshot.test"
-	var v rds.DBClusterSnapshot
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -21378,6 +21378,7 @@ type DescribeDBClusterSnapshotsInput struct {
 	// when SnapshotType is set to shared. The IncludeShared parameter doesn't apply
 	// when SnapshotType is set to public.
 	SnapshotType *string `type:"string"`
+	Tags []*Tag `locationNameList:"Tag" type:"list"`
 }
 
 // String returns the string representation

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -21378,8 +21378,9 @@ type DescribeDBClusterSnapshotsInput struct {
 	// when SnapshotType is set to shared. The IncludeShared parameter doesn't apply
 	// when SnapshotType is set to public.
 	SnapshotType *string `type:"string"`
-	const Tags = "ListTagsForResource"
 }
+
+const Tags = "ListTagsForResource"
 
 func (c *RDS) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
 	op := &request.Operation{

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -21382,22 +21382,6 @@ type DescribeDBClusterSnapshotsInput struct {
 
 const Tags = "ListTagsForResource"
 
-func (c *RDS) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
-	op := &request.Operation{
-		Name:       Tags,
-		HTTPMethod: "POST",
-		HTTPPath:   "/",
-	}
-
-	if input == nil {
-		input = &ListTagsForResourceInput{}
-	}
-
-	output = &ListTagsForResourceOutput{}
-	req = c.newRequest(op, input, output)
-	return
-}
-
 // String returns the string representation
 func (s DescribeDBClusterSnapshotsInput) String() string {
 	return awsutil.Prettify(s)

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/api.go
@@ -21378,7 +21378,23 @@ type DescribeDBClusterSnapshotsInput struct {
 	// when SnapshotType is set to shared. The IncludeShared parameter doesn't apply
 	// when SnapshotType is set to public.
 	SnapshotType *string `type:"string"`
-	Tags []*Tag `locationNameList:"Tag" type:"list"`
+	const Tags = "ListTagsForResource"
+}
+
+func (c *RDS) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
+	op := &request.Operation{
+		Name:       Tags,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListTagsForResourceInput{}
+	}
+
+	output = &ListTagsForResourceOutput{}
+	req = c.newRequest(op, input, output)
+	return
 }
 
 // String returns the string representation

--- a/website/docs/r/db_cluster_snapshot.html.markdown
+++ b/website/docs/r/db_cluster_snapshot.html.markdown
@@ -25,6 +25,7 @@ The following arguments are supported:
 
 * `db_cluster_identifier` - (Required) The DB Cluster Identifier from which to take the snapshot.
 * `db_cluster_snapshot_identifier` - (Required) The Identifier for the snapshot.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8722

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
New Argument: Tags for RDS cluster snapshot
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSDBClusterSnapshot_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSDBClusterSnapshot_ -timeout 120m
=== RUN   TestAccAWSDBClusterSnapshot_basic
=== PAUSE TestAccAWSDBClusterSnapshot_basic
=== CONT  TestAccAWSDBClusterSnapshot_basic
--- PASS: TestAccAWSDBClusterSnapshot_basic (222.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	223.010s
...
```
