### PR TITLE
modify aws db snapshot resource

### DIFF
--- a/aws/resource_aws_db_snapshot.go
+++ b/aws/resource_aws_db_snapshot.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -111,16 +110,17 @@ func resourceAwsDbSnapshot() *schema.Resource {
 func resourceAwsDbSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
+	dBInstanceIdentifier := d.Get("db_instance_identifier").(string)
 
 	params := &rds.CreateDBSnapshotInput{
-		DBInstanceIdentifier: aws.String(d.Get("db_instance_identifier").(string)),
+		DBInstanceIdentifier: aws.String(dBInstanceIdentifier),
 		DBSnapshotIdentifier: aws.String(d.Get("db_snapshot_identifier").(string)),
 		Tags:                 tags,
 	}
 
 	_, err := conn.CreateDBSnapshot(params)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating AWS DB Snapshot %s: %s", dBInstanceIdentifier, err)
 	}
 	d.SetId(d.Get("db_snapshot_identifier").(string))
 
@@ -149,8 +149,15 @@ func resourceAwsDbSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 		DBSnapshotIdentifier: aws.String(d.Id()),
 	}
 	resp, err := conn.DescribeDBSnapshots(params)
+
+	if isAWSErr(err, rds.ErrCodeDBSnapshotNotFoundFault, "") {
+		log.Printf("[WARN] AWS DB Snapshot (%s) is already gone", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		return err
+		return fmt.Errorf("Error describing AWS DB Snapshot %s: %s", d.Id(), err)
 	}
 
 	snapshot := resp.DBSnapshots[0]
@@ -185,7 +192,15 @@ func resourceAwsDbSnapshotDelete(d *schema.ResourceData, meta interface{}) error
 		DBSnapshotIdentifier: aws.String(d.Id()),
 	}
 	_, err := conn.DeleteDBSnapshot(params)
-	return err
+	if isAWSErr(err, rds.ErrCodeDBSnapshotNotFoundFault, "") {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error deleting AWS DB Snapshot %s: %s", d.Id(), err)
+	}
+
+	return nil
 }
 
 func resourceAwsDbSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -208,9 +223,9 @@ func resourceAwsDbSnapshotUpdate(d *schema.ResourceData, meta interface{}) error
 				TagKeys:      removeTagKeys,
 			}
 
-			log.Printf("[DEBUG] Untagging RDS Cluster: %s", input)
+			log.Printf("[DEBUG] Untagging DB Snapshot: %s", input)
 			if _, err := conn.RemoveTagsFromResource(input); err != nil {
-				return fmt.Errorf("error untagging RDS Cluster (%s): %s", d.Id(), err)
+				return fmt.Errorf("error untagging DB Snapshot (%s): %s", d.Id(), err)
 			}
 		}
 
@@ -220,9 +235,9 @@ func resourceAwsDbSnapshotUpdate(d *schema.ResourceData, meta interface{}) error
 				Tags:         createTags,
 			}
 
-			log.Printf("[DEBUG] Tagging RDS Cluster: %s", input)
+			log.Printf("[DEBUG] Tagging DB Snapshot: %s", input)
 			if _, err := conn.AddTagsToResource(input); err != nil {
-				return fmt.Errorf("error tagging RDS Cluster (%s): %s", d.Id(), err)
+				return fmt.Errorf("error tagging DB Snapshot (%s): %s", d.Id(), err)
 			}
 		}
 	}
@@ -242,11 +257,10 @@ func resourceAwsDbSnapshotStateRefreshFunc(
 		log.Printf("[DEBUG] DB Snapshot describe configuration: %#v", opts)
 
 		resp, err := conn.DescribeDBSnapshots(opts)
+		if isAWSErr(err, rds.ErrCodeDBSnapshotNotFoundFault, "") {
+			return nil, "", nil
+		}
 		if err != nil {
-			snapshoterr, ok := err.(awserr.Error)
-			if ok && snapshoterr.Code() == "DBSnapshotNotFound" {
-				return nil, "", nil
-			}
 			return nil, "", fmt.Errorf("Error retrieving DB Snapshots: %s", err)
 		}
 

--- a/aws/resource_aws_db_snapshot_test.go
+++ b/aws/resource_aws_db_snapshot_test.go
@@ -15,8 +15,9 @@ func TestAccAWSDBSnapshot_basic(t *testing.T) {
 	var v rds.DBSnapshot
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDbSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsDbSnapshotConfig(rInt),
@@ -32,8 +33,9 @@ func TestAccAWSDBSnapshot_tags(t *testing.T) {
 	var v rds.DBSnapshot
 	rInt := acctest.RandInt()
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDbSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsDbSnapshotConfigTags1(rInt, "key1", "value1"),
@@ -54,6 +56,38 @@ func TestAccAWSDBSnapshot_tags(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckDbSnapshotDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_db_snapshot" {
+			continue
+		}
+
+		request := &rds.DescribeDBSnapshotsInput{
+			DBSnapshotIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		resp, err := conn.DescribeDBSnapshots(request)
+
+		if isAWSErr(err, rds.ErrCodeDBSnapshotNotFoundFault, "") {
+			continue
+		}
+
+		if err == nil {
+			for _, dbSnapshot := range resp.DBSnapshots {
+				if aws.StringValue(dbSnapshot.DBSnapshotIdentifier) == rs.Primary.ID {
+					return fmt.Errorf("AWS DB Snapshot is still exist: %s", rs.Primary.ID)
+				}
+			}
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 func testAccCheckDbSnapshotExists(n string, v *rds.DBSnapshot) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG-FIXES:
- resource/aws_db_snapshot: Fix error handling when resource already gone.
ENHANCEMENTS:
- resource/aws_db_snapshot: Modify error message format.
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDBSnapshot_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDBSnapshot_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDBSnapshot_basic
=== PAUSE TestAccAWSDBSnapshot_basic
=== RUN   TestAccAWSDBSnapshot_tags
=== PAUSE TestAccAWSDBSnapshot_tags
=== RUN   TestAccAWSDBSnapshot_disappears
=== PAUSE TestAccAWSDBSnapshot_disappears
=== CONT  TestAccAWSDBSnapshot_basic
=== CONT  TestAccAWSDBSnapshot_disappears
=== CONT  TestAccAWSDBSnapshot_tags
--- PASS: TestAccAWSDBSnapshot_basic (594.11s)
--- PASS: TestAccAWSDBSnapshot_disappears (729.24s)
--- PASS: TestAccAWSDBSnapshot_tags (754.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	754.398s
```
