### PR TITLE
tests/service/lightsail: Remove hardcoded us-east-1 region from configurations except aws_lightsail_domain

### DIFF
--- a/aws/resource_aws_lightsail_instance_test.go
+++ b/aws/resource_aws_lightsail_instance_test.go
@@ -40,30 +40,6 @@ func TestAccAWSLightsailInstance_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSLightsailInstance_euRegion(t *testing.T) {
-	var conf lightsail.Instance
-	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t); testAccPreCheckAWSLightsail(t) },
-		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSLightsailInstanceConfig_euRegion(lightsailName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSLightsailInstanceExists("aws_lightsail_instance.lightsail_instance_test", &conf),
-					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "availability_zone"),
-					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
-					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
-					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAWSLightsailInstance_Name(t *testing.T) {
 	var conf lightsail.Instance
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
@@ -261,14 +237,14 @@ func testAccPreCheckAWSLightsail(t *testing.T) {
 
 func testAccAWSLightsailInstanceConfig_basic(lightsailName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 resource "aws_lightsail_instance" "lightsail_instance_test" {
   name              = "%s"
-  availability_zone = "us-east-1b"
-  blueprint_id      = "gitlab_8_12_6"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  blueprint_id      = "amazon_linux"
   bundle_id         = "nano_1_0"
 }
 `, lightsailName)
@@ -307,21 +283,6 @@ resource "aws_lightsail_instance" "lightsail_instance_test" {
     Name = "tf-test",
     ExtraName = "tf-test"
   }
-}
-`, lightsailName)
-}
-
-func testAccAWSLightsailInstanceConfig_euRegion(lightsailName string) string {
-	return fmt.Sprintf(`
-provider "aws" {
-  region = "eu-west-1"
-}
-
-resource "aws_lightsail_instance" "lightsail_instance_test" {
-  name              = "%s"
-  availability_zone = "eu-west-1a"
-  blueprint_id      = "joomla_3_6_5"
-  bundle_id         = "nano_1_0"
 }
 `, lightsailName)
 }

--- a/aws/resource_aws_lightsail_key_pair_test.go
+++ b/aws/resource_aws_lightsail_key_pair_test.go
@@ -169,10 +169,6 @@ func testAccCheckAWSLightsailKeyPairDestroy(s *terraform.State) error {
 
 func testAccAWSLightsailKeyPairConfig_basic(lightsailName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_lightsail_key_pair" "lightsail_key_pair_test" {
   name = "%s"
 }
@@ -181,10 +177,6 @@ resource "aws_lightsail_key_pair" "lightsail_key_pair_test" {
 
 func testAccAWSLightsailKeyPairConfig_imported(lightsailName, key string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_lightsail_key_pair" "lightsail_key_pair_test" {
   name = "%s"
 
@@ -195,10 +187,6 @@ resource "aws_lightsail_key_pair" "lightsail_key_pair_test" {
 
 func testAccAWSLightsailKeyPairConfig_encrypted(lightsailName, key string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_lightsail_key_pair" "lightsail_key_pair_test" {
   name = "%s"
 
@@ -211,10 +199,6 @@ EOF
 
 func testAccAWSLightsailKeyPairConfig_prefixed() string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_lightsail_key_pair" "lightsail_key_pair_test_omit" {}
 
 resource "aws_lightsail_key_pair" "lightsail_key_pair_test_prefixed" {

--- a/aws/resource_aws_lightsail_static_ip_attachment_test.go
+++ b/aws/resource_aws_lightsail_static_ip_attachment_test.go
@@ -135,8 +135,8 @@ func testAccCheckAWSLightsailStaticIpAttachmentDestroy(s *terraform.State) error
 
 func testAccAWSLightsailStaticIpAttachmentConfig_basic(staticIpName, instanceName, keypairName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
+data "aws_availability_zones" "available" {
+  state = "available"
 }
 
 resource "aws_lightsail_static_ip_attachment" "test" {
@@ -150,8 +150,8 @@ resource "aws_lightsail_static_ip" "test" {
 
 resource "aws_lightsail_instance" "test" {
   name              = "%s"
-  availability_zone = "us-east-1b"
-  blueprint_id      = "wordpress_4_6_1"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  blueprint_id      = "amazon_linux"
   bundle_id         = "micro_1_0"
   key_pair_name     = "${aws_lightsail_key_pair.test.name}"
 }

--- a/aws/resource_aws_lightsail_static_ip_test.go
+++ b/aws/resource_aws_lightsail_static_ip_test.go
@@ -181,10 +181,6 @@ func testAccCheckAWSLightsailStaticIpDestroy(s *terraform.State) error {
 
 func testAccAWSLightsailStaticIpConfig_basic(staticIpName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_lightsail_static_ip" "test" {
   name = "%s"
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/terraform-providers/terraform-provider-aws/issues/8983

When the AWS Lightsail service originally launched and was developed within Terraform, it was only available in the us-east-1 region. Here we update the test configurations to remove the hardcoded provider declaration (defaulting now to us-west-2 and passing in that region as matches in the Contributing Guide). This also switches the configurations to use the `amazon_linux` Blueprint, which is available in all Lightsail regions.

Previously before switching blueprint:

```
--- FAIL: TestAccAWSLightsailInstance_basic (8.69s)
    testing.go:568: Step 0 error: errors during apply:

        Error: InvalidInputException: The GitLab CE blueprint gitlab_8_12_6 is not available in us-west-2
```

Blueprint search in all AWS Commercial EC2 regions:

```console
$ for REGION in $(aws ec2 describe-regions --query 'Regions[].RegionName' --output text); do
  if [[ "$(aws --region $REGION lightsail get-blueprints --query 'blueprints[?blueprintId==`amazon_linux`].blueprintId' --output text)" == "amazon_linux" ]]; then
    echo "Found amazon_linux in $REGION"
  else
    echo "Missing amazon_linux in $REGION"
  fi
done

An error occurred (AccessDeniedException) when calling the GetBlueprints operation:
Missing amazon_linux in eu-north-1
Found amazon_linux in ap-south-1
Found amazon_linux in eu-west-3
Found amazon_linux in eu-west-2
Found amazon_linux in eu-west-1
Found amazon_linux in ap-northeast-2
Found amazon_linux in ap-northeast-1

Could not connect to the endpoint URL: "https://lightsail.sa-east-1.amazonaws.com/"
Missing amazon_linux in sa-east-1
Found amazon_linux in ca-central-1
Found amazon_linux in ap-southeast-1
Found amazon_linux in ap-southeast-2
Found amazon_linux in eu-central-1
Found amazon_linux in us-east-1
Found amazon_linux in us-east-2

Could not connect to the endpoint URL: "https://lightsail.us-west-1.amazonaws.com/"
Missing amazon_linux in us-west-1
Found amazon_linux in us-west-2
```

The `aws_lightsail_domain` hardcoded us-east-1 configuration will be handled in a future update as this resource is required to exist in us-east-1:

```
--- FAIL: TestAccAWSLightsailDomain_basic (5.65s)
    testing.go:568: Step 0 error: errors during apply:

        Error: InvalidInputException: Domain-related APIs are only available in the us-east-1 Region. Please set your Region configuration to us-east-1 to create, view, or edit these resources.
```

Previous output from tfproviderlint AT004 (only relevant check failures shown):

```
aws/resource_aws_lightsail_instance_test.go:180:21: AT004: provider declaration should be omitted
aws/resource_aws_lightsail_instance_test.go:195:21: AT004: provider declaration should be omitted
aws/resource_aws_lightsail_key_pair_test.go:171:21: AT004: provider declaration should be omitted
aws/resource_aws_lightsail_key_pair_test.go:183:21: AT004: provider declaration should be omitted
aws/resource_aws_lightsail_key_pair_test.go:197:21: AT004: provider declaration should be omitted
aws/resource_aws_lightsail_key_pair_test.go:213:21: AT004: provider declaration should be omitted
aws/resource_aws_lightsail_static_ip_attachment_test.go:137:21: AT004: provider declaration should be omitted
aws/resource_aws_lightsail_static_ip_test.go:183:21: AT004: provider declaration should be omitted
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSLightsailStaticIp_disappears (11.47s)
--- PASS: TestAccAWSLightsailStaticIp_basic (13.36s)
--- PASS: TestAccAWSLightsailKeyPair_imported (24.50s)
--- PASS: TestAccAWSLightsailKeyPair_encrypted (24.96s)
--- PASS: TestAccAWSLightsailKeyPair_basic (25.17s)
--- PASS: TestAccAWSLightsailKeyPair_nameprefix (25.74s)
--- PASS: TestAccAWSLightsailInstance_disapear (60.65s)
--- PASS: TestAccAWSLightsailInstance_basic (62.58s)
--- PASS: TestAccAWSLightsailStaticIpAttachment_disappears (80.43s)
--- PASS: TestAccAWSLightsailStaticIpAttachment_basic (81.75s)
```

Output from acceptance testing in AWS GovCloud (US): Service not available in this partition
