### PR TITLE
Retries after timeouts on spot resources

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -703,21 +703,20 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 	// take effect immediately, resulting in an InvalidSpotFleetRequestConfig error
 	var resp *ec2.RequestSpotFleetOutput
 	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
-		var err error
 		resp, err = conn.RequestSpotFleet(spotFleetOpts)
 
+		if isAWSErr(err, "InvalidSpotFleetRequestConfig", "") {
+			return resource.RetryableError(fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))
+		}
 		if err != nil {
-			if awsErr, ok := err.(awserr.Error); ok {
-				// IAM is eventually consistent :/
-				if awsErr.Code() == "InvalidSpotFleetRequestConfig" {
-					return resource.RetryableError(
-						fmt.Errorf("Error creating Spot fleet request, retrying: %s", err))
-				}
-			}
 			return resource.NonRetryableError(err)
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		resp, err = conn.RequestSpotFleet(spotFleetOpts)
+	}
 
 	if err != nil {
 		return fmt.Errorf("Error requesting spot fleet: %s", err)

--- a/aws/resource_aws_spot_instance_request.go
+++ b/aws/resource_aws_spot_instance_request.go
@@ -177,7 +177,6 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 
 	var resp *ec2.RequestSpotInstancesOutput
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
 		resp, err = conn.RequestSpotInstances(spotOpts)
 		// IAM instance profiles can take ~10 seconds to propagate in AWS:
 		// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
@@ -192,6 +191,10 @@ func resourceAwsSpotInstanceRequestCreate(d *schema.ResourceData, meta interface
 		}
 		return resource.NonRetryableError(err)
 	})
+
+	if isResourceTimeoutError(err) {
+		resp, err = conn.RequestSpotInstances(spotOpts)
+	}
 
 	if err != nil {
 		return fmt.Errorf("Error requesting spot instances: %s", err)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_spot_fleet_request: Add final retry when creating spot fleet request
* resource/aws_spot_instance_request: Add final retry when creating spot instance request
```

Output from acceptance testing:

```
make testacc TESTARGS="-run=TestAccAWSSpotFleetRequest"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSpotFleetRequest -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSpotFleetRequest_basic
=== PAUSE TestAccAWSSpotFleetRequest_basic
=== RUN   TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== PAUSE TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== RUN   TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== PAUSE TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== RUN   TestAccAWSSpotFleetRequest_fleetType
=== PAUSE TestAccAWSSpotFleetRequest_fleetType
=== RUN   TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== PAUSE TestAccAWSSpotFleetRequest_iamInstanceProfileArn
=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== PAUSE TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
=== RUN   TestAccAWSSpotFleetRequest_updateTargetCapacity
=== PAUSE TestAccAWSSpotFleetRequest_updateTargetCapacity
=== RUN   TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== PAUSE TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== PAUSE TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_withoutSpotPrice
=== PAUSE TestAccAWSSpotFleetRequest_withoutSpotPrice
=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation
=== PAUSE TestAccAWSSpotFleetRequest_diversifiedAllocation
=== RUN   TestAccAWSSpotFleetRequest_multipleInstancePools
=== PAUSE TestAccAWSSpotFleetRequest_multipleInstancePools
=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity
=== PAUSE TestAccAWSSpotFleetRequest_withWeightedCapacity
=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk
=== PAUSE TestAccAWSSpotFleetRequest_withEBSDisk
=== RUN   TestAccAWSSpotFleetRequest_withTags
=== PAUSE TestAccAWSSpotFleetRequest_withTags
=== RUN   TestAccAWSSpotFleetRequest_placementTenancy
=== PAUSE TestAccAWSSpotFleetRequest_placementTenancy
=== RUN   TestAccAWSSpotFleetRequest_WithELBs
=== PAUSE TestAccAWSSpotFleetRequest_WithELBs
=== RUN   TestAccAWSSpotFleetRequest_WithTargetGroups
=== PAUSE TestAccAWSSpotFleetRequest_WithTargetGroups
=== CONT  TestAccAWSSpotFleetRequest_basic
=== CONT  TestAccAWSSpotFleetRequest_placementTenancy
=== CONT  TestAccAWSSpotFleetRequest_updateTargetCapacity
=== CONT  TestAccAWSSpotFleetRequest_associatePublicIpAddress
=== CONT  TestAccAWSSpotFleetRequest_withEBSDisk
=== CONT  TestAccAWSSpotFleetRequest_WithELBs
=== CONT  TestAccAWSSpotFleetRequest_withWeightedCapacity
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion
=== CONT  TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
=== CONT  TestAccAWSSpotFleetRequest_multipleInstancePools
=== CONT  TestAccAWSSpotFleetRequest_diversifiedAllocation
=== CONT  TestAccAWSSpotFleetRequest_withoutSpotPrice
=== CONT  TestAccAWSSpotFleetRequest_overriddingSpotPrice
=== CONT  TestAccAWSSpotFleetRequest_WithTargetGroups
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet
=== CONT  TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz
=== CONT  TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList
=== CONT  TestAccAWSSpotFleetRequest_instanceInterruptionBehavior
=== CONT  TestAccAWSSpotFleetRequest_withTags
--- PASS: TestAccAWSSpotFleetRequest_placementTenancy (75.25s)
=== CONT  TestAccAWSSpotFleetRequest_fleetType
--- PASS: TestAccAWSSpotFleetRequest_withTags (262.12s)
=== CONT  TestAccAWSSpotFleetRequest_changePriceForcesNewRequest
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet (262.61s)
=== CONT  TestAccAWSSpotFleetRequest_iamInstanceProfileArn
--- PASS: TestAccAWSSpotFleetRequest_instanceInterruptionBehavior (263.65s)
--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (266.91s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion (266.91s)
--- PASS: TestAccAWSSpotFleetRequest_withoutSpotPrice (267.68s)
--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (268.48s)
--- PASS: TestAccAWSSpotFleetRequest_basic (270.01s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList (271.07s)
--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (271.15s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz (271.55s)
--- PASS: TestAccAWSSpotFleetRequest_multipleInstancePools (272.39s)
--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (273.06s)
--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList (273.45s)
--- PASS: TestAccAWSSpotFleetRequest_associatePublicIpAddress (303.36s)
--- PASS: TestAccAWSSpotFleetRequest_WithELBs (309.10s)
--- PASS: TestAccAWSSpotFleetRequest_fleetType (247.72s)
--- PASS: TestAccAWSSpotFleetRequest_WithTargetGroups (432.62s)
--- PASS: TestAccAWSSpotFleetRequest_iamInstanceProfileArn (270.49s)
--- PASS: TestAccAWSSpotFleetRequest_updateExcessCapacityTerminationPolicy (536.78s)
--- PASS: TestAccAWSSpotFleetRequest_updateTargetCapacity (779.05s)
--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesNewRequest (639.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       903.241s

make testacc TESTARGS="-run=TestAccAWSSpotInstanceRequest"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSpotInstanceRequest -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSSpotInstanceRequest_basic
=== PAUSE TestAccAWSSpotInstanceRequest_basic
=== RUN   TestAccAWSSpotInstanceRequest_withLaunchGroup
=== PAUSE TestAccAWSSpotInstanceRequest_withLaunchGroup
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
=== PAUSE TestAccAWSSpotInstanceRequest_withBlockDuration
=== RUN   TestAccAWSSpotInstanceRequest_vpc
=== PAUSE TestAccAWSSpotInstanceRequest_vpc
=== RUN   TestAccAWSSpotInstanceRequest_validUntil
=== PAUSE TestAccAWSSpotInstanceRequest_validUntil
=== RUN   TestAccAWSSpotInstanceRequest_withoutSpotPrice
=== PAUSE TestAccAWSSpotInstanceRequest_withoutSpotPrice
=== RUN   TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress
=== PAUSE TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress
=== RUN   TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes
=== PAUSE TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes
=== RUN   TestAccAWSSpotInstanceRequest_getPasswordData
=== PAUSE TestAccAWSSpotInstanceRequest_getPasswordData
=== RUN   TestAccAWSSpotInstanceRequestInterruptStop
=== PAUSE TestAccAWSSpotInstanceRequestInterruptStop
=== RUN   TestAccAWSSpotInstanceRequestInterruptHibernate
=== PAUSE TestAccAWSSpotInstanceRequestInterruptHibernate
=== CONT  TestAccAWSSpotInstanceRequest_basic
=== CONT  TestAccAWSSpotInstanceRequestInterruptHibernate
=== CONT  TestAccAWSSpotInstanceRequest_withoutSpotPrice
=== CONT  TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes
=== CONT  TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress
=== CONT  TestAccAWSSpotInstanceRequest_vpc
=== CONT  TestAccAWSSpotInstanceRequest_withBlockDuration
=== CONT  TestAccAWSSpotInstanceRequest_withLaunchGroup
=== CONT  TestAccAWSSpotInstanceRequest_validUntil
=== CONT  TestAccAWSSpotInstanceRequest_getPasswordData
=== CONT  TestAccAWSSpotInstanceRequestInterruptStop
--- PASS: TestAccAWSSpotInstanceRequestInterruptStop (72.77s)
--- PASS: TestAccAWSSpotInstanceRequest_basic (85.93s)
--- PASS: TestAccAWSSpotInstanceRequestInterruptHibernate (95.09s)
--- PASS: TestAccAWSSpotInstanceRequest_withoutSpotPrice (96.68s)
--- PASS: TestAccAWSSpotInstanceRequest_validUntil (96.70s)
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSGAndPublicIpAddress (118.14s)
--- PASS: TestAccAWSSpotInstanceRequest_withLaunchGroup (118.28s)
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (118.55s)
--- PASS: TestAccAWSSpotInstanceRequest_NetworkInterfaceAttributes (225.32s)
--- PASS: TestAccAWSSpotInstanceRequest_vpc (233.96s)
--- PASS: TestAccAWSSpotInstanceRequest_getPasswordData (281.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       281.965s
```