### PR TITLE
tests/resource/aws_subnet: Add aws_msk_cluster to test sweeper dependencies

### DIFF
--- a/aws/resource_aws_subnet_test.go
+++ b/aws/resource_aws_subnet_test.go
@@ -36,6 +36,7 @@ func init() {
 			"aws_lambda_function",
 			"aws_lb",
 			"aws_mq_broker",
+			"aws_msk_cluster",
 			"aws_network_interface",
 			"aws_redshift_cluster",
 			"aws_route53_resolver_endpoint",


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

To help prevent:

```
[19:01:16][Step 2/5] 2019/07/02 19:01:16 [ERR] error running (aws_internet_gateway): Error deleting Subnet (subnet-04ce94125fcb69849): DependencyViolation: The subnet 'subnet-04ce94125fcb69849' has dependencies and cannot be deleted.
[19:01:16][Step 2/5] 	status code: 400, request id: 547657de-8b91-4088-8dd0-24889d868449
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing: Omitting due to trivial change
