### PR TITLE
provider: Remove extraneous Computed, Optional, and Required: false schema declarations and enable tfproviderlint S019

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,6 +51,7 @@ lint:
 		-S015 \
 		-S016 \
 		-S017 \
+		-S019 \
 		./$(PKG_NAME)
 
 tools:

--- a/aws/resource_aws_cloudhsm2_cluster.go
+++ b/aws/resource_aws_cloudhsm2_cluster.go
@@ -32,7 +32,6 @@ func resourceAwsCloudHsm2Cluster() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"source_backup_identifier": {
 				Type:     schema.TypeString,
-				Computed: false,
 				Optional: true,
 				ForceNew: true,
 			},

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -240,7 +240,6 @@ func resourceAwsDbInstance() *schema.Resource {
 						},
 						"bucket_prefix": {
 							Type:     schema.TypeString,
-							Required: false,
 							Optional: true,
 							ForceNew: true,
 						},
@@ -329,7 +328,6 @@ func resourceAwsDbInstance() *schema.Resource {
 
 			"snapshot_identifier": {
 				Type:     schema.TypeString,
-				Computed: false,
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -343,7 +341,6 @@ func resourceAwsDbInstance() *schema.Resource {
 
 			"allow_major_version_upgrade": {
 				Type:     schema.TypeBool,
-				Computed: false,
 				Optional: true,
 			},
 

--- a/aws/resource_aws_default_network_acl.go
+++ b/aws/resource_aws_default_network_acl.go
@@ -35,7 +35,6 @@ func resourceAwsDefaultNetworkAcl() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				Computed: false,
 			},
 			// We want explicit management of Subnets here, so we do not allow them to be
 			// computed. Instead, an empty config will enforce just that; removal of the
@@ -54,7 +53,6 @@ func resourceAwsDefaultNetworkAcl() *schema.Resource {
 			// rules
 			"ingress": {
 				Type:     schema.TypeSet,
-				Required: false,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -100,7 +98,6 @@ func resourceAwsDefaultNetworkAcl() *schema.Resource {
 			},
 			"egress": {
 				Type:     schema.TypeSet,
-				Required: false,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/aws/resource_aws_docdb_cluster.go
+++ b/aws/resource_aws_docdb_cluster.go
@@ -226,7 +226,6 @@ func resourceAwsDocDBCluster() *schema.Resource {
 
 			"enabled_cloudwatch_logs_exports": {
 				Type:     schema.TypeList,
-				Computed: false,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/aws/resource_aws_iam_openid_connect_provider.go
+++ b/aws/resource_aws_iam_openid_connect_provider.go
@@ -28,7 +28,6 @@ func resourceAwsIamOpenIDConnectProvider() *schema.Resource {
 			},
 			"url": {
 				Type:             schema.TypeString,
-				Computed:         false,
 				Required:         true,
 				ForceNew:         true,
 				ValidateFunc:     validateOpenIdURL,

--- a/aws/resource_aws_network_acl.go
+++ b/aws/resource_aws_network_acl.go
@@ -33,13 +33,11 @@ func resourceAwsNetworkAcl() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				Computed: false,
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Computed: false,
 				Removed:  "Use `subnet_ids` argument instead",
 			},
 			"subnet_ids": {
@@ -51,7 +49,6 @@ func resourceAwsNetworkAcl() *schema.Resource {
 			},
 			"ingress": {
 				Type:       schema.TypeSet,
-				Required:   false,
 				Optional:   true,
 				Computed:   true,
 				ConfigMode: schema.SchemaConfigModeAttr,
@@ -102,7 +99,6 @@ func resourceAwsNetworkAcl() *schema.Resource {
 			},
 			"egress": {
 				Type:       schema.TypeSet,
-				Required:   false,
 				Optional:   true,
 				Computed:   true,
 				ConfigMode: schema.SchemaConfigModeAttr,

--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -225,7 +225,6 @@ func resourceAwsRDSCluster() *schema.Resource {
 						},
 						"bucket_prefix": {
 							Type:     schema.TypeString,
-							Required: false,
 							Optional: true,
 							ForceNew: true,
 						},
@@ -288,7 +287,6 @@ func resourceAwsRDSCluster() *schema.Resource {
 
 			"snapshot_identifier": {
 				Type:     schema.TypeString,
-				Computed: false,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -382,7 +380,6 @@ func resourceAwsRDSCluster() *schema.Resource {
 
 			"enabled_cloudwatch_logs_exports": {
 				Type:     schema.TypeList,
-				Computed: false,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/aws/resource_aws_vpc_peering_connection_accepter.go
+++ b/aws/resource_aws_vpc_peering_connection_accepter.go
@@ -20,7 +20,6 @@ func resourceAwsVpcPeeringConnectionAccepter() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				Computed: false,
 			},
 			"auto_accept": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/bflad/tfproviderlint/blob/master/passes/S019/README.md

Previously:

```
aws/resource_aws_cloudhsm2_cluster.go:35:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_db_instance.go:332:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_db_instance.go:346:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_db_instance.go:243:18: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_default_network_acl.go:38:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_default_network_acl.go:57:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_default_network_acl.go:103:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_docdb_cluster.go:229:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_iam_openid_connect_provider.go:31:23: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_network_acl.go:36:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_network_acl.go:42:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_network_acl.go:54:17: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_network_acl.go:105:17: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_rds_cluster.go:291:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_rds_cluster.go:385:15: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_rds_cluster.go:228:18: S019: schema should omit Computed, Optional, or Required set to false
aws/resource_aws_vpc_peering_connection_accepter.go:23:15: S019: schema should omit Computed, Optional, or Required set to false
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
I'll kick off a TeamCity run for this but these are no-op changes
```
