### PR TITLE
tests/provider: Remove hardcoded us-west-2 provider declarations in test configurations

### DIFF
--- a/aws/data_source_aws_availability_zone_test.go
+++ b/aws/data_source_aws_availability_zone_test.go
@@ -33,10 +33,6 @@ func TestAccDataSourceAwsAvailabilityZone(t *testing.T) {
 }
 
 const testAccDataSourceAwsAvailabilityZoneConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 data "aws_availability_zone" "by_name" {
   name = "us-west-2a"
 }

--- a/aws/data_source_aws_canonical_user_id_test.go
+++ b/aws/data_source_aws_canonical_user_id_test.go
@@ -42,9 +42,5 @@ func testAccDataSourceAwsCanonicalUserIdCheckExists(name string) resource.TestCh
 }
 
 const testAccDataSourceAwsCanonicalUserIdConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 data "aws_canonical_user_id" "current" { }
 `

--- a/aws/data_source_aws_kms_ciphertext_test.go
+++ b/aws/data_source_aws_kms_ciphertext_test.go
@@ -55,10 +55,6 @@ func TestAccDataSourceAwsKmsCiphertext_validate_withContext(t *testing.T) {
 }
 
 const testAccDataSourceAwsKmsCiphertextConfig_basic = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
   is_enabled = true
@@ -72,10 +68,6 @@ data "aws_kms_ciphertext" "foo" {
 `
 
 const testAccDataSourceAwsKmsCiphertextConfig_validate = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
   is_enabled = true
@@ -90,10 +82,6 @@ data "aws_kms_ciphertext" "foo" {
 `
 
 const testAccDataSourceAwsKmsCiphertextConfig_validate_withContext = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_kms_key" "foo" {
   description = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
   is_enabled = true

--- a/aws/data_source_aws_nat_gateway_test.go
+++ b/aws/data_source_aws_nat_gateway_test.go
@@ -43,10 +43,6 @@ func TestAccDataSourceAwsNatGateway(t *testing.T) {
 
 func testAccDataSourceAwsNatGatewayConfig(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "172.%d.0.0/16"
 

--- a/aws/data_source_aws_prefix_list_test.go
+++ b/aws/data_source_aws_prefix_list_test.go
@@ -58,10 +58,6 @@ func testAccDataSourceAwsPrefixListCheck(name string) resource.TestCheckFunc {
 }
 
 const testAccDataSourceAwsPrefixListConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 data "aws_prefix_list" "s3_by_id" {
   prefix_list_id = "pl-68a54001"
 }

--- a/aws/data_source_aws_sns_test.go
+++ b/aws/data_source_aws_sns_test.go
@@ -50,10 +50,6 @@ func testAccDataSourceAwsSnsTopicCheck(name string) resource.TestCheckFunc {
 }
 
 const testAccDataSourceAwsSnsTopicConfig = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_sns_topic" "tf_wrong1" {
   name = "wrong1"
 }

--- a/aws/data_source_aws_vpc_test.go
+++ b/aws/data_source_aws_vpc_test.go
@@ -132,10 +132,6 @@ func TestAccDataSourceAwsVpc_multipleCidr(t *testing.T) {
 
 func testAccDataSourceAwsVpcConfigIpv6(cidr, tag string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "test" {
   cidr_block                       = "%s"
   assign_generated_ipv6_cidr_block = true
@@ -153,10 +149,6 @@ data "aws_vpc" "by_id" {
 
 func testAccDataSourceAwsVpcConfig(cidr, tag string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "test" {
   cidr_block = "%s"
 

--- a/aws/resource_aws_autoscaling_group_test.go
+++ b/aws/resource_aws_autoscaling_group_test.go
@@ -2479,10 +2479,6 @@ resource "aws_security_group" "tf_test_self" {
 `
 
 const testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_post_duo = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "default" {
   cidr_block = "10.0.0.0/16"
 
@@ -2622,10 +2618,6 @@ resource "aws_autoscaling_group" "bar" {
 
 func testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_ELBCapacity(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "default" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = "true"

--- a/aws/resource_aws_default_route_table_test.go
+++ b/aws/resource_aws_default_route_table_test.go
@@ -239,10 +239,6 @@ resource "aws_internet_gateway" "gw" {
 }`
 
 const testAccDefaultRouteTable_change = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -289,10 +285,6 @@ resource "aws_route_table" "r" {
 `
 
 const testAccDefaultRouteTable_change_mod = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -382,10 +374,6 @@ resource "aws_default_route_table" "test" {
 }
 
 const testAccDefaultRouteTable_vpc_endpoint = `
-provider "aws" {
-    region = "us-west-2"
-}
-
 resource "aws_vpc" "test" {
     cidr_block = "10.0.0.0/16"
 

--- a/aws/resource_aws_default_vpc_test.go
+++ b/aws/resource_aws_default_vpc_test.go
@@ -48,10 +48,6 @@ func testAccCheckAWSDefaultVpcDestroy(s *terraform.State) error {
 }
 
 const testAccAWSDefaultVpcConfigBasic = `
-provider "aws" {
-    region = "us-west-2"
-}
-
 resource "aws_default_vpc" "foo" {
 	tags = {
 		Name = "Default VPC"

--- a/aws/resource_aws_elb_test.go
+++ b/aws/resource_aws_elb_test.go
@@ -1678,10 +1678,6 @@ resource "aws_elb" "bar" {
 }
 
 const testAccAWSELBConfig_subnets = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
@@ -1749,10 +1745,6 @@ resource "aws_internet_gateway" "gw" {
 `
 
 const testAccAWSELBConfig_subnet_swap = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "azelb" {
   cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true

--- a/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/aws/resource_aws_opsworks_custom_layer_test.go
@@ -347,10 +347,6 @@ resource "aws_opsworks_custom_layer" "tf-acc" {
 
 func testAccAwsOpsworksCustomLayerConfigVpcCreate(name string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_opsworks_custom_layer" "tf-acc" {
   stack_id               = "${aws_opsworks_stack.tf-acc.id}"
   name                   = "%s"

--- a/aws/resource_aws_opsworks_rails_app_layer_test.go
+++ b/aws/resource_aws_opsworks_rails_app_layer_test.go
@@ -77,10 +77,6 @@ func testAccCheckAwsOpsworksRailsAppLayerDestroy(s *terraform.State) error {
 
 func testAccAwsOpsworksRailsAppLayerConfigVpcCreate(name string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_opsworks_rails_app_layer" "tf-acc" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
   name     = "%s"
@@ -101,10 +97,6 @@ resource "aws_opsworks_rails_app_layer" "tf-acc" {
 
 func testAccAwsOpsworksRailsAppLayerNoManageBundlerConfigVpcCreate(name string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_opsworks_rails_app_layer" "tf-acc" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
   name     = "%s"

--- a/aws/resource_aws_opsworks_stack_test.go
+++ b/aws/resource_aws_opsworks_stack_test.go
@@ -724,10 +724,6 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
 
 func testAccAwsOpsworksStackConfigNoVpcCreateTags(name string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_opsworks_stack" "tf-acc" {
   name                          = "%s"
   region                        = "us-west-2"
@@ -817,10 +813,6 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
 
 func testAccAwsOpsworksStackConfigNoVpcUpdateTags(name string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_opsworks_stack" "tf-acc" {
   name                          = "%s"
   region                        = "us-west-2"

--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -454,10 +454,6 @@ resource "aws_subnet" "foo" {
 `
 
 const testAccSubnetConfigAvailabilityZoneId = `
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
   tags = {

--- a/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -103,10 +103,6 @@ func testAccCheckVpcEndpointRouteTableAssociationExists(n string, vpce *ec2.VpcE
 }
 
 const testAccVpcEndpointRouteTableAssociationConfig = `
-provider "aws" {
-    region = "us-west-2"
-}
-
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
   tags = {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8983

Test configurations should omit `provider "aws"` declarations as these:

* Prevent the same configuration from successfully running against multiple AWS partitions (e.g. AWS Commercial and AWS GovCloud (US))
* Reconfigure the default testing provider configuration, which can cause unexpected behavior across multiple tests

In this pass, we cleanup the trivial cases of `region = "us-west-2"` declarations, which matches the [default region the acceptance testing framework is configured](https://github.com/terraform-providers/terraform-provider-aws/blob/9722fb2d65252d187534345f8cf3e66f13fcea2a/aws/provider_test.go#L186-L192). As an added benefit of these changes, some of these tests may begin passing in AWS GovCloud (US) and other partitions. Future updates will handle hardcoded region and availability zone testing.

Previously from `tfproviderlint -AT004 ./aws` (only relevant failures shown):

```
aws/data_source_aws_availability_zone_test.go:35:52: AT004: provider declaration should be omitted
aws/data_source_aws_canonical_user_id_test.go:44:51: AT004: provider declaration should be omitted
aws/data_source_aws_kms_ciphertext_test.go:57:55: AT004: provider declaration should be omitted
aws/data_source_aws_kms_ciphertext_test.go:74:58: AT004: provider declaration should be omitted
aws/data_source_aws_kms_ciphertext_test.go:92:70: AT004: provider declaration should be omitted
aws/data_source_aws_nat_gateway_test.go:45:21: AT004: provider declaration should be omitted
aws/data_source_aws_prefix_list_test.go:60:46: AT004: provider declaration should be omitted
aws/data_source_aws_sns_test.go:52:44: AT004: provider declaration should be omitted
aws/data_source_aws_vpc_test.go:134:21: AT004: provider declaration should be omitted
aws/data_source_aws_vpc_test.go:155:21: AT004: provider declaration should be omitted
aws/resource_aws_autoscaling_group_test.go:2481:67: AT004: provider declaration should be omitted
aws/resource_aws_autoscaling_group_test.go:2624:21: AT004: provider declaration should be omitted
aws/resource_aws_default_route_table_test.go:241:41: AT004: provider declaration should be omitted
aws/resource_aws_default_route_table_test.go:291:45: AT004: provider declaration should be omitted
aws/resource_aws_default_route_table_test.go:384:47: AT004: provider declaration should be omitted
aws/resource_aws_default_vpc_test.go:50:41: AT004: provider declaration should be omitted
aws/resource_aws_elb_test.go:1680:37: AT004: provider declaration should be omitted
aws/resource_aws_elb_test.go:1751:41: AT004: provider declaration should be omitted
aws/resource_aws_opsworks_custom_layer_test.go:349:21: AT004: provider declaration should be omitted
aws/resource_aws_opsworks_rails_app_layer_test.go:79:21: AT004: provider declaration should be omitted
aws/resource_aws_opsworks_rails_app_layer_test.go:103:21: AT004: provider declaration should be omitted
aws/resource_aws_opsworks_stack_test.go:726:21: AT004: provider declaration should be omitted
aws/resource_aws_opsworks_stack_test.go:819:21: AT004: provider declaration should be omitted
aws/resource_aws_subnet_test.go:456:47: AT004: provider declaration should be omitted
aws/resource_aws_vpc_endpoint_route_table_association_test.go:105:55: AT004: provider declaration should be omitted
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```


Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (81.06s)
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (372.99s)
--- PASS: TestAccAWSDefaultRouteTable_basic (77.18s)
--- PASS: TestAccAWSDefaultRouteTable_Route_TransitGatewayID (314.28s)
--- PASS: TestAccAWSDefaultRouteTable_swap (62.06s)
--- PASS: TestAccAWSDefaultRouteTable_vpc_endpoint (44.30s)
--- PASS: TestAccAWSDefaultVpc_basic (23.95s)
--- PASS: TestAccAWSELB_swap_subnets (74.50s)
--- PASS: TestAccAWSOpsworksCustomLayer_importBasic (42.93s)
--- PASS: TestAccAWSOpsworksRailsAppLayer (59.16s)
--- PASS: TestAccAWSOpsworksStackNoVpcCreateTags (36.37s)
--- PASS: TestAccAWSSubnet_availabilityZoneId (32.60s)
--- PASS: TestAccAWSVpcEndpointRouteTableAssociation_basic (44.86s)
--- PASS: TestAccDataSourceAwsAvailabilityZone (12.31s)
--- PASS: TestAccDataSourceAwsCanonicalUserId_basic (11.20s)
--- PASS: TestAccDataSourceAwsKmsCiphertext_basic (39.08s)
--- PASS: TestAccDataSourceAwsKmsCiphertext_validate (39.13s)
--- PASS: TestAccDataSourceAwsKmsCiphertext_validate_withContext (39.34s)
--- PASS: TestAccDataSourceAwsNatGateway (215.82s)
--- PASS: TestAccDataSourceAwsPrefixList (11.04s)
--- PASS: TestAccDataSourceAwsSnsTopic (14.32s)
--- PASS: TestAccDataSourceAwsVpc_basic (36.01s)
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (34.89s)
--- PASS: TestAccDataSourceAwsVpc_multipleCidr (53.00s)
```
