### PR TITLE
resource/aws_codebuild_project: Add registry_credential argument for environment

### DIFF
--- a/aws/resource_aws_codebuild_project.go
+++ b/aws/resource_aws_codebuild_project.go
@@ -198,7 +198,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 							ValidateFunc: validation.StringMatch(regexp.MustCompile(`\.(pem|zip)$`), "must end in .pem or .zip"),
 						},
 						"registry_credential": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -679,17 +679,17 @@ func expandProjectEnvironment(d *schema.ResourceData) *codebuild.ProjectEnvironm
 		projectEnv.ImagePullCredentialsType = aws.String(v.(string))
 	}
 
-	if v := envConfig["registry_credential"]; v != nil {
-		config := v.(*schema.Set).List()[0].(map[string]interface{})
+	if v, ok := envConfig["registry_credential"]; ok && len(v.([]interface{})) > 0 {
+		config := v.([]interface{})[0].(map[string]interface{})
 
 		projectRegistryCredential := &codebuild.RegistryCredential{}
 
-		if v := config["credential"].(string); v != "" {
-			projectRegistryCredential.Credential = &v
+		if v, ok := config["credential"]; ok && v.(string) != "" {
+			projectRegistryCredential.Credential = aws.String(v.(string))
 		}
 
-		if v := config["credential_provider"].(string); v != "" {
-			projectRegistryCredential.CredentialProvider = &v
+		if v, ok := config["credential_provider"]; ok && v.(string) != "" {
+			projectRegistryCredential.CredentialProvider = aws.String(v.(string))
 		}
 
 		projectEnv.RegistryCredential = projectRegistryCredential

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -1448,12 +1448,12 @@ resource "aws_codebuild_project" "test" {
 }
 
 resource "aws_secretsmanager_secret" "test" {
-  name = "docker-auth"
+  name = "test"
   recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.docker-auth.id}"
+  secret_id     = "${aws_secretsmanager_secret.test.id}"
   secret_string = "${jsonencode(map("username", "user", "password", "pass"))}"
 }
 `, rName)

--- a/aws/resource_aws_codebuild_project_test.go
+++ b/aws/resource_aws_codebuild_project_test.go
@@ -912,6 +912,11 @@ func TestAccAWSCodeBuildProject_Environment_RegistryCredential(t *testing.T) {
 					testAccCheckAWSCodeBuildProjectExists(resourceName, &project),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1421,41 +1426,41 @@ resource "aws_codebuild_project" "test" {
 
 func testAccAWSCodeBuildProjectConfig_Environment_RegistryCredential(rName string) string {
 	return testAccAWSCodeBuildProjectConfig_Base_ServiceRole(rName) + fmt.Sprintf(`
-resource "aws_codebuild_project" "test" {
-  name         = %[1]q
-  service_role = "${aws_iam_role.test.arn}"
-
-  artifacts {
-    type = "NO_ARTIFACTS"
-  }
-
-  environment {
-    compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "2"
-		type                        = "LINUX_CONTAINER"
-		image_pull_credentials_type = "SERVICE_ROLE"
-
-    registry_credential {
-      credential          = "${aws_secretsmanager_secret_version.test.arn}"
-      credential_provider = "SECRETS_MANAGER"
+  resource "aws_codebuild_project" "test" {
+    name         = %[1]q
+    service_role = "${aws_iam_role.test.arn}"
+  
+    artifacts {
+      type = "NO_ARTIFACTS"
+    }
+  
+    environment {
+      compute_type                = "BUILD_GENERAL1_SMALL"
+      image                       = "2"
+      type                        = "LINUX_CONTAINER"
+      image_pull_credentials_type = "SERVICE_ROLE"
+  
+      registry_credential {
+        credential          = "${aws_secretsmanager_secret_version.test.arn}"
+        credential_provider = "SECRETS_MANAGER"
+      }
+    }
+  
+    source {
+      type     = "GITHUB"
+      location = "https://github.com/hashicorp/packer.git"
     }
   }
-
-  source {
-    type     = "GITHUB"
-    location = "https://github.com/hashicorp/packer.git"
+  
+  resource "aws_secretsmanager_secret" "test" {
+    name = "test"
+    recovery_window_in_days = 0
   }
-}
-
-resource "aws_secretsmanager_secret" "test" {
-  name = "test"
-  recovery_window_in_days = 0
-}
-
-resource "aws_secretsmanager_secret_version" "test" {
-  secret_id     = "${aws_secretsmanager_secret.test.id}"
-  secret_string = "${jsonencode(map("username", "user", "password", "pass"))}"
-}
+  
+  resource "aws_secretsmanager_secret_version" "test" {
+    secret_id     = "${aws_secretsmanager_secret.test.id}"
+    secret_string = "${jsonencode(map("username", "user", "password", "pass"))}"
+  }
 `, rName)
 }
 

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -224,6 +224,7 @@ The following arguments are supported:
 * `environment_variable` - (Optional) A set of environment variables to make available to builds for this build project.
 * `privileged_mode` - (Optional) If set to true, enables running the Docker daemon inside a Docker container. Defaults to `false`.
 * `certificate` - (Optional) The ARN of the S3 bucket, path prefix and object key that contains the PEM-encoded certificate.
+* `registry_credential` - (Optional) Information about credentials for access to a private Docker registry. Registry Credential config blocks are documented below.
 
 `environment_variable` supports the following:
 
@@ -252,6 +253,10 @@ The following arguments are supported:
 * `subnets` - (Required) The subnet IDs within which to run builds.
 * `vpc_id` - (Required) The ID of the VPC within which to run builds.
 
+`registry_credential` supports the following:
+
+* `credential` - (Required) The Amazon Resource Name (ARN) or name of credentials created using AWS Secrets Manager.
+* `credential_provider` - (Required) The service that created the credentials to access a private Docker registry. The valid value, SECRETS_MANAGER, is for AWS Secrets Manager.
 
 `secondary_artifacts` supports the following:
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #9147 #8028

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
* resource/aws_codebuild_project: Add `registry_credential` attribute ([#9147](https://github.com/terraform-providers/terraform-provider-aws/issues/9147))
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSCodeBuildProject_Environment_RegistryCredential'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSCodeBuildProject_Environment_RegistryCredential -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== PAUSE TestAccAWSCodeBuildProject_Environment_RegistryCredential
=== CONT  TestAccAWSCodeBuildProject_Environment_RegistryCredential
--- PASS: TestAccAWSCodeBuildProject_Environment_RegistryCredential (48.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       54.721s
```
