### PR TITLE
tests/provider: Enable tfproviderlint schema checks S007 through S017

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,7 +33,25 @@ websitefmtcheck:
 lint:
 	@echo "==> Checking source code against linters..."
 	@GOGC=30 golangci-lint run ./$(PKG_NAME)
-	@tfproviderlint -c 1 -S001 -S002 -S003 -S004 -S005 ./$(PKG_NAME)
+	@tfproviderlint \
+		-c 1 \
+		-S001 \
+		-S002 \
+		-S003 \
+		-S004 \
+		-S005 \
+		-S007 \
+		-S008 \
+		-S009 \
+		-S010 \
+		-S011 \
+		-S012 \
+		-S013 \
+		-S014 \
+		-S015 \
+		-S016 \
+		-S017 \
+		./$(PKG_NAME)
 
 tools:
 	GO111MODULE=on go install github.com/bflad/tfproviderlint/cmd/tfproviderlint


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References:

* https://github.com/bflad/tfproviderlint/blob/master/passes/S007/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S008/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S009/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S010/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S011/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S012/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S013/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S014/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S015/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S016/README.md
* https://github.com/bflad/tfproviderlint/blob/master/passes/S017/README.md

This enables all currently passing on master tfproviderlint@v0.4.0 schema checks. The remaining schema checks such as S006, S018, and S019 will have technical debt issues created for triage.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A (tfproviderlint handled via TravisCI)
