### PR TITLE
Fixed typo (EC2 => ECR) and remove note about ECR availability

### DIFF
--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: aws_ecr_repository
 
-Provides an EC2 Container Registry Repository.
+Provides an Elastic Container Registry Repository.
 
 ## Example Usage
 

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_ecr_repository"
 sidebar_current: "docs-aws-resource-ecr-repository"
 description: |-
-  Provides an ECR Container Registry Repository.
+  Provides an Elastic Container Registry Repository.
 ---
 
 # Resource: aws_ecr_repository

--- a/website/docs/r/ecr_repository.html.markdown
+++ b/website/docs/r/ecr_repository.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_ecr_repository"
 sidebar_current: "docs-aws-resource-ecr-repository"
 description: |-
-  Provides an EC2 Container Registry Repository.
+  Provides an ECR Container Registry Repository.
 ---
 
 # Resource: aws_ecr_repository

--- a/website/docs/r/ecr_repository_policy.html.markdown
+++ b/website/docs/r/ecr_repository_policy.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_ecr_repository_policy"
 sidebar_current: "docs-aws-resource-ecr-repository-policy"
 description: |-
-  Provides an ECR Repository Policy.
+  Provides an Elastic Container Registry Repository Policy.
 ---
 
 # Resource: aws_ecr_repository_policy


### PR DESCRIPTION
"EC2" Container Registry Repository should be "ECR". ECR doesn't really have anything to do with the AWS EC2 service.

https://aws.amazon.com/ecr/

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
