### PR TITLE
Add check destroy for aws storagegateway resources

### DIFF
--- a/aws/resource_aws_storagegateway_cache_test.go
+++ b/aws/resource_aws_storagegateway_cache_test.go
@@ -76,7 +76,7 @@ func TestAccAWSStorageGatewayCache_FileGateway(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		// Storage Gateway API does not support removing caches
-		// CheckDestroy: testAccCheckAWSStorageGatewayCacheDestroy,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSStorageGatewayCacheConfig_FileGateway(rName),
@@ -103,7 +103,7 @@ func TestAccAWSStorageGatewayCache_TapeAndVolumeGateway(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		// Storage Gateway API does not support removing caches
-		// CheckDestroy: testAccCheckAWSStorageGatewayCacheDestroy,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSStorageGatewayCacheConfig_TapeAndVolumeGateway(rName),

--- a/aws/resource_aws_storagegateway_upload_buffer_test.go
+++ b/aws/resource_aws_storagegateway_upload_buffer_test.go
@@ -76,7 +76,7 @@ func TestAccAWSStorageGatewayUploadBuffer_Basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		// Storage Gateway API does not support removing upload buffers
-		// CheckDestroy: testAccCheckAWSStorageGatewayUploadBufferDestroy,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSStorageGatewayUploadBufferConfig_Basic(rName),

--- a/aws/resource_aws_storagegateway_working_storage_test.go
+++ b/aws/resource_aws_storagegateway_working_storage_test.go
@@ -76,7 +76,7 @@ func TestAccAWSStorageGatewayWorkingStorage_Basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		// Storage Gateway API does not support removing working storages
-		// CheckDestroy: testAccCheckAWSStorageGatewayWorkingStorageDestroy,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSStorageGatewayWorkingStorageConfig_Basic(rName),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSStorageGatewayWorkingStorage_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSStorageGatewayWorkingStorage_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSStorageGatewayWorkingStorage_Basic
=== PAUSE TestAccAWSStorageGatewayWorkingStorage_Basic
=== CONT  TestAccAWSStorageGatewayWorkingStorage_Basic
--- PASS: TestAccAWSStorageGatewayWorkingStorage_Basic (284.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	285.029s
```

```
$ make testacc TESTARGS="-run=TestAccAWSStorageGatewayUploadBuffer_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSStorageGatewayUploadBuffer_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSStorageGatewayUploadBuffer_Basic
=== PAUSE TestAccAWSStorageGatewayUploadBuffer_Basic
=== CONT  TestAccAWSStorageGatewayUploadBuffer_Basic
--- PASS: TestAccAWSStorageGatewayUploadBuffer_Basic (410.73s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	410.875s
```

```
$ make testacc TESTARGS="-run=TestAccAWSStorageGatewayCache_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSStorageGatewayCache_ -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSStorageGatewayCache_FileGateway
=== PAUSE TestAccAWSStorageGatewayCache_FileGateway
=== RUN   TestAccAWSStorageGatewayCache_TapeAndVolumeGateway
=== PAUSE TestAccAWSStorageGatewayCache_TapeAndVolumeGateway
=== CONT  TestAccAWSStorageGatewayCache_FileGateway
=== CONT  TestAccAWSStorageGatewayCache_TapeAndVolumeGateway
--- PASS: TestAccAWSStorageGatewayCache_TapeAndVolumeGateway (259.71s)
--- PASS: TestAccAWSStorageGatewayCache_FileGateway (323.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	323.448s
```