### PR TITLE
Issue-9211 Doc example update of resource name

### DIFF
--- a/website/docs/r/api_gateway_integration_response.html.markdown
+++ b/website/docs/r/api_gateway_integration_response.html.markdown
@@ -41,7 +41,7 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   type        = "MOCK"
 }
 
-resource "aws_api_gateway_method_response" "200" {
+resource "aws_api_gateway_method_response" "response_200" {
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
   http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
@@ -52,7 +52,7 @@ resource "aws_api_gateway_integration_response" "MyDemoIntegrationResponse" {
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
   http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
-  status_code = "${aws_api_gateway_method_response.200.status_code}"
+  status_code = "${aws_api_gateway_method_response.response_200.status_code}"
 
   # Transforms the backend JSON response to XML
   response_templates {

--- a/website/docs/r/api_gateway_method_response.html.markdown
+++ b/website/docs/r/api_gateway_method_response.html.markdown
@@ -38,7 +38,7 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   type        = "MOCK"
 }
 
-resource "aws_api_gateway_method_response" "200" {
+resource "aws_api_gateway_method_response" "response_200" {
   rest_api_id = "${aws_api_gateway_rest_api.MyDemoAPI.id}"
   resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
   http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"


### PR DESCRIPTION
The api_gateway_integration_response example uses the resource name
"200", which is no longer allowed by the stricter enforcement of
resource names by terraform, which reports:
A name must start with a letter and may contain only letters, digits,
underscores, and dashes.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9211 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):

```release-note
Update example api_gateway_method_response resource name due to stricter terraform naming conventions.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
  <snip>
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	0.073s [no tests to run]
...
```
