### PR TITLE
Add support tags attribute for aws_appmesh_virtual_router resource

### DIFF
--- a/aws/resource_aws_appmesh_test.go
+++ b/aws/resource_aws_appmesh_test.go
@@ -24,6 +24,7 @@ func TestAccAWSAppmesh(t *testing.T) {
 		},
 		"VirtualRouter": {
 			"basic": testAccAwsAppmeshVirtualRouter_basic,
+			"tags":  testAccAwsAppmeshVirtualRouter_tags,
 		},
 		"VirtualService": {
 			"virtualNode":   testAccAwsAppmeshVirtualService_virtualNode,

--- a/aws/resource_aws_appmesh_virtual_router.go
+++ b/aws/resource_aws_appmesh_virtual_router.go
@@ -110,6 +110,8 @@ func resourceAwsAppmeshVirtualRouter() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -121,6 +123,7 @@ func resourceAwsAppmeshVirtualRouterCreate(d *schema.ResourceData, meta interfac
 		MeshName:          aws.String(d.Get("mesh_name").(string)),
 		VirtualRouterName: aws.String(d.Get("name").(string)),
 		Spec:              expandAppmeshVirtualRouterSpec(d.Get("spec").([]interface{})),
+		Tags:              tagsFromMapAppmesh(d.Get("tags").(map[string]interface{})),
 	}
 
 	log.Printf("[DEBUG] Creating App Mesh virtual router: %#v", req)
@@ -165,6 +168,16 @@ func resourceAwsAppmeshVirtualRouterRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error setting spec: %s", err)
 	}
 
+	err = saveTagsAppmesh(conn, d, aws.StringValue(resp.VirtualRouter.Metadata.Arn))
+	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] App Mesh virtual router (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error saving tags: %s", err)
+	}
+
 	return nil
 }
 
@@ -184,6 +197,16 @@ func resourceAwsAppmeshVirtualRouterUpdate(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return fmt.Errorf("error updating App Mesh virtual router: %s", err)
 		}
+	}
+
+	err := setTagsAppmesh(conn, d, d.Get("arn").(string))
+	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] App Mesh virtual router (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return resourceAwsAppmeshVirtualRouterRead(d, meta)

--- a/website/docs/r/appmesh_virtual_router.html.markdown
+++ b/website/docs/r/appmesh_virtual_router.html.markdown
@@ -47,6 +47,7 @@ The following arguments are supported:
 * `name` - (Required) The name to use for the virtual router.
 * `mesh_name` - (Required) The name of the service mesh in which to create the virtual router.
 * `spec` - (Required) The virtual router specification to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `spec` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8101

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:
- resource/aws_appmesh_virtual_router: Add `tags` argument.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh/VirtualRouter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppmesh/VirtualRouter -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/VirtualRouter
=== RUN   TestAccAWSAppmesh/VirtualRouter/basic
=== RUN   TestAccAWSAppmesh/VirtualRouter/tags
--- PASS: TestAccAWSAppmesh (128.02s)
    --- PASS: TestAccAWSAppmesh/VirtualRouter (128.02s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/basic (57.20s)
        --- PASS: TestAccAWSAppmesh/VirtualRouter/tags (70.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	128.098s
```
