### PR TITLE
add support for tags for codecommit repository

### DIFF
--- a/aws/resource_aws_codecommit_repository.go
+++ b/aws/resource_aws_codecommit_repository.go
@@ -58,6 +58,7 @@ func resourceAwsCodeCommitRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -68,6 +69,7 @@ func resourceAwsCodeCommitRepositoryCreate(d *schema.ResourceData, meta interfac
 	input := &codecommit.CreateRepositoryInput{
 		RepositoryName:        aws.String(d.Get("repository_name").(string)),
 		RepositoryDescription: aws.String(d.Get("description").(string)),
+		Tags:                  tagsFromMapCodeCommit(d.Get("tags").(map[string]interface{})),
 	}
 
 	out, err := conn.CreateRepository(input)
@@ -101,6 +103,11 @@ func resourceAwsCodeCommitRepositoryUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
+	if !d.IsNewResource() {
+		if err := setTagsCodeCommit(conn, d); err != nil {
+			return fmt.Errorf("error updating CodeCommit Repository tags for %s: %s", d.Id(), err)
+		}
+	}
 	return resourceAwsCodeCommitRepositoryRead(d, meta)
 }
 
@@ -133,6 +140,17 @@ func resourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interface{
 		if out.RepositoryMetadata.DefaultBranch != nil {
 			d.Set("default_branch", out.RepositoryMetadata.DefaultBranch)
 		}
+	}
+
+	// List tags
+	tagList, err := conn.ListTagsForResource(&codecommit.ListTagsForResourceInput{
+		ResourceArn: out.RepositoryMetadata.Arn,
+	})
+	if err != nil {
+		return fmt.Errorf("error listing CodeCommit Repository tags for %s: %s", d.Id(), err)
+	}
+	if err := d.Set("tags", tagsToMapCodeCommit(tagList.Tags)); err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return nil

--- a/aws/resource_aws_codecommit_repository_test.go
+++ b/aws/resource_aws_codecommit_repository_test.go
@@ -123,6 +123,45 @@ func TestAccAWSCodeCommitRepository_create_and_update_default_branch(t *testing.
 	})
 }
 
+func TestAccAWSCodeCommitRepository_tags(t *testing.T) {
+
+	rName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_codecommit_repository.test_repository",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckCodeCommitRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeCommitRepositoryConfigTags1(rName, "key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test_repository"),
+					resource.TestCheckResourceAttr("aws_codecommit_repository.test_repository", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_codecommit_repository.test_repository", "tags.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccAWSCodeCommitRepositoryConfigTags2(rName, "key1", "value1updated", "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test_repository"),
+					resource.TestCheckResourceAttr("aws_codecommit_repository.test_repository", "tags.%", "2"),
+					resource.TestCheckResourceAttr("aws_codecommit_repository.test_repository", "tags.key1", "value1updated"),
+					resource.TestCheckResourceAttr("aws_codecommit_repository.test_repository", "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccAWSCodeCommitRepositoryConfigTags1(rName, "key2", "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test_repository"),
+					resource.TestCheckResourceAttr("aws_codecommit_repository.test_repository", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_codecommit_repository.test_repository", "tags.key2", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCodeCommitRepositoryExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -206,4 +245,25 @@ resource "aws_codecommit_repository" "test" {
   default_branch  = "master"
 }
 `, rInt)
+}
+
+func testAccAWSCodeCommitRepositoryConfigTags1(r, tag1Key, tag1Value string) string {
+	return fmt.Sprintf(`
+resource "aws_codecommit_repository" "test_repository" {
+	repository_name = "terraform-test-%s"
+	tags = {
+		%q = %q
+	}
+	}`, r, tag1Key, tag1Value)
+}
+
+func testAccAWSCodeCommitRepositoryConfigTags2(r, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return fmt.Sprintf(`
+resource "aws_codecommit_repository" "test_repository" {
+	repository_name = "terraform-test-%s"
+	tags = {
+		%q = %q
+		%q = %q
+	  }
+	}`, r, tag1Key, tag1Value, tag2Key, tag2Value)
 }

--- a/aws/tagsCodeCommit.go
+++ b/aws/tagsCodeCommit.go
@@ -71,7 +71,7 @@ func diffTagsCodeCommit(oldTags, newTags map[string]*string) (map[string]*string
 func tagsFromMapCodeCommit(m map[string]interface{}) map[string]*string {
 	result := make(map[string]*string)
 	for k, v := range m {
-		if !tagIgnoredMskCluster(k, v.(string)) {
+		if !tagIgnoredCodeCommit(k, v.(string)) {
 			result[k] = aws.String(v.(string))
 		}
 	}
@@ -83,7 +83,7 @@ func tagsFromMapCodeCommit(m map[string]interface{}) map[string]*string {
 func tagsToMapCodeCommit(ts map[string]*string) map[string]string {
 	result := make(map[string]string)
 	for k, v := range ts {
-		if !tagIgnoredMskCluster(k, aws.StringValue(v)) {
+		if !tagIgnoredCodeCommit(k, aws.StringValue(v)) {
 			result[k] = aws.StringValue(v)
 		}
 	}

--- a/aws/tagsCodeCommit.go
+++ b/aws/tagsCodeCommit.go
@@ -1,0 +1,107 @@
+package aws
+
+import (
+	"log"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/codecommit"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// setTags is a helper to set the tags for a resource. It expects the
+// tags field to be named "tags"
+func setTagsCodeCommit(conn *codecommit.CodeCommit, d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		oraw, nraw := d.GetChange("tags")
+		o := oraw.(map[string]interface{})
+		n := nraw.(map[string]interface{})
+		create, remove := diffTagsCodeCommit(tagsFromMapCodeCommit(o), tagsFromMapCodeCommit(n))
+
+		// Set tags
+		if len(remove) > 0 {
+			log.Printf("[DEBUG] Removing tags: %#v", remove)
+			keys := make([]*string, 0, len(remove))
+			for k := range remove {
+				keys = append(keys, aws.String(k))
+			}
+
+			_, err := conn.UntagResource(&codecommit.UntagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				TagKeys:     keys,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		if len(create) > 0 {
+			log.Printf("[DEBUG] Creating tags: %#v", create)
+			_, err := conn.TagResource(&codecommit.TagResourceInput{
+				ResourceArn: aws.String(d.Get("arn").(string)),
+				Tags:        create,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// diffTags takes our tags locally and the ones remotely and returns
+// the set of tags that must be created, and the set of tags that must
+// be destroyed.
+func diffTagsCodeCommit(oldTags, newTags map[string]*string) (map[string]*string, map[string]*string) {
+	// Build the list of what to remove
+	remove := make(map[string]*string)
+	for k, v := range oldTags {
+		newVal, existsInNew := newTags[k]
+		if !existsInNew || *newVal != *v {
+			// Delete it!
+			remove[k] = v
+		} else if existsInNew {
+			delete(newTags, k)
+		}
+	}
+	return newTags, remove
+}
+
+// tagsFromMap returns the tags for the given map of data.
+func tagsFromMapCodeCommit(m map[string]interface{}) map[string]*string {
+	result := make(map[string]*string)
+	for k, v := range m {
+		if !tagIgnoredMskCluster(k, v.(string)) {
+			result[k] = aws.String(v.(string))
+		}
+	}
+
+	return result
+}
+
+// tagsToMap turns the list of tags into a map.
+func tagsToMapCodeCommit(ts map[string]*string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range ts {
+		if !tagIgnoredMskCluster(k, aws.StringValue(v)) {
+			result[k] = aws.StringValue(v)
+		}
+	}
+
+	return result
+}
+
+// compare a tag against a list of strings and checks if it should
+// be ignored or not
+func tagIgnoredCodeCommit(key, value string) bool {
+	filter := []string{"^aws:"}
+	for _, ignore := range filter {
+		log.Printf("[DEBUG] Matching %v with %v\n", ignore, key)
+		r, _ := regexp.MatchString(ignore, key)
+		if r {
+			log.Printf("[DEBUG] Found AWS specific tag %s (val %s), ignoring.\n", key, value)
+			return true
+		}
+	}
+	return false
+}

--- a/aws/tagsCodeCommit_test.go
+++ b/aws/tagsCodeCommit_test.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+)
+
+// go test -v -run="TestDiffCodeCommitTags"
+func TestDiffCodeCommitTags(t *testing.T) {
+	cases := []struct {
+		Old, New       map[string]interface{}
+		Create, Remove map[string]string
+	}{
+		// Basic add/remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"bar": "baz",
+			},
+			Create: map[string]string{
+				"bar": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Modify
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+			},
+			New: map[string]interface{}{
+				"foo": "baz",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Overlap
+		{
+			Old: map[string]interface{}{
+				"foo":   "bar",
+				"hello": "world",
+			},
+			New: map[string]interface{}{
+				"foo":   "baz",
+				"hello": "world",
+			},
+			Create: map[string]string{
+				"foo": "baz",
+			},
+			Remove: map[string]string{
+				"foo": "bar",
+			},
+		},
+
+		// Remove
+		{
+			Old: map[string]interface{}{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			New: map[string]interface{}{
+				"foo": "bar",
+			},
+			Create: map[string]string{},
+			Remove: map[string]string{
+				"bar": "baz",
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		c, r := diffTagsCodeCommit(tagsFromMapCodeCommit(tc.Old), tagsFromMapCodeCommit(tc.New))
+		cm := tagsToMapCodeCommit(c)
+		rm := tagsToMapCodeCommit(r)
+		if !reflect.DeepEqual(cm, tc.Create) {
+			t.Fatalf("%d: bad create: %#v", i, cm)
+		}
+		if !reflect.DeepEqual(rm, tc.Remove) {
+			t.Fatalf("%d: bad remove: %#v", i, rm)
+		}
+	}
+}
+
+// go test -v -run="TestIgnoringTagsCodeCommit"
+func TestIgnoringTagsCodeCommit(t *testing.T) {
+	ignoredTags := map[string]string{
+		"aws:cloudformation:logical-id": "foo",
+		"aws:foo:bar":                   "baz",
+	}
+	for k, v := range ignoredTags {
+		if !tagIgnoredCodeCommit(k, v) {
+			t.Fatalf("Tag %v with value %v not ignored, but should be!", k, v)
+		}
+	}
+}

--- a/website/docs/r/codecommit_repository.html.markdown
+++ b/website/docs/r/codecommit_repository.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 * `repository_name` - (Required) The name for the repository. This needs to be less than 100 characters.
 * `description` - (Optional) The description of the repository. This needs to be less than 1000 characters
 * `default_branch` - (Optional) The default branch of the repository. The branch specified here needs to exist.
+* `tags` - (Optional) Key-value mapping of resource tags
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8817

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```Support for tags added for codecommit repository```

Output from acceptance testing:

```
$ make testacc TEST=./aws/ TESTARGS='-run=TestAccAWSCodeCommitRepository_tags' 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws/ -v -parallel 20 -run=TestAccAWSCodeCommitRepository_tags -timeout 120m
=== RUN   TestAccAWSCodeCommitRepository_tags
=== PAUSE TestAccAWSCodeCommitRepository_tags
=== CONT  TestAccAWSCodeCommitRepository_tags
--- PASS: TestAccAWSCodeCommitRepository_tags (66.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       66.695s
```
