### PR TITLE
Modify aws snapshot create volume permission resource

### DIFF
--- a/aws/resource_aws_snapshot_create_volume_permission.go
+++ b/aws/resource_aws_snapshot_create_volume_permission.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -35,9 +36,11 @@ func resourceAwsSnapshotCreateVolumePermission() *schema.Resource {
 func resourceAwsSnapshotCreateVolumePermissionExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*AWSClient).ec2conn
 
-	snapshot_id := d.Get("snapshot_id").(string)
-	account_id := d.Get("account_id").(string)
-	return hasCreateVolumePermission(conn, snapshot_id, account_id)
+	snapshotID, accountID, err := resourceAwsSnapshotCreateVolumePermissionParseID(d.Id())
+	if err != nil {
+		return false, err
+	}
+	return hasCreateVolumePermission(conn, snapshotID, accountID)
 }
 
 func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, meta interface{}) error {
@@ -86,15 +89,17 @@ func resourceAwsSnapshotCreateVolumePermissionRead(d *schema.ResourceData, meta 
 func resourceAwsSnapshotCreateVolumePermissionDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 
-	snapshot_id := d.Get("snapshot_id").(string)
-	account_id := d.Get("account_id").(string)
+	snapshotID, accountID, err := resourceAwsSnapshotCreateVolumePermissionParseID(d.Id())
+	if err != nil {
+		return err
+	}
 
-	_, err := conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
-		SnapshotId: aws.String(snapshot_id),
+	_, err = conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
+		SnapshotId: aws.String(snapshotID),
 		Attribute:  aws.String("createVolumePermission"),
 		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
 			Remove: []*ec2.CreateVolumePermission{
-				{UserId: aws.String(account_id)},
+				{UserId: aws.String(accountID)},
 			},
 		},
 	})
@@ -106,7 +111,7 @@ func resourceAwsSnapshotCreateVolumePermissionDelete(d *schema.ResourceData, met
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"granted"},
 		Target:     []string{"denied"},
-		Refresh:    resourceAwsSnapshotCreateVolumePermissionStateRefreshFunc(conn, snapshot_id, account_id),
+		Refresh:    resourceAwsSnapshotCreateVolumePermissionStateRefreshFunc(conn, snapshotID, accountID),
 		Timeout:    5 * time.Minute,
 		Delay:      10 * time.Second,
 		MinTimeout: 10 * time.Second,
@@ -149,4 +154,12 @@ func resourceAwsSnapshotCreateVolumePermissionStateRefreshFunc(conn *ec2.EC2, sn
 		}
 		return attrs, "denied", nil
 	}
+}
+
+func resourceAwsSnapshotCreateVolumePermissionParseID(id string) (string, string, error) {
+	idParts := strings.SplitN(id, "-", 3)
+	if len(idParts) != 3 || idParts[0] != "snap" || idParts[1] == "" || idParts[2] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected SNAPSHOT_ID-ACCOUNT_ID", id)
+	}
+	return fmt.Sprintf("%s-%s", idParts[0], idParts[1]), idParts[2], nil
 }

--- a/aws/resource_aws_snapshot_create_volume_permission.go
+++ b/aws/resource_aws_snapshot_create_volume_permission.go
@@ -148,7 +148,7 @@ func resourceAwsSnapshotCreateVolumePermissionStateRefreshFunc(conn *ec2.EC2, sn
 		}
 
 		for _, vp := range attrs.CreateVolumePermissions {
-			if *vp.UserId == account_id {
+			if aws.StringValue(vp.UserId) == account_id {
 				return attrs, "granted", nil
 			}
 		}

--- a/aws/resource_aws_snapshot_create_volume_permission_test.go
+++ b/aws/resource_aws_snapshot_create_volume_permission_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -37,10 +38,10 @@ func TestAccAWSSnapshotCreateVolumePermission_Basic(t *testing.T) {
 func testAccAWSSnapshotCreateVolumePermissionExists(accountId, snapshotId *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		if has, err := hasCreateVolumePermission(conn, *snapshotId, *accountId); err != nil {
+		if has, err := hasCreateVolumePermission(conn, aws.StringValue(snapshotId), aws.StringValue(accountId)); err != nil {
 			return err
 		} else if !has {
-			return fmt.Errorf("create volume permission does not exist for '%s' on '%s'", *accountId, *snapshotId)
+			return fmt.Errorf("create volume permission does not exist for '%s' on '%s'", aws.StringValue(snapshotId), aws.StringValue(accountId))
 		}
 		return nil
 	}
@@ -49,10 +50,10 @@ func testAccAWSSnapshotCreateVolumePermissionExists(accountId, snapshotId *strin
 func testAccAWSSnapshotCreateVolumePermissionDestroyed(accountId, snapshotId *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).ec2conn
-		if has, err := hasCreateVolumePermission(conn, *snapshotId, *accountId); err != nil {
+		if has, err := hasCreateVolumePermission(conn, aws.StringValue(snapshotId), aws.StringValue(accountId)); err != nil {
 			return err
 		} else if has {
-			return fmt.Errorf("create volume permission still exists for '%s' on '%s'", *accountId, *snapshotId)
+			return fmt.Errorf("create volume permission still exists for '%s' on '%s'", aws.StringValue(snapshotId), aws.StringValue(accountId))
 		}
 		return nil
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSSnapshotCreateVolumePermission_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSSnapshotCreateVolumePermission_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSSnapshotCreateVolumePermission_Basic
=== PAUSE TestAccAWSSnapshotCreateVolumePermission_Basic
=== CONT  TestAccAWSSnapshotCreateVolumePermission_Basic
--- PASS: TestAccAWSSnapshotCreateVolumePermission_Basic (108.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	108.616s
```
