### PR TITLE
resource/aws_instance: Adding support for Root Device Encryption

### DIFF
--- a/aws/data_source_aws_instance.go
+++ b/aws/data_source_aws_instance.go
@@ -238,6 +238,16 @@ func dataSourceAwsInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+
+						"encrypted": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -98,6 +98,8 @@ interpolation.
   * `iops` - `0` If the volume is not a provisioned IOPS image, otherwise the supported IOPS count.
   * `volume_size` - The size of the volume, in GiB.
   * `volume_type` - The type of the volume.
+  * `encrypted` - If the volume is encrypted.
+  * `kms_key_id` - The ID of the KMS Key that was used to encrypt the volume.
 * `security_groups` - The associated security groups.
 * `source_dest_check` - Whether the network interface performs source/destination checking (Boolean).
 * `subnet_id` - The VPC subnet ID.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -131,6 +131,11 @@ The `root_block_device` mapping supports the following:
   using that type
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
+* `encrypted` - (Optional) Enables [EBS
+  encryption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
+  on the volume (Default: `false`).
+* `kms_key_id` - (Optional) Identifier (key ID, key alias, ID ARN, or alias ARN) for a user-managed CMK
+  under which the EBS volume is encrypted.
 
 Modifying any of the `root_block_device` settings requires resource
 replacement.


### PR DESCRIPTION
As released https://aws.amazon.com/about-aws/whats-new/2019/05/launch-encrypted-ebs-backed-ec2-instances-from-unencrypted-amis-in-a-single-step/

```
▶ acctests aws TestAccAWSInstance_encryptedRootDevice
=== RUN   TestAccAWSInstance_encryptedRootDevice
=== PAUSE TestAccAWSInstance_encryptedRootDevice
=== CONT  TestAccAWSInstance_encryptedRootDevice
--- PASS: TestAccAWSInstance_encryptedRootDevice (161.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	161.229s
```