### PR TITLE
Add support tags attribute for aws_appmesh_route resource

### DIFF
--- a/aws/resource_aws_appmesh_route.go
+++ b/aws/resource_aws_appmesh_route.go
@@ -175,6 +175,8 @@ func resourceAwsAppmeshRoute() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -187,6 +189,7 @@ func resourceAwsAppmeshRouteCreate(d *schema.ResourceData, meta interface{}) err
 		RouteName:         aws.String(d.Get("name").(string)),
 		VirtualRouterName: aws.String(d.Get("virtual_router_name").(string)),
 		Spec:              expandAppmeshRouteSpec(d.Get("spec").([]interface{})),
+		Tags:              tagsFromMapAppmesh(d.Get("tags").(map[string]interface{})),
 	}
 
 	log.Printf("[DEBUG] Creating App Mesh route: %#v", req)
@@ -233,6 +236,16 @@ func resourceAwsAppmeshRouteRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("error setting spec: %s", err)
 	}
 
+	err = saveTagsAppmesh(conn, d, aws.StringValue(resp.Route.Metadata.Arn))
+	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] App Mesh route (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error saving tags: %s", err)
+	}
+
 	return nil
 }
 
@@ -253,6 +266,16 @@ func resourceAwsAppmeshRouteUpdate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("error updating App Mesh route: %s", err)
 		}
+	}
+
+	err := setTagsAppmesh(conn, d, d.Get("arn").(string))
+	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] App Mesh route (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return resourceAwsAppmeshRouteRead(d, meta)

--- a/aws/resource_aws_appmesh_test.go
+++ b/aws/resource_aws_appmesh_test.go
@@ -14,6 +14,7 @@ func TestAccAWSAppmesh(t *testing.T) {
 		"Route": {
 			"httpRoute": testAccAwsAppmeshRoute_httpRoute,
 			"tcpRoute":  testAccAwsAppmeshRoute_tcpRoute,
+			"tags":      testAccAwsAppmeshRoute_tags,
 		},
 		"VirtualNode": {
 			"basic":                testAccAwsAppmeshVirtualNode_basic,

--- a/website/docs/r/appmesh_route.html.markdown
+++ b/website/docs/r/appmesh_route.html.markdown
@@ -71,6 +71,7 @@ The following arguments are supported:
 * `mesh_name` - (Required) The name of the service mesh in which to create the route.
 * `virtual_router_name` - (Required) The name of the virtual router in which to create the route.
 * `spec` - (Required) The route specification to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `spec` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8101

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:
- resource/aws_appmesh_route: Add `tags` argument.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh/Route'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppmesh/Route -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/Route
=== RUN   TestAccAWSAppmesh/Route/httpRoute
=== RUN   TestAccAWSAppmesh/Route/tcpRoute
=== RUN   TestAccAWSAppmesh/Route/tags
=== RUN   TestAccAWSAppmesh/VirtualRouter
=== RUN   TestAccAWSAppmesh/VirtualRouter/basic
--- PASS: TestAccAWSAppmesh (234.94s)
    --- PASS: TestAccAWSAppmesh/Route (187.98s)
        --- PASS: TestAccAWSAppmesh/Route/httpRoute (56.43s)
        --- PASS: TestAccAWSAppmesh/Route/tcpRoute (54.72s)
        --- PASS: TestAccAWSAppmesh/Route/tags (76.82s)
    --- PASS: TestAccAWSAppmesh/VirtualRouter (46.97s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/basic (46.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	235.057s
```
