### PR TITLE
Improve error handling when setting opsworks permission

### DIFF
--- a/aws/resource_aws_opsworks_permission.go
+++ b/aws/resource_aws_opsworks_permission.go
@@ -121,19 +121,20 @@ func resourceAwsOpsworksSetPermission(d *schema.ResourceData, meta interface{}) 
 	}
 
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var cerr error
-		_, cerr = client.SetPermission(req)
-		if cerr != nil {
-			log.Printf("[INFO] client error")
-			if opserr, ok := cerr.(awserr.Error); ok {
-				// XXX: handle errors
-				log.Printf("[ERROR] OpsWorks error: %s message: %s", opserr.Code(), opserr.Message())
-				return resource.RetryableError(cerr)
+		_, err := client.SetPermission(req)
+		if err != nil {
+
+			if isAWSErr(err, opsworks.ErrCodeResourceNotFoundException, "Unable to find user with ARN") {
+				return resource.RetryableError(err)
 			}
-			return resource.NonRetryableError(cerr)
+			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		_, err = client.SetPermission(req)
+	}
 
 	if err != nil {
 		return err

--- a/aws/resource_aws_opsworks_permission_test.go
+++ b/aws/resource_aws_opsworks_permission_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSOpsworksPermission(t *testing.T) {
+func TestAccAWSOpsworksPermission_basic(t *testing.T) {
 	sName := fmt.Sprintf("tf-ops-perm-%d", acctest.RandInt())
 	var opsperm opsworks.Permission
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_opsworks_permission: Improves error handing when setting opsworks permissions
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSOpsworksPermission_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSOpsworksPermission_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSOpsworksPermission_basic
=== PAUSE TestAccAWSOpsworksPermission_basic
=== CONT  TestAccAWSOpsworksPermission_basic
--- PASS: TestAccAWSOpsworksPermission_basic (167.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       170.034s
```
