### PR TITLE
Add timeouts for create and delete and refactor to use isAWSErr

### DIFF
--- a/aws/resource_aws_ebs_snapshot_test.go
+++ b/aws/resource_aws_ebs_snapshot_test.go
@@ -173,6 +173,11 @@ resource "aws_ebs_snapshot" "test" {
   tags = {
     Name = "%s"
   }
+
+  timeouts {
+	create = "10m"
+	delete = "10m"
+  }
 }
 `, rName)
 }

--- a/website/docs/r/ebs_snapshot.html.markdown
+++ b/website/docs/r/ebs_snapshot.html.markdown
@@ -39,6 +39,13 @@ The following arguments are supported:
 * `description` - (Optional) A description of what the snapshot is.
 * `tags` - (Optional) A mapping of tags to assign to the snapshot
 
+### Timeouts
+
+`aws_ebs_snapshot` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `10 minutes`) Used for creating the ebs snapshot
+- `delete` - (Default `10 minutes`) Used for deleting the ebs snapshot
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add timeouts for create and delete and refactor to use `isAWSErr`
This contribution is made by Autodesk Inc. under the terms of the Mozilla Public License (MPL) version 2.0.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8043
Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Add timeout option for ebs snapshots
```

Output from acceptance testing:

```
root@3687e71f78a7:/aws# make testacc TEST=./aws TESTARGS='-run=TestAccAWSEBSSnapshot_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSEBSSnapshot_ -timeout 120m
=== RUN   TestAccAWSEBSSnapshot_basic
=== PAUSE TestAccAWSEBSSnapshot_basic
=== RUN   TestAccAWSEBSSnapshot_withDescription
=== PAUSE TestAccAWSEBSSnapshot_withDescription
=== RUN   TestAccAWSEBSSnapshot_withKms
=== PAUSE TestAccAWSEBSSnapshot_withKms
=== CONT  TestAccAWSEBSSnapshot_basic
=== CONT  TestAccAWSEBSSnapshot_withKms
=== CONT  TestAccAWSEBSSnapshot_withDescription
--- PASS: TestAccAWSEBSSnapshot_withDescription (92.29s)
--- PASS: TestAccAWSEBSSnapshot_withKms (149.37s)
--- PASS: TestAccAWSEBSSnapshot_basic (168.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       168.832s
...
```
