### PR TITLE
Add check destroy for aws ebs snapshot copy resource & Fix error handling

### DIFF
--- a/aws/resource_aws_ebs_snapshot_copy.go
+++ b/aws/resource_aws_ebs_snapshot_copy.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -116,7 +115,7 @@ func resourceAwsEbsSnapshotCopyRead(d *schema.ResourceData, meta interface{}) er
 		SnapshotIds: []*string{aws.String(d.Id())},
 	}
 	res, err := conn.DescribeSnapshots(req)
-	if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidSnapshot.NotFound" {
+	if isAWSErr(err, "InvalidSnapshot.NotFound", "") {
 		log.Printf("Snapshot %q Not found - removing from state", d.Id())
 		d.SetId("")
 		return nil
@@ -152,17 +151,12 @@ func resourceAwsEbsSnapshotCopyDelete(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 
-		ebsErr, ok := err.(awserr.Error)
-		if ok && ebsErr.Code() == "SnapshotInUse" {
+		if isAWSErr(err, "SnapshotInUse", "") {
 			return resource.RetryableError(fmt.Errorf("EBS SnapshotInUse - trying again while it detaches"))
 		}
 
-		if ok && ebsErr.Code() == "InvalidSnapshot.NotFound" {
+		if isAWSErr(err, "InvalidSnapshot.NotFound", "") {
 			return nil
-		}
-
-		if !ok {
-			return resource.NonRetryableError(err)
 		}
 
 		return resource.NonRetryableError(err)

--- a/aws/resource_aws_ebs_snapshot_copy_test.go
+++ b/aws/resource_aws_ebs_snapshot_copy_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -129,8 +128,8 @@ func testAccCheckEbsSnapshotCopyDestroy(s *terraform.State) error {
 			SnapshotIds: []*string{aws.String(rs.Primary.ID)},
 		})
 
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidSnapshot.NotFound" {
-			return nil
+		if isAWSErr(err, "InvalidSnapshot.NotFound", "") {
+			continue
 		}
 
 		if err == nil {

--- a/aws/resource_aws_ebs_snapshot_copy_test.go
+++ b/aws/resource_aws_ebs_snapshot_copy_test.go
@@ -98,6 +98,25 @@ func TestAccAWSEbsSnapshotCopy_withKms(t *testing.T) {
 	})
 }
 
+func TestAccAWSEbsSnapshotCopy_disappears(t *testing.T) {
+	var v ec2.Snapshot
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEbsSnapshotCopyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsSnapshotCopyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEbsSnapshotCopyExists("aws_ebs_snapshot_copy.test", &v),
+					testAccCheckEbsSnapshotCopyDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckEbsSnapshotCopyDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
@@ -126,6 +145,18 @@ func testAccCheckEbsSnapshotCopyDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckEbsSnapshotCopyDisappears(snapshot *ec2.Snapshot) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		_, err := conn.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+			SnapshotId: snapshot.SnapshotId,
+		})
+
+		return err
+	}
 }
 
 func testAccCheckEbsSnapshotCopyExists(n string, v *ec2.Snapshot) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG-FIX:
- resource/aws_ebs_snapshot_copy: fix error handling when resource is gone
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEbsSnapshotCopy_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEbsSnapshotCopy_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEbsSnapshotCopy_basic
=== PAUSE TestAccAWSEbsSnapshotCopy_basic
=== RUN   TestAccAWSEbsSnapshotCopy_withDescription
=== PAUSE TestAccAWSEbsSnapshotCopy_withDescription
=== RUN   TestAccAWSEbsSnapshotCopy_withRegions
=== PAUSE TestAccAWSEbsSnapshotCopy_withRegions
=== RUN   TestAccAWSEbsSnapshotCopy_withKms
=== PAUSE TestAccAWSEbsSnapshotCopy_withKms
=== RUN   TestAccAWSEbsSnapshotCopy_disappears
=== PAUSE TestAccAWSEbsSnapshotCopy_disappears
=== CONT  TestAccAWSEbsSnapshotCopy_basic
=== CONT  TestAccAWSEbsSnapshotCopy_disappears
=== CONT  TestAccAWSEbsSnapshotCopy_withKms
=== CONT  TestAccAWSEbsSnapshotCopy_withDescription
=== CONT  TestAccAWSEbsSnapshotCopy_withRegions
--- PASS: TestAccAWSEbsSnapshotCopy_disappears (73.88s)
--- PASS: TestAccAWSEbsSnapshotCopy_withDescription (74.98s)
--- PASS: TestAccAWSEbsSnapshotCopy_withKms (101.45s)
--- PASS: TestAccAWSEbsSnapshotCopy_basic (105.72s)
--- PASS: TestAccAWSEbsSnapshotCopy_withRegions (109.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	109.851s
```
