### PR TITLE
Timeout error retries for SSM resources

### DIFF
--- a/aws/resource_aws_ssm_document.go
+++ b/aws/resource_aws_ssm_document.go
@@ -353,36 +353,33 @@ func resourceAwsSsmDocumentDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	input := &ssm.DescribeDocumentInput{
+		Name: aws.String(d.Get("name").(string)),
+	}
 	log.Printf("[DEBUG] Waiting for SSM Document %q to be deleted", d.Get("name").(string))
 	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
-		_, err := ssmconn.DescribeDocument(&ssm.DescribeDocumentInput{
-			Name: aws.String(d.Get("name").(string)),
-		})
+		_, err := ssmconn.DescribeDocument(input)
+
+		if isAWSErr(err, ssm.ErrCodeInvalidDocument, "") {
+			return nil
+		}
 
 		if err != nil {
-			awsErr, ok := err.(awserr.Error)
-			if !ok {
-				return resource.NonRetryableError(err)
-			}
-
-			if awsErr.Code() == "InvalidDocument" {
-				return nil
-			}
-
 			return resource.NonRetryableError(err)
 		}
 
 		return resource.RetryableError(fmt.Errorf("SSM Document (%s) still exists", d.Id()))
 	})
+
 	if isResourceTimeoutError(err) {
-		_, err = ssmconn.DescribeDocument(&ssm.DescribeDocumentInput{
-			Name: aws.String(d.Get("name").(string)),
-		})
+		_, err = ssmconn.DescribeDocument(input)
+	}
+	if isAWSErr(err, ssm.ErrCodeInvalidDocument, "") {
+		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("error waiting for SSM Document (%s) deletion: %s", d.Id(), err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_ssm_document - Final retries when creating and deleting SSM documents
* resource/aws_ssm_resource_data_sync - Final retry when creating SSM resource data sync

```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSSSMDocument"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSSMDocument -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSSMDocument_basic
=== PAUSE TestAccAWSSSMDocument_basic
=== RUN   TestAccAWSSSMDocument_update
=== PAUSE TestAccAWSSSMDocument_update
=== RUN   TestAccAWSSSMDocument_permission_public
=== PAUSE TestAccAWSSSMDocument_permission_public
=== RUN   TestAccAWSSSMDocument_permission_private
=== PAUSE TestAccAWSSSMDocument_permission_private
=== RUN   TestAccAWSSSMDocument_permission_batching
=== PAUSE TestAccAWSSSMDocument_permission_batching
=== RUN   TestAccAWSSSMDocument_permission_change
=== PAUSE TestAccAWSSSMDocument_permission_change
=== RUN   TestAccAWSSSMDocument_params
=== PAUSE TestAccAWSSSMDocument_params
=== RUN   TestAccAWSSSMDocument_automation
=== PAUSE TestAccAWSSSMDocument_automation
=== RUN   TestAccAWSSSMDocument_session
=== PAUSE TestAccAWSSSMDocument_session
=== RUN   TestAccAWSSSMDocument_DocumentFormat_YAML
=== PAUSE TestAccAWSSSMDocument_DocumentFormat_YAML
=== RUN   TestAccAWSSSMDocument_Tags
=== PAUSE TestAccAWSSSMDocument_Tags
=== CONT  TestAccAWSSSMDocument_basic
=== CONT  TestAccAWSSSMDocument_Tags
=== CONT  TestAccAWSSSMDocument_DocumentFormat_YAML
=== CONT  TestAccAWSSSMDocument_permission_public
=== CONT  TestAccAWSSSMDocument_permission_private
=== CONT  TestAccAWSSSMDocument_permission_change
=== CONT  TestAccAWSSSMDocument_session
=== CONT  TestAccAWSSSMDocument_update
=== CONT  TestAccAWSSSMDocument_permission_batching
=== CONT  TestAccAWSSSMDocument_automation
=== CONT  TestAccAWSSSMDocument_params
--- PASS: TestAccAWSSSMDocument_basic (27.58s)
--- PASS: TestAccAWSSSMDocument_session (30.04s)
--- PASS: TestAccAWSSSMDocument_permission_public (30.88s)
--- PASS: TestAccAWSSSMDocument_permission_private (32.35s)
--- PASS: TestAccAWSSSMDocument_params (33.34s)
--- PASS: TestAccAWSSSMDocument_permission_batching (37.19s)
--- PASS: TestAccAWSSSMDocument_automation (44.41s)
--- PASS: TestAccAWSSSMDocument_DocumentFormat_YAML (46.44s)
--- PASS: TestAccAWSSSMDocument_Tags (65.37s)
--- PASS: TestAccAWSSSMDocument_permission_change (69.51s)
--- PASS: TestAccAWSSSMDocument_update (71.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       73.176s


make testacc TESTARGS="-run=TestAccAWSSsmResourceDataSync"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSsmResourceDataSync -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSsmResourceDataSync_basic
=== PAUSE TestAccAWSSsmResourceDataSync_basic
=== RUN   TestAccAWSSsmResourceDataSync_update
=== PAUSE TestAccAWSSsmResourceDataSync_update
=== RUN   TestAccAWSSsmResourceDataSync_import
=== PAUSE TestAccAWSSsmResourceDataSync_import
=== CONT  TestAccAWSSsmResourceDataSync_basic
=== CONT  TestAccAWSSsmResourceDataSync_import
=== CONT  TestAccAWSSsmResourceDataSync_update
--- PASS: TestAccAWSSsmResourceDataSync_basic (58.64s)
--- PASS: TestAccAWSSsmResourceDataSync_import (62.04s)
--- PASS: TestAccAWSSsmResourceDataSync_update (112.33s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       114.737s
```