### PR TITLE
Document ecs_service block in codedeploy_deployment_group

### DIFF
--- a/website/docs/r/codedeploy_deployment_group.html.markdown
+++ b/website/docs/r/codedeploy_deployment_group.html.markdown
@@ -277,6 +277,13 @@ Multiple occurrences of `ec2_tag_filter` are allowed, where any instance that ma
 
 You can form a tag group by putting a set of tag filters into `ec2_tag_set`. If multiple tag groups are specified, any instance that matches to at least one tag filter of every tag group is selected.
 
+### ecs_service Argument Reference
+
+Each `ecs_service` configuration block supports the following:
+
+* `cluster_name` - (Required) The name of the ECS cluster.
+* `service_name` - (Required) The name of the ECS service.
+
 ### load_balancer_info Argument Reference
 
 You can configure the **Load Balancer** to use in a deployment. `load_balancer_info` supports the following:


### PR DESCRIPTION
Currently the documentation for this block is missing, although it is used within the second example on this page.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->