### PR TITLE
Add support import for aws_wafregional_web_acl resource

### DIFF
--- a/aws/resource_aws_wafregional_web_acl.go
+++ b/aws/resource_aws_wafregional_web_acl.go
@@ -18,6 +18,9 @@ func resourceAwsWafRegionalWebAcl() *schema.Resource {
 		Read:   resourceAwsWafRegionalWebAclRead,
 		Update: resourceAwsWafRegionalWebAclUpdate,
 		Delete: resourceAwsWafRegionalWebAclDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arn": {

--- a/aws/resource_aws_wafregional_web_acl_test.go
+++ b/aws/resource_aws_wafregional_web_acl_test.go
@@ -119,6 +119,7 @@ func testSweepWafRegionalWebAcls(region string) error {
 func TestAccAWSWafRegionalWebAcl_basic(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -128,21 +129,26 @@ func TestAccAWSWafRegionalWebAcl_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
-					testAccMatchResourceAttrRegionalARN("aws_wafregional_web_acl.waf_acl", "arn", "waf-regional", regexp.MustCompile(`webacl/.+`)),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
+					testAccMatchResourceAttrRegionalARN(resourceName, "arn", "waf-regional", regexp.MustCompile(`webacl/.+`)),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "logging_configuration.#", "0"),
+						resourceName, "logging_configuration.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -151,6 +157,7 @@ func TestAccAWSWafRegionalWebAcl_basic(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_createRateBased(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -160,17 +167,17 @@ func TestAccAWSWafRegionalWebAcl_createRateBased(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfigRateBased(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
 			},
 		},
@@ -180,6 +187,7 @@ func TestAccAWSWafRegionalWebAcl_createRateBased(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_createGroup(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -189,18 +197,23 @@ func TestAccAWSWafRegionalWebAcl_createGroup(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfigGroup(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -210,6 +223,7 @@ func TestAccAWSWafRegionalWebAcl_changeNameForceNew(t *testing.T) {
 	var before, after waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
 	wafAclNewName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -219,34 +233,39 @@ func TestAccAWSWafRegionalWebAcl_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &before),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalWebAclConfig_changeName(wafAclNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &after),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclNewName),
+						resourceName, "name", wafAclNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclNewName),
+						resourceName, "metric_name", wafAclNewName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -256,6 +275,7 @@ func TestAccAWSWafRegionalWebAcl_changeDefaultAction(t *testing.T) {
 	var before, after waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
 	wafAclNewName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -265,34 +285,39 @@ func TestAccAWSWafRegionalWebAcl_changeDefaultAction(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &before),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclName),
+						resourceName, "metric_name", wafAclName),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalWebAclConfig_changeDefaultAction(wafAclNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &after),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "BLOCK"),
+						resourceName, "default_action.0.type", "BLOCK"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclNewName),
+						resourceName, "name", wafAclNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "metric_name", wafAclNewName),
+						resourceName, "metric_name", wafAclNewName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -301,6 +326,7 @@ func TestAccAWSWafRegionalWebAcl_changeDefaultAction(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_disappears(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -310,7 +336,7 @@ func TestAccAWSWafRegionalWebAcl_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
 					testAccCheckAWSWafRegionalWebAclDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
@@ -322,6 +348,7 @@ func TestAccAWSWafRegionalWebAcl_disappears(t *testing.T) {
 func TestAccAWSWafRegionalWebAcl_noRules(t *testing.T) {
 	var v waf.WebACL
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -331,16 +358,21 @@ func TestAccAWSWafRegionalWebAcl_noRules(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalWebAclConfig_noRules(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "0"),
+						resourceName, "rule.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -351,6 +383,7 @@ func TestAccAWSWafRegionalWebAcl_changeRules(t *testing.T) {
 	var r waf.Rule
 	var idx int
 	wafAclName := fmt.Sprintf("wafacl%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_web_acl.waf_acl"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -361,32 +394,37 @@ func TestAccAWSWafRegionalWebAcl_changeRules(t *testing.T) {
 				Config: testAccAWSWafRegionalWebAclConfig(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRegionalRuleExists("aws_wafregional_rule.wafrule", &r),
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "1"),
+						resourceName, "rule.#", "1"),
 					computeWafRegionalWebAclRuleIndex(&r.RuleId, 1, "REGULAR", "BLOCK", &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_wafregional_web_acl.waf_acl", "rule.%d.priority", &idx, "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "rule.%d.priority", &idx, "1"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalWebAclConfig_changeRules(wafAclName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalWebAclExists("aws_wafregional_web_acl.waf_acl", &v),
+					testAccCheckAWSWafRegionalWebAclExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.#", "1"),
+						resourceName, "default_action.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "default_action.0.type", "ALLOW"),
+						resourceName, "default_action.0.type", "ALLOW"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "name", wafAclName),
+						resourceName, "name", wafAclName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_web_acl.waf_acl", "rule.#", "2"),
+						resourceName, "rule.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -427,6 +465,11 @@ func TestAccAWSWafRegionalWebAcl_LoggingConfiguration(t *testing.T) {
 					testAccCheckAWSWafRegionalWebAclExists(resourceName, &webACL3),
 					resource.TestCheckResourceAttr(resourceName, "logging_configuration.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/wafregional_web_acl.html.markdown
+++ b/website/docs/r/wafregional_web_acl.html.markdown
@@ -154,3 +154,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `arn` - Amazon Resource Name (ARN) of the WAF Regional WebACL.
 * `id` - The ID of the WAF Regional WebACL.
+
+## Import
+
+WAF Regional Rule Group can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_web_acl.wafacl a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_web_acl: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalWebAcl_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalWebAcl_ -timeout 120m
=== RUN   TestAccAWSWafRegionalWebAcl_basic
=== PAUSE TestAccAWSWafRegionalWebAcl_basic
=== RUN   TestAccAWSWafRegionalWebAcl_createRateBased
=== PAUSE TestAccAWSWafRegionalWebAcl_createRateBased
=== RUN   TestAccAWSWafRegionalWebAcl_createGroup
=== PAUSE TestAccAWSWafRegionalWebAcl_createGroup
=== RUN   TestAccAWSWafRegionalWebAcl_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalWebAcl_changeNameForceNew
=== RUN   TestAccAWSWafRegionalWebAcl_changeDefaultAction
=== PAUSE TestAccAWSWafRegionalWebAcl_changeDefaultAction
=== RUN   TestAccAWSWafRegionalWebAcl_disappears
=== PAUSE TestAccAWSWafRegionalWebAcl_disappears
=== RUN   TestAccAWSWafRegionalWebAcl_noRules
=== PAUSE TestAccAWSWafRegionalWebAcl_noRules
=== RUN   TestAccAWSWafRegionalWebAcl_changeRules
=== PAUSE TestAccAWSWafRegionalWebAcl_changeRules
=== RUN   TestAccAWSWafRegionalWebAcl_LoggingConfiguration
=== PAUSE TestAccAWSWafRegionalWebAcl_LoggingConfiguration
=== CONT  TestAccAWSWafRegionalWebAcl_basic
=== CONT  TestAccAWSWafRegionalWebAcl_LoggingConfiguration
=== CONT  TestAccAWSWafRegionalWebAcl_changeNameForceNew
=== CONT  TestAccAWSWafRegionalWebAcl_createGroup
=== CONT  TestAccAWSWafRegionalWebAcl_createRateBased
=== CONT  TestAccAWSWafRegionalWebAcl_noRules
=== CONT  TestAccAWSWafRegionalWebAcl_changeRules
=== CONT  TestAccAWSWafRegionalWebAcl_disappears
=== CONT  TestAccAWSWafRegionalWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafRegionalWebAcl_noRules (55.64s)
--- PASS: TestAccAWSWafRegionalWebAcl_disappears (73.04s)
--- PASS: TestAccAWSWafRegionalWebAcl_createGroup (80.93s)
--- PASS: TestAccAWSWafRegionalWebAcl_basic (89.51s)
--- PASS: TestAccAWSWafRegionalWebAcl_createRateBased (91.06s)
--- PASS: TestAccAWSWafRegionalWebAcl_changeRules (95.57s)
--- PASS: TestAccAWSWafRegionalWebAcl_changeNameForceNew (112.68s)
--- PASS: TestAccAWSWafRegionalWebAcl_changeDefaultAction (114.04s)
--- PASS: TestAccAWSWafRegionalWebAcl_LoggingConfiguration (224.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	224.200s
```
