### PR TITLE
Add clarification about lightsail's name uniqueness constraints

### DIFF
--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -31,8 +31,7 @@ resource "aws_lightsail_instance" "gitlab_test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Lightsail Instance. *This must be unique (within your
-account), and cannot be the same as a name given to a `lightsail_static_ip`.*
+* `name` - (Required) The name of the Lightsail Instance. Names be unique within each AWS Region in your Lightsail account.
 * `availability_zone` - (Required) The Availability Zone in which to create your
 instance (see list below)
 * `blueprint_id` - (Required) The ID for a virtual private server image

--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -31,7 +31,8 @@ resource "aws_lightsail_instance" "gitlab_test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Lightsail Instance
+* `name` - (Required) The name of the Lightsail Instance. *This must be unique (within your
+account), and cannot be the same as a name given to a `lightsail_static_ip`.*
 * `availability_zone` - (Required) The Availability Zone in which to create your
 instance (see list below)
 * `blueprint_id` - (Required) The ID for a virtual private server image


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

This is purely a documentation change to make it easier to get up and running with Lightsail instances using Terraform.