### PR TITLE
Add Missing CheckDestroy for aws_vpc_dhcp_options resource

### DIFF
--- a/aws/resource_aws_vpc_dhcp_options_test.go
+++ b/aws/resource_aws_vpc_dhcp_options_test.go
@@ -91,8 +91,9 @@ func TestAccAWSDHCPOptions_importBasic(t *testing.T) {
 	resourceName := "aws_vpc_dhcp_options.foo"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDHCPOptionsDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDHCPOptionsConfig,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSDHCPOptions_importBasic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSDHCPOptions_importBasic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSDHCPOptions_importBasic
=== PAUSE TestAccAWSDHCPOptions_importBasic
=== CONT  TestAccAWSDHCPOptions_importBasic
--- PASS: TestAccAWSDHCPOptions_importBasic (33.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	33.943s
```
