### PR TITLE
Remove extra retry and cleanup errors for deleting api gateway resource

### DIFF
--- a/aws/resource_aws_api_gateway_resource.go
+++ b/aws/resource_aws_api_gateway_resource.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -145,29 +143,18 @@ func resourceAwsApiGatewayResourceDelete(d *schema.ResourceData, meta interface{
 	conn := meta.(*AWSClient).apigateway
 	log.Printf("[DEBUG] Deleting API Gateway Resource: %s", d.Id())
 
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		log.Printf("[DEBUG] schema is %#v", d)
-		_, err := conn.DeleteResource(&apigateway.DeleteResourceInput{
-			ResourceId: aws.String(d.Id()),
-			RestApiId:  aws.String(d.Get("rest_api_id").(string)),
-		})
-		if err == nil {
-			return nil
-		}
-
-		if apigatewayErr, ok := err.(awserr.Error); ok && apigatewayErr.Code() == "NotFoundException" {
-			return nil
-		}
-
-		return resource.NonRetryableError(err)
+	log.Printf("[DEBUG] schema is %#v", d)
+	_, err := conn.DeleteResource(&apigateway.DeleteResourceInput{
+		ResourceId: aws.String(d.Id()),
+		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
 	})
 
-	if isResourceTimeoutError(err) {
-		_, err = conn.DeleteResource(&apigateway.DeleteResourceInput{
-			ResourceId: aws.String(d.Id()),
-			RestApiId:  aws.String(d.Get("rest_api_id").(string)),
-		})
+	if isAWSErr(err, apigateway.ErrCodeNotFoundException, "") {
+		return nil
 	}
 
-	return err
+	if err != nil {
+		return fmt.Errorf("Error deleting API Gateway Resource: %s", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_api_gateway_resource: Removes an extraneous retry when deleting API gateway resource
```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSAPIGatewayResource"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayResource -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayResource_basic
=== PAUSE TestAccAWSAPIGatewayResource_basic
=== RUN   TestAccAWSAPIGatewayResource_update
=== PAUSE TestAccAWSAPIGatewayResource_update
=== CONT  TestAccAWSAPIGatewayResource_basic
=== CONT  TestAccAWSAPIGatewayResource_update
--- PASS: TestAccAWSAPIGatewayResource_basic (30.35s)
--- PASS: TestAccAWSAPIGatewayResource_update (62.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       63.059s
```
