### PR TITLE
Add support import for aws_wafregional_rule_group resource

### DIFF
--- a/aws/resource_aws_wafregional_rule_group.go
+++ b/aws/resource_aws_wafregional_rule_group.go
@@ -16,6 +16,9 @@ func resourceAwsWafRegionalRuleGroup() *schema.Resource {
 		Read:   resourceAwsWafRegionalRuleGroupRead,
 		Update: resourceAwsWafRegionalRuleGroupUpdate,
 		Delete: resourceAwsWafRegionalRuleGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_rule_group_test.go
+++ b/aws/resource_aws_wafregional_rule_group_test.go
@@ -66,6 +66,7 @@ func TestAccAWSWafRegionalRuleGroup_basic(t *testing.T) {
 
 	ruleName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	groupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -76,15 +77,20 @@ func TestAccAWSWafRegionalRuleGroup_basic(t *testing.T) {
 				Config: testAccAWSWafRegionalRuleGroupConfig(ruleName, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test", &rule),
-					testAccCheckAWSWafRegionalRuleGroupExists("aws_wafregional_rule_group.test", &group),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "activated_rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "metric_name", groupName),
+					testAccCheckAWSWafRegionalRuleGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_name", groupName),
 					computeWafActivatedRuleWithRuleId(&rule, "COUNT", 50, &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.action.0.type", &idx, "COUNT"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.priority", &idx, "50"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.type", &idx, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx, "COUNT"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx, "50"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx, waf.WafRuleTypeRegular),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -96,6 +102,7 @@ func TestAccAWSWafRegionalRuleGroup_changeNameForceNew(t *testing.T) {
 	ruleName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	groupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	newGroupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -105,20 +112,25 @@ func TestAccAWSWafRegionalRuleGroup_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRuleGroupConfig(ruleName, groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleGroupExists("aws_wafregional_rule_group.test", &before),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "activated_rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "metric_name", groupName),
+					testAccCheckAWSWafRegionalRuleGroupExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_name", groupName),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRuleGroupConfig(ruleName, newGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleGroupExists("aws_wafregional_rule_group.test", &after),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "name", newGroupName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "activated_rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "metric_name", newGroupName),
+					testAccCheckAWSWafRegionalRuleGroupExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", newGroupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_name", newGroupName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -128,6 +140,7 @@ func TestAccAWSWafRegionalRuleGroup_disappears(t *testing.T) {
 	var group waf.RuleGroup
 	ruleName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	groupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -137,7 +150,7 @@ func TestAccAWSWafRegionalRuleGroup_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRuleGroupConfig(ruleName, groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleGroupExists("aws_wafregional_rule_group.test", &group),
+					testAccCheckAWSWafRegionalRuleGroupExists(resourceName, &group),
 					testAccCheckAWSWafRegionalRuleGroupDisappears(&group),
 				),
 				ExpectNonEmptyPlan: true,
@@ -155,6 +168,7 @@ func TestAccAWSWafRegionalRuleGroup_changeActivatedRules(t *testing.T) {
 	ruleName1 := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	ruleName2 := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	ruleName3 := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,40 +179,45 @@ func TestAccAWSWafRegionalRuleGroup_changeActivatedRules(t *testing.T) {
 				Config: testAccAWSWafRegionalRuleGroupConfig(ruleName1, groupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test", &rule0),
-					testAccCheckAWSWafRegionalRuleGroupExists("aws_wafregional_rule_group.test", &groupBefore),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "activated_rule.#", "1"),
+					testAccCheckAWSWafRegionalRuleGroupExists(resourceName, &groupBefore),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
 					computeWafActivatedRuleWithRuleId(&rule0, "COUNT", 50, &idx0),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.action.0.type", &idx0, "COUNT"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.priority", &idx0, "50"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.type", &idx0, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx0, "COUNT"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx0, "50"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx0, waf.WafRuleTypeRegular),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalRuleGroupConfig_changeActivatedRules(ruleName1, ruleName2, ruleName3, groupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_wafregional_rule_group.test", "activated_rule.#", "3"),
-					testAccCheckAWSWafRegionalRuleGroupExists("aws_wafregional_rule_group.test", &groupAfter),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "3"),
+					testAccCheckAWSWafRegionalRuleGroupExists(resourceName, &groupAfter),
 
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test", &rule1),
 					computeWafActivatedRuleWithRuleId(&rule1, "BLOCK", 10, &idx1),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.action.0.type", &idx1, "BLOCK"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.priority", &idx1, "10"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.type", &idx1, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx1, "BLOCK"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx1, "10"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx1, waf.WafRuleTypeRegular),
 
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test2", &rule2),
 					computeWafActivatedRuleWithRuleId(&rule2, "COUNT", 1, &idx2),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.action.0.type", &idx2, "COUNT"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.priority", &idx2, "1"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.type", &idx2, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx2, "COUNT"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx2, "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx2, waf.WafRuleTypeRegular),
 
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.test3", &rule3),
 					computeWafActivatedRuleWithRuleId(&rule3, "BLOCK", 15, &idx3),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.action.0.type", &idx3, "BLOCK"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.priority", &idx3, "15"),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_rule_group.test", "activated_rule.%d.type", &idx3, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx3, "BLOCK"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx3, "15"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx3, waf.WafRuleTypeRegular),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -207,6 +226,7 @@ func TestAccAWSWafRegionalRuleGroup_changeActivatedRules(t *testing.T) {
 func TestAccAWSWafRegionalRuleGroup_noActivatedRules(t *testing.T) {
 	var group waf.RuleGroup
 	groupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -216,11 +236,11 @@ func TestAccAWSWafRegionalRuleGroup_noActivatedRules(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalRuleGroupConfig_noActivatedRules(groupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalRuleGroupExists("aws_wafregional_rule_group.test", &group),
+					testAccCheckAWSWafRegionalRuleGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule_group.test", "name", groupName),
+						resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_rule_group.test", "activated_rule.#", "0"),
+						resourceName, "activated_rule.#", "0"),
 				),
 			},
 		},

--- a/website/docs/r/wafregional_rule_group.html.markdown
+++ b/website/docs/r/wafregional_rule_group.html.markdown
@@ -58,3 +58,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF Regional Rule Group.
+
+## Import
+
+WAF Regional Rule Group can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_rule_group.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_rule_group: Support resource import
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
