### PR TITLE
Fix doc casing `sm_maintenance_window` when targeting InstanceIds

### DIFF
--- a/website/docs/r/ssm_maintenance_window_target.html.markdown
+++ b/website/docs/r/ssm_maintenance_window_target.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `name` - (Optional) The name of the maintenance window target.
 * `description` - (Optional) The description of the maintenance window target.
 * `resource_type` - (Required) The type of target being registered with the Maintenance Window. Possible values `INSTANCE`.
-* `targets` - (Required) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value.
+* `targets` - (Required) The targets (either instances or tags). Instances are specified using Key=InstanceIds,Values=InstanceId1,InstanceId2. Tags are specified using Key=tag name,Values=tag value.
 * `owner_information` - (Optional) User-provided value that will be included in any CloudWatch events raised while running tasks for these targets in this Maintenance Window.
 
 ## Attributes Reference


### PR DESCRIPTION
Fix casing when targeting InstanceIds to avoid the following error:

> Error: ValidationException: Targets must be specified in one of the following formats: 1) 1 target with "Key=InstanceIds" and "Values=" a list of up to 50 instance IDs, or 2) Up to 5 targets, each of which can be either "Key=tag:<key>,Values=<tag_values>" or "Key=tag-key,Values=<tag_keys>", and each with up to 5 unique tag keys/values.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
	NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
