### PR TITLE
service/organizations: Automatically retry API calls on ConcurrentModificationException error

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -586,6 +586,14 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	})
 
+	client.organizationsconn.Handlers.Retry.PushBack(func(r *request.Request) {
+		// Retry on the following error:
+		// ConcurrentModificationException: AWS Organizations can't complete your request because it conflicts with another attempt to modify the same entity. Try again later.
+		if isAWSErr(r.Error, organizations.ErrCodeConcurrentModificationException, "Try again later") {
+			r.Retryable = aws.Bool(true)
+		}
+	})
+
 	client.storagegatewayconn.Handlers.Retry.PushBack(func(r *request.Request) {
 		// InvalidGatewayRequestException: The specified gateway proxy network connection is busy.
 		if isAWSErr(r.Error, storagegateway.ErrCodeInvalidGatewayRequestException, "The specified gateway proxy network connection is busy") {

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -20,6 +20,11 @@ func TestAccAWSOrganizations(t *testing.T) {
 			"basic": testAccAwsOrganizationsOrganizationalUnit_basic,
 			"Name":  testAccAwsOrganizationsOrganizationalUnit_Name,
 		},
+		"Policy": {
+			"basic":       testAccAwsOrganizationsPolicy_basic,
+			"concurrent":  testAccAwsOrganizationsPolicy_concurrent,
+			"Description": testAccAwsOrganizationsPolicy_description,
+		},
 		"PolicyAttachment": {
 			"Account":            testAccAwsOrganizationsPolicyAttachment_Account,
 			"OrganizationalUnit": testAccAwsOrganizationsPolicyAttachment_OrganizationalUnit,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #5073

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* service/organizations: Automatically retry API calls on `ConcurrentModificationException` error
```

Previous output from the new acceptance testing before migrating the testing to the serialized Organizations testing:

```
--- FAIL: TestAccAwsOrganizationsPolicy_concurrent (6.73s)
    testing.go:568: Step 0 error: errors during apply:

        Error: error creating Organizations Policy: AWSOrganizationsNotInUseException: Your account is not a member of an organization.
```

Previous output from the new acceptance testing before adding the service client retry logic:

```
        --- FAIL: TestAccAWSOrganizations/Policy/concurrent (16.40s)
            testing.go:629: Error destroying resource! WARNING: Dangling resources
                may exist. The full state and error is shown below.

                Error: errors during apply: ConcurrentModificationException: AWS Organizations can't complete your request because it conflicts with another attempt to modify the same entity. Try again later.
```

Output from acceptance testing:

```
--- PASS: TestAccAWSOrganizations (246.04s)
    --- PASS: TestAccAWSOrganizations/Organization (87.29s)
        --- PASS: TestAccAWSOrganizations/Organization/AwsServiceAccessPrincipals (25.19s)
        --- PASS: TestAccAWSOrganizations/Organization/EnabledPolicyTypes (33.61s)
        --- PASS: TestAccAWSOrganizations/Organization/FeatureSet (10.42s)
        --- PASS: TestAccAWSOrganizations/Organization/basic (18.07s)
    --- PASS: TestAccAWSOrganizations/Account (0.00s)
        --- SKIP: TestAccAWSOrganizations/Account/basic (0.00s)
            resource_aws_organizations_account_test.go:15: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
        --- SKIP: TestAccAWSOrganizations/Account/ParentId (0.00s)
            resource_aws_organizations_account_test.go:57: AWS Organizations Account testing is not currently automated due to manual account deletion steps.
    --- PASS: TestAccAWSOrganizations/OrganizationalUnit (36.87s)
        --- PASS: TestAccAWSOrganizations/OrganizationalUnit/basic (14.79s)
        --- PASS: TestAccAWSOrganizations/OrganizationalUnit/Name (22.08s)
    --- PASS: TestAccAWSOrganizations/Policy (63.90s)
        --- PASS: TestAccAWSOrganizations/Policy/concurrent (18.56s)
        --- PASS: TestAccAWSOrganizations/Policy/Description (21.93s)
        --- PASS: TestAccAWSOrganizations/Policy/basic (23.41s)
    --- PASS: TestAccAWSOrganizations/PolicyAttachment (57.98s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/Account (17.75s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/OrganizationalUnit (21.75s)
        --- PASS: TestAccAWSOrganizations/PolicyAttachment/Root (18.48s)
PASS
```

