### PR TITLE
Use 0.12 syntax for aws_ses_domain_mail_from

### DIFF
--- a/website/docs/r/ses_domain_mail_from.html.markdown
+++ b/website/docs/r/ses_domain_mail_from.html.markdown
@@ -16,7 +16,7 @@ Provides an SES domain MAIL FROM resource.
 
 ```hcl
 resource "aws_ses_domain_mail_from" "example" {
-  domain           = "${aws_ses_domain_identity.example.domain}"
+  domain           = aws_ses_domain_identity.example.domain
   mail_from_domain = "bounce.${aws_ses_domain_identity.example.domain}"
 }
 
@@ -27,8 +27,8 @@ resource "aws_ses_domain_identity" "example" {
 
 # Example Route53 MX record
 resource "aws_route53_record" "example_ses_domain_mail_from_mx" {
-  zone_id = "${aws_route53_zone.example.id}"
-  name    = "${aws_ses_domain_mail_from.example.mail_from_domain}"
+  zone_id = aws_route53_zone.example.id
+  name    = aws_ses_domain_mail_from.example.mail_from_domain
   type    = "MX"
   ttl     = "600"
   records = ["10 feedback-smtp.us-east-1.amazonses.com"]           # Change to the region in which `aws_ses_domain_identity.example` is created
@@ -36,8 +36,8 @@ resource "aws_route53_record" "example_ses_domain_mail_from_mx" {
 
 # Example Route53 TXT record for SPF
 resource "aws_route53_record" "example_ses_domain_mail_from_txt" {
-  zone_id = "${aws_route53_zone.example.id}"
-  name    = "${aws_ses_domain_mail_from.example.mail_from_domain}"
+  zone_id = aws_route53_zone.example.id
+  name    = aws_ses_domain_mail_from.example.mail_from_domain
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:amazonses.com -all"]


### PR DESCRIPTION
The values are no longer required to be wrapped as string explicitly, so the simpler syntax should be used.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
