### PR TITLE
Add overrideArtifactName flag for aws_codebuild_project

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -604,6 +604,10 @@ func expandProjectArtifactData(data map[string]interface{}) codebuild.ProjectArt
 		projectArtifacts.Path = aws.String(data["path"].(string))
 	}
 
+	if data["override_artifact_name"] != nil {
+		projectArtifacts.OverrideArtifactName = aws.Bool(data["override_artifact_name"].(bool))
+	}
+
 	return projectArtifacts
 }
 

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -208,6 +208,7 @@ The following arguments are supported:
 * `namespace_type` - (Optional) The namespace to use in storing build artifacts. If `type` is set to `S3`, then valid values for this parameter are: `BUILD_ID` or `NONE`.
 * `packaging` - (Optional) The type of build output artifact to create. If `type` is set to `S3`, valid values for this parameter are: `NONE` or `ZIP`
 * `path` - (Optional) If `type` is set to `S3`, this is the path to the output artifact
+* `override_artifact_name` - (Optional) If the flag is set, a name specified in the buildspec file overrides the artifact name.
 
 `cache` supports the following:
 


### PR DESCRIPTION
The overrideArtifactName (aka. semantic_versioning on the GUI) allows
the user to define the artifact name in the buildspec.yml. The name may
be dynamically calculated during the build.

The flag was missing from the Terraform provider until now.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8079

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_codebuild_project now supports overrideArtifactName (aka. semantic versioning on the GUI)
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
