### PR TITLE
Add support tags attribute for aws_appmesh_virtual_service resource

### DIFF
--- a/aws/resource_aws_appmesh_test.go
+++ b/aws/resource_aws_appmesh_test.go
@@ -28,6 +28,7 @@ func TestAccAWSAppmesh(t *testing.T) {
 		"VirtualService": {
 			"virtualNode":   testAccAwsAppmeshVirtualService_virtualNode,
 			"virtualRouter": testAccAwsAppmeshVirtualService_virtualRouter,
+			"tags":          testAccAwsAppmeshVirtualService_tags,
 		},
 	}
 

--- a/aws/resource_aws_appmesh_virtual_service.go
+++ b/aws/resource_aws_appmesh_virtual_service.go
@@ -105,6 +105,8 @@ func resourceAwsAppmeshVirtualService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -116,6 +118,7 @@ func resourceAwsAppmeshVirtualServiceCreate(d *schema.ResourceData, meta interfa
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
 		VirtualServiceName: aws.String(d.Get("name").(string)),
 		Spec:               expandAppmeshVirtualServiceSpec(d.Get("spec").([]interface{})),
+		Tags:               tagsFromMapAppmesh(d.Get("tags").(map[string]interface{})),
 	}
 
 	log.Printf("[DEBUG] Creating App Mesh virtual service: %#v", req)
@@ -160,6 +163,16 @@ func resourceAwsAppmeshVirtualServiceRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("error setting spec: %s", err)
 	}
 
+	err = saveTagsAppmesh(conn, d, aws.StringValue(resp.VirtualService.Metadata.Arn))
+	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] App Mesh virtual service (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error saving tags: %s", err)
+	}
+
 	return nil
 }
 
@@ -179,6 +192,16 @@ func resourceAwsAppmeshVirtualServiceUpdate(d *schema.ResourceData, meta interfa
 		if err != nil {
 			return fmt.Errorf("error updating App Mesh virtual service: %s", err)
 		}
+	}
+
+	err := setTagsAppmesh(conn, d, d.Get("arn").(string))
+	if isAWSErr(err, appmesh.ErrCodeNotFoundException, "") {
+		log.Printf("[WARN] App Mesh virtual service (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error setting tags: %s", err)
 	}
 
 	return resourceAwsAppmeshVirtualServiceRead(d, meta)

--- a/website/docs/r/appmesh_virtual_service.html.markdown
+++ b/website/docs/r/appmesh_virtual_service.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
 * `name` - (Required) The name to use for the virtual service.
 * `mesh_name` - (Required) The name of the service mesh in which to create the virtual service.
 * `spec` - (Required) The virtual service specification to apply.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `spec` object supports the following:
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #8101

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:
- resource/aws_appmesh_virtual_service: Add `tags` argument.
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSAppmesh/VirtualService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSAppmesh/VirtualService -timeout 120m
=== RUN   TestAccAWSAppmesh
=== RUN   TestAccAWSAppmesh/VirtualService
=== RUN   TestAccAWSAppmesh/VirtualService/virtualNode
=== RUN   TestAccAWSAppmesh/VirtualService/virtualRouter
=== RUN   TestAccAWSAppmesh/VirtualService/tags
--- PASS: TestAccAWSAppmesh (196.69s)
    --- PASS: TestAccAWSAppmesh/VirtualService (196.69s)
        --- PASS: TestAccAWSAppmesh/VirtualService/virtualNode (68.24s)
        --- PASS: TestAccAWSAppmesh/VirtualService/virtualRouter (50.90s)
        --- PASS: TestAccAWSAppmesh/VirtualService/tags (77.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	196.777s
```
