### PR TITLE
Cleanup around resource.Retry methods for various api gateway resources

### DIFF
--- a/aws/resource_aws_api_gateway_account.go
+++ b/aws/resource_aws_api_gateway_account.go
@@ -111,6 +111,9 @@ func resourceAwsApiGatewayAccountUpdate(d *schema.ResourceData, meta interface{}
 
 		return nil
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.UpdateAccount(&input)
+	}
 	if err != nil {
 		return fmt.Errorf("Updating API Gateway Account failed: %s", err)
 	}

--- a/aws/resource_aws_api_gateway_usage_plan.go
+++ b/aws/resource_aws_api_gateway_usage_plan.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )
@@ -491,15 +489,14 @@ func resourceAwsApiGatewayUsagePlanDelete(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Deleting API Gateway Usage Plan: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteUsagePlan(&apigateway.DeleteUsagePlanInput{
-			UsagePlanId: aws.String(d.Id()),
-		})
-
-		if err == nil {
-			return nil
-		}
-
-		return resource.NonRetryableError(err)
+	_, err := conn.DeleteUsagePlan(&apigateway.DeleteUsagePlanInput{
+		UsagePlanId: aws.String(d.Id()),
 	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting API gateway usage plan: %s", err)
+	}
+
+	return nil
+
 }

--- a/aws/resource_aws_api_gateway_usage_plan_key.go
+++ b/aws/resource_aws_api_gateway_usage_plan_key.go
@@ -3,12 +3,10 @@ package aws
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/apigateway"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -97,19 +95,17 @@ func resourceAwsApiGatewayUsagePlanKeyDelete(d *schema.ResourceData, meta interf
 	conn := meta.(*AWSClient).apigateway
 
 	log.Printf("[DEBUG] Deleting API Gateway Usage Plan Key: %s", d.Id())
-
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := conn.DeleteUsagePlanKey(&apigateway.DeleteUsagePlanKeyInput{
-			UsagePlanId: aws.String(d.Get("usage_plan_id").(string)),
-			KeyId:       aws.String(d.Get("key_id").(string)),
-		})
-		if err == nil {
-			return nil
-		}
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
-			return nil
-		}
-
-		return resource.NonRetryableError(err)
+	_, err := conn.DeleteUsagePlanKey(&apigateway.DeleteUsagePlanKeyInput{
+		UsagePlanId: aws.String(d.Get("usage_plan_id").(string)),
+		KeyId:       aws.String(d.Get("key_id").(string)),
 	})
+	if isAWSErr(err, "NotFoundException", "") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error deleting API Gateway usage plan key: %s", err)
+	}
+
+	return nil
+
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_api_gateway_account: Fix error handling during update
* resource/aws_api_gateway_base_path_mapping: Fix error handling during create
* resource/aws_api_gateway_domain_name: Remove unnecessary retry during delete
* resource/aws_api_gateway_gateway_response: Remove unnecessary retry during delete
* resource/aws_api_gateway_model: Remove unnecessary retry during delete
* resource/aws_api_gateway_usage_plan: Remove unnecessary retry during delete
* resource/aws_api_gateway_usage_plan_key: Remove unnecessary retry during delete
```

Output from acceptance testing:

```
NOTE: All test failures below are current failures on master, not regressions


$ make testacc TESTARGS="-run=TestAccAWSAPIGatewayBasePathMapping"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayBasePathMapping -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayBasePathMapping_basic
=== PAUSE TestAccAWSAPIGatewayBasePathMapping_basic
=== RUN   TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty
=== PAUSE TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty
=== CONT  TestAccAWSAPIGatewayBasePathMapping_basic
=== CONT  TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty
--- FAIL: TestAccAWSAPIGatewayBasePathMapping_basic (25.12s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error creating API Gateway Domain Name: BadRequestException: The certificate that is attached to your distribution doesn't cover the alternate domain name (CNAME) that you're trying to add. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements (Service: AmazonCloudFront; Status Code: 400; Error Code: InvalidViewerCertificate; Request ID: e4e04c98-935c-11e9-98e4-f5b91aaa816d)
                status code: 400, request id: e45635cf-935c-11e9-9dc3-43a1ebc4a8b3
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test392111873/main.tf line 41:
          (source code not available)
        
        
--- FAIL: TestAccAWSAPIGatewayBasePathMapping_BasePath_Empty (77.80s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error creating API Gateway Domain Name: BadRequestException: The certificate that is attached to your distribution doesn't cover the alternate domain name (CNAME) that you're trying to add. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements (Service: AmazonCloudFront; Status Code: 400; Error Code: InvalidViewerCertificate; Request ID: 05aa28cf-935d-11e9-a609-0f5a836a68a8)
                status code: 400, request id: 05114500-935d-11e9-bbba-cb17e00e0ce4
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test827674732/main.tf line 34:
          (source code not available)
        
        
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       84.393s
make: *** [testacc] Error 1

make testacc TESTARGS="-run=TestAccAWSAPIGatewayModel"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayModel -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayModel_basic
=== PAUSE TestAccAWSAPIGatewayModel_basic
=== CONT  TestAccAWSAPIGatewayModel_basic
--- PASS: TestAccAWSAPIGatewayModel_basic (31.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       34.784s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayUsagePlan"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayUsagePlan -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayUsagePlanKey_basic
=== PAUSE TestAccAWSAPIGatewayUsagePlanKey_basic
=== RUN   TestAccAWSAPIGatewayUsagePlan_importBasic
=== PAUSE TestAccAWSAPIGatewayUsagePlan_importBasic
=== RUN   TestAccAWSAPIGatewayUsagePlan_basic
=== PAUSE TestAccAWSAPIGatewayUsagePlan_basic
=== RUN   TestAccAWSAPIGatewayUsagePlan_description
=== PAUSE TestAccAWSAPIGatewayUsagePlan_description
=== RUN   TestAccAWSAPIGatewayUsagePlan_productCode
=== PAUSE TestAccAWSAPIGatewayUsagePlan_productCode
=== RUN   TestAccAWSAPIGatewayUsagePlan_throttling
=== PAUSE TestAccAWSAPIGatewayUsagePlan_throttling
=== RUN   TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit
=== PAUSE TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit
=== RUN   TestAccAWSAPIGatewayUsagePlan_quota
=== PAUSE TestAccAWSAPIGatewayUsagePlan_quota
=== RUN   TestAccAWSAPIGatewayUsagePlan_apiStages
=== PAUSE TestAccAWSAPIGatewayUsagePlan_apiStages
=== CONT  TestAccAWSAPIGatewayUsagePlanKey_basic
=== CONT  TestAccAWSAPIGatewayUsagePlan_apiStages
=== CONT  TestAccAWSAPIGatewayUsagePlan_productCode
=== CONT  TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit
=== CONT  TestAccAWSAPIGatewayUsagePlan_throttling
=== CONT  TestAccAWSAPIGatewayUsagePlan_description
=== CONT  TestAccAWSAPIGatewayUsagePlan_basic
=== CONT  TestAccAWSAPIGatewayUsagePlan_importBasic
=== CONT  TestAccAWSAPIGatewayUsagePlan_quota
--- PASS: TestAccAWSAPIGatewayUsagePlan_importBasic (89.69s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttling (122.80s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_throttlingInitialRateLimit (152.58s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_apiStages (203.17s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_basic (257.13s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_productCode (322.28s)
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_basic (379.63s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_quota (560.05s)
--- PASS: TestAccAWSAPIGatewayUsagePlan_description (611.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       612.840s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayGatewayResponse"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayGatewayResponse -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayGatewayResponse_basic
=== PAUSE TestAccAWSAPIGatewayGatewayResponse_basic
=== CONT  TestAccAWSAPIGatewayGatewayResponse_basic
--- PASS: TestAccAWSAPIGatewayGatewayResponse_basic (49.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       52.189s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayUsagePlanKey"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayUsagePlanKey -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayUsagePlanKey_basic
=== PAUSE TestAccAWSAPIGatewayUsagePlanKey_basic
=== CONT  TestAccAWSAPIGatewayUsagePlanKey_basic
--- PASS: TestAccAWSAPIGatewayUsagePlanKey_basic (117.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       122.104s

make testacc TESTARGS="-run=TestAccAWSAPIGatewayDomainName"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayDomainName -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayDomainName_CertificateArn
--- SKIP: TestAccAWSAPIGatewayDomainName_CertificateArn (0.00s)
    resource_aws_api_gateway_domain_name_test.go:26: Environment variable AWS_API_GATEWAY_DOMAIN_NAME_CERTIFICATE_ARN is not set. This environment variable must be set to the ARN of an ISSUED ACM certificate in us-east-1 to enable this test.
=== RUN   TestAccAWSAPIGatewayDomainName_CertificateName
=== PAUSE TestAccAWSAPIGatewayDomainName_CertificateName
=== RUN   TestAccAWSAPIGatewayDomainName_RegionalCertificateArn
--- SKIP: TestAccAWSAPIGatewayDomainName_RegionalCertificateArn (0.00s)
    resource_aws_api_gateway_domain_name_test.go:111: Environment variable AWS_API_GATEWAY_DOMAIN_NAME_REGIONAL_CERTIFICATE_ARN is not set. This environment variable must be set to the ARN of an ISSUED ACM certificate in the region where this test is running to enable the test.
=== RUN   TestAccAWSAPIGatewayDomainName_RegionalCertificateName
--- SKIP: TestAccAWSAPIGatewayDomainName_RegionalCertificateName (0.00s)
    resource_aws_api_gateway_domain_name_test.go:147: Environment variable AWS_API_GATEWAY_DOMAIN_NAME_REGIONAL_CERTIFICATE_NAME_ENABLED is not set. This environment variable must be set to any non-empty value in a region where uploading REGIONAL certificates is allowed to enable the test.
=== CONT  TestAccAWSAPIGatewayDomainName_CertificateName
--- FAIL: TestAccAWSAPIGatewayDomainName_CertificateName (11.10s)
    testing.go:568: Step 0 error: errors during apply:
        
        Error: Error creating API Gateway Domain Name: BadRequestException: The certificate that is attached to your distribution doesn't cover the alternate domain name (CNAME) that you're trying to add. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements (Service: AmazonCloudFront; Status Code: 400; Error Code: InvalidViewerCertificate; Request ID: c6484d5b-9373-11e9-8e1e-bdd4755c3768)
                status code: 400, request id: c5b9546e-9373-11e9-a107-814a5c68611c
        
          on /var/folders/pd/swwl85ks1nvbfy2pht84q2m40000gq/T/tf-test087542092/main.tf line 2:
          (source code not available)
        
        
FAIL
FAIL    github.com/terraform-providers/terraform-provider-aws/aws       13.713s
make: *** [testacc] Error 1

make testacc TESTARGS="-run=TestAccAWSAPIGatewayAccount"   
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAPIGatewayAccount -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSAPIGatewayAccount_importBasic
=== PAUSE TestAccAWSAPIGatewayAccount_importBasic
=== RUN   TestAccAWSAPIGatewayAccount_basic
=== PAUSE TestAccAWSAPIGatewayAccount_basic
=== CONT  TestAccAWSAPIGatewayAccount_importBasic
=== CONT  TestAccAWSAPIGatewayAccount_basic
--- PASS: TestAccAWSAPIGatewayAccount_importBasic (22.56s)
--- PASS: TestAccAWSAPIGatewayAccount_basic (108.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       109.996s

```