### PR TITLE
resource/aws_cloudformation_stack: Fix perpetual diff on template with transform

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -291,7 +291,8 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 	}
 
 	tInput := cloudformation.GetTemplateInput{
-		StackName: aws.String(d.Id()),
+		StackName:     aws.String(d.Id()),
+		TemplateStage: aws.String("Original"),
 	}
 	out, err := conn.GetTemplate(&tInput)
 	if err != nil {

--- a/aws/resource_aws_cloudformation_stack_test.go
+++ b/aws/resource_aws_cloudformation_stack_test.go
@@ -258,6 +258,32 @@ func TestAccAWSCloudFormationStack_withUrl_withParams_noUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudFormationStack_withTransform(t *testing.T) {
+	var stack cloudformation.Stack
+	rName := fmt.Sprintf("tf-acc-test-with-transform-%s", acctest.RandString(10))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudFormationStackConfig_withTransform(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-transform", &stack),
+				),
+			},
+			{
+				PlanOnly: true,
+				Config:   testAccAWSCloudFormationStackConfig_withTransform(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-transform", &stack),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCloudFormationStackExists(n string, stack *cloudformation.Stack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -709,4 +735,59 @@ resource "aws_cloudformation_stack" "with-url-and-params-and-yaml" {
   timeout_in_minutes = 1
 }
 `, rName, bucketKey, vpcCidr)
+}
+
+func testAccAWSCloudFormationStackConfig_withTransform(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack" "with-transform" {
+  name = "%[1]s"
+
+  template_body      = <<STACK
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Transform": "AWS::Serverless-2016-10-31",
+  "Resources": {
+    "Api": {
+      "Type": "AWS::Serverless::Api",
+      "Properties": {
+        "StageName": "Prod",
+        "EndpointConfiguration": "REGIONAL",
+        "DefinitionBody": {
+          "swagger": "2.0",
+          "paths": {
+            "/": {
+              "get": {
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "responses": {
+                  "200": {
+                    "description": "200 response"
+                  }
+                },
+                "x-amazon-apigateway-integration": {
+                  "responses": {
+                    "default": {
+                      "statusCode": "200"
+                    }
+                  },
+                  "requestTemplates": {
+                    "application/json": "{\"statusCode\": 200}"
+                  },
+                  "passthroughBehavior": "when_no_match",
+                  "type": "mock"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+STACK
+  capabilities       = ["CAPABILITY_AUTO_EXPAND"]
+  on_failure         = "DELETE"
+  timeout_in_minutes = 10
+}
+`, rName)
 }


### PR DESCRIPTION
In refreshing the state of an aws_cloudformation_stack, request the "Original" template body with CFn GetTemplate API to avoid perpetual diff in case the template uses macro transform, such as the AWS::Serverless framework.

ref: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_GetTemplate.html

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #6662

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_cloudformation_stack: Fix perpetual diff on template with transform
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCloudFormationStack_withTransform'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSCloudFormationStack_withTransform -timeout 120m
=== RUN   TestAccAWSCloudFormationStack_withTransform
=== PAUSE TestAccAWSCloudFormationStack_withTransform
=== CONT  TestAccAWSCloudFormationStack_withTransform
--- PASS: TestAccAWSCloudFormationStack_withTransform (58.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       (cached)
```
