### PR TITLE
Final retries for docdb cluster operations

### DIFF
--- a/aws/resource_aws_docdb_cluster.go
+++ b/aws/resource_aws_docdb_cluster.go
@@ -340,6 +340,9 @@ func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) err
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.RestoreDBClusterFromSnapshot(&opts)
+		}
 		if err != nil {
 			return fmt.Errorf("Error creating DocDB Cluster: %s", err)
 		}
@@ -421,6 +424,9 @@ func resourceAwsDocDBClusterCreate(d *schema.ResourceData, meta interface{}) err
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			resp, err = conn.CreateDBCluster(createOpts)
+		}
 		if err != nil {
 			return fmt.Errorf("error creating DocDB cluster: %s", err)
 		}
@@ -636,6 +642,9 @@ func resourceAwsDocDBClusterUpdate(d *schema.ResourceData, meta interface{}) err
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.ModifyDBCluster(req)
+		}
 		if err != nil {
 			return fmt.Errorf("Failed to modify DocDB Cluster (%s): %s", d.Id(), err)
 		}
@@ -692,6 +701,9 @@ func resourceAwsDocDBClusterDelete(d *schema.ResourceData, meta interface{}) err
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteDBCluster(&deleteOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("DocDB Cluster cannot be deleted: %s", err)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_docdb_cluster: Retries after timeout errors for docdb cluster operations
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDocDBCluster"==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDocDBCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSDocDBClusterInstance_basic
=== PAUSE TestAccAWSDocDBClusterInstance_basic
=== RUN   TestAccAWSDocDBClusterInstance_az
=== PAUSE TestAccAWSDocDBClusterInstance_az
=== RUN   TestAccAWSDocDBClusterInstance_namePrefix
=== PAUSE TestAccAWSDocDBClusterInstance_namePrefix
=== RUN   TestAccAWSDocDBClusterInstance_generatedName
=== PAUSE TestAccAWSDocDBClusterInstance_generatedName
=== RUN   TestAccAWSDocDBClusterInstance_kmsKey
=== PAUSE TestAccAWSDocDBClusterInstance_kmsKey
=== RUN   TestAccAWSDocDBClusterInstance_disappears
=== PAUSE TestAccAWSDocDBClusterInstance_disappears
=== RUN   TestAccAWSDocDBClusterParameterGroup_basic
=== PAUSE TestAccAWSDocDBClusterParameterGroup_basic
=== RUN   TestAccAWSDocDBClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSDocDBClusterParameterGroup_namePrefix
=== RUN   TestAccAWSDocDBClusterParameterGroup_generatedName
=== PAUSE TestAccAWSDocDBClusterParameterGroup_generatedName
=== RUN   TestAccAWSDocDBClusterParameterGroup_Description
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Description
=== RUN   TestAccAWSDocDBClusterParameterGroup_disappears
=== PAUSE TestAccAWSDocDBClusterParameterGroup_disappears
=== RUN   TestAccAWSDocDBClusterParameterGroup_Parameter
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Parameter
=== RUN   TestAccAWSDocDBClusterParameterGroup_Tags
=== PAUSE TestAccAWSDocDBClusterParameterGroup_Tags
=== RUN   TestAccAWSDocDBClusterSnapshot_basic
=== PAUSE TestAccAWSDocDBClusterSnapshot_basic
=== RUN   TestAccAWSDocDBCluster_basic
=== PAUSE TestAccAWSDocDBCluster_basic
=== RUN   TestAccAWSDocDBCluster_namePrefix
=== PAUSE TestAccAWSDocDBCluster_namePrefix
=== RUN   TestAccAWSDocDBCluster_generatedName
=== PAUSE TestAccAWSDocDBCluster_generatedName
=== RUN   TestAccAWSDocDBCluster_takeFinalSnapshot
=== PAUSE TestAccAWSDocDBCluster_takeFinalSnapshot
=== RUN   TestAccAWSDocDBCluster_missingUserNameCausesError
=== PAUSE TestAccAWSDocDBCluster_missingUserNameCausesError
=== RUN   TestAccAWSDocDBCluster_updateTags
=== PAUSE TestAccAWSDocDBCluster_updateTags
=== RUN   TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== PAUSE TestAccAWSDocDBCluster_updateCloudwatchLogsExports
=== RUN   TestAccAWSDocDBCluster_kmsKey
=== PAUSE TestAccAWSDocDBCluster_kmsKey
=== RUN   TestAccAWSDocDBCluster_encrypted
=== PAUSE TestAccAWSDocDBCluster_encrypted
=== RUN   TestAccAWSDocDBCluster_backupsUpdate
=== PAUSE TestAccAWSDocDBCluster_backupsUpdate
=== RUN   TestAccAWSDocDBCluster_Port
=== PAUSE TestAccAWSDocDBCluster_Port
=== CONT  TestAccAWSDocDBClusterInstance_basic
=== CONT  TestAccAWSDocDBCluster_Port
=== CONT  TestAccAWSDocDBClusterParameterGroup_Parameter
=== CONT  TestAccAWSDocDBCluster_basic
=== CONT  TestAccAWSDocDBClusterParameterGroup_namePrefix
=== CONT  TestAccAWSDocDBClusterInstance_namePrefix
=== CONT  TestAccAWSDocDBClusterParameterGroup_basic
=== CONT  TestAccAWSDocDBClusterInstance_disappears
=== CONT  TestAccAWSDocDBClusterInstance_kmsKey
=== CONT  TestAccAWSDocDBClusterInstance_generatedName
=== CONT  TestAccAWSDocDBClusterParameterGroup_Tags
=== CONT  TestAccAWSDocDBClusterParameterGroup_Description
=== CONT  TestAccAWSDocDBCluster_updateTags
=== CONT  TestAccAWSDocDBCluster_missingUserNameCausesError
=== CONT  TestAccAWSDocDBCluster_takeFinalSnapshot
=== CONT  TestAccAWSDocDBCluster_generatedName
=== CONT  TestAccAWSDocDBCluster_namePrefix
=== CONT  TestAccAWSDocDBClusterParameterGroup_disappears
=== CONT  TestAccAWSDocDBClusterInstance_az
=== CONT  TestAccAWSDocDBClusterSnapshot_basic
=== CONT  TestAccAWSDocDBCluster_backupsUpdate
--- PASS: TestAccAWSDocDBCluster_missingUserNameCausesError (10.08s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_disappears (21.85s)
=== CONT  TestAccAWSDocDBCluster_encrypted
--- PASS: TestAccAWSDocDBClusterParameterGroup_namePrefix (33.34s)
=== CONT  TestAccAWSDocDBCluster_kmsKey
--- PASS: TestAccAWSDocDBClusterParameterGroup_Description (33.39s)
=== CONT  TestAccAWSDocDBCluster_updateCloudwatchLogsExports
--- PASS: TestAccAWSDocDBClusterParameterGroup_basic (33.44s)
=== CONT  TestAccAWSDocDBClusterParameterGroup_generatedName
--- PASS: TestAccAWSDocDBClusterParameterGroup_Parameter (52.53s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_generatedName (29.91s)
--- PASS: TestAccAWSDocDBClusterParameterGroup_Tags (75.16s)
--- PASS: TestAccAWSDocDBCluster_encrypted (121.67s)
--- PASS: TestAccAWSDocDBCluster_generatedName (166.94s)
--- PASS: TestAccAWSDocDBCluster_namePrefix (167.07s)
--- PASS: TestAccAWSDocDBCluster_basic (167.11s)
--- PASS: TestAccAWSDocDBCluster_takeFinalSnapshot (190.08s)
--- PASS: TestAccAWSDocDBCluster_updateTags (205.24s)
--- PASS: TestAccAWSDocDBCluster_backupsUpdate (202.10s)
--- PASS: TestAccAWSDocDBCluster_kmsKey (183.55s)
--- PASS: TestAccAWSDocDBCluster_updateCloudwatchLogsExports (190.83s)
--- PASS: TestAccAWSDocDBClusterSnapshot_basic (274.88s)
--- PASS: TestAccAWSDocDBCluster_Port (299.84s)
--- PASS: TestAccAWSDocDBClusterInstance_disappears (703.34s)
--- PASS: TestAccAWSDocDBClusterInstance_az (704.32s)
--- PASS: TestAccAWSDocDBClusterInstance_namePrefix (759.67s)
--- PASS: TestAccAWSDocDBClusterInstance_kmsKey (773.79s)
--- PASS: TestAccAWSDocDBClusterInstance_generatedName (796.45s)
--- PASS: TestAccAWSDocDBClusterInstance_basic (1371.85s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1372.686s
```