### PR TITLE
Clarified WAF predicate documentation

### DIFF
--- a/website/docs/r/waf_rate_based_rule.html.markdown
+++ b/website/docs/r/waf_rate_based_rule.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `name` - (Required) The name or description of the rule.
 * `rate_key` - (Required) Valid value is IP.
 * `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 2000.
-* `predicates` - (Optional) One of ByteMatchSet, IPSet, SizeConstraintSet, SqlInjectionMatchSet, or XssMatchSet objects to include in a rule.
+* `predicates` - (Optional) The objects to include in a rule (documented below).
 
 ## Nested Blocks
 

--- a/website/docs/r/waf_rule.html.markdown
+++ b/website/docs/r/waf_rule.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this rule. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace.
 * `name` - (Required) The name or description of the rule.
-* `predicates` - (Optional) One of ByteMatchSet, IPSet, SizeConstraintSet, SqlInjectionMatchSet, or XssMatchSet objects to include in a rule.
+* `predicates` - (Optional) The objects to include in a rule (documented below).
 
 ## Nested Blocks
 

--- a/website/docs/r/wafregional_rate_based_rule.html.markdown
+++ b/website/docs/r/wafregional_rate_based_rule.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `name` - (Required) The name or description of the rule.
 * `rate_key` - (Required) Valid value is IP.
 * `rate_limit` - (Required) The maximum number of requests, which have an identical value in the field specified by the RateKey, allowed in a five-minute period. Minimum value is 2000.
-* `predicate` - (Optional) One of ByteMatchSet, IPSet, SizeConstraintSet, SqlInjectionMatchSet, or XssMatchSet objects to include in a rule.
+* `predicate` - (Optional) The objects to include in a rule (documented below).
 
 ## Nested Blocks
 

--- a/website/docs/r/wafregional_rule.html.markdown
+++ b/website/docs/r/wafregional_rule.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name or description of the rule.
 * `metric_name` - (Required) The name or description for the Amazon CloudWatch metric of this rule.
-* `predicate` - (Optional) The objects to include in a rule.
+* `predicate` - (Optional) The objects to include in a rule (documented below).
 
 ## Nested Fields
 


### PR DESCRIPTION
predicate is a nested structure in terraform. Referenced predicate
documentation instead of referring to underlying WAF *Set objects.
Hopefully prevents user error of form:
> Error: aws_waf_rule.example: expected predicates.0.type to be one of
>  [ByteMatch GeoMatch IPMatch RegexMatch SizeConstraint SqlInjectionMatch XssMatch]

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```