### PR TITLE
Feature/add check destroy for aws iam instance profile resource

### DIFF
--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -42,8 +42,9 @@ func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
 
 	rName := acctest.RandString(5)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsIamInstanceProfileConfig(rName),
@@ -60,8 +61,9 @@ func TestAccAWSIAMInstanceProfile_withRoleNotRoles(t *testing.T) {
 
 	rName := acctest.RandString(5)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSInstanceProfileWithRoleSpecified(rName),
@@ -76,8 +78,9 @@ func TestAccAWSIAMInstanceProfile_withRoleNotRoles(t *testing.T) {
 func TestAccAWSIAMInstanceProfile_missingRoleThrowsError(t *testing.T) {
 	rName := acctest.RandString(5)
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSInstanceProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAwsIamInstanceProfileConfigMissingRole(rName),

--- a/aws/resource_aws_iam_instance_profile_test.go
+++ b/aws/resource_aws_iam_instance_profile_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -146,14 +145,11 @@ func testAccCheckAWSInstanceProfileDestroy(s *terraform.State) error {
 			return fmt.Errorf("still exist.")
 		}
 
-		// Verify the error is what we want
-		ec2err, ok := err.(awserr.Error)
-		if !ok {
-			return err
+		if isAWSErr(err, "NoSuchEntity", "") {
+			continue
 		}
-		if ec2err.Code() != "NoSuchEntity" {
-			return err
-		}
+
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSIAMInstanceProfile_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSIAMInstanceProfile_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSIAMInstanceProfile_importBasic
=== PAUSE TestAccAWSIAMInstanceProfile_importBasic
=== RUN   TestAccAWSIAMInstanceProfile_basic
=== PAUSE TestAccAWSIAMInstanceProfile_basic
=== RUN   TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== PAUSE TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== RUN   TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== PAUSE TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== RUN   TestAccAWSIAMInstanceProfile_namePrefix
=== PAUSE TestAccAWSIAMInstanceProfile_namePrefix
=== CONT  TestAccAWSIAMInstanceProfile_importBasic
=== CONT  TestAccAWSIAMInstanceProfile_withRoleNotRoles
=== CONT  TestAccAWSIAMInstanceProfile_missingRoleThrowsError
=== CONT  TestAccAWSIAMInstanceProfile_basic
=== CONT  TestAccAWSIAMInstanceProfile_namePrefix
--- PASS: TestAccAWSIAMInstanceProfile_missingRoleThrowsError (18.35s)
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (39.99s)
--- PASS: TestAccAWSIAMInstanceProfile_withRoleNotRoles (40.01s)
--- PASS: TestAccAWSIAMInstanceProfile_basic (40.10s)
--- PASS: TestAccAWSIAMInstanceProfile_importBasic (42.86s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	42.956s
```
