### PR TITLE
Add support for Transit gateway blackhole route

### DIFF
--- a/aws/resource_aws_ec2_transit_gateway_route.go
+++ b/aws/resource_aws_ec2_transit_gateway_route.go
@@ -28,9 +28,15 @@ func resourceAwsEc2TransitGatewayRoute() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"blackhole": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
 			"transit_gateway_attachment_id": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -52,6 +58,7 @@ func resourceAwsEc2TransitGatewayRouteCreate(d *schema.ResourceData, meta interf
 
 	input := &ec2.CreateTransitGatewayRouteInput{
 		DestinationCidrBlock:       aws.String(destination),
+		Blackhole:                  aws.Bool(d.Get("blackhole").(bool)),
 		TransitGatewayAttachmentId: aws.String(d.Get("transit_gateway_attachment_id").(string)),
 		TransitGatewayRouteTableId: aws.String(transitGatewayRouteTableID),
 	}
@@ -130,8 +137,10 @@ func resourceAwsEc2TransitGatewayRouteRead(d *schema.ResourceData, meta interfac
 	d.Set("transit_gateway_attachment_id", "")
 	if len(transitGatewayRoute.TransitGatewayAttachments) > 0 && transitGatewayRoute.TransitGatewayAttachments[0] != nil {
 		d.Set("transit_gateway_attachment_id", transitGatewayRoute.TransitGatewayAttachments[0].TransitGatewayAttachmentId)
+		d.Set("blackhole", false)
+	} else {
+		d.Set("blackhole", true)
 	}
-
 	d.Set("transit_gateway_route_table_id", transitGatewayRouteTableID)
 
 	return nil

--- a/website/docs/r/ec2_transit_gateway_route.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_route.html.markdown
@@ -12,10 +12,22 @@ Manages an EC2 Transit Gateway Route.
 
 ## Example Usage
 
+### Standard usage
+
 ```hcl
 resource "aws_ec2_transit_gateway_route" "example" {
   destination_cidr_block         = "0.0.0.0/0"
   transit_gateway_attachment_id  = "${aws_ec2_transit_gateway_vpc_attachment.example.id}"
+  transit_gateway_route_table_id = "${aws_ec2_transit_gateway.example.association_default_route_table_id}"
+}
+```
+
+### Blackhole route
+
+```hcl
+resource "aws_ec2_transit_gateway_route" "example" {
+  destination_cidr_block         = "0.0.0.0/0"
+  blackhole                      = true
   transit_gateway_route_table_id = "${aws_ec2_transit_gateway.example.association_default_route_table_id}"
 }
 ```
@@ -25,7 +37,8 @@ resource "aws_ec2_transit_gateway_route" "example" {
 The following arguments are supported:
 
 * `destination_cidr_block` - (Required) IPv4 CIDR range used for destination matches. Routing decisions are based on the most specific match.
-* `transit_gateway_attachment_id` - (Required) Identifier of EC2 Transit Gateway Attachment.
+* `transit_gateway_attachment_id` - (Optional) Identifier of EC2 Transit Gateway Attachment (required if `blackhole` is set to false).
+* `blackhole` - (Optional) Indicates whether to drop traffic that matches this route (default to `false`).
 * `transit_gateway_route_table_id` - (Required) Identifier of EC2 Transit Gateway Route Table.
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #9046

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_ec2_transit_gateway_route: Add support for blackhole routes
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSEc2TransitGatewayRoute_blackhole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSEc2TransitGatewayRoute_blackhole -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSEc2TransitGatewayRoute_blackhole
=== PAUSE TestAccAWSEc2TransitGatewayRoute_blackhole
=== CONT  TestAccAWSEc2TransitGatewayRoute_blackhole
--- PASS: TestAccAWSEc2TransitGatewayRoute_blackhole (410.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       410.451s

```
