### PR TITLE
New Resource: aws_servicequotas_service_quota

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -681,6 +681,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_service_discovery_private_dns_namespace":             resourceAwsServiceDiscoveryPrivateDnsNamespace(),
 			"aws_service_discovery_public_dns_namespace":              resourceAwsServiceDiscoveryPublicDnsNamespace(),
 			"aws_service_discovery_service":                           resourceAwsServiceDiscoveryService(),
+			"aws_servicequotas_service_quota":                         resourceAwsServiceQuotasServiceQuota(),
 			"aws_shield_protection":                                   resourceAwsShieldProtection(),
 			"aws_simpledb_domain":                                     resourceAwsSimpleDBDomain(),
 			"aws_ssm_activation":                                      resourceAwsSsmActivation(),

--- a/aws/resource_aws_servicequotas_service_quota.go
+++ b/aws/resource_aws_servicequotas_service_quota.go
@@ -116,7 +116,6 @@ func resourceAwsServiceQuotasServiceQuotaCreate(d *schema.ResourceData, meta int
 func resourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).servicequotasconn
 
-	requestID := d.Get("request_id").(string)
 	serviceCode, quotaCode, err := resourceAwsServiceQuotasServiceQuotaParseID(d.Id())
 
 	if err != nil {
@@ -161,6 +160,8 @@ func resourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta inter
 	d.Set("service_code", output.Quota.ServiceCode)
 	d.Set("service_name", output.Quota.ServiceName)
 	d.Set("value", output.Quota.Value)
+
+	requestID := d.Get("request_id").(string)
 
 	if requestID != "" {
 		input := &servicequotas.GetRequestedServiceQuotaChangeInput{

--- a/aws/resource_aws_servicequotas_service_quota.go
+++ b/aws/resource_aws_servicequotas_service_quota.go
@@ -1,0 +1,239 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsServiceQuotasServiceQuota() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsServiceQuotasServiceQuotaCreate,
+		Read:   resourceAwsServiceQuotasServiceQuotaRead,
+		Update: resourceAwsServiceQuotasServiceQuotaUpdate,
+		Delete: schema.Noop,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"adjustable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_value": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"quota_code": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"quota_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"request_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"request_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_code": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:     schema.TypeFloat,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsServiceQuotasServiceQuotaCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).servicequotasconn
+
+	quotaCode := d.Get("quota_code").(string)
+	serviceCode := d.Get("service_code").(string)
+	value := d.Get("value").(float64)
+
+	d.SetId(fmt.Sprintf("%s/%s", serviceCode, quotaCode))
+
+	input := &servicequotas.GetServiceQuotaInput{
+		QuotaCode:   aws.String(quotaCode),
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	output, err := conn.GetServiceQuota(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty result", d.Id())
+	}
+
+	if value > aws.Float64Value(output.Quota.Value) {
+		input := &servicequotas.RequestServiceQuotaIncreaseInput{
+			DesiredValue: aws.Float64(value),
+			QuotaCode:    aws.String(quotaCode),
+			ServiceCode:  aws.String(serviceCode),
+		}
+
+		output, err := conn.RequestServiceQuotaIncrease(input)
+
+		if err != nil {
+			return fmt.Errorf("error requesting Service Quota (%s) increase: %s", d.Id(), err)
+		}
+
+		if output == nil || output.RequestedQuota == nil {
+			return fmt.Errorf("error requesting Service Quota (%s) increase: empty result", d.Id())
+		}
+
+		d.Set("request_id", output.RequestedQuota.Id)
+	}
+
+	return resourceAwsServiceQuotasServiceQuotaRead(d, meta)
+}
+
+func resourceAwsServiceQuotasServiceQuotaRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).servicequotasconn
+
+	requestID := d.Get("request_id").(string)
+	serviceCode, quotaCode, err := resourceAwsServiceQuotasServiceQuotaParseID(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	input := &servicequotas.GetServiceQuotaInput{
+		QuotaCode:   aws.String(quotaCode),
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	output, err := conn.GetServiceQuota(input)
+
+	if err != nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): %s", d.Id(), err)
+	}
+
+	if output == nil {
+		return fmt.Errorf("error getting Service Quotas Service Quota (%s): empty result", d.Id())
+	}
+
+	defaultInput := &servicequotas.GetAWSDefaultServiceQuotaInput{
+		QuotaCode:   aws.String(quotaCode),
+		ServiceCode: aws.String(serviceCode),
+	}
+
+	defaultOutput, err := conn.GetAWSDefaultServiceQuota(defaultInput)
+
+	if err != nil {
+		return fmt.Errorf("error getting Service Quotas Default Service Quota (%s): %s", d.Id(), err)
+	}
+
+	if defaultOutput == nil {
+		return fmt.Errorf("error getting Service Quotas Default Service Quota (%s): empty result", d.Id())
+	}
+
+	d.Set("adjustable", output.Quota.Adjustable)
+	d.Set("arn", output.Quota.QuotaArn)
+	d.Set("default_value", defaultOutput.Quota.Value)
+	d.Set("quota_code", output.Quota.QuotaCode)
+	d.Set("quota_name", output.Quota.QuotaName)
+	d.Set("service_code", output.Quota.ServiceCode)
+	d.Set("service_name", output.Quota.ServiceName)
+	d.Set("value", output.Quota.Value)
+
+	if requestID != "" {
+		input := &servicequotas.GetRequestedServiceQuotaChangeInput{
+			RequestId: aws.String(requestID),
+		}
+
+		output, err := conn.GetRequestedServiceQuotaChange(input)
+
+		if isAWSErr(err, servicequotas.ErrCodeNoSuchResourceException, "") {
+			d.Set("request_id", "")
+			d.Set("request_status", "")
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error getting Service Quotas Requested Service Quota Change (%s): %s", requestID, err)
+		}
+
+		if output == nil || output.RequestedQuota == nil {
+			return fmt.Errorf("error getting Service Quotas Requested Service Quota Change (%s): empty result", requestID)
+		}
+
+		requestStatus := aws.StringValue(output.RequestedQuota.Status)
+		d.Set("request_status", requestStatus)
+
+		switch requestStatus {
+		case servicequotas.RequestStatusApproved, servicequotas.RequestStatusCaseClosed, servicequotas.RequestStatusDenied:
+			d.Set("request_id", "")
+		case servicequotas.RequestStatusCaseOpened, servicequotas.RequestStatusPending:
+			d.Set("value", output.RequestedQuota.DesiredValue)
+		}
+	}
+
+	return nil
+}
+
+func resourceAwsServiceQuotasServiceQuotaUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).servicequotasconn
+
+	value := d.Get("value").(float64)
+	serviceCode, quotaCode, err := resourceAwsServiceQuotasServiceQuotaParseID(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	input := &servicequotas.RequestServiceQuotaIncreaseInput{
+		DesiredValue: aws.Float64(value),
+		QuotaCode:    aws.String(quotaCode),
+		ServiceCode:  aws.String(serviceCode),
+	}
+
+	output, err := conn.RequestServiceQuotaIncrease(input)
+
+	if err != nil {
+		return fmt.Errorf("error requesting Service Quota (%s) increase: %s", d.Id(), err)
+	}
+
+	if output == nil || output.RequestedQuota == nil {
+		return fmt.Errorf("error requesting Service Quota (%s) increase: empty result", d.Id())
+	}
+
+	d.Set("request_id", output.RequestedQuota.Id)
+
+	return resourceAwsServiceQuotasServiceQuotaRead(d, meta)
+}
+
+func resourceAwsServiceQuotasServiceQuotaParseID(id string) (string, string, error) {
+	parts := strings.SplitN(id, "/", 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected SERVICE-CODE/QUOTA-CODE", id)
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/aws/resource_aws_servicequotas_service_quota_test.go
+++ b/aws/resource_aws_servicequotas_service_quota_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-// This resource different than many since quotas are pre-existing
+// This resource is different than many since quotas are pre-existing
 // and the resource is only designed to help with increases.
 // In the basic case, we test that the resource can match the existing quota
 // without unexpected changes.

--- a/aws/resource_aws_servicequotas_service_quota_test.go
+++ b/aws/resource_aws_servicequotas_service_quota_test.go
@@ -1,0 +1,177 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// This resource different than many since quotas are pre-existing
+// and the resource is only designed to help with increases.
+// In the basic case, we test that the resource can match the existing quota
+// without unexpected changes.
+func TestAccAwsServiceQuotasServiceQuota_basic(t *testing.T) {
+	dataSourceName := "data.aws_servicequotas_service_quota.test"
+	resourceName := "aws_servicequotas_service_quota.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceQuotas(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsServiceQuotasServiceQuotaConfigSameValue("L-F678F1CE", "vpc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "adjustable", dataSourceName, "adjustable"),
+					resource.TestCheckResourceAttrPair(resourceName, "arn", dataSourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "default_value", dataSourceName, "default_value"),
+					resource.TestCheckResourceAttrPair(resourceName, "quota_code", dataSourceName, "quota_code"),
+					resource.TestCheckResourceAttrPair(resourceName, "quota_name", dataSourceName, "quota_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_code", dataSourceName, "service_code"),
+					resource.TestCheckResourceAttrPair(resourceName, "service_name", dataSourceName, "service_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "value", dataSourceName, "value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnCreate(t *testing.T) {
+	quotaCode := os.Getenv("SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE")
+	if quotaCode == "" {
+		t.Skip(
+			"Environment variable SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE is not set. " +
+				"WARNING: This test will submit a real service quota increase!")
+	}
+
+	serviceCode := os.Getenv("SERVICEQUOTAS_INCREASE_ON_CREATE_SERVICE_CODE")
+	if serviceCode == "" {
+		t.Skip(
+			"Environment variable SERVICEQUOTAS_INCREASE_ON_CREATE_SERVICE_CODE is not set. " +
+				"WARNING: This test will submit a real service quota increase!")
+	}
+
+	value := os.Getenv("SERVICEQUOTAS_INCREASE_ON_CREATE_VALUE")
+	if value == "" {
+		t.Skip(
+			"Environment variable SERVICEQUOTAS_INCREASE_ON_CREATE_VALUE is not set. " +
+				"WARNING: This test will submit a real service quota increase!")
+	}
+
+	resourceName := "aws_servicequotas_service_quota.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceQuotas(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsServiceQuotasServiceQuotaConfigValue(quotaCode, serviceCode, value),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
+					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(resourceName, "value", value),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnUpdate(t *testing.T) {
+	quotaCode := os.Getenv("SERVICEQUOTAS_INCREASE_ON_UPDATE_QUOTA_CODE")
+	if quotaCode == "" {
+		t.Skip(
+			"Environment variable SERVICEQUOTAS_INCREASE_ON_UPDATE_QUOTA_CODE is not set. " +
+				"WARNING: This test will submit a real service quota increase!")
+	}
+
+	serviceCode := os.Getenv("SERVICEQUOTAS_INCREASE_ON_UPDATE_SERVICE_CODE")
+	if serviceCode == "" {
+		t.Skip(
+			"Environment variable SERVICEQUOTAS_INCREASE_ON_UPDATE_SERVICE_CODE is not set. " +
+				"WARNING: This test will submit a real service quota increase!")
+	}
+
+	value := os.Getenv("SERVICEQUOTAS_INCREASE_ON_UPDATE_VALUE")
+	if value == "" {
+		t.Skip(
+			"Environment variable SERVICEQUOTAS_INCREASE_ON_UPDATE_VALUE is not set. " +
+				"WARNING: This test will submit a real service quota increase!")
+	}
+
+	dataSourceName := "aws_servicequotas_service_quota.test"
+	resourceName := "aws_servicequotas_service_quota.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSServiceQuotas(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsServiceQuotasServiceQuotaConfigSameValue(quotaCode, serviceCode),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
+					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttrPair(resourceName, "value", dataSourceName, "value"),
+				),
+			},
+			{
+				Config: testAccAwsServiceQuotasServiceQuotaConfigValue(quotaCode, serviceCode, value),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "quota_code", quotaCode),
+					resource.TestCheckResourceAttr(resourceName, "service_code", serviceCode),
+					resource.TestCheckResourceAttr(resourceName, "value", value),
+				),
+			},
+		},
+	})
+}
+
+func testAccPreCheckAWSServiceQuotas(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).servicequotasconn
+
+	input := &servicequotas.ListServicesInput{}
+
+	_, err := conn.ListServices(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccAwsServiceQuotasServiceQuotaConfigSameValue(quotaCode, serviceCode string) string {
+	return fmt.Sprintf(`
+data "aws_servicequotas_service_quota" "test" {
+  quota_code   = %[1]q
+  service_code = %[2]q
+}
+
+resource "aws_servicequotas_service_quota" "test" {
+  quota_code   = "${data.aws_servicequotas_service_quota.test.quota_code}"
+  service_code = "${data.aws_servicequotas_service_quota.test.service_code}"
+  value        = "${data.aws_servicequotas_service_quota.test.value}"
+}
+`, quotaCode, serviceCode)
+}
+
+func testAccAwsServiceQuotasServiceQuotaConfigValue(quotaCode, serviceCode, value string) string {
+	return fmt.Sprintf(`
+resource "aws_servicequotas_service_quota" "test" {
+  quota_code   = %[1]q
+  service_code = %[2]q
+  value        = %[3]s
+}
+`, quotaCode, serviceCode, value)
+}

--- a/website/aws.erb
+++ b/website/aws.erb
@@ -2479,6 +2479,17 @@
                 </li>
 
                 <li>
+                    <a href="#">Service Quotas Resources</a>
+                    <ul class="nav">
+
+                        <li>
+                            <a href="/docs/providers/aws/r/servicequotas_service_quota.html">aws_servicequotas_service_quota</a>
+                        </li>
+
+                    </ul>
+                </li>
+
+                <li>
                     <a href="#">Shield Resources</a>
                     <ul class="nav">
 

--- a/website/docs/r/servicequotas_service_quota.html.markdown
+++ b/website/docs/r/servicequotas_service_quota.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "aws"
+page_title: "AWS: aws_servicequotas_service_quota"
+sidebar_current: "docs-aws-resource-servicequotas-service-quota"
+description: |-
+  Manages an individual Service Quota
+---
+
+# Resource: aws_servicequotas_service_quota
+
+Manages an individual Service Quota.
+
+## Example Usage
+
+```hcl
+resource "aws_servicequotas_service_quota" "example" {
+  quota_code   = "L-F678F1CE"
+  service_code = "vpc"
+  value        = 75
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `quota_code` - (Required) Code of the service quota to track. For example: `L-F678F1CE`. Available values can be found with the [AWS CLI service-quotas list-service-quotas command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-service-quotas.html).
+* `service_code` - (Required) Code of the service to track. For example: `vpc`. Available values can be found with the [AWS CLI service-quotas list-services command](https://docs.aws.amazon.com/cli/latest/reference/service-quotas/list-services.html).
+* `value` - (Required) Float specifying the desired value for the service quota. If the desired value is higher than the current value, a quota increase request is submitted. When a known request is submitted and pending, the value reflects the desired value of the pending request.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `adjustable` - Whether the service quota can be increased.
+* `arn` - Amazon Resource Name (ARN) of the service quota.
+* `default_value` - Default value of the service quota.
+* `id` - Service code and quota code, separated by a front slash (`/`)
+* `quota_name` - Name of the quota.
+* `service_name` - Name of the service.
+
+## Import
+
+~> *NOTE* This resource does not require explicit import and will assume management of an existing service quota on Terraform resource creation.
+
+`aws_servicequotas_service_quota` can be imported by using the service code and quota code, separated by a front slash (`/`), e.g.
+
+```
+$ terraform import aws_servicequotas_service_quota.example vpc/L-F678F1CE
+```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Replacing #9121 due to bad rebase...
Closes #9118

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `aws_servicequotas_service_quota`
```

Output from acceptance testing (requesting increase of t3.nano and t3.micro limits in testing account):

```
export SERVICEQUOTAS_INCREASE_ON_CREATE_QUOTA_CODE=L-55EB784E
export SERVICEQUOTAS_INCREASE_ON_CREATE_SERVICE_CODE=ec2
export SERVICEQUOTAS_INCREASE_ON_CREATE_VALUE=25
export SERVICEQUOTAS_INCREASE_ON_UPDATE_QUOTA_CODE=L-0F0ED007
export SERVICEQUOTAS_INCREASE_ON_UPDATE_SERVICE_CODE=ec2
export SERVICEQUOTAS_INCREASE_ON_UPDATE_VALUE=25

--- PASS: TestAccAwsServiceQuotasServiceQuota_basic (13.83s)
--- PASS: TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnCreate (12.52s)
--- PASS: TestAccAwsServiceQuotasServiceQuota_Value_IncreaseOnUpdate (20.00s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAwsServiceQuotasServiceQuota_basic (2.51s)
    resource_aws_servicequotas_service_quota_test.go:138: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://servicequotas.us-gov-west-1.amazonaws.com/: dial tcp: lookup servicequotas.us-gov-west-1.amazonaws.com: no such host
```

