### PR TITLE
resource/aws_organizations_account: Add tags argument

### DIFF
--- a/aws/resource_aws_organizations_account_test.go
+++ b/aws/resource_aws_organizations_account_test.go
@@ -42,6 +42,7 @@ func testAccAwsOrganizationsAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_organizations_account.test", "name", name),
 					resource.TestCheckResourceAttr("aws_organizations_account.test", "email", email),
 					resource.TestCheckResourceAttrSet("aws_organizations_account.test", "status"),
+					resource.TestCheckResourceAttr("aws_organizations_account.test", "tags.%", "0"),
 				),
 			},
 			{
@@ -93,6 +94,60 @@ func testAccAwsOrganizationsAccount_ParentId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsOrganizationsAccountExists(resourceName, &account),
 					resource.TestCheckResourceAttrPair(resourceName, "parent_id", parentIdResourceName2, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsOrganizationsAccount_Tags(t *testing.T) {
+	t.Skip("AWS Organizations Account testing is not currently automated due to manual account deletion steps.")
+
+	var account organizations.Account
+
+	orgsEmailDomain, ok := os.LookupEnv("TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN")
+
+	if !ok {
+		t.Skip("'TEST_AWS_ORGANIZATION_ACCOUNT_EMAIL_DOMAIN' not set, skipping test.")
+	}
+
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("tf_acctest_%d", rInt)
+	email := fmt.Sprintf("tf-acctest+%d@%s", rInt, orgsEmailDomain)
+	resourceName := "aws_organizations_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOrganizationsAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOrganizationsAccountConfigTags1(name, email, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsAccountExists(resourceName, &account),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAwsOrganizationsAccountConfigTags2(name, email, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsAccountExists(resourceName, &account),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAwsOrganizationsAccountConfig(name, email),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsOrganizationsAccountExists("aws_organizations_account.test", &account),
+					resource.TestCheckResourceAttr("aws_organizations_account.test", "tags.%", "0"),
 				),
 			},
 		},
@@ -209,4 +264,35 @@ resource "aws_organizations_account" "test" {
   parent_id = "${aws_organizations_organizational_unit.test2.id}"
 }
 `, name, email)
+}
+
+func testAccAwsOrganizationsAccountConfigTags1(name, email, tagKey1, tagValue1 string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {}
+
+resource "aws_organizations_account" "test" {
+  name  = %[1]q
+  email = %[2]q
+
+  tags = {
+    %[3]q = %[4]q
+  }
+}
+`, name, email, tagKey1, tagValue1)
+}
+
+func testAccAwsOrganizationsAccountConfigTags2(name, email, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_organizations_organization" "test" {}
+
+resource "aws_organizations_account" "test" {
+  name  = %[1]q
+  email = %[2]q
+
+  tags = {
+    %[3]q = %[4]q
+    %[5]q = %[6]q
+  }
+}
+`, name, email, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/aws/resource_aws_organizations_test.go
+++ b/aws/resource_aws_organizations_test.go
@@ -15,6 +15,7 @@ func TestAccAWSOrganizations(t *testing.T) {
 		"Account": {
 			"basic":    testAccAwsOrganizationsAccount_basic,
 			"ParentId": testAccAwsOrganizationsAccount_ParentId,
+			"Tags":     testAccAwsOrganizationsAccount_Tags,
 		},
 		"OrganizationalUnit": {
 			"basic": testAccAwsOrganizationsOrganizationalUnit_basic,

--- a/aws/tagsOrganizations.go
+++ b/aws/tagsOrganizations.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+)
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsOrganizations(oldTags, newTags []*organizations.Tag) ([]*organizations.Tag, []*string) {
+	// First, we're creating everything we have
+	create := make(map[string]interface{})
+	for _, t := range newTags {
+		create[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+	}
+
+	// Build the list of what to remove
+	var remove []*string
+	for _, t := range oldTags {
+		old, ok := create[aws.StringValue(t.Key)]
+		if !ok || old != aws.StringValue(t.Value) {
+			remove = append(remove, t.Key)
+		} else if ok {
+			// already present so remove from new
+			delete(create, aws.StringValue(t.Key))
+		}
+	}
+
+	return tagsFromMapOrganizations(create), remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapOrganizations(m map[string]interface{}) []*organizations.Tag {
+	var result []*organizations.Tag
+	for k, v := range m {
+		t := &organizations.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v.(string)),
+		}
+		if !tagIgnoredOrganizations(t) {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapOrganizations(ts []*organizations.Tag) map[string]string {
+	result := make(map[string]string)
+	for _, t := range ts {
+		if !tagIgnoredOrganizations(t) {
+			result[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredOrganizations(t *organizations.Tag) bool {
+	filter := []string{"^aws:"}
+	for _, v := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", v, aws.StringValue(t.Key))
+		r, _ := regexp.MatchString(v, aws.StringValue(t.Key))
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val: %s), ignoring.\n", aws.StringValue(t.Key), aws.StringValue(t.Value))
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsOrganizations_test.go
+++ b/aws/tagsOrganizations_test.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+)
+
+func TestDiffOrganizationsTags(t *testing.T) {
+	cases := []struct {
+		Old, New map[string]interface{}
+		Create   map[string]string
+		Remove   []string
+	}{
+		// Add
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: []string{},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: []string{
+				"foo",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: []string{
+				"foo",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: []string{
+				"bar",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsOrganizations(tagsFromMapOrganizations(tc.Old), tagsFromMapOrganizations(tc.New))
+		cm := tagsToMapOrganizations(c)
+		rl := []string{}
+		for _, tagName := range r {
+			rl = append(rl, aws.StringValue(tagName))
+		}
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rl, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rl)
+		}
+	}
+}
+
+func TestIgnoringTagsOrganizations(t *testing.T) {
+	var ignoredTags []*organizations.Tag
+	ignoredTags = append(ignoredTags, &organizations.Tag{
+		Key:   aws.String("aws:cloudformation:logical-id"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &organizations.Tag{
+		Key:   aws.String("aws:foo:bar"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if !tagIgnoredOrganizations(tag) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", aws.StringValue(tag.Key), aws.StringValue(tag.Value))
+		}
+	}
+}

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `iam_user_access_to_billing` - (Optional) If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information.
 * `parent_id` - (Optional) Parent Organizational Unit ID or Root ID for the account. Defaults to the Organization default Root ID. A configuration must be present for this argument to perform drift detection.
 * `role_name` - (Optional) The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the master account, allowing users in the master account to assume the role, as permitted by the master account administrator. The role has administrator permissions in the new member account. The Organizations API provides no method for reading this information after account creation, so Terraform cannot perform drift detection on its value and will always show a difference for a configured value after import unless [`ignore_changes`](/docs/configuration/resources.html#ignore_changes) is used.
+* `tags` - (Optional) Key-value mapping of resource tags.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #8896

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* resource/aws_organizations_account: Add `tags` argument
```

AWS Organizations Account testing is manual due to the lack of an automated deletion APIs. Manually verified with locally updated Terraform AWS Provider binary.

Starting configuration:

```hcl
resource "aws_organizations_account" "bflad-dev2" {
  name  = "bflad-dev2"
  email = "--OMITTED--"
}
```

Planned:

```console
$ terraform plan
...
No changes. Infrastructure is up-to-date.
```

Updated configuration:

```hcl
resource "aws_organizations_account" "bflad-dev2" {
  name  = "bflad-dev2"
  email = "--OMITTED--"

  tags = {
    key1 = "value1"
  }
}
```

Applied and state:

```console
$ terraform apply
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_organizations_account.bflad-dev2 will be updated in-place
  ~ resource "aws_organizations_account" "bflad-dev2" {
        arn           = "arn:aws:organizations::--OMITTED--:account/o-p687o6l073/--OMITTED--"
        email         = "--OMITTED--"
        id            = "--OMITTED--"
        joined_method = "INVITED"
        name          = "bflad-dev2"
        parent_id     = "r-cg2b"
        status        = "ACTIVE"
      ~ tags          = {
          + "key1" = "value1"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_organizations_account.bflad-dev2: Modifying... [id=--OMITTED--]
aws_organizations_account.bflad-dev2: Modifications complete after 0s [id=--OMITTED--]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ terraform state show aws_organizations_account.bflad-dev2
resource "aws_organizations_account" "bflad-dev2" {
    arn           = "arn:aws:organizations::--OMITTED--:account/o-p687o6l073/--OMITTED--"
    email         = "--OMITTED--"
    id            = "--OMITTED--"
    joined_method = "INVITED"
    name          = "bflad-dev2"
    parent_id     = "r-cg2b"
    status        = "ACTIVE"
    tags          = {
        "key1" = "value1"
    }
}
```

Updated configuration:

```hcl
resource "aws_organizations_account" "bflad-dev2" {
  name  = "bflad-dev2"
  email = "--OMITTED--"

  tags = {
    key1 = "value1updated"
    key2 = "value2"
  }
}
```

Applied and state:

```console
$ terraform apply
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_organizations_account.bflad-dev2 will be updated in-place
  ~ resource "aws_organizations_account" "bflad-dev2" {
        arn           = "arn:aws:organizations::--OMITTED--:account/o-p687o6l073/--OMITTED--"
        email         = "--OMITTED--"
        id            = "--OMITTED--"
        joined_method = "INVITED"
        name          = "bflad-dev2"
        parent_id     = "r-cg2b"
        status        = "ACTIVE"
      ~ tags          = {
          ~ "key1" = "value1" -> "value1updated"
          + "key2" = "value2"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_organizations_account.bflad-dev2: Modifying... [id=--OMITTED--]
aws_organizations_account.bflad-dev2: Modifications complete after 1s [id=--OMITTED--]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ terraform state show aws_organizations_account.bflad-dev2
resource "aws_organizations_account" "bflad-dev2" {
    arn           = "arn:aws:organizations::--OMITTED--:account/o-p687o6l073/--OMITTED--"
    email         = "--OMITTED--"
    id            = "--OMITTED--"
    joined_method = "INVITED"
    name          = "bflad-dev2"
    parent_id     = "r-cg2b"
    status        = "ACTIVE"
    tags          = {
        "key1" = "value1updated"
        "key2" = "value2"
    }
}
```

Updated configuration:

```hcl
resource "aws_organizations_account" "bflad-dev2" {
  name  = "bflad-dev2"
  email = "--OMITTED--"
}
```

Applied and state:

```console
$ terraform apply
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_organizations_account.bflad-dev2 will be updated in-place
  ~ resource "aws_organizations_account" "bflad-dev2" {
        arn           = "arn:aws:organizations::--OMITTED--:account/o-p687o6l073/--OMITTED--"
        email         = "--OMITTED--"
        id            = "--OMITTED--"
        joined_method = "INVITED"
        name          = "bflad-dev2"
        parent_id     = "r-cg2b"
        status        = "ACTIVE"
      ~ tags          = {
          - "key1" = "value1updated" -> null
          - "key2" = "value2" -> null
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_organizations_account.bflad-dev2: Modifying... [id=--OMITTED--]
aws_organizations_account.bflad-dev2: Modifications complete after 0s [id=--OMITTED--]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ terraform state show aws_organizations_account.bflad-dev2
resource "aws_organizations_account" "bflad-dev2" {
    arn           = "arn:aws:organizations::--OMITTED--:account/o-p687o6l073/--OMITTED--"
    email         = "--OMITTED--"
    id            = "--OMITTED--"
    joined_method = "INVITED"
    name          = "bflad-dev2"
    parent_id     = "r-cg2b"
    status        = "ACTIVE"
    tags          = {}
}
```
