### PR TITLE
Timeout retries for ECR resources

### DIFF
--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -164,6 +164,10 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 	if isResourceTimeoutError(err) {
 		_, err = conn.DescribeRepositories(input)
 	}
+	
+	if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
+		return nil
+	}
 
 	if err != nil {
 		return fmt.Errorf("error deleting ECR repository: %s", err)

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -81,8 +81,8 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		RepositoryNames: aws.StringSlice([]string{d.Id()}),
 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+	var err error
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		out, err = conn.DescribeRepositories(input)
 		if d.IsNewResource() && isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
 			return resource.RetryableError(err)
@@ -92,6 +92,10 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		return nil
 	})
+
+	if isResourceTimeoutError(err) {
+		out, err = conn.DescribeRepositories(input)
+	}
 
 	if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
 		log.Printf("[WARN] ECR Repository (%s) not found, removing from state", d.Id())
@@ -143,10 +147,11 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	log.Printf("[DEBUG] Waiting for ECR Repository %q to be deleted", d.Id())
+	input := &ecr.DescribeRepositoriesInput{
+		RepositoryNames: aws.StringSlice([]string{d.Id()}),
+	}
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		_, err := conn.DescribeRepositories(&ecr.DescribeRepositoriesInput{
-			RepositoryNames: aws.StringSlice([]string{d.Id()}),
-		})
+		_, err = conn.DescribeRepositories(input)
 		if err != nil {
 			if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
 				return nil
@@ -154,9 +159,12 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 			return resource.NonRetryableError(err)
 		}
 
-		return resource.RetryableError(
-			fmt.Errorf("%q: Timeout while waiting for the ECR Repository to be deleted", d.Id()))
+		return resource.RetryableError(fmt.Errorf("%q: Timeout while waiting for the ECR Repository to be deleted", d.Id()))
 	})
+	if isResourceTimeoutError(err) {
+		_, err = conn.DescribeRepositories(input)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error deleting ECR repository: %s", err)
 	}

--- a/aws/resource_aws_ecr_repository.go
+++ b/aws/resource_aws_ecr_repository.go
@@ -164,7 +164,7 @@ func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 	if isResourceTimeoutError(err) {
 		_, err = conn.DescribeRepositories(input)
 	}
-	
+
 	if isAWSErr(err, ecr.ErrCodeRepositoryNotFoundException, "") {
 		return nil
 	}

--- a/aws/resource_aws_ecr_repository_policy.go
+++ b/aws/resource_aws_ecr_repository_policy.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -51,9 +52,9 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Creating ECR resository policy: %s", input)
 
 	// Retry due to IAM eventual consistency
+	var err error
 	var out *ecr.SetRepositoryPolicyOutput
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var err error
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		out, err = conn.SetRepositoryPolicy(&input)
 
 		if isAWSErr(err, "InvalidParameterException", "Invalid repository policy provided") {
@@ -62,8 +63,11 @@ func resourceAwsEcrRepositoryPolicyCreate(d *schema.ResourceData, meta interface
 		}
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.SetRepositoryPolicy(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating ECR Repository Policy: %s", err)
 	}
 
 	repositoryPolicy := *out
@@ -124,9 +128,9 @@ func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Updating ECR resository policy: %s", input)
 
 	// Retry due to IAM eventual consistency
+	var err error
 	var out *ecr.SetRepositoryPolicyOutput
-	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		var err error
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
 		out, err = conn.SetRepositoryPolicy(&input)
 
 		if isAWSErr(err, "InvalidParameterException", "Invalid repository policy provided") {
@@ -135,8 +139,11 @@ func resourceAwsEcrRepositoryPolicyUpdate(d *schema.ResourceData, meta interface
 		}
 		return resource.NonRetryableError(err)
 	})
+	if isResourceTimeoutError(err) {
+		out, err = conn.SetRepositoryPolicy(&input)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Error updating ECR Repository Policy: %s", err)
 	}
 
 	repositoryPolicy := *out


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related #7873

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* resource/aws_ecr_repository: Final retries when reading and deleting ECR repositories
* resource/aws_ecr_repository_policy: Final retries when creating and updating ECR repository policies
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEcrRepository"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEcrRepository -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEcrRepositoryPolicy_basic
=== PAUSE TestAccAWSEcrRepositoryPolicy_basic
=== RUN   TestAccAWSEcrRepositoryPolicy_iam
=== PAUSE TestAccAWSEcrRepositoryPolicy_iam
=== RUN   TestAccAWSEcrRepository_basic
=== PAUSE TestAccAWSEcrRepository_basic
=== RUN   TestAccAWSEcrRepository_tags
=== PAUSE TestAccAWSEcrRepository_tags
=== CONT  TestAccAWSEcrRepositoryPolicy_basic
=== CONT  TestAccAWSEcrRepository_tags
=== CONT  TestAccAWSEcrRepositoryPolicy_iam
=== CONT  TestAccAWSEcrRepository_basic
--- PASS: TestAccAWSEcrRepository_basic (27.12s)
--- PASS: TestAccAWSEcrRepositoryPolicy_basic (30.13s)
--- PASS: TestAccAWSEcrRepository_tags (40.61s)
--- PASS: TestAccAWSEcrRepositoryPolicy_iam (41.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       43.083s

make testacc TESTARGS="-run=TestAccAWSEcrRepositoryPolicy"    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEcrRepositoryPolicy -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEcrRepositoryPolicy_basic
=== PAUSE TestAccAWSEcrRepositoryPolicy_basic
=== RUN   TestAccAWSEcrRepositoryPolicy_iam
=== PAUSE TestAccAWSEcrRepositoryPolicy_iam
=== CONT  TestAccAWSEcrRepositoryPolicy_basic
=== CONT  TestAccAWSEcrRepositoryPolicy_iam
--- PASS: TestAccAWSEcrRepositoryPolicy_basic (33.12s)
--- PASS: TestAccAWSEcrRepositoryPolicy_iam (38.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       39.698s
```