### PR TITLE
Add support resource tags for aws codepipeline resources

### DIFF
--- a/aws/resource_aws_codepipeline.go
+++ b/aws/resource_aws_codepipeline.go
@@ -161,6 +161,7 @@ func resourceAwsCodePipeline() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -169,6 +170,7 @@ func resourceAwsCodePipelineCreate(d *schema.ResourceData, meta interface{}) err
 	conn := meta.(*AWSClient).codepipelineconn
 	params := &codepipeline.CreatePipelineInput{
 		Pipeline: expandAwsCodePipeline(d),
+		Tags:     tagsFromMapCodePipeline(d.Get("tags").(map[string]interface{})),
 	}
 
 	var resp *codepipeline.CreatePipelineOutput
@@ -447,6 +449,11 @@ func resourceAwsCodePipelineRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("arn", metadata.PipelineArn)
 	d.Set("name", pipeline.Name)
 	d.Set("role_arn", pipeline.RoleArn)
+
+	if err := saveTagsCodePipeline(conn, d); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -463,6 +470,10 @@ func resourceAwsCodePipelineUpdate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf(
 			"[ERROR] Error updating CodePipeline (%s): %s",
 			d.Id(), err)
+	}
+
+	if err := setTagsCodePipeline(conn, d); err != nil {
+		return fmt.Errorf("Error updating CodePipeline tags: %s", d.Id())
 	}
 
 	return resourceAwsCodePipelineRead(d, meta)

--- a/aws/resource_aws_codepipeline_webhook.go
+++ b/aws/resource_aws_codepipeline_webhook.go
@@ -93,6 +93,11 @@ func resourceAwsCodePipelineWebhook() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -144,6 +149,7 @@ func resourceAwsCodePipelineWebhookCreate(d *schema.ResourceData, meta interface
 			TargetPipeline:              aws.String(d.Get("target_pipeline").(string)),
 			AuthenticationConfiguration: extractCodePipelineWebhookAuthConfig(authType, authConfig),
 		},
+		Tags: tagsFromMapCodePipeline(d.Get("tags").(map[string]interface{})),
 	}
 
 	webhook, err := conn.PutWebhook(request)
@@ -263,6 +269,10 @@ func resourceAwsCodePipelineWebhookRead(d *schema.ResourceData, meta interface{}
 
 	if err := d.Set("filter", flattenCodePipelineWebhookFilters(webhook.Definition.Filters)); err != nil {
 		return fmt.Errorf("error setting filter: %s", err)
+	}
+
+	if err := d.Set("tags", tagsToMapCodePipeline(webhook.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -107,6 +107,58 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 	})
 }
 
+func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	resourceName := "aws_codepipeline_webhook.bar"
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodePipelineWebhookConfigWithTags(name, "tag1value", "tag2value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					testAccCheckAWSCodePipelineWebhookExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", fmt.Sprintf("test-webhook-%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag1", "tag1value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag2", "tag2value"),
+				),
+			},
+			{
+				Config: testAccAWSCodePipelineWebhookConfigWithTags(name, "tag1valueUpdate", "tag2valueUpdate"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					testAccCheckAWSCodePipelineWebhookExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Name", fmt.Sprintf("test-webhook-%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag1", "tag1valueUpdate"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag2", "tag2valueUpdate"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAWSCodePipelineWebhookConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					testAccCheckAWSCodePipelineWebhookExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSCodePipelineWebhookExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -179,6 +231,32 @@ resource "aws_codepipeline_webhook" "bar" {
     }
 }
 `, rName))
+}
+
+func testAccAWSCodePipelineWebhookConfigWithTags(rName, tag1, tag2 string) string {
+	return testAccAWSCodePipelineWebhookConfig_codePipeline(rName, fmt.Sprintf(`
+resource "aws_codepipeline_webhook" "bar" {
+    name            = "test-webhook-%[1]s" 
+    authentication  = "GITHUB_HMAC" 
+    target_action   = "Source"
+    target_pipeline = "${aws_codepipeline.bar.name}"
+
+    authentication_configuration {
+      secret_token = "super-secret"
+    }
+
+    filter {
+      json_path    = "$.ref"
+      match_equals = "refs/head/{Branch}"
+    }
+
+    tags = {
+      Name = "test-webhook-%[1]s"
+      tag1 = %[2]q
+      tag2 = %[3]q
+    }
+}
+`, rName, tag1, tag2))
 }
 
 func testAccAWSCodePipelineWebhookConfig_codePipeline(rName string, webhook string) string {

--- a/aws/tagsCodePipeline.go
+++ b/aws/tagsCodePipeline.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codepipeline"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsCodePipeline(conn *codepipeline.CodePipeline, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsCodePipeline(tagsFromMapCodePipeline(o), tagsFromMapCodePipeline(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			k := make([]*string, len(remove))
+			for i, t := range remove {
+				k[i] = t.Key
+			}
+
+			_, err := conn.UntagResource(&codepipeline.UntagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				TagKeys:     k,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&codepipeline.TagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsCodePipeline(oldTags, newTags []*codepipeline.Tag) ([]*codepipeline.Tag, []*codepipeline.Tag) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*codepipeline.Tag
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			// Delete it!
+			remove = append(remove, t)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapCodePipeline(create), remove
+}
+
+func saveTagsCodePipeline(conn *codepipeline.CodePipeline, d *schema.ResourceData) error {
+	resp, err := conn.ListTagsForResource(&codepipeline.ListTagsForResourceInput{
+		ResourceArn: aws.String(d.Get("arn").(string)),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retreiving tags for ARN: %s", d.Get("arn").(string))
+	}
+
+	var dt []*codepipeline.Tag
+	if len(resp.Tags) > 0 {
+		dt = resp.Tags
+	}
+
+	return d.Set("tags", tagsToMapCodePipeline(dt))
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapCodePipeline(m map[string]interface{}) []*codepipeline.Tag {
+	result := make([]*codepipeline.Tag, 0, len(m))
+	for k, v := range m {
+		t := &codepipeline.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredCodePipeline(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapCodePipeline(ts []*codepipeline.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredCodePipeline(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredCodePipeline(t *codepipeline.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		r, _ := regexp.MatchString(v, aws.StringValue(t.Key))
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsCodePipeline_test.go
+++ b/aws/tagsCodePipeline_test.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codepipeline"
+)
+
+// go test -v -run="TestDiffCodePipelineTags"
+func TestDiffCodePipelineTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsCodePipeline(tagsFromMapCodePipeline(tc.Old), tagsFromMapCodePipeline(tc.New))
+		cm := tagsToMapCodePipeline(c)
+		rm := tagsToMapCodePipeline(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsCodePipeline"
+func TestIgnoringTagsCodePipeline(t *testing.T) {
+	var ignoredTags []*codepipeline.Tag
+	ignoredTags = append(ignoredTags, &codepipeline.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &codepipeline.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredCodePipeline(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", *tag.Key, *tag.Value)
+		}
+	}
+}

--- a/website/docs/r/codepipeline.markdown
+++ b/website/docs/r/codepipeline.markdown
@@ -158,6 +158,7 @@ The following arguments are supported:
 * `role_arn` - (Required) A service role Amazon Resource Name (ARN) that grants AWS CodePipeline permission to make calls to AWS services on your behalf.
 * `artifact_store` (Required) An artifact_store block. Artifact stores are documented below.
 * `stage` (Minimum of at least two `stage` blocks is required) A stage block. Stages are documented below.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 
 An `artifact_store` block supports the following arguments:

--- a/website/docs/r/codepipeline_webhook.markdown
+++ b/website/docs/r/codepipeline_webhook.markdown
@@ -115,6 +115,7 @@ The following arguments are supported:
 * `filter` (Required) One or more `filter` blocks. Filter blocks are documented below.
 * `target_action` - (Required) The name of the action in a pipeline you want to connect to the webhook. The action must be from the source (first) stage of the pipeline.
 * `target_pipeline` - (Required) The name of the pipeline.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 An `authentication_configuration` block supports the following arguments:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8650 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add support `tags` attribute for `aws_codepipeline` and `aws_codepipeline_webhook`
```

Output from acceptance testing:

- `r/aws_codepipeline`
```
$  make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCodePipeline_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSCodePipeline_ -timeout 120m
=== RUN   TestAccAWSCodePipeline_Import_basic
=== PAUSE TestAccAWSCodePipeline_Import_basic
=== RUN   TestAccAWSCodePipeline_basic
=== PAUSE TestAccAWSCodePipeline_basic
=== RUN   TestAccAWSCodePipeline_emptyArtifacts
=== PAUSE TestAccAWSCodePipeline_emptyArtifacts
=== RUN   TestAccAWSCodePipeline_deployWithServiceRole
=== PAUSE TestAccAWSCodePipeline_deployWithServiceRole
=== RUN   TestAccAWSCodePipeline_tags
=== PAUSE TestAccAWSCodePipeline_tags
=== CONT  TestAccAWSCodePipeline_Import_basic
=== CONT  TestAccAWSCodePipeline_tags
=== CONT  TestAccAWSCodePipeline_deployWithServiceRole
=== CONT  TestAccAWSCodePipeline_emptyArtifacts
=== CONT  TestAccAWSCodePipeline_basic
--- PASS: TestAccAWSCodePipeline_Import_basic (57.18s)
--- PASS: TestAccAWSCodePipeline_emptyArtifacts (57.32s)
--- PASS: TestAccAWSCodePipeline_deployWithServiceRole (69.09s)
--- PASS: TestAccAWSCodePipeline_basic (88.46s)
--- PASS: TestAccAWSCodePipeline_tags (131.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws    131.400s
```

- `r/aws_codepipeline_webhook`

```
$  make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCodePipelineWebhook_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSCodePipelineWebhook_ -timeout 120m
=== RUN   TestAccAWSCodePipelineWebhook_basic
--- PASS: TestAccAWSCodePipelineWebhook_basic (60.90s)
=== RUN   TestAccAWSCodePipelineWebhook_ipAuth
--- PASS: TestAccAWSCodePipelineWebhook_ipAuth (61.42s)
=== RUN   TestAccAWSCodePipelineWebhook_unauthenticated
--- PASS: TestAccAWSCodePipelineWebhook_unauthenticated (59.44s)
=== RUN   TestAccAWSCodePipelineWebhook_tags
--- PASS: TestAccAWSCodePipelineWebhook_tags (141.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws    323.783s
```