### PR TITLE
Add support to import terraform aws_iam_group_policy resources

### DIFF
--- a/aws/resource_aws_iam_group_policy.go
+++ b/aws/resource_aws_iam_group_policy.go
@@ -118,12 +118,18 @@ func resourceAwsIamGroupPolicyRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if err := d.Set("policy", policy); err != nil {
-		return err
+		return fmt.Errorf("error setting policy: %s", err)
 	}
+
 	if err := d.Set("name", name); err != nil {
-		return err
+		return fmt.Errorf("error setting name: %s", err)
 	}
-	return d.Set("group", group)
+
+	if err := d.Set("group", group); err != nil {
+		return fmt.Errorf("error setting group: %s", err)
+	}
+
+	return nil
 }
 
 func resourceAwsIamGroupPolicyDelete(d *schema.ResourceData, meta interface{}) error {
@@ -150,7 +156,7 @@ func resourceAwsIamGroupPolicyDelete(d *schema.ResourceData, meta interface{}) e
 
 func resourceAwsIamGroupPolicyParseId(id string) (groupName, policyName string, err error) {
 	parts := strings.SplitN(id, ":", 2)
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		err = fmt.Errorf("group_policy id must be of the form <group name>:<policy name>")
 		return
 	}

--- a/aws/resource_aws_iam_group_policy.go
+++ b/aws/resource_aws_iam_group_policy.go
@@ -62,13 +62,7 @@ func resourceAwsIamGroupPolicyPut(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	var policyName string
-	var err error
-	if !d.IsNewResource() {
-		_, policyName, err = resourceAwsIamGroupPolicyParseId(d.Id())
-		if err != nil {
-			return err
-		}
-	} else if v, ok := d.GetOk("name"); ok {
+	if v, ok := d.GetOk("name"); ok {
 		policyName = v.(string)
 	} else if v, ok := d.GetOk("name_prefix"); ok {
 		policyName = resource.PrefixedUniqueId(v.(string))

--- a/aws/resource_aws_iam_group_policy_test.go
+++ b/aws/resource_aws_iam_group_policy_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -181,9 +180,9 @@ func testAccCheckIAMGroupPolicyDestroy(s *terraform.State) error {
 
 		getResp, err := conn.GetGroupPolicy(request)
 		if err != nil {
-			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+			if isAWSErr(err, iam.ErrCodeNoSuchEntityException, "") {
 				// none found, that's good
-				return nil
+				continue
 			}
 			return fmt.Errorf("Error reading IAM policy %s from group %s: %s", name, group, err)
 		}

--- a/aws/resource_aws_iam_group_policy_test.go
+++ b/aws/resource_aws_iam_group_policy_test.go
@@ -31,6 +31,11 @@ func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "aws_iam_group_policy.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccIAMGroupPolicyConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicyExists(
@@ -40,6 +45,11 @@ func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
 					),
 					testAccCheckAWSIAMGroupPolicyNameChanged(&groupPolicy1, &groupPolicy2),
 				),
+			},
+			{
+				ResourceName:      "aws_iam_group_policy.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -100,6 +110,11 @@ func TestAccAWSIAMGroupPolicy_namePrefix(t *testing.T) {
 					testAccCheckAWSIAMGroupPolicyNameMatches(&groupPolicy1, &groupPolicy2),
 				),
 			},
+			{
+				ResourceName:      "aws_iam_group_policy.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -134,25 +149,8 @@ func TestAccAWSIAMGroupPolicy_generatedName(t *testing.T) {
 					testAccCheckAWSIAMGroupPolicyNameMatches(&groupPolicy1, &groupPolicy2),
 				),
 			},
-		},
-	})
-}
-
-func TestAccAWSIAMGroupPolicy_importBasic(t *testing.T) {
-	suffix := randomString(10)
-	resourceName := fmt.Sprintf("aws_iam_group_policy.foo_%s", suffix)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
-		Steps: []resource.TestStep{
 			{
-				Config: testAccAwsIamGroupPolicyConfig(suffix),
-			},
-
-			{
-				ResourceName:      resourceName,
+				ResourceName:      "aws_iam_group_policy.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -362,27 +360,4 @@ resource "aws_iam_group_policy" "bar" {
   policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
 }
 `, rInt, rInt, rInt)
-}
-
-func testAccAwsIamGroupPolicyConfig(suffix string) string {
-	return fmt.Sprintf(`
-resource "aws_iam_group" "group_%[1]s" {
-	name = "tf_test_group_test_%[1]s"
-	path = "/"
-}
-resource "aws_iam_group_policy" "foo_%[1]s" {
-	name = "tf_test_policy_test_%[1]s"
-	group = "${aws_iam_group.group_%[1]s.name}"
-	policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
-}
-EOF
-}
-`, suffix)
 }

--- a/website/docs/r/iam_group_policy.html.markdown
+++ b/website/docs/r/iam_group_policy.html.markdown
@@ -56,3 +56,11 @@ assign a random, unique name.
 * `group` - The group to which this policy applies.
 * `name` - The name of the policy.
 * `policy` - The policy document attached to the group.
+
+## Import
+
+IAM Group Policies can be imported using the `group_name:group_policy_name`, e.g.
+
+```
+$ terraform import aws_iam_group_policy.mypolicy group_of_mypolicy_name:mypolicy_name
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #8788 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_iam_group_policy: Support resource import
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSIAMGroupPolicy_importBasic'
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSIAMGroupPolicy_importBasic
--- PASS: TestAccAWSIAMGroupPolicy_importBasic (30.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       30.845s
...
```
