### PR TITLE
tests/service/kafka: Add PreCheck for service availability

### DIFF
--- a/aws/data_source_aws_msk_cluster_test.go
+++ b/aws/data_source_aws_msk_cluster_test.go
@@ -14,7 +14,7 @@ func TestAccAWSMskClusterDataSource_Name(t *testing.T) {
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_msk_cluster_test.go
+++ b/aws/resource_aws_msk_cluster_test.go
@@ -61,7 +61,7 @@ func TestAccAWSMskCluster_basic(t *testing.T) {
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +116,7 @@ func TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize(t *testing.T) {
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -159,7 +159,7 @@ func TestAccAWSMskCluster_ClientAuthentication_Tls_CertificateAuthorityArns(t *t
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -194,7 +194,7 @@ func TestAccAWSMskCluster_ConfigurationInfo_Revision(t *testing.T) {
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -236,7 +236,7 @@ func TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn(t *testing.T)
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -266,7 +266,7 @@ func TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker(t *tes
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -298,7 +298,7 @@ func TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster(t *testin
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -330,7 +330,7 @@ func TestAccAWSMskCluster_EnhancedMonitoring(t *testing.T) {
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -360,7 +360,7 @@ func TestAccAWSMskCluster_NumberOfBrokerNodes(t *testing.T) {
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -398,7 +398,7 @@ func TestAccAWSMskCluster_Tags(t *testing.T) {
 	resourceName := "aws_msk_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskClusterDestroy,
 		Steps: []resource.TestStep{
@@ -522,6 +522,22 @@ func testAccCheckMskClusterTags(td *kafka.ListTagsForResourceOutput, key string,
 			return fmt.Errorf("%s: bad value: %s", key, v)
 		}
 		return nil
+	}
+}
+
+func testAccPreCheckAWSMsk(t *testing.T) {
+	conn := testAccProvider.Meta().(*AWSClient).kafkaconn
+
+	input := &kafka.ListClustersInput{}
+
+	_, err := conn.ListClusters(input)
+
+	if testAccPreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
 	}
 }
 

--- a/aws/resource_aws_msk_configuration_test.go
+++ b/aws/resource_aws_msk_configuration_test.go
@@ -18,7 +18,7 @@ func TestAccAWSMskConfiguration_basic(t *testing.T) {
 	resourceName := "aws_msk_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -49,7 +49,7 @@ func TestAccAWSMskConfiguration_Description(t *testing.T) {
 	resourceName := "aws_msk_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +75,7 @@ func TestAccAWSMskConfiguration_KafkaVersions(t *testing.T) {
 	resourceName := "aws_msk_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -101,7 +101,7 @@ func TestAccAWSMskConfiguration_ServerProperties(t *testing.T) {
 	resourceName := "aws_msk_configuration.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSMsk(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMskConfigurationDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial (provided as a smoke test):

```
--- PASS: TestAccAWSMskConfiguration_basic (43.75s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- SKIP: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_InCluster (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskConfiguration_KafkaVersions (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskCluster_EncryptionInfo_EncryptionInTransit_ClientBroker (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskCluster_EncryptionInfo_EncryptionAtRestKmsKeyArn (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskCluster_EnhancedMonitoring (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskConfiguration_ServerProperties (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskCluster_Tags (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskClusterDataSource_Name (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskCluster_basic (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskConfiguration_Description (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskCluster_NumberOfBrokerNodes (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskCluster_BrokerNodeGroupInfo_EbsVolumeSize (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
--- SKIP: TestAccAWSMskConfiguration_basic (2.18s)
    resource_aws_msk_cluster_test.go:536: skipping acceptance testing: RequestError: send request failed
        caused by: Get https://kafka.us-gov-west-1.amazonaws.com/v1/clusters: dial tcp: lookup kafka.us-gov-west-1.amazonaws.com: no such host
PASS
```