### PR TITLE
resource/aws_iam_service_linked_role: Automatically suppress Application Autoscaling custom_suffix differences

### DIFF
--- a/aws/resource_aws_iam_service_linked_role.go
+++ b/aws/resource_aws_iam_service_linked_role.go
@@ -67,6 +67,12 @@ func resourceAwsIamServiceLinkedRole() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if strings.Contains(d.Get("aws_service_name").(string), ".application-autoscaling.") && new == "" {
+						return true
+					}
+					return false
+				},
 			},
 
 			"description": {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #4439

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_iam_service_linked_role: Automatically suppress Application Autoscaling custom_suffix differences
```

IAM Service Linked Roles for Application Autoscaling are slightly different than others since they use a fourth level domain then automatically add a `custom_suffix`, which is not compatible to specify during creation. Reference: https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-service-linked-roles.html

Previously:

```
--- FAIL: TestAccAWSIAMServiceLinkedRole_CustomSuffix_DiffSuppressFunc (17.09s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        DESTROY/CREATE: aws_iam_service_linked_role.test
          arn:              "arn:aws:iam::--OMITTED--:role/aws-service-role/custom-resource.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_CustomResource" => "<computed>"
          aws_service_name: "custom-resource.application-autoscaling.amazonaws.com" => "custom-resource.application-autoscaling.amazonaws.com"
          create_date:      "" => "<computed>"
          custom_suffix:    "CustomResource" => "" (forces new resource)
          description:      "" => ""
          id:               "arn:aws:iam::--OMITTED--:role/aws-service-role/custom-resource.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_CustomResource" => "<computed>"
          name:             "AWSServiceRoleForApplicationAutoScaling_CustomResource" => "<computed>"
          path:             "/aws-service-role/custom-resource.application-autoscaling.amazonaws.com/" => "<computed>"
          unique_id:        "AROASXIXB4ZJ7W7CHKUUX" => "<computed>"
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSIAMServiceLinkedRole_basic (19.36s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix_DiffSuppressFunc (19.78s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix (19.80s)
--- PASS: TestAccAWSIAMServiceLinkedRole_Description (22.87s)
```

Output from acceptance testing in AWS GovCloud (US) (now passing with usage of `testAccCheckResourceAttrGlobalARN`):

```
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix_DiffSuppressFunc (25.54s)
--- PASS: TestAccAWSIAMServiceLinkedRole_CustomSuffix (25.58s)
--- PASS: TestAccAWSIAMServiceLinkedRole_basic (26.78s)
--- PASS: TestAccAWSIAMServiceLinkedRole_Description (34.22s)
```