### PR TITLE
Fixing the input for the worklink fleet test sweeper

### DIFF
--- a/aws/resource_aws_worklink_fleet_test.go
+++ b/aws/resource_aws_worklink_fleet_test.go
@@ -342,7 +342,9 @@ func testAccCheckAWSWorkLinkFleetExists(n string) resource.TestCheckFunc {
 func testAccPreCheckAWSWorkLink(t *testing.T) {
 	conn := testAccProvider.Meta().(*AWSClient).worklinkconn
 
-	input := &worklink.ListFleetsInput{}
+	input := &worklink.ListFleetsInput{
+		MaxResults: aws.Int64(1),
+	}
 
 	_, err := conn.ListFleets(input)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

This fixes some ongoing failures in the worklink acceptance tests caused by one of the sweeper functions.


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-run=TestAccAWSWorkLinkFleet"      
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v -parallel 20 -run=TestAccAWSWorkLinkFleet -timeout 120m
?       github.com/terraform-providers/terraform-provider-aws   [no test files]
=== RUN   TestAccAWSWorkLinkFleet_Basic
=== PAUSE TestAccAWSWorkLinkFleet_Basic
=== RUN   TestAccAWSWorkLinkFleet_DisplayName
=== PAUSE TestAccAWSWorkLinkFleet_DisplayName
=== RUN   TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation
=== PAUSE TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation
=== RUN   TestAccAWSWorkLinkFleet_AuditStreamArn
=== PAUSE TestAccAWSWorkLinkFleet_AuditStreamArn
=== RUN   TestAccAWSWorkLinkFleet_Network
=== PAUSE TestAccAWSWorkLinkFleet_Network
=== RUN   TestAccAWSWorkLinkFleet_DeviceCaCertificate
=== PAUSE TestAccAWSWorkLinkFleet_DeviceCaCertificate
=== RUN   TestAccAWSWorkLinkFleet_IdentityProvider
=== PAUSE TestAccAWSWorkLinkFleet_IdentityProvider
=== RUN   TestAccAWSWorkLinkFleet_Disappears
=== PAUSE TestAccAWSWorkLinkFleet_Disappears
=== CONT  TestAccAWSWorkLinkFleet_Basic
=== CONT  TestAccAWSWorkLinkFleet_Network
=== CONT  TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation
=== CONT  TestAccAWSWorkLinkFleet_AuditStreamArn
=== CONT  TestAccAWSWorkLinkFleet_IdentityProvider
=== CONT  TestAccAWSWorkLinkFleet_DisplayName
=== CONT  TestAccAWSWorkLinkFleet_Disappears
=== CONT  TestAccAWSWorkLinkFleet_DeviceCaCertificate
--- PASS: TestAccAWSWorkLinkFleet_Disappears (65.98s)
--- PASS: TestAccAWSWorkLinkFleet_Basic (66.94s)
--- PASS: TestAccAWSWorkLinkFleet_OptimizeForEndUserLocation (98.39s)
--- PASS: TestAccAWSWorkLinkFleet_IdentityProvider (102.94s)
--- PASS: TestAccAWSWorkLinkFleet_DeviceCaCertificate (106.25s)
--- PASS: TestAccAWSWorkLinkFleet_DisplayName (107.44s)
--- PASS: TestAccAWSWorkLinkFleet_AuditStreamArn (147.91s)
--- PASS: TestAccAWSWorkLinkFleet_Network (177.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       178.868s
```
