### PR TITLE
service/directconnect: Implement aws_dx_gateway_association_proposal sweeper and handle cross-region associations in aws_dx_gateway_association test sweeper

### DIFF
--- a/aws/resource_aws_dx_gateway_association_proposal_test.go
+++ b/aws/resource_aws_dx_gateway_association_proposal_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,6 +12,70 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_dx_gateway_association_proposal", &resource.Sweeper{
+		Name: "aws_dx_gateway_association_proposal",
+		F:    testSweepDirectConnectGatewayAssociationProposals,
+	})
+}
+
+func testSweepDirectConnectGatewayAssociationProposals(region string) error {
+	client, err := sharedClientForRegion(region)
+
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.(*AWSClient).dxconn
+	input := &directconnect.DescribeDirectConnectGatewayAssociationProposalsInput{}
+
+	for {
+		output, err := conn.DescribeDirectConnectGatewayAssociationProposals(input)
+
+		if testSweepSkipSweepError(err) {
+			log.Printf("[WARN] Skipping Direct Connect Gateway sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error retrieving Direct Connect Gateway Association Proposals: %s", err)
+		}
+
+		for _, gatewayAssociationProposal := range output.DirectConnectGatewayAssociationProposals {
+			proposalID := aws.StringValue(gatewayAssociationProposal.ProposalId)
+
+			if aws.StringValue(gatewayAssociationProposal.AssociatedGateway.Region) != region {
+				log.Printf("[INFO] Skipping Direct Connect Gateway Association Proposal (%s) in different home region: %s", proposalID, aws.StringValue(gatewayAssociationProposal.AssociatedGateway.Region))
+				continue
+			}
+
+			if aws.StringValue(gatewayAssociationProposal.ProposalState) != directconnect.GatewayAssociationProposalStateAccepted {
+				log.Printf("[INFO] Skipping Direct Connect Gateway Association Proposal (%s) in non-accepted (%s) state", proposalID, aws.StringValue(gatewayAssociationProposal.ProposalState))
+				continue
+			}
+
+			input := &directconnect.DeleteDirectConnectGatewayAssociationProposalInput{
+				ProposalId: gatewayAssociationProposal.ProposalId,
+			}
+
+			log.Printf("[INFO] Deleting Direct Connect Gateway Association Proposal: %s", proposalID)
+			_, err := conn.DeleteDirectConnectGatewayAssociationProposal(input)
+
+			if err != nil {
+				return fmt.Errorf("error deleting Direct Connect Gateway Association Proposal (%s): %s", proposalID, err)
+			}
+		}
+
+		if aws.StringValue(output.NextToken) == "" {
+			break
+		}
+
+		input.NextToken = output.NextToken
+	}
+
+	return nil
+}
 
 func TestAccAwsDxGatewayAssociationProposal_VpnGatewayId(t *testing.T) {
 	var proposal1 directconnect.GatewayAssociationProposal

--- a/aws/resource_aws_dx_gateway_association_test.go
+++ b/aws/resource_aws_dx_gateway_association_test.go
@@ -18,6 +18,9 @@ func init() {
 	resource.AddTestSweepers("aws_dx_gateway_association", &resource.Sweeper{
 		Name: "aws_dx_gateway_association",
 		F:    testSweepDirectConnectGatewayAssociations,
+		Dependencies: []string{
+			"aws_dx_gateway_association_proposal",
+		},
 	})
 }
 
@@ -57,6 +60,11 @@ func testSweepDirectConnectGatewayAssociations(region string) error {
 
 				for _, association := range associationOutput.DirectConnectGatewayAssociations {
 					gatewayID := aws.StringValue(association.AssociatedGateway.Id)
+
+					if aws.StringValue(association.AssociatedGateway.Region) != region {
+						log.Printf("[INFO] Skipping Direct Connect Gateway (%s) Association (%s) in different home region: %s", directConnectGatewayID, gatewayID, aws.StringValue(association.AssociatedGateway.Region))
+						continue
+					}
 
 					if aws.StringValue(association.AssociationState) != directconnect.GatewayAssociationStateAssociated {
 						log.Printf("[INFO] Skipping Direct Connect Gateway (%s) Association in non-available (%s) state: %s", directConnectGatewayID, aws.StringValue(association.AssociationState), gatewayID)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

If acceptance testing for cross-account/cross-region Direct Connect Gateway Associations left dangling resources, the previous `aws_dx_gateway_association` test sweeper could error trying to perform cross-account/cross-region deletions.

Previous output from test sweeper:

```
2019/06/24 15:31:24 [ERR] error running (aws_dx_gateway_association): error deleting Direct Connect Gateway (981f3b93-5990-4898-ab36-65a1a1026f5b) Association (tgw-0e74150d6d8cf4ae3): DirectConnectClientException: Direct Connect Gateway Association does not exist
 status code: 400, request id: 201855db-9695-11e9-84dc-35056662952f
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```



Output from test sweeper:

```
$ go test ./aws -v -sweep=us-west-2,us-east-1 -sweep-run=aws_dx_gateway_association -timeout 10h
...
2019/06/24 21:21:32 [INFO] Deleting Direct Connect Gateway Association Proposal: 43f90510-88d8-4197-beac-f9e094109e44
2019/06/24 21:21:32 [INFO] Deleting Direct Connect Gateway Association Proposal: 17631b23-75b0-47ae-9723-fc5aaab79979
...
2019/06/24 21:21:35 [INFO] Deleting Direct Connect Gateway (981f3b93-5990-4898-ab36-65a1a1026f5b) Association: tgw-0e74150d6d8cf4ae3
...
2019/06/24 21:34:04 Sweeper Tests ran:
  - aws_dx_gateway_association_proposal
  - aws_dx_gateway_association
2019/06/24 21:34:04 [DEBUG] Running Sweepers for region (us-east-1):
...
2019/06/24 21:34:07 [INFO] Skipping Direct Connect Gateway (981f3b93-5990-4898-ab36-65a1a1026f5b) Association (tgw-0e74150d6d8cf4ae3) in different home region: us-west-2
2019/06/24 21:34:07 Sweeper Tests ran:
  - aws_dx_gateway_association_proposal
  - aws_dx_gateway_association
```