### PR TITLE
Cleaning up some resource retries for cloudwatch functions

### DIFF
--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -154,47 +154,6 @@ func resourceAwsCloudWatchEventPermissionRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	/*	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			log.Printf("[DEBUG] Reading CloudWatch Events bus: %s", input)
-			debo, err := conn.DescribeEventBus(&input)
-			if err != nil {
-				return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
-			}
-
-			if debo.Policy == nil {
-				return resource.RetryableError(&resource.NotFoundError{
-					Message: fmt.Sprintf("CloudWatch Events permission %q not found"+
-						"in given results from DescribeEventBus", d.Id()),
-					LastResponse: debo,
-					LastRequest:  input,
-				})
-			}
-
-			// TODO maybe this should be out of the block?
-			err = json.Unmarshal([]byte(*debo.Policy), &policyDoc)
-			if err != nil {
-				return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
-			}
-
-			// TODO This feels like it should be a separate retry block
-			policyStatement, err = findCloudWatchEventPermissionPolicyStatementByID(&policyDoc, d.Id())
-			// TODO also what if err is nil here?
-			return resource.RetryableError(err)
-		})
-
-		if err != nil {
-			// Missing statement inside valid policy
-			// TODO use isAWSErr here
-			if nfErr, ok := err.(*resource.NotFoundError); ok {
-				log.Printf("[WARN] %s", nfErr)
-				d.SetId("")
-				return nil
-			}
-
-			return err
-		}
-	*/
-
 	d.Set("action", policyStatement.Action)
 
 	if err := d.Set("condition", flattenCloudWatchEventPermissionPolicyStatementCondition(policyStatement.Condition)); err != nil {

--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -103,40 +103,97 @@ func resourceAwsCloudWatchEventPermissionRead(d *schema.ResourceData, meta inter
 	var policyStatement *CloudWatchEventPermissionPolicyStatement
 
 	// Especially with concurrent PutPermission calls there can be a slight delay
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	var out *events.DescribeEventBusOutput
+	var err error
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		log.Printf("[DEBUG] Reading CloudWatch Events bus: %s", input)
-		debo, err := conn.DescribeEventBus(&input)
+		out, err = conn.DescribeEventBus(&input)
+
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
 		}
 
-		if debo.Policy == nil {
+		if out.Policy == nil {
 			return resource.RetryableError(&resource.NotFoundError{
 				Message: fmt.Sprintf("CloudWatch Events permission %q not found"+
 					"in given results from DescribeEventBus", d.Id()),
-				LastResponse: debo,
+				LastResponse: out,
 				LastRequest:  input,
 			})
 		}
-
-		err = json.Unmarshal([]byte(*debo.Policy), &policyDoc)
-		if err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
-		}
-
-		policyStatement, err = findCloudWatchEventPermissionPolicyStatementByID(&policyDoc, d.Id())
-		return resource.RetryableError(err)
+		return nil
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.DescribeEventBus(&input)
+	}
 	if err != nil {
-		// Missing statement inside valid policy
+		return fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error())
+	}
+
+	err = json.Unmarshal([]byte(*out.Policy), &policyDoc)
+	if err != nil {
+		return fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error())
+	}
+
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		policyStatement, err = findCloudWatchEventPermissionPolicyStatementByID(&policyDoc, d.Id())
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
+	})
+	if isResourceTimeoutError(err) {
+		policyStatement, err = findCloudWatchEventPermissionPolicyStatementByID(&policyDoc, d.Id())
+	}
+	if err != nil {
 		if nfErr, ok := err.(*resource.NotFoundError); ok {
 			log.Printf("[WARN] %s", nfErr)
 			d.SetId("")
 			return nil
 		}
-
 		return err
 	}
+
+	/*	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+			log.Printf("[DEBUG] Reading CloudWatch Events bus: %s", input)
+			debo, err := conn.DescribeEventBus(&input)
+			if err != nil {
+				return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
+			}
+
+			if debo.Policy == nil {
+				return resource.RetryableError(&resource.NotFoundError{
+					Message: fmt.Sprintf("CloudWatch Events permission %q not found"+
+						"in given results from DescribeEventBus", d.Id()),
+					LastResponse: debo,
+					LastRequest:  input,
+				})
+			}
+
+			// TODO maybe this should be out of the block?
+			err = json.Unmarshal([]byte(*debo.Policy), &policyDoc)
+			if err != nil {
+				return resource.NonRetryableError(fmt.Errorf("Reading CloudWatch Events permission '%s' failed: %s", d.Id(), err.Error()))
+			}
+
+			// TODO This feels like it should be a separate retry block
+			policyStatement, err = findCloudWatchEventPermissionPolicyStatementByID(&policyDoc, d.Id())
+			// TODO also what if err is nil here?
+			return resource.RetryableError(err)
+		})
+
+		if err != nil {
+			// Missing statement inside valid policy
+			// TODO use isAWSErr here
+			if nfErr, ok := err.(*resource.NotFoundError); ok {
+				log.Printf("[WARN] %s", nfErr)
+				d.SetId("")
+				return nil
+			}
+
+			return err
+		}
+	*/
 
 	d.Set("action", policyStatement.Action)
 

--- a/aws/resource_aws_cloudwatch_event_permission.go
+++ b/aws/resource_aws_cloudwatch_event_permission.go
@@ -103,8 +103,7 @@ func resourceAwsCloudWatchEventPermissionRead(d *schema.ResourceData, meta inter
 	var policyStatement *CloudWatchEventPermissionPolicyStatement
 
 	// Especially with concurrent PutPermission calls there can be a slight delay
-	var err error
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
 		log.Printf("[DEBUG] Reading CloudWatch Events bus: %s", input)
 		output, err := conn.DescribeEventBus(&input)
 		if err != nil {

--- a/aws/resource_aws_cloudwatch_log_destination.go
+++ b/aws/resource_aws_cloudwatch_log_destination.go
@@ -2,11 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -64,28 +62,34 @@ func resourceAwsCloudWatchLogDestinationPut(d *schema.ResourceData, meta interfa
 		TargetArn:       aws.String(target_arn),
 	}
 
-	return resource.Retry(3*time.Minute, func() *resource.RetryError {
-		resp, err := conn.PutDestination(params)
+	var resp *cloudwatchlogs.PutDestinationOutput
+	var err error
+	err = resource.Retry(3*time.Minute, func() *resource.RetryError {
+		resp, err = conn.PutDestination(params)
 
-		if err == nil {
-			d.SetId(name)
-			d.Set("arn", *resp.Destination.Arn)
-		}
-
-		awsErr, ok := err.(awserr.Error)
-		if !ok {
+		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not deliver test message to specified") {
 			return resource.RetryableError(err)
 		}
-
-		if awsErr.Code() == "InvalidParameterException" {
-			if strings.Contains(awsErr.Message(), "Could not deliver test message to specified") {
-				return resource.RetryableError(err)
-			}
+		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "") {
 			return resource.NonRetryableError(err)
 		}
-
-		return resource.NonRetryableError(err)
+		if isAWSErr(err, "", "") {
+			return resource.NonRetryableError(err)
+		}
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
 	})
+	if isResourceTimeoutError(err) {
+		resp, err = conn.PutDestination(params)
+	}
+	if err != nil {
+		return fmt.Errorf("Error putting cloudwatch log destination: %s", err)
+	}
+	d.SetId(name)
+	d.Set("arn", *resp.Destination.Arn)
+	return nil
 }
 
 func resourceAwsCloudWatchLogDestinationRead(d *schema.ResourceData, meta interface{}) error {

--- a/aws/resource_aws_cloudwatch_log_destination.go
+++ b/aws/resource_aws_cloudwatch_log_destination.go
@@ -88,7 +88,7 @@ func resourceAwsCloudWatchLogDestinationPut(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error putting cloudwatch log destination: %s", err)
 	}
 	d.SetId(name)
-	d.Set("arn", *resp.Destination.Arn)
+	d.Set("arn", resp.Destination.Arn)
 	return nil
 }
 

--- a/aws/resource_aws_cloudwatch_log_destination.go
+++ b/aws/resource_aws_cloudwatch_log_destination.go
@@ -70,14 +70,8 @@ func resourceAwsCloudWatchLogDestinationPut(d *schema.ResourceData, meta interfa
 		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not deliver test message to specified") {
 			return resource.RetryableError(err)
 		}
-		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "") {
-			return resource.NonRetryableError(err)
-		}
-		if isAWSErr(err, "", "") {
-			return resource.NonRetryableError(err)
-		}
 		if err != nil {
-			return resource.RetryableError(err)
+			return resource.NonRetryableError(err)
 		}
 		return nil
 	})

--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -73,13 +73,10 @@ func resourceAwsCloudwatchLogSubscriptionFilterCreate(d *schema.ResourceData, me
 		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not execute the lambda function") {
 			return resource.RetryableError(err)
 		}
-		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "") {
+		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-		if isAWSErr(err, "", "") {
-			return resource.NonRetryableError(err)
-		}
-		return resource.RetryableError(err)
+		return nil
 	})
 
 	if isResourceTimeoutError(err) {

--- a/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -64,32 +64,35 @@ func resourceAwsCloudwatchLogSubscriptionFilterCreate(d *schema.ResourceData, me
 	params := getAwsCloudWatchLogsSubscriptionFilterInput(d)
 	log.Printf("[DEBUG] Creating SubscriptionFilter %#v", params)
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.PutSubscriptionFilter(&params)
 
-		if err == nil {
-			d.SetId(cloudwatchLogsSubscriptionFilterId(d.Get("log_group_name").(string)))
-			log.Printf("[DEBUG] Cloudwatch logs subscription %q created", d.Id())
-		}
-
-		awsErr, ok := err.(awserr.Error)
-		if !ok {
+		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not deliver test message to specified") {
 			return resource.RetryableError(err)
 		}
-
-		if awsErr.Code() == "InvalidParameterException" {
-			log.Printf("[DEBUG] Caught message: %q, code: %q: Retrying", awsErr.Message(), awsErr.Code())
-			if strings.Contains(awsErr.Message(), "Could not deliver test message to specified") {
-				return resource.RetryableError(err)
-			}
-			if strings.Contains(awsErr.Message(), "Could not execute the lambda function") {
-				return resource.RetryableError(err)
-			}
-			resource.NonRetryableError(err)
+		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "Could not execute the lambda function") {
+			return resource.RetryableError(err)
 		}
-
-		return resource.NonRetryableError(err)
+		if isAWSErr(err, cloudwatchlogs.ErrCodeInvalidParameterException, "") {
+			return resource.NonRetryableError(err)
+		}
+		if isAWSErr(err, "", "") {
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(err)
 	})
+
+	if isResourceTimeoutError(err) {
+		_, err = conn.PutSubscriptionFilter(&params)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error creating Cloudwatch log subscription filter: %s", err)
+	}
+
+	d.SetId(cloudwatchLogsSubscriptionFilterId(d.Get("log_group_name").(string)))
+	log.Printf("[DEBUG] Cloudwatch logs subscription %q created", d.Id())
+	return nil
 }
 
 func resourceAwsCloudwatchLogSubscriptionFilterUpdate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_cloudwatch_event_permissions: Clean up error handling when reading event permissions
* resource/aws_cloudwatch_event_rule: Retry error handling when creating and updating event rules
* resource/aws_cloudwatch_log_destination: Clean up error handling when putting log destination
* resource/aws_cloudwatch_log_subscription_filter: Clean up error handling when creating log subscription filter
```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSCloudwatchLogDestination"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudwatchLogDestination -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudwatchLogDestinationPolicy_importBasic
=== PAUSE TestAccAWSCloudwatchLogDestinationPolicy_importBasic
=== RUN   TestAccAWSCloudwatchLogDestinationPolicy_basic
=== PAUSE TestAccAWSCloudwatchLogDestinationPolicy_basic
=== RUN   TestAccAWSCloudwatchLogDestination_importBasic
=== PAUSE TestAccAWSCloudwatchLogDestination_importBasic
=== RUN   TestAccAWSCloudwatchLogDestination_basic
=== PAUSE TestAccAWSCloudwatchLogDestination_basic
=== CONT  TestAccAWSCloudwatchLogDestinationPolicy_importBasic
=== CONT  TestAccAWSCloudwatchLogDestination_importBasic
=== CONT  TestAccAWSCloudwatchLogDestinationPolicy_basic
=== CONT  TestAccAWSCloudwatchLogDestination_basic
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_basic (118.58s)
--- PASS: TestAccAWSCloudwatchLogDestinationPolicy_importBasic (121.74s)
--- PASS: TestAccAWSCloudwatchLogDestination_importBasic (124.64s)
--- PASS: TestAccAWSCloudwatchLogDestination_basic (125.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       127.614s

make testacc TESTARGS="-run=TestAccAWSCloudWatchEventRule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchEventRule -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchEventRule_importBasic
=== PAUSE TestAccAWSCloudWatchEventRule_importBasic
=== RUN   TestAccAWSCloudWatchEventRule_basic
=== PAUSE TestAccAWSCloudWatchEventRule_basic
=== RUN   TestAccAWSCloudWatchEventRule_prefix
=== PAUSE TestAccAWSCloudWatchEventRule_prefix
=== RUN   TestAccAWSCloudWatchEventRule_tags
=== PAUSE TestAccAWSCloudWatchEventRule_tags
=== RUN   TestAccAWSCloudWatchEventRule_full
=== PAUSE TestAccAWSCloudWatchEventRule_full
=== RUN   TestAccAWSCloudWatchEventRule_enable
=== PAUSE TestAccAWSCloudWatchEventRule_enable
=== CONT  TestAccAWSCloudWatchEventRule_importBasic
=== CONT  TestAccAWSCloudWatchEventRule_full
=== CONT  TestAccAWSCloudWatchEventRule_basic
=== CONT  TestAccAWSCloudWatchEventRule_enable
=== CONT  TestAccAWSCloudWatchEventRule_tags
=== CONT  TestAccAWSCloudWatchEventRule_prefix
--- PASS: TestAccAWSCloudWatchEventRule_prefix (27.20s)
--- PASS: TestAccAWSCloudWatchEventRule_full (27.41s)
--- PASS: TestAccAWSCloudWatchEventRule_importBasic (29.77s)
--- PASS: TestAccAWSCloudWatchEventRule_basic (47.79s)
--- PASS: TestAccAWSCloudWatchEventRule_enable (68.30s)
--- PASS: TestAccAWSCloudWatchEventRule_tags (72.23s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       74.035s

make testacc TESTARGS="-run=TestAccAWSCloudwatchLogSubscriptionFilter"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudwatchLogSubscriptionFilter -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== PAUSE TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_disappears
=== PAUSE TestAccAWSCloudwatchLogSubscriptionFilter_disappears
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup
=== PAUSE TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup
=== CONT  TestAccAWSCloudwatchLogSubscriptionFilter_basic
=== CONT  TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup
=== CONT  TestAccAWSCloudwatchLogSubscriptionFilter_disappears
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_disappears (46.10s)
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_disappears_LogGroup (46.17s)
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_basic (46.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       49.312s

make testacc TESTARGS="-run=TestAccAWSCloudWatchEventPermission"==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCloudWatchEventPermission -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCloudWatchEventPermission_Basic
=== PAUSE TestAccAWSCloudWatchEventPermission_Basic
=== RUN   TestAccAWSCloudWatchEventPermission_Action
=== PAUSE TestAccAWSCloudWatchEventPermission_Action
=== RUN   TestAccAWSCloudWatchEventPermission_Condition
=== PAUSE TestAccAWSCloudWatchEventPermission_Condition
=== RUN   TestAccAWSCloudWatchEventPermission_Multiple
=== PAUSE TestAccAWSCloudWatchEventPermission_Multiple
=== RUN   TestAccAWSCloudWatchEventPermission_Disappears
=== PAUSE TestAccAWSCloudWatchEventPermission_Disappears
=== CONT  TestAccAWSCloudWatchEventPermission_Basic
=== CONT  TestAccAWSCloudWatchEventPermission_Multiple
=== CONT  TestAccAWSCloudWatchEventPermission_Action
=== CONT  TestAccAWSCloudWatchEventPermission_Condition
=== CONT  TestAccAWSCloudWatchEventPermission_Disappears
--- PASS: TestAccAWSCloudWatchEventPermission_Action (24.19s)
--- PASS: TestAccAWSCloudWatchEventPermission_Multiple (39.32s)
--- PASS: TestAccAWSCloudWatchEventPermission_Basic (40.09s)
--- PASS: TestAccAWSCloudWatchEventPermission_Condition (40.25s)
--- PASS: TestAccAWSCloudWatchEventPermission_Disappears (80.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       81.191s
```