### PR TITLE
Automate labeling of new issues for triage

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -22,7 +22,7 @@ action "pr-label" {
 }
 
 workflow "Issue triage" {
-  on = "issue"
+  on = "issues"
   resolves = "Apply Triage Label"
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -20,3 +20,14 @@ action "pr-label" {
         LABEL_SPEC_FILE = ".github/PULL_REQUEST_LABELS.yml"
     }
 }
+
+workflow "Issue triage" {
+  on = "issue"
+  resolves = "Apply Triage Label"
+}
+
+action "Apply Triage Label" {
+  uses = "actions/github@v1.0.0"
+  args = "label needs-triage --action=opened" # Only when issues are opened!
+  secrets = ["GITHUB_TOKEN"]
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,7 +5,7 @@ workflow "Pull Request Updates" {
 
 action "pr-filter-sync" {
     uses = "actions/bin/filter@master"
-    args = "action 'opened|review_requested|synchronize'"
+    args = "action 'opened|synchronize'"
 }
 
 action "pr-label" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds a GitHub action workflow to automatically apply a `needs-triage` label to new issues for filtering.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
N/A
```
