### PR TITLE
tests/resource/aws_db_subnet_group: Use aws_availability_zones data source to make testing region agnostic

### DIFF
--- a/aws/resource_aws_db_subnet_group_test.go
+++ b/aws/resource_aws_db_subnet_group_test.go
@@ -284,6 +284,10 @@ func testAccCheckDBSubnetGroupExists(n string, v *rds.DBSubnetGroup) resource.Te
 
 func testAccDBSubnetGroupConfig(rName string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -294,7 +298,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   vpc_id            = "${aws_vpc.foo.id}"
 
   tags = {
@@ -304,7 +308,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   vpc_id            = "${aws_vpc.foo.id}"
 
   tags = {
@@ -325,6 +329,10 @@ resource "aws_db_subnet_group" "foo" {
 
 func testAccDBSubnetGroupConfig_updatedDescription(rName string) string {
 	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
 
@@ -335,7 +343,7 @@ resource "aws_vpc" "foo" {
 
 resource "aws_subnet" "foo" {
   cidr_block        = "10.1.1.0/24"
-  availability_zone = "us-west-2a"
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
   vpc_id            = "${aws_vpc.foo.id}"
 
   tags = {
@@ -345,7 +353,7 @@ resource "aws_subnet" "foo" {
 
 resource "aws_subnet" "bar" {
   cidr_block        = "10.1.2.0/24"
-  availability_zone = "us-west-2b"
+  availability_zone = "${data.aws_availability_zones.available.names[1]}"
   vpc_id            = "${aws_vpc.foo.id}"
 
   tags = {
@@ -366,6 +374,10 @@ resource "aws_db_subnet_group" "foo" {
 }
 
 const testAccDBSubnetGroupConfig_namePrefix = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
@@ -376,7 +388,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "us-west-2a"
+	availability_zone = "${data.aws_availability_zones.available.names[0]}"
 	tags = {
 		Name = "tf-acc-db-subnet-group-name-prefix-a"
 	}
@@ -385,7 +397,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
-	availability_zone = "us-west-2b"
+	availability_zone = "${data.aws_availability_zones.available.names[1]}"
 	tags = {
 		Name = "tf-acc-db-subnet-group-name-prefix-b"
 	}
@@ -397,6 +409,10 @@ resource "aws_db_subnet_group" "test" {
 }`
 
 const testAccDBSubnetGroupConfig_generatedName = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "test" {
 	cidr_block = "10.1.0.0/16"
 	tags = {
@@ -407,7 +423,7 @@ resource "aws_vpc" "test" {
 resource "aws_subnet" "a" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.1.0/24"
-	availability_zone = "us-west-2a"
+	availability_zone = "${data.aws_availability_zones.available.names[0]}"
 	tags = {
 		Name = "tf-acc-db-subnet-group-generated-name-a"
 	}
@@ -416,7 +432,7 @@ resource "aws_subnet" "a" {
 resource "aws_subnet" "b" {
 	vpc_id = "${aws_vpc.test.id}"
 	cidr_block = "10.1.2.0/24"
-	availability_zone = "us-west-2b"
+	availability_zone = "${data.aws_availability_zones.available.names[1]}"
 	tags = {
 		Name = "tf-acc-db-subnet-group-generated-name-a"
 	}
@@ -427,6 +443,10 @@ resource "aws_db_subnet_group" "test" {
 }`
 
 const testAccDBSubnetGroupConfig_withUnderscoresAndPeriodsAndSpaces = `
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 resource "aws_vpc" "main" {
     cidr_block = "192.168.0.0/16"
 	tags = {
@@ -436,7 +456,7 @@ resource "aws_vpc" "main" {
 
 resource "aws_subnet" "frontend" {
     vpc_id = "${aws_vpc.main.id}"
-    availability_zone = "us-west-2b"
+    availability_zone = "${data.aws_availability_zones.available.names[0]}"
     cidr_block = "192.168.1.0/24"
   tags = {
         Name = "tf-acc-db-subnet-group-w-underscores-etc-front"
@@ -445,7 +465,7 @@ resource "aws_subnet" "frontend" {
 
 resource "aws_subnet" "backend" {
     vpc_id = "${aws_vpc.main.id}"
-    availability_zone = "us-west-2c"
+    availability_zone = "${data.aws_availability_zones.available.names[1]}"
     cidr_block = "192.168.2.0/24"
   tags = {
         Name = "tf-acc-db-subnet-group-w-underscores-etc-back"


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing in AWS Commercial:

```
--- PASS: TestAccAWSDBSubnetGroup_namePrefix (30.36s)
--- PASS: TestAccAWSDBSubnetGroup_generatedName (30.56s)
--- PASS: TestAccAWSDBSubnetGroup_basic (30.60s)
--- PASS: TestAccAWSDBSubnetGroup_importBasic (30.82s)
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (32.38s)
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (48.99s)
```

Output from acceptance testing in AWS GovCloud (US):

```
--- PASS: TestAccAWSDBSubnetGroup_basic (33.86s)
--- PASS: TestAccAWSDBSubnetGroup_namePrefix (34.13s)
--- PASS: TestAccAWSDBSubnetGroup_generatedName (34.13s)
--- PASS: TestAccAWSDBSubnetGroup_importBasic (34.71s)
--- PASS: TestAccAWSDBSubnetGroup_withUndocumentedCharacters (36.21s)
--- PASS: TestAccAWSDBSubnetGroup_updateDescription (55.57s)
```
