### PR TITLE
Add CheckDestroy for aws_inspector_resource_group resource

### DIFF
--- a/aws/resource_aws_inspector_resource_group_test.go
+++ b/aws/resource_aws_inspector_resource_group_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestAccAWSInspectorResourceGroup_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSInspectorResourceGroup,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8958 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSInspectorResourceGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSInspectorResourceGroup_basic -timeout 120m
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
=== RUN   TestAccAWSInspectorResourceGroup_basic
=== PAUSE TestAccAWSInspectorResourceGroup_basic
=== CONT  TestAccAWSInspectorResourceGroup_basic
--- PASS: TestAccAWSInspectorResourceGroup_basic (35.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	36.042s
```
