### PR TITLE
provider: Automatically configure AWS China Route 53 region and endpoint

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -481,6 +481,13 @@ func (c *Config) Client() (interface{}, error) {
 		globalAcceleratorConfig.Region = aws.String(endpoints.UsWest2RegionID)
 		route53Config.Region = aws.String(endpoints.UsEast1RegionID)
 		shieldConfig.Region = aws.String(endpoints.UsEast1RegionID)
+	case endpoints.AwsCnPartitionID:
+		// The AWS Go SDK is missing endpoint information for Route 53 in the AWS China partition.
+		// This can likely be removed in the future.
+		if aws.StringValue(route53Config.Endpoint) == "" {
+			route53Config.Endpoint = aws.String("https://api.route53.cn")
+		}
+		route53Config.Region = aws.String(endpoints.CnNorthwest1RegionID)
 	case endpoints.AwsUsGovPartitionID:
 		// The AWS Go SDK is missing endpoint information for Route 53 in the AWS GovCloud (US) partition.
 		// This can likely be removed in the future.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9052

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* provider: Properly configure Route 53 service client in AWS China
```

Output from acceptance testing: N/A this is a best effort fix for AWS China Route 53 support as the maintainers do not have access to AWS China.