### PR TITLE
Final retries after timeouts for various Neptune resources

### DIFF
--- a/aws/resource_aws_neptune_cluster.go
+++ b/aws/resource_aws_neptune_cluster.go
@@ -350,6 +350,13 @@ func resourceAwsNeptuneClusterCreate(d *schema.ResourceData, meta interface{}) e
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		if restoreDBClusterFromSnapshot {
+			_, err = conn.RestoreDBClusterFromSnapshot(restoreDBClusterFromSnapshotInput)
+		} else {
+			_, err = conn.CreateDBCluster(createDbClusterInput)
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("error creating Neptune Cluster: %s", err)
 	}
@@ -542,6 +549,9 @@ func resourceAwsNeptuneClusterUpdate(d *schema.ResourceData, meta interface{}) e
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.ModifyDBCluster(req)
+		}
 		if err != nil {
 			return fmt.Errorf("Failed to modify Neptune Cluster (%s): %s", d.Id(), err)
 		}
@@ -636,6 +646,9 @@ func resourceAwsNeptuneClusterDelete(d *schema.ResourceData, meta interface{}) e
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteDBCluster(&deleteOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("Neptune Cluster cannot be deleted: %s", err)
 	}

--- a/aws/resource_aws_neptune_cluster_instance.go
+++ b/aws/resource_aws_neptune_cluster_instance.go
@@ -247,6 +247,9 @@ func resourceAwsNeptuneClusterInstanceCreate(d *schema.ResourceData, meta interf
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.CreateDBInstance(createOpts)
+	}
 	if err != nil {
 		return fmt.Errorf("error creating Neptune Instance: %s", err)
 	}
@@ -407,6 +410,9 @@ func resourceAwsNeptuneClusterInstanceUpdate(d *schema.ResourceData, meta interf
 			}
 			return nil
 		})
+		if isResourceTimeoutError(err) {
+			_, err = conn.ModifyDBInstance(req)
+		}
 		if err != nil {
 			return fmt.Errorf("Error modifying Neptune Instance %s: %s", d.Id(), err)
 		}

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -296,6 +296,10 @@ func resourceAwsNeptuneParameterGroupDelete(d *schema.ResourceData, meta interfa
 		_, err = conn.DeleteDBParameterGroup(&deleteOpts)
 	}
 
+	if isAWSErr(err, neptune.ErrCodeDBParameterGroupNotFoundFault, "") {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error deleting Neptune Parameter Group: %s", err)
 	}

--- a/aws/resource_aws_neptune_parameter_group.go
+++ b/aws/resource_aws_neptune_parameter_group.go
@@ -229,6 +229,9 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 				}
 				return nil
 			})
+			if isResourceTimeoutError(err) {
+				_, err = conn.ResetDBParameterGroup(&resetOpts)
+			}
 			if err != nil {
 				return fmt.Errorf("Error resetting Neptune Parameter Group: %s", err)
 			}
@@ -272,10 +275,10 @@ func resourceAwsNeptuneParameterGroupUpdate(d *schema.ResourceData, meta interfa
 func resourceAwsNeptuneParameterGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).neptuneconn
 
-	return resource.Retry(3*time.Minute, func() *resource.RetryError {
-		deleteOpts := neptune.DeleteDBParameterGroupInput{
-			DBParameterGroupName: aws.String(d.Id()),
-		}
+	deleteOpts := neptune.DeleteDBParameterGroupInput{
+		DBParameterGroupName: aws.String(d.Id()),
+	}
+	err := resource.Retry(3*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteDBParameterGroup(&deleteOpts)
 		if err != nil {
 			if isAWSErr(err, neptune.ErrCodeDBParameterGroupNotFoundFault, "") {
@@ -288,4 +291,14 @@ func resourceAwsNeptuneParameterGroupDelete(d *schema.ResourceData, meta interfa
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.DeleteDBParameterGroup(&deleteOpts)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error deleting Neptune Parameter Group: %s", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_neptune_cluster: Final retries when creating, updating, and deleting Neptune clusters
* resource/aws_neptune_cluster_instance: Final retries creating and updating cluster instances
* resource/aws_neptune_parameter_group: Final retries updating and deleting parameter groups

```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSNeptuneCluster"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSNeptuneCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSNeptuneClusterInstance_basic
=== PAUSE TestAccAWSNeptuneClusterInstance_basic
=== RUN   TestAccAWSNeptuneClusterInstance_withaz
=== PAUSE TestAccAWSNeptuneClusterInstance_withaz
=== RUN   TestAccAWSNeptuneClusterInstance_namePrefix
=== PAUSE TestAccAWSNeptuneClusterInstance_namePrefix
=== RUN   TestAccAWSNeptuneClusterInstance_withSubnetGroup
=== PAUSE TestAccAWSNeptuneClusterInstance_withSubnetGroup
=== RUN   TestAccAWSNeptuneClusterInstance_generatedName
=== PAUSE TestAccAWSNeptuneClusterInstance_generatedName
=== RUN   TestAccAWSNeptuneClusterInstance_kmsKey
=== PAUSE TestAccAWSNeptuneClusterInstance_kmsKey
=== RUN   TestAccAWSNeptuneClusterParameterGroup_basic
=== PAUSE TestAccAWSNeptuneClusterParameterGroup_basic
=== RUN   TestAccAWSNeptuneClusterParameterGroup_namePrefix
=== PAUSE TestAccAWSNeptuneClusterParameterGroup_namePrefix
=== RUN   TestAccAWSNeptuneClusterParameterGroup_generatedName
=== PAUSE TestAccAWSNeptuneClusterParameterGroup_generatedName
=== RUN   TestAccAWSNeptuneClusterParameterGroup_Description
=== PAUSE TestAccAWSNeptuneClusterParameterGroup_Description
=== RUN   TestAccAWSNeptuneClusterParameterGroup_Parameter
=== PAUSE TestAccAWSNeptuneClusterParameterGroup_Parameter
=== RUN   TestAccAWSNeptuneClusterParameterGroup_Tags
=== PAUSE TestAccAWSNeptuneClusterParameterGroup_Tags
=== RUN   TestAccAWSNeptuneClusterSnapshot_basic
=== PAUSE TestAccAWSNeptuneClusterSnapshot_basic
=== RUN   TestAccAWSNeptuneCluster_basic
=== PAUSE TestAccAWSNeptuneCluster_basic
=== RUN   TestAccAWSNeptuneCluster_namePrefix
=== PAUSE TestAccAWSNeptuneCluster_namePrefix
=== RUN   TestAccAWSNeptuneCluster_takeFinalSnapshot
=== PAUSE TestAccAWSNeptuneCluster_takeFinalSnapshot
=== RUN   TestAccAWSNeptuneCluster_updateTags
=== PAUSE TestAccAWSNeptuneCluster_updateTags
=== RUN   TestAccAWSNeptuneCluster_updateIamRoles
=== PAUSE TestAccAWSNeptuneCluster_updateIamRoles
=== RUN   TestAccAWSNeptuneCluster_kmsKey
=== PAUSE TestAccAWSNeptuneCluster_kmsKey
=== RUN   TestAccAWSNeptuneCluster_encrypted
=== PAUSE TestAccAWSNeptuneCluster_encrypted
=== RUN   TestAccAWSNeptuneCluster_backupsUpdate
=== PAUSE TestAccAWSNeptuneCluster_backupsUpdate
=== RUN   TestAccAWSNeptuneCluster_iamAuth
=== PAUSE TestAccAWSNeptuneCluster_iamAuth
=== CONT  TestAccAWSNeptuneClusterInstance_basic
=== CONT  TestAccAWSNeptuneCluster_iamAuth
=== CONT  TestAccAWSNeptuneCluster_namePrefix
=== CONT  TestAccAWSNeptuneClusterInstance_withaz
=== CONT  TestAccAWSNeptuneClusterParameterGroup_generatedName
=== CONT  TestAccAWSNeptuneClusterInstance_kmsKey
=== CONT  TestAccAWSNeptuneCluster_backupsUpdate
=== CONT  TestAccAWSNeptuneCluster_encrypted
=== CONT  TestAccAWSNeptuneCluster_kmsKey
=== CONT  TestAccAWSNeptuneCluster_updateIamRoles
=== CONT  TestAccAWSNeptuneCluster_updateTags
=== CONT  TestAccAWSNeptuneCluster_takeFinalSnapshot
=== CONT  TestAccAWSNeptuneClusterInstance_generatedName
=== CONT  TestAccAWSNeptuneClusterInstance_withSubnetGroup
=== CONT  TestAccAWSNeptuneClusterParameterGroup_basic
=== CONT  TestAccAWSNeptuneClusterParameterGroup_Parameter
=== CONT  TestAccAWSNeptuneClusterParameterGroup_Description
=== CONT  TestAccAWSNeptuneClusterInstance_namePrefix
=== CONT  TestAccAWSNeptuneClusterSnapshot_basic
=== CONT  TestAccAWSNeptuneClusterParameterGroup_Tags
--- PASS: TestAccAWSNeptuneClusterParameterGroup_generatedName (32.62s)
=== CONT  TestAccAWSNeptuneCluster_basic
--- PASS: TestAccAWSNeptuneClusterParameterGroup_basic (32.89s)
=== CONT  TestAccAWSNeptuneClusterParameterGroup_namePrefix
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Description (33.80s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Parameter (52.07s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_namePrefix (29.14s)
--- PASS: TestAccAWSNeptuneClusterParameterGroup_Tags (75.15s)
--- PASS: TestAccAWSNeptuneCluster_updateTags (153.44s)
--- PASS: TestAccAWSNeptuneCluster_namePrefix (157.60s)
--- PASS: TestAccAWSNeptuneCluster_iamAuth (157.61s)
--- PASS: TestAccAWSNeptuneCluster_kmsKey (184.88s)
--- PASS: TestAccAWSNeptuneCluster_encrypted (187.67s)
--- PASS: TestAccAWSNeptuneCluster_backupsUpdate (197.13s)
--- PASS: TestAccAWSNeptuneCluster_basic (165.54s)
--- PASS: TestAccAWSNeptuneClusterSnapshot_basic (217.99s)
--- PASS: TestAccAWSNeptuneCluster_updateIamRoles (220.53s)
--- PASS: TestAccAWSNeptuneCluster_takeFinalSnapshot (224.89s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (765.18s)
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (798.26s)
--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (810.45s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (834.49s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (859.23s)
--- PASS: TestAccAWSNeptuneClusterInstance_basic (1635.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws

make testacc TESTARGS="-run=TestAccAWSNeptuneClusterInstance"   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSNeptuneClusterInstance -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSNeptuneClusterInstance_basic
=== PAUSE TestAccAWSNeptuneClusterInstance_basic
=== RUN   TestAccAWSNeptuneClusterInstance_withaz
=== PAUSE TestAccAWSNeptuneClusterInstance_withaz
=== RUN   TestAccAWSNeptuneClusterInstance_namePrefix
=== PAUSE TestAccAWSNeptuneClusterInstance_namePrefix
=== RUN   TestAccAWSNeptuneClusterInstance_withSubnetGroup
=== PAUSE TestAccAWSNeptuneClusterInstance_withSubnetGroup
=== RUN   TestAccAWSNeptuneClusterInstance_generatedName
=== PAUSE TestAccAWSNeptuneClusterInstance_generatedName
=== RUN   TestAccAWSNeptuneClusterInstance_kmsKey
=== PAUSE TestAccAWSNeptuneClusterInstance_kmsKey
=== CONT  TestAccAWSNeptuneClusterInstance_basic
=== CONT  TestAccAWSNeptuneClusterInstance_generatedName
=== CONT  TestAccAWSNeptuneClusterInstance_withaz
=== CONT  TestAccAWSNeptuneClusterInstance_kmsKey
=== CONT  TestAccAWSNeptuneClusterInstance_withSubnetGroup
=== CONT  TestAccAWSNeptuneClusterInstance_namePrefix
--- PASS: TestAccAWSNeptuneClusterInstance_withSubnetGroup (752.92s)
--- PASS: TestAccAWSNeptuneClusterInstance_namePrefix (755.13s)
--- PASS: TestAccAWSNeptuneClusterInstance_withaz (786.51s)
--- PASS: TestAccAWSNeptuneClusterInstance_generatedName (806.21s)
--- PASS: TestAccAWSNeptuneClusterInstance_kmsKey (875.11s)
--- PASS: TestAccAWSNeptuneClusterInstance_basic (1569.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       1570.981s


make testacc TESTARGS="-run=TestAccAWSNeptuneParameterGroup" 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSNeptuneParameterGroup -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSNeptuneParameterGroup_basic
=== PAUSE TestAccAWSNeptuneParameterGroup_basic
=== RUN   TestAccAWSNeptuneParameterGroup_Description
=== PAUSE TestAccAWSNeptuneParameterGroup_Description
=== RUN   TestAccAWSNeptuneParameterGroup_Parameter
=== PAUSE TestAccAWSNeptuneParameterGroup_Parameter
=== RUN   TestAccAWSNeptuneParameterGroup_Tags
=== PAUSE TestAccAWSNeptuneParameterGroup_Tags
=== CONT  TestAccAWSNeptuneParameterGroup_basic
=== CONT  TestAccAWSNeptuneParameterGroup_Tags
=== CONT  TestAccAWSNeptuneParameterGroup_Description
=== CONT  TestAccAWSNeptuneParameterGroup_Parameter
--- PASS: TestAccAWSNeptuneParameterGroup_basic (32.01s)
--- PASS: TestAccAWSNeptuneParameterGroup_Description (32.74s)
--- PASS: TestAccAWSNeptuneParameterGroup_Parameter (61.28s)
--- PASS: TestAccAWSNeptuneParameterGroup_Tags (74.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       76.611s
```