### PR TITLE
Add support import for aws_waf_rule_group resource

### DIFF
--- a/aws/resource_aws_waf_rule_group.go
+++ b/aws/resource_aws_waf_rule_group.go
@@ -15,6 +15,9 @@ func resourceAwsWafRuleGroup() *schema.Resource {
 		Read:   resourceAwsWafRuleGroupRead,
 		Update: resourceAwsWafRuleGroupUpdate,
 		Delete: resourceAwsWafRuleGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_waf_rule_group_test.go
+++ b/aws/resource_aws_waf_rule_group_test.go
@@ -66,6 +66,7 @@ func TestAccAWSWafRuleGroup_basic(t *testing.T) {
 
 	ruleName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	groupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_waf_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -76,15 +77,20 @@ func TestAccAWSWafRuleGroup_basic(t *testing.T) {
 				Config: testAccAWSWafRuleGroupConfig(ruleName, groupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test", &rule),
-					testAccCheckAWSWafRuleGroupExists("aws_waf_rule_group.test", &group),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "activated_rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "metric_name", groupName),
+					testAccCheckAWSWafRuleGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_name", groupName),
 					computeWafActivatedRuleWithRuleId(&rule, "COUNT", 50, &idx),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.action.0.type", &idx, "COUNT"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.priority", &idx, "50"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.type", &idx, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx, "COUNT"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx, "50"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx, waf.WafRuleTypeRegular),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -96,6 +102,7 @@ func TestAccAWSWafRuleGroup_changeNameForceNew(t *testing.T) {
 	ruleName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	groupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	newGroupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_waf_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -105,20 +112,25 @@ func TestAccAWSWafRuleGroup_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRuleGroupConfig(ruleName, groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRuleGroupExists("aws_waf_rule_group.test", &before),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "activated_rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "metric_name", groupName),
+					testAccCheckAWSWafRuleGroupExists(resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_name", groupName),
 				),
 			},
 			{
 				Config: testAccAWSWafRuleGroupConfig(ruleName, newGroupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRuleGroupExists("aws_waf_rule_group.test", &after),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "name", newGroupName),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "activated_rule.#", "1"),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "metric_name", newGroupName),
+					testAccCheckAWSWafRuleGroupExists(resourceName, &after),
+					resource.TestCheckResourceAttr(resourceName, "name", newGroupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric_name", newGroupName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -128,6 +140,7 @@ func TestAccAWSWafRuleGroup_disappears(t *testing.T) {
 	var group waf.RuleGroup
 	ruleName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	groupName := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_waf_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -137,7 +150,7 @@ func TestAccAWSWafRuleGroup_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRuleGroupConfig(ruleName, groupName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRuleGroupExists("aws_waf_rule_group.test", &group),
+					testAccCheckAWSWafRuleGroupExists(resourceName, &group),
 					testAccCheckAWSWafRuleGroupDisappears(&group),
 				),
 				ExpectNonEmptyPlan: true,
@@ -155,6 +168,7 @@ func TestAccAWSWafRuleGroup_changeActivatedRules(t *testing.T) {
 	ruleName1 := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	ruleName2 := fmt.Sprintf("tfacc%s", acctest.RandString(5))
 	ruleName3 := fmt.Sprintf("tfacc%s", acctest.RandString(5))
+	resourceName := "aws_waf_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -165,40 +179,45 @@ func TestAccAWSWafRuleGroup_changeActivatedRules(t *testing.T) {
 				Config: testAccAWSWafRuleGroupConfig(ruleName1, groupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test", &rule0),
-					testAccCheckAWSWafRuleGroupExists("aws_waf_rule_group.test", &groupBefore),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "activated_rule.#", "1"),
+					testAccCheckAWSWafRuleGroupExists(resourceName, &groupBefore),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "1"),
 					computeWafActivatedRuleWithRuleId(&rule0, "COUNT", 50, &idx0),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.action.0.type", &idx0, "COUNT"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.priority", &idx0, "50"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.type", &idx0, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx0, "COUNT"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx0, "50"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx0, waf.WafRuleTypeRegular),
 				),
 			},
 			{
 				Config: testAccAWSWafRuleGroupConfig_changeActivatedRules(ruleName1, ruleName2, ruleName3, groupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "name", groupName),
-					resource.TestCheckResourceAttr("aws_waf_rule_group.test", "activated_rule.#", "3"),
-					testAccCheckAWSWafRuleGroupExists("aws_waf_rule_group.test", &groupAfter),
+					resource.TestCheckResourceAttr(resourceName, "name", groupName),
+					resource.TestCheckResourceAttr(resourceName, "activated_rule.#", "3"),
+					testAccCheckAWSWafRuleGroupExists(resourceName, &groupAfter),
 
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test", &rule1),
 					computeWafActivatedRuleWithRuleId(&rule1, "BLOCK", 10, &idx1),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.action.0.type", &idx1, "BLOCK"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.priority", &idx1, "10"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.type", &idx1, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx1, "BLOCK"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx1, "10"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx1, waf.WafRuleTypeRegular),
 
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test2", &rule2),
 					computeWafActivatedRuleWithRuleId(&rule2, "COUNT", 1, &idx2),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.action.0.type", &idx2, "COUNT"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.priority", &idx2, "1"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.type", &idx2, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx2, "COUNT"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx2, "1"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx2, waf.WafRuleTypeRegular),
 
 					testAccCheckAWSWafRuleExists("aws_waf_rule.test3", &rule3),
 					computeWafActivatedRuleWithRuleId(&rule3, "BLOCK", 15, &idx3),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.action.0.type", &idx3, "BLOCK"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.priority", &idx3, "15"),
-					testCheckResourceAttrWithIndexesAddr("aws_waf_rule_group.test", "activated_rule.%d.type", &idx3, waf.WafRuleTypeRegular),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.action.0.type", &idx3, "BLOCK"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.priority", &idx3, "15"),
+					testCheckResourceAttrWithIndexesAddr(resourceName, "activated_rule.%d.type", &idx3, waf.WafRuleTypeRegular),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -231,6 +250,7 @@ func computeWafActivatedRuleWithRuleId(rule *waf.Rule, actionType string, priori
 func TestAccAWSWafRuleGroup_noActivatedRules(t *testing.T) {
 	var group waf.RuleGroup
 	groupName := fmt.Sprintf("test%s", acctest.RandString(5))
+	resourceName := "aws_waf_rule_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t); testAccPreCheckAWSWaf(t) },
@@ -240,11 +260,11 @@ func TestAccAWSWafRuleGroup_noActivatedRules(t *testing.T) {
 			{
 				Config: testAccAWSWafRuleGroupConfig_noActivatedRules(groupName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRuleGroupExists("aws_waf_rule_group.test", &group),
+					testAccCheckAWSWafRuleGroupExists(resourceName, &group),
 					resource.TestCheckResourceAttr(
-						"aws_waf_rule_group.test", "name", groupName),
+						resourceName, "name", groupName),
 					resource.TestCheckResourceAttr(
-						"aws_waf_rule_group.test", "activated_rule.#", "0"),
+						resourceName, "activated_rule.#", "0"),
 				),
 			},
 		},

--- a/website/docs/r/waf_rule_group.html.markdown
+++ b/website/docs/r/waf_rule_group.html.markdown
@@ -58,3 +58,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF rule group.
+
+## Import
+
+WAF Rule Group can be imported using the id, e.g.
+
+```
+$ terraform import aws_waf_rule_group.example a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_waf_rule_group: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRuleGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRuleGroup_ -timeout 120m
=== RUN   TestAccAWSWafRuleGroup_basic
=== PAUSE TestAccAWSWafRuleGroup_basic
=== RUN   TestAccAWSWafRuleGroup_changeNameForceNew
=== PAUSE TestAccAWSWafRuleGroup_changeNameForceNew
=== RUN   TestAccAWSWafRuleGroup_disappears
=== PAUSE TestAccAWSWafRuleGroup_disappears
=== RUN   TestAccAWSWafRuleGroup_changeActivatedRules
=== PAUSE TestAccAWSWafRuleGroup_changeActivatedRules
=== RUN   TestAccAWSWafRuleGroup_noActivatedRules
=== PAUSE TestAccAWSWafRuleGroup_noActivatedRules
=== CONT  TestAccAWSWafRuleGroup_basic
=== CONT  TestAccAWSWafRuleGroup_disappears
=== CONT  TestAccAWSWafRuleGroup_changeActivatedRules
=== CONT  TestAccAWSWafRuleGroup_noActivatedRules
=== CONT  TestAccAWSWafRuleGroup_changeNameForceNew
--- FAIL: TestAccAWSWafRuleGroup_changeNameForceNew (31.18s)
    testing.go:568: Step 0 error: errors during apply:

        Error: WAFLimitsExceededException: Operation would result in exceeding resource limits.
        	status code: 400, request id: c223e71f-9f9f-11e9-b8f1-7d8164ac8db6

          on /var/folders/w9/yq_zm9bj24z06tlty8163139j7txby/T/tf-test327365376/main.tf line 7:
          (source code not available)


--- FAIL: TestAccAWSWafRuleGroup_disappears (33.42s)
    testing.go:568: Step 0 error: errors during apply:

        Error: WAFLimitsExceededException: Operation would result in exceeding resource limits.
        	status code: 400, request id: c3148954-9f9f-11e9-a420-835668605bb5

          on /var/folders/w9/yq_zm9bj24z06tlty8163139j7txby/T/tf-test402598450/main.tf line 7:
          (source code not available)


--- PASS: TestAccAWSWafRuleGroup_noActivatedRules (35.92s)
--- PASS: TestAccAWSWafRuleGroup_basic (58.25s)
--- PASS: TestAccAWSWafRuleGroup_changeActivatedRules (89.01s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-aws/aws	89.107s
make: *** [testacc] Error 1
```
