### PR TITLE
docs/provider: Update Contributing Guide to elide HashiCorp vs. Community Providers section, add links to GitHub Help, and add Go Coding Style references

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,7 +13,6 @@ ability to merge PRs and respond to issues.
 
 <!-- TOC depthFrom:2 -->
 
-- [HashiCorp vs. Community Providers](#hashicorp-vs-community-providers)
 - [Issues](#issues)
     - [Issue Reporting Checklists](#issue-reporting-checklists)
         - [Bug Reports](#bug-reports)
@@ -29,6 +28,7 @@ ability to merge PRs and respond to issues.
         - [New Service](#new-service)
         - [New Region](#new-region)
     - [Common Review Items](#common-review-items)
+        - [Go Coding Style](#go-coding-style)
         - [Resource Contribution Guidelines](#resource-contribution-guidelines)
         - [Acceptance Testing Guidelines](#acceptance-testing-guidelines)
     - [Writing Acceptance Tests](#writing-acceptance-tests)
@@ -38,38 +38,6 @@ ability to merge PRs and respond to issues.
         - [Writing and running Cross-Account Acceptance Tests](#writing-and-running-cross-account-acceptance-tests)
 
 <!-- /TOC -->
-
-## HashiCorp vs. Community Providers
-
-We separate providers out into what we call "HashiCorp Providers" and
-"Community Providers".
-
-HashiCorp providers are providers that we dedicate full-time resources to
-improving, supporting the latest features, and fixing bugs. These are providers
-we understand deeply and are confident we have the resources to manage
-ourselves.
-
-Community providers are providers where we depend on the community to contribute
-fixes and enhancements to improve. HashiCorp will run automated tests and ensure
-these providers continue to work, but will not dedicate full-time resources to
-add new features to these providers. These providers are available in official
-Terraform releases, but the functionality is primarily contributed.
-
-The current list of HashiCorp Providers is as follows:
-
- * `aws`
- * `azurerm`
- * `google`
- * `opc`
-
-Our testing standards are the same for both HashiCorp and Community providers,
-and HashiCorp runs full acceptance test suites for every provider nightly to
-ensure Terraform remains stable.
-
-We make the distinction between these two types of providers to help
-highlight the vast amounts of community effort that goes in to making Terraform
-great, and to help contributors better understand the role HashiCorp employees
-play in the various areas of the code base.
 
 ## Issues
 
@@ -153,27 +121,28 @@ expect:
 
 ### Pull Request Lifecycle
 
-1. You are welcome to submit your pull request for commentary or review before
-   it is fully completed. Please prefix the title of your pull request with
-   "[WIP]" to indicate this. It's also a good idea to include specific
-   questions or items you'd like feedback on.
+1. [Fork the GitHub repository](https://help.github.com/en/articles/fork-a-repo),
+   modify the code, and [create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
+   You are welcome to submit your pull request for commentary or review before
+   it is fully completed by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
+   and including specific questions or items you'd like feedback on.
 
-2. Once you believe your pull request is ready to be merged, you can remove the
-   "[WIP]" prefix from the title and a team member will review. Follow [the
-   checklists below](#checklists-for-contribution) to help ensure that your
-   contribution will be merged quickly.
+1. Once you believe your pull request is ready to be reviewed, ensure the
+   pull request is not a draft pull request, and a team member will review. Follow
+   [the checklists below](#checklists-for-contribution) to help ensure that your
+   contribution can be easily reviewed and potentially merged.
 
-3. One of Terraform's provider team members will look over your contribution and
+1. One of Terraform's provider team members will look over your contribution and
    either approve it or provide comments letting you know if there is anything
    left to do. We do our best to keep up with the volume of PRs waiting for
    review, but it may take some time depending on the complexity of the work.
 
-4. Once all outstanding comments and checklist items have been addressed, your
+1. Once all outstanding comments and checklist items have been addressed, your
    contribution will be merged! Merged PRs will be included in the next
    Terraform release. The provider team takes care of updating the CHANGELOG as
    they merge.
 
-5. In some cases, we might decide that a PR should be closed without merging.
+1. In some cases, we might decide that a PR should be closed without merging.
    We'll make sure to provide clear reasoning when this happens.
 
 ### Checklists for Contribution
@@ -332,6 +301,13 @@ are generally expected to adhere to these items to maintain Terraform Provider
 quality. For any guidelines listed, contributors are encouraged to ask any
 questions and community reviewers are encouraged to provide review suggestions
 based on these guidelines to speed up the review and merge process.
+
+#### Go Coding Style
+
+The following Go language resources provide common coding preferences that may be referenced during review, if not automatically handled by the project's linting tools.
+
+- [Effective Go](https://golang.org/doc/effective_go.html)
+- [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
 
 #### Resource Contribution Guidelines
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -125,12 +125,15 @@ expect:
    modify the code, and [create a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork).
    You are welcome to submit your pull request for commentary or review before
    it is fully completed by creating a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
-   and including specific questions or items you'd like feedback on.
+   or adding `[WIP]` to the beginning of the pull request title.
+   Please include specific questions or items you'd like feedback on.
 
 1. Once you believe your pull request is ready to be reviewed, ensure the
-   pull request is not a draft pull request, and a team member will review. Follow
-   [the checklists below](#checklists-for-contribution) to help ensure that your
-   contribution can be easily reviewed and potentially merged.
+   pull request is not a draft pull request by [marking it ready for review](https://help.github.com/en/articles/changing-the-stage-of-a-pull-request)
+   or removing `[WIP]` from the pull request title if necessary, and a
+   maintainer will review it. Follow [the checklists below](#checklists-for-contribution)
+   to help ensure that your contribution can be easily reviewed and potentially
+   merged.
 
 1. One of Terraform's provider team members will look over your contribution and
    either approve it or provide comments letting you know if there is anything


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

The HashiCorp vs. Community Providers section of the contributing guide has been passed down from when the main hashicorp/terraform repository contained all Terraform Providers. Since the Terraform 0.10 split and the formation of the terraform-providers GitHub organization with individual Terraform Provider repositories, this documentation is extraneous and potentially confusing for contributors.

The additional links in the Pull Request Lifecycle section are designed to provide some extra assistance to those not familiar with GitHub. This also switches the recommendation for "not quite ready" pull requests from "[WIP]" in the pull request title to GitHub's draft pull request feature.

The final update of adding the Go Coding Style section under the Common Review Items section is to provide additional references of stylistic preferences within the codebase, especially for contributors from other programming languages and where our linting tooling does not provide automated recommendations.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: N/A documentation update
