### PR TITLE
Added import section to aws_s3_bucket_object doco. Closes #9196.

### DIFF
--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -120,3 +120,13 @@ The following attributes are exported
 * `etag` - the ETag generated for the object (an MD5 sum of the object content). For plaintext objects or objects encrypted with an AWS-managed key, the hash is an MD5 digest of the object data. For objects encrypted with a KMS key or objects created by either the Multipart Upload or Part Copy operation, the hash is not an MD5 digest, regardless of the method of encryption. More information on possible values can be found on [Common Response Headers](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html).
 * `version_id` - A unique version ID value for the object, if bucket versioning
 is enabled.
+
+## Import
+
+S3 objects cannot be imported at this stage. The state is updated when the object is created. 
+
+**Import alternatives:**
+
+1. Overwrite the object by running `apply` command to update your _.tfstate_ file. Consider S3 versioning, notifications and other unintended consequences before applying.
+
+2. Create the object by running `apply` in a different bucket and then modify your _.tfstate_ file to match the intended destination.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9196

Added **Import** section to explain it's not available and offered 2 workarounds. 

NOTE TO REVIEWERS: please, let me know if there is a better way of handling the missing import.
I used both ways I suggested in the edit, but neither is error-proof.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
NONE
```

Output from acceptance testing:

```
NONE
```
