### PR TITLE
Add CheckDestroy for aws_ebs_volum resource

### DIFF
--- a/aws/resource_aws_ebs_volume_test.go
+++ b/aws/resource_aws_ebs_volume_test.go
@@ -74,6 +74,7 @@ func TestAccAWSEBSVolume_basic(t *testing.T) {
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsVolumeConfig,
@@ -105,6 +106,7 @@ func TestAccAWSEBSVolume_updateAttachedEbsVolume(t *testing.T) {
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsAttachedVolumeConfig,
@@ -137,6 +139,7 @@ func TestAccAWSEBSVolume_updateSize(t *testing.T) {
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsVolumeConfig,
@@ -169,6 +172,7 @@ func TestAccAWSEBSVolume_updateType(t *testing.T) {
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsVolumeConfig,
@@ -201,6 +205,7 @@ func TestAccAWSEBSVolume_updateIops(t *testing.T) {
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsVolumeConfigWithIops,
@@ -236,6 +241,7 @@ func TestAccAWSEBSVolume_kmsKey(t *testing.T) {
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -259,8 +265,9 @@ func TestAccAWSEBSVolume_NoIops(t *testing.T) {
 	resourceName := "aws_ebs_volume.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsVolumeConfigWithNoIops,
@@ -285,6 +292,7 @@ func TestAccAWSEBSVolume_withTags(t *testing.T) {
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: resourceName,
 		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsEbsVolumeConfigWithTags,
@@ -301,6 +309,38 @@ func TestAccAWSEBSVolume_withTags(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckVolumeDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ebs_volume" {
+			continue
+		}
+
+		request := &ec2.DescribeVolumesInput{
+			VolumeIds: []*string{aws.String(rs.Primary.ID)},
+		}
+
+		resp, err := conn.DescribeVolumes(request)
+
+		if isAWSErr(err, "InvalidVolume.NotFound", "") {
+			continue
+		}
+
+		if err == nil {
+			for _, volume := range resp.Volumes {
+				if aws.StringValue(volume.VolumeId) == rs.Primary.ID {
+					return fmt.Errorf("Volume still exists")
+				}
+			}
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 func testAccCheckVolumeExists(n string, v *ec2.Volume) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSEBSVolume_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEBSVolume_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSEBSVolume_basic
=== PAUSE TestAccAWSEBSVolume_basic
=== RUN   TestAccAWSEBSVolume_updateAttachedEbsVolume
=== PAUSE TestAccAWSEBSVolume_updateAttachedEbsVolume
=== RUN   TestAccAWSEBSVolume_updateSize
=== PAUSE TestAccAWSEBSVolume_updateSize
=== RUN   TestAccAWSEBSVolume_updateType
=== PAUSE TestAccAWSEBSVolume_updateType
=== RUN   TestAccAWSEBSVolume_updateIops
=== PAUSE TestAccAWSEBSVolume_updateIops
=== RUN   TestAccAWSEBSVolume_kmsKey
=== PAUSE TestAccAWSEBSVolume_kmsKey
=== RUN   TestAccAWSEBSVolume_NoIops
=== PAUSE TestAccAWSEBSVolume_NoIops
=== RUN   TestAccAWSEBSVolume_withTags
=== PAUSE TestAccAWSEBSVolume_withTags
=== CONT  TestAccAWSEBSVolume_basic
=== CONT  TestAccAWSEBSVolume_updateSize
=== CONT  TestAccAWSEBSVolume_updateIops
=== CONT  TestAccAWSEBSVolume_NoIops
=== CONT  TestAccAWSEBSVolume_withTags
=== CONT  TestAccAWSEBSVolume_updateType
=== CONT  TestAccAWSEBSVolume_updateAttachedEbsVolume
=== CONT  TestAccAWSEBSVolume_kmsKey
--- PASS: TestAccAWSEBSVolume_withTags (40.30s)
--- PASS: TestAccAWSEBSVolume_basic (40.41s)
--- PASS: TestAccAWSEBSVolume_NoIops (40.45s)
--- PASS: TestAccAWSEBSVolume_updateIops (70.76s)
--- PASS: TestAccAWSEBSVolume_kmsKey (71.48s)
--- PASS: TestAccAWSEBSVolume_updateSize (71.70s)
--- PASS: TestAccAWSEBSVolume_updateType (72.10s)
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (205.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	205.707s
```
