### PR TITLE
tests/resource/aws_rds_cluster: Various refactoring to allow the testing to be more region/partition agnostic

### DIFF
--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -761,7 +761,7 @@ func TestAccAWSRDSCluster_EngineMode_Global(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
@@ -886,7 +886,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
@@ -920,7 +920,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Add(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
@@ -947,7 +947,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{
@@ -978,7 +978,7 @@ func TestAccAWSRDSCluster_GlobalClusterIdentifier_Update(t *testing.T) {
 	resourceName := "aws_rds_cluster.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSRdsGlobalCluster(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSClusterDestroy,
 		Steps: []resource.TestStep{

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -499,8 +499,9 @@ func TestAccAWSRDSCluster_updateIamRoles(t *testing.T) {
 }
 
 func TestAccAWSRDSCluster_kmsKey(t *testing.T) {
-	var v rds.DBCluster
-	keyRegex := regexp.MustCompile("^arn:aws:kms:")
+	var dbCluster1 rds.DBCluster
+	kmsKeyResourceName := "aws_kms_key.foo"
+	resourceName := "aws_rds_cluster.default"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -510,9 +511,8 @@ func TestAccAWSRDSCluster_kmsKey(t *testing.T) {
 			{
 				Config: testAccAWSClusterConfig_kmsKey(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSClusterExists("aws_rds_cluster.default", &v),
-					resource.TestMatchResourceAttr(
-						"aws_rds_cluster.default", "kms_key_id", keyRegex),
+					testAccCheckAWSClusterExists(resourceName, &dbCluster1),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
 				),
 			},
 		},
@@ -1519,9 +1519,8 @@ func TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore(t *testing.T) {
 	var dbCluster, sourceDbCluster rds.DBCluster
 	var dbClusterSnapshot rds.DBClusterSnapshot
 
-	keyRegex := regexp.MustCompile("^arn:aws:kms:")
-
 	rName := acctest.RandomWithPrefix("tf-acc-test")
+	kmsKeyResourceName := "aws_kms_key.test"
 	sourceDbResourceName := "aws_rds_cluster.source"
 	snapshotResourceName := "aws_db_cluster_snapshot.test"
 	resourceName := "aws_rds_cluster.test"
@@ -1537,10 +1536,8 @@ func TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore(t *testing.T) {
 					testAccCheckAWSClusterExists(sourceDbResourceName, &sourceDbCluster),
 					testAccCheckDbClusterSnapshotExists(snapshotResourceName, &dbClusterSnapshot),
 					testAccCheckAWSClusterExists(resourceName, &dbCluster),
-					resource.TestMatchResourceAttr(
-						"aws_rds_cluster.test", "kms_key_id", keyRegex),
-					resource.TestCheckResourceAttr(
-						"aws_rds_cluster.test", "storage_encrypted", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_id", kmsKeyResourceName, "arn"),
+					resource.TestCheckResourceAttr(resourceName, "storage_encrypted", "true"),
 				),
 			},
 		},

--- a/aws/resource_aws_rds_cluster_test.go
+++ b/aws/resource_aws_rds_cluster_test.go
@@ -154,7 +154,7 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "engine_version"),
 					resource.TestCheckResourceAttr(resourceName, "global_cluster_identifier", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "hosted_zone_id"),
-					resource.TestCheckResourceAttr(resourceName,"enabled_cloudwatch_logs_exports.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Each commit outlines a separate refactoring step with relevant acceptance testing outputs. This work was mainly for driving down the AWS GovCloud (US) test failures as seen here:

Originally:

```
Tests failed: 30, passed: 11, ignored: 1
```

Now:

```
Tests failed: 14, passed: 24, ignored: 6
```

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial (test failures present on `master`):

```
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (7.77s)
--- PASS: TestAccAWSRDSCluster_iamAuth (134.73s)
--- PASS: TestAccAWSRDSCluster_basic (135.34s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (136.27s)
--- PASS: TestAccAWSRDSCluster_updateIamRoles (139.61s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (142.94s)
--- PASS: TestAccAWSRDSCluster_importBasic (145.09s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (145.19s)
--- PASS: TestAccAWSRDSCluster_kmsKey (154.41s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (158.68s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (158.73s)
--- PASS: TestAccAWSRDSCluster_generatedName (165.26s)
--- PASS: TestAccAWSRDSCluster_BacktrackWindow (180.12s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (180.30s)
--- PASS: TestAccAWSRDSCluster_Tags (184.76s)
--- PASS: TestAccAWSRDSCluster_encrypted (193.85s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
--- PASS: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (206.34s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (233.92s)
--- PASS: TestAccAWSRDSCluster_EngineMode_ParallelQuery (99.26s)
--- PASS: TestAccAWSRDSCluster_EngineMode_Global (99.89s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier (113.27s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove (121.59s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Update (115.54s)
--- PASS: TestAccAWSRDSCluster_EngineVersion (140.49s)
--- PASS: TestAccAWSRDSCluster_GlobalClusterIdentifier_Add (132.87s)
--- FAIL: TestAccAWSRDSCluster_EngineMode (310.58s)
--- PASS: TestAccAWSRDSCluster_Port (284.99s)
--- PASS: TestAccAWSRDSCluster_ScalingConfiguration (328.00s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (345.62s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (352.60s)
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (303.10s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (357.35s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (366.90s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (347.08s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (350.03s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (358.58s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (406.72s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (467.89s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (408.47s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (497.75s)
--- PASS: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (1135.56s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (1496.53s)
--- PASS: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1502.94s)
```

Output from acceptance testing in AWS GovCloud (US) (remaining test failures will require complex `PreCheck` implementations to bypass various RDS Cluster functionality missing in this partition, skipping for now):

```
--- FAIL: TestAccAWSRDSCluster_BacktrackWindow (5.56s)
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (5.98s)
--- FAIL: TestAccAWSRDSCluster_EnabledCloudwatchLogsExports (6.23s)
--- FAIL: TestAccAWSRDSCluster_EncryptedCrossRegionReplication (1.85s)
--- FAIL: TestAccAWSRDSCluster_s3Restore (8.10s)
--- FAIL: TestAccAWSRDSCluster_iamAuth (1.37s)
--- FAIL: TestAccAWSRDSCluster_EngineMode (0.59s)
--- SKIP: TestAccAWSRDSCluster_EngineMode_Global (0.14s)
--- FAIL: TestAccAWSRDSCluster_EngineMode_ParallelQuery (0.58s)
--- FAIL: TestAccAWSRDSCluster_EngineVersion (0.84s)
--- FAIL: TestAccAWSRDSCluster_EngineVersionWithPrimaryInstance (0.85s)
--- SKIP: TestAccAWSRDSCluster_GlobalClusterIdentifier (0.13s)
--- SKIP: TestAccAWSRDSCluster_GlobalClusterIdentifier_Add (0.13s)
--- SKIP: TestAccAWSRDSCluster_GlobalClusterIdentifier_Remove (0.13s)
--- SKIP: TestAccAWSRDSCluster_GlobalClusterIdentifier_Update (0.14s)
--- PASS: TestAccAWSRDSCluster_generatedName (118.27s)
--- PASS: TestAccAWSRDSCluster_importBasic (118.71s)
--- FAIL: TestAccAWSRDSCluster_ScalingConfiguration (0.94s)
--- PASS: TestAccAWSRDSCluster_DbSubnetGroupName (120.37s)
--- PASS: TestAccAWSRDSCluster_Tags (120.72s)
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_ParallelQuery (0.96s)
--- SKIP: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Serverless (0.00s)
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Different (1.44s)
--- FAIL: TestAccAWSRDSCluster_SnapshotIdentifier_EngineVersion_Equal (0.67s)
--- PASS: TestAccAWSRDSCluster_basic (138.00s)
--- PASS: TestAccAWSRDSCluster_ClusterIdentifierPrefix (138.35s)
--- PASS: TestAccAWSRDSCluster_AvailabilityZones (139.57s)
--- PASS: TestAccAWSRDSCluster_encrypted (147.11s)
--- PASS: TestAccAWSRDSCluster_kmsKey (158.11s)
--- FAIL: TestAccAWSRDSCluster_updateIamRoles (161.00s)
--- PASS: TestAccAWSRDSCluster_backupsUpdate (176.90s)
--- PASS: TestAccAWSRDSCluster_DeletionProtection (175.31s)
--- PASS: TestAccAWSRDSCluster_takeFinalSnapshot (198.58s)
--- PASS: TestAccAWSRDSCluster_copyTagsToSnapshot (217.99s)
--- PASS: TestAccAWSRDSCluster_Port (254.88s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredBackupWindow (339.04s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EngineMode_Provisioned (350.28s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier (409.73s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_PreferredMaintenanceWindow (430.27s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_DeletionProtection (451.31s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds_Tags (440.80s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_VpcSecurityGroupIds (460.43s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_Tags (470.02s)
--- PASS: TestAccAWSRDSCluster_SnapshotIdentifier_EncryptedRestore (551.61s)
```