### PR TITLE
Add CheckDestroy step for aws_autoscaling_attachment resources acctest

### DIFF
--- a/aws/resource_aws_autoscaling_attachment_test.go
+++ b/aws/resource_aws_autoscaling_attachment_test.go
@@ -16,8 +16,9 @@ func TestAccAWSAutoscalingAttachment_elb(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutocalingAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAutoscalingAttachment_elb(rInt),
@@ -58,8 +59,9 @@ func TestAccAWSAutoscalingAttachment_albTargetGroup(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAutocalingAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAutoscalingAttachment_alb(rInt),
@@ -93,6 +95,32 @@ func TestAccAWSAutoscalingAttachment_albTargetGroup(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSAutocalingAttachmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).autoscalingconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_autoscaling_attachment" {
+			continue
+		}
+
+		resp, err := conn.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+			AutoScalingGroupNames: []*string{aws.String(rs.Primary.ID)},
+		})
+
+		if err == nil {
+			for _, autoscalingGroup := range resp.AutoScalingGroups {
+				if aws.StringValue(autoscalingGroup.AutoScalingGroupName) == rs.Primary.ID {
+					return fmt.Errorf("AWS Autoscaling Attachment is still exist: %s", rs.Primary.ID)
+				}
+			}
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 func testAccCheckAWSAutocalingElbAttachmentExists(asgname string, loadBalancerCount int) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSAutoscalingAttachment_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSAutoscalingAttachment_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSAutoscalingAttachment_elb
=== PAUSE TestAccAWSAutoscalingAttachment_elb
=== RUN   TestAccAWSAutoscalingAttachment_albTargetGroup
=== PAUSE TestAccAWSAutoscalingAttachment_albTargetGroup
=== CONT  TestAccAWSAutoscalingAttachment_elb
=== CONT  TestAccAWSAutoscalingAttachment_albTargetGroup
--- PASS: TestAccAWSAutoscalingAttachment_elb (137.01s)
--- PASS: TestAccAWSAutoscalingAttachment_albTargetGroup (192.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	192.331s
```
