### PR TITLE
Final retries for kinesis applications

### DIFF
--- a/aws/resource_aws_kinesis_analytics_application.go
+++ b/aws/resource_aws_kinesis_analytics_application.go
@@ -614,6 +614,13 @@ func resourceAwsKinesisAnalyticsApplicationCreate(d *schema.ResourceData, meta i
 		d.SetId(aws.StringValue(output.ApplicationSummary.ApplicationARN))
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		var output *kinesisanalytics.CreateApplicationOutput
+		output, err = conn.CreateApplication(createOpts)
+		d.SetId(aws.StringValue(output.ApplicationSummary.ApplicationARN))
+	}
+
 	if err != nil {
 		return fmt.Errorf("Unable to create Kinesis Analytics application: %s", err)
 	}
@@ -722,6 +729,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					}
 					return nil
 				})
+				if isResourceTimeoutError(err) {
+					_, err = conn.AddApplicationCloudWatchLoggingOption(addOpts)
+				}
+
 				if err != nil {
 					return fmt.Errorf("Unable to add CloudWatch logging options: %s", err)
 				}
@@ -754,6 +765,10 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					}
 					return nil
 				})
+				if isResourceTimeoutError(err) {
+					_, err = conn.AddApplicationInput(addOpts)
+				}
+
 				if err != nil {
 					return fmt.Errorf("Unable to add application inputs: %s", err)
 				}
@@ -786,6 +801,9 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					}
 					return nil
 				})
+				if isResourceTimeoutError(err) {
+					_, err = conn.AddApplicationOutput(addOpts)
+				}
 				if err != nil {
 					return fmt.Errorf("Unable to add application outputs: %s", err)
 				}
@@ -821,6 +839,9 @@ func resourceAwsKinesisAnalyticsApplicationUpdate(d *schema.ResourceData, meta i
 					}
 					return nil
 				})
+				if isResourceTimeoutError(err) {
+					_, err = conn.AddApplicationReferenceDataSource(addOpts)
+				}
 				if err != nil {
 					return fmt.Errorf("Unable to add application reference data source: %s", err)
 				}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_kinesis_analytics_application - Final retries for AWS timeout errors
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSKinesisAnalyticsApplication"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSKinesisAnalyticsApplication -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSKinesisAnalyticsApplication_basic
=== PAUSE TestAccAWSKinesisAnalyticsApplication_basic
=== RUN   TestAccAWSKinesisAnalyticsApplication_update
=== PAUSE TestAccAWSKinesisAnalyticsApplication_update
=== RUN   TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== PAUSE TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== RUN   TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== PAUSE TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== RUN   TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== PAUSE TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== RUN   TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== PAUSE TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== RUN   TestAccAWSKinesisAnalyticsApplication_tags
=== PAUSE TestAccAWSKinesisAnalyticsApplication_tags
=== CONT  TestAccAWSKinesisAnalyticsApplication_basic
=== CONT  TestAccAWSKinesisAnalyticsApplication_tags
=== CONT  TestAccAWSKinesisAnalyticsApplication_update
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate
=== CONT  TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsMultiple
=== CONT  TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsAdd
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream
=== CONT  TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose
=== CONT  TestAccAWSKinesisAnalyticsApplication_referenceDataSource
=== CONT  TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions
=== CONT  TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions
--- PASS: TestAccAWSKinesisAnalyticsApplication_basic (29.92s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_update (46.68s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Create (54.26s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_addCloudwatchLoggingOptions (60.69s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSource (68.79s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_Outputs_Lambda_Add (71.56s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_updateCloudwatchLoggingOptions (78.10s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_tags (83.27s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsKinesisStream (114.00s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisStream (114.29s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_referenceDataSourceUpdate (126.80s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsMultiple (129.33s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsAdd (134.30s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsAdd (135.11s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsKinesisFirehose (147.99s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_inputsUpdateKinesisStream (207.88s)
--- PASS: TestAccAWSKinesisAnalyticsApplication_outputsUpdateKinesisStream (213.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       214.320s
```