### PR TITLE
Add support tags attribute for aws_appmesh_virtual_node resource

### DIFF
--- a/aws/resource_aws_appmesh_test.go
+++ b/aws/resource_aws_appmesh_test.go
@@ -19,6 +19,7 @@ func TestAccAWSAppmesh(t *testing.T) {
 			"basic":                testAccAwsAppmeshVirtualNode_basic,
 			"listenerHealthChecks": testAccAwsAppmeshVirtualNode_listenerHealthChecks,
 			"logging":              testAccAwsAppmeshVirtualNode_logging,
+			"tags":                 testAccAwsAppmeshVirtualNode_tags,
 		},
 		"VirtualRouter": {
 			"basic": testAccAwsAppmeshVirtualRouter_basic,

--- a/aws/resource_aws_appmesh_virtual_node_test.go
+++ b/aws/resource_aws_appmesh_virtual_node_test.go
@@ -179,6 +179,59 @@ func testAccAwsAppmeshVirtualNode_logging(t *testing.T) {
 	})
 }
 
+func testAccAwsAppmeshVirtualNode_tags(t *testing.T) {
+	var vn appmesh.VirtualNodeData
+	resourceName := "aws_appmesh_virtual_node.foo"
+	meshName := fmt.Sprintf("tf-test-mesh-%d", acctest.RandInt())
+	vnName := fmt.Sprintf("tf-test-node-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAppmeshVirtualNodeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, "foo", "bar", "good", "bad"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.good", "bad"),
+				),
+			},
+			{
+				Config: testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, "foo2", "bar", "good", "bad2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.foo2", "bar"),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.good", "bad2"),
+				),
+			},
+			{
+				Config: testAccAppmeshVirtualNodeConfig_basic(meshName, vnName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppmeshVirtualNodeExists(resourceName, &vn),
+					resource.TestCheckResourceAttr(
+						resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateId:     fmt.Sprintf("%s/%s", meshName, vnName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAppmeshVirtualNodeDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).appmeshconn
 
@@ -376,4 +429,24 @@ resource "aws_appmesh_virtual_node" "foo" {
   }
 }
 `, meshName, vnName, path)
+}
+
+func testAccAppmeshVirtualNodeConfig_tags(meshName, vnName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_appmesh_mesh" "foo" {
+  name = %[1]q
+}
+
+resource "aws_appmesh_virtual_node" "foo" {
+  name      = %[2]q
+  mesh_name = "${aws_appmesh_mesh.foo.id}"
+
+  spec {}
+
+  tags = {
+	  %[3]s = %[4]q
+	  %[5]s = %[6]q
+  }
+}
+`, meshName, vnName, tagKey1, tagValue1, tagKey2, tagValue2)
 }

--- a/website/docs/r/appmesh_virtual_node.html.markdown
+++ b/website/docs/r/appmesh_virtual_node.html.markdown
@@ -137,6 +137,7 @@ The following arguments are supported:
 * `name` - (Required) The name to use for the virtual node.
 * `mesh_name` - (Required) The name of the service mesh in which to create the virtual node.
 * `spec` - (Required) The virtual node specification to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `spec` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8101

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:
- resource/aws_appmesh_virtual_node: Add `tags` argument.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh/VirtualNode'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppmesh/VirtualNode -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/VirtualNode
=== RUN   TestAccAWSAppmesh/VirtualNode/basic
=== RUN   TestAccAWSAppmesh/VirtualNode/listenerHealthChecks
=== RUN   TestAccAWSAppmesh/VirtualNode/logging
=== RUN   TestAccAWSAppmesh/VirtualNode/tags
--- PASS: TestAccAWSAppmesh (204.58s)
    --- PASS: TestAccAWSAppmesh/VirtualNode (204.58s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/basic (32.18s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/listenerHealthChecks (49.15s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/logging (51.81s)
        --- PASS: TestAccAWSAppmesh/VirtualNode/tags (71.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	204.669s
```
