### PR TITLE
resource/aws_db_instance: Add max_allocated_storage argument (support Storage Autoscaling)

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -198,7 +198,6 @@ func resourceAwsDbInstance() *schema.Resource {
 			"max_allocated_storage": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if old == "0" && new == fmt.Sprintf("%d", d.Get("allocated_storage").(int)) {
 						return true

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1506,6 +1506,9 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		d.SetPartial("max_allocated_storage")
 		mas := d.Get("max_allocated_storage").(int)
 
+		// The API expects the max allocated storage value to be set to the allocated storage
+		// value when disabling autoscaling. This check ensures that value is set correctly
+		// if the update to the Terraform configuration was removing the argument completely.
 		if mas == 0 {
 			mas = d.Get("allocated_storage").(int)
 		}

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -750,11 +750,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.AvailabilityZone = aws.String(attr.(string))
 		}
 
-		if attr, ok := d.GetOk("max_allocated_storage"); ok {
-			modifyDbInstanceInput.MaxAllocatedStorage = aws.Int64(int64(attr.(int)))
-			requiresModifyDbInstance = true
-		}
-
 		if attr, ok := d.GetOk("monitoring_role_arn"); ok {
 			opts.MonitoringRoleArn = aws.String(attr.(string))
 		}

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -127,7 +127,7 @@ Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00". See [RDS
 Maintenance Window
 docs](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow)
 for more information.
-* `max_allocated_storage` - (Optional) When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to `allocated_storage`. Must be configured to perform drift detection and its value must be greater than or equal to `allocated_storage` or `0` to disable Storage Autoscaling.
+* `max_allocated_storage` - (Optional) When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to `allocated_storage`. Must be greater than or equal to `allocated_storage` or `0` to disable Storage Autoscaling.
 * `monitoring_interval` - (Optional) The interval, in seconds, between points
 when Enhanced Monitoring metrics are collected for the DB instance. To disable
 collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -54,6 +54,17 @@ resource "aws_db_instance" "default" {
 
 ### Storage Autoscaling
 
+To enable Storage Autoscaling with instances that support the feature, define the `max_allocated_storage` argument higher than the `allocated_storage` argument. Terraform will automatically hide differences with the `allocated_storage` argument value if autoscaling occurs.
+
+```hcl
+resource "aws_db_instance" "example {
+  # ... other configuration ...
+
+  allocated_storage     = 50
+  max_allocated_storage = 100
+}
+```
+
 ## Argument Reference
 
 For more detailed documentation about each argument, refer to the [AWS official

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -36,6 +36,8 @@ about [DB Instance Class Types](https://docs.aws.amazon.com/AmazonRDS/latest/Use
 
 ## Example Usage
 
+### Basic Usage
+
 ```hcl
 resource "aws_db_instance" "default" {
   allocated_storage    = 20
@@ -50,6 +52,8 @@ resource "aws_db_instance" "default" {
 }
 ```
 
+### Storage Autoscaling
+
 ## Argument Reference
 
 For more detailed documentation about each argument, refer to the [AWS official
@@ -57,8 +61,7 @@ documentation](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Crea
 
 The following arguments are supported:
 
-* `allocated_storage` - (Required unless a `snapshot_identifier` or
-`replicate_source_db` is provided) The allocated storage in gibibytes.
+* `allocated_storage` - (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) The allocated storage in gibibytes. If `max_allocated_storage` is configured, this argument represents the initial storage allocation and differences from the configuration will be ignored automatically when Storage Autoscaling occurs.
 * `allow_major_version_upgrade` - (Optional) Indicates that major version
 upgrades are allowed. Changing this parameter does not result in an outage and
 the change is asynchronously applied as soon as possible.
@@ -124,6 +127,7 @@ Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00". See [RDS
 Maintenance Window
 docs](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow)
 for more information.
+* `max_allocated_storage` - (Optional) When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to `allocated_storage`. Must be configured to perform drift detection and its value must be greater than or equal to `allocated_storage` or `0` to disable Storage Autoscaling.
 * `monitoring_interval` - (Optional) The interval, in seconds, between points
 when Enhanced Monitoring metrics are collected for the DB instance. To disable
 collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #9076

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_instance: Add max_allocated_storage argument (support Storage Autoscaling)
```

Output from acceptance testing (test failures present in master):

```
--- FAIL: TestAccAWSDBInstance_optionGroup (9.60s)
--- PASS: TestAccAWSDBInstance_IsAlreadyBeingDeleted (407.82s)
--- PASS: TestAccAWSDBInstance_kmsKey (447.28s)
--- PASS: TestAccAWSDBInstance_iamAuth (468.51s)
--- PASS: TestAccAWSDBInstance_basic (469.82s)
--- PASS: TestAccAWSDBInstance_generatedName (509.47s)
--- PASS: TestAccAWSDBInstance_namePrefix (509.57s)
--- PASS: TestAccAWSDBInstance_DeletionProtection (534.93s)
--- PASS: TestAccAWSDBInstance_MaxAllocatedStorage (554.00s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier_SkipFinalSnapshot (640.05s)
--- FAIL: TestAccAWSDBInstance_ReplicateSourceDb_AutoMinorVersionUpgrade (839.74s)
--- PASS: TestAccAWSDBInstance_subnetGroup (864.75s)
--- PASS: TestAccAWSDBInstance_FinalSnapshotIdentifier (975.11s)
--- FAIL: TestAccAWSDBInstance_S3Import (661.46s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupWindow (1464.99s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaxAllocatedStorage (1520.22s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AvailabilityZone (1536.83s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_IamDatabaseAuthenticationEnabled (1586.30s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MaintenanceWindow (1635.73s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb (1697.74s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier (1263.54s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_VpcSecurityGroupIds (1349.56s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_BackupRetentionPeriod (1940.63s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage (1949.99s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Port (1519.48s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AllocatedStorage (1475.69s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage (1389.89s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_Monitoring (1623.10s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AutoMinorVersionUpgrade (1233.00s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_AvailabilityZone (1245.29s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_ParameterGroupName (1661.06s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod (1285.34s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_MultiAZ (2146.49s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_IamDatabaseAuthenticationEnabled (1083.14s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_DeletionProtection (1149.70s)
--- PASS: TestAccAWSDBInstance_portUpdate (570.32s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupWindow (1234.86s)
--- PASS: TestAccAWSDBInstance_enhancedMonitoring (670.62s)
--- PASS: TestAccAWSDBInstance_separate_iops_update (632.53s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaintenanceWindow (1335.83s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Monitoring (1225.51s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MaxAllocatedStorage (1295.29s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_BackupRetentionPeriod_Unset (1799.33s)
--- PASS: TestAccAWSDBInstance_MinorVersion (343.49s)
--- PASS: TestAccAWSDBInstance_ec2Classic (395.42s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Port (1173.81s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds_Tags (1094.16s)
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (443.64s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_Tags (1223.46s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfiguration (511.70s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_ParameterGroupName (1284.52s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_VpcSecurityGroupIds (1196.15s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Postgresql (495.06s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ (1638.76s)
--- PASS: TestAccAWSDBInstance_cloudwatchLogsExportConfigurationUpdate (759.27s)
--- PASS: TestAccAWSDBInstance_EnabledCloudwatchLogsExports_Oracle (686.93s)
--- PASS: TestAccAWSDBInstance_MSSQL_TZ (1926.59s)
--- PASS: TestAccAWSDBInstance_MySQL_SnapshotRestoreWithEngineVersion (1864.61s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_PerformanceInsightsEnabled (1527.89s)
--- PASS: TestAccAWSDBInstance_ReplicateSourceDb_PerformanceInsightsEnabled (1632.72s)
--- PASS: TestAccAWSDBInstance_MSSQL_Domain (3296.64s)
--- PASS: TestAccAWSDBInstance_MSSQL_DomainSnapshotRestore (3228.09s)
--- PASS: TestAccAWSDBInstance_SnapshotIdentifier_MultiAZ_SQLServer (4095.19s)
```
