### PR TITLE
fix: appsync_resolver resource names

### DIFF
--- a/website/docs/r/appsync_resolver.html.markdown
+++ b/website/docs/r/appsync_resolver.html.markdown
@@ -15,7 +15,7 @@ Provides an AppSync Resolver.
 ```hcl
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = "API_KEY"
-  name                = "tf-example"
+  name                = "tf_example"
 
   schema = <<EOF
 type Mutation {
@@ -40,7 +40,7 @@ EOF
 
 resource "aws_appsync_datasource" "test" {
   api_id = "${aws_appsync_graphql_api.test.id}"
-  name   = "tf-example"
+  name   = "tf_example"
   type   = "HTTP"
 
   http_config {


### PR DESCRIPTION
Renaming `tf-name` for `tf_name` which was resulting in an invalid resource name error.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
