### PR TITLE
Move tag creation for secrets manager from being a seperate step to be part of the creati…

### DIFF
--- a/aws/resource_aws_secretsmanager_secret.go
+++ b/aws/resource_aws_secretsmanager_secret.go
@@ -117,6 +117,11 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		Name:        aws.String(secretName),
 	}
 
+	if v, ok := d.GetOk("tags"); ok {
+		input.Tags = tagsFromMapSecretsManager(v.(map[string]interface{}))
+		log.Printf("[DEBUG] Tagging Secrets Manager Secret: %s", input.Tags)
+	}
+
 	if v, ok := d.GetOk("kms_key_id"); ok && v.(string) != "" {
 		input.KmsKeyId = aws.String(v.(string))
 	}
@@ -179,19 +184,6 @@ func resourceAwsSecretsManagerSecretCreate(d *schema.ResourceData, meta interfac
 		})
 		if err != nil {
 			return fmt.Errorf("error enabling Secrets Manager Secret %q rotation: %s", d.Id(), err)
-		}
-	}
-
-	if v, ok := d.GetOk("tags"); ok {
-		input := &secretsmanager.TagResourceInput{
-			SecretId: aws.String(d.Id()),
-			Tags:     tagsFromMapSecretsManager(v.(map[string]interface{})),
-		}
-
-		log.Printf("[DEBUG] Tagging Secrets Manager Secret: %s", input)
-		_, err := conn.TagResource(input)
-		if err != nil {
-			return fmt.Errorf("error tagging Secrets Manager Secret %q: %s", d.Id(), input)
 		}
 	}
 


### PR DESCRIPTION
…on.  This is necessary when IAM policies are in place that have conditions for RequestTag.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Tags will now be created as part of the initial secret creation.  This will accommodate IAM policies that have aws:RequestTag in the condition block.
```

Output from acceptance testing:

```
make testacc TEST=./aws TESTARGS='-run=TestAccAwsSecretsManager*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAwsSecretsManager* -timeout 120m
=== RUN   TestAccAwsSecretsManagerSecret_Basic
=== PAUSE TestAccAwsSecretsManagerSecret_Basic
=== RUN   TestAccAwsSecretsManagerSecret_withNamePrefix
=== PAUSE TestAccAwsSecretsManagerSecret_withNamePrefix
=== RUN   TestAccAwsSecretsManagerSecret_Description
=== PAUSE TestAccAwsSecretsManagerSecret_Description
=== RUN   TestAccAwsSecretsManagerSecret_KmsKeyID
=== PAUSE TestAccAwsSecretsManagerSecret_KmsKeyID
=== RUN   TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate
=== PAUSE TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate
=== RUN   TestAccAwsSecretsManagerSecret_RotationLambdaARN
=== PAUSE TestAccAwsSecretsManagerSecret_RotationLambdaARN
=== RUN   TestAccAwsSecretsManagerSecret_RotationRules
=== PAUSE TestAccAwsSecretsManagerSecret_RotationRules
=== RUN   TestAccAwsSecretsManagerSecret_Tags
=== PAUSE TestAccAwsSecretsManagerSecret_Tags
=== RUN   TestAccAwsSecretsManagerSecret_policy
=== PAUSE TestAccAwsSecretsManagerSecret_policy
=== RUN   TestAccAwsSecretsManagerSecretVersion_BasicString
=== PAUSE TestAccAwsSecretsManagerSecretVersion_BasicString
=== RUN   TestAccAwsSecretsManagerSecretVersion_Base64Binary
=== PAUSE TestAccAwsSecretsManagerSecretVersion_Base64Binary
=== RUN   TestAccAwsSecretsManagerSecretVersion_VersionStages
=== PAUSE TestAccAwsSecretsManagerSecretVersion_VersionStages
=== CONT  TestAccAwsSecretsManagerSecret_Basic
=== CONT  TestAccAwsSecretsManagerSecretVersion_VersionStages
=== CONT  TestAccAwsSecretsManagerSecret_Tags
=== CONT  TestAccAwsSecretsManagerSecret_RotationLambdaARN
=== CONT  TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate
=== CONT  TestAccAwsSecretsManagerSecret_KmsKeyID
=== CONT  TestAccAwsSecretsManagerSecret_RotationRules
=== CONT  TestAccAwsSecretsManagerSecret_Description
=== CONT  TestAccAwsSecretsManagerSecretVersion_Base64Binary
=== CONT  TestAccAwsSecretsManagerSecretVersion_BasicString
=== CONT  TestAccAwsSecretsManagerSecret_policy
=== CONT  TestAccAwsSecretsManagerSecret_withNamePrefix
--- PASS: TestAccAwsSecretsManagerSecret_policy (13.25s)
--- PASS: TestAccAwsSecretsManagerSecret_Basic (15.06s)
--- PASS: TestAccAwsSecretsManagerSecret_withNamePrefix (15.08s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_BasicString (16.01s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_Base64Binary (16.15s)
--- PASS: TestAccAwsSecretsManagerSecret_Description (24.31s)
--- PASS: TestAccAwsSecretsManagerSecretVersion_VersionStages (35.71s)
--- PASS: TestAccAwsSecretsManagerSecret_RecoveryWindowInDays_Recreate (41.21s)
--- PASS: TestAccAwsSecretsManagerSecret_Tags (42.95s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationRules (49.37s)
--- PASS: TestAccAwsSecretsManagerSecret_RotationLambdaARN (50.14s)
--- PASS: TestAccAwsSecretsManagerSecret_KmsKeyID (50.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       50.941s
...
```
