### PR TITLE
resource/aws_db_instance: Prevent InvalidParameterCombination: No modifications were requested error when updating only allow_major_version_upgrade argument

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1470,7 +1470,8 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("allow_major_version_upgrade") {
 		d.SetPartial("allow_major_version_upgrade")
 		req.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
-		requestUpdate = true
+		// Having allowing_major_version_upgrade by itself should not trigger ModifyDBInstance
+		// InvalidParameterCombination: No modifications were requested
 	}
 	if d.HasChange("backup_retention_period") {
 		d.SetPartial("backup_retention_period")

--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -1471,7 +1471,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		d.SetPartial("allow_major_version_upgrade")
 		req.AllowMajorVersionUpgrade = aws.Bool(d.Get("allow_major_version_upgrade").(bool))
 		// Having allowing_major_version_upgrade by itself should not trigger ModifyDBInstance
-		// InvalidParameterCombination: No modifications were requested
+		// as it results in InvalidParameterCombination: No modifications were requested
 	}
 	if d.HasChange("backup_retention_period") {
 		d.SetPartial("backup_retention_period")

--- a/aws/resource_aws_db_instance_test.go
+++ b/aws/resource_aws_db_instance_test.go
@@ -293,6 +293,13 @@ func TestAccAWSDBInstance_AllowMajorVersionUpgrade(t *testing.T) {
 					"skip_final_snapshot",
 				},
 			},
+			{
+				Config: testAccAWSDBInstanceConfigAllowMajorVersionUpgrade(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists(resourceName, &dbInstance1),
+					resource.TestCheckResourceAttr(resourceName, "allow_major_version_upgrade", "false"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #500

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_db_instance: Prevent `InvalidParameterCombination: No modifications were requested` error when updating only `allow_major_version_upgrade` argument
```

Previous output from updated acceptance testing:

```
--- FAIL: TestAccAWSDBInstance_AllowMajorVersionUpgrade (491.43s)
    testing.go:568: Step 2 error: errors during apply:

        Error: Error modifying DB Instance tf-acc-test-4576888905000364877: InvalidParameterCombination: No modifications were requested
```

Output from acceptance testing:

```
--- PASS: TestAccAWSDBInstance_AllowMajorVersionUpgrade (433.02s)
```
