### PR TITLE
tests/service/codepipeline: Add PreCheck for service availability

### DIFF
--- a/aws/resource_aws_codepipeline_test.go
+++ b/aws/resource_aws_codepipeline_test.go
@@ -21,7 +21,7 @@ func TestAccAWSCodePipeline_Import_basic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -46,7 +46,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -82,7 +82,7 @@ func TestAccAWSCodePipeline_emptyArtifacts(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +116,7 @@ func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -144,7 +144,7 @@ func TestAccAWSCodePipeline_tags(t *testing.T) {
 	resourceName := "aws_codepipeline.bar"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -224,6 +224,22 @@ func testAccCheckAWSCodePipelineDestroy(s *terraform.State) error {
 	}
 
 	return fmt.Errorf("Default error in CodePipeline Test")
+}
+
+func testAccPreCheckAWSCodePipeline(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).codepipelineconn
+
+	input := &codepipeline.ListPipelinesInput{}
+
+	_, err := conn.ListPipelines(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccAWSCodePipelineConfig_basic(rName string) string {

--- a/aws/resource_aws_codepipeline_webhook_test.go
+++ b/aws/resource_aws_codepipeline_webhook_test.go
@@ -19,7 +19,7 @@ func TestAccAWSCodePipelineWebhook_basic(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -52,7 +52,7 @@ func TestAccAWSCodePipelineWebhook_ipAuth(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -85,7 +85,7 @@ func TestAccAWSCodePipelineWebhook_unauthenticated(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +116,7 @@ func TestAccAWSCodePipelineWebhook_tags(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSCodePipeline(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial (provided as a smoke test):

```
--- PASS: TestAccAWSCodePipelineWebhook_basic (65.17s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSCodePipelineWebhook_basic (2.16s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipelineWebhook_ipAuth (1.84s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipelineWebhook_unauthenticated (1.24s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipelineWebhook_tags (1.07s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipeline_deployWithServiceRole (1.07s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipeline_tags (1.07s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipeline_basic (1.07s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipeline_Import_basic (1.07s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSCodePipeline_emptyArtifacts (1.09s)
    resource_aws_codepipeline_test.go:237: skipping acceptance testing: RequestError: send request failed
        caused by: Post https://codepipeline.us-gov-west-1.amazonaws.com/: dial tcp: lookup codepipeline.us-gov-west-1.amazonaws.com: no such host
PASS
```
