### PR TITLE
New data sources: aws_route53_resolver_rule and aws_route53_resolver_rules

### DIFF
--- a/aws/data_source_aws_route53_resolver_rule.go
+++ b/aws/data_source_aws_route53_resolver_rule.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsRoute53ResolverRule() *schema.Resource {

--- a/aws/data_source_aws_route53_resolver_rule.go
+++ b/aws/data_source_aws_route53_resolver_rule.go
@@ -1,0 +1,152 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+)
+
+func dataSourceAwsRoute53ResolverRule() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRoute53ResolverRuleRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"domain_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validation.StringLenBetween(1, 256),
+				ConflictsWith: []string{"resolver_rule_id"},
+			},
+
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validateRoute53ResolverName,
+				ConflictsWith: []string{"resolver_rule_id"},
+			},
+
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"resolver_endpoint_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"resolver_rule_id"},
+			},
+
+			"resolver_rule_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"domain_name", "name", "resolver_endpoint_id", "rule_type"},
+			},
+
+			"rule_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					route53resolver.RuleTypeOptionForward,
+					route53resolver.RuleTypeOptionSystem,
+					route53resolver.RuleTypeOptionRecursive,
+				}, false),
+				ConflictsWith: []string{"resolver_rule_id"},
+			},
+
+			"share_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsRoute53ResolverRuleRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	var rule *route53resolver.ResolverRule
+	if v, ok := d.GetOk("resolver_rule_id"); ok {
+		ruleRaw, state, err := route53ResolverRuleRefresh(conn, v.(string))()
+		if err != nil {
+			return fmt.Errorf("error getting Route53 Resolver rule (%s): %s", v, err)
+		}
+
+		if state == route53ResolverRuleStatusDeleted {
+			return fmt.Errorf("no Route53 Resolver rules matched")
+		}
+
+		rule = ruleRaw.(*route53resolver.ResolverRule)
+	} else {
+		req := &route53resolver.ListResolverRulesInput{
+			Filters: buildRoute53ResolverAttributeFilterList(map[string]string{
+				"DOMAIN_NAME":          d.Get("domain_name").(string),
+				"NAME":                 d.Get("name").(string),
+				"RESOLVER_ENDPOINT_ID": d.Get("resolver_endpoint_id").(string),
+				"TYPE":                 d.Get("rule_type").(string),
+			}),
+		}
+
+		log.Printf("[DEBUG] Listing Route53 Resolver rules: %s", req)
+		resp, err := conn.ListResolverRules(req)
+		if err != nil {
+			return fmt.Errorf("error getting Route53 Resolver rules: %s", err)
+		}
+
+		if n := len(resp.ResolverRules); n == 0 {
+			return fmt.Errorf("no Route53 Resolver rules matched")
+		} else if n > 1 {
+			return fmt.Errorf("%d Route53 Resolver rules matched; use additional constraints to reduce matches to a rule", n)
+		}
+
+		rule = resp.ResolverRules[0]
+	}
+
+	d.SetId(aws.StringValue(rule.Id))
+	d.Set("arn", rule.Arn)
+	d.Set("domain_name", rule.DomainName)
+	d.Set("name", rule.Name)
+	d.Set("owner_id", rule.OwnerId)
+	d.Set("resolver_endpoint_id", rule.ResolverEndpointId)
+	d.Set("resolver_rule_id", rule.Id)
+	d.Set("rule_type", rule.RuleType)
+	d.Set("share_status", rule.ShareStatus)
+	if err := getTagsRoute53Resolver(conn, d); err != nil {
+		return fmt.Errorf("error reading Route 53 Resolver rule (%s) tags: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func buildRoute53ResolverAttributeFilterList(attrs map[string]string) []*route53resolver.Filter {
+	filters := []*route53resolver.Filter{}
+
+	for k, v := range attrs {
+		if v == "" {
+			continue
+		}
+
+		filters = append(filters, &route53resolver.Filter{
+			Name:   aws.String(k),
+			Values: aws.StringSlice([]string{v}),
+		})
+	}
+
+	return filters
+}

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -1,0 +1,140 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsRoute53ResolverRule_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+	resourceName := "aws_route53_resolver_rule.example"
+	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_rule_id"
+	ds2ResourceName := "data.aws_route53_resolver_rule.by_domain_name"
+	ds3ResourceName := "data.aws_route53_resolver_rule.by_name_and_rule_type"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ResolverRule_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_endpoint_id", resourceName, "resolver_endpoint_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_rule_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "rule_type", resourceName, "rule_type"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "share_status", resourceName, "share_status"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "tags.%", resourceName, "tags.%"),
+
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "resolver_endpoint_id", resourceName, "resolver_endpoint_id"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "resolver_rule_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "rule_type", resourceName, "rule_type"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "share_status", resourceName, "share_status"),
+					resource.TestCheckResourceAttrPair(ds2ResourceName, "tags.%", resourceName, "tags.%"),
+
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "resolver_endpoint_id", resourceName, "resolver_endpoint_id"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "resolver_rule_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "rule_type", resourceName, "rule_type"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "share_status", resourceName, "share_status"),
+					resource.TestCheckResourceAttrPair(ds3ResourceName, "tags.%", resourceName, "tags.%"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags(t *testing.T) {
+	rName := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+	resourceName := "aws_route53_resolver_rule.example"
+	ds1ResourceName := "data.aws_route53_resolver_rule.by_resolver_endpoint_id"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ResolverRule_resolverEndpointIdWithTags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "domain_name", resourceName, "domain_name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "owner_id", resourceName, "owner_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_endpoint_id", resourceName, "resolver_endpoint_id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "resolver_rule_id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "rule_type", resourceName, "rule_type"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "share_status", resourceName, "share_status"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "tags.%", resourceName, "tags.%"),
+					resource.TestCheckResourceAttr(ds1ResourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "tags.Key1", resourceName, "tags.Key1"),
+					resource.TestCheckResourceAttrPair(ds1ResourceName, "tags.Key2", resourceName, "tags.Key2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRoute53ResolverRule_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "example" {
+  domain_name = "example.com"
+  rule_type   = "SYSTEM"
+  name        = %[1]q
+}
+
+data "aws_route53_resolver_rule" "by_resolver_rule_id" {
+  resolver_rule_id = "${aws_route53_resolver_rule.example.id}"
+}
+
+data "aws_route53_resolver_rule" "by_domain_name" {
+  domain_name = "${aws_route53_resolver_rule.example.domain_name}"
+}
+
+data "aws_route53_resolver_rule" "by_name_and_rule_type" {
+  name      = "${aws_route53_resolver_rule.example.name}"
+  rule_type = "${aws_route53_resolver_rule.example.rule_type}"
+}
+`, rName)
+}
+
+func testAccDataSourceAwsRoute53ResolverRule_resolverEndpointIdWithTags(rName string) string {
+	return testAccRoute53ResolverRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "example" {
+  domain_name = "example.com"
+  rule_type   = "FORWARD"
+  name        = %[1]q
+
+  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+
+  target_ip {
+    ip = "192.0.2.7"
+  }
+
+  tags = {
+    "Key1" = "Value1"
+    "Key2" = "Value2"
+  }
+}
+
+data "aws_route53_resolver_rule" "by_resolver_endpoint_id" {
+  resolver_endpoint_id = "${aws_route53_resolver_rule.example.resolver_endpoint_id}"
+}
+`, rName)
+}

--- a/aws/data_source_aws_route53_resolver_rule_test.go
+++ b/aws/data_source_aws_route53_resolver_rule_test.go
@@ -94,7 +94,7 @@ func TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags(t *testi
 func testAccDataSourceAwsRoute53ResolverRule_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "example" {
-  domain_name = "example.com"
+  domain_name = "%[1]s.example.com"
   rule_type   = "SYSTEM"
   name        = %[1]q
 }
@@ -117,7 +117,7 @@ data "aws_route53_resolver_rule" "by_name_and_rule_type" {
 func testAccDataSourceAwsRoute53ResolverRule_resolverEndpointIdWithTags(rName string) string {
 	return testAccRoute53ResolverRuleConfig_resolverEndpoint(rName) + fmt.Sprintf(`
 resource "aws_route53_resolver_rule" "example" {
-  domain_name = "example.com"
+  domain_name = "%[1]s.example.com"
   rule_type   = "FORWARD"
   name        = %[1]q
 

--- a/aws/data_source_aws_route53_resolver_rules.go
+++ b/aws/data_source_aws_route53_resolver_rules.go
@@ -1,0 +1,102 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53resolver"
+)
+
+func dataSourceAwsRoute53ResolverRules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRoute53ResolverRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"owner_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.Any(
+					validateAwsAccountId,
+					// The owner of the default Internet Resolver rule.
+					validation.StringInSlice([]string{"Route 53 Resolver"}, false),
+				),
+			},
+
+			"resolver_endpoint_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"resolver_rule_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"rule_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					route53resolver.RuleTypeOptionForward,
+					route53resolver.RuleTypeOptionSystem,
+					route53resolver.RuleTypeOptionRecursive,
+				}, false),
+			},
+
+			"share_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					route53resolver.ShareStatusNotShared,
+					route53resolver.ShareStatusSharedWithMe,
+					route53resolver.ShareStatusSharedByMe,
+				}, false),
+			},
+		},
+	}
+}
+
+func dataSourceAwsRoute53ResolverRulesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).route53resolverconn
+
+	req := &route53resolver.ListResolverRulesInput{}
+	resolverRuleIds := []*string{}
+
+	log.Printf("[DEBUG] Listing Route53 Resolver rules: %s", req)
+	err := conn.ListResolverRulesPages(req, func(page *route53resolver.ListResolverRulesOutput, isLast bool) bool {
+		for _, rule := range page.ResolverRules {
+			if v, ok := d.GetOk("owner_id"); ok && aws.StringValue(rule.OwnerId) != v.(string) {
+				continue
+			}
+			if v, ok := d.GetOk("resolver_endpoint_id"); ok && aws.StringValue(rule.ResolverEndpointId) != v.(string) {
+				continue
+			}
+			if v, ok := d.GetOk("rule_type"); ok && aws.StringValue(rule.RuleType) != v.(string) {
+				continue
+			}
+			if v, ok := d.GetOk("share_status"); ok && aws.StringValue(rule.ShareStatus) != v.(string) {
+				continue
+			}
+
+			resolverRuleIds = append(resolverRuleIds, rule.Id)
+		}
+		return !isLast
+	})
+	if err != nil {
+		return fmt.Errorf("error getting Route53 Resolver rules: %s", err)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	err = d.Set("resolver_rule_ids", flattenStringSet(resolverRuleIds))
+	if err != nil {
+		return fmt.Errorf("error setting resolver_rule_ids: %s", err)
+	}
+
+	return nil
+}

--- a/aws/data_source_aws_route53_resolver_rules.go
+++ b/aws/data_source_aws_route53_resolver_rules.go
@@ -5,11 +5,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53resolver"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func dataSourceAwsRoute53ResolverRules() *schema.Resource {

--- a/aws/data_source_aws_route53_resolver_rules_test.go
+++ b/aws/data_source_aws_route53_resolver_rules_test.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsRoute53ResolverRules_basic(t *testing.T) {
+	dsResourceName := "data.aws_route53_resolver_rules.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ResolverRules_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.#", "1"),
+					resource.TestCheckResourceAttr(dsResourceName, "resolver_rule_ids.1743502667", "rslvr-autodefined-rr-internet-resolver"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId(t *testing.T) {
+	rName1 := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+	rName2 := fmt.Sprintf("tf-testacc-r53-resolver-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum))
+	ds1ResourceName := "data.aws_route53_resolver_rules.by_resolver_endpoint_id"
+	ds2ResourceName := "data.aws_route53_resolver_rules.by_rule_type"
+	ds3ResourceName := "data.aws_route53_resolver_rules.by_share_status"
+	ds4ResourceName := "data.aws_route53_resolver_rules.by_invalid_owner_id"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t); testAccPreCheckAWSRoute53Resolver(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsRoute53ResolverRules_resolverEndpointId(rName1, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(ds1ResourceName, "resolver_rule_ids.#", "1"),
+					resource.TestCheckResourceAttr(ds2ResourceName, "resolver_rule_ids.#", "1"),
+					resource.TestCheckResourceAttr(ds3ResourceName, "resolver_rule_ids.#", "2"),
+					resource.TestCheckResourceAttr(ds4ResourceName, "resolver_rule_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsRoute53ResolverRules_basic = `
+# The default Internet Resolver rule.
+data "aws_route53_resolver_rules" "test" {
+  owner_id     = "Route 53 Resolver"
+  rule_type    = "RECURSIVE"
+  share_status = "NOT_SHARED"
+}
+`
+
+func testAccDataSourceAwsRoute53ResolverRules_resolverEndpointId(rName1, rName2 string) string {
+	return testAccRoute53ResolverRuleConfig_resolverEndpoint(rName1) + fmt.Sprintf(`
+resource "aws_route53_resolver_rule" "forward" {
+  domain_name = "example.com"
+  rule_type   = "FORWARD"
+  name        = %[1]q
+
+  resolver_endpoint_id = "${aws_route53_resolver_endpoint.bar.id}"
+
+  target_ip {
+    ip = "192.0.2.7"
+  }
+}
+
+resource "aws_route53_resolver_rule" "system" {
+  domain_name = "example.org"
+  rule_type   = "SYSTEM"
+  name        = %[2]q
+}
+
+data "aws_route53_resolver_rules" "by_resolver_endpoint_id" {
+  owner_id             = "${aws_route53_resolver_rule.system.owner_id}"
+  resolver_endpoint_id = "${aws_route53_resolver_rule.forward.resolver_endpoint_id}"
+}
+
+data "aws_route53_resolver_rules" "by_rule_type" {
+  owner_id  = "${aws_route53_resolver_rule.forward.owner_id}"
+  rule_type = "${aws_route53_resolver_rule.system.rule_type}"
+}
+
+data "aws_route53_resolver_rules" "by_share_status" {
+  owner_id     = "${aws_route53_resolver_rule.forward.owner_id}"
+  share_status = "${aws_route53_resolver_rule.system.share_status}"
+}
+
+data "aws_route53_resolver_rules" "by_invalid_owner_id" {
+  owner_id     = "000000000000"
+  share_status = "SHARED_WITH_ME"
+}
+`, rName1, rName2)
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -250,6 +250,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route_tables":                              dataSourceAwsRouteTables(),
 			"aws_route53_delegation_set":                    dataSourceAwsDelegationSet(),
 			"aws_route53_resolver_rule":                     dataSourceAwsRoute53ResolverRule(),
+			"aws_route53_resolver_rules":                    dataSourceAwsRoute53ResolverRules(),
 			"aws_route53_zone":                              dataSourceAwsRoute53Zone(),
 			"aws_s3_bucket":                                 dataSourceAwsS3Bucket(),
 			"aws_s3_bucket_object":                          dataSourceAwsS3BucketObject(),

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -249,6 +249,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_route_table":                               dataSourceAwsRouteTable(),
 			"aws_route_tables":                              dataSourceAwsRouteTables(),
 			"aws_route53_delegation_set":                    dataSourceAwsDelegationSet(),
+			"aws_route53_resolver_rule":                     dataSourceAwsRoute53ResolverRule(),
 			"aws_route53_zone":                              dataSourceAwsRoute53Zone(),
 			"aws_s3_bucket":                                 dataSourceAwsS3Bucket(),
 			"aws_s3_bucket_object":                          dataSourceAwsS3BucketObject(),

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2407,6 +2407,17 @@
                     <a href="#">Route53 Resolver</a>
                     <ul class="nav">
                         <li>
+                            <a href="#">Data Sources</a>
+                            <ul class="nav nav-auto-expand">
+                                <li>
+                                    <a href="/docs/providers/aws/d/route53_resolver_rule.html">aws_route53_resolver_rule</a>
+                                </li>
+                                <li>
+                                    <a href="/docs/providers/aws/d/route53_resolver_rules.html">aws_route53_resolver_rules</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
                             <a href="#">Resources</a>
                             <ul class="nav nav-auto-expand">
                                 <li>

--- a/website/docs/d/route53_resolver_rule.html.markdown
+++ b/website/docs/d/route53_resolver_rule.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_rule"
+sidebar_current: "docs-aws-datasource-route53-resolver-rule"
+description: |-
+    Provides details about a specific Route53 Resolver rule
+---
+
+# Data Source: aws_route53_resolver_rule
+
+`aws_route53_resolver_rule` provides details about a specific Route53 Resolver rule.
+
+## Example Usage
+
+The following example shows how to get a Route53 Resolver rule based on its associated domain name and rule type.
+
+```hcl
+data "aws_route53_resolver_rule" "example" {
+  domain_name = "subdomain.example.com"
+  rule_type   = "SYSTEM"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available resolver rules in the current region.
+The given filters must match exactly one resolver rule whose data will be exported as attributes.
+
+* `domain_name` - (Optional) The domain name the desired resolver rule forwards DNS queries for. Conflicts with `resolver_rule_id`.
+* `name` - (Optional) The friendly name of the desired resolver rule. Conflicts with `resolver_rule_id`.
+* `resolver_endpoint_id` (Optional) The ID of the outbound resolver endpoint of the desired resolver rule. Conflicts with `resolver_rule_id`.
+* `resolver_rule_id` (Optional) The ID of the desired resolver rule. Conflicts with `domain_name`, `name`, `resolver_endpoint_id` and `rule_type`.
+* `rule_type` - (Optional) The rule type of the desired resolver rule. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`. Conflicts with `resolver_rule_id`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the resolver rule.
+* `arn` - The ARN (Amazon Resource Name) for the resolver rule.
+* `owner_id` - When a rule is shared with another AWS account, the account ID of the account that the rule is shared with.
+* `share_status` - Whether the rules is shared and, if so, whether the current account is sharing the rule with another account, or another account is sharing the rule with the current account.
+Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
+* `tags` - A mapping of tags assigned to the resolver rule.

--- a/website/docs/d/route53_resolver_rules.html.markdown
+++ b/website/docs/d/route53_resolver_rules.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route53_resolver_rules"
+sidebar_current: "docs-aws-datasource-route53-resolver-rules"
+description: |-
+    Provides details about a set of Route53 Resolver rules
+---
+
+# Data Source: aws_route53_resolver_rules
+
+`aws_route53_resolver_rules` provides details about a set of Route53 Resolver rules.
+
+## Example Usage
+
+The following example shows how to get Route53 Resolver rules based on tags.
+
+```hcl
+data "aws_route53_resolver_rules" "example" {
+  tags = {
+    Environment = "dev"
+  }
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available resolver rules in the current region.
+
+* `owner_id` (Optional) When the desired resolver rules are shared shared with another AWS account, the account ID of the account that the rules are shared with.
+* `resolver_endpoint_id` (Optional) The ID of the outbound resolver endpoint of the desired resolver rules.
+* `rule_type` (Optional) The rule type of the desired resolver rules. Valid values are `FORWARD`, `SYSTEM` and `RECURSIVE`.
+* `share_status` (Optional) Whether the desired resolver rules are shared and, if so, whether the current account is sharing the rules with another account, or another account is sharing the rules with the current account.
+Values are `NOT_SHARED`, `SHARED_BY_ME` or `SHARED_WITH_ME`
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `resolver_rule_ids` - The IDs of the matched resolver rules.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/8508.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- New Data Source:  aws_route53_resolver_rule
- New Data Source:  aws_route53_resolver_rules
```

Output from acceptance testing:

```console
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsRoute53ResolverRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsRoute53ResolverRule_ -timeout 120m
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_basic
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_basic
=== RUN   TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
=== PAUSE TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_basic
=== CONT  TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_basic (41.30s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRule_ResolverEndpointIdWithTags (252.57s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	252.604s
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccDataSourceAwsRoute53ResolverRules_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccDataSourceAwsRoute53ResolverRules_ -timeout 120m
=== RUN   TestAccDataSourceAwsRoute53ResolverRules_basic
=== PAUSE TestAccDataSourceAwsRoute53ResolverRules_basic
=== RUN   TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId
=== PAUSE TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId
=== CONT  TestAccDataSourceAwsRoute53ResolverRules_basic
=== CONT  TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_basic (20.62s)
--- PASS: TestAccDataSourceAwsRoute53ResolverRules_ResolverEndpointId (257.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	257.496s
```