### PR TITLE
Add support import for aws_wafregional_rule resource

### DIFF
--- a/aws/resource_aws_wafregional_rule.go
+++ b/aws/resource_aws_wafregional_rule.go
@@ -18,6 +18,9 @@ func resourceAwsWafRegionalRule() *schema.Resource {
 		Read:   resourceAwsWafRegionalRuleRead,
 		Update: resourceAwsWafRegionalRuleUpdate,
 		Delete: resourceAwsWafRegionalRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_rule_test.go
+++ b/aws/resource_aws_wafregional_rule_test.go
@@ -119,6 +119,8 @@ func testSweepWafRegionalRules(region string) error {
 func TestAccAWSWafRegionalRule_basic(t *testing.T) {
 	var v waf.Rule
 	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule.wafrule"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -127,14 +129,19 @@ func TestAccAWSWafRegionalRule_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &v),
+					testAccCheckAWSWafRegionalRuleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "name", wafRuleName),
+						resourceName, "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "1"),
+						resourceName, "predicate.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "metric_name", wafRuleName),
+						resourceName, "metric_name", wafRuleName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -144,6 +151,7 @@ func TestAccAWSWafRegionalRule_changeNameForceNew(t *testing.T) {
 	var before, after waf.Rule
 	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
 	wafRuleNewName := fmt.Sprintf("wafrulenew%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule.wafrule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -153,26 +161,31 @@ func TestAccAWSWafRegionalRule_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &before),
+					testAccCheckAWSWafRegionalRuleExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "name", wafRuleName),
+						resourceName, "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "1"),
+						resourceName, "predicate.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "metric_name", wafRuleName),
+						resourceName, "metric_name", wafRuleName),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRuleConfigChangeName(wafRuleNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &after),
+					testAccCheckAWSWafRegionalRuleExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "name", wafRuleNewName),
+						resourceName, "name", wafRuleNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "1"),
+						resourceName, "predicate.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "metric_name", wafRuleNewName),
+						resourceName, "metric_name", wafRuleNewName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -181,6 +194,8 @@ func TestAccAWSWafRegionalRule_changeNameForceNew(t *testing.T) {
 func TestAccAWSWafRegionalRule_disappears(t *testing.T) {
 	var v waf.Rule
 	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule.wafrule"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -189,7 +204,7 @@ func TestAccAWSWafRegionalRule_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRuleConfig(wafRuleName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &v),
+					testAccCheckAWSWafRegionalRuleExists(resourceName, &v),
 					testAccCheckAWSWafRegionalRuleDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -201,6 +216,8 @@ func TestAccAWSWafRegionalRule_disappears(t *testing.T) {
 func TestAccAWSWafRegionalRule_noPredicates(t *testing.T) {
 	var v waf.Rule
 	wafRuleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule.wafrule"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -209,12 +226,17 @@ func TestAccAWSWafRegionalRule_noPredicates(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRule_noPredicates(wafRuleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &v),
+					testAccCheckAWSWafRegionalRuleExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "name", wafRuleName),
+						resourceName, "name", wafRuleName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule.wafrule", "predicate.#", "0"),
+						resourceName, "predicate.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -227,6 +249,7 @@ func TestAccAWSWafRegionalRule_changePredicates(t *testing.T) {
 	var before, after waf.Rule
 	var idx int
 	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule.wafrule"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -237,28 +260,33 @@ func TestAccAWSWafRegionalRule_changePredicates(t *testing.T) {
 				Config: testAccAWSWafRegionalRuleConfig(ruleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalIPSetExists("aws_wafregional_ipset.ipset", &ipset),
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &before),
-					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "predicate.#", "1"),
+					testAccCheckAWSWafRegionalRuleExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "1"),
 					computeWafRegionalRulePredicate(&ipset.IPSetId, false, "IPMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.negated", &idx, "false"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.type", &idx, "IPMatch"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.negated", &idx, "false"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.type", &idx, "IPMatch"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRule_changePredicates(ruleName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalXssMatchSetExists("aws_wafregional_xss_match_set.xss_match_set", &xssMatchSet),
-					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "name", ruleName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule.wafrule", "predicate.#", "2"),
+					testAccCheckAWSWafRegionalRuleExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", ruleName),
+					resource.TestCheckResourceAttr(resourceName, "predicate.#", "2"),
 					computeWafRegionalRulePredicate(&xssMatchSet.XssMatchSetId, true, "XssMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.negated", &idx, "true"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.type", &idx, "XssMatch"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.negated", &idx, "true"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.type", &idx, "XssMatch"),
 					computeWafRegionalRulePredicate(&ipset.IPSetId, true, "IPMatch", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.negated", &idx, "true"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule.wafrule", "predicate.%d.type", &idx, "IPMatch"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.negated", &idx, "true"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "predicate.%d.type", &idx, "IPMatch"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/wafregional_rule.html.markdown
+++ b/website/docs/r/wafregional_rule.html.markdown
@@ -61,3 +61,11 @@ See the [WAF Documentation](https://docs.aws.amazon.com/waf/latest/APIReference/
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF Regional Rule.
+
+## Import
+
+WAF Regional Rule can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_rule.wafrule a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_rule: Support resource import
```

Output from acceptance testing:

```
 make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalRule_ -timeout 120m
=== RUN   TestAccAWSWafRegionalRule_basic
=== PAUSE TestAccAWSWafRegionalRule_basic
=== RUN   TestAccAWSWafRegionalRule_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalRule_changeNameForceNew
=== RUN   TestAccAWSWafRegionalRule_disappears
=== PAUSE TestAccAWSWafRegionalRule_disappears
=== RUN   TestAccAWSWafRegionalRule_noPredicates
=== PAUSE TestAccAWSWafRegionalRule_noPredicates
=== RUN   TestAccAWSWafRegionalRule_changePredicates
=== PAUSE TestAccAWSWafRegionalRule_changePredicates
=== CONT  TestAccAWSWafRegionalRule_basic
=== CONT  TestAccAWSWafRegionalRule_noPredicates
=== CONT  TestAccAWSWafRegionalRule_disappears
=== CONT  TestAccAWSWafRegionalRule_changePredicates
=== CONT  TestAccAWSWafRegionalRule_changeNameForceNew
--- PASS: TestAccAWSWafRegionalRule_noPredicates (32.01s)
--- PASS: TestAccAWSWafRegionalRule_basic (57.51s)
--- PASS: TestAccAWSWafRegionalRule_disappears (65.44s)
--- PASS: TestAccAWSWafRegionalRule_changePredicates (91.05s)
--- PASS: TestAccAWSWafRegionalRule_changeNameForceNew (97.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	97.165s
```
