### PR TITLE
resource/ssm_parameter: Add version as output

### DIFF
--- a/aws/data_source_aws_ssm_parameter.go
+++ b/aws/data_source_aws_ssm_parameter.go
@@ -37,6 +37,10 @@ func dataSourceAwsSsmParameter() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -72,6 +76,7 @@ func dataAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", param.Name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)
+	d.Set("version", param.Version)
 
 	return nil
 }

--- a/aws/data_source_aws_ssm_parameter_test.go
+++ b/aws/data_source_aws_ssm_parameter_test.go
@@ -27,6 +27,7 @@ func TestAccAWSSsmParameterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "String"),
 					resource.TestCheckResourceAttr(resourceName, "value", "TestValue"),
 					resource.TestCheckResourceAttr(resourceName, "with_decryption", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
 			},
 			{

--- a/aws/resource_aws_ssm_parameter.go
+++ b/aws/resource_aws_ssm_parameter.go
@@ -75,6 +75,10 @@ func resourceAwsSsmParameter() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 		},
 
@@ -121,6 +125,7 @@ func resourceAwsSsmParameterRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("name", param.Name)
 	d.Set("type", param.Type)
 	d.Set("value", param.Value)
+	d.Set("version", param.Version)
 
 	describeParamsInput := &ssm.DescribeParametersInput{
 		ParameterFilters: []*ssm.ParameterStringFilter{

--- a/aws/resource_aws_ssm_parameter_test.go
+++ b/aws/resource_aws_ssm_parameter_test.go
@@ -54,6 +54,7 @@ func TestAccAWSSSMParameter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "tier", "Standard"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "tags.%", "1"),
 					resource.TestCheckResourceAttr("aws_ssm_parameter.foo", "tags.Name", "My Parameter"),
+					resource.TestCheckResourceAttrSet("aws_ssm_parameter.foo", "version"),
 				),
 			},
 		},

--- a/website/docs/d/ssm_parameter.html.markdown
+++ b/website/docs/d/ssm_parameter.html.markdown
@@ -39,3 +39,4 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - The name of the parameter.
 * `type` - The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - The value of the parameter.
+* `version` - The version of the parameter.

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -76,6 +76,7 @@ In addition to all arguments above, the following attributes are exported:
 * `description` - (Required) The description of the parameter.
 * `type` - (Required) The type of the parameter. Valid types are `String`, `StringList` and `SecureString`.
 * `value` - (Required) The value of the parameter.
+* `version` - The version of the parameter.
 
 ## Import
 


### PR DESCRIPTION
Fixes: #9104

```
▶ acctests aws TestAccAWSSsmParameterDataSource_
=== RUN   TestAccAWSSsmParameterDataSource_basic
=== PAUSE TestAccAWSSsmParameterDataSource_basic
=== RUN   TestAccAWSSsmParameterDataSource_fullPath
=== PAUSE TestAccAWSSsmParameterDataSource_fullPath
=== CONT  TestAccAWSSsmParameterDataSource_basic
=== CONT  TestAccAWSSsmParameterDataSource_fullPath
--- PASS: TestAccAWSSsmParameterDataSource_fullPath (36.58s)
--- PASS: TestAccAWSSsmParameterDataSource_basic (57.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	57.936s
```

```
▶ acctests aws TestAccAWSSSMParameter_
=== RUN   TestAccAWSSSMParameter_importBasic
=== PAUSE TestAccAWSSSMParameter_importBasic
=== RUN   TestAccAWSSSMParameter_basic
=== PAUSE TestAccAWSSSMParameter_basic
=== RUN   TestAccAWSSSMParameter_Tier
=== PAUSE TestAccAWSSSMParameter_Tier
=== RUN   TestAccAWSSSMParameter_disappears
=== PAUSE TestAccAWSSSMParameter_disappears
=== RUN   TestAccAWSSSMParameter_overwrite
=== PAUSE TestAccAWSSSMParameter_overwrite
=== RUN   TestAccAWSSSMParameter_updateTags
=== PAUSE TestAccAWSSSMParameter_updateTags
=== RUN   TestAccAWSSSMParameter_updateDescription
=== PAUSE TestAccAWSSSMParameter_updateDescription
=== RUN   TestAccAWSSSMParameter_changeNameForcesNew
=== PAUSE TestAccAWSSSMParameter_changeNameForcesNew
=== RUN   TestAccAWSSSMParameter_fullPath
=== PAUSE TestAccAWSSSMParameter_fullPath
=== RUN   TestAccAWSSSMParameter_secure
=== PAUSE TestAccAWSSSMParameter_secure
=== RUN   TestAccAWSSSMParameter_secure_with_key
=== PAUSE TestAccAWSSSMParameter_secure_with_key
=== RUN   TestAccAWSSSMParameter_secure_keyUpdate
=== PAUSE TestAccAWSSSMParameter_secure_keyUpdate
=== CONT  TestAccAWSSSMParameter_importBasic
=== CONT  TestAccAWSSSMParameter_changeNameForcesNew
=== CONT  TestAccAWSSSMParameter_overwrite
=== CONT  TestAccAWSSSMParameter_disappears
--- PASS: TestAccAWSSSMParameter_disappears (21.59s)
=== CONT  TestAccAWSSSMParameter_updateDescription
--- PASS: TestAccAWSSSMParameter_importBasic (35.16s)
=== CONT  TestAccAWSSSMParameter_Tier
--- PASS: TestAccAWSSSMParameter_overwrite (53.83s)
=== CONT  TestAccAWSSSMParameter_updateTags
--- PASS: TestAccAWSSSMParameter_changeNameForcesNew (54.77s)
=== CONT  TestAccAWSSSMParameter_basic
--- PASS: TestAccAWSSSMParameter_updateDescription (51.00s)
=== CONT  TestAccAWSSSMParameter_secure_with_key
--- PASS: TestAccAWSSSMParameter_basic (29.44s)
=== CONT  TestAccAWSSSMParameter_secure_keyUpdate
--- PASS: TestAccAWSSSMParameter_updateTags (53.12s)
=== CONT  TestAccAWSSSMParameter_secure
--- PASS: TestAccAWSSSMParameter_Tier (77.31s)
=== CONT  TestAccAWSSSMParameter_fullPath
--- PASS: TestAccAWSSSMParameter_secure (29.33s)
--- PASS: TestAccAWSSSMParameter_fullPath (30.45s)
--- PASS: TestAccAWSSSMParameter_secure_with_key (74.49s)
--- PASS: TestAccAWSSSMParameter_secure_keyUpdate (98.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	182.479s
```