### PR TITLE
Add support import for aws_wafregional_byte_match_set resource

### DIFF
--- a/aws/resource_aws_wafregional_byte_match_set.go
+++ b/aws/resource_aws_wafregional_byte_match_set.go
@@ -16,6 +16,9 @@ func resourceAwsWafRegionalByteMatchSet() *schema.Resource {
 		Read:   resourceAwsWafRegionalByteMatchSetRead,
 		Update: resourceAwsWafRegionalByteMatchSetUpdate,
 		Delete: resourceAwsWafRegionalByteMatchSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/aws/resource_aws_wafregional_byte_match_set_test.go
+++ b/aws/resource_aws_wafregional_byte_match_set_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
 	var v waf.ByteMatchSet
 	byteMatchSet := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_byte_match_set.byte_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,36 +25,41 @@ func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalByteMatchSetConfig(byteMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &v),
+					testAccCheckAWSWafRegionalByteMatchSetExists(resourceName, &v),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSet),
+						resourceName, "name", byteMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+						resourceName, "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
+						resourceName, "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
+						resourceName, "byte_match_tuples.2081155357.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -63,6 +69,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 	var before, after waf.ByteMatchSet
 	byteMatchSet := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
 	byteMatchSetNewName := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_byte_match_set.byte_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -72,70 +79,75 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalByteMatchSetConfig(byteMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &before),
+					testAccCheckAWSWafRegionalByteMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSet),
+						resourceName, "name", byteMatchSet),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+						resourceName, "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
+						resourceName, "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
+						resourceName, "byte_match_tuples.2081155357.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalByteMatchSetConfigChangeName(byteMatchSetNewName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &after),
+					testAccCheckAWSWafRegionalByteMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSetNewName),
+						resourceName, "name", byteMatchSetNewName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+						resourceName, "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
+						resourceName, "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
+						resourceName, "byte_match_tuples.2081155357.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -144,6 +156,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
 func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 	var before, after waf.ByteMatchSet
 	byteMatchSetName := fmt.Sprintf("byte-batch-set-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_byte_match_set.byte_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -153,66 +166,71 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalByteMatchSetConfig(byteMatchSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &before),
+					testAccCheckAWSWafRegionalByteMatchSetExists(resourceName, &before),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSetName),
+						resourceName, "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+						resourceName, "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.3483354334.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.3483354334.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.target_string", "badrefer1"),
+						resourceName, "byte_match_tuples.3483354334.target_string", "badrefer1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.3483354334.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.3483354334.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.data", "referer"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
+						resourceName, "byte_match_tuples.2081155357.field_to_match.0.type", "HEADER"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
+						resourceName, "byte_match_tuples.2081155357.positional_constraint", "CONTAINS"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.target_string", "badrefer2"),
+						resourceName, "byte_match_tuples.2081155357.target_string", "badrefer2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2081155357.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.2081155357.text_transformation", "NONE"),
 				),
 			},
 			{
 				Config: testAccAWSWafRegionalByteMatchSetConfigChangeByteMatchTuples(byteMatchSetName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &after),
+					testAccCheckAWSWafRegionalByteMatchSetExists(resourceName, &after),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSetName),
+						resourceName, "name", byteMatchSetName),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+						resourceName, "byte_match_tuples.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.2069994922.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.field_to_match.0.data", ""),
+						resourceName, "byte_match_tuples.2069994922.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.field_to_match.0.type", "METHOD"),
+						resourceName, "byte_match_tuples.2069994922.field_to_match.0.type", "METHOD"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.positional_constraint", "EXACTLY"),
+						resourceName, "byte_match_tuples.2069994922.positional_constraint", "EXACTLY"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.target_string", "GET"),
+						resourceName, "byte_match_tuples.2069994922.target_string", "GET"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2069994922.text_transformation", "NONE"),
+						resourceName, "byte_match_tuples.2069994922.text_transformation", "NONE"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.field_to_match.#", "1"),
+						resourceName, "byte_match_tuples.2506804529.field_to_match.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.field_to_match.0.data", ""),
+						resourceName, "byte_match_tuples.2506804529.field_to_match.0.data", ""),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.field_to_match.0.type", "URI"),
+						resourceName, "byte_match_tuples.2506804529.field_to_match.0.type", "URI"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.positional_constraint", "ENDS_WITH"),
+						resourceName, "byte_match_tuples.2506804529.positional_constraint", "ENDS_WITH"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.target_string", "badrefer2+"),
+						resourceName, "byte_match_tuples.2506804529.target_string", "badrefer2+"),
 					resource.TestCheckResourceAttr(
-						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.2506804529.text_transformation", "LOWERCASE"),
+						resourceName, "byte_match_tuples.2506804529.text_transformation", "LOWERCASE"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -221,6 +239,7 @@ func TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples(t *testing.T) {
 func TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples(t *testing.T) {
 	var byteMatchSet waf.ByteMatchSet
 	byteMatchSetName := fmt.Sprintf("byte-batch-set-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_byte_match_set.byte_match_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -230,10 +249,15 @@ func TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalByteMatchSetConfig_noDescriptors(byteMatchSetName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_match_set", &byteMatchSet),
-					resource.TestCheckResourceAttr("aws_wafregional_byte_match_set.byte_match_set", "name", byteMatchSetName),
-					resource.TestCheckResourceAttr("aws_wafregional_byte_match_set.byte_match_set", "byte_match_tuples.#", "0"),
+					testAccCheckAWSWafRegionalByteMatchSetExists(resourceName, &byteMatchSet),
+					resource.TestCheckResourceAttr(resourceName, "name", byteMatchSetName),
+					resource.TestCheckResourceAttr(resourceName, "byte_match_tuples.#", "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -242,6 +266,7 @@ func TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples(t *testing.T) {
 func TestAccAWSWafRegionalByteMatchSet_disappears(t *testing.T) {
 	var v waf.ByteMatchSet
 	byteMatchSet := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
+	resourceName := "aws_wafregional_byte_match_set.byte_set"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -251,7 +276,7 @@ func TestAccAWSWafRegionalByteMatchSet_disappears(t *testing.T) {
 			{
 				Config: testAccAWSWafRegionalByteMatchSetConfig(byteMatchSet),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &v),
+					testAccCheckAWSWafRegionalByteMatchSetExists(resourceName, &v),
 					testAccCheckAWSWafRegionalByteMatchSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,

--- a/website/docs/r/wafregional_byte_match_set.html.markdown
+++ b/website/docs/r/wafregional_byte_match_set.html.markdown
@@ -56,3 +56,11 @@ FieldToMatch(field_to_match) support following:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the WAF ByteMatchSet.
+
+## Import
+
+WAF Regional Byte Match Set can be imported using the id, e.g.
+
+```
+$ terraform import aws_wafregional_byte_match_set.byte_set a1b2c3d4-d5f6-7777-8888-9999aaaabbbbcccc
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference #9212

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/aws_wafregional_byte_match_set: Support resource import
```

Output from acceptance testing:

```
$ make testacc TEST=./aws TESTARGS='-run=TestAccAWSWafRegionalByteMatchSet_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -parallel 20 -run=TestAccAWSWafRegionalByteMatchSet_ -timeout 120m
=== RUN   TestAccAWSWafRegionalByteMatchSet_basic
=== PAUSE TestAccAWSWafRegionalByteMatchSet_basic
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
=== PAUSE TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
=== RUN   TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== PAUSE TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== RUN   TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== PAUSE TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== RUN   TestAccAWSWafRegionalByteMatchSet_disappears
=== PAUSE TestAccAWSWafRegionalByteMatchSet_disappears
=== CONT  TestAccAWSWafRegionalByteMatchSet_basic
=== CONT  TestAccAWSWafRegionalByteMatchSet_disappears
=== CONT  TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples
=== CONT  TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples
=== CONT  TestAccAWSWafRegionalByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafRegionalByteMatchSet_noByteMatchTuples (29.88s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_disappears (34.55s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_basic (39.63s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeByteMatchTuples (53.50s)
--- PASS: TestAccAWSWafRegionalByteMatchSet_changeNameForceNew (64.35s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	64.468s
```
