### PR TITLE
Timeout retry when deleting EMR cluster

### DIFF
--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -879,8 +879,11 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		}
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.RunJobFlow(params)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error with instance profile: %s", err)
 	}
 
 	d.SetId(*resp.JobFlowId)
@@ -1318,46 +1321,70 @@ func resourceAwsEMRClusterDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	input := &emr.ListInstancesInput{
+		ClusterId: aws.String(d.Id()),
+	}
+	var resp *emr.ListInstancesOutput
+	var count int
 	err = resource.Retry(20*time.Minute, func() *resource.RetryError {
-		resp, err := conn.ListInstances(&emr.ListInstancesInput{
-			ClusterId: aws.String(d.Id()),
-		})
+		var err error
+		resp, err = conn.ListInstances(input)
 
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
 
-		instanceCount := len(resp.Instances)
-
-		if resp == nil || instanceCount == 0 {
-			log.Printf("[DEBUG] No instances found for EMR Cluster (%s)", d.Id())
-			return nil
+		count = countEMRRemainingInstances(resp, d.Id())
+		if count != 0 {
+			return resource.RetryableError(fmt.Errorf("EMR Cluster (%s) has (%d) Instances remaining", d.Id(), count))
 		}
-
-		// Collect instance status states, wait for all instances to be terminated
-		// before moving on
-		var terminated []string
-		for j, i := range resp.Instances {
-			if i.Status != nil {
-				if aws.StringValue(i.Status.State) == emr.InstanceStateTerminated {
-					terminated = append(terminated, *i.Ec2InstanceId)
-				}
-			} else {
-				log.Printf("[DEBUG] Cluster instance (%d : %s) has no status", j, *i.Ec2InstanceId)
-			}
-		}
-		if len(terminated) == instanceCount {
-			log.Printf("[DEBUG] All (%d) EMR Cluster (%s) Instances terminated", instanceCount, d.Id())
-			return nil
-		}
-		return resource.RetryableError(fmt.Errorf("EMR Cluster (%s) has (%d) Instances remaining, retrying", d.Id(), len(resp.Instances)))
+		return nil
 	})
 
+	if isResourceTimeoutError(err) {
+		resp, err = conn.ListInstances(input)
+
+		if err == nil {
+			count = countEMRRemainingInstances(resp, d.Id())
+		}
+	}
+
+	if count != 0 {
+		return fmt.Errorf("EMR Cluster (%s) has (%d) Instances remaining", d.Id(), count)
+	}
+
 	if err != nil {
-		return fmt.Errorf("error waiting for EMR Cluster (%s) Instances to drain", d.Id())
+		return fmt.Errorf("error waiting for EMR Cluster (%s) Instances to drain: %s", d.Id(), err)
 	}
 
 	return nil
+}
+
+func countEMRRemainingInstances(resp *emr.ListInstancesOutput, emrClusterId string) int {
+	instanceCount := len(resp.Instances)
+
+	if resp == nil || instanceCount == 0 {
+		log.Printf("[DEBUG] No instances found for EMR Cluster (%s)", emrClusterId)
+		return 0
+	}
+
+	// Collect instance status states, wait for all instances to be terminated
+	// before moving on
+	var terminated []string
+	for j, i := range resp.Instances {
+		if i.Status != nil {
+			if aws.StringValue(i.Status.State) == emr.InstanceStateTerminated {
+				terminated = append(terminated, *i.Ec2InstanceId)
+			}
+		} else {
+			log.Printf("[DEBUG] Cluster instance (%d : %s) has no status", j, *i.Ec2InstanceId)
+		}
+	}
+	if len(terminated) == instanceCount {
+		log.Printf("[DEBUG] All (%d) EMR Cluster (%s) Instances terminated", instanceCount, emrClusterId)
+		return 0
+	}
+	return len(resp.Instances)
 }
 
 func expandApplications(apps []interface{}) []*emr.Application {

--- a/aws/resource_aws_emr_cluster.go
+++ b/aws/resource_aws_emr_cluster.go
@@ -883,7 +883,7 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		resp, err = conn.RunJobFlow(params)
 	}
 	if err != nil {
-		return fmt.Errorf("Error with instance profile: %s", err)
+		return fmt.Errorf("error running EMR Job Flow: %s", err)
 	}
 
 	d.SetId(*resp.JobFlowId)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_emr_cluster: Final retry after timeout error when deleting EMR cluster

```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSEMRCluster"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEMRCluster -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRCluster_basic
=== PAUSE TestAccAWSEMRCluster_basic
=== RUN   TestAccAWSEMRCluster_additionalInfo
=== PAUSE TestAccAWSEMRCluster_additionalInfo
=== RUN   TestAccAWSEMRCluster_configurationsJson
=== PAUSE TestAccAWSEMRCluster_configurationsJson
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
=== RUN   TestAccAWSEMRCluster_CoreInstanceGroup_Name
=== PAUSE TestAccAWSEMRCluster_CoreInstanceGroup_Name
=== RUN   TestAccAWSEMRCluster_instance_group
=== PAUSE TestAccAWSEMRCluster_instance_group
=== RUN   TestAccAWSEMRCluster_instance_group_names
=== PAUSE TestAccAWSEMRCluster_instance_group_names
=== RUN   TestAccAWSEMRCluster_instance_group_update
=== PAUSE TestAccAWSEMRCluster_instance_group_update
=== RUN   TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== PAUSE TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== RUN   TestAccAWSEMRCluster_updateAutoScalingPolicy
=== PAUSE TestAccAWSEMRCluster_updateAutoScalingPolicy
=== RUN   TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== PAUSE TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== RUN   TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== PAUSE TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== RUN   TestAccAWSEMRCluster_security_config
=== PAUSE TestAccAWSEMRCluster_security_config
=== RUN   TestAccAWSEMRCluster_Step_Basic
=== PAUSE TestAccAWSEMRCluster_Step_Basic
=== RUN   TestAccAWSEMRCluster_Step_ConfigMode
=== PAUSE TestAccAWSEMRCluster_Step_ConfigMode
=== RUN   TestAccAWSEMRCluster_Step_Multiple
=== PAUSE TestAccAWSEMRCluster_Step_Multiple
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
=== PAUSE TestAccAWSEMRCluster_bootstrap_ordering
=== RUN   TestAccAWSEMRCluster_terminationProtected
=== PAUSE TestAccAWSEMRCluster_terminationProtected
=== RUN   TestAccAWSEMRCluster_keepJob
=== PAUSE TestAccAWSEMRCluster_keepJob
=== RUN   TestAccAWSEMRCluster_visibleToAllUsers
=== PAUSE TestAccAWSEMRCluster_visibleToAllUsers
=== RUN   TestAccAWSEMRCluster_s3Logging
=== PAUSE TestAccAWSEMRCluster_s3Logging
=== RUN   TestAccAWSEMRCluster_tags
=== PAUSE TestAccAWSEMRCluster_tags
=== RUN   TestAccAWSEMRCluster_root_volume_size
=== PAUSE TestAccAWSEMRCluster_root_volume_size
=== RUN   TestAccAWSEMRCluster_custom_ami_id
=== PAUSE TestAccAWSEMRCluster_custom_ami_id
=== CONT  TestAccAWSEMRCluster_basic
=== CONT  TestAccAWSEMRCluster_custom_ami_id
=== CONT  TestAccAWSEMRCluster_Step_ConfigMode
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice
=== CONT  TestAccAWSEMRCluster_root_volume_size
=== CONT  TestAccAWSEMRCluster_tags
=== CONT  TestAccAWSEMRCluster_s3Logging
=== CONT  TestAccAWSEMRCluster_Step_Basic
=== CONT  TestAccAWSEMRCluster_security_config
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Name
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup
=== CONT  TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc
=== CONT  TestAccAWSEMRCluster_updateAutoScalingPolicy
=== CONT  TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1
=== CONT  TestAccAWSEMRCluster_instance_group_update
=== CONT  TestAccAWSEMRCluster_instance_group_names
=== CONT  TestAccAWSEMRCluster_instance_group
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Name
=== CONT  TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType
--- FAIL: TestAccAWSEMRCluster_basic (150.33s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": TERMINATING: VALIDATION_ERROR: The requested instance type c4.large is not supported in the requested availability zone. Learn more at https://docs.aws.amazon.com/console/elasticmapreduce/ERROR_noinstancetype
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test144138385/main.tf line 2:
          (source code not available)
        
        
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup
--- PASS: TestAccAWSEMRCluster_security_config (456.37s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType
--- PASS: TestAccAWSEMRCluster_Step_Basic (494.05s)
=== CONT  TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_instance_group_EBSVolumeType_st1 (547.80s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType
--- PASS: TestAccAWSEMRCluster_instance_group_update (551.19s)
=== CONT  TestAccAWSEMRCluster_visibleToAllUsers
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_InstanceGroup (571.31s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount
--- PASS: TestAccAWSEMRCluster_updateAutoScalingPolicy (594.57s)
=== CONT  TestAccAWSEMRCluster_keepJob
--- FAIL: TestAccAWSEMRCluster_terminationProtected (104.08s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": TERMINATED_WITH_ERRORS: VALIDATION_ERROR: The requested instance type c4.large is not supported in the requested availability zone. Learn more at https://docs.aws.amazon.com/console/elasticmapreduce/ERROR_noinstancetype
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test212915209/main.tf line 2:
          (source code not available)
        
        
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice
--- PASS: TestAccAWSEMRCluster_instance_group_names (607.68s)
=== CONT  TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Migration_MasterInstanceType (609.21s)
=== CONT  TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_custom_ami_id (611.40s)
=== CONT  TestAccAWSEMRCluster_configurationsJson
--- PASS: TestAccAWSEMRCluster_s3Logging (651.91s)
=== CONT  TestAccAWSEMRCluster_Step_Multiple
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_InstanceGroup (513.35s)
=== CONT  TestAccAWSEMRCluster_additionalInfo
--- PASS: TestAccAWSEMRCluster_instance_group (670.99s)
--- PASS: TestAccAWSEMRCluster_Kerberos_ClusterDedicatedKdc (697.30s)
--- FAIL: TestAccAWSEMRCluster_bootstrap_ordering (91.83s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": TERMINATING: VALIDATION_ERROR: The requested instance type c4.large is not supported in the requested availability zone. Learn more at https://docs.aws.amazon.com/console/elasticmapreduce/ERROR_noinstancetype
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test464554276/main.tf line 2:
          (source code not available)
        
        
--- FAIL: TestAccAWSEMRCluster_additionalInfo (120.22s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": TERMINATING: VALIDATION_ERROR: The requested instance type c4.large is not supported in the requested availability zone. Learn more at https://docs.aws.amazon.com/console/elasticmapreduce/ERROR_noinstancetype
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test351706333/main.tf line 2:
          (source code not available)
        
        
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_InstanceType (847.93s)
--- PASS: TestAccAWSEMRCluster_tags (882.94s)
--- PASS: TestAccAWSEMRCluster_root_volume_size (931.75s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_Name (966.34s)
--- PASS: TestAccAWSEMRCluster_keepJob (403.05s)
--- PASS: TestAccAWSEMRCluster_configurationsJson (400.06s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Migration_CoreInstanceType (562.73s)
--- PASS: TestAccAWSEMRCluster_MasterInstanceGroup_BidPrice (1044.69s)
--- PASS: TestAccAWSEMRCluster_Step_ConfigMode (1107.78s)
--- PASS: TestAccAWSEMRCluster_Step_Multiple (475.20s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_Name (1135.51s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_AutoscalingPolicy (595.05s)
--- PASS: TestAccAWSEMRCluster_visibleToAllUsers (882.57s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceType (894.86s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_BidPrice (1019.45s)
--- PASS: TestAccAWSEMRCluster_CoreInstanceGroup_InstanceCount (1186.78s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       1759.028s
make: *** [testacc] Error 1


make testacc TESTARGS="-run=TestAccAWSEMRCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEMRCluster_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRCluster_basic
=== PAUSE TestAccAWSEMRCluster_basic
=== CONT  TestAccAWSEMRCluster_basic
--- PASS: TestAccAWSEMRCluster_basic (417.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       418.713s


make testacc TESTARGS="-run=TestAccAWSEMRCluster_terminationProtected"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEMRCluster_terminationProtected -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRCluster_terminationProtected
=== PAUSE TestAccAWSEMRCluster_terminationProtected
=== CONT  TestAccAWSEMRCluster_terminationProtected
--- PASS: TestAccAWSEMRCluster_terminationProtected (540.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       541.182s


make testacc TESTARGS="-run=TestAccAWSEMRCluster_bootstrap_ordering"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEMRCluster_bootstrap_ordering -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRCluster_bootstrap_ordering
=== PAUSE TestAccAWSEMRCluster_bootstrap_ordering
=== CONT  TestAccAWSEMRCluster_bootstrap_ordering
--- PASS: TestAccAWSEMRCluster_bootstrap_ordering (457.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       458.758

make testacc TESTARGS="-run=TestAccAWSEMRCluster_additionalInfo"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEMRCluster_additionalInfo -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEMRCluster_additionalInfo
=== PAUSE TestAccAWSEMRCluster_additionalInfo
=== CONT  TestAccAWSEMRCluster_additionalInfo
--- PASS: TestAccAWSEMRCluster_additionalInfo (405.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       406.531s
```