### PR TITLE
resource_aws_kinesis_firehose_delivery_stream: Avoid invalid state on refresh

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -337,7 +337,7 @@ func flattenFirehoseDataFormatConversionConfiguration(dfcc *firehose.DataFormatC
 	// 1. With a nil value
 	// 2. With enabled set to false and nil for ALL the config sections.
 	// These two cases are equivalent so we use the same state description, to avoid diffs.
-	if enabled == false && len(ifc) == 0 && len(ofc) == 0 && len(sc) == 0 {
+	if !enabled && len(ifc) == 0 && len(ofc) == 0 && len(sc) == 0 {
 		log.Printf("Found ambiguous AWS response")
 		return []map[string]interface{}{}
 	}
@@ -551,7 +551,7 @@ func flattenProcessingConfiguration(pc *firehose.ProcessingConfiguration, roleAr
 	// 1. With a nil value
 	// 2. With an empty processor list and enabled set to false.
 	// These are equivalent so we use the same state description, to avoid diffs.
-	if enabled == false && len(pc.Processors) == 0 {
+	if !enabled && len(pc.Processors) == 0 {
 		return []map[string]interface{}{}
 	}
 


### PR DESCRIPTION
When refreshing the state of a aws_kinesis_firehose_delivery_stream
resource, the AWS SDK may have more that one way to describe the same
configuration. In the case of ProcessingConfiguration, this can lead to
perpetual diffs and for DataFormatConversionConfiguration it can lead to
invalid state that causes later refresh and plan operations to crash.

We have solved these two situations here by detecting the alternative
representation of the "disabled" configuration, and disambiguated the
terraform state data.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8982 and possibly also #6053 and #4392

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_kinesis_firehose_delivery_stream: After manual edit in AWS console, refresh no longer causes invalid state file.
```
