### PR TITLE
Update resource name

### DIFF
--- a/website/docs/r/ses_domain_dkim.html.markdown
+++ b/website/docs/r/ses_domain_dkim.html.markdown
@@ -40,7 +40,7 @@ resource "aws_ses_domain_dkim" "example" {
   domain = "${aws_ses_domain_identity.example.domain}"
 }
 
-resource "aws_route53_record" "example_amazonses_verification_record" {
+resource "aws_route53_record" "example_amazonses_dkim_record" {
   count   = 3
   zone_id = "ABCDEFGHIJ123"
   name    = "${element(aws_ses_domain_dkim.example.dkim_tokens, count.index)}._domainkey.example.com"


### PR DESCRIPTION
The example resource used the same name as the one used in the documentation for `aws_ses_domain_identity`. The record shown here is not used for verification, but for DKIM. Thus, the example resource name should reflect the intended usage.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
