### PR TITLE
Final retries for RDS cluster functions

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -516,6 +516,9 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.RestoreDBClusterFromSnapshot(&opts)
+		}
 		if err != nil {
 			return fmt.Errorf("Error creating RDS Cluster: %s", err)
 		}
@@ -602,6 +605,9 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			resp, err = conn.CreateDBCluster(createOpts)
+		}
 		if err != nil {
 			return fmt.Errorf("error creating RDS cluster: %s", err)
 		}
@@ -695,8 +701,10 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 		log.Printf("[DEBUG] RDS Cluster restore options: %s", createOpts)
 		// Retry for IAM/S3 eventual consistency
+		var resp *rds.RestoreDBClusterFromS3Output
 		err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-			resp, err := conn.RestoreDBClusterFromS3(createOpts)
+			var err error
+			resp, err = conn.RestoreDBClusterFromS3(createOpts)
 			if err != nil {
 				// InvalidParameterValue: Files from the specified Amazon S3 bucket cannot be downloaded.
 				// Make sure that you have created an AWS Identity and Access Management (IAM) role that lets Amazon RDS access Amazon S3 for you.
@@ -714,6 +722,9 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			log.Printf("[DEBUG]: RDS Cluster create response: %s", resp)
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			resp, err = conn.RestoreDBClusterFromS3(createOpts)
+		}
 
 		if err != nil {
 			log.Printf("[ERROR] Error creating RDS Cluster: %s", err)
@@ -837,6 +848,9 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			resp, err = conn.CreateDBCluster(createOpts)
+		}
 		if err != nil {
 			return fmt.Errorf("error creating RDS cluster: %s", err)
 		}
@@ -1128,6 +1142,9 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.ModifyDBCluster(req)
+		}
 		if err != nil {
 			return fmt.Errorf("Failed to modify RDS Cluster (%s): %s", d.Id(), err)
 		}

--- a/aws/resource_aws_rds_cluster_instance.go
+++ b/aws/resource_aws_rds_cluster_instance.go
@@ -291,6 +291,9 @@ func resourceAwsRDSClusterInstanceCreate(d *schema.ResourceData, meta interface{
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateDBInstance(createOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("error creating RDS DB Instance: %s", err)
 	}
@@ -500,6 +503,9 @@ func resourceAwsRDSClusterInstanceUpdate(d *schema.ResourceData, meta interface{
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.ModifyDBInstance(req)
+		}
 		if err != nil {
 			return fmt.Errorf("Error modifying DB Instance %s: %s", d.Id(), err)
 		}

--- a/aws/resource_aws_rds_global_cluster.go
+++ b/aws/resource_aws_rds_global_cluster.go
@@ -196,6 +196,10 @@ func resourceAwsRDSGlobalClusterDelete(d *schema.ResourceData, meta interface{})
 		return nil
 	})
 
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteGlobalCluster(input)
+	}
+
 	if isAWSErr(err, rds.ErrCodeGlobalClusterNotFoundFault, "") {
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_rds_cluster - Final retries after timeout creating and updating cluster
* resource/aws_rds_cluster_instance - Final retry after timeout creating cluster instance
* resource/aws_rds_global_cluster - Final retry after timeout deleting global cluster

```

Output from acceptance testing:

```
NOTE: the failures in TestAccAWSRDSCluster are existing failures against master, not new failures


make testacc TESTARGS="-run=TestAccAWSRDSCluster"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRDSCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]



=== RUN   TestAccAWSRDSClusterEndpoint_basic
=== PAUSE TestAccAWSRDSClusterEndpoint_basic
=== RUN   TestAccAWSRDSClusterInstance_basic
=== PAUSE TestAccAWSRDSClusterInstance_basic
=== RUN   TestAccAWSRDSClusterInstance_az
=== PAUSE TestAccAWSRDSClusterInstance_az
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
=== PAUSE TestAccAWSRDSClusterInstance_namePrefix
=== RUN   TestAccAWSRDSClusterInstance_generatedName
=== PAUSE TestAccAWSRDSClusterInstance_generatedName
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
=== PAUSE TestAccAWSRDSClusterInstance_kmsKey
=== RUN   TestAccAWSRDSClusterInstance_disappears
=== PAUSE TestAccAWSRDSClusterInstance_disappears
=== RUN   TestAccAWSRDSClusterInstance_PubliclyAccessible
=== PAUSE TestAccAWSRDSClusterInstance_PubliclyAccessible
=== RUN   TestAccAWSRDSClusterInstance_CopyTagsToSnapshot
=== PAUSE TestAccAWSRDSClusterInstance_CopyTagsToSnapshot
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
=== PAUSE TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
=== RUN   TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
=== PAUSE TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
=== RUN   TestAccAWSRDSCluster_importBasic
=== PAUSE TestAccAWSRDSCluster_importBasic
=== RUN   TestAccAWSRDSCluster_basic
=== PAUSE TestAccAWSRDSCluster_basic
=== RUN   TestAccAWSRDSCluster_BacktrackWindow
=== PAUSE TestAccAWSRDSCluster_BacktrackWindow
=== RUN   TestAccAWSRDSCluster_namePrefix
=== PAUSE TestAccAWSRDSCluster_namePrefix
=== RUN   TestAccAWSRDSCluster_s3Restore
=== PAUSE TestAccAWSRDSCluster_s3Restore
=== RUN   TestAccAWSRDSCluster_generatedName
=== PAUSE TestAccAWSRDSCluster_generatedName
=== RUN   TestAccAWSRDSCluster_takeFinalSnapshot
=== PAUSE TestAccAWSRDSCluster_takeFinalSnapshot
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
=== PAUSE TestAccAWSRDSCluster_missingUserNameCausesError
=== RUN   TestAccAWSRDSCluster_updateTags
=== PAUSE TestAccAWSRDSCluster_updateTags
=== RUN   TestAccAWSRDSCluster_updateCloudwatchLogsExports
=== PAUSE TestAccAWSRDSCluster_updateCloudwatchLogsExports
=== RUN   TestAccAWSRDSCluster_updateIamRoles
=== PAUSE TestAccAWSRDSCluster_updateIamRoles
=== RUN   TestAccAWSRDSCluster_kmsKey
=== PAUSE TestAccAWSRDSCluster_kmsKey
=== RUN   TestAccAWSRDSCluster_encrypted
=== PAUSE TestAccAWSRDSCluster_encrypted
=== RUN   TestAccAWSRDSCluster_copyTagsToSnapshot
=== PAUSE TestAccAWSRDSCluster_copyTagsToSnapshot
=== RUN   TestAccAWSRDSCluster_EncryptedCrossRegionReplication
=== PAUSE TestAccAWSRDSCluster_EncryptedCrossRegionReplication
=== RUN   TestAccAWSRDSCluster_backupsUpdate
=== PAUSE TestAccAWSRDSCluster_backupsUpdate
=== RUN   TestAccAWSRDSCluster_iamAuth
=== PAUSE TestAccAWSRDSCluster_iamAuth
=== RUN   TestAccAWSRDSCluster_DeletionProtection
=== PAUSE TestAccAWSRDSCluster_DeletionProtection
=== RUN   TestAccAWSRDSCluster_EngineMode
=== PAUSE TestAccAWSRDSCluster_EngineMode
=== RUN   TestAccAWSRDSCluster_EngineMode_Global
=== PAUSE TestAccAWSRDSCluster_EngineMode_Global
=== RUN   TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== PAUSE TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== RUN   TestAccAWSRDSCluster_EngineVersion
=== PAUSE TestAccAWSRDSCluster_EngineVersion
=== RUN   TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== PAUSE TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== RUN   TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== PAUSE TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== RUN   TestAccAWSRDSCluster_Port
=== PAUSE TestAccAWSRDSCluster_Port
=== RUN   TestAccAWSRDSCluster_ScalingConfiguration
=== PAUSE TestAccAWSRDSCluster_ScalingConfiguration
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
    resource_aws_rds_cluster_test.go:1134: serverless does not support snapshot restore on an empty volume
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== RUN   TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== PAUSE TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== CONT  TestAccAWSRDSClusterEndpoint_basic
=== CONT  TestAccAWSRDSCluster_iamAuth
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore
=== CONT  TestAccAWSRDSCluster_Port
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Update
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier_Add
=== CONT  TestAccAWSRDSCluster_ScalingConfiguration
=== CONT  TestAccAWSRDSCluster_GlobalClusterIdentifier
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_Tags
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal
=== CONT  TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance
=== CONT  TestAccAWSRDSCluster_EngineVersion
=== CONT  TestAccAWSRDSCluster_EngineMode_ParallelQuery
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different
=== CONT  TestAccAWSRDSCluster_EngineMode_Global
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (125.87s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned
--- PASS: TestAccAWSRDSCluster_iamAuth (127.30s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (127.36s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Add (134.22s)
=== CONT  TestAccAWSRDSCluster_EngineMode
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier (138.41s)
=== CONT  TestAccAWSRDSCluster_DeletionProtection
--- PASS: TestAccAWSRDSCluster_EngineVersion (151.02s)
=== CONT  TestAccAWSRDSCluster_SnapshotIdentifier
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Update (179.53s)
=== CONT  TestAccAWSRDSCluster_namePrefix
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove (196.94s)
=== CONT  TestAccAWSRDSCluster_backupsUpdate
--- PASS: TestAccAWSRDSCluster_Port (240.61s)
=== CONT  TestAccAWSRDSClusterInstance_generatedName
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (289.32s)
=== CONT  TestAccAWSRDSCluster_updateCloudwatchLogsExports
--- PASS: TestAccAWSRDSCluster_DeletionProtection (175.10s)
=== CONT  TestAccAWSRDSClusterInstance_PubliclyAccessible
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (336.70s)
=== CONT  TestAccAWSRDSCluster_takeFinalSnapshot
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (339.83s)
=== CONT  TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (358.51s)
=== CONT  TestAccAWSRDSClusterInstance_kmsKey
--- FAIL: TestAccAWSRDSCluster_EngineMode (224.74s)
    testing.go:568: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: aws_rds_cluster.test
        ...
          scaling_configuration.0.min_capacity:             "1" => "2"
        ...
        
        
        
        STATE:
        ...
=== CONT  TestAccAWSRDSCluster_BacktrackWindow
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (359.26s)
=== CONT  TestAccAWSRDSCluster_updateTags
--- PASS: TestAccAWSRDSCluster_namePrefix (181.69s)
=== CONT  TestAccAWSRDSCluster_missingUserNameCausesError
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (9.43s)
=== CONT  TestAccAWSRDSCluster_generatedName
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (378.61s)
=== CONT  TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (378.80s)
=== CONT  TestAccAWSRDSCluster_s3Restore
--- PASS: TestAccAWSRDSCluster_backupsUpdate (221.88s)
=== CONT  TestAccAWSRDSCluster_kmsKey
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (425.78s)
=== CONT  TestAccAWSRDSCluster_updateIamRoles
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (443.12s)
=== CONT  TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_updateCloudwatchLogsExports (180.11s)
=== CONT  TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (140.72s)
=== CONT  TestAccAWSRDSClusterInstance_CopyTagsToSnapshot
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (361.74s)
=== CONT  TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (351.37s)
=== CONT  TestAccAWSRDSCluster_importBasic
--- PASS: TestAccAWSRDSCluster_generatedName (145.33s)
=== CONT  TestAccAWSRDSCluster_EncryptedCrossRegionReplication
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (407.98s)
=== CONT  TestAccAWSRDSClusterInstance_namePrefix
--- PASS: TestAccAWSRDSCluster_updateTags (181.28s)
=== CONT  TestAccAWSRDSCluster_encrypted
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (184.11s)
=== CONT  TestAccAWSRDSClusterInstance_az
--- PASS: TestAccAWSRDSCluster_basic (114.65s)
=== CONT  TestAccAWSRDSCluster_copyTagsToSnapshot
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (434.31s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (172.08s)
--- PASS: TestAccAWSRDSCluster_importBasic (119.91s)
--- PASS: TestAccAWSRDSCluster_kmsKey (215.78s)
--- PASS: TestAccAWSRDSCluster_encrypted (132.87s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (228.30s)
--- PASS: TestAccAWSRDSClusterInstance_generatedName (759.97s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (734.24s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (795.28s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (779.72s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (706.60s)
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (811.13s)
--- PASS: TestAccAWSRDSClusterEndpoint_basic (1207.08s)
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (753.61s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (692.06s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1249.13s)
--- PASS: TestAccAWSRDSClusterInstance_az (747.10s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1550.68s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error waiting for RDS Cluster state to be "available": unexpected state 'migration-failed', wanted target 'available'. last error: %!s(<nil>)
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test252432724/main.tf line 68:
          (source code not available)
        
        
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1522.09s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1590.36s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       2081.850s
make: *** [testacc] Error 1


make testacc TESTARGS="-run=TestAccAWSRdsGlobalCluster"                 ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRdsGlobalCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRdsGlobalCluster_basic
=== PAUSE TestAccAWSRdsGlobalCluster_basic
=== RUN   TestAccAWSRdsGlobalCluster_disappears
=== PAUSE TestAccAWSRdsGlobalCluster_disappears
=== RUN   TestAccAWSRdsGlobalCluster_DatabaseName
=== PAUSE TestAccAWSRdsGlobalCluster_DatabaseName
=== RUN   TestAccAWSRdsGlobalCluster_DeletionProtection
=== PAUSE TestAccAWSRdsGlobalCluster_DeletionProtection
=== RUN   TestAccAWSRdsGlobalCluster_Engine_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_Engine_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== PAUSE TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
=== RUN   TestAccAWSRdsGlobalCluster_StorageEncrypted
=== PAUSE TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_basic
=== CONT  TestAccAWSRdsGlobalCluster_Engine_Aurora
=== CONT  TestAccAWSRdsGlobalCluster_disappears
=== CONT  TestAccAWSRdsGlobalCluster_DeletionProtection
=== CONT  TestAccAWSRdsGlobalCluster_DatabaseName
=== CONT  TestAccAWSRdsGlobalCluster_StorageEncrypted
=== CONT  TestAccAWSRdsGlobalCluster_EngineVersion_Aurora
--- PASS: TestAccAWSRdsGlobalCluster_disappears (22.19s)
--- PASS: TestAccAWSRdsGlobalCluster_basic (29.14s)
--- PASS: TestAccAWSRdsGlobalCluster_EngineVersion_Aurora (29.41s)
--- PASS: TestAccAWSRdsGlobalCluster_Engine_Aurora (30.37s)
--- PASS: TestAccAWSRdsGlobalCluster_DeletionProtection (46.06s)
--- PASS: TestAccAWSRdsGlobalCluster_StorageEncrypted (49.30s)
--- PASS: TestAccAWSRdsGlobalCluster_DatabaseName (50.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.728s

make testacc TESTARGS="-run=TestAccAWSRDSClusterInstance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRDSClusterInstance -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSRDSClusterInstance_basic
=== PAUSE TestAccAWSRDSClusterInstance_basic
=== RUN   TestAccAWSRDSClusterInstance_az
=== PAUSE TestAccAWSRDSClusterInstance_az
=== RUN   TestAccAWSRDSClusterInstance_namePrefix
=== PAUSE TestAccAWSRDSClusterInstance_namePrefix
=== RUN   TestAccAWSRDSClusterInstance_generatedName
=== PAUSE TestAccAWSRDSClusterInstance_generatedName
=== RUN   TestAccAWSRDSClusterInstance_kmsKey
=== PAUSE TestAccAWSRDSClusterInstance_kmsKey
=== RUN   TestAccAWSRDSClusterInstance_disappears
=== PAUSE TestAccAWSRDSClusterInstance_disappears
=== RUN   TestAccAWSRDSClusterInstance_PubliclyAccessible
=== PAUSE TestAccAWSRDSClusterInstance_PubliclyAccessible
=== RUN   TestAccAWSRDSClusterInstance_CopyTagsToSnapshot
=== PAUSE TestAccAWSRDSClusterInstance_CopyTagsToSnapshot
=== RUN   TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
=== PAUSE TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
=== RUN   TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
=== PAUSE TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
=== CONT  TestAccAWSRDSClusterInstance_basic
=== CONT  TestAccAWSRDSClusterInstance_PubliclyAccessible
=== CONT  TestAccAWSRDSClusterInstance_az
=== CONT  TestAccAWSRDSClusterInstance_CopyTagsToSnapshot
=== CONT  TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor
=== CONT  TestAccAWSRDSClusterInstance_kmsKey
=== CONT  TestAccAWSRDSClusterInstance_generatedName
=== CONT  TestAccAWSRDSClusterInstance_namePrefix
=== CONT  TestAccAWSRDSClusterInstance_withInstancePerformanceInsights
=== CONT  TestAccAWSRDSClusterInstance_disappears
--- PASS: TestAccAWSRDSClusterInstance_generatedName (660.97s)
--- PASS: TestAccAWSRDSClusterInstance_withInstanceEnhancedMonitor (689.81s)
--- PASS: TestAccAWSRDSClusterInstance_CopyTagsToSnapshot (699.34s)
--- PASS: TestAccAWSRDSClusterInstance_disappears (705.60s)
--- PASS: TestAccAWSRDSClusterInstance_kmsKey (727.54s)
--- PASS: TestAccAWSRDSClusterInstance_az (735.46s)
--- PASS: TestAccAWSRDSClusterInstance_PubliclyAccessible (740.25s)
--- PASS: TestAccAWSRDSClusterInstance_withInstancePerformanceInsights (748.17s)
--- PASS: TestAccAWSRDSClusterInstance_basic (1296.83s)
--- PASS: TestAccAWSRDSClusterInstance_namePrefix (2058.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       2061.307s
```