### PR TITLE
fix: appsync_function example

### DIFF
--- a/website/docs/r/appsync_function.html.markdown
+++ b/website/docs/r/appsync_function.html.markdown
@@ -50,7 +50,7 @@ resource "aws_appsync_datasource" "test" {
 resource "aws_appsync_function" "test" {
   api_id      = "${aws_appsync_graphql_api.test.id}"
   data_source = "${aws_appsync_datasource.test.name}"
-  name        = "tf-example"
+  name        = "tf_example"
   request_mapping_template = <<EOF
 {
     "version": "2018-05-29",


### PR DESCRIPTION
Prevents the following error:

```
Error: BadRequestException: Invalid data source name given, must match pattern [_A-Za-z][_0-9A-Za-z]*
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
