### PR TITLE
Add CheckDestroy for aws_ses_domain_dkim resource

### DIFF
--- a/aws/resource_aws_ses_domain_dkim_test.go
+++ b/aws/resource_aws_ses_domain_dkim_test.go
@@ -23,7 +23,8 @@ func TestAccAWSSESDomainDkim_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckAWSSES(t)
 		},
-		Providers: testAccProviders,
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsSESDomainDkimDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccAwsSESDomainDkimConfig, domain),
@@ -34,6 +35,35 @@ func TestAccAWSSESDomainDkim_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAwsSESDomainDkimDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).sesConn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ses_domain_dkim" {
+			continue
+		}
+
+		domain := rs.Primary.ID
+		params := &ses.GetIdentityDkimAttributesInput{
+			Identities: []*string{
+				aws.String(domain),
+			},
+		}
+
+		resp, err := conn.GetIdentityDkimAttributes(params)
+
+		if err != nil {
+			return err
+		}
+
+		if resp.DkimAttributes[domain] != nil {
+			return fmt.Errorf("SES Domain Dkim %s still exists.", domain)
+		}
+	}
+
+	return nil
 }
 
 func testAccCheckAwsSESDomainDkimExists(n string) resource.TestCheckFunc {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSSESDomainDkim_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSESDomainDkim_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSESDomainDkim_basic
=== PAUSE TestAccAWSSESDomainDkim_basic
=== CONT  TestAccAWSSESDomainDkim_basic
--- PASS: TestAccAWSSESDomainDkim_basic (25.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	25.271s
```
