### PR TITLE
Add CheckDestroy:nil for aws_kms_ciphertext resource acctest

### DIFF
--- a/aws/resource_aws_kms_ciphertext_test.go
+++ b/aws/resource_aws_kms_ciphertext_test.go
@@ -8,8 +8,9 @@ import (
 
 func TestAccResourceAwsKmsCiphertext_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceAwsKmsCiphertextConfig_basic,
@@ -27,8 +28,9 @@ func TestAccResourceAwsKmsCiphertext_validate(t *testing.T) {
 	resourceName := "aws_kms_ciphertext.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceAwsKmsCiphertextConfig_validate,
@@ -46,8 +48,9 @@ func TestAccResourceAwsKmsCiphertext_validate_withContext(t *testing.T) {
 	resourceName := "aws_kms_ciphertext.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceAwsKmsCiphertextConfig_validate_withContext,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccResourceAwsKmsCiphertext_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccResourceAwsKmsCiphertext_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccResourceAwsKmsCiphertext_basic
=== PAUSE TestAccResourceAwsKmsCiphertext_basic
=== RUN   TestAccResourceAwsKmsCiphertext_validate
=== PAUSE TestAccResourceAwsKmsCiphertext_validate
=== RUN   TestAccResourceAwsKmsCiphertext_validate_withContext
=== PAUSE TestAccResourceAwsKmsCiphertext_validate_withContext
=== CONT  TestAccResourceAwsKmsCiphertext_basic
=== CONT  TestAccResourceAwsKmsCiphertext_validate_withContext
=== CONT  TestAccResourceAwsKmsCiphertext_validate
--- PASS: TestAccResourceAwsKmsCiphertext_basic (65.58s)
--- PASS: TestAccResourceAwsKmsCiphertext_validate_withContext (71.12s)
--- PASS: TestAccResourceAwsKmsCiphertext_validate (71.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	71.438s
```
