### PR TITLE
Add support for terraform import to resource backup_vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ website/node_modules
 *~
 .*.swp
 .idea
+.vscode
 *.iml
 *.test
 *.iml

--- a/aws/resource_aws_backup_vault.go
+++ b/aws/resource_aws_backup_vault.go
@@ -18,6 +18,9 @@ func resourceAwsBackupVault() *schema.Resource {
 		Read:   resourceAwsBackupVaultRead,
 		Update: resourceAwsBackupVaultUpdate,
 		Delete: resourceAwsBackupVaultDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -91,7 +94,7 @@ func resourceAwsBackupVaultRead(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return fmt.Errorf("error reading Backup Vault (%s): %s", d.Id(), err)
 	}
-
+	d.Set("name", resp.BackupVaultName)
 	d.Set("kms_key_arn", resp.EncryptionKeyArn)
 	d.Set("arn", resp.BackupVaultArn)
 	d.Set("recovery_points", resp.NumberOfRecoveryPoints)

--- a/aws/resource_aws_backup_vault_test.go
+++ b/aws/resource_aws_backup_vault_test.go
@@ -15,6 +15,7 @@ func TestAccAwsBackupVault_basic(t *testing.T) {
 	var vault backup.DescribeBackupVaultOutput
 
 	rInt := acctest.RandInt()
+	resourceName := "aws_backup_vault.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
@@ -23,8 +24,13 @@ func TestAccAwsBackupVault_basic(t *testing.T) {
 			{
 				Config: testAccBackupVaultConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
+					testAccCheckAwsBackupVaultExists(resourceName, &vault),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -34,6 +40,7 @@ func TestAccAwsBackupVault_withKmsKey(t *testing.T) {
 	var vault backup.DescribeBackupVaultOutput
 
 	rInt := acctest.RandInt()
+	resourceName := "aws_backup_vault.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
@@ -42,9 +49,14 @@ func TestAccAwsBackupVault_withKmsKey(t *testing.T) {
 			{
 				Config: testAccBackupVaultWithKmsKey(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
-					resource.TestCheckResourceAttrPair("aws_backup_vault.test", "kms_key_arn", "aws_kms_key.test", "arn"),
+					testAccCheckAwsBackupVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_arn", "aws_kms_key.test", "arn"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -54,6 +66,7 @@ func TestAccAwsBackupVault_withTags(t *testing.T) {
 	var vault backup.DescribeBackupVaultOutput
 
 	rInt := acctest.RandInt()
+	resourceName := "aws_backup_vault.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSBackup(t) },
 		Providers:    testAccProviders,
@@ -62,30 +75,35 @@ func TestAccAwsBackupVault_withTags(t *testing.T) {
 			{
 				Config: testAccBackupVaultWithTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.up", "down"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.left", "right"),
+					testAccCheckAwsBackupVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.up", "down"),
+					resource.TestCheckResourceAttr(resourceName, "tags.left", "right"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccBackupVaultWithUpdateTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.%", "4"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.up", "downdown"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.left", "rightright"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.fizz", "buzz"),
+					testAccCheckAwsBackupVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.up", "downdown"),
+					resource.TestCheckResourceAttr(resourceName, "tags.left", "rightright"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
 				),
 			},
 			{
 				Config: testAccBackupVaultWithRemoveTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsBackupVaultExists("aws_backup_vault.test", &vault),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr("aws_backup_vault.test", "tags.fizz", "buzz"),
+					testAccCheckAwsBackupVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.fizz", "buzz"),
 				),
 			},
 		},

--- a/website/docs/r/backup_vault.html.markdown
+++ b/website/docs/r/backup_vault.html.markdown
@@ -34,3 +34,11 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The name of the vault.
 * `arn` - The ARN of the vault.
 * `recovery_points` - The number of recovery points that are stored in a backup vault.
+
+## Import
+
+Backup vault can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_backup_vault.test-vault TestVault
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8821

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/backup_vault: Add support for terraform import
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAwsBackupVault*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAwsBackupVault* -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAwsBackupVault_basic
=== PAUSE TestAccAwsBackupVault_basic
=== RUN   TestAccAwsBackupVault_withKmsKey
=== PAUSE TestAccAwsBackupVault_withKmsKey
=== RUN   TestAccAwsBackupVault_withTags
=== PAUSE TestAccAwsBackupVault_withTags
=== CONT  TestAccAwsBackupVault_basic
=== CONT  TestAccAwsBackupVault_withTags
=== CONT  TestAccAwsBackupVault_withKmsKey
--- PASS: TestAccAwsBackupVault_basic (35.66s)
--- PASS: TestAccAwsBackupVault_withTags (73.89s)
--- PASS: TestAccAwsBackupVault_withKmsKey (75.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       75.500s
```
