### PR TITLE
Feature/fix removed resource error handling for aws cloudwatch event permission resource

### DIFF
--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -111,7 +111,12 @@ func resourceAwsCloudWatchEventPermissionRead(d *schema.ResourceData, meta inter
 		}
 
 		if debo.Policy == nil {
-			return resource.RetryableError(fmt.Errorf("CloudWatch Events permission %q not found", d.Id()))
+			return resource.RetryableError(&resource.NotFoundError{
+				Message: fmt.Sprintf("CloudWatch Events permission %q not found"+
+					"in given results from DescribeEventBus", d.Id()),
+				LastResponse: debo,
+				LastRequest:  input,
+			})
 		}
 
 		err = json.Unmarshal([]byte(*debo.Policy), &policyDoc)
@@ -167,6 +172,11 @@ func resourceAwsCloudWatchEventPermissionUpdate(d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Update CloudWatch Events permission: %s", input)
 	_, err := conn.PutPermission(&input)
+	if isAWSErr(err, events.ErrCodeResourceNotFoundException, "") {
+		log.Printf("[WARN] CloudWatch Events permission %q not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("Updating CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error())
 	}
@@ -182,6 +192,9 @@ func resourceAwsCloudWatchEventPermissionDelete(d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Delete CloudWatch Events permission: %s", input)
 	_, err := conn.RemovePermission(&input)
+	if isAWSErr(err, events.ErrCodeResourceNotFoundException, "") {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("Deleting CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error())
 	}

--- a/aws/resource_aws_cloudwatch_event_permission_test.go
+++ b/aws/resource_aws_cloudwatch_event_permission_test.go
@@ -248,6 +248,48 @@ func TestAccAWSCloudWatchEventPermission_Multiple(t *testing.T) {
 	})
 }
 
+func TestAccAWSCloudWatchEventPermission_Disappears(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_permission.test1"
+	principal := "111111111111"
+	statementID := acctest.RandomWithPrefix(t.Name())[:64]
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudWatchEventPermissionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsCloudWatchEventPermissionResourceConfigBasic(principal, statementID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventPermissionExists(resourceName),
+					testAccCheckCloudWatchEventPermissionDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCloudWatchEventPermissionDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No resource ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn
+		input := events.RemovePermissionInput{
+			StatementId: aws.String(rs.Primary.ID),
+		}
+		_, err := conn.RemovePermission(&input)
+		return err
+	}
+}
+
 func testAccCheckCloudWatchEventPermissionExists(pr string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).cloudwatcheventsconn


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9025

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Bug Fix
- resource/aws_cloudwatch_event_permission: fix error handling when resource already removed.
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSCloudWatchEventPermission_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchEventPermission_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSCloudWatchEventPermission_Basic
=== PAUSE TestAccAWSCloudWatchEventPermission_Basic
=== RUN   TestAccAWSCloudWatchEventPermission_Action
=== PAUSE TestAccAWSCloudWatchEventPermission_Action
=== RUN   TestAccAWSCloudWatchEventPermission_Condition
=== PAUSE TestAccAWSCloudWatchEventPermission_Condition
=== RUN   TestAccAWSCloudWatchEventPermission_Multiple
=== PAUSE TestAccAWSCloudWatchEventPermission_Multiple
=== RUN   TestAccAWSCloudWatchEventPermission_Disappears
=== PAUSE TestAccAWSCloudWatchEventPermission_Disappears
=== CONT  TestAccAWSCloudWatchEventPermission_Basic
=== CONT  TestAccAWSCloudWatchEventPermission_Multiple
=== CONT  TestAccAWSCloudWatchEventPermission_Disappears
=== CONT  TestAccAWSCloudWatchEventPermission_Action
=== CONT  TestAccAWSCloudWatchEventPermission_Condition
--- PASS: TestAccAWSCloudWatchEventPermission_Action (35.66s)
--- PASS: TestAccAWSCloudWatchEventPermission_Multiple (50.37s)
--- PASS: TestAccAWSCloudWatchEventPermission_Condition (53.14s)
--- PASS: TestAccAWSCloudWatchEventPermission_Basic (55.14s)
--- PASS: TestAccAWSCloudWatchEventPermission_Disappears (86.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	86.216s
```
