### PR TITLE
add validation for route53 healthcheck request_interval

### DIFF
--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -47,9 +47,10 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Optional: true,
 			},
 			"request_interval": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true, // todo this should be updateable but the awslabs route53 service doesnt have the ability
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true, // todo this should be updateable but the awslabs route53 service doesnt have the ability
+				ValidateFunc: validation.IntInSlice([]int{10, 30}),
 			},
 			"ip_address": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This patch proposes: 
* add validation for `request_interval` of route53 healthcheck resource

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSRoute53HealthCheck_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSRoute53HealthCheck_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSRoute53HealthCheck_basic
=== PAUSE TestAccAWSRoute53HealthCheck_basic
=== CONT  TestAccAWSRoute53HealthCheck_basic
--- PASS: TestAccAWSRoute53HealthCheck_basic (57.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	57.319s
```
