### PR TITLE
Update route53_health_check.html.markdown

### DIFF
--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -107,6 +107,12 @@ The following arguments are supported:
 
 At least one of either `fqdn` or `ip_address` must be specified.
 
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The id of the health check
+
 
 ## Import
 


### PR DESCRIPTION
Adding exported id under the Attributes Reference. This appears to be undocumented behavior

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9137

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Updated Documentation to include ID as exported attribute for r53_health_check
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
