### PR TITLE
resource/ssm_maintenance_window_target: name and description are optional

### DIFF
--- a/aws/resource_aws_ssm_maintenance_window_target.go
+++ b/aws/resource_aws_ssm_maintenance_window_target.go
@@ -81,8 +81,14 @@ func resourceAwsSsmMaintenanceWindowTargetCreate(d *schema.ResourceData, meta in
 		WindowId:     aws.String(d.Get("window_id").(string)),
 		ResourceType: aws.String(d.Get("resource_type").(string)),
 		Targets:      expandAwsSsmTargets(d.Get("targets").([]interface{})),
-		Name:         aws.String(d.Get("name").(string)),
-		Description:  aws.String(d.Get("description").(string)),
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		params.Name = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		params.Description = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("owner_information"); ok {
@@ -152,6 +158,14 @@ func resourceAwsSsmMaintenanceWindowTargetUpdate(d *schema.ResourceData, meta in
 		Targets:        expandAwsSsmTargets(d.Get("targets").([]interface{})),
 		WindowId:       aws.String(d.Get("window_id").(string)),
 		WindowTargetId: aws.String(d.Id()),
+	}
+
+	if d.HasChange("name") {
+		params.Name = aws.String(d.Get("name").(string))
+	}
+
+	if d.HasChange("description") {
+		params.Description = aws.String(d.Get("description").(string))
 	}
 
 	if d.HasChange("owner_information") {


### PR DESCRIPTION
Fixes: #8791

the name ane description fields were optional but we never implemented
the d.GetOk(fieldName) on them. This just changes that to remove the
validation errors

The docs and the schema were already correct so this is a very simple
change

```
▶ acctests aws TestAccAWSSSMMaintenanceWindowTarget_
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_basic
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_basic
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_validation
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_validation
=== RUN   TestAccAWSSSMMaintenanceWindowTarget_update
=== PAUSE TestAccAWSSSMMaintenanceWindowTarget_update
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_basic
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_update
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_validation
=== CONT  TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_validation (4.60s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_noNameOrDescription (34.75s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_basic (34.95s)
--- PASS: TestAccAWSSSMMaintenanceWindowTarget_update (51.77s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	51.842s
```
