### PR TITLE
Add support for AllowMajorVersionUpgrade flags on creation

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -539,15 +539,12 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("availability_zone"); ok {
 			opts.AvailabilityZone = aws.String(attr.(string))
-    }
+		}
 
-    if attr, ok := d.GetOk("auto_major_version_upgrade"); ok {
-      modifyDbInstanceInput.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
-      opts.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
-      requiresModifyDbInstance = true
-    }
-    
-    AutoMajorVersionUpgrade:    aws.Bool(d.Get("auto_major_version_upgrade").(bool)),
+		if attr, ok := d.GetOk("allow_major_version_upgrade"); ok {
+			modifyDbInstanceInput.AllowMajorVersionUpgrade = aws.Bool(attr.(bool))
+			requiresModifyDbInstance = true
+		}
 
 		if attr, ok := d.GetOk("backup_retention_period"); ok {
 			modifyDbInstanceInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
@@ -701,12 +698,12 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 		if _, ok := d.GetOk("timezone"); ok {
 			return fmt.Errorf(`provider.aws: aws_db_instance: %s: "timezone" doesn't work with with restores"`, d.Get("name").(string))
-    }
-    
-    if attr, ok := d.GetOk("auto_major_version_upgrade"); ok {
-      opts.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
-      requiresModifyDbInstance = true
-    }
+		}
+
+		if attr, ok := d.GetOk("allow_major_version_upgrade"); ok {
+			modifyDbInstanceInput.AllowMajorVersionUpgrade = aws.Bool(attr.(bool))
+			requiresModifyDbInstance = true
+		}
 
 		attr := d.Get("backup_retention_period")
 		opts.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
@@ -873,13 +870,12 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("availability_zone"); ok {
 			opts.AvailabilityZone = aws.String(attr.(string))
-    }
-    
-    if attr, ok := d.GetOk("auto_major_version_upgrade"); ok {
-      modifyDbInstanceInput.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
-      opts.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
-      requiresModifyDbInstance = true
-    }
+		}
+
+		if attr, ok := d.GetOk("allow_major_version_upgrade"); ok {
+			modifyDbInstanceInput.AllowMajorVersionUpgrade = aws.Bool(attr.(bool))
+			requiresModifyDbInstance = true
+		}
 
 		if attr, ok := d.GetOkExists("backup_retention_period"); ok {
 			modifyDbInstanceInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
@@ -1273,8 +1269,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("engine_version", v.EngineVersion)
 	d.Set("allocated_storage", v.AllocatedStorage)
 	d.Set("iops", v.Iops)
-  d.Set("copy_tags_to_snapshot", v.CopyTagsToSnapshot)
-  d.Set("auto_major_version_upgrade", v.AutoMajorVersionUpgrade)
+	d.Set("copy_tags_to_snapshot", v.CopyTagsToSnapshot)
 	d.Set("auto_minor_version_upgrade", v.AutoMinorVersionUpgrade)
 	d.Set("storage_type", v.StorageType)
 	d.Set("instance_class", v.DBInstanceClass)

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -539,7 +539,15 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("availability_zone"); ok {
 			opts.AvailabilityZone = aws.String(attr.(string))
-		}
+    }
+
+    if attr, ok := d.GetOk("auto_major_version_upgrade"); ok {
+      modifyDbInstanceInput.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
+      opts.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
+      requiresModifyDbInstance = true
+    }
+    
+    AutoMajorVersionUpgrade:    aws.Bool(d.Get("auto_major_version_upgrade").(bool)),
 
 		if attr, ok := d.GetOk("backup_retention_period"); ok {
 			modifyDbInstanceInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
@@ -686,7 +694,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("multi_az"); ok {
 			opts.MultiAZ = aws.Bool(attr.(bool))
-
 		}
 
 		if _, ok := d.GetOk("character_set_name"); ok {
@@ -694,7 +701,12 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 		if _, ok := d.GetOk("timezone"); ok {
 			return fmt.Errorf(`provider.aws: aws_db_instance: %s: "timezone" doesn't work with with restores"`, d.Get("name").(string))
-		}
+    }
+    
+    if attr, ok := d.GetOk("auto_major_version_upgrade"); ok {
+      opts.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
+      requiresModifyDbInstance = true
+    }
 
 		attr := d.Get("backup_retention_period")
 		opts.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
@@ -861,7 +873,13 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 
 		if attr, ok := d.GetOk("availability_zone"); ok {
 			opts.AvailabilityZone = aws.String(attr.(string))
-		}
+    }
+    
+    if attr, ok := d.GetOk("auto_major_version_upgrade"); ok {
+      modifyDbInstanceInput.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
+      opts.AutoMajorVersionUpgrade = aws.Bool(attr.(bool))
+      requiresModifyDbInstance = true
+    }
 
 		if attr, ok := d.GetOkExists("backup_retention_period"); ok {
 			modifyDbInstanceInput.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
@@ -1255,7 +1273,8 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("engine_version", v.EngineVersion)
 	d.Set("allocated_storage", v.AllocatedStorage)
 	d.Set("iops", v.Iops)
-	d.Set("copy_tags_to_snapshot", v.CopyTagsToSnapshot)
+  d.Set("copy_tags_to_snapshot", v.CopyTagsToSnapshot)
+  d.Set("auto_major_version_upgrade", v.AutoMajorVersionUpgrade)
 	d.Set("auto_minor_version_upgrade", v.AutoMinorVersionUpgrade)
 	d.Set("storage_type", v.StorageType)
 	d.Set("instance_class", v.DBInstanceClass)

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -700,11 +700,6 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf(`provider.aws: aws_db_instance: %s: "timezone" doesn't work with with restores"`, d.Get("name").(string))
 		}
 
-		if attr, ok := d.GetOk("allow_major_version_upgrade"); ok {
-			modifyDbInstanceInput.AllowMajorVersionUpgrade = aws.Bool(attr.(bool))
-			requiresModifyDbInstance = true
-		}
-
 		attr := d.Get("backup_retention_period")
 		opts.BackupRetentionPeriod = aws.Int64(int64(attr.(int)))
 

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -77,8 +77,8 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance1),
 					testAccCheckAWSDBInstanceAttributes(&dbInstance1),
-          resource.TestCheckResourceAttr(resourceName, "allocated_storage", "10"),
-          resource.TestCheckResourceAttr(resourceName, "auto_major_version_upgrade", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allocated_storage", "10"),
+					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "true"),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "true"),
 					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "rds", regexp.MustCompile(`db:.+`)),
 					resource.TestCheckResourceAttrSet(resourceName, "availability_zone"),
@@ -471,7 +471,7 @@ func TestAccAWSDBInstance_ReplicateSourceDb_AllocatedStorage(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBInstance_ReplicateSourceDb_AutoMajorVersionUpgrade(t *testing.T) {
+func TestAccAWSDBInstance_ReplicateSourceDb_AllowMajorVersionUpgrade(t *testing.T) {
 	var dbInstance, sourceDbInstance rds.DBInstance
 
 	rName := acctest.RandomWithPrefix("tf-acc-test")
@@ -484,12 +484,12 @@ func TestAccAWSDBInstance_ReplicateSourceDb_AutoMajorVersionUpgrade(t *testing.T
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfig_ReplicateSourceDb_AutoMajorVersionUpgrade(rName, false),
+				Config: testAccAWSDBInstanceConfig_ReplicateSourceDb_AllowMajorVersionUpgrade(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(sourceResourceName, &sourceDbInstance),
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
 					testAccCheckAWSDBInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "auto_major_version_upgrade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "false"),
 				),
 			},
 		},
@@ -944,7 +944,7 @@ func TestAccAWSDBInstance_SnapshotIdentifier_Io1Storage(t *testing.T) {
 	})
 }
 
-func TestAccAWSDBInstance_SnapshotIdentifier_AutoMajorVersionUpgrade(t *testing.T) {
+func TestAccAWSDBInstance_SnapshotIdentifier_AllowMajorVersionUpgrade(t *testing.T) {
 	var dbInstance, sourceDbInstance rds.DBInstance
 	var dbSnapshot rds.DBSnapshot
 
@@ -959,12 +959,12 @@ func TestAccAWSDBInstance_SnapshotIdentifier_AutoMajorVersionUpgrade(t *testing.
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_AutoMajorVersionUpgrade(rName, false),
+				Config: testAccAWSDBInstanceConfig_SnapshotIdentifier_AllowMajorVersionUpgrade(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists(sourceDbResourceName, &sourceDbInstance),
 					testAccCheckDbSnapshotExists(snapshotResourceName, &dbSnapshot),
 					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance),
-					resource.TestCheckResourceAttr(resourceName, "auto_major_version_upgrade", "false"),
+					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "false"),
 				),
 			},
 		},
@@ -1689,7 +1689,7 @@ func TestAccAWSDBInstance_MajorVersion(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDBInstanceConfigAutoMajorVersion,
+				Config: testAccAWSDBInstanceConfigAllowMajorVersion,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
 				),
@@ -3562,7 +3562,7 @@ resource "aws_security_group_rule" "rds-mysql-1" {
 `, rInt)
 }
 
-var testAccAWSDBInstanceConfigAutoMajorVersion = fmt.Sprintf(`
+var testAccAWSDBInstanceConfigAllowMajorVersion = fmt.Sprintf(`
 resource "aws_db_instance" "bar" {
   identifier = "foobarbaz-test-terraform-%d"
 	allocated_storage = 10
@@ -3990,7 +3990,7 @@ resource "aws_db_instance" "test" {
 `, rName, allocatedStorage, rName)
 }
 
-func testAccAWSDBInstanceConfig_ReplicateSourceDb_AutoMajorVersionUpgrade(rName string, autoMajorVersionUpgrade bool) string {
+func testAccAWSDBInstanceConfig_ReplicateSourceDb_AllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
 	return fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage       = 5
@@ -4004,13 +4004,13 @@ resource "aws_db_instance" "source" {
 }
 
 resource "aws_db_instance" "test" {
-  auto_major_version_upgrade = %t
+  allow_major_version_upgrade = %t
   identifier                 = %q
   instance_class             = "${aws_db_instance.source.instance_class}"
   replicate_source_db        = "${aws_db_instance.source.id}"
   skip_final_snapshot        = true
 }
-`, rName, autoMajorVersionUpgrade, rName)
+`, rName, allowMajorVersionUpgrade, rName)
 }
 
 func testAccAWSDBInstanceConfig_ReplicateSourceDb_AutoMinorVersionUpgrade(rName string, autoMinorVersionUpgrade bool) string {
@@ -4451,7 +4451,7 @@ resource "aws_db_instance" "test" {
 `, rName, rName, rName, iops)
 }
 
-func testAccAWSDBInstanceConfig_SnapshotIdentifier_AutoMajorVersionUpgrade(rName string, autoMajorVersionUpgrade bool) string {
+func testAccAWSDBInstanceConfig_SnapshotIdentifier_AllowMajorVersionUpgrade(rName string, allowMajorVersionUpgrade bool) string {
 	return fmt.Sprintf(`
 resource "aws_db_instance" "source" {
   allocated_storage   = 5
@@ -4469,13 +4469,13 @@ resource "aws_db_snapshot" "test" {
 }
 
 resource "aws_db_instance" "test" {
-  auto_major_version_upgrade = %t
+  allow_major_version_upgrade = %t
   identifier                 = %q
   instance_class             = "${aws_db_instance.source.instance_class}"
   snapshot_identifier        = "${aws_db_snapshot.test.id}"
   skip_final_snapshot        = true
 }
-`, rName, rName, autoMajorVersionUpgrade, rName)
+`, rName, rName, allowMajorVersionUpgrade, rName)
 }
 
 func testAccAWSDBInstanceConfig_SnapshotIdentifier_AutoMinorVersionUpgrade(rName string, autoMinorVersionUpgrade bool) string {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #9148 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Added support for "allow_major_version_upgrade" value when creating an RDS instance from a replica  or snapshot to allow RDS to properly perform the needed modifications.
```

Output from acceptance testing:

```
N/A
```

Don't have a personal account with which I can perform the acceptance testing, only utilizing business account.  I performed the actions for a new instance from a db snapshot (9.6.11 to 11.1) successfully, however.  Prior, as mentioned in issue #9148, after the initial creation of the database, the apply process would error out with a complaint that the `allow_major_version_upgrade` value was not passed.
