### PR TITLE
resource/alb_target_group: Add support for UDP protocol

### DIFF
--- a/aws/resource_aws_lb_listener.go
+++ b/aws/resource_aws_lb_listener.go
@@ -61,6 +61,8 @@ func resourceAwsLbListener() *schema.Resource {
 					elbv2.ProtocolEnumHttps,
 					elbv2.ProtocolEnumTcp,
 					elbv2.ProtocolEnumTls,
+					elbv2.ProtocolEnumUdp,
+					elbv2.ProtocolEnumTcpUdp,
 				}, true),
 			},
 

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -71,6 +71,8 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 					elbv2.ProtocolEnumHttps,
 					elbv2.ProtocolEnumTcp,
 					elbv2.ProtocolEnumTls,
+					elbv2.ProtocolEnumUdp,
+					elbv2.ProtocolEnumTcpUdp,
 				}, true),
 			},
 

--- a/aws/resource_aws_lb_target_group_test.go
+++ b/aws/resource_aws_lb_target_group_test.go
@@ -134,6 +134,36 @@ func TestAccAWSLBTargetGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLBTargetGroup_basicUdp(t *testing.T) {
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLBTargetGroupConfig_basicUdp(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLBTargetGroupExists("aws_lb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "port", "514"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "protocol", "UDP"),
+					resource.TestCheckResourceAttrSet("aws_lb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.port", "514"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "health_check.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_lb_target_group.test", "tags.TestName", "TestAccAWSLBTargetGroup_basic"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLBTargetGroup_withoutHealthcheck(t *testing.T) {
 	var conf elbv2.TargetGroup
 	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
@@ -1132,6 +1162,32 @@ func testAccAWSLBTargetGroupConfig_basic(targetGroupName string) string {
     healthy_threshold = 3
     unhealthy_threshold = 3
     matcher = "200-299"
+  }
+
+  tags = {
+    TestName = "TestAccAWSLBTargetGroup_basic"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    TestName = "terraform-testacc-lb-target-group-basic"
+  }
+}`, targetGroupName)
+}
+
+func testAccAWSLBTargetGroupConfig_basicUdp(targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_lb_target_group" "test" {
+  name = "%s"
+  port = 514
+  protocol = "UDP"
+  vpc_id = "${aws_vpc.test.id}"
+
+  health_check {
+    protocol = "TCP"
+	port = 514
   }
 
   tags = {

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -175,7 +175,7 @@ The following arguments are supported:
 
 * `load_balancer_arn` - (Required, Forces New Resource) The ARN of the load balancer.
 * `port` - (Required) The port on which the load balancer is listening.
-* `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `TLS`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
+* `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `TLS`, `UDP`, `TCP_UDP`, `HTTP` and `HTTPS`. Defaults to `HTTP`.
 * `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`.
 * `certificate_arn` - (Optional) The ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. For adding additional SSL certificates, see the [`aws_lb_listener_certificate` resource](/docs/providers/aws/r/lb_listener_certificate.html).
 * `default_action` - (Required) An Action block. Action blocks are documented below.

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Cannot be longer than 6 characters.
 
 * `port` - (Optional, Forces new resource) The port on which targets receive traffic, unless overridden when registering a specific target. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
-* `protocol` - (Optional, Forces new resource) The protocol to use for routing traffic to the targets. Should be one of "TCP", "TLS", "HTTP" or "HTTPS". Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
+* `protocol` - (Optional, Forces new resource) The protocol to use for routing traffic to the targets. Should be one of "TCP", "TLS", "UDP", "TCP_UDP", "HTTP" or "HTTPS". Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `vpc_id` - (Optional, Forces new resource) The identifier of the VPC in which to create the target group. Required when `target_type` is `instance` or `ip`. Does not apply when `target_type` is `lambda`.
 * `deregistration_delay` - (Optional) The amount time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds.
 * `slow_start` - (Optional) The amount time for targets to warm up before the load balancer sends them a full share of requests. The range is 30-900 seconds or 0 to disable. The default value is 0 seconds.


### PR DESCRIPTION
Fixes: #9109

All this does is to restrict the validation in the `protocol` and updates the documentation. AFACIT, there are no other specific changes required for UDP LoadBalancers

If someone does notice differences, then we can easily add them

```
▶ acctests aws TestAccAWSLBTargetGroup_basicUdp
=== RUN   TestAccAWSLBTargetGroup_basicUdp
=== PAUSE TestAccAWSLBTargetGroup_basicUdp
=== CONT  TestAccAWSLBTargetGroup_basicUdp
--- PASS: TestAccAWSLBTargetGroup_basicUdp (59.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	59.888s
```

```
▶ acctests aws TestAccAWSLBListener_basicUdp
=== RUN   TestAccAWSLBListener_basicUdp
=== PAUSE TestAccAWSLBListener_basicUdp
=== CONT  TestAccAWSLBListener_basicUdp
--- PASS: TestAccAWSLBListener_basicUdp (292.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	292.138s
```